### PR TITLE
Use wrap_resources_for_execution in Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Type, Union
 
 import dagster._check as check
 from dagster._annotations import public


### PR DESCRIPTION
Summary & Motivation: It turns out we already had a function in the code base that did the resource and i/o manager coercion. Let's just use that.

Test Plan: BK
