### PR TITLE
remove parameter tag from dagstermill notebook

### DIFF
--- a/examples/tutorial_notebook_assets/tutorial_template/notebooks/iris-kmeans.ipynb
+++ b/examples/tutorial_notebook_assets/tutorial_template/notebooks/iris-kmeans.ipynb
@@ -39,9 +39,7 @@
    "execution_count": null,
    "id": "a684c101",
    "metadata": {
-    "tags": [
-     "parameters"
-    ]
+    "tags": []
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
### Summary & Motivation
a cell in the notebook got the parameter tag added when it shouldn't have 

### How I Tested These Changes
