### PR TITLE
[declarative-scheduling] Fix bug with declarative scheduling where repeated calls to get_latest_materialization_record could return incorrect results

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -639,19 +639,10 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 & constraint_keys
             ) | {key}
 
-            print("-----------------------")
-            import os
-            if key in {
-                AssetKey(["ANALYTICS", "company_perf"]),
-                AssetKey(["ANALYTICS", "company_stats"]),
-            }:
-                os.environ["SHOULD_LOG"] = "yes"
             # figure out the current contents of this asset with respect to its constraints
             current_data_times = get_current_data_times_for_key(
                 instance_queryer, asset_graph, relevant_upstream_keys, key
             )
-            print(key, current_data_times)
-            os.environ["SHOULD_LOG"] = "no"
 
             # should not execute if key is not targeted or previous run failed
             if key not in target_asset_keys or instance_queryer.failed_in_latest_run(asset_key=key):
@@ -705,8 +696,6 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 # current times for this asset, as it's not going to be updated
                 expected_data_times_by_key[key] = current_data_times
 
-            print("************************")
-
     return to_materialize, eventually_materialize
 
 
@@ -728,8 +717,6 @@ def reconcile(
         asset_graph=asset_graph,
         target_asset_selection=asset_selection,
     )
-    print("FOR FRESHNESS", asset_partitions_to_reconcile_for_freshness)
-    print("EVENTUAL", eventual_asset_partitions_to_reconcile_for_freshness)
 
     (
         asset_partitions_to_reconcile,
@@ -743,8 +730,6 @@ def reconcile(
         target_asset_selection=asset_selection,
         eventual_asset_partitions_to_reconcile_for_freshness=eventual_asset_partitions_to_reconcile_for_freshness,
     )
-
-    print("FOR RECONCILE", asset_partitions_to_reconcile)
 
     assets_to_reconcile_by_partitions_def_partition_key: Mapping[
         Tuple[Optional[PartitionsDefinition], Optional[str]], Set[AssetKey]
@@ -895,8 +880,6 @@ def build_asset_reconciliation_sensor(
     check.opt_mapping_param(run_tags, "run_tags", key_type=str, value_type=str)
 
     def sensor_fn(context):
-        print("====================================================")
-        print("START" * 10)
         cursor = (
             AssetReconciliationCursor.from_serialized(
                 context.cursor, context.repository_def.asset_graph
@@ -913,8 +896,6 @@ def build_asset_reconciliation_sensor(
         )
 
         context.update_cursor(updated_cursor.serialize())
-        print("END" * 15)
-        print("====================================================")
         return run_requests
 
     return SensorDefinition(

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -173,13 +173,32 @@ class CachingInstanceQueryer:
         else:
             asset_partition = asset
 
+        import os
+
+        should_log = os.getenv("SHOULD_LOG") == "yes"
+
+        # do not use the latest materialization cache with before_cursor
+
+        if before_cursor is not None:
+            if should_log:
+                print(asset, "SKIPPED")
+            return self._get_materialization_record(
+                asset_partition=asset_partition,
+                after_cursor=after_cursor,
+                before_cursor=before_cursor,
+            )
+
         if asset_partition in self._latest_materialization_record_cache:
+            if should_log:
+                print("WAS IN CACHE")
             cached_record = self._latest_materialization_record_cache[asset_partition]
-            if (after_cursor is None or after_cursor < cached_record.storage_id) and (
-                before_cursor is None or before_cursor > cached_record.storage_id
-            ):
+            if after_cursor is None or after_cursor < cached_record.storage_id:
+                if should_log:
+                    print("RETURNED FROM CACHE")
                 return cached_record
             else:
+                if should_log:
+                    print("RETURNED NONE")
                 return None
         elif asset_partition in self._no_materializations_after_cursor_cache:
             if (
@@ -196,7 +215,7 @@ class CachingInstanceQueryer:
             self._latest_materialization_record_cache[asset_partition] = record
             return record
         else:
-            if after_cursor is not None and before_cursor is None:
+            if after_cursor is not None:
                 self._no_materializations_after_cursor_cache[asset_partition] = min(
                     after_cursor,
                     self._no_materializations_after_cursor_cache.get(asset_partition, after_cursor),
@@ -266,6 +285,7 @@ class CachingInstanceQueryer:
         new_known_data: Dict[AssetKey, Tuple[Optional[int], Optional[float]]],
     ):
         event_log_storage = self._instance.event_log_storage
+        return
         if (
             event_log_storage.supports_add_asset_event_tags()
             and record.asset_key is not None
@@ -329,6 +349,9 @@ class CachingInstanceQueryer:
         required_keys: AbstractSet[AssetKey],
     ) -> Dict[AssetKey, Tuple[Optional[int], Optional[float]]]:
 
+        import os
+
+        should_log = os.getenv("SHOULD_LOG") == "yes"
         if record_id is None:
             return {key: (None, None) for key in required_keys}
 
@@ -336,6 +359,10 @@ class CachingInstanceQueryer:
         known_data = self.get_known_used_data(asset_key, record_id)
         if asset_key in required_keys:
             known_data[asset_key] = (record_id, record_timestamp)
+
+        if should_log:
+            print("key:", asset_key)
+            print("known data:", known_data)
 
         # not all required keys have known values
         unknown_required_keys = required_keys - set(known_data.keys())
@@ -350,6 +377,9 @@ class CachingInstanceQueryer:
                 upstream_required_keys = self._upstream_subset(
                     asset_graph, start_key=parent_key, input_keys=unknown_required_keys
                 )
+                if should_log:
+                    print("eval parent:", parent_key)
+                    print("upstream req:", upstream_required_keys)
 
                 input_event_pointer_tag = get_input_event_pointer_tag_key(parent_key)
                 if input_event_pointer_tag in record_tags:
@@ -359,6 +389,11 @@ class CachingInstanceQueryer:
                     parent_record = self.get_latest_materialization_record(
                         parent_key, before_cursor=input_record_id + 1
                     )
+                    if should_log:
+                        print("used pointer", input_record_id)
+                        print(
+                            "parent_record_id", parent_record.storage_id if parent_record else None
+                        )
                 else:
                     # if the input event id was not recorded (materialized pre-1.1.0), just grab
                     # the most recent asset materialization for this parent which happened before
@@ -366,6 +401,11 @@ class CachingInstanceQueryer:
                     parent_record = self.get_latest_materialization_record(
                         parent_key, before_cursor=record_id
                     )
+                    if should_log:
+                        print("used time", record_id)
+                        print(
+                            "parent_record_id", parent_record.storage_id if parent_record else None
+                        )
 
                 # recurse to find the data times of this parent
                 for key, tup in self._calculate_used_data(
@@ -424,6 +464,10 @@ class CachingInstanceQueryer:
         )
         self.set_known_used_data(record, new_known_data=data)
 
+        import os
+
+        if os.getenv("SHOULD_LOG") == "yes":
+            print("compiled data:", data)
         return {
             key: datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
             if timestamp is not None

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -959,33 +959,6 @@ def test_reconciliation(scenario):
 @pytest.mark.parametrize(
     "scenario",
     [
-        scenarios["freshness_complex_subsettable"],
-    ],
-)
-def test_reconciliation_no_tags(scenario):
-    # simulates an environment where asset_event_tags cannot be added
-    instance = DagsterInstance.ephemeral()
-
-    run_requests, _ = scenario.do_scenario(instance)
-
-    assert len(run_requests) == len(scenario.expected_run_requests)
-
-    def sort_run_request_key_fn(run_request):
-        return (min(run_request.asset_selection), run_request.partition_key)
-
-    sorted_run_requests = sorted(run_requests, key=sort_run_request_key_fn)
-    sorted_expected_run_requests = sorted(
-        scenario.expected_run_requests, key=sort_run_request_key_fn
-    )
-
-    for run_request, expected_run_request in zip(sorted_run_requests, sorted_expected_run_requests):
-        assert set(run_request.asset_selection) == set(expected_run_request.asset_selection)
-        assert run_request.partition_key == expected_run_request.partition_key
-
-
-@pytest.mark.parametrize(
-    "scenario",
-    [
         scenarios["diamond_never_materialized"],
         scenarios["one_asset_daily_partitions_never_materialized"],
     ],


### PR DESCRIPTION
### Summary & Motivation

TLDR; The test failed before this change, now it passes.

In cases where you call `get_latest_materialization_record(AssetKey("foo"))`, this will return the latest materialization record, and cache it in `self._latest_materialization_record_cache`. Let's say the latest record's id is `500`.

Subsequent calls (assuming no arguments are supplied) will hit that cache. However, if you call `get_latest_materialization_record(AssetKey("foo"), before_cursor=300)`, this will go into the code path that says that AssetKey("foo") is in the cache (well really asset partition, but that's not important), but then it will compare `before_cursor` to the latest record id, and see that it is not greater than the latest record id. This causes it to incorrectly return `None`.

So the bug is actually fairly obvious in hindsight, but what's not obvious is how it avoided detection, as it seems like this would cause problems in most normal test cases. The reason it doesn't is that this problem only crops up if `get_latest_materialization_record(AssetKey("foo"))` is called BEFORE `get_latest_materialization_record(..., before_cursor=...)`. When we do the first loop through the asset reconciliation sensor, we first calculate the used data for each asset with a freshness policy, which is a recursive function that calls that function with the `before_cursor` argument supplied. Because `_calculate_used_data()` is a `@cached_method`, if the asset with a freshness policy is at the bottom of the graph, then all of the `get_latest_materialization_record` calls with that argument supplied happen before later parts of the logic which call the method without that argument.

Even more so, this will only cause problems if an asset materialization consumes an upstream materialization record from a run that is not the most recent run. These two conditions combined make it pretty hard to reproduce in a unit test.

This specific added unit test could probably be minified, but you do need two separate freshness policies in order to force two separate calls to _calculate_used_data for the same asset key. These calls can't use the same upstream cached record, so you need to force a run where one freshness policy follows a different recursive path than the other.

### How I Tested These Changes
