### PR TITLE
factor out asset reconciliation graph traversal into util

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -1,8 +1,12 @@
+import functools
 from collections import defaultdict, deque
+from heapq import heapify, heappop, heappush
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
+    Callable,
     Dict,
+    Iterable,
     Iterator,
     Mapping,
     NamedTuple,
@@ -25,6 +29,7 @@ from .freshness_policy import FreshnessPolicy
 from .partition import PartitionsDefinition
 from .partition_mapping import PartitionMapping, infer_partition_mapping
 from .source_asset import SourceAsset
+from .time_window_partitions import TimeWindowPartitionsDefinition
 
 if TYPE_CHECKING:
     from dagster._core.host_representation.external_data import ExternalAssetNode
@@ -316,8 +321,122 @@ class AssetGraph(NamedTuple):
     def has_self_dependency(self, asset_key: AssetKey) -> bool:
         return asset_key in self.get_parents(asset_key)
 
+    def bfs_filter_asset_partitions(
+        self,
+        condition_fn: Callable[
+            [Iterable[AssetKeyPartitionKey], AbstractSet[AssetKeyPartitionKey]], bool
+        ],
+        initial_asset_partitions: Iterable[AssetKeyPartitionKey],
+    ) -> AbstractSet[AssetKeyPartitionKey]:
+        """
+        Returns asset partitions within the graph that
+        - Are >= initial_asset_partitions
+        - Match the condition_fn
+        - All of their ancestors >= initial_asset_partitions match the condition_fn
+        Visits parents before children.
+
+        When asset partitions are part of the same non-subsettable multi-asset, they're provided all
+        at once to the condition_fn.
+        """
+        all_nodes = set(initial_asset_partitions)
+
+        # invariant: we never consider an asset partition before considering its ancestors
+        queue = ToposortedPriorityQueue(self, all_nodes)
+
+        result: Set[AssetKeyPartitionKey] = set()
+
+        while len(queue) > 0:
+            candidates_unit = queue.dequeue()
+
+            if condition_fn(candidates_unit, result):
+                result.update(candidates_unit)
+
+                for candidate in candidates_unit:
+                    for child in self.get_children_partitions(
+                        candidate.asset_key, candidate.partition_key
+                    ):
+                        if child not in all_nodes:
+                            queue.enqueue(child)
+                            all_nodes.add(child)
+
+        return result
+
     def __hash__(self):
         return id(self)
 
     def __eq__(self, other):
         return self is other
+
+
+class ToposortedPriorityQueue:
+    """Queue that returns parents before their children"""
+
+    @functools.total_ordering
+    class QueueItem(NamedTuple):
+        level: int
+        partition_sort_key: Optional[float]
+        multi_asset_partition: Iterable[AssetKeyPartitionKey]
+
+        def __eq__(self, other):
+            return self.level == other.level and self.partition_sort_key == other.partition_sort_key
+
+        def __lt__(self, other):
+            return self.level < other.level or (
+                self.level == other.level
+                and self.partition_sort_key is not None
+                and self.partition_sort_key < other.partition_sort_key
+            )
+
+    def __init__(self, asset_graph: AssetGraph, items: Iterable[AssetKeyPartitionKey]):
+        self._asset_graph = asset_graph
+        toposorted_asset_keys = asset_graph.toposort_asset_keys()
+        self._toposort_level_by_asset_key = {
+            asset_key: i
+            for i, asset_keys in enumerate(toposorted_asset_keys)
+            for asset_key in asset_keys
+        }
+        self._heap = [self._queue_item(asset_partition) for asset_partition in items]
+        heapify(self._heap)
+
+    def enqueue(self, asset_partition: AssetKeyPartitionKey) -> None:
+        heappush(self._heap, self._queue_item(asset_partition))
+
+    def dequeue(self) -> Iterable[AssetKeyPartitionKey]:
+        return heappop(self._heap).multi_asset_partition
+
+    def _queue_item(self, asset_partition: AssetKeyPartitionKey):
+        asset_key = asset_partition.asset_key
+
+        required_multi_asset_keys = self._asset_graph.get_required_multi_asset_keys(asset_key) | {
+            asset_key
+        }
+        level = max(
+            self._toposort_level_by_asset_key[required_asset_key]
+            for required_asset_key in required_multi_asset_keys
+        )
+        if self._asset_graph.has_self_dependency(asset_key):
+            partitions_def = self._asset_graph.get_partitions_def(asset_key)
+            if partitions_def is not None and isinstance(
+                partitions_def, TimeWindowPartitionsDefinition
+            ):
+                partition_sort_key = (
+                    cast(TimeWindowPartitionsDefinition, partitions_def)
+                    .time_window_for_partition_key(cast(str, asset_partition.partition_key))
+                    .start.timestamp()
+                )
+            else:
+                check.failed("Assets with self-dependencies must have time-window partitions")
+        else:
+            partition_sort_key = None
+
+        return ToposortedPriorityQueue.QueueItem(
+            level,
+            partition_sort_key,
+            [
+                AssetKeyPartitionKey(ak, asset_partition.partition_key)
+                for ak in required_multi_asset_keys
+            ],
+        )
+
+    def __len__(self) -> int:
+        return len(self._heap)

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -1,11 +1,9 @@
 # pylint: disable=anomalous-backslash-in-string
 
 import datetime
-import functools
 import itertools
 import json
 from collections import defaultdict
-from heapq import heapify, heappop, heappush
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -34,12 +32,10 @@ from .partition import PartitionsDefinition, PartitionsSubset
 from .repository_definition import RepositoryDefinition
 from .run_request import RunRequest
 from .sensor_definition import DefaultSensorStatus, SensorDefinition
-from .time_window_partitions import TimeWindowPartitionsDefinition
 from .utils import check_valid_name
 
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance
-    from dagster._core.storage.event_log.base import EventLogRecord
 
 
 class AssetReconciliationCursor(NamedTuple):
@@ -183,80 +179,6 @@ class AssetReconciliationCursor(NamedTuple):
         return serialized
 
 
-class ToposortedPriorityQueue:
-    """Queue that returns parents before their children"""
-
-    @functools.total_ordering
-    class QueueItem(NamedTuple):
-        level: int
-        partition_sort_key: Optional[float]
-        multi_asset_partition: Iterable[AssetKeyPartitionKey]
-
-        def __eq__(self, other):
-            return self.level == other.level and self.partition_sort_key == other.partition_sort_key
-
-        def __lt__(self, other):
-            return self.level < other.level or (
-                self.level == other.level
-                and self.partition_sort_key is not None
-                and self.partition_sort_key < other.partition_sort_key
-            )
-
-    def __init__(self, asset_graph: AssetGraph, items: Iterable[AssetKeyPartitionKey]):
-        self._asset_graph = asset_graph
-        toposorted_asset_keys = asset_graph.toposort_asset_keys()
-        self._toposort_level_by_asset_key = {
-            asset_key: i
-            for i, asset_keys in enumerate(toposorted_asset_keys)
-            for asset_key in asset_keys
-        }
-        self._heap = [self._queue_item(asset_partition) for asset_partition in items]
-        heapify(self._heap)
-
-    def enqueue(self, asset_partition: AssetKeyPartitionKey) -> None:
-        heappush(self._heap, self._queue_item(asset_partition))
-
-    def dequeue(self) -> Iterable[AssetKeyPartitionKey]:
-        return heappop(self._heap).multi_asset_partition
-
-    def _queue_item(self, asset_partition: AssetKeyPartitionKey):
-        asset_key = asset_partition.asset_key
-
-        required_multi_asset_keys = self._asset_graph.get_required_multi_asset_keys(asset_key) | {
-            asset_key
-        }
-        level = max(
-            self._toposort_level_by_asset_key[required_asset_key]
-            for required_asset_key in required_multi_asset_keys
-        )
-        if self._asset_graph.has_self_dependency(asset_key):
-            partitions_def = self._asset_graph.get_partitions_def(asset_key)
-            if partitions_def is not None and isinstance(
-                partitions_def, TimeWindowPartitionsDefinition
-            ):
-                partition_sort_key = (
-                    cast(TimeWindowPartitionsDefinition, partitions_def)
-                    .time_window_for_partition_key(cast(str, asset_partition.partition_key))
-                    .start.timestamp()
-                )
-            else:
-                check.failed("Assets with self-dependencies must have time-window partitions")
-        else:
-            partition_sort_key = None
-
-        return ToposortedPriorityQueue.QueueItem(
-            level,
-            partition_sort_key,
-            [
-                AssetKeyPartitionKey(ak, asset_partition.partition_key)
-                for ak in required_multi_asset_keys
-            ],
-        )
-
-    def __len__(self) -> int:
-        return len(self._heap)
-
-
 def find_stale_candidates(
     instance_queryer: CachingInstanceQueryer,
     cursor: AssetReconciliationCursor,
@@ -379,13 +301,10 @@ def determine_asset_partitions_to_reconcile(
 
     target_asset_keys = target_asset_selection.resolve(asset_graph)
 
-    to_reconcile: Set[AssetKeyPartitionKey] = set()
-    all_candidates = set(itertools.chain(never_materialized_or_requested_roots, stale_candidates))
-
-    # invariant: we never consider a candidate before considering its ancestors
-    candidates_queue = ToposortedPriorityQueue(asset_graph, all_candidates)
-
-    def parents_will_be_reconciled(candidate: AssetKeyPartitionKey) -> bool:
+    def parents_will_be_reconciled(
+        candidate: AssetKeyPartitionKey,
+        to_reconcile: AbstractSet[AssetKeyPartitionKey],
+    ) -> bool:
         return all(
             (
                 (
@@ -403,37 +322,28 @@ def determine_asset_partitions_to_reconcile(
             )
         )
 
-    while len(candidates_queue) > 0:
-        candidates_unit = candidates_queue.dequeue()
-
-        # no need to update this now, as it will be updated later
+    def should_reconcile(
+        candidates_unit: Iterable[AssetKeyPartitionKey],
+        to_reconcile: AbstractSet[AssetKeyPartitionKey],
+    ) -> bool:
         if any(
             candidate in eventual_asset_partitions_to_reconcile_for_freshness
+            or candidate.asset_key not in target_asset_keys
             for candidate in candidates_unit
         ):
-            continue
+            return False
 
-        # already handled as a required multi-asset key
-        if any(candidate in to_reconcile for candidate in candidates_unit):
-            continue
-
-        if all(parents_will_be_reconciled(candidate) for candidate in candidates_unit) and any(
+        return all(
+            parents_will_be_reconciled(candidate, to_reconcile) for candidate in candidates_unit
+        ) and any(
             not instance_queryer.is_reconciled(asset_partition=candidate, asset_graph=asset_graph)
             for candidate in candidates_unit
-        ):
-            to_reconcile.update(candidates_unit)
+        )
 
-            for candidate in candidates_unit:
-                for child in asset_graph.get_children_partitions(
-                    candidate.asset_key, candidate.partition_key
-                ):
-                    if (
-                        child.asset_key in target_asset_keys
-                        and child not in all_candidates
-                        and asset_graph.have_same_partitioning(child.asset_key, candidate.asset_key)
-                    ):
-                        candidates_queue.enqueue(child)
-                        all_candidates.add(child)
+    to_reconcile = asset_graph.bfs_filter_asset_partitions(
+        should_reconcile,
+        set(itertools.chain(never_materialized_or_requested_roots, stale_candidates)),
+    )
 
     return (
         to_reconcile,


### PR DESCRIPTION
### Summary & Motivation

This utility will be used by partition-mapped backfills. It also serves to make the asset reconciliation code itself a little simpler. This does not change behavior.

### How I Tested These Changes
