### PR TITLE
[dagster-aws] Extend fake S3 resource

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/s3_fake_resource.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/s3_fake_resource.py
@@ -29,15 +29,18 @@ class S3FakeSession:
         return {"ContentLength": len(self.buckets.get(Bucket, {}).get(Key, b""))}
 
     def _list_objects(self, Bucket, Prefix):
-        key = self.buckets.get(Bucket, {}).get(Prefix)
-        if key:
-            return {"KeyCount": 1, "Contents": [{"Key": key}], "IsTruncated": False}
-        else:
-            return {"KeyCount": 0, "Contents": [], "IsTruncated": False}
+        bucket = self.buckets.get(Bucket, {})
+        contents = []
+        for key in sorted(bucket.keys()):
+            if key.startswith(Prefix):
+                contents.append({"Key": key})
+        return {"Contents": contents, "IsTruncated": False}
 
     def list_objects_v2(self, Bucket, Prefix, *args, **kwargs):
         self.mock_extras.list_objects_v2(*args, **kwargs)
-        return self._list_objects(Bucket, Prefix)
+        response = self._list_objects(Bucket, Prefix)
+        response["KeyCount"] = len(response["Contents"])
+        return response
 
     def list_objects(self, Bucket, Prefix, *args, **kwargs):
         self.mock_extras.list_objects(*args, **kwargs)
@@ -45,7 +48,10 @@ class S3FakeSession:
 
     def put_object(self, Bucket, Key, Body, *args, **kwargs):
         self.mock_extras.put_object(*args, **kwargs)
-        self.buckets[Bucket][Key] = Body.read()
+        if isinstance(Body, bytes):
+            self.buckets[Bucket][Key] = Body
+        else:
+            self.buckets[Bucket][Key] = Body.read()
 
     def get_object(self, Bucket, Key, *args, **kwargs):
         if not self.has_object(Bucket, Key):
@@ -53,6 +59,16 @@ class S3FakeSession:
 
         self.mock_extras.get_object(*args, **kwargs)
         return {"Body": self._get_byte_stream(Bucket, Key)}
+
+    def delete_object(self, Bucket, Key, *args, **kwargs):
+        self.mock_extras.delete_object(*args, **kwargs)
+        if Bucket in self.buckets:
+            self.buckets[Bucket].pop(Key, None)
+
+    def upload_file(self, Filename, Bucket, Key, *args, **kwargs):
+        self.mock_extras.upload_file(*args, **kwargs)
+        with open(Filename, "rb") as fileobj:
+            self.buckets[Bucket][Key] = fileobj.read()
 
     def upload_fileobj(self, fileobj, bucket, key, *args, **kwargs):
         self.mock_extras.upload_fileobj(*args, **kwargs)
@@ -68,3 +84,7 @@ class S3FakeSession:
         self.mock_extras.download_file(*args, **kwargs)
         with open(Filename, "wb") as ff:
             ff.write(self._get_byte_stream(Bucket, Key).read())
+
+    def download_fileobj(self, Bucket, Key, Fileobj, *args, **kwargs):
+        self.mock_extras.download_fileobj(*args, **kwargs)
+        Fileobj.write(self._get_byte_stream(Bucket, Key).read())


### PR DESCRIPTION
### Summary & Motivation

In our Dagster pipelines we are using more features of the S3 client than was provided by `FakeS3Session`. Since we use this class in our tests, we extended it to align it better with the [boto3 S3 client API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html).

The changes:
- `list_objects` and `list_objects_v2` return all keys starting with the supplied prefix, not just one key matching the prefix
- `list_objects_v2` returns keys in sorted order (`list_objects` does too, but the actual ordering is not specified in the API documentation)
- `put_object` accepts a `bytes` object in addition to a file-like object
- `delete_object`, `upload_file`, and `download_fileobj` were implemented

These changes all follow the semantics of the boto3 API.

### How I Tested These Changes

We have been using this version for quite some time already in our Dagster repositories as the S3 resource for tests.