### PR TITLE
make schedules produced by build_schedule_from_partitioned_job more p…

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -215,11 +215,19 @@ class PartitionsDefinition(ABC, Generic[T]):
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
         return [partition.name for partition in self.get_partitions(current_time)]
 
-    def get_last_partition_key(self, current_time: Optional[datetime] = None) -> str:
-        return self.get_partitions(current_time)[-1].name
+    def get_last_partition_key(self, current_time: Optional[datetime] = None) -> Optional[str]:
+        partitions = self.get_partitions(current_time)
+        if partitions:
+            return partitions[-1].name
+        else:
+            return None
 
-    def get_first_partition_key(self, current_time: Optional[datetime] = None) -> str:
-        return self.get_partitions(current_time)[0].name
+    def get_first_partition_key(self, current_time: Optional[datetime] = None) -> Optional[str]:
+        partitions = self.get_partitions(current_time)
+        if partitions:
+            return partitions[0].name
+        else:
+            return None
 
     def get_default_partition_mapping(self):
         from dagster._core.definitions.partition_mapping import IdentityPartitionMapping

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -152,16 +152,27 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
 
 @whitelist_for_serdes
 class AllPartitionMapping(PartitionMapping, NamedTuple("_AllPartitionMapping", [])):
+    def get_upstream_partitions_for_partitions(
+        self,
+        downstream_partitions_subset: Optional[PartitionsSubset],
+        upstream_partitions_def: PartitionsDefinition,
+    ) -> PartitionsSubset:
+        first = upstream_partitions_def.get_first_partition_key()
+        last = upstream_partitions_def.get_last_partition_key()
+
+        empty_subset = upstream_partitions_def.empty_subset()
+        if first is not None and last is not None:
+            return empty_subset.with_partition_key_range(PartitionKeyRange(first, last))
+        else:
+            return empty_subset
+
     def get_upstream_partitions_for_partition_range(
         self,
         downstream_partition_key_range: Optional[PartitionKeyRange],
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
     ) -> PartitionKeyRange:
-        return PartitionKeyRange(
-            upstream_partitions_def.get_first_partition_key(),
-            upstream_partitions_def.get_last_partition_key(),
-        )
+        raise NotImplementedError()
 
     def get_downstream_partitions_for_partition_range(
         self,
@@ -174,14 +185,26 @@ class AllPartitionMapping(PartitionMapping, NamedTuple("_AllPartitionMapping", [
 
 @whitelist_for_serdes
 class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping", [])):
+    def get_upstream_partitions_for_partitions(
+        self,
+        downstream_partitions_subset: Optional[PartitionsSubset],
+        upstream_partitions_def: PartitionsDefinition,
+    ) -> PartitionsSubset:
+        last = upstream_partitions_def.get_last_partition_key()
+
+        empty_subset = upstream_partitions_def.empty_subset()
+        if last is not None:
+            return empty_subset.with_partition_keys([last])
+        else:
+            return empty_subset
+
     def get_upstream_partitions_for_partition_range(
         self,
         downstream_partition_key_range: Optional[PartitionKeyRange],
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
     ) -> PartitionKeyRange:
-        last_partition_key = upstream_partitions_def.get_last_partition_key()
-        return PartitionKeyRange(last_partition_key, last_partition_key)
+        raise NotImplementedError()
 
     def get_downstream_partitions_for_partition_range(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -53,12 +53,10 @@ def build_schedule_from_partitioned_job(
         description=check.opt_str_param(description, "description"),
     )
     def schedule_def(context):
-        partition_keys = partitions_def.get_partition_keys(context.scheduled_execution_time)
-        if len(partition_keys) == 0:
-            return SkipReason("The job's PartitionsDefinition has no partitions")
-
         # Run for the latest partition. Prior partitions will have been handled by prior ticks.
-        partition_key = partition_keys[-1]
+        partition_key = partitions_def.get_last_partition_key(context.scheduled_execution_time)
+        if partition_key is None:
+            return SkipReason("The job's PartitionsDefinition has no partitions")
 
         yield job.run_request_for_partition(
             partition_key=partition_key, run_key=partition_key, tags=tags

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -169,7 +169,7 @@ class TimeWindowPartitionMapping(
                 window_end = (
                     to_partitions_def.end_time_for_partition_key(to_end_partition_key)
                     if to_end_partition_key
-                    else to_partitions_def.get_last_partition_window().end
+                    else cast(TimeWindow, to_partitions_def.get_last_partition_window()).end
                 )
 
                 time_windows.append(TimeWindow(window_start, window_end))

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_partitioned_schedule.py
@@ -334,3 +334,24 @@ def test_monthly_schedule_with_offsets():
     @repository
     def _repo():
         return [my_schedule]
+
+
+def test_empty_partitions():
+    @daily_partitioned_config(start_date="2021-05-05")
+    def my_partitioned_config(start, end):
+        del start
+        del end
+        assert False
+
+    my_schedule = schedule_for_partitioned_config(
+        my_partitioned_config, hour_of_day=9, minute_of_hour=30
+    )
+
+    result = my_schedule.evaluate_tick(
+        build_schedule_context(
+            scheduled_execution_time=datetime.strptime("2021-05-05", DATE_FORMAT)
+        )
+    )
+
+    assert len(result.run_requests) == 0
+    assert result.skip_message is not None

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_sensor_invocation.py
@@ -598,6 +598,7 @@ def test_multi_asset_sensor_custom_partition_mapping():
                     "Expected downstream_partitions_def to be a PartitionsDefinition"
                 )
             first_partition_key = downstream_partitions_def.get_first_partition_key()
+            assert first_partition_key is not None
             return PartitionKeyRange(first_partition_key, first_partition_key)
 
     @asset(partitions_def=DailyPartitionsDefinition("2022-07-01"))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -153,8 +153,10 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             )
 
         if self._partitions_def and self._partition_key_to_vars_fn:
-            partition_key = self._partitions_def.get_last_partition_key()
-            partition_var = self._partition_key_to_vars_fn(partition_key)
+            last_partition_key = self._partitions_def.get_last_partition_key()
+            if last_partition_key is None:
+                check.failed("PartitionsDefinition has no partitions")
+            partition_var = self._partition_key_to_vars_fn(last_partition_key)
 
             dbt_compile_options.append(f"--vars '{json.dumps(partition_var)}'")
 


### PR DESCRIPTION
…erfomant

### Summary & Motivation

Instead of getting a list of all the partition keys, just ask the `PartitionsDefinition` for the last one.

Implementing this required making the return type of `PartitionsDefinition.get_last_partition_key` optional, so we can gracefully skip if there are no partitions yet.

### How I Tested These Changes
