### PR TITLE
Delete op version of _resolve_bound_config and call generic one

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -97,12 +97,15 @@ def _check_invocation_requirements(
 
 def _get_friendly_string(configurable_def: ConfigurableDefinition) -> str:
     from dagster._core.definitions.logger_definition import LoggerDefinition
+    from dagster._core.definitions.node_definition import NodeDefinition
     from dagster._core.definitions.resource_definition import ResourceDefinition
 
     if isinstance(configurable_def, ResourceDefinition):
         return "resource"
     elif isinstance(configurable_def, LoggerDefinition):
         return "logger"
+    elif isinstance(configurable_def, NodeDefinition):
+        return configurable_def.node_type_str
 
     check.failed(f"Invalid definition type {configurable_def}")
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -14,7 +14,6 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._config import Shape
 from dagster._core.definitions.composition import PendingNodeInvocation
 from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
 from dagster._core.definitions.dependency import Node, NodeHandle
@@ -38,7 +37,6 @@ from dagster._core.definitions.resource_definition import (
 from dagster._core.definitions.resource_requirement import ensure_requirements_satisfied
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.errors import (
-    DagsterInvalidConfigError,
     DagsterInvalidInvocationError,
     DagsterInvalidPropertyError,
     DagsterInvariantViolationError,
@@ -241,6 +239,8 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
         _validate_resource_requirements(self._resource_defs, op_def)
 
+        from dagster._core.definitions.resource_invocation import _resolve_bound_config
+
         solid_config = _resolve_bound_config(self.solid_config, op_def)
 
         return BoundOpExecutionContext(
@@ -321,34 +321,6 @@ def _validate_resource_requirements(
         for requirement in op_def.get_resource_requirements():
             if not requirement.is_io_manager_requirement:
                 ensure_requirements_satisfied(resource_defs, [requirement])
-
-
-def _resolve_bound_config(solid_config: Any, op_def: OpDefinition) -> Any:
-    """Validate config against config schema, and return validated config."""
-    from dagster._config import process_config
-
-    # Config processing system expects the top level config schema to be a dictionary, but solid
-    # config schema can be scalar. Thus, we wrap it in another layer of indirection.
-    outer_config_shape = Shape({"config": op_def.get_config_field()})
-    config_evr = process_config(
-        outer_config_shape, {"config": solid_config} if solid_config else {}
-    )
-    if not config_evr.success:
-        raise DagsterInvalidConfigError(
-            f"Error in config for {op_def.node_type_str} ",
-            config_evr.errors,
-            solid_config,
-        )
-    validated_config = cast(Dict, config_evr.value).get("config")
-    mapped_config_evr = op_def.apply_config_mapping({"config": validated_config})
-    if not mapped_config_evr.success:
-        raise DagsterInvalidConfigError(
-            f"Error in config for {op_def.node_type_str} ",
-            mapped_config_evr.errors,
-            solid_config,
-        )
-    validated_config = cast(Dict, mapped_config_evr.value).get("config")
-    return validated_config
 
 
 class BoundOpExecutionContext(OpExecutionContext):


### PR DESCRIPTION
### Summary & Motivation

Similar to https://github.com/dagster-io/dagster/pull/11209. I am consolidating duplicated code in three versions of `_resolve_bound_config`. This makes the op/graph codepath call the unified function.


### How I Tested These Changes
