### PR TITLE
Do a single pip install in tox suites [OSS]

### DIFF
--- a/.buildkite/dagster-buildkite/tox.ini
+++ b/.buildkite/dagster-buildkite/tox.ini
@@ -3,12 +3,12 @@ envlist = pylint,mypy
 skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD
 deps =
   -e ../../python_modules/dagster[mypy,test]
+  -e .
 
 [testenv:mypy]
 commands =

--- a/docs/dagit-screenshot/tox.ini
+++ b/docs/dagit-screenshot/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = mypy,pylint
+skipsdist = true
 
 [testenv]
 setenv =

--- a/examples/assets_dbt_python/tox.ini
+++ b/examples/assets_dbt_python/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -14,6 +14,7 @@ deps =
   -e ../../python_modules/libraries/dagster-dbt/
   -e ../../python_modules/libraries/dagster-duckdb/
   -e ../../python_modules/libraries/dagster-duckdb-pandas/
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/assets_modern_data_stack/tox.ini
+++ b/examples/assets_modern_data_stack/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -14,6 +14,7 @@ deps =
   -e ../../python_modules/libraries/dagster-airbyte/
   -e ../../python_modules/libraries/dagster-postgres/
   -e ../../python_modules/libraries/dagster-pandas/
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/assets_pandas_pyspark/tox.ini
+++ b/examples/assets_pandas_pyspark/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -13,6 +13,7 @@ deps =
   -e ../../python_modules/libraries/dagster-spark
   -e ../../python_modules/libraries/dagster-pyspark
   -e .[test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/assets_pandas_type_metadata/tox.ini
+++ b/examples/assets_pandas_type_metadata/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -12,6 +12,7 @@ deps =
   -e ../../python_modules/dagster-graphql
   -e ../../python_modules/dagster[mypy,test]
   -e ../../python_modules/libraries/dagster-pandera/
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/assets_smoke_test/tox.ini
+++ b/examples/assets_smoke_test/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -14,6 +14,7 @@ deps =
   -e ../../python_modules/libraries/dagster-dbt/
   -e ../../python_modules/libraries/dagster-snowflake/
   -e ../../python_modules/libraries/dagster-snowflake-pandas/
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  full
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_DB_HOST BUILDKITE*
@@ -25,6 +23,7 @@ deps =
   -e ../../python_modules/libraries/dagster-postgres
   -e ../../python_modules/libraries/dagster-slack
   -e ../../python_modules/dagit
+  -e .[full]
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/feature_graph_backed_assets/tox.ini
+++ b/examples/feature_graph_backed_assets/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39, 38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -10,6 +10,7 @@ deps =
   -e ../../python_modules/dagster[mypy,test]
   -e ../../python_modules/dagit
   -e ../../python_modules/dagster-graphql
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/project_fully_featured/tox.ini
+++ b/examples/project_fully_featured/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD

--- a/examples/with_airflow/tox.ini
+++ b/examples/with_airflow/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39, 38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -11,6 +11,7 @@ deps =
   -e ../../python_modules/dagit
   -e ../../python_modules/dagster-graphql
   -e ../../python_modules/libraries/dagster-airflow[test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/with_great_expectations/tox.ini
+++ b/examples/with_great_expectations/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39, 38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -12,6 +12,7 @@ deps =
   -e ../../python_modules/dagster-graphql
   -e ../../python_modules/libraries/dagster-pandas
   -e ../../python_modules/libraries/dagster-ge
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/with_pyspark/tox.ini
+++ b/examples/with_pyspark/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39, 38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -12,6 +12,7 @@ deps =
   -e ../../python_modules/dagster-graphql
   -e ../../python_modules/libraries/dagster-spark
   -e ../../python_modules/libraries/dagster-pyspark
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/examples/with_pyspark_emr/tox.ini
+++ b/examples/with_pyspark_emr/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39, 38, 37},pylint,mypy
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -13,6 +13,7 @@ deps =
   -e ../../python_modules/libraries/dagster-aws[test]
   -e ../../python_modules/libraries/dagster-spark
   -e ../../python_modules/libraries/dagster-pyspark
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
 setenv =
@@ -13,9 +14,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-gcp
   -e ../../../python_modules/libraries/dagster-k8s
   pyparsing<3.0.0 # Hint to nudge pypi to avoid a conflict between various dagster deps
-usedevelop = true
-extras =
-  test
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
 setenv =
@@ -14,7 +15,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-celery-k8s
   -e ../../../python_modules/libraries/dagster-postgres
   -e ../../../python_modules/libraries/dagster-aws
-usedevelop = true
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
 setenv =
@@ -8,7 +9,7 @@ passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../dagster[mypy,test]
   -e ../dagster-graphql
-usedevelop = true
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -4,14 +4,16 @@ envlist =
   py{39,38,37,36}-{unix,windows}-postgres-{graphql_context_variants,instance_multi_location,instance_managed_grpc_env,instance_deployed_grpc_env}
   mypy,pylint
 
+skipsdist = true
+
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* POSTGRES_TEST_DB_HOST
 deps =
   -e ../dagster[mypy,test]
   postgres: -e ../libraries/dagster-postgres
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/dagster-test/tox.ini
+++ b/python_modules/dagster-test/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -20,6 +20,7 @@ deps =
   -e ../libraries/dagster-celery-k8s
   -e ../libraries/dagster-celery-docker
   -e ../libraries/dagstermill
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -1,11 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows}-{api_tests,cli_tests,core_tests,definitions_tests_old_pendulum,daemon_sensor_tests,daemon_tests,general_tests,scheduler_tests,scheduler_tests_old_pendulum},pylint,mypy
+skipsdist = True
 
 [testenv]
-usedevelop = true
-extras =
-  mypy
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
   !windows: COVERAGE_ARGS =  --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
@@ -16,6 +13,7 @@ deps =
   definitions_tests_old_pendulum: pendulum==1.4.4
   core_tests_old_sqlalchemy: sqlalchemy==1.3.24
   -e ../dagster-test
+  -e .[mypy,test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-airbyte/tox.ini
+++ b/python_modules/libraries/dagster-airbyte/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist = py{38,37,36}-{unix,windows}-{unit,integration},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
-extras =
-  test
 deps =
   -e ../../dagster[mypy,test]
   -e ../../dagster-test
   -e ../dagster-managed-elements
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =
@@ -17,13 +16,9 @@ commands =
   unit: pytest -c ../../../pyproject.toml --ignore ./dagster_airbyte_tests/integration -vv {posargs}
   integration: pytest -c ../../../pyproject.toml ./dagster_airbyte_tests/integration -vv {posargs}
 [testenv:mypy]
-extras =
-  test
 commands =
   mypy --config=../../../pyproject.toml --non-interactive --install-types {posargs} .
 
 [testenv:pylint]
-extras =
-  test
 commands =
   pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_airbyte dagster_airbyte_tests

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -1,11 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows}-{default,requiresairflowdb}-airflow{1,2},pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  airflow1: test_airflow_1
-  airflow2: test_airflow_2
 setenv =
   VIRTUALENV_PIP=21.3.1
   SLUGIFY_USES_TEXT_UNIDECODE = yes
@@ -18,6 +15,8 @@ deps =
   -e ../dagster-gcp
   -e ../dagster-postgres
   -e ../../dagster-test
+  !airflow2: -e .[test_airflow_1]
+  airflow2: -e .[test_airflow_2]
 allowlist_externals =
   /bin/bash
 commands =
@@ -32,7 +31,5 @@ commands =
   mypy --config=../../../pyproject.toml --non-interactive --install-types {posargs} .
 
 [testenv:pylint]
-extras =
-  test_airflow_1
 commands =
   pylint -j0 --rcfile=../../../pyproject.toml {posargs} dagster_airflow dagster_airflow_tests

--- a/python_modules/libraries/dagster-aws/tox.ini
+++ b/python_modules/libraries/dagster-aws/tox.ini
@@ -1,11 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  redshift
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE* SSH_*
@@ -13,6 +10,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-spark
   -e ../dagster-pyspark
+  -e .[redshift,test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-azure/tox.ini
+++ b/python_modules/libraries/dagster-azure/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
@@ -10,6 +10,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-spark
   -e ../dagster-pyspark
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-celery-docker/tox.ini
+++ b/python_modules/libraries/dagster-celery-docker/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS BUILDKITE* AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID DAGSTER_DOCKER_* POSTGRES_TEST_DB_HOST
@@ -15,6 +15,7 @@ deps =
   -e ../dagster-gcp
   -e ../dagster-celery
   -e ../dagster-postgres
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-celery-k8s/tox.ini
+++ b/python_modules/libraries/dagster-celery-k8s/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -20,6 +20,7 @@ deps =
   -e ../dagster-airflow
   -e ../dagster-aws
   -e ../dagster-gcp
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-celery/tox.ini
+++ b/python_modules/libraries/dagster-celery/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = HOME CI_PULL_REQUEST COVERALLS_REPO_TOKEN DASK_ADDRESS AWS_* BUILDKITE* DAGSTER_*
@@ -17,6 +17,7 @@ deps =
   -e ../dagster-gcp
   -e ../dagster-celery-k8s
   -e ../dagster-celery-docker
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-census/tox.ini
+++ b/python_modules/libraries/dagster-census/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
   -e .
-usedevelop = true
 whitelist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-dask/tox.ini
+++ b/python_modules/libraries/dagster-dask/tox.ini
@@ -1,13 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  kube
-  pbs
-  test
-  yarn
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_PULL_REQUEST COVERALLS_REPO_TOKEN DASK_ADDRESS AWS_* BUILDKITE*
@@ -16,6 +11,7 @@ deps =
   -e ../../dagster-graphql
   -e ../dagster-aws
   -e ../dagster-pandas
+  -e .[kube,pbs,test,yarn]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-databricks/tox.ini
+++ b/python_modules/libraries/dagster-databricks/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN DATABRICKS_* BUILDKITE* SSH_*
@@ -12,6 +12,7 @@ deps =
   -e ../dagster-azure
   -e ../dagster-spark
   -e ../dagster-pyspark
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-datadog/tox.ini
+++ b/python_modules/libraries/dagster-datadog/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-datahub/tox.ini
+++ b/python_modules/libraries/dagster-datahub/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_* BUILDKITE* SSH_*
 deps =
   -e ../../dagster[mypy,test]
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -1,16 +1,15 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* POSTGRES_TEST_DB_DBT_HOST DBT_TARGET_PATH
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-postgres
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-docker/tox.ini
+++ b/python_modules/libraries/dagster-docker/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = HOME CI_* COVERALLS_REPO_TOKEN BUILDKITE* AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID DAGSTER_DOCKER_* DOCKER_* GOOGLE_* POSTGRES_TEST_DB_HOST
@@ -18,6 +18,7 @@ deps =
   -e ../dagster-k8s
   -e ../dagster-celery-k8s
   -e ../dagster-postgres
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-duckdb-pandas/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pandas/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist = py{39,38,37}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-duckdb
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-duckdb-pyspark/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist = py{39,38,37}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-duckdb
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-duckdb/tox.ini
+++ b/python_modules/libraries/dagster-duckdb/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AZURE_* BUILDKITE* SSH_*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-managed-elements
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-gcp/tox.ini
+++ b/python_modules/libraries/dagster-gcp/tox.ini
@@ -1,16 +1,15 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  pyarrow
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
+  -e .[pyarrow]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-ge/tox.ini
+++ b/python_modules/libraries/dagster-ge/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN GOOGLE_APPLICATION_CREDENTIALS GCP_PROJECT_ID BUILDKITE*
@@ -11,6 +11,7 @@ deps =
   -e ../dagster-pandas
   -e ../dagster-spark
   -e ../dagster-pyspark
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-github/tox.ini
+++ b/python_modules/libraries/dagster-github/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
@@ -17,6 +17,7 @@ deps =
   -e ../../libraries/dagster-postgres
   -e ../../libraries/dagster-celery-k8s
   -e ../../libraries/dagster-celery-docker
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-managed-elements/tox.ini
+++ b/python_modules/libraries/dagster-managed-elements/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist = py{38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-msteams/tox.ini
+++ b/python_modules/libraries/dagster-msteams/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-mysql/tox.ini
+++ b/python_modules/libraries/dagster-mysql/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN MYSQL_TEST_* BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-pagerduty/tox.ini
+++ b/python_modules/libraries/dagster-pagerduty/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-pandas/tox.ini
+++ b/python_modules/libraries/dagster-pandas/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagstermill[test]
-
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 
 allowlist_externals =
   /bin/bash
@@ -15,6 +16,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
   pytest -v{posargs}
+
 [testenv:mypy]
 commands =
   mypy --config=../../../pyproject.toml --non-interactive --install-types {posargs} .

--- a/python_modules/libraries/dagster-papertrail/tox.ini
+++ b/python_modules/libraries/dagster-papertrail/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-postgres/tox.ini
+++ b/python_modules/libraries/dagster-postgres/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN POSTGRES_TEST_* BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-prometheus/tox.ini
+++ b/python_modules/libraries/dagster-prometheus/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-pyspark/tox.ini
+++ b/python_modules/libraries/dagster-pyspark/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -10,6 +10,7 @@ deps =
   -e ../../dagster[mypy,test]
   -e ../../libraries/dagster-spark
   -e ../../libraries/dagster-aws
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-shell/tox.ini
+++ b/python_modules/libraries/dagster-shell/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-slack/tox.ini
+++ b/python_modules/libraries/dagster-slack/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-snowflake-pandas/tox.ini
+++ b/python_modules/libraries/dagster-snowflake-pandas/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist = py{38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* SNOWFLAKE_BUILDKITE_PASSWORD SNOWFLAKE_ACCOUNT
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-snowflake
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-spark/tox.ini
+++ b/python_modules/libraries/dagster-spark/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-ssh/tox.ini
+++ b/python_modules/libraries/dagster-ssh/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-twilio/tox.ini
+++ b/python_modules/libraries/dagster-twilio/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist = py{39,38,37,36}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN TWILIO_* BUILDKITE*
 deps =
   -e ../../dagster[mypy,test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 envlist = py{39,38,37,36}-{papermill1,papermill2}-{unix,windows},mypy,pylint
+skipsdist = true
 
 [testenv]
-usedevelop = true
-extras =
-  test
 setenv =
   VIRTUALENV_PIP=21.3.1
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
@@ -17,6 +15,7 @@ deps =
   papermill1: markupsafe<=2.0.1
   -e ../../dagster[mypy,test]
   -e ../dagster-pandas
+  -e .[test]
 allowlist_externals =
   /bin/bash
 commands =


### PR DESCRIPTION
Summary:
The current impl here appears to do two separate pip installs - the first installs all the package's deps locally, then the current package from pypi. The second pass installs the actual package locally. Believe by restructuring the tox files we can make it do it all in a single pass, which should be faster and more like what a real user does to install it.

### Summary & Motivation

### How I Tested These Changes
