### PR TITLE
[dagster-fivetran] Allow managing config of individual schemas in a Fivetran connection

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -229,6 +229,16 @@ def reconcile_sources(
                         ),
                     )
                     source_id = create_result["sourceId"]
+            if not dry_run:
+                status = res.make_request(
+                    endpoint="/sources/check_connection",
+                    data={"sourceId": source_id},
+                )
+                print(source_id)
+                print(status)
+                import time
+
+                time.sleep(15)
 
             if source_name in initialized_sources:
                 # Preserve to be able to initialize old connection object

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -146,6 +146,9 @@ class AirbyteResource:
                     return None
                 return response.json()
             except RequestException as e:
+                print(response.text)
+                print(data)
+                print(endpoint)
                 self._log.error("Request to Airbyte API failed: %s", e)
                 if num_retries == self._request_max_retries:
                     break

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/types.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/managed/types.py
@@ -12,10 +12,19 @@ class FivetranDestination:
         self,
         name: str,
         destination_type: str,
-        region: str,
         destination_configuration: Dict[str, Any],
+        region: str = "GCP_US_EAST4",
         time_zone_offset: Optional[int] = None,
     ):
+        """
+        Args:
+            name (str): The name of the destination.
+            destination_type (str): The type of the destination. See the Fivetran API docs for a list
+                of valid destination types.
+            destination_configuration (Dict[str, Any]): The configuration of the destination.
+            region (str): The region of the destination. Defaults to "GCP_US_EAST4".
+            time_zone_offset (Optional[int]): The UTC time zone offset of the destination. Defaults to 0 (UTC).
+        """
         self.name = check.str_param(name, "name")
         self.region = check.str_param(region, "region")
         self.time_zone_offset = check.opt_int_param(time_zone_offset, "time_zone_offset") or 0
@@ -48,14 +57,41 @@ class InitializedFivetranDestination:
 
 
 class FivetranConnector:
+    """
+    Represents a user-defined Fivetran connector.
+    """
+
     def __init__(
         self,
         schema_name: str,
         source_type: str,
         source_configuration: Dict[str, Any],
         destination: Optional[FivetranDestination],
+        schema_configuration: Optional[Dict[str, Any]] = None,
         auth_configuration: Optional[Dict[str, Any]] = None,
     ):
+        """
+        Args:
+            schema_name (str): The name of the schema to create in the destination.
+            source_type (str): The type of source to connect to. See the Fivetran API docs for a
+                list of supported source types: https://fivetran.com/docs/rest-api/connectors#create-a-connector
+            source_configuration (Dict[str, Any]): The configuration for the source, as defined by the Fivetran API.
+            destination (Optional[FivetranDestination]): The destination to connect to.
+            schema_configuration (Optional[Dict[str, Any]]): Optional schema configuration, to select certain schemas
+                or tables from the source to sync. By default, selects all schemas and tables. Input is a map of schema
+                names to either True (to select all tables in the schema) or a map of table names to True (to select
+                individual tables). For example, to select all tables in schema "my_schema_1" and only table "my_table_1"
+                in schema "my_schema_2", use the following configuration:
+
+                .. code-block:: python
+                    {
+                        "my_schema_1": True,
+                        "my_schema_2": {
+                            "my_table_1": True,
+                            "my_table_2": False,
+                        },
+                    }
+        """
         self.schema_name = check.str_param(schema_name, "schema_name")
         self.source_type = check.str_param(source_type, "source_type")
         self.source_configuration = check.dict_param(
@@ -66,9 +102,31 @@ class FivetranConnector:
         )
         self.paused = True
         self.destination = check.opt_inst_param(destination, "destination", FivetranDestination)
+        self.schema_configuration = check.opt_dict_param(
+            schema_configuration, "schema_configuration", key_type=str
+        )
 
     def must_be_recreated(self, other: "FivetranConnector") -> bool:
         return self.schema_name != other.schema_name or self.source_type != other.source_type
+
+
+def _table_json_to_table_configuration(schema: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        table["name_in_destination"]: True
+        for table in schema["tables"].values()
+        if table["enabled"]
+    }
+
+
+def _schemas_json_to_schema_configuration(schemas: Dict[str, Any]) -> Dict[str, Any]:
+    if not "schemas" in schemas:
+        return {}
+    return {
+        schema["name_in_destination"]: schema["enabled"]
+        if "tables" not in schema
+        else _table_json_to_table_configuration(schema)
+        for schema in schemas["schemas"].values()
+    }
 
 
 class InitializedFivetranConnector:
@@ -77,7 +135,7 @@ class InitializedFivetranConnector:
         self.connector_id = connector_id
 
     @classmethod
-    def from_api_json(cls, api_json: Dict[str, Any]):
+    def from_api_json(cls, api_json: Dict[str, Any], schemas_json: Dict[str, Any]):
         return cls(
             connector=FivetranConnector(
                 schema_name=api_json["schema"],
@@ -85,6 +143,7 @@ class InitializedFivetranConnector:
                 source_configuration=api_json["config"] or {},
                 auth_configuration=api_json.get("auth") or {},
                 destination=None,
+                schema_configuration=_schemas_json_to_schema_configuration(schemas_json),
             ),
             connector_id=api_json["id"],
         )


### PR DESCRIPTION
## Summary

Adds the ability for users to turn on and off data streams for a Fivetran managed connection. Users can specify specific stream or table names to enable or disable, which will be rendered in the diff and applied as needed:

```
❯ dagster-fivetran check -m repo -d .
Loading module...
Found 1 reconcilers, checking...

Changes found:


~ github:
  ~ schemas:
    ~ github:
      + column: True
      ~ card: True -> False
```

## Test Plan

Added a new unit test for this functionality; tested locally.