### PR TITLE
[dagit] Virtualized Asset Catalog

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
@@ -1,4 +1,4 @@
-import {Colors, Icon, Tooltip, Box, Spinner, Tag, Caption} from '@dagster-io/ui';
+import {Colors, Icon, Tooltip, Box, Spinner, Tag, CaptionMono} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -105,13 +105,11 @@ export const AssetRunLink: React.FC<{
   runId: string;
   event?: Parameters<typeof linkToRunEvent>[1];
 }> = ({runId, children, event}) => (
-  <Caption>
-    <Link
-      to={event ? linkToRunEvent({runId}, event) : `/runs/${runId}`}
-      target="_blank"
-      rel="noreferrer"
-    >
-      {children || titleForRun({runId})}
-    </Link>
-  </Caption>
+  <Link
+    to={event ? linkToRunEvent({runId}, event) : `/runs/${runId}`}
+    target="_blank"
+    rel="noreferrer"
+  >
+    {children || <CaptionMono>{titleForRun({runId})}</CaptionMono>}
+  </Link>
 );

--- a/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTable.tsx
@@ -1,64 +1,53 @@
-import {gql, RefetchQueriesFunction} from '@apollo/client';
+import {RefetchQueriesFunction} from '@apollo/client';
 import {
   Box,
   Button,
-  Checkbox,
   Colors,
   Icon,
   MenuItem,
   Menu,
   Popover,
-  Table,
-  Mono,
   Tooltip,
+  Checkbox,
+  NonIdealState,
 } from '@dagster-io/ui';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
 
 import {usePermissions} from '../app/Permissions';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
-import {AssetLatestRunWithNotices, AssetRunLink} from '../asset-graph/AssetRunLinking';
-import {LiveData, toGraphId} from '../asset-graph/Utils';
-import {StaleTag} from '../assets/StaleTag';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
-import {RepositoryLink} from '../nav/RepositoryLink';
-import {TimestampDisplay} from '../schedules/TimestampDisplay';
-import {AnchorButton} from '../ui/AnchorButton';
-import {markdownToPlaintext} from '../ui/markdownToPlaintext';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {workspacePathFromAddress} from '../workspace/workspacePath';
+import {AssetGroupSelector} from '../types/globalTypes';
+import {VirtualizedAssetTable} from '../workspace/VirtualizedAssetTable';
 
-import {AssetActionMenu} from './AssetActionMenu';
-import {AssetLink} from './AssetLink';
 import {AssetWipeDialog} from './AssetWipeDialog';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
-import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetTableFragment as Asset} from './types/AssetTableFragment';
 import {AssetViewType} from './useAssetView';
 
 type AssetKey = {path: string[]};
 
-export const AssetTable = ({
-  view,
-  assets,
-  actionBarComponents,
-  refreshState,
-  liveDataByNode,
-  prefixPath,
-  displayPathForAsset,
-  maxDisplayCount,
-  requery,
-}: {
+interface Props {
   view: AssetViewType;
   assets: Asset[];
   refreshState: QueryRefreshState;
   actionBarComponents: React.ReactNode;
-  liveDataByNode: LiveData;
   prefixPath: string[];
   displayPathForAsset: (asset: Asset) => string[];
-  maxDisplayCount?: number;
   requery?: RefetchQueriesFunction;
+  searchPath: string;
+  searchGroup: AssetGroupSelector | null;
+}
+
+export const AssetTable: React.FC<Props> = ({
+  assets,
+  actionBarComponents,
+  refreshState,
+  prefixPath,
+  displayPathForAsset,
+  requery,
+  searchPath,
+  searchGroup,
+  view,
 }) => {
   const [toWipe, setToWipe] = React.useState<AssetKey[] | undefined>();
 
@@ -79,7 +68,7 @@ export const AssetTable = ({
   const checkedAssets: Asset[] = [];
   const checkedPathsOnscreen: string[] = [];
 
-  const pageDisplayPathKeys = Object.keys(groupedByFirstComponent).sort().slice(0, maxDisplayCount);
+  const pageDisplayPathKeys = Object.keys(groupedByFirstComponent).sort();
   pageDisplayPathKeys.forEach((pathKey) => {
     if (checkedPaths.has(pathKey)) {
       checkedPathsOnscreen.push(pathKey);
@@ -87,83 +76,114 @@ export const AssetTable = ({
     }
   });
 
-  return (
-    <Box flex={{direction: 'column'}}>
-      <Box
-        background={Colors.White}
-        flex={{alignItems: 'center', gap: 12}}
-        padding={{vertical: 8, left: 24, right: 12}}
-        style={{position: 'sticky', top: 0, zIndex: 1}}
-      >
-        {actionBarComponents}
-        <div style={{flex: 1}} />
-        <QueryRefreshCountdown refreshState={refreshState} />
-
-        <Box flex={{alignItems: 'center', gap: 8}}>
-          {checkedAssets.some((c) => !c.definition) ? (
-            <Tooltip content="One or more selected assets are not software-defined and cannot be launched directly.">
-              <Button intent="primary" icon={<Icon name="materialization" />} disabled>
-                {checkedAssets.length > 1 ? `Materialize (${checkedAssets.length})` : 'Materialize'}
-              </Button>
-            </Tooltip>
-          ) : (
-            <LaunchAssetExecutionButton
-              scope={{selected: checkedAssets.map((a) => ({...a.definition!, assetKey: a.key}))}}
+  const content = () => {
+    if (!assets.length) {
+      if (searchPath) {
+        return (
+          <Box padding={{top: 64}}>
+            <NonIdealState
+              icon="search"
+              title="No matching assets"
+              description={
+                searchGroup ? (
+                  <div>
+                    No assets matching <strong>{searchPath}</strong> were found in{' '}
+                    <strong>{searchGroup.groupName}</strong>
+                  </div>
+                ) : (
+                  <div>
+                    No assets matching <strong>{searchPath}</strong> were found
+                  </div>
+                )
+              }
             />
-          )}
-          <MoreActionsDropdown selected={checkedAssets} clearSelection={() => onToggleAll(false)} />
+          </Box>
+        );
+      }
+
+      return (
+        <Box padding={{top: 20}}>
+          <NonIdealState
+            icon="search"
+            title="No assets"
+            description={
+              searchGroup ? (
+                <div>
+                  No assets were found in <strong>{searchGroup.groupName}</strong>
+                </div>
+              ) : (
+                'No assets were found'
+              )
+            }
+          />
         </Box>
-      </Box>
-      <Table>
-        <thead>
-          <tr>
-            <th style={{width: 42, paddingTop: 0, paddingBottom: 0}}>
-              <Checkbox
-                indeterminate={
-                  checkedPathsOnscreen.length > 0 &&
-                  checkedPathsOnscreen.length !== pageDisplayPathKeys.length
-                }
-                checked={
-                  checkedPathsOnscreen.length > 0 &&
-                  checkedPathsOnscreen.length === pageDisplayPathKeys.length
-                }
-                onChange={(e) => {
-                  if (e.target instanceof HTMLInputElement) {
-                    onToggleAll(checkedPathsOnscreen.length !== pageDisplayPathKeys.length);
-                  }
-                }}
+      );
+    }
+
+    return (
+      <VirtualizedAssetTable
+        headerCheckbox={
+          <Checkbox
+            indeterminate={
+              checkedPathsOnscreen.length > 0 &&
+              checkedPathsOnscreen.length !== pageDisplayPathKeys.length
+            }
+            checked={
+              checkedPathsOnscreen.length > 0 &&
+              checkedPathsOnscreen.length === pageDisplayPathKeys.length
+            }
+            onChange={(e) => {
+              if (e.target instanceof HTMLInputElement) {
+                onToggleAll(checkedPathsOnscreen.length !== pageDisplayPathKeys.length);
+              }
+            }}
+          />
+        }
+        prefixPath={prefixPath}
+        groups={groupedByFirstComponent}
+        checkedPaths={checkedPaths}
+        onToggleFactory={onToggleFactory}
+        showRepoColumn
+        view={view}
+        onWipe={(assets: Asset[]) => setToWipe(assets.map((asset) => asset.key))}
+      />
+    );
+  };
+
+  return (
+    <>
+      <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+        <Box
+          background={Colors.White}
+          flex={{alignItems: 'center', gap: 12}}
+          padding={{vertical: 8, left: 24, right: 12}}
+          style={{position: 'sticky', top: 0, zIndex: 1}}
+        >
+          {actionBarComponents}
+          <div style={{flex: 1}} />
+          <QueryRefreshCountdown refreshState={refreshState} />
+          <Box flex={{alignItems: 'center', gap: 8}}>
+            {checkedAssets.some((c) => !c.definition) ? (
+              <Tooltip content="One or more selected assets are not software-defined and cannot be launched directly.">
+                <Button intent="primary" icon={<Icon name="materialization" />} disabled>
+                  {checkedAssets.length > 1
+                    ? `Materialize (${checkedAssets.length.toLocaleString()})`
+                    : 'Materialize'}
+                </Button>
+              </Tooltip>
+            ) : (
+              <LaunchAssetExecutionButton
+                scope={{selected: checkedAssets.map((a) => ({...a.definition!, assetKey: a.key}))}}
               />
-            </th>
-            <th style={{minWidth: 300}}>
-              {view === 'directory' ? 'Asset key prefix' : 'Asset key'}
-            </th>
-            <th style={{width: 340}}>Defined in</th>
-            <th style={{width: 265}}>Materialized</th>
-            <th style={{width: 215}}>Latest run</th>
-            <th style={{width: 80}}>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {pageDisplayPathKeys.length ? (
-            pageDisplayPathKeys.map((pathStr, idx) => {
-              return (
-                <AssetEntryRow
-                  key={idx}
-                  prefixPath={prefixPath}
-                  path={JSON.parse(pathStr)}
-                  assets={groupedByFirstComponent[pathStr] || []}
-                  liveDataByNode={liveDataByNode}
-                  isSelected={checkedPaths.has(pathStr)}
-                  onToggleChecked={onToggleFactory(pathStr)}
-                  onWipe={(assets: Asset[]) => setToWipe(assets.map((asset) => asset.key))}
-                />
-              );
-            })
-          ) : (
-            <AssetEmptyRow />
-          )}
-        </tbody>
-      </Table>
+            )}
+            <MoreActionsDropdown
+              selected={checkedAssets}
+              clearSelection={() => onToggleAll(false)}
+            />
+          </Box>
+        </Box>
+        {content()}
+      </Box>
       <AssetWipeDialog
         assetKeys={toWipe || []}
         isOpen={!!toWipe}
@@ -171,136 +191,9 @@ export const AssetTable = ({
         onComplete={() => setToWipe(undefined)}
         requery={requery}
       />
-    </Box>
+    </>
   );
 };
-
-const AssetEmptyRow = () => {
-  return (
-    <tr>
-      <td colSpan={6}>
-        <Box flex={{justifyContent: 'center', alignItems: 'center'}}>
-          <Box margin={{left: 8}}>No assets to display</Box>
-        </Box>
-      </td>
-    </tr>
-  );
-};
-
-const AssetEntryRow: React.FC<{
-  prefixPath: string[];
-  path: string[];
-  isSelected: boolean;
-  onToggleChecked: (values: {checked: boolean; shiftKey: boolean}) => void;
-  assets: Asset[];
-  liveDataByNode: LiveData;
-  onWipe: (assets: Asset[]) => void;
-}> = React.memo(
-  ({prefixPath, path, assets, isSelected, onToggleChecked, onWipe, liveDataByNode}) => {
-    const fullPath = [...prefixPath, ...path];
-    const linkUrl = assetDetailsPathForKey({path: fullPath});
-
-    const isGroup = assets.length > 1 || fullPath.join('/') !== assets[0].key.path.join('/');
-    const asset = !isGroup ? assets[0] : null;
-
-    const onChange = (e: React.FormEvent<HTMLInputElement>) => {
-      if (e.target instanceof HTMLInputElement) {
-        const {checked} = e.target;
-        const shiftKey =
-          e.nativeEvent instanceof MouseEvent && e.nativeEvent.getModifierState('Shift');
-        onToggleChecked({checked, shiftKey});
-      }
-    };
-
-    const liveData = asset && liveDataByNode[toGraphId(asset.key)];
-    const repoAddress = asset?.definition
-      ? buildRepoAddress(
-          asset.definition.repository.name,
-          asset.definition.repository.location.name,
-        )
-      : null;
-
-    return (
-      <tr>
-        <td style={{paddingRight: 8}}>
-          <Checkbox checked={isSelected} onChange={onChange} />
-        </td>
-        <td>
-          <AssetLink
-            path={path}
-            url={linkUrl}
-            isGroup={isGroup}
-            icon={isGroup ? 'folder' : asset?.definition ? 'asset' : 'asset_non_sda'}
-          />
-          <Description>
-            {asset?.definition &&
-              asset.definition.description &&
-              markdownToPlaintext(asset.definition.description).split('\n')[0]}
-          </Description>
-        </td>
-        <td>
-          {repoAddress && (
-            <Box flex={{direction: 'column', gap: 4}}>
-              <RepositoryLink showIcon showRefresh={false} repoAddress={repoAddress} />
-              {asset?.definition && asset?.definition.groupName ? (
-                <Link
-                  to={workspacePathFromAddress(
-                    repoAddress,
-                    `/asset-groups/${asset.definition.groupName}`,
-                  )}
-                >
-                  <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-                    <Icon color={Colors.Gray400} name="asset_group" /> {asset.definition.groupName}
-                  </Box>
-                </Link>
-              ) : undefined}
-            </Box>
-          )}
-        </td>
-        <td>
-          {liveData ? (
-            <Box flex={{gap: 8, alignItems: 'center', justifyContent: 'space-between'}}>
-              {liveData.lastMaterialization ? (
-                <Mono style={{flex: 1}}>
-                  <AssetRunLink
-                    runId={liveData.lastMaterialization.runId}
-                    event={{
-                      stepKey: liveData.stepKey,
-                      timestamp: liveData.lastMaterialization.timestamp,
-                    }}
-                  >
-                    <TimestampDisplay
-                      timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
-                      timeFormat={{showSeconds: false, showTimezone: false}}
-                    />
-                  </AssetRunLink>
-                </Mono>
-              ) : (
-                <span>–</span>
-              )}
-              <StaleTag liveData={liveData} />
-            </Box>
-          ) : undefined}
-        </td>
-        <td>
-          {liveData && (
-            <AssetLatestRunWithNotices liveData={liveData} includeFreshness includeRunStatus />
-          )}
-        </td>
-        <td>
-          {asset ? (
-            <Box flex={{gap: 8, alignItems: 'center'}}>
-              <AnchorButton to={assetDetailsPathForKey({path})}>View details</AnchorButton>
-              <AssetActionMenu repoAddress={repoAddress} asset={asset} onWipe={onWipe} />
-            </Box>
-          ) : (
-            <span />
-          )}
-        </td>
-      </tr>
-    );
-  },
-);
 
 const MoreActionsDropdown: React.FC<{
   selected: Asset[];
@@ -347,43 +240,3 @@ const MoreActionsDropdown: React.FC<{
     </>
   );
 });
-
-export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
-  fragment AssetTableDefinitionFragment on AssetNode {
-    id
-    groupName
-    isSource
-    partitionDefinition {
-      description
-    }
-    description
-    repository {
-      id
-      name
-      location {
-        id
-        name
-      }
-    }
-  }
-`;
-
-export const ASSET_TABLE_FRAGMENT = gql`
-  fragment AssetTableFragment on Asset {
-    __typename
-    id
-    key {
-      path
-    }
-    definition {
-      id
-      ...AssetTableDefinitionFragment
-    }
-  }
-  ${ASSET_TABLE_DEFINITION_FRAGMENT}
-`;
-
-const Description = styled.div`
-  color: ${Colors.Gray800};
-  font-size: 14px;
-`;

--- a/js_modules/dagit/packages/core/src/assets/AssetTableFragment.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTableFragment.tsx
@@ -1,0 +1,36 @@
+import {gql} from '@apollo/client';
+
+export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
+  fragment AssetTableDefinitionFragment on AssetNode {
+    id
+    groupName
+    isSource
+    partitionDefinition {
+      description
+    }
+    description
+    repository {
+      id
+      name
+      location {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const ASSET_TABLE_FRAGMENT = gql`
+  fragment AssetTableFragment on Asset {
+    __typename
+    id
+    key {
+      path
+    }
+    definition {
+      id
+      ...AssetTableDefinitionFragment
+    }
+  }
+  ${ASSET_TABLE_DEFINITION_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Page, Spinner} from '@dagster-io/ui';
+import {Box, Colors, Page, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import {useHistory} from 'react-router';
 import {useParams} from 'react-router-dom';
@@ -42,33 +42,44 @@ export const AssetsCatalogRoot = () => {
       : 'Assets',
   );
 
-  return queryResult.loading ? (
-    <Page>
-      <AssetPageHeader assetKey={{path: currentPath}} />
-      <Box padding={64}>
-        <Spinner purpose="page" />
-      </Box>
-    </Page>
-  ) : currentPath.length === 0 ||
-    queryResult.data?.assetOrError.__typename === 'AssetNotFoundError' ? (
-    <Page>
-      <AssetPageHeader
-        assetKey={{path: currentPath}}
-        right={
-          <Box flex={{gap: 12, alignItems: 'center'}}>
-            <AssetGlobalLineageLink />
-            <ReloadAllButton label="Reload definitions" />
+  if (queryResult.loading) {
+    return (
+      <Page>
+        <AssetPageHeader assetKey={{path: currentPath}} />
+        <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
+            <Spinner purpose="body-text" />
+            <div style={{color: Colors.Gray600}}>Loading assets…</div>
           </Box>
-        }
-      />
-      <AssetsCatalogTable
-        prefixPath={currentPath}
-        setPrefixPath={(prefixPath) => history.push(assetDetailsPathForKey({path: prefixPath}))}
-      />
-    </Page>
-  ) : (
-    <AssetView assetKey={{path: currentPath}} />
-  );
+        </Box>
+      </Page>
+    );
+  }
+
+  if (
+    currentPath.length === 0 ||
+    queryResult.data?.assetOrError.__typename === 'AssetNotFoundError'
+  ) {
+    return (
+      <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+        <AssetPageHeader
+          assetKey={{path: currentPath}}
+          right={
+            <Box flex={{gap: 12, alignItems: 'center'}}>
+              <AssetGlobalLineageLink />
+              <ReloadAllButton label="Reload definitions" />
+            </Box>
+          }
+        />
+        <AssetsCatalogTable
+          prefixPath={currentPath}
+          setPrefixPath={(prefixPath) => history.push(assetDetailsPathForKey({path: prefixPath}))}
+        />
+      </Box>
+    );
+  }
+
+  return <AssetView assetKey={{path: currentPath}} />;
 };
 
 // Imported via React.lazy, which requires a default export.

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -1,33 +1,21 @@
 import {gql, QueryResult, useQuery} from '@apollo/client';
-import {
-  Box,
-  CursorPaginationControls,
-  CursorPaginationProps,
-  TextInput,
-  Suggest,
-  MenuItem,
-  Icon,
-  ButtonGroup,
-} from '@dagster-io/ui';
+import {Box, TextInput, Suggest, MenuItem, Icon, ButtonGroup} from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import uniqBy from 'lodash/uniqBy';
 import * as React from 'react';
-import styled from 'styled-components/macro';
 
 import {PythonErrorInfo, PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
-import {FIFTEEN_SECONDS, useMergedRefresh, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment';
-import {useLiveDataForAssetKeys} from '../asset-graph/useLiveDataForAssetKeys';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {AssetGroupSelector} from '../types/globalTypes';
 import {ClearButton} from '../ui/ClearButton';
 import {LoadingSpinner} from '../ui/Loading';
-import {StickyTableContainer} from '../ui/StickyTableContainer';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 
-import {AssetTable, ASSET_TABLE_DEFINITION_FRAGMENT, ASSET_TABLE_FRAGMENT} from './AssetTable';
+import {AssetTable} from './AssetTable';
+import {ASSET_TABLE_DEFINITION_FRAGMENT, ASSET_TABLE_FRAGMENT} from './AssetTableFragment';
 import {AssetsEmptyState} from './AssetsEmptyState';
-import {AssetKey} from './types';
 import {
   AssetCatalogGroupTableQuery,
   AssetCatalogGroupTableQueryVariables,
@@ -40,8 +28,6 @@ import {
 import {AssetTableFragment} from './types/AssetTableFragment';
 import {useAssetSearch} from './useAssetSearch';
 import {AssetViewType, useAssetView} from './useAssetView';
-
-const PAGE_SIZE = 50;
 
 type Asset = AssetCatalogTableQuery_assetsOrError_AssetConnection_nodes;
 
@@ -96,7 +82,6 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
   groupSelector,
 }) => {
   const [view, setView] = useAssetView();
-  const [cursor, setCursor] = useQueryPersistedState<string | undefined>({queryKey: 'cursor'});
   const [search, setSearch] = useQueryPersistedState<string | undefined>({queryKey: 'q'});
   const [searchGroup, setSearchGroup] = useQueryPersistedState<AssetGroupSelector | null>({
     queryKey: 'g',
@@ -118,23 +103,12 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
     [pathMatches, searchGroup],
   );
 
-  const {displayPathForAsset, displayed, nextCursor, prevCursor} =
+  const {displayPathForAsset, displayed} =
     view === 'flat'
-      ? buildFlatProps(filtered, prefixPath, cursor)
-      : buildNamespaceProps(filtered, prefixPath, cursor);
+      ? buildFlatProps(filtered, prefixPath)
+      : buildNamespaceProps(filtered, prefixPath);
 
-  const displayedKeys = React.useMemo(
-    () => displayed.map<AssetKey>((a) => ({path: a.key.path})),
-    [displayed],
-  );
-  const {liveDataByNode, liveDataRefreshState, runWatchers} = useLiveDataForAssetKeys(
-    displayedKeys,
-  );
-
-  const refreshState = useMergedRefresh(
-    useQueryRefreshAtInterval(query, FIFTEEN_SECONDS),
-    liveDataRefreshState,
-  );
+  const refreshState = useQueryRefreshAtInterval(query, FIFTEEN_SECONDS);
 
   React.useEffect(() => {
     if (view !== 'directory' && prefixPath.length) {
@@ -145,9 +119,11 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
   if (error) {
     return <PythonErrorInfo error={error} />;
   }
+
   if (!assets) {
     return <LoadingSpinner purpose="page" />;
   }
+
   if (!assets.length) {
     return (
       <Box padding={{vertical: 64}}>
@@ -156,66 +132,47 @@ export const AssetsCatalogTable: React.FC<AssetCatalogTableProps> = ({
     );
   }
 
-  const paginationProps: CursorPaginationProps = {
-    hasPrevCursor: !!prevCursor,
-    hasNextCursor: !!nextCursor,
-    popCursor: () => setCursor(prevCursor),
-    advanceCursor: () => setCursor(nextCursor),
-    reset: () => {
-      setCursor(undefined);
-    },
-  };
-
   return (
-    <Wrapper>
-      {runWatchers}
-      {/* 48px allows for the toolbar to be sticky as well */}
-      <StickyTableContainer $top={48}>
-        <AssetTable
-          view={view}
-          assets={displayed}
-          liveDataByNode={liveDataByNode}
-          actionBarComponents={
-            <>
-              <ButtonGroup<AssetViewType>
-                activeItems={new Set([view])}
-                buttons={[
-                  {id: 'flat', icon: 'view_list', tooltip: 'List view'},
-                  {id: 'directory', icon: 'folder', tooltip: 'Folder view'},
-                ]}
-                onClick={(view) => {
-                  setView(view);
-                  if (view === 'flat' && prefixPath.length) {
-                    setPrefixPath([]);
-                  }
-                }}
-              />
-              <TextInput
-                value={search || ''}
-                style={{width: '30vw', minWidth: 150, maxWidth: 400}}
-                placeholder={
-                  prefixPath.length
-                    ? `Filter asset keys in ${prefixPath.join('/')}…`
-                    : `Filter asset keys…`
-                }
-                onChange={(e: React.ChangeEvent<any>) => setSearch(e.target.value)}
-              />
-              {!groupSelector ? (
-                <AssetGroupSuggest assets={assets} value={searchGroup} onChange={setSearchGroup} />
-              ) : undefined}
-            </>
-          }
-          refreshState={refreshState}
-          prefixPath={prefixPath || []}
-          displayPathForAsset={displayPathForAsset}
-          maxDisplayCount={PAGE_SIZE}
-          requery={(_) => [{query: ASSET_CATALOG_TABLE_QUERY}]}
-        />
-      </StickyTableContainer>
-      <Box padding={{bottom: 64}}>
-        <CursorPaginationControls {...paginationProps} />
-      </Box>
-    </Wrapper>
+    <AssetTable
+      view={view}
+      assets={displayed}
+      actionBarComponents={
+        <>
+          <ButtonGroup<AssetViewType>
+            activeItems={new Set([view])}
+            buttons={[
+              {id: 'flat', icon: 'view_list', tooltip: 'List view'},
+              {id: 'directory', icon: 'folder', tooltip: 'Folder view'},
+            ]}
+            onClick={(view) => {
+              setView(view);
+              if (view === 'flat' && prefixPath.length) {
+                setPrefixPath([]);
+              }
+            }}
+          />
+          <TextInput
+            value={search || ''}
+            style={{width: '30vw', minWidth: 150, maxWidth: 400}}
+            placeholder={
+              prefixPath.length
+                ? `Filter asset keys in ${prefixPath.join('/')}…`
+                : `Filter asset keys…`
+            }
+            onChange={(e: React.ChangeEvent<any>) => setSearch(e.target.value)}
+          />
+          {!groupSelector ? (
+            <AssetGroupSuggest assets={assets} value={searchGroup} onChange={setSearchGroup} />
+          ) : undefined}
+        </>
+      }
+      refreshState={refreshState}
+      prefixPath={prefixPath || []}
+      searchPath={searchPath}
+      searchGroup={searchGroup}
+      displayPathForAsset={displayPathForAsset}
+      requery={(_) => [{query: ASSET_CATALOG_TABLE_QUERY}]}
+    />
   );
 };
 
@@ -286,16 +243,6 @@ const AssetGroupSuggest: React.FC<{
     />
   );
 };
-const Wrapper = styled.div`
-  flex: 1 1;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  min-width: 0;
-  position: relative;
-  z-index: 0;
-`;
 
 const ASSET_CATALOG_TABLE_QUERY = gql`
   query AssetCatalogTableQuery {
@@ -330,7 +277,6 @@ const ASSET_CATALOG_GROUP_TABLE_QUERY = gql`
 // When we load the AssetCatalogTable for a particular asset group, we retrieve `assetNodes`,
 // not `assets`. To narrow the scope of this difference we coerce the nodes to look like
 // AssetCatalogTableQuery results.
-//
 function definitionToAssetTableFragment(
   definition: AssetCatalogGroupTableQuery_assetNodes,
 ): AssetTableFragment {
@@ -347,21 +293,14 @@ function buildAssetGroupSelector(a: Asset) {
     : null;
 }
 
-function buildFlatProps(assets: Asset[], prefixPath: string[], cursor: string | undefined) {
-  const cursorValue = (asset: Asset) => JSON.stringify([...prefixPath, ...asset.key.path]);
-  const cursorIndex = cursor ? assets.findIndex((ns) => cursor <= cursorValue(ns)) : 0;
-  const prevPageIndex = Math.max(0, cursorIndex - PAGE_SIZE);
-  const nextPageIndex = cursorIndex + PAGE_SIZE;
-
+function buildFlatProps(assets: Asset[], _: string[]) {
   return {
-    displayed: assets.slice(cursorIndex, cursorIndex + PAGE_SIZE),
+    displayed: assets,
     displayPathForAsset: (asset: Asset) => asset.key.path,
-    prevCursor: cursorIndex > 0 ? cursorValue(assets[prevPageIndex]) : undefined,
-    nextCursor: nextPageIndex < assets.length ? cursorValue(assets[nextPageIndex]) : undefined,
   };
 }
 
-function buildNamespaceProps(assets: Asset[], prefixPath: string[], cursor: string | undefined) {
+function buildNamespaceProps(assets: Asset[], prefixPath: string[]) {
   // Return all assets from the next PAGE_SIZE namespaces - the AssetTable component will later
   // group them by namespace
 
@@ -380,33 +319,11 @@ function buildNamespaceProps(assets: Asset[], prefixPath: string[], cursor: stri
     .map((x) => JSON.parse(x))
     .sort();
 
-  const cursorValue = (ns: string[]) => JSON.stringify([...prefixPath, ...ns]);
-  const cursorIndex = cursor ? namespaces.findIndex((ns) => cursor <= cursorValue(ns)) : 0;
-
-  if (cursorIndex === -1) {
-    return {
-      displayPathForAsset: namespaceForAsset,
-      displayed: [],
-      prevCursor: undefined,
-      nextCursor: undefined,
-    };
-  }
-
-  const namespaceSlice = namespaces.slice(cursorIndex, cursorIndex + PAGE_SIZE);
-
-  const prevPageIndex = Math.max(0, cursorIndex - PAGE_SIZE);
-  const prevCursor = cursorIndex !== 0 ? cursorValue(namespaces[prevPageIndex]) : undefined;
-  const nextPageIndex = cursorIndex + PAGE_SIZE;
-  const nextCursor =
-    namespaces.length > nextPageIndex ? cursorValue(namespaces[nextPageIndex]) : undefined;
-
   return {
-    nextCursor,
-    prevCursor,
     displayPathForAsset: namespaceForAsset,
     displayed: filterAssetsByNamespace(
       assetsWithPathPrefix,
-      namespaceSlice.map((ns) => [...prefixPath, ...ns]),
+      namespaces.map((ns) => [...prefixPath, ...ns]),
     ),
   };
 }

--- a/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
@@ -30,7 +30,7 @@ export const CurrentMinutesLateTag: React.FC<{
   const description = policyOnHover ? freshnessPolicyDescription(freshnessPolicy) : '';
 
   if (!freshnessInfo) {
-    return <span />;
+    return null;
   }
 
   if (freshnessInfo.currentMinutesLate === null) {

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -1,0 +1,281 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {Box, Caption, Checkbox, Colors, Icon} from '@dagster-io/ui';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {ASSET_NODE_LIVE_FRAGMENT} from '../asset-graph/AssetNode';
+import {AssetLatestRunWithNotices, AssetRunLink} from '../asset-graph/AssetRunLinking';
+import {buildLiveDataForNode} from '../asset-graph/Utils';
+import {ASSET_LATEST_INFO_FRAGMENT} from '../asset-graph/useLiveDataForAssetKeys';
+import {AssetActionMenu} from '../assets/AssetActionMenu';
+import {AssetLink} from '../assets/AssetLink';
+import {ASSET_TABLE_FRAGMENT} from '../assets/AssetTableFragment';
+import {StaleTag} from '../assets/StaleTag';
+import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {AssetTableFragment} from '../assets/types/AssetTableFragment';
+import {AssetViewType} from '../assets/useAssetView';
+import {RepositoryLink} from '../nav/RepositoryLink';
+import {TimestampDisplay} from '../schedules/TimestampDisplay';
+import {HeaderCell, Row, RowCell} from '../ui/VirtualizedTable';
+
+import {LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
+import {RepoAddress} from './types';
+import {SingleAssetQuery, SingleAssetQueryVariables} from './types/SingleAssetQuery';
+import {workspacePathFromAddress} from './workspacePath';
+
+const TEMPLATE_COLUMNS = '1.3fr 1fr 1fr 80px';
+const TEMPLATE_COLUMNS_FOR_CATALOG = '76px 1.3fr 1.3fr 1fr 1fr 80px';
+
+interface AssetRowProps {
+  checked: boolean;
+  type: 'folder' | 'asset' | 'asset_non_sda';
+  view?: AssetViewType;
+  onToggleChecked: (values: {checked: boolean; shiftKey: boolean}) => void;
+  showCheckboxColumn: boolean;
+  showRepoColumn: boolean;
+  path: string[];
+  repoAddress: RepoAddress | null;
+  height: number;
+  start: number;
+  onWipe: (assets: AssetTableFragment[]) => void;
+}
+
+export const VirtualizedAssetRow = (props: AssetRowProps) => {
+  const {
+    path,
+    type,
+    repoAddress,
+    start,
+    height,
+    checked,
+    onToggleChecked,
+    onWipe,
+    showCheckboxColumn = false,
+    showRepoColumn,
+    view = 'flat',
+  } = props;
+
+  const [queryAsset, queryResult] = useLazyQuery<SingleAssetQuery, SingleAssetQueryVariables>(
+    SINGLE_ASSET_QUERY,
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: {input: {path}},
+    },
+  );
+
+  useDelayedRowQuery(queryAsset);
+  const {data} = queryResult;
+
+  const onChange = (e: React.FormEvent<HTMLInputElement>) => {
+    if (onToggleChecked && e.target instanceof HTMLInputElement) {
+      const {checked} = e.target;
+      const shiftKey =
+        e.nativeEvent instanceof MouseEvent && e.nativeEvent.getModifierState('Shift');
+      onToggleChecked({checked, shiftKey});
+    }
+  };
+
+  const asset = React.useMemo(() => {
+    if (data?.assetOrError.__typename === 'Asset') {
+      return data.assetOrError;
+    }
+    return null;
+  }, [data]);
+
+  const liveData = React.useMemo(() => {
+    if (asset?.definition && data?.assetsLatestInfo) {
+      const latestInfoForAsset = data.assetsLatestInfo[0];
+      if (latestInfoForAsset) {
+        return buildLiveDataForNode(asset.definition, latestInfoForAsset);
+      }
+    }
+    return null;
+  }, [data, asset]);
+
+  const linkUrl = assetDetailsPathForKey({path});
+
+  return (
+    <Row $height={height} $start={start}>
+      <RowGrid
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        $showRepoColumn={showRepoColumn}
+      >
+        {showCheckboxColumn ? (
+          <RowCell>
+            <Checkbox checked={checked} onChange={onChange} />
+          </RowCell>
+        ) : null}
+        <RowCell>
+          <div style={{maxWidth: '100%'}}>
+            <AssetLink
+              path={type === 'folder' || view === 'directory' ? path.slice(-1) : path}
+              url={linkUrl}
+              isGroup={type === 'folder'}
+              icon={type}
+              textStyle="middle-truncate"
+            />
+          </div>
+          <div
+            style={{
+              maxWidth: '100%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            <Caption
+              style={{
+                color: Colors.Gray500,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {asset?.definition?.description}
+            </Caption>
+          </div>
+        </RowCell>
+        {showRepoColumn ? (
+          <RowCell>
+            {repoAddress ? (
+              <Box
+                flex={{direction: 'column', gap: 4}}
+                style={{maxWidth: '100%', overflow: 'hidden'}}
+              >
+                <RepositoryLink repoAddress={repoAddress} showIcon showRefresh={false} />
+                {asset?.definition && asset?.definition.groupName ? (
+                  <Link
+                    to={workspacePathFromAddress(
+                      repoAddress,
+                      `/asset-groups/${asset.definition.groupName}`,
+                    )}
+                  >
+                    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                      <Icon color={Colors.Gray400} name="asset_group" />
+                      {asset.definition.groupName}
+                    </Box>
+                  </Link>
+                ) : null}
+              </Box>
+            ) : (
+              <span>{'\u2013'}</span>
+            )}
+          </RowCell>
+        ) : null}
+        <RowCell>
+          {liveData?.lastMaterialization ? (
+            <Box flex={{gap: 4, alignItems: 'flex-start', justifyContent: 'space-between'}}>
+              <AssetRunLink
+                runId={liveData.lastMaterialization.runId}
+                event={{
+                  stepKey: liveData.stepKey,
+                  timestamp: liveData.lastMaterialization.timestamp,
+                }}
+              >
+                <TimestampDisplay
+                  timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
+                  timeFormat={{showSeconds: false, showTimezone: false}}
+                />
+              </AssetRunLink>
+              <div style={{marginTop: '-2px'}}>
+                <StaleTag liveData={liveData} />
+              </div>
+            </Box>
+          ) : (
+            <LoadingOrNone queryResult={queryResult} noneString={'\u2013'} />
+          )}
+        </RowCell>
+        <RowCell>
+          {liveData ? (
+            <AssetLatestRunWithNotices liveData={liveData} includeFreshness includeRunStatus />
+          ) : (
+            <LoadingOrNone queryResult={queryResult} noneString={'\u2013'} />
+          )}
+        </RowCell>
+        <RowCell>
+          {asset ? (
+            <AssetActionMenu repoAddress={repoAddress} asset={asset} onWipe={onWipe} />
+          ) : null}
+        </RowCell>
+      </RowGrid>
+    </Row>
+  );
+};
+
+export const VirtualizedAssetCatalogHeader: React.FC<{
+  headerCheckbox: React.ReactNode;
+  view: AssetViewType;
+}> = ({headerCheckbox, view}) => {
+  return (
+    <Box
+      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: TEMPLATE_COLUMNS_FOR_CATALOG,
+        height: '32px',
+        fontSize: '12px',
+        color: Colors.Gray600,
+      }}
+    >
+      <HeaderCell>{headerCheckbox}</HeaderCell>
+      <HeaderCell>{view === 'flat' ? 'Asset name' : 'Asset key prefix'}</HeaderCell>
+      <HeaderCell>Repository / Asset group</HeaderCell>
+      <HeaderCell>Materialized</HeaderCell>
+      <HeaderCell>Latest run</HeaderCell>
+      <HeaderCell></HeaderCell>
+    </Box>
+  );
+};
+
+export const VirtualizedAssetHeader: React.FC<{
+  nameLabel: React.ReactNode;
+}> = ({nameLabel}) => {
+  return (
+    <Box
+      border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: TEMPLATE_COLUMNS,
+        height: '32px',
+        fontSize: '12px',
+        color: Colors.Gray600,
+      }}
+    >
+      <HeaderCell>{nameLabel}</HeaderCell>
+      <HeaderCell>Materialized</HeaderCell>
+      <HeaderCell>Latest run</HeaderCell>
+      <HeaderCell></HeaderCell>
+    </Box>
+  );
+};
+
+const RowGrid = styled(Box)<{$showRepoColumn: boolean}>`
+  display: grid;
+  grid-template-columns: ${({$showRepoColumn}) =>
+    $showRepoColumn ? TEMPLATE_COLUMNS_FOR_CATALOG : TEMPLATE_COLUMNS};
+  height: 100%;
+`;
+
+const SINGLE_ASSET_QUERY = gql`
+  query SingleAssetQuery($input: AssetKeyInput!) {
+    assetOrError(assetKey: $input) {
+      ... on Asset {
+        id
+        assetMaterializations(limit: 1) {
+          runId
+          timestamp
+        }
+        ...AssetTableFragment
+        definition {
+          id
+          ...AssetNodeLiveFragment
+        }
+      }
+    }
+    assetsLatestInfo(assetKeys: [$input]) {
+      ...AssetLatestInfoFragment
+    }
+  }
+
+  ${ASSET_TABLE_FRAGMENT}
+  ${ASSET_NODE_LIVE_FRAGMENT}
+  ${ASSET_LATEST_INFO_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -1,129 +1,101 @@
-import {gql, useLazyQuery} from '@apollo/client';
-import {Box, Caption, Colors, Icon, IconWrapper, Tag} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
-import {Link} from 'react-router-dom';
-import styled from 'styled-components/macro';
 
-import {AppContext} from '../app/AppContext';
-import {ASSET_NODE_LIVE_FRAGMENT} from '../asset-graph/AssetNode';
-import {AssetLatestRunWithNotices, AssetRunLink} from '../asset-graph/AssetRunLinking';
-import {buildLiveDataForNode} from '../asset-graph/Utils';
-import {ASSET_LATEST_INFO_FRAGMENT} from '../asset-graph/useLiveDataForAssetKeys';
-import {AssetActionMenu} from '../assets/AssetActionMenu';
-import {AssetLink} from '../assets/AssetLink';
-import {ASSET_TABLE_FRAGMENT} from '../assets/AssetTable';
-import {StaleTag} from '../assets/StaleTag';
-import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {useStateWithStorage} from '../hooks/useStateWithStorage';
-import {TimestampDisplay} from '../schedules/TimestampDisplay';
-import {Container, HeaderCell, Inner, Row, RowCell} from '../ui/VirtualizedTable';
+import {AssetTableFragment} from '../assets/types/AssetTableFragment';
+import {AssetViewType} from '../assets/useAssetView';
+import {Container, Inner} from '../ui/VirtualizedTable';
 
-import {LoadingOrNone, useDelayedRowQuery} from './VirtualizedWorkspaceTable';
-import {repoAddressAsHumanString} from './repoAddressAsString';
-import {RepoAddress} from './types';
-import {SingleAssetQuery, SingleAssetQueryVariables} from './types/SingleAssetQuery';
-import {workspacePathFromAddress} from './workspacePath';
+import {VirtualizedAssetCatalogHeader, VirtualizedAssetRow} from './VirtualizedAssetRow';
+import {buildRepoAddress} from './buildRepoAddress';
 
-type Asset = {id: string; groupName: string | null; assetKey: {path: string[]}};
+type Row =
+  | {type: 'asset'; path: string[]; asset: AssetTableFragment}
+  | {type: 'folder'; path: string[]; assets: AssetTableFragment[]};
 
 interface Props {
-  repoAddress: RepoAddress;
-  assets: Asset[];
+  headerCheckbox: React.ReactNode;
+  prefixPath: string[];
+  groups: {[path: string]: AssetTableFragment[]};
+  checkedPaths: Set<string>;
+  onToggleFactory: (path: string) => (values: {checked: boolean; shiftKey: boolean}) => void;
+  onWipe: (assets: AssetTableFragment[]) => void;
+  showRepoColumn: boolean;
+  view?: AssetViewType;
 }
 
-type RowType =
-  | {type: 'group'; name: string; assetCount: number}
-  | {type: 'asset'; id: string; path: string[]};
-
-const UNGROUPED_NAME = 'UNGROUPED';
-const ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY = 'assets-virtualized-expansion-state';
-
-export const VirtualizedAssetTable: React.FC<Props> = ({repoAddress, assets}) => {
+export const VirtualizedAssetTable: React.FC<Props> = (props) => {
+  const {
+    headerCheckbox,
+    prefixPath,
+    groups,
+    checkedPaths,
+    onToggleFactory,
+    onWipe,
+    showRepoColumn,
+    view = 'flat',
+  } = props;
   const parentRef = React.useRef<HTMLDivElement | null>(null);
-  const repoKey = repoAddressAsHumanString(repoAddress);
-  const {expandedKeys, onToggle} = useAssetGroupExpansionState(
-    `${repoKey}-${ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY}`,
-  );
-
-  const grouped: {[key: string]: Asset[]} = React.useMemo(() => {
-    const groups = {};
-    for (const asset of assets) {
-      const groupName = asset.groupName || UNGROUPED_NAME;
-      const assetsForGroup = groups[groupName] || [];
-      groups[groupName] = [...assetsForGroup, asset];
-    }
-    return groups;
-  }, [assets]);
-
-  const flattened: RowType[] = React.useMemo(() => {
-    const flat: RowType[] = [];
-    Object.keys(grouped).forEach((groupName) => {
-      const assetsForGroup = grouped[groupName];
-      flat.push({type: 'group', name: groupName, assetCount: assetsForGroup.length});
-      if (expandedKeys.includes(groupName)) {
-        assetsForGroup.forEach(({id, assetKey}) => {
-          flat.push({type: 'asset', id, path: assetKey.path});
-        });
-      }
-    });
-    return flat;
-  }, [grouped, expandedKeys]);
+  const count = Object.keys(groups).length;
 
   const rowVirtualizer = useVirtualizer({
-    count: flattened.length,
+    count,
     getScrollElement: () => parentRef.current,
-    estimateSize: (ii: number) => {
-      const row = flattened[ii];
-      return row?.type === 'group' ? 48 : 64;
-    },
+    estimateSize: () => 64,
     overscan: 10,
   });
 
   const totalHeight = rowVirtualizer.getTotalSize();
   const items = rowVirtualizer.getVirtualItems();
 
+  const rows: Row[] = React.useMemo(() => {
+    return Object.keys(groups).map((key) => {
+      const path = [...prefixPath, ...JSON.parse(key)];
+      const assets = groups[key];
+      const isFolder = assets.length > 1 || path.join('/') !== assets[0].key.path.join('/');
+      return isFolder ? {type: 'folder', path, assets} : {type: 'asset', path, asset: assets[0]};
+    });
+  }, [prefixPath, groups]);
+
   return (
     <>
-      <Box
-        border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '40% 30% 20% 10%',
-          height: '32px',
-          fontSize: '12px',
-          color: Colors.Gray600,
-        }}
-      >
-        <HeaderCell>Asset name</HeaderCell>
-        <HeaderCell>Materialized</HeaderCell>
-        <HeaderCell>Latest run</HeaderCell>
-        <HeaderCell>Actions</HeaderCell>
-      </Box>
+      <VirtualizedAssetCatalogHeader headerCheckbox={headerCheckbox} view={view} />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: RowType = flattened[index];
-              const type = row!.type;
-              return type === 'group' ? (
-                <GroupNameRow
-                  repoAddress={repoAddress}
-                  groupName={row.name}
-                  assetCount={row.assetCount}
-                  expanded={expandedKeys.includes(row.name)}
+              const row: Row = rows[index];
+              const path = JSON.stringify(row.path);
+              const rowType = () => {
+                if (row.type === 'folder') {
+                  return 'folder';
+                }
+                return row.asset.definition ? 'asset' : 'asset_non_sda';
+              };
+
+              const repoAddress = () => {
+                if (row.type === 'folder' || !row.asset.definition) {
+                  return null;
+                }
+                const repository = row.asset.definition.repository;
+                return buildRepoAddress(repository.name, repository.location.name);
+              };
+
+              const wipeableAssets = row.type === 'folder' ? row.assets : [row.asset];
+
+              return (
+                <VirtualizedAssetRow
                   key={key}
-                  height={size}
-                  start={start}
-                  onToggle={onToggle}
-                />
-              ) : (
-                <AssetRow
-                  key={key}
+                  view={view}
+                  type={rowType()}
                   path={row.path}
-                  repoAddress={repoAddress}
+                  repoAddress={repoAddress()}
+                  showCheckboxColumn
+                  showRepoColumn={showRepoColumn}
                   height={size}
                   start={start}
+                  checked={checkedPaths.has(path)}
+                  onToggleChecked={onToggleFactory(path)}
+                  onWipe={() => onWipe(wipeableAssets)}
                 />
               );
             })}
@@ -131,258 +103,5 @@ export const VirtualizedAssetTable: React.FC<Props> = ({repoAddress, assets}) =>
         </Container>
       </div>
     </>
-  );
-};
-
-interface JobRowProps {
-  path: string[];
-  repoAddress: RepoAddress;
-  height: number;
-  start: number;
-}
-
-const AssetRow = (props: JobRowProps) => {
-  const {path, repoAddress, start, height} = props;
-
-  const [queryAsset, queryResult] = useLazyQuery<SingleAssetQuery, SingleAssetQueryVariables>(
-    SINGLE_ASSET_QUERY,
-    {
-      fetchPolicy: 'cache-and-network',
-      variables: {input: {path}},
-    },
-  );
-
-  useDelayedRowQuery(queryAsset);
-  const {data} = queryResult;
-
-  const asset = React.useMemo(() => {
-    if (data?.assetOrError.__typename === 'Asset') {
-      return data.assetOrError;
-    }
-    return null;
-  }, [data]);
-
-  const liveData = React.useMemo(() => {
-    if (asset?.definition && data?.assetsLatestInfo) {
-      const latestInfoForAsset = data.assetsLatestInfo[0];
-      if (latestInfoForAsset) {
-        return buildLiveDataForNode(asset.definition, latestInfoForAsset);
-      }
-    }
-    return null;
-  }, [data, asset]);
-
-  const linkUrl = assetDetailsPathForKey({path});
-
-  return (
-    <Row $height={height} $start={start}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
-        <RowCell>
-          <div style={{fontWeight: 500, maxWidth: '100%', overflow: 'hidden'}}>
-            <AssetLink
-              path={path}
-              url={linkUrl}
-              isGroup={false}
-              icon="asset"
-              textStyle="middle-truncate"
-            />
-          </div>
-          <div
-            style={{
-              maxWidth: '100%',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            <Caption
-              style={{
-                color: Colors.Gray500,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {asset?.definition?.description}
-            </Caption>
-          </div>
-        </RowCell>
-        <RowCell>
-          {liveData?.lastMaterialization ? (
-            <Box flex={{gap: 8, alignItems: 'center'}}>
-              <>
-                <AssetRunLink
-                  runId={liveData.lastMaterialization.runId}
-                  event={{
-                    stepKey: liveData.stepKey,
-                    timestamp: liveData.lastMaterialization.timestamp,
-                  }}
-                >
-                  <TimestampDisplay
-                    timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
-                    timeFormat={{showSeconds: false, showTimezone: false}}
-                  />
-                </AssetRunLink>
-              </>
-              <StaleTag liveData={liveData} />
-            </Box>
-          ) : (
-            <LoadingOrNone queryResult={queryResult} />
-          )}
-        </RowCell>
-        <RowCell>
-          {liveData ? (
-            <AssetLatestRunWithNotices liveData={liveData} includeFreshness includeRunStatus />
-          ) : (
-            <LoadingOrNone queryResult={queryResult} />
-          )}
-        </RowCell>
-        <RowCell>
-          {asset ? (
-            <div>
-              <AssetActionMenu repoAddress={repoAddress} asset={asset} />
-            </div>
-          ) : null}
-        </RowCell>
-      </RowGrid>
-    </Row>
-  );
-};
-
-export const GroupNameRow: React.FC<{
-  repoAddress: RepoAddress;
-  groupName: string;
-  assetCount: number;
-  expanded: boolean;
-  height: number;
-  start: number;
-  onToggle: (groupName: string) => void;
-}> = ({repoAddress, groupName, assetCount, expanded, height, start, onToggle}) => {
-  return (
-    <ClickableRow
-      $height={height}
-      $start={start}
-      onClick={() => onToggle(groupName)}
-      $open={expanded}
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.code === 'Space' || e.code === 'Enter') {
-          e.preventDefault();
-          onToggle(groupName);
-        }
-      }}
-    >
-      <Box
-        background={Colors.Gray50}
-        flex={{direction: 'row', alignItems: 'center', gap: 8, justifyContent: 'space-between'}}
-        padding={{horizontal: 24}}
-        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-        style={{height: '100%'}}
-      >
-        <Box flex={{alignItems: 'center', gap: 8}}>
-          <Icon name="asset_group" />
-          {groupName === UNGROUPED_NAME ? (
-            <div>Ungrouped assets</div>
-          ) : (
-            <>
-              <strong>{groupName}</strong>
-              {groupName !== UNGROUPED_NAME ? (
-                <Box margin={{left: 12}}>
-                  <Link to={workspacePathFromAddress(repoAddress, `/asset-groups/${groupName}`)}>
-                    <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                      <span>View lineage</span>
-                      <Icon name="open_in_new" size={16} color={Colors.Link} />
-                    </Box>
-                  </Link>
-                </Box>
-              ) : null}
-            </>
-          )}
-        </Box>
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
-          <Tag>{assetCount === 1 ? '1 asset' : `${assetCount} assets`}</Tag>
-          <Icon name="arrow_drop_down" size={20} />
-        </Box>
-      </Box>
-    </ClickableRow>
-  );
-};
-
-const ClickableRow = styled(Row)<{$open: boolean}>`
-  cursor: pointer;
-
-  :focus,
-  :active {
-    outline: none;
-  }
-
-  ${IconWrapper}[aria-label="arrow_drop_down"] {
-    transition: transform 100ms linear;
-    ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
-  }
-`;
-
-const RowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: 40% 30% 20% 10%;
-  height: 100%;
-`;
-
-const SINGLE_ASSET_QUERY = gql`
-  query SingleAssetQuery($input: AssetKeyInput!) {
-    assetOrError(assetKey: $input) {
-      ... on Asset {
-        id
-        assetMaterializations(limit: 1) {
-          runId
-          timestamp
-        }
-        ...AssetTableFragment
-        definition {
-          id
-          ...AssetNodeLiveFragment
-        }
-      }
-    }
-    assetsLatestInfo(assetKeys: [$input]) {
-      ...AssetLatestInfoFragment
-    }
-  }
-
-  ${ASSET_TABLE_FRAGMENT}
-  ${ASSET_NODE_LIVE_FRAGMENT}
-  ${ASSET_LATEST_INFO_FRAGMENT}
-`;
-
-const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
-
-/**
- * Use localStorage to persist the expanded/collapsed visual state of asset groups.
- */
-export const useAssetGroupExpansionState = (storageKey: string) => {
-  const {basePath} = React.useContext(AppContext);
-  const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
-    `${basePath}:dagit.${storageKey}`,
-    validateExpandedKeys,
-  );
-
-  const onToggle = React.useCallback(
-    (groupName: string) => {
-      setExpandedKeys((current) => {
-        const nextExpandedKeys = new Set(current || []);
-        if (nextExpandedKeys.has(groupName)) {
-          nextExpandedKeys.delete(groupName);
-        } else {
-          nextExpandedKeys.add(groupName);
-        }
-        return Array.from(nextExpandedKeys);
-      });
-    },
-    [setExpandedKeys],
-  );
-
-  return React.useMemo(
-    () => ({
-      expandedKeys,
-      onToggle,
-    }),
-    [expandedKeys, onToggle],
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -1,0 +1,226 @@
+import {Box, Colors, Icon, IconWrapper, Tag} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {AppContext} from '../app/AppContext';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import {Container, Inner, Row} from '../ui/VirtualizedTable';
+
+import {VirtualizedAssetHeader, VirtualizedAssetRow} from './VirtualizedAssetRow';
+import {repoAddressAsHumanString} from './repoAddressAsString';
+import {RepoAddress} from './types';
+import {workspacePathFromAddress} from './workspacePath';
+
+type Asset = {id: string; groupName: string | null; assetKey: {path: string[]}};
+
+interface Props {
+  repoAddress: RepoAddress;
+  assets: Asset[];
+}
+
+type RowType =
+  | {type: 'group'; name: string; assetCount: number}
+  | {type: 'asset'; id: string; path: string[]};
+
+const UNGROUPED_NAME = 'UNGROUPED';
+const ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY = 'assets-virtualized-expansion-state';
+
+export const VirtualizedRepoAssetTable: React.FC<Props> = ({repoAddress, assets}) => {
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+  const repoKey = repoAddressAsHumanString(repoAddress);
+  const {expandedKeys, onToggle} = useAssetGroupExpansionState(
+    `${repoKey}-${ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY}`,
+  );
+
+  const grouped: {[key: string]: Asset[]} = React.useMemo(() => {
+    const groups = {};
+    for (const asset of assets) {
+      const groupName = asset.groupName || UNGROUPED_NAME;
+      const assetsForGroup = groups[groupName] || [];
+      groups[groupName] = [...assetsForGroup, asset];
+    }
+    return groups;
+  }, [assets]);
+
+  const flattened: RowType[] = React.useMemo(() => {
+    const flat: RowType[] = [];
+    Object.keys(grouped).forEach((groupName) => {
+      const assetsForGroup = grouped[groupName];
+      flat.push({type: 'group', name: groupName, assetCount: assetsForGroup.length});
+      if (expandedKeys.includes(groupName)) {
+        assetsForGroup.forEach(({id, assetKey}) => {
+          flat.push({type: 'asset', id, path: assetKey.path});
+        });
+      }
+    });
+    return flat;
+  }, [grouped, expandedKeys]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: flattened.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (ii: number) => {
+      const row = flattened[ii];
+      return row?.type === 'group' ? 48 : 64;
+    },
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  return (
+    <>
+      <VirtualizedAssetHeader nameLabel="Asset name" />
+      <div style={{overflow: 'hidden'}}>
+        <Container ref={parentRef}>
+          <Inner $totalHeight={totalHeight}>
+            {items.map(({index, key, size, start}) => {
+              const row: RowType = flattened[index];
+              const type = row!.type;
+              return type === 'group' ? (
+                <GroupNameRow
+                  repoAddress={repoAddress}
+                  groupName={row.name}
+                  assetCount={row.assetCount}
+                  expanded={expandedKeys.includes(row.name)}
+                  key={key}
+                  height={size}
+                  start={start}
+                  onToggle={onToggle}
+                />
+              ) : (
+                <VirtualizedAssetRow
+                  showCheckboxColumn={false}
+                  key={key}
+                  // todo dish: Fix this
+                  type="asset"
+                  path={row.path}
+                  repoAddress={repoAddress}
+                  showRepoColumn={false}
+                  height={size}
+                  start={start}
+                  // todo dish: Fix this
+                  checked={false}
+                  onToggleChecked={() => {}}
+                  onWipe={() => {}}
+                />
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </>
+  );
+};
+
+export const GroupNameRow: React.FC<{
+  repoAddress: RepoAddress;
+  groupName: string;
+  assetCount: number;
+  expanded: boolean;
+  height: number;
+  start: number;
+  onToggle: (groupName: string) => void;
+}> = ({repoAddress, groupName, assetCount, expanded, height, start, onToggle}) => {
+  return (
+    <ClickableRow
+      $height={height}
+      $start={start}
+      onClick={() => onToggle(groupName)}
+      $open={expanded}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.code === 'Space' || e.code === 'Enter') {
+          e.preventDefault();
+          onToggle(groupName);
+        }
+      }}
+    >
+      <Box
+        background={Colors.Gray50}
+        flex={{direction: 'row', alignItems: 'center', gap: 8, justifyContent: 'space-between'}}
+        padding={{horizontal: 24}}
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        style={{height: '100%'}}
+      >
+        <Box flex={{alignItems: 'center', gap: 8}}>
+          <Icon name="asset_group" />
+          {groupName === UNGROUPED_NAME ? (
+            <div>Ungrouped assets</div>
+          ) : (
+            <>
+              <strong>{groupName}</strong>
+              {groupName !== UNGROUPED_NAME ? (
+                <Box margin={{left: 12}}>
+                  <Link to={workspacePathFromAddress(repoAddress, `/asset-groups/${groupName}`)}>
+                    <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                      <span>View lineage</span>
+                      <Icon name="open_in_new" size={16} color={Colors.Link} />
+                    </Box>
+                  </Link>
+                </Box>
+              ) : null}
+            </>
+          )}
+        </Box>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
+          <Tag>{assetCount === 1 ? '1 asset' : `${assetCount} assets`}</Tag>
+          <Icon name="arrow_drop_down" size={20} />
+        </Box>
+      </Box>
+    </ClickableRow>
+  );
+};
+
+const ClickableRow = styled(Row)<{$open: boolean}>`
+  cursor: pointer;
+
+  :focus,
+  :active {
+    outline: none;
+  }
+
+  ${IconWrapper}[aria-label="arrow_drop_down"] {
+    transition: transform 100ms linear;
+    ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
+  }
+`;
+
+const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
+
+/**
+ * Use localStorage to persist the expanded/collapsed visual state of asset groups.
+ */
+export const useAssetGroupExpansionState = (storageKey: string) => {
+  const {basePath} = React.useContext(AppContext);
+  const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
+    `${basePath}:dagit.${storageKey}`,
+    validateExpandedKeys,
+  );
+
+  const onToggle = React.useCallback(
+    (groupName: string) => {
+      setExpandedKeys((current) => {
+        const nextExpandedKeys = new Set(current || []);
+        if (nextExpandedKeys.has(groupName)) {
+          nextExpandedKeys.delete(groupName);
+        } else {
+          nextExpandedKeys.add(groupName);
+        }
+        return Array.from(nextExpandedKeys);
+      });
+    },
+    [setExpandedKeys],
+  );
+
+  return React.useMemo(
+    () => ({
+      expandedKeys,
+      onToggle,
+    }),
+    [expandedKeys, onToggle],
+  );
+};

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -43,10 +43,15 @@ export const RepoRow: React.FC<{
   );
 };
 
-export const LoadingOrNone: React.FC<{queryResult: QueryResult<any, any>}> = ({queryResult}) => {
+export const LoadingOrNone: React.FC<{
+  queryResult: QueryResult<any, any>;
+  noneString?: React.ReactNode;
+}> = ({queryResult, noneString = 'None'}) => {
   const {called, loading, data} = queryResult;
   return (
-    <div style={{color: Colors.Gray500}}>{!called || (loading && !data) ? 'Loading' : 'None'}</div>
+    <div style={{color: Colors.Gray500}}>
+      {!called || (loading && !data) ? 'Loading' : noneString}
+    </div>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceAssetsRoot.tsx
@@ -7,7 +7,7 @@ import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useAssetNodeSearch} from '../assets/useAssetSearch';
 
-import {VirtualizedAssetTable} from './VirtualizedAssetTable';
+import {VirtualizedRepoAssetTable} from './VirtualizedRepoAssetTable';
 import {WorkspaceHeader} from './WorkspaceHeader';
 import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressToSelector} from './repoAddressToSelector';
@@ -85,7 +85,7 @@ export const WorkspaceAssetsRoot = ({repoAddress}: {repoAddress: RepoAddress}) =
       );
     }
 
-    return <VirtualizedAssetTable repoAddress={repoAddress} assets={filteredBySearch} />;
+    return <VirtualizedRepoAssetTable repoAddress={repoAddress} assets={filteredBySearch} />;
   };
 
   return (


### PR DESCRIPTION
### Summary & Motivation

Use a virtualized table to render the asset catalog.

This uses the full list of available assets as a skeleton, then queries for materialization details per-row, just like the overview and repository tables elsewhere in Dagit.

<img width="1443" alt="Screenshot 2022-12-19 at 9 42 11 AM" src="https://user-images.githubusercontent.com/2823852/208469803-6967e74b-61c2-47bd-991e-9dc2a275d509.png">
<img width="1443" alt="Screenshot 2022-12-19 at 9 42 46 AM" src="https://user-images.githubusercontent.com/2823852/208469806-eface736-f8d4-41c3-9084-cad0acde3b95.png">


### How I Tested These Changes

View asset catalog.

- Verify that virtualized table rendering and scrolling is correct.
- Verify correct data and rendering for materialization info, actions menu.
- Verify appropriate string search behavior, including group name search.
- Verify that `flat` and `directory` rendering is the same as it currently is.
