### PR TITLE
fix precedence ordering when merging dictionaries in container context

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/container_context.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/container_context.py
@@ -6,7 +6,6 @@ from dagster._config import process_config
 from dagster._core.container_context import process_shared_container_context_config
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.storage.pipeline_run import DagsterRun
-from dagster._utils import merge_dicts
 
 if TYPE_CHECKING:
     from . import DockerRunLauncher
@@ -88,7 +87,7 @@ class DockerContainerContext(
             registry=other.registry if other.registry != None else self.registry,
             env_vars=[*self.env_vars, *other.env_vars],
             networks=[*self.networks, *other.networks],
-            container_kwargs=merge_dicts(other.container_kwargs, self.container_kwargs),
+            container_kwargs={**self.container_kwargs, **other.container_kwargs},
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -8,7 +8,7 @@ from dagster._core.container_context import process_shared_container_context_con
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.utils import parse_env_var
-from dagster._utils import make_readonly_value, merge_dicts
+from dagster._utils import make_readonly_value
 
 if TYPE_CHECKING:
     from . import K8sRunLauncher
@@ -103,7 +103,7 @@ class K8sContainerContext(
             env_vars=_dedupe_list([*other.env_vars, *self.env_vars]),
             volume_mounts=_dedupe_list([*other.volume_mounts, *self.volume_mounts]),
             volumes=_dedupe_list([*other.volumes, *self.volumes]),
-            labels=merge_dicts(other.labels, self.labels),
+            labels={**self.labels, **other.labels},
             namespace=other.namespace if other.namespace else self.namespace,
             resources=other.resources if other.resources else self.resources,
             scheduler_name=other.scheduler_name if other.scheduler_name else self.scheduler_name,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -64,7 +64,7 @@ def other_container_context_config():
                 }
             ],
             "volumes": [{"name": "bar", "config_map": {"name": "your-settings-cm"}}],
-            "labels": {"bar_label": "baz_value"},
+            "labels": {"bar_label": "baz_value", "foo_label": "override_value"},
             "namespace": "your_namespace",
             "resources": {
                 "limits": {"memory": "64Mi", "cpu": "250m"},
@@ -250,7 +250,7 @@ def test_merge(empty_container_context, container_context, other_container_conte
             {"name": "foo", "config_map": {"name": "settings-cm"}},
         ],
     )
-    assert merged.labels == {"foo_label": "bar_value", "bar_label": "baz_value"}
+    assert merged.labels == {"foo_label": "override_value", "bar_label": "baz_value"}
     assert merged.namespace == "your_namespace"
     assert merged.resources == {
         "limits": {"memory": "64Mi", "cpu": "250m"},


### PR DESCRIPTION
Summary:
Fixes an issue where we were being inconsistent with container_context with dict fields - with scalar fields we prefer the passed in container context (to support things like per-job config overriding global config), but for dictionaries we were doing the reverse.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
