### PR TITLE
[WIP] asset backfills with run-level execution dependencies

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -1,6 +1,9 @@
+from typing import TYPE_CHECKING, Any, Mapping, Union
+
 import pendulum
 
 import dagster._check as check
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.errors import DagsterError
 from dagster._core.events import AssetKey
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -13,85 +16,122 @@ from ..utils import capture_error
 BACKFILL_CHUNK_SIZE = 25
 
 
-@capture_error
-def create_and_launch_partition_backfill(graphene_info, backfill_params):
+if TYPE_CHECKING:
     from ...schema.backfill import GrapheneLaunchBackfillSuccess
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
-    partition_set_selector = backfill_params.get("selector")
-    partition_set_name = partition_set_selector.get("partitionSetName")
-    repository_selector = RepositorySelector.from_graphql_input(
-        partition_set_selector.get("repositorySelector")
-    )
-    location = graphene_info.context.get_repository_location(repository_selector.location_name)
-    repository = location.get_repository(repository_selector.repository_name)
-    matches = [
-        partition_set
-        for partition_set in repository.get_external_partition_sets()
-        if partition_set.name == partition_set_selector.get("partitionSetName")
-    ]
-    if not matches:
-        return GraphenePartitionSetNotFoundError(partition_set_name)
 
-    check.invariant(
-        len(matches) == 1,
-        "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
-            num=len(matches), partition_set_name=partition_set_name
-        ),
-    )
-
-    external_partition_set = next(iter(matches))
-
-    if backfill_params.get("allPartitions"):
-        result = graphene_info.context.get_external_partition_names(external_partition_set)
-        partition_names = result.partition_names
-    elif backfill_params.get("partitionNames"):
-        partition_names = backfill_params.get("partitionNames")
-    else:
-        raise DagsterError(
-            'Backfill requested without specifying either "allPartitions" or "partitionNames" '
-            "arguments"
-        )
+@capture_error
+def create_and_launch_partition_backfill(
+    graphene_info, backfill_params: Mapping[str, Any]
+) -> Union["GrapheneLaunchBackfillSuccess", "GraphenePartitionSetNotFoundError"]:
+    from ...schema.backfill import GrapheneLaunchBackfillSuccess
+    from ...schema.errors import GraphenePartitionSetNotFoundError
 
     backfill_id = make_new_backfill_id()
-    backfill = PartitionBackfill(
-        backfill_id=backfill_id,
-        partition_set_origin=external_partition_set.get_external_origin(),
-        status=BulkActionStatus.REQUESTED,
-        partition_names=partition_names,
-        from_failure=bool(backfill_params.get("fromFailure")),
-        reexecution_steps=backfill_params.get("reexecutionSteps"),
-        tags={t["key"]: t["value"] for t in backfill_params.get("tags", [])},
-        backfill_timestamp=pendulum.now("UTC").timestamp(),
-        asset_selection=[
-            AssetKey.from_graphql_input(asset_key)
-            for asset_key in backfill_params.get("assetSelection")
-        ]
+
+    asset_selection = (
+        [AssetKey.from_graphql_input(asset_key) for asset_key in backfill_params["assetSelection"]]
         if backfill_params.get("assetSelection")
-        else None,
+        else None
     )
 
-    if backfill_params.get("forceSynchronousSubmission"):
-        # should only be used in a test situation
-        to_submit = [name for name in partition_names]
-        submitted_run_ids = []
+    tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
+    backfill_timestamp = pendulum.now("UTC").timestamp()
 
-        while to_submit:
-            chunk = to_submit[:BACKFILL_CHUNK_SIZE]
-            to_submit = to_submit[BACKFILL_CHUNK_SIZE:]
-            submitted_run_ids.extend(
-                run_id
-                for run_id in submit_backfill_runs(
-                    graphene_info.context.instance,
-                    workspace=graphene_info.context,
-                    repo_location=location,
-                    backfill_job=backfill,
-                    partition_names=chunk,
-                )
-                if run_id != None
+    if backfill_params.get("selector") is not None:  # job backfill
+        partition_set_selector = backfill_params["selector"]
+        partition_set_name = partition_set_selector.get("partitionSetName")
+        repository_selector = RepositorySelector.from_graphql_input(
+            partition_set_selector.get("repositorySelector")
+        )
+        location = graphene_info.context.get_repository_location(repository_selector.location_name)
+        repository = location.get_repository(repository_selector.repository_name)
+        matches = [
+            partition_set
+            for partition_set in repository.get_external_partition_sets()
+            if partition_set.name == partition_set_selector.get("partitionSetName")
+        ]
+        if not matches:
+            return GraphenePartitionSetNotFoundError(partition_set_name)
+
+        check.invariant(
+            len(matches) == 1,
+            "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
+                num=len(matches), partition_set_name=partition_set_name
+            ),
+        )
+        external_partition_set = next(iter(matches))
+
+        if backfill_params.get("allPartitions"):
+            result = graphene_info.context.get_external_partition_names(external_partition_set)
+            partition_names = result.partition_names
+        elif backfill_params.get("partitionNames"):
+            partition_names = backfill_params["partitionNames"]
+        else:
+            raise DagsterError(
+                'Backfill requested without specifying either "allPartitions" or "partitionNames" '
+                "arguments"
             )
-        return GrapheneLaunchBackfillSuccess(
-            backfill_id=backfill_id, launched_run_ids=submitted_run_ids
+
+        backfill = PartitionBackfill(
+            backfill_id=backfill_id,
+            partition_set_origin=external_partition_set.get_external_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=partition_names,
+            from_failure=bool(backfill_params.get("fromFailure")),
+            reexecution_steps=backfill_params.get("reexecutionSteps"),
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+        )
+
+        if backfill_params.get("forceSynchronousSubmission"):
+            # should only be used in a test situation
+            to_submit = [name for name in partition_names]
+            submitted_run_ids = []
+
+            while to_submit:
+                chunk = to_submit[:BACKFILL_CHUNK_SIZE]
+                to_submit = to_submit[BACKFILL_CHUNK_SIZE:]
+                submitted_run_ids.extend(
+                    run_id
+                    for run_id in submit_backfill_runs(
+                        graphene_info.context.instance,
+                        workspace=graphene_info.context,
+                        repo_location=location,
+                        backfill_job=backfill,
+                        partition_names=chunk,
+                    )
+                    if run_id != None
+                )
+            return GrapheneLaunchBackfillSuccess(
+                backfill_id=backfill_id, launched_run_ids=submitted_run_ids
+            )
+    elif asset_selection is not None:  # pure asset backfill
+        if backfill_params.get("forceSynchronousSubmission"):
+            raise DagsterError(
+                "forceSynchronousSubmission is not supported for pure asset backfills"
+            )
+
+        if backfill_params.get("fromFailure"):
+            raise DagsterError("fromFailure is not supported for pure asset backfills")
+
+        if backfill_params.get("allPartitions"):
+            raise DagsterError("allPartitions is not supported for pure asset backfills")
+
+        backfill = PartitionBackfill.from_asset_partitions(
+            asset_graph=ExternalAssetGraph.from_workspace_request_context(graphene_info.context),
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+            partition_names=backfill_params["partitionNames"],
+        )
+    else:
+        raise DagsterError(
+            "Backfill requested without specifying partition set selector or asset selection"
         )
 
     graphene_info.context.instance.add_backfill(backfill)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -3,11 +3,8 @@ import pendulum
 import dagster._check as check
 from dagster._core.errors import DagsterError
 from dagster._core.events import AssetKey
-from dagster._core.execution.backfill import (
-    BulkActionStatus,
-    PartitionBackfill,
-    submit_backfill_runs,
-)
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.job_backfill import submit_backfill_runs
 from dagster._core.host_representation import RepositorySelector
 from dagster._core.utils import make_new_backfill_id
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -143,7 +143,7 @@ class GraphenePartitionSetSelector(graphene.InputObjectType):
 
 
 class GrapheneLaunchBackfillParams(graphene.InputObjectType):
-    selector = graphene.NonNull(GraphenePartitionSetSelector)
+    selector = GraphenePartitionSetSelector
     partitionNames = graphene.List(graphene.NonNull(graphene.String))
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.InputField(graphene.List(graphene.NonNull(GrapheneAssetKeyInput)))

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1,0 +1,62 @@
+from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
+
+from dagster import Definitions, StaticPartitionsDefinition, asset
+from dagster._core.execution.asset_backfill import AssetBackfillData
+from dagster._core.test_utils import instance_for_test
+
+
+def get_repo():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        ...
+
+    @asset(partitions_def=partitions_def)
+    def asset2():
+        ...
+
+    return Definitions(assets=[asset1, asset2]).get_repository_def()
+
+
+def test_launch_asset_backfill():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.all_asset_keys
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            assert result
+            assert result.data
+            error_msg = (
+                (
+                    "".join(result.data["launchPartitionBackfill"]["stack"])
+                    + result.data["launchPartitionBackfill"]["message"]
+                )
+                if "message" in result.data["launchPartitionBackfill"]
+                else None
+            )
+            assert "backfillId" in result.data["launchPartitionBackfill"], error_msg
+
+            backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
+            assert result.data["launchPartitionBackfill"]["launchedRunIds"] is None
+
+            backfills = instance.get_backfills()
+            assert len(backfills) == 1
+            backfill = backfills[0]
+            assert backfill.backfill_id == backfill_id
+            assert backfill.serialized_asset_backfill_data
+            asset_backfill_data = AssetBackfillData.from_serialized(
+                backfill.serialized_asset_backfill_data, repo.asset_graph
+            )
+            assert asset_backfill_data.target_subsets_by_asset_key.keys() == all_asset_keys

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -27,11 +27,8 @@ from dagster._cli.workspace.cli_target import (
 from dagster._core.definitions.pipeline_base import IPipeline
 from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
-from dagster._core.execution.backfill import (
-    BulkActionStatus,
-    PartitionBackfill,
-    create_backfill_run,
-)
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.job_backfill import create_backfill_run
 from dagster._core.host_representation import (
     ExternalPipeline,
     ExternalRepository,

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -1,0 +1,83 @@
+from collections import defaultdict
+from typing import AbstractSet, Dict, Iterable, Mapping, cast
+
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+
+from .asset_graph import AssetGraph
+from .events import AssetKey, AssetKeyPartitionKey
+
+
+class AssetGraphSubset:
+    def __init__(
+        self,
+        partitions_subsets_by_asset_key: Mapping[AssetKey, PartitionsSubset],
+        asset_graph: AssetGraph,
+    ):
+        self._partitions_subsets_by_asset_key = partitions_subsets_by_asset_key
+        self._asset_graph = asset_graph
+
+    @property
+    def asset_graph(self):
+        return self._asset_graph
+
+    @property
+    def partitions_subsets_by_asset_key(self):
+        return self._partitions_subsets_by_asset_key
+
+    @property
+    def asset_keys(self) -> Iterable[AssetKey]:
+        return self.partitions_subsets_by_asset_key.keys()
+
+    def get_partitions_subset(self, asset_key: AssetKey) -> PartitionsSubset:
+        partitions_def = cast(PartitionsDefinition, self.asset_graph.get_partitions_def(asset_key))
+        return self.partitions_subsets_by_asset_key.get(asset_key, partitions_def.empty_subset())
+
+    def __contains__(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        partitions_subset = self.partitions_subsets_by_asset_key.get(asset_partition.asset_key)
+        return partitions_subset is not None and asset_partition.partition_key in partitions_subset
+
+    def to_storage_dict(self) -> Mapping[str, str]:
+        return {
+            key.to_user_string(): value.serialize()
+            for key, value in self.partitions_subsets_by_asset_key.items()
+        }
+
+    def __or__(self, other: Mapping[AssetKey, AbstractSet[str]]) -> "AssetGraphSubset":
+        result_partition_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for asset_key in self.partitions_subsets_by_asset_key.keys() | other.keys():
+            subset = self.get_partitions_subset(asset_key)
+            result_partition_subsets_by_asset_key[asset_key] = subset.with_partition_keys(
+                other.get(asset_key, [])
+            )
+
+        return AssetGraphSubset(result_partition_subsets_by_asset_key, self.asset_graph)
+
+    @classmethod
+    def from_asset_partition_set(
+        cls, asset_partitions_set: AbstractSet[AssetKeyPartitionKey], asset_graph: AssetGraph
+    ) -> "AssetGraphSubset":
+        partitions_by_asset_key = defaultdict(set)
+        for asset_key, partition_key in asset_partitions_set:
+            partitions_by_asset_key[asset_key].add(cast(str, partition_key))
+
+        return AssetGraphSubset(
+            {
+                asset_key: cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+                .empty_subset()
+                .with_partition_keys(partition_keys)
+                for asset_key, partition_keys in partitions_by_asset_key.items()
+            },
+            asset_graph,
+        )
+
+    @classmethod
+    def from_storage_dict(
+        cls, serialized_dict: Mapping[str, str], asset_graph: AssetGraph
+    ) -> "AssetGraphSubset":
+        result: Dict[AssetKey, PartitionsSubset] = {}
+        for key, value in serialized_dict.items():
+            asset_key = AssetKey.from_user_string(key)
+            partitions_def = cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+            result[asset_key] = partitions_def.deserialize_subset(value)
+
+        return AssetGraphSubset(result, asset_graph)

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -28,6 +28,7 @@ from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_selection import AssetGraph, AssetSelection
+from .decorators.sensor_decorator import sensor
 from .partition import PartitionsDefinition, PartitionsSubset
 from .repository_definition import RepositoryDefinition
 from .run_request import RunRequest
@@ -179,47 +180,41 @@ class AssetReconciliationCursor(NamedTuple):
         return serialized
 
 
-def find_stale_candidates(
+def find_parent_materialized_asset_partitions(
     instance_queryer: CachingInstanceQueryer,
-    cursor: AssetReconciliationCursor,
+    latest_storage_id: Optional[int],
     target_asset_selection: AssetSelection,
     asset_graph: AssetGraph,
 ) -> Tuple[AbstractSet[AssetKeyPartitionKey], Optional[int]]:
     """
-    Cheaply identifies a set of reconciliation candidates, which can then be vetted with more
-    heavyweight logic after.
-
-    The contract of this function is:
-    - Every asset (partition) that requires reconciliation must either be one of the returned
-        candidates or a descendant of one of the returned candidates.
-    - Not every returned candidate must require reconciliation.
+    Finds asset partitions in the given selection whose parents have been materialized since
+    latest_storage_id.
 
     Returns:
-        - A set of reconciliation candidates.
+        - A set of asset partitions.
         - The latest observed storage_id across all relevant assets. Can be used to avoid scanning
             the same events the next time this function is called.
     """
-
-    stale_candidates: Set[AssetKeyPartitionKey] = set()
-    latest_storage_id = None
+    result_asset_partitions: Set[AssetKeyPartitionKey] = set()
+    result_latest_storage_id = latest_storage_id
 
     target_asset_keys = target_asset_selection.resolve(asset_graph)
 
     for asset_key, record in instance_queryer.get_latest_materialization_records_by_key(
         target_asset_selection.upstream(depth=1).resolve(asset_graph),
-        cursor.latest_storage_id,
+        latest_storage_id,
     ).items():
         # The children of updated assets might now be unreconciled:
         for child in asset_graph.get_children_partitions(asset_key, record.partition_key):
             if child.asset_key in target_asset_keys and not instance_queryer.is_asset_in_run(
                 record.run_id, child
             ):
-                stale_candidates.add(child)
+                result_asset_partitions.add(child)
 
-        if latest_storage_id is None or record.storage_id > latest_storage_id:
-            latest_storage_id = record.storage_id
+        if result_latest_storage_id is None or record.storage_id > result_latest_storage_id:
+            result_latest_storage_id = record.storage_id
 
-    return (stale_candidates, latest_storage_id)
+    return (result_asset_partitions, result_latest_storage_id)
 
 
 def find_never_materialized_or_requested_root_asset_partitions(
@@ -292,9 +287,9 @@ def determine_asset_partitions_to_reconcile(
         asset_graph=asset_graph,
     )
 
-    stale_candidates, latest_storage_id = find_stale_candidates(
+    stale_candidates, latest_storage_id = find_parent_materialized_asset_partitions(
         instance_queryer=instance_queryer,
-        cursor=cursor,
+        latest_storage_id=cursor.latest_storage_id,
         target_asset_selection=target_asset_selection,
         asset_graph=asset_graph,
     )
@@ -671,13 +666,31 @@ def reconcile(
         eventual_asset_partitions_to_reconcile_for_freshness=eventual_asset_partitions_to_reconcile_for_freshness,
     )
 
+    run_requests = build_run_requests(
+        asset_partitions_to_reconcile | asset_partitions_to_reconcile_for_freshness,
+        asset_graph,
+        run_tags,
+    )
+
+    return run_requests, cursor.with_updates(
+        latest_storage_id=latest_storage_id,
+        run_requests=run_requests,
+        asset_graph=repository_def.asset_graph,
+        newly_materialized_root_asset_keys=newly_materialized_root_asset_keys,
+        newly_materialized_root_partitions_by_asset_key=newly_materialized_root_partitions_by_asset_key,
+    )
+
+
+def build_run_requests(
+    asset_partitions: Iterable[AssetKeyPartitionKey],
+    asset_graph: AssetGraph,
+    run_tags: Optional[Mapping[str, str]],
+) -> Sequence[RunRequest]:
     assets_to_reconcile_by_partitions_def_partition_key: Mapping[
         Tuple[Optional[PartitionsDefinition], Optional[str]], Set[AssetKey]
     ] = defaultdict(set)
 
-    for asset_partition in (
-        asset_partitions_to_reconcile | asset_partitions_to_reconcile_for_freshness
-    ):
+    for asset_partition in asset_partitions:
         assets_to_reconcile_by_partitions_def_partition_key[
             asset_graph.get_partitions_def(asset_partition.asset_key), asset_partition.partition_key
         ].add(asset_partition.asset_key)
@@ -699,13 +712,7 @@ def reconcile(
             )
         )
 
-    return run_requests, cursor.with_updates(
-        latest_storage_id=latest_storage_id,
-        run_requests=run_requests,
-        asset_graph=repository_def.asset_graph,
-        newly_materialized_root_asset_keys=newly_materialized_root_asset_keys,
-        newly_materialized_root_partitions_by_asset_key=newly_materialized_root_partitions_by_asset_key,
-    )
+    return run_requests
 
 
 @experimental
@@ -819,7 +826,14 @@ def build_asset_reconciliation_sensor(
     check_valid_name(name)
     check.opt_mapping_param(run_tags, "run_tags", key_type=str, value_type=str)
 
-    def sensor_fn(context):
+    @sensor(
+        name=name,
+        asset_selection=asset_selection,
+        minimum_interval_seconds=minimum_interval_seconds,
+        description=description,
+        default_status=default_status,
+    )
+    def _sensor(context):
         cursor = (
             AssetReconciliationCursor.from_serialized(
                 context.cursor, context.repository_def.asset_graph
@@ -838,11 +852,4 @@ def build_asset_reconciliation_sensor(
         context.update_cursor(updated_cursor.serialize())
         return run_requests
 
-    return SensorDefinition(
-        evaluation_fn=sensor_fn,
-        name=name,
-        asset_selection=asset_selection,
-        minimum_interval_seconds=minimum_interval_seconds,
-        description=description,
-        default_status=default_status,
-    )
+    return _sensor

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -168,6 +168,9 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
             return AssetKey(asset_key["path"])
         return None
 
+    def to_graphql_input(self) -> Mapping[str, Sequence[str]]:
+        return {"path": self.path}
+
     @staticmethod
     def from_coerceable(arg: "CoercibleToAssetKey") -> "AssetKey":
         if isinstance(arg, AssetKey):

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1,0 +1,382 @@
+import json
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    cast,
+)
+
+import dagster._check as check
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    build_run_requests,
+    find_parent_materialized_asset_partitions,
+)
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.assets_job import is_base_asset_job_name
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.mode import DEFAULT_MODE_NAME
+from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.run_request import RunRequest
+from dagster._core.host_representation.selector import PipelineSelector
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
+from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG
+from dagster._core.workspace.context import BaseWorkspaceRequestContext
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+if TYPE_CHECKING:
+    from .backfill import PartitionBackfill
+
+
+class AssetBackfillData(NamedTuple):
+    target_asset_partitions: AssetGraphSubset
+    roots_were_requested: bool
+    latest_storage_id: Optional[int]
+    materialized_asset_partitions: AssetGraphSubset
+    failed_asset_partitions: AssetGraphSubset
+
+    def is_complete(self) -> bool:
+        return all(
+            len(self.materialized_asset_partitions.get_partitions_subset(asset_key))
+            + len(self.failed_asset_partitions.get_partitions_subset(asset_key))
+            == len(self.target_asset_partitions.get_partitions_subset(asset_key))
+            for asset_key in self.target_asset_partitions.asset_keys
+        )
+
+    def get_target_root_asset_partitions(
+        self, asset_graph: AssetGraph
+    ) -> Iterable[AssetKeyPartitionKey]:
+        root_asset_keys = (
+            AssetSelection.keys(*self.target_asset_partitions.asset_keys)
+            .sources()
+            .resolve(asset_graph)
+        )
+        return [
+            AssetKeyPartitionKey(asset_key, partition_key)
+            for asset_key in root_asset_keys
+            for partition_key in self.target_asset_partitions.get_partitions_subset(
+                asset_key
+            ).get_partition_keys()
+        ]
+
+    @classmethod
+    def empty(
+        cls,
+        target_subsets_by_asset_key: Mapping[AssetKey, PartitionsSubset],
+        asset_graph: AssetGraph,
+    ) -> "AssetBackfillData":
+        return cls(
+            target_asset_partitions=AssetGraphSubset(target_subsets_by_asset_key, asset_graph),
+            roots_were_requested=False,
+            materialized_asset_partitions=AssetGraphSubset({}, asset_graph),
+            failed_asset_partitions=AssetGraphSubset({}, asset_graph),
+            latest_storage_id=None,
+        )
+
+    @classmethod
+    def from_serialized(cls, serialized: str, asset_graph: AssetGraph) -> "AssetBackfillData":
+        storage_dict = json.loads(serialized)
+
+        return cls(
+            target_asset_partitions=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_target_asset_partitions"], asset_graph
+            ),
+            roots_were_requested=storage_dict["roots_were_requested"],
+            materialized_asset_partitions=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_materialized_asset_partitions"], asset_graph
+            ),
+            failed_asset_partitions=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_failed_asset_partitions"], asset_graph
+            ),
+            latest_storage_id=storage_dict["latest_storage_id"],
+        )
+
+    def serialize(self) -> str:
+        storage_dict = {
+            "roots_were_requested": self.roots_were_requested,
+            "serialized_target_asset_partitions": self.target_asset_partitions.to_storage_dict(),
+            "latest_storage_id": self.latest_storage_id,
+            "serialized_materialized_asset_partitions": self.materialized_asset_partitions.to_storage_dict(),
+            "serialized_failed_asset_partitions": self.failed_asset_partitions.to_storage_dict(),
+        }
+        return json.dumps(storage_dict)
+
+
+def execute_asset_backfill_iteration(
+    backfill: "PartitionBackfill", workspace: BaseWorkspaceRequestContext, instance: DagsterInstance
+):
+    asset_graph = ExternalAssetGraph.from_workspace_request_context(workspace)
+    if backfill.serialized_asset_backfill_data is None:
+        check.failed("Asset backfill missing serialized_asset_backfill_data")
+
+    asset_backfill_data = AssetBackfillData.from_serialized(
+        backfill.serialized_asset_backfill_data, asset_graph
+    )
+
+    result = execute_asset_backfill_iteration_inner(
+        backfill_id=backfill.backfill_id,
+        asset_backfill_data=asset_backfill_data,
+        instance=instance,
+        asset_graph=asset_graph,
+    )
+
+    updated_backfill = backfill.with_asset_backfill_data(result.backfill_data)
+
+    for run_request in result.run_requests:
+        submit_run_request(
+            run_request=run_request,
+            asset_graph=asset_graph,
+            workspace=workspace,
+            instance=instance,
+        )
+
+    instance.update_backfill(updated_backfill)
+
+    yield None
+
+
+def submit_run_request(
+    asset_graph: ExternalAssetGraph,
+    run_request: RunRequest,
+    instance: DagsterInstance,
+    workspace: BaseWorkspaceRequestContext,
+) -> None:
+    repo_handle = asset_graph.get_repository_handle(
+        cast(Sequence[AssetKey], run_request.asset_selection)[0]
+    )
+    location_name = repo_handle.repository_location_origin.location_name
+    repo_location = workspace.get_repository_location(
+        repo_handle.repository_location_origin.location_name
+    )
+    job_name = _get_implicit_job_name_for_assets(
+        asset_graph, cast(Sequence[AssetKey], run_request.asset_selection)
+    )
+    if job_name is None:
+        check.failed(
+            f"Could not find an implicit asset job for the given assets: {run_request.asset_selection}"
+        )
+    pipeline_selector = PipelineSelector(
+        location_name=location_name,
+        repository_name=repo_handle.repository_name,
+        pipeline_name=job_name,
+        asset_selection=run_request.asset_selection,
+        solid_selection=None,
+    )
+    external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
+
+    external_execution_plan = repo_location.get_external_execution_plan(
+        external_pipeline,
+        {},
+        DEFAULT_MODE_NAME,
+        step_keys_to_execute=None,
+        known_state=None,
+        instance=instance,
+    )
+
+    if not run_request.asset_selection:
+        check.failed("Expected RunRequest to have an asset selection")
+
+    run = instance.create_run(
+        pipeline_snapshot=external_pipeline.pipeline_snapshot,
+        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
+        pipeline_name=external_pipeline.name,
+        run_id=None,
+        solids_to_execute=None,
+        run_config={},
+        mode=DEFAULT_MODE_NAME,
+        step_keys_to_execute=None,
+        tags=run_request.tags,
+        root_run_id=None,
+        parent_run_id=None,
+        status=DagsterRunStatus.NOT_STARTED,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+        solid_selection=None,
+        asset_selection=frozenset(run_request.asset_selection),
+    )
+
+    instance.submit_run(run.run_id, workspace)
+
+
+def _get_implicit_job_name_for_assets(
+    asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
+) -> Optional[str]:
+    job_names = set(asset_graph.get_job_names(asset_keys[0]))
+    for asset_key in asset_keys[1:]:
+        job_names &= set(asset_graph.get_job_names(asset_key))
+
+    return next(job_name for job_name in job_names if is_base_asset_job_name(job_name))
+
+
+class AssetBackfillIterationResult(NamedTuple):
+    run_requests: Sequence[RunRequest]
+    backfill_data: AssetBackfillData
+
+
+def execute_asset_backfill_iteration_inner(
+    backfill_id: str,
+    asset_backfill_data: AssetBackfillData,
+    asset_graph: ExternalAssetGraph,
+    instance: "DagsterInstance",
+) -> AssetBackfillIterationResult:
+    instance_queryer = CachingInstanceQueryer(instance=instance)
+
+    initial_candidates: Set[AssetKeyPartitionKey] = set()
+    request_roots = not asset_backfill_data.roots_were_requested
+    if request_roots:
+        root_asset_partitions = asset_backfill_data.get_target_root_asset_partitions(asset_graph)
+        initial_candidates.update(root_asset_partitions)
+
+    (
+        parent_materialized_asset_partitions,
+        next_latest_storage_id,
+    ) = find_parent_materialized_asset_partitions(
+        asset_graph=asset_graph,
+        instance_queryer=instance_queryer,
+        target_asset_selection=AssetSelection.keys(
+            *asset_backfill_data.target_asset_partitions.asset_keys
+        ),
+        latest_storage_id=asset_backfill_data.latest_storage_id,
+    )
+    initial_candidates.update(parent_materialized_asset_partitions)
+
+    recently_materialized_partitions_by_asset_key: Mapping[AssetKey, AbstractSet[str]] = {
+        asset_key: {
+            cast(str, record.partition_key)
+            for record in instance_queryer.get_materialization_records(
+                asset_key=asset_key, after_cursor=asset_backfill_data.latest_storage_id
+            )
+        }
+        for asset_key in asset_backfill_data.target_asset_partitions.asset_keys
+        # TODO: filter by backfill tag?
+        # TODO: filter by partition?
+    }
+
+    updated_materialized_asset_partitions = (
+        asset_backfill_data.materialized_asset_partitions
+        | recently_materialized_partitions_by_asset_key
+    )
+
+    failed_asset_partitions = AssetGraphSubset.from_asset_partition_set(
+        asset_graph.bfs_filter_asset_partitions(
+            lambda asset_partitions, _: any(
+                asset_partition in asset_backfill_data.target_asset_partitions
+                for asset_partition in asset_partitions
+            ),
+            _get_failed_asset_partitions(instance_queryer, backfill_id),
+        ),
+        asset_graph,
+    )
+
+    asset_partitions_to_request = asset_graph.bfs_filter_asset_partitions(
+        lambda unit, visited: should_backfill_atomic_asset_partitions_unit(
+            candidates_unit=unit,
+            asset_partitions_to_request=visited,
+            asset_graph=asset_graph,
+            materialized_asset_partitions=updated_materialized_asset_partitions,
+            target_asset_partitions=asset_backfill_data.target_asset_partitions,
+            failed_asset_partitions=failed_asset_partitions,
+        ),
+        initial_asset_partitions=initial_candidates,
+    )
+
+    run_requests = build_run_requests(
+        asset_partitions_to_request, asset_graph, {BACKFILL_ID_TAG: backfill_id}
+    )
+
+    if request_roots:
+        check.invariant(
+            asset_partitions_to_request >= set(root_asset_partitions), "Not all roots are included"
+        )
+
+    updated_asset_backfill_data = AssetBackfillData(
+        target_asset_partitions=asset_backfill_data.target_asset_partitions,
+        latest_storage_id=next_latest_storage_id or asset_backfill_data.latest_storage_id,
+        roots_were_requested=asset_backfill_data.roots_were_requested or request_roots,
+        materialized_asset_partitions=updated_materialized_asset_partitions,
+        failed_asset_partitions=failed_asset_partitions,
+    )
+    return AssetBackfillIterationResult(run_requests, updated_asset_backfill_data)
+
+
+def should_backfill_atomic_asset_partitions_unit(
+    asset_graph: ExternalAssetGraph,
+    candidates_unit: Iterable[AssetKeyPartitionKey],
+    asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
+    target_asset_partitions: AssetGraphSubset,
+    materialized_asset_partitions: AssetGraphSubset,
+    failed_asset_partitions: AssetGraphSubset,
+) -> bool:
+    """
+    candidates_unit: A set of asset partitions that must all be materialized if any is materialized.
+    """
+    for candidate in candidates_unit:
+        if (
+            candidate not in target_asset_partitions
+            or candidate in failed_asset_partitions
+            or candidate in materialized_asset_partitions
+        ):
+            return False
+
+        for parent in asset_graph.get_parents_partitions(*candidate):
+            can_run_with_parent = (
+                parent in asset_partitions_to_request
+                and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
+                and parent.partition_key == candidate.partition_key
+                and asset_graph.get_repository_handle(candidate.asset_key)
+                is asset_graph.get_repository_handle(parent.asset_key)
+            )
+
+            if (
+                parent in target_asset_partitions
+                and not can_run_with_parent
+                and parent not in materialized_asset_partitions
+            ):
+                return False
+
+    return True
+
+
+def _get_failed_asset_partitions(
+    instance_queryer: CachingInstanceQueryer, backfill_id: str
+) -> Sequence[AssetKeyPartitionKey]:
+    """
+    Returns asset partitions that materializations were requested for as part of the backfill, but
+    will not be materialized.
+
+    Includes canceled asset partitions. Implementation assumes that successful runs won't have any
+    failed partitions.
+    """
+    runs = instance_queryer.instance.get_runs(
+        filters=RunsFilter(
+            tags={BACKFILL_ID_TAG: backfill_id},
+            statuses=[DagsterRunStatus.CANCELED, DagsterRunStatus.FAILURE],
+        )
+    )
+
+    result: List[AssetKeyPartitionKey] = []
+
+    for run in runs:
+        partition_key = run.tags[PARTITION_NAME_TAG]
+        planned_asset_keys = instance_queryer.get_planned_materializations_for_run_from_events(
+            run_id=run.run_id
+        )
+        completed_asset_keys = instance_queryer.get_current_materializations_for_run(
+            run_id=run.run_id
+        )
+        result.extend(
+            AssetKeyPartitionKey(asset_key, partition_key)
+            for asset_key in planned_asset_keys - completed_asset_keys
+        )
+
+    return result

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,34 +1,10 @@
 from enum import Enum
-from typing import Iterable, Mapping, NamedTuple, Optional, Sequence
+from typing import Mapping, NamedTuple, Optional, Sequence
 
-import dagster._check as check
+from dagster import _check as check
 from dagster._core.definitions import AssetKey
-from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
-from dagster._core.execution.plan.state import KnownExecutionState
-from dagster._core.host_representation import (
-    ExternalPartitionSet,
-    ExternalPipeline,
-    PipelineSelector,
-    RepositoryLocation,
-)
-from dagster._core.host_representation.external_data import (
-    ExternalPartitionExecutionParamData,
-    ExternalPartitionSetExecutionParamData,
-)
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
-from dagster._core.instance import DagsterInstance
-from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, RunsFilter
-from dagster._core.storage.tags import (
-    PARENT_RUN_ID_TAG,
-    PARTITION_NAME_TAG,
-    PARTITION_SET_TAG,
-    ROOT_RUN_ID_TAG,
-)
-from dagster._core.telemetry import BACKFILL_RUN_CREATED, hash_name, log_action
-from dagster._core.utils import make_new_run_id
-from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
-from dagster._utils import merge_dicts
 from dagster._utils.error import SerializableErrorInfo
 
 
@@ -50,32 +26,33 @@ class PartitionBackfill(
         "_PartitionBackfill",
         [
             ("backfill_id", str),
-            ("partition_set_origin", ExternalPartitionSetOrigin),
             ("status", BulkActionStatus),
-            ("partition_names", Sequence[str]),
             ("from_failure", bool),
-            ("reexecution_steps", Sequence[str]),
             ("tags", Mapping[str, str]),
             ("backfill_timestamp", float),
-            ("last_submitted_partition_name", Optional[str]),
             ("error", Optional[SerializableErrorInfo]),
             ("asset_selection", Optional[Sequence[AssetKey]]),
+            # fields that are only used by job backfills
+            ("partition_set_origin", Optional[ExternalPartitionSetOrigin]),
+            ("partition_names", Optional[Sequence[str]]),
+            ("last_submitted_partition_name", Optional[str]),
+            ("reexecution_steps", Optional[Sequence[str]]),
         ],
     ),
 ):
     def __new__(
         cls,
         backfill_id: str,
-        partition_set_origin: ExternalPartitionSetOrigin,
         status: BulkActionStatus,
-        partition_names: Sequence[str],
         from_failure: bool,
-        reexecution_steps: Optional[Sequence[str]],
         tags: Mapping[str, str],
         backfill_timestamp: float,
-        last_submitted_partition_name: Optional[str] = None,
         error: Optional[SerializableErrorInfo] = None,
         asset_selection: Optional[Sequence[AssetKey]] = None,
+        partition_set_origin: Optional[ExternalPartitionSetOrigin] = None,
+        partition_names: Optional[Sequence[str]] = None,
+        last_submitted_partition_name: Optional[str] = None,
+        reexecution_steps: Optional[Sequence[str]] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
@@ -84,255 +61,68 @@ class PartitionBackfill(
         return super(PartitionBackfill, cls).__new__(
             cls,
             check.str_param(backfill_id, "backfill_id"),
-            check.inst_param(
-                partition_set_origin, "partition_set_origin", ExternalPartitionSetOrigin
-            ),
             check.inst_param(status, "status", BulkActionStatus),
-            check.sequence_param(partition_names, "partition_names", of_type=str),
             check.bool_param(from_failure, "from_failure"),
-            check.opt_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
             check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
             check.float_param(backfill_timestamp, "backfill_timestamp"),
-            check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
             check.opt_inst_param(error, "error", SerializableErrorInfo),
             check.opt_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
+            check.opt_inst_param(
+                partition_set_origin, "partition_set_origin", ExternalPartitionSetOrigin
+            ),
+            check.opt_sequence_param(partition_names, "partition_names", of_type=str),
+            check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
+            check.opt_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
         )
 
     @property
     def selector_id(self):
-        return self.partition_set_origin.get_selector_id()
+        return self.partition_set_origin.get_selector_id() if self.partition_set_origin else None
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)
         return PartitionBackfill(
-            self.backfill_id,
-            self.partition_set_origin,
-            status,
-            self.partition_names,
-            self.from_failure,
-            self.reexecution_steps,
-            self.tags,
-            self.backfill_timestamp,
-            self.last_submitted_partition_name,
-            self.error,
-            self.asset_selection,
+            status=status,
+            backfill_id=self.backfill_id,
+            partition_set_origin=self.partition_set_origin,
+            partition_names=self.partition_names,
+            from_failure=self.from_failure,
+            reexecution_steps=self.reexecution_steps,
+            tags=self.tags,
+            backfill_timestamp=self.backfill_timestamp,
+            last_submitted_partition_name=self.last_submitted_partition_name,
+            error=self.error,
+            asset_selection=self.asset_selection,
         )
 
     def with_partition_checkpoint(self, last_submitted_partition_name):
         check.str_param(last_submitted_partition_name, "last_submitted_partition_name")
         return PartitionBackfill(
-            self.backfill_id,
-            self.partition_set_origin,
-            self.status,
-            self.partition_names,
-            self.from_failure,
-            self.reexecution_steps,
-            self.tags,
-            self.backfill_timestamp,
-            last_submitted_partition_name,
-            self.error,
-            self.asset_selection,
+            status=self.status,
+            backfill_id=self.backfill_id,
+            partition_set_origin=self.partition_set_origin,
+            partition_names=self.partition_names,
+            from_failure=self.from_failure,
+            reexecution_steps=self.reexecution_steps,
+            tags=self.tags,
+            backfill_timestamp=self.backfill_timestamp,
+            last_submitted_partition_name=last_submitted_partition_name,
+            error=self.error,
+            asset_selection=self.asset_selection,
         )
 
     def with_error(self, error):
         check.opt_inst_param(error, "error", SerializableErrorInfo)
         return PartitionBackfill(
-            self.backfill_id,
-            self.partition_set_origin,
-            self.status,
-            self.partition_names,
-            self.from_failure,
-            self.reexecution_steps,
-            self.tags,
-            self.backfill_timestamp,
-            self.last_submitted_partition_name,
-            error,
-            self.asset_selection,
+            status=self.status,
+            backfill_id=self.backfill_id,
+            partition_set_origin=self.partition_set_origin,
+            partition_names=self.partition_names,
+            from_failure=self.from_failure,
+            reexecution_steps=self.reexecution_steps,
+            tags=self.tags,
+            backfill_timestamp=self.backfill_timestamp,
+            last_submitted_partition_name=self.last_submitted_partition_name,
+            error=error,
+            asset_selection=self.asset_selection,
         )
-
-
-def submit_backfill_runs(
-    instance: DagsterInstance,
-    workspace: IWorkspace,
-    repo_location: RepositoryLocation,
-    backfill_job: PartitionBackfill,
-    partition_names: Optional[Sequence[str]] = None,
-) -> Iterable[Optional[str]]:
-    """Returns the run IDs of the submitted runs"""
-
-    repository_origin = backfill_job.partition_set_origin.external_repository_origin
-    repo_name = repository_origin.repository_name
-
-    if not partition_names:
-        partition_names = backfill_job.partition_names
-
-    check.invariant(
-        repo_location.has_repository(repo_name),
-        "Could not find repository {repo_name} in location {repo_location_name}".format(
-            repo_name=repo_name, repo_location_name=repo_location.name
-        ),
-    )
-    external_repo = repo_location.get_repository(repo_name)
-    partition_set_name = backfill_job.partition_set_origin.partition_set_name
-    external_partition_set = external_repo.get_external_partition_set(partition_set_name)
-    result = repo_location.get_external_partition_set_execution_param_data(
-        external_repo.handle, partition_set_name, partition_names
-    )
-
-    assert isinstance(result, ExternalPartitionSetExecutionParamData)
-    if backfill_job.asset_selection:
-        # need to make another call to the user code location to properly subset
-        # for an asset selection
-        pipeline_selector = PipelineSelector(
-            location_name=repo_location.name,
-            repository_name=repo_name,
-            pipeline_name=external_partition_set.pipeline_name,
-            solid_selection=None,
-            asset_selection=backfill_job.asset_selection,
-        )
-        external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
-    else:
-        external_pipeline = external_repo.get_full_external_job(
-            external_partition_set.pipeline_name
-        )
-    for partition_data in result.partition_data:
-        pipeline_run = create_backfill_run(
-            instance,
-            repo_location,
-            external_pipeline,
-            external_partition_set,
-            backfill_job,
-            partition_data,
-        )
-        if pipeline_run:
-            # we skip runs in certain cases, e.g. we are running a `from_failure` backfill job
-            # and the partition has had a successful run since the time the backfill was
-            # scheduled
-            instance.submit_run(pipeline_run.run_id, workspace)
-            yield pipeline_run.run_id
-        yield None
-
-
-def create_backfill_run(
-    instance: DagsterInstance,
-    repo_location: RepositoryLocation,
-    external_pipeline: ExternalPipeline,
-    external_partition_set: ExternalPartitionSet,
-    backfill_job: PartitionBackfill,
-    partition_data: ExternalPartitionExecutionParamData,
-) -> Optional[DagsterRun]:
-    from dagster._daemon.daemon import get_telemetry_daemon_session_id
-
-    log_action(
-        instance,
-        BACKFILL_RUN_CREATED,
-        metadata={
-            "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
-            "repo_hash": hash_name(repo_location.name),
-            "pipeline_name_hash": hash_name(external_pipeline.name),
-        },
-    )
-
-    tags = merge_dicts(
-        external_pipeline.tags,
-        partition_data.tags,
-        DagsterRun.tags_for_backfill_id(backfill_job.backfill_id),
-        backfill_job.tags,
-    )
-
-    solids_to_execute = None
-    solid_selection = None
-    if not backfill_job.from_failure and not backfill_job.reexecution_steps:
-        step_keys_to_execute = None
-        parent_run_id = None
-        root_run_id = None
-        known_state = None
-        if external_partition_set.solid_selection:
-            solids_to_execute = frozenset(external_partition_set.solid_selection)
-            solid_selection = external_partition_set.solid_selection
-
-    elif backfill_job.from_failure:
-        last_run = _fetch_last_run(instance, external_partition_set, partition_data.name)
-        if not last_run or last_run.status != DagsterRunStatus.FAILURE:
-            return None
-        return instance.create_reexecuted_run(
-            last_run,
-            repo_location,
-            external_pipeline,
-            ReexecutionStrategy.FROM_FAILURE,
-            extra_tags=tags,
-            run_config=partition_data.run_config,
-            mode=external_partition_set.mode,
-            use_parent_run_tags=False,  # don't inherit tags from the previous run
-        )
-
-    elif backfill_job.reexecution_steps:
-        last_run = _fetch_last_run(instance, external_partition_set, partition_data.name)
-        parent_run_id = last_run.run_id if last_run else None
-        root_run_id = (last_run.root_run_id or last_run.run_id) if last_run else None
-        if parent_run_id and root_run_id:
-            tags = merge_dicts(
-                tags, {PARENT_RUN_ID_TAG: parent_run_id, ROOT_RUN_ID_TAG: root_run_id}
-            )
-        step_keys_to_execute = backfill_job.reexecution_steps
-        if last_run and last_run.status == DagsterRunStatus.SUCCESS:
-            known_state = KnownExecutionState.build_for_reexecution(
-                instance,
-                last_run,
-            ).update_for_step_selection(step_keys_to_execute)
-        else:
-            known_state = None
-
-        if external_partition_set.solid_selection:
-            solids_to_execute = frozenset(external_partition_set.solid_selection)
-            solid_selection = external_partition_set.solid_selection
-
-    external_execution_plan = repo_location.get_external_execution_plan(
-        external_pipeline,
-        partition_data.run_config,
-        check.not_none(external_partition_set.mode),
-        step_keys_to_execute=step_keys_to_execute,
-        known_state=known_state,
-        instance=instance,
-    )
-
-    return instance.create_run(
-        pipeline_snapshot=external_pipeline.pipeline_snapshot,
-        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
-        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
-        pipeline_name=external_pipeline.name,
-        run_id=make_new_run_id(),
-        solids_to_execute=solids_to_execute,
-        run_config=partition_data.run_config,
-        mode=external_partition_set.mode,
-        step_keys_to_execute=step_keys_to_execute,
-        tags=tags,
-        root_run_id=root_run_id,
-        parent_run_id=parent_run_id,
-        status=DagsterRunStatus.NOT_STARTED,
-        external_pipeline_origin=external_pipeline.get_external_origin(),
-        pipeline_code_origin=external_pipeline.get_python_origin(),
-        solid_selection=solid_selection,
-        asset_selection=frozenset(backfill_job.asset_selection)
-        if backfill_job.asset_selection
-        else None,
-    )
-
-
-def _fetch_last_run(instance, external_partition_set, partition_name):
-    check.inst_param(instance, "instance", DagsterInstance)
-    check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
-    check.str_param(partition_name, "partition_name")
-
-    runs = instance.get_runs(
-        RunsFilter(
-            pipeline_name=external_partition_set.pipeline_name,
-            tags={
-                PARTITION_SET_TAG: external_partition_set.name,
-                PARTITION_NAME_TAG: partition_name,
-            },
-        ),
-        limit=1,
-    )
-
-    return runs[0] if runs else None

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,11 +1,16 @@
 from enum import Enum
-from typing import Mapping, NamedTuple, Optional, Sequence
+from typing import Dict, Mapping, NamedTuple, Optional, Sequence, cast
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
+
+from .asset_backfill import AssetBackfillData
 
 
 @whitelist_for_serdes
@@ -37,6 +42,8 @@ class PartitionBackfill(
             ("partition_names", Optional[Sequence[str]]),
             ("last_submitted_partition_name", Optional[str]),
             ("reexecution_steps", Optional[Sequence[str]]),
+            # only used by asset backfills
+            ("serialized_asset_backfill_data", Optional[str]),
         ],
     ),
 ):
@@ -53,11 +60,19 @@ class PartitionBackfill(
         partition_names: Optional[Sequence[str]] = None,
         last_submitted_partition_name: Optional[str] = None,
         reexecution_steps: Optional[Sequence[str]] = None,
+        serialized_asset_backfill_data: Optional[str] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
             "Can't supply both an asset_selection and reexecution_steps to a PartitionBackfill.",
         )
+
+        if serialized_asset_backfill_data is not None:
+            check.invariant(partition_set_origin is None)
+            check.invariant(partition_names is None)
+            check.invariant(last_submitted_partition_name is None)
+            check.invariant(reexecution_steps is None)
+
         return super(PartitionBackfill, cls).__new__(
             cls,
             check.str_param(backfill_id, "backfill_id"),
@@ -66,18 +81,30 @@ class PartitionBackfill(
             check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
             check.float_param(backfill_timestamp, "backfill_timestamp"),
             check.opt_inst_param(error, "error", SerializableErrorInfo),
-            check.opt_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
+            check.opt_nullable_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
             check.opt_inst_param(
                 partition_set_origin, "partition_set_origin", ExternalPartitionSetOrigin
             ),
-            check.opt_sequence_param(partition_names, "partition_names", of_type=str),
+            check.opt_nullable_sequence_param(partition_names, "partition_names", of_type=str),
             check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
-            check.opt_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
+            check.opt_nullable_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
+            check.opt_str_param(serialized_asset_backfill_data, "serialized_asset_backfill_data"),
         )
 
     @property
     def selector_id(self):
         return self.partition_set_origin.get_selector_id() if self.partition_set_origin else None
+
+    @property
+    def is_asset_backfill(self) -> bool:
+        return self.serialized_asset_backfill_data is not None
+
+    @property
+    def bulk_action_type(self) -> BulkActionType:
+        if self.is_asset_backfill:
+            return BulkActionType.MULTI_RUN_ASSET_ACTION
+        else:
+            return BulkActionType.PARTITION_BACKFILL
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)
@@ -93,6 +120,7 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
         )
 
     def with_partition_checkpoint(self, last_submitted_partition_name):
@@ -109,6 +137,7 @@ class PartitionBackfill(
             last_submitted_partition_name=last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
         )
 
     def with_error(self, error):
@@ -125,4 +154,52 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
+        )
+
+    def with_asset_backfill_data(
+        self, asset_backfill_data: AssetBackfillData
+    ) -> "PartitionBackfill":
+        return PartitionBackfill(
+            status=self.status,
+            backfill_id=self.backfill_id,
+            partition_set_origin=self.partition_set_origin,
+            partition_names=self.partition_names,
+            from_failure=self.from_failure,
+            reexecution_steps=self.reexecution_steps,
+            tags=self.tags,
+            backfill_timestamp=self.backfill_timestamp,
+            last_submitted_partition_name=self.last_submitted_partition_name,
+            error=self.error,
+            asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=asset_backfill_data.serialize(),
+        )
+
+    @classmethod
+    def from_asset_partitions(
+        cls,
+        backfill_id: str,
+        asset_graph: AssetGraph,
+        partition_names: Sequence[str],
+        asset_selection: Sequence[AssetKey],
+        backfill_timestamp: float,
+        tags: Mapping[str, str],
+    ) -> "PartitionBackfill":
+        target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for asset_key in asset_selection:
+            partitions_def = cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+            target_subsets_by_asset_key[
+                asset_key
+            ] = partitions_def.empty_subset().with_partition_keys(partition_names)
+
+        return cls(
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            from_failure=False,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+            serialized_asset_backfill_data=AssetBackfillData.empty(
+                target_subsets_by_asset_key, asset_graph
+            ).serialize(),
         )

--- a/python_modules/dagster/dagster/_core/execution/bulk_actions.py
+++ b/python_modules/dagster/dagster/_core/execution/bulk_actions.py
@@ -6,3 +6,4 @@ from dagster._serdes import whitelist_for_serdes
 @whitelist_for_serdes
 class BulkActionType(Enum):
     PARTITION_BACKFILL = "PARTITION_BACKFILL"
+    MULTI_RUN_ASSET_ACTION = "MULTI_RUN_ASSET_ACTION"

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -1,0 +1,373 @@
+import logging
+import os
+import sys
+import time
+from typing import Iterable, Mapping, Optional, Sequence, Tuple, cast
+
+import dagster._check as check
+from dagster._core.errors import DagsterBackfillFailedError
+from dagster._core.execution.backfill import BulkActionStatus
+from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
+from dagster._core.execution.plan.state import KnownExecutionState
+from dagster._core.host_representation import (
+    ExternalPartitionSet,
+    ExternalPipeline,
+    PipelineSelector,
+    RepositoryLocation,
+)
+from dagster._core.host_representation.external_data import (
+    ExternalPartitionExecutionParamData,
+    ExternalPartitionSetExecutionParamData,
+)
+from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, RunsFilter
+from dagster._core.storage.tags import (
+    PARENT_RUN_ID_TAG,
+    PARTITION_NAME_TAG,
+    PARTITION_SET_TAG,
+    ROOT_RUN_ID_TAG,
+)
+from dagster._core.telemetry import BACKFILL_RUN_CREATED, hash_name, log_action
+from dagster._core.utils import make_new_run_id
+from dagster._core.workspace.context import BaseWorkspaceRequestContext
+from dagster._core.workspace.workspace import IWorkspace
+from dagster._utils import merge_dicts
+from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+
+from .backfill import BulkActionStatus, PartitionBackfill
+
+# out of abundance of caution, sleep at checkpoints in case we are pinning CPU by submitting lots
+# of jobs all at once
+CHECKPOINT_INTERVAL = 1
+CHECKPOINT_COUNT = 25
+
+
+def execute_job_backfill_iteration(
+    backfill: PartitionBackfill,
+    logger: logging.Logger,
+    workspace: BaseWorkspaceRequestContext,
+    debug_crash_flags: Optional[Mapping[str, int]],
+    instance: DagsterInstance,
+) -> Iterable[Optional[SerializableErrorInfo]]:
+    if not backfill.last_submitted_partition_name:
+        logger.info(f"Starting backfill for {backfill.backfill_id}")
+    else:
+        logger.info(
+            f"Resuming backfill for {backfill.backfill_id} from {backfill.last_submitted_partition_name}"
+        )
+
+    origin = cast(
+        ExternalPartitionSetOrigin, backfill.partition_set_origin
+    ).external_repository_origin.repository_location_origin
+
+    try:
+        repo_location = workspace.get_repository_location(origin.location_name)
+
+        _check_repo_has_partition_set(repo_location, backfill)
+
+        has_more = True
+        while has_more:
+            if backfill.status != BulkActionStatus.REQUESTED:
+                break
+
+            chunk, checkpoint, has_more = _get_partitions_chunk(
+                instance, logger, backfill, CHECKPOINT_COUNT
+            )
+            _check_for_debug_crash(debug_crash_flags, "BEFORE_SUBMIT")
+
+            if chunk:
+                for _run_id in submit_backfill_runs(
+                    instance, workspace, repo_location, backfill, chunk
+                ):
+                    yield None
+                    # before submitting, refetch the backfill job to check for status changes
+                    backfill = cast(PartitionBackfill, instance.get_backfill(backfill.backfill_id))
+                    if backfill.status != BulkActionStatus.REQUESTED:
+                        return
+
+            _check_for_debug_crash(debug_crash_flags, "AFTER_SUBMIT")
+
+            if has_more:
+                # refetch, in case the backfill was updated in the meantime
+                backfill = cast(PartitionBackfill, instance.get_backfill(backfill.backfill_id))
+                instance.update_backfill(backfill.with_partition_checkpoint(checkpoint))
+                yield None
+                time.sleep(CHECKPOINT_INTERVAL)
+            else:
+                partition_names = cast(Sequence[str], backfill.partition_names)
+                logger.info(
+                    f"Backfill completed for {backfill.backfill_id} for {len(partition_names)} partitions"
+                )
+                instance.update_backfill(backfill.with_status(BulkActionStatus.COMPLETED))
+                yield None
+    except Exception:
+        error_info = serializable_error_info_from_exc_info(sys.exc_info())
+        instance.update_backfill(
+            backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
+        )
+        logger.error(f"Backfill failed for {backfill.backfill_id}: {error_info.to_string()}")
+        yield error_info
+
+
+def _check_repo_has_partition_set(
+    repo_location: RepositoryLocation, backfill_job: PartitionBackfill
+) -> None:
+    origin = cast(ExternalPartitionSetOrigin, backfill_job.partition_set_origin)
+
+    repo_name = origin.external_repository_origin.repository_name
+    if not repo_location.has_repository(repo_name):
+        raise DagsterBackfillFailedError(
+            f"Could not find repository {repo_name} in location {repo_location.name} to "
+            f"run backfill {backfill_job.backfill_id}."
+        )
+
+    partition_set_name = origin.partition_set_name
+    external_repo = repo_location.get_repository(repo_name)
+    if not external_repo.has_external_partition_set(partition_set_name):
+        raise DagsterBackfillFailedError(
+            f"Could not find partition set {partition_set_name} in repository {repo_name}. "
+        )
+
+
+def _get_partitions_chunk(
+    instance: DagsterInstance,
+    logger: logging.Logger,
+    backfill_job: PartitionBackfill,
+    chunk_size: int,
+) -> Tuple[Sequence[str], str, bool]:
+    partition_names = cast(Sequence[str], backfill_job.partition_names)
+    checkpoint = backfill_job.last_submitted_partition_name
+
+    if (
+        backfill_job.last_submitted_partition_name
+        and backfill_job.last_submitted_partition_name in partition_names
+    ):
+        index = partition_names.index(backfill_job.last_submitted_partition_name)
+        partition_names = partition_names[index + 1 :]
+
+    # for idempotence, fetch all runs with the current backfill id
+    backfill_runs = instance.get_runs(
+        RunsFilter(tags=DagsterRun.tags_for_backfill_id(backfill_job.backfill_id))
+    )
+    completed_partitions = set([run.tags.get(PARTITION_NAME_TAG) for run in backfill_runs])
+    initial_checkpoint = (
+        partition_names.index(checkpoint) + 1 if checkpoint and checkpoint in partition_names else 0
+    )
+    partition_names = partition_names[initial_checkpoint:]
+    has_more = chunk_size < len(partition_names)
+    partitions_chunk = partition_names[:chunk_size]
+    next_checkpoint = partitions_chunk[-1]
+
+    to_skip = set(partitions_chunk).intersection(completed_partitions)
+    if to_skip:
+        logger.info(
+            f"Found {len(to_skip)} existing runs for backfill {backfill_job.backfill_id}, skipping"
+        )
+    to_submit = [
+        partition_name
+        for partition_name in partitions_chunk
+        if partition_name not in completed_partitions
+    ]
+    return to_submit, next_checkpoint, has_more
+
+
+def submit_backfill_runs(
+    instance: DagsterInstance,
+    workspace: IWorkspace,
+    repo_location: RepositoryLocation,
+    backfill_job: PartitionBackfill,
+    partition_names: Optional[Sequence[str]] = None,
+) -> Iterable[Optional[str]]:
+    """Returns the run IDs of the submitted runs"""
+    origin = cast(ExternalPartitionSetOrigin, backfill_job.partition_set_origin)
+
+    repository_origin = origin.external_repository_origin
+    repo_name = repository_origin.repository_name
+
+    if not partition_names:
+        partition_names = cast(Sequence[str], backfill_job.partition_names)
+
+    check.invariant(
+        repo_location.has_repository(repo_name),
+        "Could not find repository {repo_name} in location {repo_location_name}".format(
+            repo_name=repo_name, repo_location_name=repo_location.name
+        ),
+    )
+    external_repo = repo_location.get_repository(repo_name)
+    partition_set_name = origin.partition_set_name
+    external_partition_set = external_repo.get_external_partition_set(partition_set_name)
+    result = repo_location.get_external_partition_set_execution_param_data(
+        external_repo.handle, partition_set_name, partition_names
+    )
+
+    assert isinstance(result, ExternalPartitionSetExecutionParamData)
+    if backfill_job.asset_selection:
+        # need to make another call to the user code location to properly subset
+        # for an asset selection
+        pipeline_selector = PipelineSelector(
+            location_name=repo_location.name,
+            repository_name=repo_name,
+            pipeline_name=external_partition_set.pipeline_name,
+            solid_selection=None,
+            asset_selection=backfill_job.asset_selection,
+        )
+        external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
+    else:
+        external_pipeline = external_repo.get_full_external_job(
+            external_partition_set.pipeline_name
+        )
+    for partition_data in result.partition_data:
+        pipeline_run = create_backfill_run(
+            instance,
+            repo_location,
+            external_pipeline,
+            external_partition_set,
+            backfill_job,
+            partition_data,
+        )
+        if pipeline_run:
+            # we skip runs in certain cases, e.g. we are running a `from_failure` backfill job
+            # and the partition has had a successful run since the time the backfill was
+            # scheduled
+            instance.submit_run(pipeline_run.run_id, workspace)
+            yield pipeline_run.run_id
+        yield None
+
+
+def create_backfill_run(
+    instance: DagsterInstance,
+    repo_location: RepositoryLocation,
+    external_pipeline: ExternalPipeline,
+    external_partition_set: ExternalPartitionSet,
+    backfill_job: PartitionBackfill,
+    partition_data: ExternalPartitionExecutionParamData,
+) -> Optional[DagsterRun]:
+    from dagster._daemon.daemon import get_telemetry_daemon_session_id
+
+    log_action(
+        instance,
+        BACKFILL_RUN_CREATED,
+        metadata={
+            "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
+            "repo_hash": hash_name(repo_location.name),
+            "pipeline_name_hash": hash_name(external_pipeline.name),
+        },
+    )
+
+    tags = merge_dicts(
+        external_pipeline.tags,
+        partition_data.tags,
+        DagsterRun.tags_for_backfill_id(backfill_job.backfill_id),
+        backfill_job.tags,
+    )
+
+    solids_to_execute = None
+    solid_selection = None
+    if not backfill_job.from_failure and not backfill_job.reexecution_steps:
+        step_keys_to_execute = None
+        parent_run_id = None
+        root_run_id = None
+        known_state = None
+        if external_partition_set.solid_selection:
+            solids_to_execute = frozenset(external_partition_set.solid_selection)
+            solid_selection = external_partition_set.solid_selection
+
+    elif backfill_job.from_failure:
+        last_run = _fetch_last_run(instance, external_partition_set, partition_data.name)
+        if not last_run or last_run.status != DagsterRunStatus.FAILURE:
+            return None
+        return instance.create_reexecuted_run(
+            last_run,
+            repo_location,
+            external_pipeline,
+            ReexecutionStrategy.FROM_FAILURE,
+            extra_tags=tags,
+            run_config=partition_data.run_config,
+            mode=external_partition_set.mode,
+            use_parent_run_tags=False,  # don't inherit tags from the previous run
+        )
+
+    elif backfill_job.reexecution_steps:
+        last_run = _fetch_last_run(instance, external_partition_set, partition_data.name)
+        parent_run_id = last_run.run_id if last_run else None
+        root_run_id = (last_run.root_run_id or last_run.run_id) if last_run else None
+        if parent_run_id and root_run_id:
+            tags = merge_dicts(
+                tags, {PARENT_RUN_ID_TAG: parent_run_id, ROOT_RUN_ID_TAG: root_run_id}
+            )
+        step_keys_to_execute = backfill_job.reexecution_steps
+        if last_run and last_run.status == DagsterRunStatus.SUCCESS:
+            known_state = KnownExecutionState.build_for_reexecution(
+                instance,
+                last_run,
+            ).update_for_step_selection(step_keys_to_execute)
+        else:
+            known_state = None
+
+        if external_partition_set.solid_selection:
+            solids_to_execute = frozenset(external_partition_set.solid_selection)
+            solid_selection = external_partition_set.solid_selection
+
+    external_execution_plan = repo_location.get_external_execution_plan(
+        external_pipeline,
+        partition_data.run_config,
+        check.not_none(external_partition_set.mode),
+        step_keys_to_execute=step_keys_to_execute,
+        known_state=known_state,
+        instance=instance,
+    )
+
+    return instance.create_run(
+        pipeline_snapshot=external_pipeline.pipeline_snapshot,
+        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
+        pipeline_name=external_pipeline.name,
+        run_id=make_new_run_id(),
+        solids_to_execute=solids_to_execute,
+        run_config=partition_data.run_config,
+        mode=external_partition_set.mode,
+        step_keys_to_execute=step_keys_to_execute,
+        tags=tags,
+        root_run_id=root_run_id,
+        parent_run_id=parent_run_id,
+        status=DagsterRunStatus.NOT_STARTED,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+        solid_selection=solid_selection,
+        asset_selection=frozenset(backfill_job.asset_selection)
+        if backfill_job.asset_selection
+        else None,
+    )
+
+
+def _fetch_last_run(instance, external_partition_set, partition_name):
+    check.inst_param(instance, "instance", DagsterInstance)
+    check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
+    check.str_param(partition_name, "partition_name")
+
+    runs = instance.get_runs(
+        RunsFilter(
+            pipeline_name=external_partition_set.pipeline_name,
+            tags={
+                PARTITION_SET_TAG: external_partition_set.name,
+                PARTITION_NAME_TAG: partition_name,
+            },
+        ),
+        limit=1,
+    )
+
+    return runs[0] if runs else None
+
+
+def _check_for_debug_crash(debug_crash_flags: Optional[Mapping[str, int]], key) -> None:
+    if not debug_crash_flags:
+        return
+
+    kill_signal = debug_crash_flags.get(key)
+    if not kill_signal:
+        return
+
+    os.kill(os.getpid(), kill_signal)
+    time.sleep(10)
+    raise Exception("Process didn't terminate after sending crash signal")

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -238,6 +238,31 @@ class ExternalRepository:
         ]
         return matching[0] if matching else None
 
+    # def get_base_job_name_for_assets(self, asset_keys: Sequence[AssetKey]) -> Optional[str]:
+    #     # TODO: cache this
+    #     print()
+
+    #     from dagster._core.definitions.assets_job import ASSET_BASE_JOB_PREFIX
+
+    #     asset_keys_by_job_name: Dict[str, Set[AssetKey]] = defaultdict(set)
+    #     for external_asset_node in self.get_external_asset_nodes():
+    #         for job_name in external_asset_node.job_names:
+    #             asset_keys_by_job_name[job_name].add(external_asset_node.asset_key)
+
+    #     if self.has_external_job(ASSET_BASE_JOB_PREFIX):
+    #         if all(key in asset_keys_by_job_name[ASSET_BASE_JOB_PREFIX] for key in asset_keys):
+    #             return ASSET_BASE_JOB_PREFIX
+    #     else:
+    #         i = 0
+    #         while self.has_external_job(f"{ASSET_BASE_JOB_PREFIX}_{i}"):
+    #             base_job_name = f"{ASSET_BASE_JOB_PREFIX}_{i}"
+    #             if all(key in asset_keys_by_job_name[base_job_name] for key in asset_keys):
+    #                 return base_job_name
+
+    #             i += 1
+
+    #     return None
+
     def get_display_metadata(self) -> Mapping[str, str]:
         return self.handle.display_metadata
 

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -6,8 +6,8 @@ from tqdm import tqdm
 import dagster._check as check
 from dagster._serdes import deserialize_as
 
-from ...execution.backfill import PartitionBackfill
 from ...execution.bulk_actions import BulkActionType
+from ...execution.job_backfill import PartitionBackfill
 from ..pipeline_run import DagsterRun, DagsterRunStatus
 from ..runs.base import RunStorage
 from ..runs.schema import BulkActionsTable, RunTagsTable, RunsTable

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -6,7 +6,6 @@ from tqdm import tqdm
 import dagster._check as check
 from dagster._serdes import deserialize_as
 
-from ...execution.bulk_actions import BulkActionType
 from ...execution.job_backfill import PartitionBackfill
 from ..pipeline_run import DagsterRun, DagsterRunStatus
 from ..runs.base import RunStorage
@@ -246,10 +245,7 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn=None):
                 storage_id = row[1]
                 conn.execute(
                     BulkActionsTable.update()
-                    .values(
-                        selector_id=backfill.selector_id,
-                        action_type=BulkActionType.PARTITION_BACKFILL.value,
-                    )
+                    .values(selector_id=backfill.selector_id, action_type=backfill.bulk_action_type)
                     .where(BulkActionsTable.c.id == storage_id)
                 )
                 cursor = storage_id

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -5,7 +5,21 @@ from abc import abstractmethod
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum
-from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import pendulum
 import sqlalchemy as db
@@ -1068,11 +1082,11 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     def add_backfill(self, partition_backfill: PartitionBackfill):
         check.inst_param(partition_backfill, "partition_backfill", PartitionBackfill)
-        values = dict(
+        values: Dict[str, Any] = dict(
             key=partition_backfill.backfill_id,
             status=partition_backfill.status.value,
             timestamp=utc_datetime_from_timestamp(partition_backfill.backfill_timestamp),
-            body=serialize_dagster_namedtuple(partition_backfill),
+            body=serialize_dagster_namedtuple(cast(NamedTuple, partition_backfill)),
         )
 
         if self.has_bulk_actions_selector_cols():

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -33,7 +33,6 @@ from dagster._core.errors import (
 )
 from dagster._core.events import EVENT_TYPE_TO_PIPELINE_RUN_STATUS, DagsterEvent, DagsterEventType
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPipelineOrigin
 from dagster._core.snap import (
     ExecutionPlanSnapshot,
@@ -1091,7 +1090,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         if self.has_bulk_actions_selector_cols():
             values["selector_id"] = partition_backfill.selector_id
-            values["action_type"] = BulkActionType.PARTITION_BACKFILL.value
+            values["action_type"] = partition_backfill.bulk_action_type.value
 
         with self.connect() as conn:
             conn.execute(

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,10 +1,12 @@
 import logging
+import sys
 from typing import Iterable, Mapping, Optional, cast
 
+from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._utils.error import SerializableErrorInfo
+from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 
 def execute_backfill_iteration(
@@ -27,6 +29,17 @@ def execute_backfill_iteration(
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-        yield from execute_job_backfill_iteration(
-            backfill, logger, workspace, debug_crash_flags, instance
-        )
+        try:
+            if backfill.is_asset_backfill:
+                yield from execute_asset_backfill_iteration(backfill, workspace, instance)
+            else:
+                yield from execute_job_backfill_iteration(
+                    backfill, logger, workspace, debug_crash_flags, instance
+                )
+        except Exception:
+            error_info = serializable_error_info_from_exc_info(sys.exc_info())
+            instance.update_backfill(
+                backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
+            )
+            logger.error(f"Backfill failed for {backfill.backfill_id}: {error_info.to_string()}")
+            yield error_info

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,180 +1,32 @@
 import logging
-import os
-import sys
-import time
-from typing import Iterable, Optional, Sequence, Tuple, cast
+from typing import Iterable, Mapping, Optional, cast
 
-from dagster._core.errors import DagsterBackfillFailedError
-from dagster._core.execution.backfill import (
-    BulkActionStatus,
-    PartitionBackfill,
-    submit_backfill_runs,
-)
-from dagster._core.host_representation.repository_location import RepositoryLocation
-from dagster._core.instance import DagsterInstance
-from dagster._core.storage.pipeline_run import DagsterRun, RunsFilter
-from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
-
-# out of abundance of caution, sleep at checkpoints in case we are pinning CPU by submitting lots
-# of jobs all at once
-CHECKPOINT_INTERVAL = 1
-CHECKPOINT_COUNT = 25
-
-
-def _check_for_debug_crash(debug_crash_flags, key):
-    if not debug_crash_flags:
-        return
-
-    kill_signal = debug_crash_flags.get(key)
-    if not kill_signal:
-        return
-
-    os.kill(os.getpid(), kill_signal)
-    time.sleep(10)
-    raise Exception("Process didn't terminate after sending crash signal")
+from dagster._utils.error import SerializableErrorInfo
 
 
 def execute_backfill_iteration(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    debug_crash_flags=None,
+    debug_crash_flags: Optional[Mapping[str, int]] = None,
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     instance = workspace_process_context.instance
-    backfill_jobs = instance.get_backfills(status=BulkActionStatus.REQUESTED)
+    backfills = instance.get_backfills(status=BulkActionStatus.REQUESTED)
 
-    if not backfill_jobs:
+    if not backfills:
         logger.debug("No backfill jobs requested.")
         yield None
         return
 
     workspace = workspace_process_context.create_request_context()
 
-    for backfill_job in backfill_jobs:
+    for backfill_job in backfills:
         backfill_id = backfill_job.backfill_id
 
         # refetch, in case the backfill was updated in the meantime
-        backfill_job = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-
-        if not backfill_job.last_submitted_partition_name:
-            logger.info(f"Starting backfill for {backfill_id}")
-        else:
-            logger.info(
-                f"Resuming backfill for {backfill_id} from {backfill_job.last_submitted_partition_name}"
-            )
-
-        origin = (
-            backfill_job.partition_set_origin.external_repository_origin.repository_location_origin
+        backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
+        yield from execute_job_backfill_iteration(
+            backfill, logger, workspace, debug_crash_flags, instance
         )
-
-        try:
-            repo_location = workspace.get_repository_location(origin.location_name)
-
-            _check_repo_has_partition_set(repo_location, backfill_job)
-
-            has_more = True
-            while has_more:
-                if backfill_job.status != BulkActionStatus.REQUESTED:
-                    break
-
-                chunk, checkpoint, has_more = _get_partitions_chunk(
-                    instance, logger, backfill_job, CHECKPOINT_COUNT
-                )
-                _check_for_debug_crash(debug_crash_flags, "BEFORE_SUBMIT")
-
-                if chunk:
-                    for _run_id in submit_backfill_runs(
-                        instance, workspace, repo_location, backfill_job, chunk
-                    ):
-                        yield None
-                        # before submitting, refetch the backfill job to check for status changes
-                        backfill_job = cast(
-                            PartitionBackfill, instance.get_backfill(backfill_job.backfill_id)
-                        )
-                        if backfill_job.status != BulkActionStatus.REQUESTED:
-                            return
-
-                _check_for_debug_crash(debug_crash_flags, "AFTER_SUBMIT")
-
-                if has_more:
-                    # refetch, in case the backfill was updated in the meantime
-                    backfill_job = cast(
-                        PartitionBackfill, instance.get_backfill(backfill_job.backfill_id)
-                    )
-                    instance.update_backfill(backfill_job.with_partition_checkpoint(checkpoint))
-                    yield None
-                    time.sleep(CHECKPOINT_INTERVAL)
-                else:
-                    logger.info(
-                        f"Backfill completed for {backfill_id} for {len(backfill_job.partition_names)} partitions"
-                    )
-                    instance.update_backfill(backfill_job.with_status(BulkActionStatus.COMPLETED))
-                    yield None
-        except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            instance.update_backfill(
-                backfill_job.with_status(BulkActionStatus.FAILED).with_error(error_info)
-            )
-            logger.error(f"Backfill failed for {backfill_id}: {error_info.to_string()}")
-            yield error_info
-
-
-def _check_repo_has_partition_set(
-    repo_location: RepositoryLocation, backfill_job: PartitionBackfill
-) -> None:
-    repo_name = backfill_job.partition_set_origin.external_repository_origin.repository_name
-    if not repo_location.has_repository(repo_name):
-        raise DagsterBackfillFailedError(
-            f"Could not find repository {repo_name} in location {repo_location.name} to "
-            f"run backfill {backfill_job.backfill_id}."
-        )
-
-    partition_set_name = backfill_job.partition_set_origin.partition_set_name
-    external_repo = repo_location.get_repository(repo_name)
-    if not external_repo.has_external_partition_set(partition_set_name):
-        raise DagsterBackfillFailedError(
-            f"Could not find partition set {partition_set_name} in repository {repo_name}. "
-        )
-
-
-def _get_partitions_chunk(
-    instance: DagsterInstance,
-    logger: logging.Logger,
-    backfill_job: PartitionBackfill,
-    chunk_size: int,
-) -> Tuple[Sequence[str], str, bool]:
-    partition_names = backfill_job.partition_names
-    checkpoint = backfill_job.last_submitted_partition_name
-
-    if (
-        backfill_job.last_submitted_partition_name
-        and backfill_job.last_submitted_partition_name in partition_names
-    ):
-        index = partition_names.index(backfill_job.last_submitted_partition_name)
-        partition_names = partition_names[index + 1 :]
-
-    # for idempotence, fetch all runs with the current backfill id
-    backfill_runs = instance.get_runs(
-        RunsFilter(tags=DagsterRun.tags_for_backfill_id(backfill_job.backfill_id))
-    )
-    completed_partitions = set([run.tags.get(PARTITION_NAME_TAG) for run in backfill_runs])
-    initial_checkpoint = (
-        partition_names.index(checkpoint) + 1 if checkpoint and checkpoint in partition_names else 0
-    )
-    partition_names = partition_names[initial_checkpoint:]
-    has_more = chunk_size < len(partition_names)
-    partitions_chunk = partition_names[:chunk_size]
-    next_checkpoint = partitions_chunk[-1]
-
-    to_skip = set(partitions_chunk).intersection(completed_partitions)
-    if to_skip:
-        logger.info(
-            f"Found {len(to_skip)} existing runs for backfill {backfill_job.backfill_id}, skipping"
-        )
-    to_submit = [
-        partition_name
-        for partition_name in partitions_chunk
-        if partition_name not in completed_partitions
-    ]
-    return to_submit, next_checkpoint, has_more

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -202,6 +202,18 @@ class CachingInstanceQueryer:
         return result
 
     @cached_method
+    def get_materialization_records(
+        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+    ) -> Iterable["EventLogRecord"]:
+        return self._instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+                after_cursor=after_cursor,
+            )
+        )
+
+    @cached_method
     def is_reconciled(
         self,
         asset_partition: AssetKeyPartitionKey,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1,0 +1,251 @@
+"""
+To consider
+- Multiple backfills target the same asset
+- Parent assets not included in the backfill
+- Failure
+- Failure with transitive dependencies
+- Two parents
+- Two children
+- Asset has two parents and one succeeds and one fails
+- Asset has two parents and one is materialized and the other isn't
+- Materialization happens to one of the asset partitions in the backfill, outside of the backfill
+- Asset has two parents and only one is in the backfill
+- Self-deps
+- Non-partitioned assets
+- Partition mappings
+- Multi-assets
+- Reconciliation sensor should avoid targeting targets of ongoing backfills
+"""
+from typing import AbstractSet, Dict, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dagster_tests.definitions_tests.test_asset_reconciliation_sensor import (
+    RunSpec,
+    do_run,
+    one_asset_one_partition,
+    one_asset_two_partitions,
+    two_assets_in_sequence_fan_in_partitions,
+    two_assets_in_sequence_fan_out_partitions,
+    two_assets_in_sequence_one_partition,
+    two_assets_in_sequence_two_partitions,
+)
+
+from dagster import (
+    AssetKey,
+    AssetSelection,
+    AssetsDefinition,
+    DagsterInstance,
+    Definitions,
+    PartitionsDefinition,
+    RunRequest,
+    SourceAsset,
+)
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.execution.asset_backfill import (
+    AssetBackfillData,
+    execute_asset_backfill_iteration_inner,
+)
+from dagster._core.host_representation.external_data import external_asset_graph_from_defs
+
+
+class AssetBackfillScenario(NamedTuple):
+    assets: Sequence[Union[SourceAsset, AssetsDefinition]]
+    unevaluated_runs: Sequence[RunSpec] = []
+    expected_run_requests: Optional[Sequence[RunRequest]] = None
+    expected_iterations: Optional[int] = None
+
+
+assets_by_repo_name_by_scenario_name: Mapping[str, Mapping[str, Sequence[AssetsDefinition]]] = {
+    "one_asset_one_partition": {"repo": one_asset_one_partition},
+    "one_asset_two_partitions": {"repo": one_asset_two_partitions},
+    "two_assets_in_sequence_one_partition": {"repo": two_assets_in_sequence_one_partition},
+    "two_assets_in_sequence_one_partition_cross_repo": {
+        "repo1": [two_assets_in_sequence_one_partition[0]],
+        "repo2": [two_assets_in_sequence_one_partition[1]],
+    },
+    "two_assets_in_sequence_two_partitions": {"repo": two_assets_in_sequence_two_partitions},
+    "two_assets_in_sequence_fan_in_partitions": {"repo": two_assets_in_sequence_fan_in_partitions},
+    "two_assets_in_sequence_fan_out_partitions": {
+        "repo": two_assets_in_sequence_fan_out_partitions
+    },
+}
+
+
+@pytest.mark.parametrize("some_or_all", ["all", "some"])
+@pytest.mark.parametrize("failures", ["no_failures", "root_failures", "random_half_failures"])
+@pytest.mark.parametrize("scenario_name", list(assets_by_repo_name_by_scenario_name.keys()))
+def test_scenario_to_completion(scenario_name: str, failures: str, some_or_all: str):
+    assets_by_repo_name = assets_by_repo_name_by_scenario_name[scenario_name]
+
+    with patch(
+        "dagster._core.host_representation.external_data.get_builtin_partition_mapping_types"
+    ) as get_builtin_partition_mapping_types:
+        get_builtin_partition_mapping_types.return_value = tuple(
+            assets_def.infer_partition_mapping(dep_key).__class__
+            for assets in assets_by_repo_name.values()
+            for assets_def in assets
+            for dep_key in assets_def.dependency_keys
+        )
+        asset_graph = external_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
+
+    asset_keys = asset_graph.all_asset_keys
+    root_asset_keys = AssetSelection.keys(*asset_keys).sources().resolve(asset_graph)
+
+    if some_or_all == "all":
+        target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for assets in assets_by_repo_name.values():
+            for asset_def in assets:
+                partitions_def = cast(PartitionsDefinition, asset_def.partitions_def)
+                target_subsets_by_asset_key[
+                    asset_def.key
+                ] = partitions_def.empty_subset().with_partition_keys(
+                    partitions_def.get_partition_keys()
+                )
+    elif some_or_all == "some":
+        # all partitions downstream of half of the partitions in each root asset
+        root_asset_partitions: Set[AssetKeyPartitionKey] = set()
+        for root_asset_key in root_asset_keys:
+            partitions_def = asset_graph.get_partitions_def(root_asset_key)
+            assert partitions_def is not None
+            partition_keys = list(partitions_def.get_partition_keys())
+            start_index = len(partition_keys) // 2
+            chosen_partition_keys = partition_keys[start_index:]
+            root_asset_partitions.update(
+                AssetKeyPartitionKey(root_asset_key, partition_key)
+                for partition_key in chosen_partition_keys
+            )
+
+        target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+            lambda _a, _b: True, root_asset_partitions
+        )
+
+        target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for asset_key, partition_key in target_asset_partitions:
+            assert partition_key is not None
+            partitions_def = asset_graph.get_partitions_def(asset_key)
+            assert partitions_def is not None
+            subset = target_subsets_by_asset_key.get(asset_key, partitions_def.empty_subset())
+            target_subsets_by_asset_key[asset_key] = subset.with_partition_keys([partition_key])
+
+    else:
+        assert False
+
+    if failures == "no_failures":
+        fail_asset_partitions: Set[AssetKeyPartitionKey] = set()
+    elif failures == "root_failures":
+        fail_asset_partitions: Set[AssetKeyPartitionKey] = {
+            AssetKeyPartitionKey(root_asset_key, partition_key)
+            for root_asset_key in root_asset_keys
+            for partition_key in target_subsets_by_asset_key[root_asset_key].get_partition_keys()
+        }
+    elif failures == "random_half_failures":
+        fail_asset_partitions: Set[AssetKeyPartitionKey] = {
+            AssetKeyPartitionKey(asset_key, partition_key)
+            for asset_key, subset in target_subsets_by_asset_key.items()
+            for partition_key in subset.get_partition_keys()
+            if hash(str(asset_key) + partition_key) % 2 == 0
+        }
+
+    else:
+        assert False
+
+    backfill = AssetBackfillData.empty(target_subsets_by_asset_key, asset_graph)
+    run_backfill_to_completion(
+        asset_graph, assets_by_repo_name, "backfillid_x", backfill, fail_asset_partitions
+    )
+
+
+def run_backfill_to_completion(
+    asset_graph: ExternalAssetGraph,
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
+    backfill_id: str,
+    backfill_data: AssetBackfillData,
+    fail_asset_partitions: AbstractSet[AssetKeyPartitionKey],
+) -> None:
+    iteration_count = 0
+    instance = DagsterInstance.ephemeral()
+
+    # assert each asset partition only targeted once
+    requested_asset_partitions: Set[AssetKeyPartitionKey] = set()
+
+    while not backfill_data.is_complete():
+        iteration_count += 1
+        result1 = execute_asset_backfill_iteration_inner(
+            backfill_id=backfill_id,
+            asset_backfill_data=backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
+        # iteration_count += 1
+        assert result1.backfill_data != backfill_data
+
+        # if nothing changes, nothing should happen in the iteration
+        result2 = execute_asset_backfill_iteration_inner(
+            backfill_id=backfill_id,
+            asset_backfill_data=result1.backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
+        assert result2.backfill_data == result1.backfill_data
+        assert result2.run_requests == []
+
+        backfill_data = result2.backfill_data
+
+        for run_request in result1.run_requests:
+            for asset_key in run_request.asset_selection:
+                asset_partition = AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                assert (
+                    asset_partition not in requested_asset_partitions
+                ), f"{asset_partition} requested twice. Requested: {requested_asset_partitions}"
+                requested_asset_partitions.add(asset_partition)
+                # TODO: assert that partitions downstream of failures are not requested
+
+            assets = assets_by_repo_name[
+                asset_graph.get_repository_handle(run_request.asset_selection[0]).repository_name
+            ]
+            do_run(
+                all_assets=assets,
+                asset_keys=run_request.asset_selection,
+                partition_key=run_request.partition_key,
+                instance=instance,
+                failed_asset_keys=[
+                    asset_key
+                    for asset_key in run_request.asset_selection
+                    if AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                    in fail_asset_partitions
+                ],
+                tags=run_request.tags,
+            )
+
+    assert iteration_count <= len(requested_asset_partitions) + 1
+
+    # TODO: expected iterations
+    # if there are no non-identify partiion mappings, the number of iterations should be the number
+    # of partitions
+    # if scenario.expected_iterations:
+    #     assert iteration_count == scenario.expected_iterations
+
+
+def external_asset_graph_from_assets_by_repo_name(
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
+) -> ExternalAssetGraph:
+    from_repository_handles_and_external_asset_nodes = []
+
+    for repo_name, assets in assets_by_repo_name.items():
+
+        repo = Definitions(assets=assets).get_repository_def()
+
+        external_asset_nodes = external_asset_graph_from_defs(
+            repo.get_all_pipelines(), source_assets_by_key=repo.source_assets_by_key
+        )
+        repo_handle = MagicMock(repository_name=repo_name)
+        from_repository_handles_and_external_asset_nodes.extend(
+            [(repo_handle, asset_node) for asset_node in external_asset_nodes]
+        )
+
+    return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
+        from_repository_handles_and_external_asset_nodes
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -105,17 +105,12 @@ class AssetReconciliationScenario(NamedTuple):
                                 asset.subset_for(asset.keys - selected_keys).to_source_assets()
                             )
 
-                materialize_to_memory(
-                    instance=instance,
+                do_run(
+                    asset_keys=run.asset_keys,
                     partition_key=run.partition_key,
-                    assets=assets_in_run,
-                    run_config={
-                        "ops": {
-                            failed_asset_key.path[-1]: {"config": {"fail": True}}
-                            for failed_asset_key in (run.failed_asset_keys or [])
-                        }
-                    },
-                    raise_on_error=False,
+                    all_assets=self.assets,
+                    instance=instance,
+                    failed_asset_keys=run.failed_asset_keys,
                 )
 
         if self.evaluation_delta is not None:
@@ -135,6 +130,45 @@ class AssetReconciliationScenario(NamedTuple):
             assert base_job is not None
 
         return run_requests, cursor
+
+
+def do_run(
+    asset_keys: Sequence[AssetKey],
+    partition_key: Optional[str],
+    all_assets: Sequence[Union[SourceAsset, AssetsDefinition]],
+    instance: DagsterInstance,
+    failed_asset_keys: Optional[Sequence[AssetKey]] = None,
+    tags: Optional[Mapping[str, str]] = None,
+) -> None:
+    assets_in_run: List[Union[SourceAsset, AssetsDefinition]] = []
+    asset_keys_set = set(asset_keys)
+    for asset in all_assets:
+        if isinstance(asset, SourceAsset):
+            assets_in_run.append(asset)
+        else:
+            selected_keys = asset_keys_set.intersection(asset.keys)
+            if selected_keys == asset.keys:
+                assets_in_run.append(asset)
+            elif not selected_keys:
+                assets_in_run.extend(asset.to_source_assets())
+            else:
+                assets_in_run.append(asset.subset_for(asset_keys_set))
+                assets_in_run.extend(
+                    asset.subset_for(asset.keys - selected_keys).to_source_assets()
+                )
+    materialize_to_memory(
+        instance=instance,
+        partition_key=partition_key,
+        assets=assets_in_run,
+        run_config={
+            "ops": {
+                failed_asset_key.path[-1]: {"config": {"fail": True}}
+                for failed_asset_key in (failed_asset_keys or [])
+            }
+        },
+        raise_on_error=False,
+        tags=tags,
+    )
 
 
 def single_asset_run(asset_key: str, partition_key: Optional[str] = None) -> RunSpec:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -462,6 +462,10 @@ two_assets_in_sequence_one_partition = [
     asset_def("asset1", partitions_def=one_partition_partitions_def),
     asset_def("asset2", ["asset1"], partitions_def=one_partition_partitions_def),
 ]
+two_assets_in_sequence_two_partitions = [
+    asset_def("asset1", partitions_def=two_partitions_partitions_def),
+    asset_def("asset2", ["asset1"], partitions_def=two_partitions_partitions_def),
+]
 
 two_assets_in_sequence_fan_in_partitions = [
     asset_def("asset1", partitions_def=fanned_out_partitions_def),

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1196,13 +1196,12 @@ class TestRunStorage:
 
         one = PartitionBackfill(
             "one",
-            origin,
-            BulkActionStatus.REQUESTED,
-            ["a", "b", "c"],
-            False,
-            None,
-            None,
-            pendulum.now().timestamp(),
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=pendulum.now().timestamp(),
         )
         storage.add_backfill(one)
         assert len(storage.get_backfills()) == 1


### PR DESCRIPTION
### Summary & Motivation

This aims to add support for:
- Handling assets where partitions depend on earlier partitions of the same asset
- Including assets in the same backfill that have different `PartitionsDefinition`s
- Including assets in the same backfill that have different repositories / code locations

The idea is basically that, if asset partition X -> asset partition Y, but a single run can't target both of them, the backfill daemon will wait for X to be materialized before submitting the run for Y.

### How I Tested These Changes
