### PR TITLE
[dagit] Left nav: show entire code location string for non-dunder repos

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -1,4 +1,4 @@
-import {BaseTag, Box, Colors, Icon, IconWrapper, StyledTag} from '@dagster-io/ui';
+import {BaseTag, Box, Colors, Icon, IconWrapper, MiddleTruncate, StyledTag} from '@dagster-io/ui';
 import * as React from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -174,9 +174,6 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
     );
   };
 
-  const {name: repoName, location: repoLocation} = repoAddress;
-  const isDunderName = repoName === DUNDER_REPO_NAME;
-
   return (
     <Box background={Colors.Gray100} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
       <SectionHeader
@@ -194,17 +191,12 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
             <Icon name="folder_open" size={16} />
           </Box>
           <RepoNameContainer>
-            <Box flex={{direction: 'column'}} style={{flex: 1, minWidth: 0}}>
-              <RepoName style={{fontWeight: 500}} data-tooltip={option.repository.name}>
-                {isDunderName ? repoLocation : repoName}
-              </RepoName>
-              {showRepoLocation && !isDunderName ? (
-                <RepoLocation data-tooltip={`@${option.repositoryLocation.name}`} $disabled={empty}>
-                  @{option.repositoryLocation.name}
-                </RepoLocation>
-              ) : null}
-            </Box>
-
+            <RepoName
+              data-tooltip={repoAddressAsHumanString(repoAddress)}
+              data-tooltip-style={CodeLocationTooltipStyles}
+            >
+              <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} showTitle={false} />
+            </RepoName>
             {/* Wrapper div to prevent tag from stretching vertically */}
             <div>
               <BaseTag
@@ -226,6 +218,19 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
     </Box>
   );
 });
+
+const CodeLocationTooltipStyles = JSON.stringify({
+  background: Colors.Gray100,
+  filter: `brightness(97%)`,
+  color: Colors.Gray900,
+  fontWeight: 500,
+  border: 'none',
+  borderRadius: 7,
+  overflow: 'hidden',
+  fontSize: 14,
+  padding: '5px 10px',
+  transform: 'translate(-10px,-5px)',
+} as React.CSSProperties);
 
 type PathMatch = {
   repoPath: string;
@@ -356,15 +361,5 @@ const RepoNameContainer = styled.div`
 const RepoName = styled.div`
   font-weight: 500;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const RepoLocation = styled.div<{$disabled: boolean}>`
-  color: ${({$disabled}) => ($disabled ? Colors.Gray400 : Colors.Gray700)};
-  font-size: 12px;
-  margin-top: 4px;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 `;

--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
@@ -68,12 +68,10 @@ export const CodeLocationRowSet: React.FC<Props> = ({locationNode}) => {
         const repoAddress = buildRepoAddress(repository.name, name);
         return (
           <tr key={repoAddressAsHumanString(repoAddress)}>
-            <td style={{maxWidth: '400px'}}>
-              <strong>
-                <Link to={workspacePathFromAddress(repoAddress)}>
-                  <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
-                </Link>
-              </strong>
+            <td style={{maxWidth: '400px', fontWeight: 500}}>
+              <Link to={workspacePathFromAddress(repoAddress)}>
+                <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
+              </Link>
             </td>
             <td>
               <LocationStatus location={repository.name} locationOrError={locationNode} />

--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.tsx
@@ -14,51 +14,53 @@ import {calculateMiddleTruncation} from './calculateMiddleTruncation';
  *
  * When the DOM element resizes, the measurement and calculation steps will occur again.
  */
-export const MiddleTruncate: React.FC<{text: string}> = React.memo(({text}) => {
-  // Track the font style and target maximum width. `null` means no measurement has
-  // taken place yet.
-  const [truncatedText, setTruncatedText] = React.useState<string | null>(null);
+export const MiddleTruncate: React.FC<{text: string; showTitle?: boolean}> = React.memo(
+  ({text, showTitle = true}) => {
+    // Track the font style and target maximum width. `null` means no measurement has
+    // taken place yet.
+    const [truncatedText, setTruncatedText] = React.useState<string | null>(null);
 
-  // An element that renders the full text into the container, for the purpose of
-  // measuring the maximum available/necessary width for our truncated string.
-  const measure = React.useRef<HTMLDivElement>(null);
+    // An element that renders the full text into the container, for the purpose of
+    // measuring the maximum available/necessary width for our truncated string.
+    const measure = React.useRef<HTMLDivElement>(null);
 
-  // Given the target font style and allotted width, calculate the largest possible middle-
-  // truncated string.
-  const calculateTargetStyle = React.useCallback(() => {
-    if (measure.current) {
-      setTruncatedText(calculateMiddleTruncatedText(measure.current, text));
-    }
-  }, [text]);
+    // Given the target font style and allotted width, calculate the largest possible middle-
+    // truncated string.
+    const calculateTargetStyle = React.useCallback(() => {
+      if (measure.current) {
+        setTruncatedText(calculateMiddleTruncatedText(measure.current, text));
+      }
+    }, [text]);
 
-  // Use a layout effect to trigger the process of calculating the truncated text, for the
-  // initial render.
-  React.useLayoutEffect(() => {
-    calculateTargetStyle();
-  }, [calculateTargetStyle]);
+    // Use a layout effect to trigger the process of calculating the truncated text, for the
+    // initial render.
+    React.useLayoutEffect(() => {
+      calculateTargetStyle();
+    }, [calculateTargetStyle]);
 
-  // If the container has just been resized, recalculate.
-  useResizeObserver(measure.current, () => {
-    calculateTargetStyle();
-  });
+    // If the container has just been resized, recalculate.
+    useResizeObserver(measure.current, () => {
+      calculateTargetStyle();
+    });
 
-  // Copy the full text, not just the truncated version shown in the DOM.
-  const handleCopy = React.useCallback(
-    (e: React.ClipboardEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      const clipboardAPI = navigator.clipboard;
-      clipboardAPI.writeText(text);
-    },
-    [text],
-  );
+    // Copy the full text, not just the truncated version shown in the DOM.
+    const handleCopy = React.useCallback(
+      (e: React.ClipboardEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        const clipboardAPI = navigator.clipboard;
+        clipboardAPI.writeText(text);
+      },
+      [text],
+    );
 
-  return (
-    <Container onCopy={handleCopy} title={text}>
-      <span>{truncatedText}</span>
-      <MeasureWidth ref={measure}>{text}</MeasureWidth>
-    </Container>
-  );
-});
+    return (
+      <Container onCopy={handleCopy} title={showTitle ? text : undefined}>
+        <span>{truncatedText}</span>
+        <MeasureWidth ref={measure}>{text}</MeasureWidth>
+      </Container>
+    );
+  },
+);
 
 // An invisible target element that contains the full, no-wrapped text. This is used
 // to measure the maximum available width for our truncated string.


### PR DESCRIPTION
### Summary & Motivation

In the Dagit left nav, show the full `repo@location` string for all non-dunder repo names. This matches what we show in the Code Locations table, and gives the user information about multi-repo locations vs. single-repo locations.

Also slightly reduced the font-weight on the Code Locations table `name` column.

<img width="1492" alt="Screenshot 2022-12-14 at 3 58 36 PM" src="https://user-images.githubusercontent.com/2823852/207726361-6b33b33c-dc03-4cff-b73f-7d4105f81c96.png">
<img width="342" alt="Screenshot 2022-12-14 at 3 59 00 PM" src="https://user-images.githubusercontent.com/2823852/207726366-6100db4b-7b5d-488d-a59b-874d04afb192.png">


### How I Tested These Changes

View Dagit with default workspace loaded. Verify that repo names are middle-truncated `repo@location` strings, with hover tooltips that correctly render overlaying the truncated string.
