### PR TITLE
[dagster-airflow] pex compatibility for ephemeral db

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -472,8 +472,6 @@ def make_dagster_pipeline_from_airflow_dag(
         os.makedirs(airflow_home_path, exist_ok=True)
         with Locker(airflow_home_path):
             airflow_initialized = os.path.exists(f"{airflow_home_path}/airflow.db")
-            if not airflow_initialized:
-                db.initdb()
             # because AIRFLOW_HOME has been overriden airflow needs to be reloaded
             if airflow_version >= "2.0.0":
                 importlib.reload(airflow.configuration)
@@ -481,6 +479,9 @@ def make_dagster_pipeline_from_airflow_dag(
                 importlib.reload(airflow)
             else:
                 importlib.reload(airflow)
+
+            if not airflow_initialized:
+                db.initdb()
 
             dag_bag = airflow.models.dagbag.DagBag(
                 dag_folder=context.resource_config["dag_location"], include_examples=True

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -2,7 +2,6 @@ import datetime
 import importlib
 import logging
 import os
-import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager, nullcontext

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -685,6 +685,8 @@ def make_dagster_solid_from_airflow_task(
         },
     )
     def _solid(context):  # pylint: disable=unused-argument
+        # reloading forces picking up any config that's been set for execution
+        importlib.reload(airflow)
         mock_xcom = context.op_config["mock_xcom"]
         use_ephemeral_airflow_db = context.op_config["use_ephemeral_airflow_db"]
         if AIRFLOW_EXECUTION_DATE_STR not in context.pipeline_run.tags:

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
@@ -191,6 +191,9 @@ def test_template_task_dag():
             ),
             instance=instance,
         )
+        assert result.success
+        for event in result.step_event_list:
+            assert event.event_type_value != "STEP_FAILURE"
 
         capture_events = [
             event

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
@@ -100,6 +100,9 @@ def test_pipeline_tags():
             ),
             instance=instance,
         )
+        assert result.success
+        for event in result.step_event_list:
+            assert event.event_type_value != "STEP_FAILURE"
         check_captured_logs(manager, result, EXECUTION_DATE_MINUS_WEEK.strftime("%Y-%m-%d"))
 
 
@@ -116,6 +119,9 @@ def test_pipeline_auto_tag():
             pipeline=make_dagster_pipeline_from_airflow_dag(dag=dag),
             instance=instance,
         )
+        assert result.success
+        for event in result.step_event_list:
+            assert event.event_type_value != "STEP_FAILURE"
 
         capture_events = [
             event


### PR DESCRIPTION
### Summary & Motivation

currently dagster-airflow uses subprocess to call the airflow cli to do db initialization, this doesn't work when dagster repo is inside a pex artifact since the airflow dep won't be added to the system path. This pr switches to reaching into the db airflow module to call the initdb function directly.

### How I Tested These Changes
