### PR TITLE
[dagit] Fix dragging on the DAG clearing your selection / clicking links

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -318,6 +318,8 @@ const AssetInsetForHoverEffect = styled.div`
 `;
 
 export const AssetNodeContainer = styled.div<{$selected: boolean}>`
+  user-select: none;
+  cursor: default;
   padding: 4px;
 `;
 

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -324,6 +324,8 @@ const NodeContainer = styled.div<{
 }>`
   opacity: ${({$dim}) => ($dim ? 0.3 : 1)};
   pointer-events: auto;
+  user-select: none;
+  cursor: default;
 
   .highlight-box {
     border-radius: 13px;


### PR DESCRIPTION
### Summary & Motivation

This is a fix for two interactions that have been driving me crazy in our Asset / Op DAG UI:

- If you click, drag, and release the mouse to pan around, it will clear your selected asset(s) because you clicked in white space.

- If you click and drag and happen to have dragged on top of a run link, it navigates to the run when you let go.

- If you click and drag on top of a run link, onDragStart triggers and starts dragging the actual link DOM node around.

### How I Tested These Changes

I viewed both op and asset jobs and panned / zoomed / clicked around after making these changes.

Tested in Chrome, FF and Safari