### PR TITLE
[declarative-scheduling] Fix issue where in-progress runs were not properly handled

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -629,7 +629,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 # calculate the data times you would expect if the latest currently-executing run
                 # were to successfully complete
                 in_progress_data_times = instance_queryer.get_in_progress_data_times_for_key(
-                    asset_graph, key, relevant_upstream_keys, current_time
+                    asset_graph, key, frozenset(relevant_upstream_keys), current_time
                 )
 
                 # calculate the data times you'd expect for this key if you were to run it

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -492,10 +492,24 @@ def get_in_progress_data_times_for_key(
     ):
         return {upstream_key: None for upstream_key in relevant_upstream_keys}
     else:
-        # if run hasn't started yet
         root_data_time = latest_run_record.start_time or current_time
-        # if the source data key is in this run, then use the run's time as the data time, otherwise
-        # fetch the current time
+        materializing_with = instance_queryer.get_planned_materializations_for_run(run_id)
+        # TODO: this is an optimistic heuristic, and doesn't take into account the following
+        # scenarios (assume graph of A -> B -> C -> D):
+        #
+        # * A run is manually kicked off only `A` and `C`. It will be assumed that when this run
+        #   completes, `C` will contain all data of `A` up until `root_data_time`, which is
+        #   inaccurate.
+        # * A run is kicked off of `B`, `C`, and `D`. `B` executes quickly, but `C` takes a very
+        #   long time to complete, and while it's executing, a new run of `A` completes. It will be
+        #   assumed that at the end of the `B,C,D` run, all assets will contain the newest version
+        #   of `A`, which is inaccurate.
+        #
+        # In either of these scenarios
+        ret = {}
+        for upstream_key in relevant_upstream_keys:
+            pass
+        return ret
 
 
 def get_expected_data_times_for_key(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -1,6 +1,17 @@
 import datetime
 import json
-from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Mapping, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster._core.definitions.asset_graph import AssetGraph
@@ -14,6 +25,7 @@ from dagster._core.storage.event_log.sql_event_log import AssetEventTagsTable
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
+    DagsterRunStatus,
     RunRecord,
     RunsFilter,
 )
@@ -42,29 +54,47 @@ class CachingInstanceQueryer:
         self._no_materializations_after_cursor_cache: Dict[AssetKeyPartitionKey, int] = {}
 
     @cached_method
-    def get_latest_run_record_for_key(self, asset_key: AssetKey) -> Optional[RunRecord]:
-        # the latest asset record is updated whenever a new run is created
+    def failed_in_latest_run(self, asset_key: AssetKey) -> bool:
         asset_records = self._instance.get_asset_records([asset_key])
         asset_record = next(iter(asset_records), None)
-        if asset_record is None or asset_record.asset_entry.last_run_id is None:
-            return None
-        run_id = asset_record.asset_entry.last_run_id
-        return self._get_run_record_by_id(run_id=run_id)
 
-    def is_asset_partition_in_run(self, run_id: str, asset_partition: AssetKeyPartitionKey) -> bool:
+        # no latest run
+        if asset_record is None or asset_record.asset_entry.last_run_id is None:
+            return False
+
+        run_id = asset_record.asset_entry.last_run_id
+        latest_run_record = self._get_run_record_by_id(run_id=run_id)
+
+        # latest run did not fail
+        if (
+            latest_run_record is None
+            or latest_run_record.pipeline_run.status != DagsterRunStatus.FAILURE
+        ):
+            return False
+
+        # if asset was still materialized in the run count as success
+        latest_materialization = asset_record.asset_entry.last_materialization
+        if (
+            latest_materialization is not None
+            and latest_materialization.run_id == latest_run_record.pipeline_run.run_id
+        ):
+            return False
+
+        return True
+
+    def is_asset_in_run(self, run_id: str, asset: Union[AssetKey, AssetKeyPartitionKey]) -> bool:
         run = self._get_run_by_id(run_id=run_id)
         if not run:
             check.failed("")
 
-        if run.tags.get(PARTITION_NAME_TAG) != asset_partition.partition_key:
-            return False
-
-        if run.asset_selection:
-            return asset_partition.asset_key in run.asset_selection
+        if isinstance(asset, AssetKeyPartitionKey):
+            asset_key = asset.asset_key
+            if run.tags.get(PARTITION_NAME_TAG) != asset.partition_key:
+                return False
         else:
-            return asset_partition.asset_key in self.get_planned_materializations_for_run(
-                run_id=run_id
-            )
+            asset_key = asset
+
+        return asset_key in self._get_expected_materializations_for_run(run_id=run_id)
 
     def _get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
         run_record = self._get_run_record_by_id(run_id=run_id)
@@ -80,12 +110,32 @@ class CachingInstanceQueryer:
         )
 
     @cached_method
-    def get_planned_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
+    def _get_planned_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
         materializations_planned = self._instance.get_records_for_run(
             run_id=run_id,
             of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
         ).records
         return set(cast(AssetKey, record.asset_key) for record in materializations_planned)
+
+    @cached_method
+    def _get_expected_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
+        run = self._get_run_by_id(run_id=run_id)
+        if run is None:
+            return set()
+
+        if run.asset_selection:
+            return run.asset_selection
+        else:
+            # must resort to querying the event log
+            return self._get_planned_materializations_for_run(run_id=run_id)
+
+    @cached_method
+    def _get_current_materializations_for_run(self, run_id: str) -> AbstractSet[AssetKey]:
+        materializations = self._instance.get_records_for_run(
+            run_id=run_id,
+            of_type=DagsterEventType.ASSET_MATERIALIZATION,
+        ).records
+        return set(cast(AssetKey, record.asset_key) for record in materializations)
 
     @cached_method
     def _get_materialization_record(
@@ -254,8 +304,20 @@ class CachingInstanceQueryer:
             }
         return {}
 
+    def _upstream_subset(
+        self, asset_graph: AssetGraph, start_key: AssetKey, input_keys: AbstractSet[AssetKey]
+    ) -> AbstractSet[AssetKey]:
+        """Helper method which returns the set up keys in the input set which are upstream of start_key"""
+        ret = set()
+        if start_key in input_keys:
+            ret.add(start_key)
+        for upstream_key in asset_graph.upstream_key_iterator(start_key):
+            if upstream_key in input_keys:
+                ret.add(upstream_key)
+        return ret
+
     @cached_method
-    def calculate_used_data(
+    def _calculate_used_data(
         self,
         asset_graph: AssetGraph,
         asset_key: AssetKey,
@@ -283,12 +345,9 @@ class CachingInstanceQueryer:
                     continue
 
                 # the set of required keys which are upstream of this parent
-                upstream_required_keys = set()
-                if parent_key in unknown_required_keys:
-                    upstream_required_keys.add(parent_key)
-                for upstream_key in asset_graph.upstream_key_iterator(parent_key):
-                    if upstream_key in unknown_required_keys:
-                        upstream_required_keys.add(upstream_key)
+                upstream_required_keys = self._upstream_subset(
+                    asset_graph, start_key=parent_key, input_keys=unknown_required_keys
+                )
 
                 input_event_pointer_tag = get_input_event_pointer_tag_key(parent_key)
                 if input_event_pointer_tag in record_tags:
@@ -307,7 +366,7 @@ class CachingInstanceQueryer:
                     )
 
                 # recurse to find the data times of this parent
-                for key, tup in self.calculate_used_data(
+                for key, tup in self._calculate_used_data(
                     asset_graph=asset_graph,
                     asset_key=parent_key,
                     record_id=parent_record.storage_id if parent_record else None,
@@ -353,7 +412,7 @@ class CachingInstanceQueryer:
         if upstream_keys is None:
             upstream_keys = asset_graph.get_non_source_roots(record.asset_key)
 
-        data = self.calculate_used_data(
+        data = self._calculate_used_data(
             asset_graph=asset_graph,
             asset_key=record.asset_key,
             record_id=record.storage_id,
@@ -369,6 +428,110 @@ class CachingInstanceQueryer:
             else None
             for key, (_, timestamp) in data.items()
         }
+
+    @cached_method
+    def _get_in_progress_run_ids(self) -> Sequence[str]:
+        return [
+            record.pipeline_run.run_id
+            for record in self._instance.get_run_records(
+                filters=RunsFilter(statuses=IN_PROGRESS_RUN_STATUSES), limit=25
+            )
+        ]
+
+    @cached_method
+    def _get_in_progress_data_times_for_key_in_run(
+        self,
+        run_id: str,
+        current_time: datetime.datetime,
+        asset_graph: AssetGraph,
+        asset_key: AssetKey,
+        required_keys: AbstractSet[AssetKey],
+    ) -> Mapping[AssetKey, Optional[datetime.datetime]]:
+        """Returns the upstream data times that a given asset key will be expected to have at the
+        completion of the given run.
+        """
+        expected_keys = self._get_expected_materializations_for_run(run_id=run_id)
+        materialized_keys = self._get_current_materializations_for_run(run_id=run_id)
+
+        # if key is not pending materialization within the run, then downstream pending
+        # materializations will (in general) read from the current state of the data
+        if asset_key not in expected_keys or asset_key in materialized_keys:
+            latest_record = self.get_latest_materialization_record(asset_key)
+            latest_used_data = self._calculate_used_data(
+                asset_graph=asset_graph,
+                asset_key=asset_key,
+                record_id=latest_record.storage_id if latest_record else None,
+                record_timestamp=latest_record.event_log_entry.timestamp if latest_record else None,
+                record_tags=frozendict(
+                    (
+                        latest_record.asset_materialization.tags
+                        if latest_record and latest_record.asset_materialization
+                        else None
+                    )
+                    or {}
+                ),
+                required_keys=frozenset(required_keys),
+            )
+            return {
+                key: datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
+                if timestamp is not None
+                else None
+                for key, (_, timestamp) in latest_used_data.items()
+            }
+
+        # if you're here, then this asset is planned, but not materialized
+        upstream_data_times: Dict[AssetKey, Optional[datetime.datetime]] = {}
+        if asset_key in required_keys:
+            # in the worst case (data-time wise), this asset gets materialized right now
+            upstream_data_times[asset_key] = current_time
+
+        for parent_key in asset_graph.get_parents(asset_key):
+            # the set of required keys which are upstream of this parent
+            upstream_required_keys = self._upstream_subset(
+                asset_graph, start_key=parent_key, input_keys=required_keys
+            )
+            for upstream_key, upstream_time in self._get_in_progress_data_times_for_key_in_run(
+                run_id=run_id,
+                current_time=current_time,
+                asset_graph=asset_graph,
+                asset_key=parent_key,
+                required_keys=upstream_required_keys,
+            ):
+                current_value = upstream_data_times.get(upstream_key, upstream_time)
+                if current_value is None or upstream_time is None:
+                    upstream_data_times[upstream_key] = None
+                else:
+                    upstream_data_times[upstream_key] = max(current_value, upstream_time)
+        return upstream_data_times
+
+    def get_in_progress_data_times_for_key(
+        self,
+        asset_graph: AssetGraph,
+        asset_key: AssetKey,
+        upstream_keys: AbstractSet[AssetKey],
+        current_time: datetime.datetime,
+    ) -> Mapping[AssetKey, datetime.datetime]:
+        """Returns a mapping containing the maximum upstream data time that the input asset will
+        have once all in-progress runs complete.
+        """
+        in_progress_times: Dict[AssetKey, datetime.datetime] = {}
+
+        for run_id in self._get_in_progress_run_ids():
+            if not self.is_asset_in_run(run_id=run_id, asset=asset_key):
+                continue
+
+            for upstream_key, upstream_time in self._get_in_progress_data_times_for_key_in_run(
+                run_id=run_id,
+                current_time=current_time,
+                asset_graph=asset_graph,
+                asset_key=asset_key,
+                required_keys=upstream_keys,
+            ):
+                if upstream_time is not None:
+                    in_progress_times[upstream_key] = max(
+                        in_progress_times.get(upstream_key, datetime.datetime.min), upstream_time
+                    )
+        return in_progress_times
 
     def get_current_minutes_late_for_key(
         self,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -314,7 +314,7 @@ class CachingInstanceQueryer:
         for upstream_key in asset_graph.upstream_key_iterator(start_key):
             if upstream_key in input_keys:
                 ret.add(upstream_key)
-        return ret
+        return frozenset(ret)
 
     @cached_method
     def _calculate_used_data(
@@ -381,7 +381,7 @@ class CachingInstanceQueryer:
                         )
                         or {}
                     ),
-                    required_keys=frozenset(upstream_required_keys),
+                    required_keys=upstream_required_keys,
                 ).items():
                     # if root data is missing, this overrides other values
                     if tup == (None, None) or known_data.get(key) == (None, None):
@@ -470,7 +470,7 @@ class CachingInstanceQueryer:
                     )
                     or {}
                 ),
-                required_keys=frozenset(required_keys),
+                required_keys=required_keys,
             )
             return {
                 key: datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
@@ -496,7 +496,7 @@ class CachingInstanceQueryer:
                 asset_graph=asset_graph,
                 asset_key=parent_key,
                 required_keys=upstream_required_keys,
-            ):
+            ).items():
                 current_value = upstream_data_times.get(upstream_key, upstream_time)
                 if current_value is None or upstream_time is None:
                     upstream_data_times[upstream_key] = None
@@ -526,10 +526,10 @@ class CachingInstanceQueryer:
                 asset_graph=asset_graph,
                 asset_key=asset_key,
                 required_keys=upstream_keys,
-            ):
+            ).items():
                 if upstream_time is not None:
                     in_progress_times[upstream_key] = max(
-                        in_progress_times.get(upstream_key, datetime.datetime.min), upstream_time
+                        in_progress_times.get(upstream_key, upstream_time), upstream_time
                     )
         return in_progress_times
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -657,6 +657,27 @@ scenarios = {
         unevaluated_runs=[run(["asset1", "asset2"])],
         expected_run_requests=[run_request(asset_keys=["asset3", "asset4"])],
     ),
+    "freshness_half_run_with_failure": AssetReconciliationScenario(
+        assets=diamond_freshness,
+        unevaluated_runs=[
+            run(["asset1", "asset2", "asset3", "asset4"]),
+            run(["asset3"], failed_asset_keys=["asset3"]),
+        ],
+        evaluation_delta=datetime.timedelta(minutes=35),
+        # only request 1 and 2 because 3 failed (and 4 is downstream of 3)
+        expected_run_requests=[run_request(asset_keys=["asset1", "asset2"])],
+    ),
+    "freshness_half_run_with_failure2": AssetReconciliationScenario(
+        assets=diamond_freshness,
+        unevaluated_runs=[
+            run(["asset1", "asset2", "asset3", "asset4"]),
+            run(["asset1", "asset3"], failed_asset_keys=["asset3"]),
+        ],
+        evaluation_delta=datetime.timedelta(minutes=35),
+        # same reasoning as above, but make sure asset1 can still execute even though it was part
+        # of a failed run
+        expected_run_requests=[run_request(asset_keys=["asset1", "asset2"])],
+    ),
     "freshness_half_run_stale": AssetReconciliationScenario(
         assets=diamond_freshness,
         unevaluated_runs=[run(["asset1", "asset2"])],


### PR DESCRIPTION
### Summary & Motivation

Previously, the way we calculated if an in-progress run would solve a given constraint was very naive, and only covered a small subset of the actual scenarios. Specifically, for a given asset key, it would check if the required upstream data key was in the most recent run of the given asset key.

However, this would not take into account situations where a currently-executing run of that asset key did not contain that upstream key, but would still pull in fresher data than the asset currently had (which is a pretty common scenario).

### How I Tested These Changes
