### PR TITLE
Allow setting resources on EcsContainerContext and EcsRunLauncher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping, Optional
 from dagster._core.events import EngineEventData, MetadataEntry
 from dagster._core.storage.pipeline_run import DagsterRun
 
+from .container_context import EcsContainerContext
 from .launcher import EcsRunLauncher
 
 
@@ -39,7 +40,9 @@ class CustomECSRunLauncher(EcsRunLauncher):
     def from_config_value(inst_data, config_value):
         return CustomECSRunLauncher(inst_data=inst_data, **config_value)
 
-    def get_cpu_and_memory_overrides(self, run: DagsterRun) -> Mapping[str, str]:
+    def get_cpu_and_memory_overrides(
+        self, container_context: EcsContainerContext, run: DagsterRun
+    ) -> Mapping[str, str]:
         return {"cpu": "4096", "memory": "16384"}
 
     def _get_task_overrides(self, run: DagsterRun) -> Mapping[str, Any]:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -139,6 +139,19 @@ def instance(instance_cm):
 
 
 @pytest.fixture
+def instance_with_resources(instance_cm):
+    with instance_cm(
+        config={
+            "run_resources": {
+                "cpu": "1024",
+                "memory": "2048",
+            }
+        }
+    ) as dagster_instance:
+        yield dagster_instance
+
+
+@pytest.fixture
 def instance_dont_use_current_task(instance_cm, subnet):
     with instance_cm(
         config={
@@ -341,6 +354,14 @@ def container_context_config(configured_secret):
             "secrets_tags": ["dagster"],
             "env_vars": ["FOO_ENV_VAR=BAR_VALUE"],
             "container_name": "foo",
+            "run_resources": {
+                "cpu": "4096",
+                "memory": "8192",
+            },
+            "server_resources": {
+                "cpu": "1024",
+                "memory": "2048",
+            },
         },
     }
 
@@ -359,6 +380,13 @@ def other_container_context_config(other_configured_secret):
             "secrets_tags": ["other_secret_tag"],
             "env_vars": ["OTHER_FOO_ENV_VAR"],
             "container_name": "bar",
+            "run_resources": {
+                "cpu": "256",
+            },
+            "server_resources": {
+                "cpu": "2048",
+                "memory": "4096",
+            },
         },
     }
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
@@ -85,6 +85,15 @@ def test_merge(
 
     assert merged.container_name == "bar"
 
+    assert merged.run_resources == {
+        "cpu": "256",
+        "memory": "8192",
+    }
+    assert merged.server_resources == {
+        "cpu": "2048",
+        "memory": "4096",
+    }
+
     with pytest.raises(
         Exception, match="Tried to load environment variable OTHER_FOO_ENV_VAR, but it was not set"
     ):


### PR DESCRIPTION
Summary:
- lets you set a deployment-level limit on the EcsRunLauncher for all runs (instead of relying on tags for all resources)
- lets you set per-location values via EcsContainerCotnext

Learning my lesson from k8s and allowing these to be set separately for gRPC servers and runs

### Summary & Motivation

### How I Tested These Changes
