### PR TITLE
[dagit] Optimizations to backfill UI for large partition key sets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -42,10 +42,7 @@ import {RepoAddress} from '../workspace/types';
 import {executionParamsForAssetJob} from './LaunchAssetExecutionButton';
 import {explodePartitionKeysInRanges, mergedAssetHealth} from './MultipartitioningSupport';
 import {RunningBackfillsNotice} from './RunningBackfillsNotice';
-import {
-  LaunchAssetExecutionAssetNodeFragment_partitionDefinition,
-  LaunchAssetExecutionAssetNodeFragment_partitionKeysByDimension,
-} from './types/LaunchAssetExecutionAssetNodeFragment';
+import {LaunchAssetExecutionAssetNodeFragment_partitionDefinition} from './types/LaunchAssetExecutionAssetNodeFragment';
 import {usePartitionDimensionRanges} from './usePartitionDimensionRanges';
 import {PartitionHealthDimensionRange, usePartitionHealthData} from './usePartitionHealthData';
 import {usePartitionNameForPipeline} from './usePartitionNameForPipeline';
@@ -57,7 +54,6 @@ interface Props {
   assets: {
     assetKey: AssetKey;
     opNames: string[];
-    partitionKeysByDimension: LaunchAssetExecutionAssetNodeFragment_partitionKeysByDimension[];
     partitionDefinition: LaunchAssetExecutionAssetNodeFragment_partitionDefinition | null;
   }[];
   upstreamAssetKeys: AssetKey[]; // single layer of upstream dependencies
@@ -108,11 +104,14 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   const assetHealth = usePartitionHealthData(partitionedAssets.map((a) => a.assetKey));
   const mergedHealth = React.useMemo(() => mergedAssetHealth(assetHealth), [assetHealth]);
 
+  console.log(partitionedAssets[0].partitionDefinition);
+  const knownDimensions = partitionedAssets[0].partitionDefinition?.dimensionTypes || [];
   const [ranges, setRanges] = usePartitionDimensionRanges({
-    knownDimensionNames: partitionedAssets[0].partitionKeysByDimension.map((d) => d.name),
+    knownDimensionNames: knownDimensions.map((d) => d.name),
     modifyQueryString: false,
     assetHealth: mergedHealth,
   });
+  console.log(ranges);
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([
     PartitionState.MISSING,

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -104,7 +104,6 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   const assetHealth = usePartitionHealthData(partitionedAssets.map((a) => a.assetKey));
   const mergedHealth = React.useMemo(() => mergedAssetHealth(assetHealth), [assetHealth]);
 
-  console.log(partitionedAssets[0].partitionDefinition);
   const knownDimensions = partitionedAssets[0].partitionDefinition?.dimensionTypes || [];
   const [ranges, setRanges] = usePartitionDimensionRanges({
     knownDimensionNames: knownDimensions.map((d) => d.name),
@@ -379,8 +378,11 @@ const UpstreamUnavailableWarning: React.FC<{
   // unavailable partitions in the multi-dimensional case and our "two range inputs" won't
   // allow us to remove missing individual pairs.
   const upstreamAssetHealth = usePartitionHealthData(upstreamAssetKeys);
+  if (upstreamAssetHealth.length === 0) {
+    return <span />;
+  }
+
   const upstreamUnavailable = (singleDimensionKey: string) =>
-    upstreamAssetHealth.length > 0 &&
     upstreamAssetHealth.some((a) => {
       // If the key is not undefined, it's present in the partition key space of the asset
       return a.stateForKey([singleDimensionKey]) === PartitionState.MISSING;

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -110,7 +110,6 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     modifyQueryString: false,
     assetHealth: mergedHealth,
   });
-  console.log(ranges);
 
   const [stateFilters, setStateFilters] = React.useState<PartitionState[]>([
     PartitionState.MISSING,

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -535,9 +535,9 @@ export const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
     graphName
     partitionDefinition {
       description
-    }
-    partitionKeysByDimension {
-      name
+      dimensionTypes {
+        name
+      }
     }
     isObservable
     isSource

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionAssetNodeFragment.ts
@@ -7,14 +7,15 @@
 // GraphQL fragment: LaunchAssetExecutionAssetNodeFragment
 // ====================================================
 
+export interface LaunchAssetExecutionAssetNodeFragment_partitionDefinition_dimensionTypes {
+  __typename: "DimensionDefinitionType";
+  name: string;
+}
+
 export interface LaunchAssetExecutionAssetNodeFragment_partitionDefinition {
   __typename: "PartitionDefinition";
   description: string;
-}
-
-export interface LaunchAssetExecutionAssetNodeFragment_partitionKeysByDimension {
-  __typename: "DimensionPartitionKeys";
-  name: string;
+  dimensionTypes: LaunchAssetExecutionAssetNodeFragment_partitionDefinition_dimensionTypes[];
 }
 
 export interface LaunchAssetExecutionAssetNodeFragment_assetKey {
@@ -569,7 +570,6 @@ export interface LaunchAssetExecutionAssetNodeFragment {
   jobNames: string[];
   graphName: string | null;
   partitionDefinition: LaunchAssetExecutionAssetNodeFragment_partitionDefinition | null;
-  partitionKeysByDimension: LaunchAssetExecutionAssetNodeFragment_partitionKeysByDimension[];
   isObservable: boolean;
   isSource: boolean;
   assetKey: LaunchAssetExecutionAssetNodeFragment_assetKey;

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetLoaderQuery.ts
@@ -9,14 +9,15 @@ import { AssetKeyInput } from "./../../types/globalTypes";
 // GraphQL query operation: LaunchAssetLoaderQuery
 // ====================================================
 
+export interface LaunchAssetLoaderQuery_assetNodes_partitionDefinition_dimensionTypes {
+  __typename: "DimensionDefinitionType";
+  name: string;
+}
+
 export interface LaunchAssetLoaderQuery_assetNodes_partitionDefinition {
   __typename: "PartitionDefinition";
   description: string;
-}
-
-export interface LaunchAssetLoaderQuery_assetNodes_partitionKeysByDimension {
-  __typename: "DimensionPartitionKeys";
-  name: string;
+  dimensionTypes: LaunchAssetLoaderQuery_assetNodes_partitionDefinition_dimensionTypes[];
 }
 
 export interface LaunchAssetLoaderQuery_assetNodes_assetKey {
@@ -571,7 +572,6 @@ export interface LaunchAssetLoaderQuery_assetNodes {
   jobNames: string[];
   graphName: string | null;
   partitionDefinition: LaunchAssetLoaderQuery_assetNodes_partitionDefinition | null;
-  partitionKeysByDimension: LaunchAssetLoaderQuery_assetNodes_partitionKeysByDimension[];
   isObservable: boolean;
   isSource: boolean;
   assetKey: LaunchAssetLoaderQuery_assetNodes_assetKey;

--- a/js_modules/dagit/packages/core/src/assets/usePartitionDimensionRanges.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionDimensionRanges.tsx
@@ -41,8 +41,9 @@ export const usePartitionDimensionRanges = (opts: {
   const [local, setLocal] = React.useState<DimensionQueryState[]>([]);
 
   const knownDimensionNamesJSON = JSON.stringify(knownDimensionNames);
+
   const inflated = React.useMemo((): PartitionHealthDimensionRange[] => {
-    if (!assetHealth) {
+    if (!assetHealth || !assetHealth.dimensions.length) {
       return JSON.parse(knownDimensionNamesJSON).map(placeholderDimensionRange);
     }
     return assetHealth.dimensions.map((dimension) => {

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRangeInput.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRangeInput.tsx
@@ -21,7 +21,9 @@ export const PartitionRangeInput: React.FC<{
   }, [value, partitionNameJSON, isTimeseries]);
 
   const placeholder = React.useMemo(() => {
-    return placeholderForPartitions(partitionKeys, isTimeseries);
+    return partitionKeys.length === 0
+      ? 'Loading partition keys...'
+      : placeholderForPartitions(partitionKeys, isTimeseries);
   }, [partitionKeys, isTimeseries]);
 
   const tryCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
@@ -27,6 +27,7 @@ export function allPartitionsSpan({partitionKeys}: {partitionKeys: string[]}) {
 export function textToPartitions(selected: string, all: string[]) {
   const terms = selected.split(',').map((s) => s.trim());
   const result = [];
+
   for (const term of terms) {
     if (term.length === 0) {
       continue;
@@ -51,11 +52,15 @@ export function textToPartitions(selected: string, all: string[]) {
       result.push(term);
     }
   }
-  return result.sort((a, b) => all.indexOf(a) - all.indexOf(b));
+  return Array.from(new Set(result));
 }
 
 export function partitionsToText(selected: string[], all: string[]) {
-  return assembleIntoSpans(all, (key) => selected.includes(key))
+  if (selected.length === all.length) {
+    return allPartitionsSpan({partitionKeys: all});
+  }
+  const selectedSet = new Set(selected);
+  return assembleIntoSpans(all, (key) => selectedSet.has(key))
     .filter((s) => s.status)
     .map((s) => stringForSpan(s, all))
     .join(', ');

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -344,7 +344,9 @@ class GraphenePartitionDefinition(graphene.ObjectType):
                 GrapheneDimensionDefinitionType(
                     name="default",
                     description="",
-                    type=GraphenePartitionDefinitionType.from_partition_def_data(partition_def_data)
+                    type=GraphenePartitionDefinitionType.from_partition_def_data(
+                        partition_def_data
+                    ),
                 )
             ],
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -340,7 +340,13 @@ class GraphenePartitionDefinition(graphene.ObjectType):
                 for dim in partition_def_data.external_partition_dimension_definitions
             ]
             if isinstance(partition_def_data, ExternalMultiPartitionsDefinitionData)
-            else [],
+            else [
+                GrapheneDimensionDefinitionType(
+                    name="default",
+                    description="",
+                    type=GraphenePartitionDefinitionType.from_partition_def_data(partition_def_data)
+                )
+            ],
         )
 
 


### PR DESCRIPTION
### Summary & Motivation

This PR addresses performance issues reported in https://github.com/dagster-io/dagster/issues/11157

With a large set of partition keys (35000 in this example), the Dagit backfill modal is unacceptably slow to load, and then also renders very slowly as you interact with it. These tweaks make things more reasonable: https://www.loom.com/share/c446d0f2123a45059b5182d533aca057

1) When you open the modal, we fetch the names of the partition dimensions via `dimensionTypes[].name` rather than `partitionKeysByDimension.name` which is much faster. I also extended this backend API to work in the single dimension case so that it matches the number of dimensions returned by partitionKeysByDimension (cc @clairelin135  on this bit!)

2) Add a few optimizations for the "select all" case - when we see the selected partition count and the all partition count are the same, we can show `[A...Z]` fast.

3) Add a few useMemo's that were missing

4) Stop unnecessarily sorting the selected keys. We actually don't rely on this anywhere as far as I can tell and it's very expensive.

5) For 35k items, it turns out it's quite a bit faster to convert the Array to a Set and then use JS's `Set.has()`. Ideally we would convert the selection state itself from an Array to a Set, but it would make this PR much larger and the Set constructor is very very fast. 

6) Update PartitionStatus.tsx to use a helper for building "spans" that creates fewer intermediate data structures.

### How I Tested These Changes

Tested the backfill modal with existing assets in various states to make sure the spans, etc. still behave the same way. Tested with an asset with 35k partitions to see speed improvements.