### PR TITLE
fix a small bug in UPathIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -45,7 +45,7 @@ class UPathIOManager(MemoizableIOManager):
 
     def get_metadata(
         self,
-        context: InputContext,
+        context: OutputContext,
         obj: Any,  # pylint: disable=unused-argument
     ) -> Dict[str, MetadataValue]:
         """Child classes should override this method to add custom metadata to the outputs."""

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -45,7 +45,7 @@ class UPathIOManager(MemoizableIOManager):
 
     def get_metadata(
         self,
-        context: OutputContext,
+        context: OutputContext,  # pylint: disable=unused-argument
         obj: Any,  # pylint: disable=unused-argument
     ) -> Dict[str, MetadataValue]:
         """Child classes should override this method to add custom metadata to the outputs."""
@@ -101,6 +101,7 @@ class UPathIOManager(MemoizableIOManager):
     def _load_single_input(self, path: UPath, context: InputContext) -> Any:
         context.log.debug(f"Loading file from: {path}")
         obj = self.load_from_path(context=context, path=path)
+        context.add_input_metadata({"path": str(path)})
         return obj
 
     def _load_multiple_inputs(self, context: InputContext) -> Dict[str, Any]:

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -45,7 +45,7 @@ class UPathIOManager(MemoizableIOManager):
 
     def get_metadata(
         self,
-        context: Union[InputContext, OutputContext],
+        context: InputContext,
         obj: Any,  # pylint: disable=unused-argument
     ) -> Dict[str, MetadataValue]:
         """Child classes should override this method to add custom metadata to the outputs."""
@@ -100,14 +100,7 @@ class UPathIOManager(MemoizableIOManager):
 
     def _load_single_input(self, path: UPath, context: InputContext) -> Any:
         context.log.debug(f"Loading file from: {path}")
-
         obj = self.load_from_path(context=context, path=path)
-
-        metadata = {"path": MetadataValue.path(path)}
-        custom_metadata = self.get_metadata(context=context, obj=obj)
-        metadata.update(custom_metadata)  # type: ignore
-        context.add_input_metadata(metadata)
-
         return obj
 
     def _load_multiple_inputs(self, context: InputContext) -> Dict[str, Any]:

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -102,7 +102,7 @@ class UPathIOManager(MemoizableIOManager):
         obj = self.load_from_path(context=context, path=path)
 
         metadata = {"path": MetadataValue.path(path)}
-        custom_metadata = self.get_metadata(obj, context)
+        custom_metadata = self.get_metadata(context=context, obj=obj)
         metadata.update(custom_metadata)  # type: ignore
         context.add_input_metadata(metadata)
 

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -44,7 +44,7 @@ class UPathIOManager(MemoizableIOManager):
         """Child classes should override this method to load the object from the filesystem."""
 
     def get_metadata(
-        self, context: OutputContext, obj: Any  # pylint: disable=unused-argument
+        self, context: Union[InputContext, OutputContext], obj: Any  # pylint: disable=unused-argument
     ) -> Dict[str, MetadataValue]:
         """Child classes should override this method to add custom metadata to the outputs."""
         return {}

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -101,7 +101,7 @@ class UPathIOManager(MemoizableIOManager):
     def _load_single_input(self, path: UPath, context: InputContext) -> Any:
         context.log.debug(f"Loading file from: {path}")
         obj = self.load_from_path(context=context, path=path)
-        context.add_input_metadata({"path": str(path)})
+        context.add_input_metadata({"path": MetadataValue.path(path)})
         return obj
 
     def _load_multiple_inputs(self, context: InputContext) -> Dict[str, Any]:

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -44,7 +44,9 @@ class UPathIOManager(MemoizableIOManager):
         """Child classes should override this method to load the object from the filesystem."""
 
     def get_metadata(
-        self, context: Union[InputContext, OutputContext], obj: Any  # pylint: disable=unused-argument
+        self,
+        context: Union[InputContext, OutputContext],
+        obj: Any,  # pylint: disable=unused-argument
     ) -> Dict[str, MetadataValue]:
         """Child classes should override this method to add custom metadata to the outputs."""
         return {}

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -101,7 +101,7 @@ class UPathIOManager(MemoizableIOManager):
     def _load_single_input(self, path: UPath, context: InputContext) -> Any:
         context.log.debug(f"Loading file from: {path}")
         obj = self.load_from_path(context=context, path=path)
-        context.add_input_metadata({"path": MetadataValue.path(path)})
+        context.add_input_metadata({"path": MetadataValue.path(str(path))})
         return obj
 
     def _load_multiple_inputs(self, context: InputContext) -> Dict[str, Any]:
@@ -226,7 +226,7 @@ class UPathIOManager(MemoizableIOManager):
         context.log.debug(f"Writing file at: {path}")
         self.dump_to_path(context=context, obj=obj, path=path)
 
-        metadata = {"path": MetadataValue.path(path)}
+        metadata = {"path": MetadataValue.path(str(path))}
         custom_metadata = self.get_metadata(context=context, obj=obj)
         metadata.update(custom_metadata)  # type: ignore
 


### PR DESCRIPTION
`self.get_metadata` was called with arguments in the wrong order

### Summary & Motivation

### How I Tested These Changes
