### PR TITLE
[dagit] Don’t show assets as stale if projectedLogicalVersion is null

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/StaleTag.tsx
@@ -6,8 +6,15 @@ import {LiveDataForNode} from '../asset-graph/Utils';
 export const isAssetMissing = (liveData?: LiveDataForNode) =>
   liveData && liveData.currentLogicalVersion === null;
 
+/* Note: 
+- `projectedLogicalVersion` is null for partitioned assets
+- `currentLogicalVersion` is null for assets that have never materialized
+- `currentLogicalVersion` is INITIAL for source assets that have never been
+  observed and for assets materialized before the launch of this feature (edited) 
+*/
 export const isAssetStale = (liveData?: LiveDataForNode) =>
   liveData &&
+  liveData.projectedLogicalVersion &&
   liveData.currentLogicalVersion !== null &&
   liveData.currentLogicalVersion !== 'INITIAL' &&
   liveData.currentLogicalVersion !== liveData.projectedLogicalVersion;


### PR DESCRIPTION
### Summary & Motivation

This is a small fix based on the conversation here: https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1671212665301559. 

We're going to give all partitioned assets the `projectedLogicalVersion: null` so that they are not displayed as stale.

### How I Tested These Changes

This helper is the only place the `projectedLogicalVersion` comparison is made in Dagit and returning false from this method will hide the Stale tag everywhere, so there's not too much to test here. 