### PR TITLE
keep track of max timestamps client side for code location updates

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -24,6 +24,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
   const history = useHistory();
 
   const [showSpinner, setShowSpinner] = React.useState(false);
+  const [lastLocationTimestamps, setLastLocationTimestamps] = React.useState({});
 
   const queryData = useQuery<CodeLocationStatusQuery>(CODE_LOCATION_STATUS_QUERY, {
     fetchPolicy: 'network-only',
@@ -113,14 +114,28 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
       currentEntries.some(
         (entry) =>
           !(entry.id in previousEntriesByName) ||
-          previousEntriesByName[entry.id].updateTimestamp <
-            currentEntriesByName[entry.id].updateTimestamp,
+          Math.max(
+            previousEntriesByName[entry.id].updateTimestamp,
+            lastLocationTimestamps[entry.id] || 0,
+          ) < currentEntriesByName[entry.id].updateTimestamp,
       );
+
+    const _updateLocationTimestamps = (entries: LocationStatusEntry[]) => {
+      const timestamps = {};
+      entries.forEach((entry) => {
+        timestamps[entry.id] = Math.max(
+          entry.updateTimestamp,
+          lastLocationTimestamps[entry.id] || 0,
+        );
+      });
+      setLastLocationTimestamps(timestamps);
+    };
 
     // At least one code location has been removed. Reload, but don't make a big deal about it
     // since this was probably done manually.
     if (previousEntries.length > currentEntries.length && !hasUpdatedEntries) {
       reloadWorkspaceQuietly();
+      _updateLocationTimestamps(currentEntries);
       return;
     }
 
@@ -174,6 +189,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
       });
 
       reloadWorkspaceLoudly();
+      _updateLocationTimestamps(currentEntries);
       return;
     }
 
@@ -203,24 +219,35 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         icon: 'refresh',
       });
 
+      _updateLocationTimestamps(currentEntries);
       return;
     }
 
     // A location was previously loading, and no longer is. Our workspace is ready. Refetch it.
     if (anyPreviouslyLoading && !anyCurrentlyLoading) {
       reloadWorkspaceLoudly();
+      _updateLocationTimestamps(currentEntries);
       return;
     }
 
     if (hasUpdatedEntries) {
       reloadWorkspaceLoudly();
+      _updateLocationTimestamps(currentEntries);
       return;
     }
 
     // It's unlikely that we've made it to this point, since being inside this effect should
     // indicate that `data` and `previousData` have differences that would have been handled by
     // the conditionals above.
-  }, [data, previousData, reloadWorkspaceQuietly, reloadWorkspaceLoudly, onClickViewButton]);
+  }, [
+    data,
+    previousData,
+    reloadWorkspaceQuietly,
+    reloadWorkspaceLoudly,
+    onClickViewButton,
+    lastLocationTimestamps,
+    setLastLocationTimestamps,
+  ]);
 
   if (showSpinner) {
     return {


### PR DESCRIPTION
### Summary & Motivation
Users with more than 1 dagit instance running, may get repeated 'Definitions updated' toasts because each dagit instance keeps a timestamp of when the locations were loaded into memory, and we show toasts based on the timestamp being greater than the last timestamp queried.

This diff keeps track of the largest timestamp seen per location, to guard against repeated requests.  You may still see N-1 number of toasts, where N is the number of dagit instances you have servicing graphql requests.

We could also try to implement this polling via a server-side subscription, but might be out of scope for now.

### How I Tested These Changes
Changed the graphql resolver to randomly return one of two timestamps, saw the repeated toasts.  Checked that this solution kept track of the max timestamp.