### PR TITLE
[dagit] Round middle truncate calculations for Firefox

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
@@ -45,6 +45,33 @@ export const Simple = () => {
   );
 };
 
+export const FlexboxContainerUsage = () => {
+  return (
+    <Box>
+      {[
+        'asset1',
+        'example',
+        'test1234',
+        'example_1',
+        'helloworld',
+        'example_12',
+        'example_123',
+        'otherstring',
+        'example_1234',
+        'variable_width',
+      ].map((text) => (
+        <Box key={text} style={{maxWidth: '100%'}} flex={{direction: 'row', gap: 8}}>
+          <Box>
+            <Icon name="asset_non_sda" />
+          </Box>
+          <a style={{overflow: 'hidden'}} href="#/">
+            <MiddleTruncate text={text} />
+          </a>
+        </Box>
+      ))}
+    </Box>
+  );
+};
 export const TagUsage = () => {
   return (
     <Tag icon="job">

--- a/js_modules/dagit/packages/ui/src/components/calculateMiddleTruncation.tsx
+++ b/js_modules/dagit/packages/ui/src/components/calculateMiddleTruncation.tsx
@@ -1,3 +1,8 @@
+// We've observed that Firefox's DOM APIs and Canvas APIs do not return
+// identical values given the same rendered text, in particular when the DOM
+// element is inside a flexbox. They're floating point numbers off by ~0.05.
+const FIREFOX_WIDTH_VARIANCE = 0.1;
+
 /**
  * Binary search to find the maximum middle-truncated text that will fit within the specified target width.
  * The truncation will occur in the center of the string, with the same number of characters on either side.
@@ -7,8 +12,9 @@ export const calculateMiddleTruncation = (
   targetWidth: number,
   measure: (value: string) => number,
 ): string => {
-  // Skip the search if the text will already fit as-is.
-  if (measure(text) <= targetWidth) {
+  // Skip the search if the text will already fit as-is (or is very, very close).
+  const fullWidth = measure(text);
+  if (fullWidth < targetWidth || Math.abs(fullWidth - targetWidth) < FIREFOX_WIDTH_VARIANCE) {
     return text;
   }
 


### PR DESCRIPTION
### Summary & Motivation

We've seen rendering issues with MiddleTruncate choosing to truncate where it's not necessary in Firefox. This appears to be caused by a /tiny/ discrepancy between `container.getBoundingClientRect().width` (DOM method of measuring the space allocated to us based on the intrinsic size of the text) and `(ctx.measureText(value).width` (the canvas method for measuring text length)

In cases where a flexbox is sizing the box, the former is ~0.03-0.06px smaller than the latter, which makes MiddleTruncate chop one character out of the center of the string.

### How I Tested These Changes

I added a Storybook that reproduces this flexbox-parent scenario (which is reproduced in Dagit in the left nav and the Asset Table), and then confirmed that rounding up the values fixes the error and does not produce regressions in the other storybook cases.
