### PR TITLE
enable run status sensor logging

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Sequence,
 import pendulum
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, public
+from dagster._annotations import public
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -129,12 +129,12 @@ class RunStatusSensorContext:
 
     @public  # type: ignore
     @property
-    def dagster_event(self) -> DagsterRun:
+    def dagster_event(self) -> DagsterEvent:
         return self._dagster_event
 
     @public  # type: ignore
     @property
-    def instance(self) -> DagsterRun:
+    def instance(self) -> DagsterInstance:
         return self._instance
 
     @public  # type: ignore

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -500,6 +500,14 @@ def logging_sensor(context):
     return SkipReason()
 
 
+@run_status_sensor(
+    monitor_all_repositories=True,
+    run_status=DagsterRunStatus.SUCCESS,
+)
+def logging_status_sensor(context):
+    context.log.info(f"run succeeded: {context.dagster_run.run_id}")
+
+
 @repository
 def the_repo():
     return [
@@ -547,6 +555,7 @@ def the_repo():
         asset_selection_sensor,
         targets_asset_selection_sensor,
         logging_sensor,
+        logging_status_sensor,
     ]
 
 


### PR DESCRIPTION
### Summary & Motivation
Propagates the sensor evaluation context to the run status sensor context, to give access to the context logger.

Passed the context instead of the logger to avoid the logger instantiation until it was actually used.  Required converting the context object from a namedtuple to an actual class (should be safe since it does not cross a serialization boundary).

### How I Tested These Changes
BK