### PR TITLE
Move jobs concept guide to refer to Definitions

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/jobs.mdx
@@ -39,10 +39,10 @@ Jobs can be created in several ways:
 
 ### From software-defined assets
 
-Asset jobs materialize a fixed set of assets each time they run. Additionally, multiple jobs in the same repository can target overlapping sets of assets:
+Asset jobs materialize a fixed set of assets each time they run. Additionally, multiple jobs can target overlapping sets of assets:
 
 ```python file=/concepts/assets/build_job.py startafter=start_marker endbefore=end_marker
-from dagster import asset, define_asset_job, repository
+from dagster import Definitions, asset, define_asset_job
 
 
 @asset
@@ -59,9 +59,10 @@ all_assets_job = define_asset_job(name="all_assets_job")
 asset1_job = define_asset_job(name="asset1_job", selection="asset1")
 
 
-@repository
-def repo():
-    return [asset1, asset2, all_assets_job, asset1_job]
+defs = Definitions(
+    assets=[asset1, asset2],
+    jobs=[all_assets_job, asset1_job],
+)
 ```
 
 Unlike jobs created using the <PyObject object="job"/> decorator where you explicitly define the dependencies when you create the job, the topology of an asset-based job is based on the [assets](/concepts/assets/software-defined-assets) and their dependencies.
@@ -218,12 +219,12 @@ if __name__ == "__main__":
 
 ---
 
-## Including jobs in repositories
+## Making jobs available to Dagster tools
 
-You make jobs available to Dagit, GraphQLs, and the command line by including them inside [repositories](/concepts/repositories-workspaces/repositories). If you include schedules or sensors in a repository, the repository will automatically include jobs that those schedules or sensors target.
+You make jobs available to Dagit, GraphQL, and the command line by including them in <PyObject object="Definitions"/> object at the top-level of Python module or file. When that module is loaded by a tool, it becomes a code location. If you include schedules or sensors, the code location will automatically include jobs that those schedules or sensors target.
 
 ```python file=/concepts/ops_jobs_graphs/repo_with_job.py
-from dagster import job, repository
+from dagster import Definitions, job
 
 
 @job
@@ -231,16 +232,14 @@ def do_it_all():
     ...
 
 
-@repository
-def my_repo():
-    return [do_it_all]
+defs = Definitions(jobs=[do_it_all])
 ```
 
 ---
 
 ## Testing jobs
 
-Dagster has built-in support for testing your data applications, including separating business logic from environments and setting explicit expectations on uncontrollable inputs. Refer to the [Testing guide](/concepts/testing) for more info and examples.
+Dagster has built-in support for testing, including separating business logic from environments and setting explicit expectations on uncontrollable inputs. Refer to the [Testing guide](/concepts/testing) for more info and examples.
 
 ---
 

--- a/docs/content/concepts/ops-jobs-graphs/jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/jobs.mdx
@@ -221,7 +221,7 @@ if __name__ == "__main__":
 
 ## Making jobs available to Dagster tools
 
-You make jobs available to Dagit, GraphQL, and the command line by including them in <PyObject object="Definitions"/> object at the top-level of Python module or file. When that module is loaded by a tool, it becomes a code location. If you include schedules or sensors, the code location will automatically include jobs that those schedules or sensors target.
+You make jobs available to Dagit, GraphQL, and the command line by including them in <PyObject object="Definitions"/> object at the top-level of Python module or file. The tool loads that module as a code location. If you include schedules or sensors, the code location will automatically include jobs that those schedules or sensors target.
 
 ```python file=/concepts/ops_jobs_graphs/repo_with_job.py
 from dagster import Definitions, job

--- a/examples/docs_snippets/docs_snippets/concepts/assets/build_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/build_job.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-outer-name
 # start_marker
-from dagster import asset, define_asset_job, repository
+from dagster import Definitions, asset, define_asset_job
 
 
 @asset
@@ -17,9 +17,10 @@ all_assets_job = define_asset_job(name="all_assets_job")
 asset1_job = define_asset_job(name="asset1_job", selection="asset1")
 
 
-@repository
-def repo():
-    return [asset1, asset2, all_assets_job, asset1_job]
+defs = Definitions(
+    assets=[asset1, asset2],
+    jobs=[all_assets_job, asset1_job],
+)
 
 
 # end_marker

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/repo_with_job.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/repo_with_job.py
@@ -1,4 +1,4 @@
-from dagster import job, repository
+from dagster import Definitions, job
 
 
 @job
@@ -6,6 +6,4 @@ def do_it_all():
     ...
 
 
-@repository
-def my_repo():
-    return [do_it_all]
+defs = Definitions(jobs=[do_it_all])

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_build_job.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_build_job.py
@@ -1,6 +1,6 @@
-from docs_snippets.concepts.assets.build_job import repo
+from docs_snippets.concepts.assets.build_job import defs
 
 
-def test():
-    assert repo.get_job("all_assets_job").execute_in_process().success
-    assert repo.get_job("asset1_job").execute_in_process().success
+def test_build_job_doc_snippet():
+    assert defs.get_job_def("all_assets_job").execute_in_process().success
+    assert defs.get_job_def("asset1_job").execute_in_process().success


### PR DESCRIPTION
Summary & Motivation: Rework the jobs page to refer to Definitions rather than repository

[Preview](https://dagster-git-schrockn-move-jobs-concept-guide-to-3f7996-elementl.vercel.app/concepts/resources)

Test Plan: Read
