### PR TITLE
[docs] - [definitions] Update Dagster daemon docs

### DIFF
--- a/docs/content/deployment/dagster-daemon.mdx
+++ b/docs/content/deployment/dagster-daemon.mdx
@@ -167,7 +167,7 @@ The following daemons are currently available:
   </tbody>
 </table>
 
-Daemons that need to load code location(s) will do so by periodically reloading your instance's [workspace file](/concepts/code-locations/workspace-files). This means that the `dagster-daemon` process doesn't need to be restarted when workspace files are changed.
+If the daemon is configured to use a [workspace file](/concepts/code-locations/workspace-files) to load code location(s), note that they will periodically reload the file. This means that the `dagster-daemon` process doesn't need to be restarted when workspace files are changed.
 
 ---
 

--- a/docs/content/deployment/dagster-daemon.mdx
+++ b/docs/content/deployment/dagster-daemon.mdx
@@ -1,36 +1,119 @@
 ---
-title: Dagster Daemon | Dagster
+title: Dagster daemon | Dagster
 description: Several Dagster features require a long-running daemon process within your deployment.
 ---
 
-# Dagster Daemon
+# Dagster daemon
 
 Several Dagster features, like [schedules](/concepts/partitions-schedules-sensors/schedules), [sensors](/concepts/partitions-schedules-sensors/sensors), and [run queueing](/deployment/run-coordinator#limiting-run-concurrency), require a long-running `dagster-daemon` process to be included with your deployment.
 
-To start the `dagster-daemon` process locally, launch the following command in the same folder as your [`workspace.yaml`](/concepts/code-locations/workspace-files#understanding-workspace-files) file and keep the process running:
+---
+
+## Starting the daemon
+
+To start the `dagster-daemon` process locally, launch the following command in the same folder as your [workspace file (`workspace.yaml`)](/concepts/code-locations/workspace-files) file and keep the process running:
 
 ```shell
 $ dagster-daemon run
 ```
 
-Check the [deployment guides](/deployment/guides) for more information on how to deploy the daemon in other environments, like Docker or Kubernetes.
+Refer to the [deployment guides](/deployment/guides) for more information on deploying the daemon in other environments, such as Docker or Kubernetes.
+
+---
 
 ## Available daemons
 
-The `dagster-daemon` process reads from your [Dagster instance](/deployment/dagster-instance) file to determine which daemons it should include. Each of those daemons then runs on a regular interval in its own threads. Daemons that need to load your workspace will periodically reload the workspace from your `workspace.yaml` file. If you change your `workspace.yaml` file, you do not need to reload the `dagster-daemon` process in order for those changes to be included.
+The `dagster-daemon` process reads from your [Dagster instance](/deployment/dagster-instance) file to determine which daemons should be included. Each of the included daemons then runs on a regular interval in its own threads.
 
 The following daemons are currently available:
 
-- The _scheduler daemon_ is responsible for creating runs from any [schedules](/concepts/partitions-schedules-sensors/schedules) that are turned on. This daemon will run as long as you have not overridden the default <PyObject module="dagster._core.scheduler" object="DagsterDaemonScheduler" /> as the scheduler on your instance.
+<table
+  className="table"
+  style={{
+    width: "100%",
+  }}
+>
+  <thead>
+    <tr>
+      <th
+        style={{
+          width: "20%",
+        }}
+      >
+        Name
+      </th>
+      <th>Description</th>
+      <th>Enabled by</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Scheduler daemon</td>
+      <td>
+        Creates runs from active{" "}
+        <a href="/concepts/partitions-schedules-sensors/schedules">schedules</a>
+      </td>
+      <td>
+        Enabled / runs as long as the default{" "}
+        <PyObject
+          module="dagster._core.scheduler"
+          object="DagsterDaemonScheduler"
+        />{" "}
+        isn't overriden as the scheduler on your instance.
+      </td>
+    </tr>
+    <tr>
+      <td>Run queue daemon</td>
+      <td>
+        Launches queued runs, taking into account any limits and prioritization
+        rules set on your instance
+      </td>
+      <td>
+        Setting the <a href="/deployment/run-coordinator">run coordinator</a> on
+        your instance to{" "}
+        <PyObject
+          module="dagster._core.run_coordinator"
+          object="QueuedRunCoordinator"
+        />
+        .
+      </td>
+    </tr>
+    <tr>
+      <td>Sensor daemon</td>
+      <td>
+        Creates runs from active{" "}
+        <a href="/concepts/partitions-schedules-sensors/sensors">sensors</a>{" "}
+        that are turned on
+      </td>
+      <td>Always enabled</td>
+    </tr>
+    <tr>
+      <td>Run monitoring daemon</td>
+      <td>
+        Handles <a href="/deployment/overview#job-execution-flow">run worker</a>{" "}
+        failures
+      </td>
+      <td>
+        Using the <code>run_monitoring</code> field in your instance. Refer to
+        the{" "}
+        <a href="/deployment/run-monitoring">Run monitoring documentation</a>{" "}
+        for more info.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-- The _run queue daemon_ is responsible for launching queued runs, taking into account any limits and prioritization rules you've set on your instance. You can enable this daemon by setting the [run coordinator](/deployment/run-coordinator) on your instance to <PyObject module="dagster._core.run_coordinator" object="QueuedRunCoordinator" />.
+Daemons that need to load code location(s) will do so by periodically reloading your instance's [workspace file](/concepts/code-locations/workspace-files). This means that the `dagster-daemon` process doesn't need to be restarted when workspace files are changed.
 
-- The _sensor daemon_ is responsible for creating runs from any [sensors](/concepts/partitions-schedules-sensors/sensors) that are turned on. This daemon is always enabled.
+---
 
-- The _run monitoring daemon_ is responsible for handling [run worker](/deployment/overview#job-execution-flow) failures. This daemon can be enabled with the [`run_monitoring`](/deployment/run-monitoring) field in your instance.
+## Checking daemon status in Dagit
 
-## Daemons in Dagit
+To check the status of the `dagster-daemon` process within Dagit:
 
-To check the status of your `dagster-daemon` process within Dagit, click on "Status" in the left nav. This will take you a page where you can see information about each daemon that's currently configured on your instance.
+1. In the top navigation, click **Deployment**.
+2. Click the **Daemons** tab.
 
-Each daemon periodically writes a heartbeat to your instance storage, so if a daemon doesn't show a recent heartbeat on this page, it likely indicates that you should check the logs from your `dagster-daemon` process for errors.
+This tab displays information about all the daemons currently configured on your instance.
+
+Each daemon periodically writes a heartbeat to your instance storage. If a daemon doesn't show a recent heartbeat, check the logs from your `dagster-daemon` process for errors.

--- a/docs/content/deployment/dagster-daemon.mdx
+++ b/docs/content/deployment/dagster-daemon.mdx
@@ -11,13 +11,77 @@ Several Dagster features, like [schedules](/concepts/partitions-schedules-sensor
 
 ## Starting the daemon
 
-To start the `dagster-daemon` process locally, launch the following command in the same folder as your [workspace file (`workspace.yaml`)](/concepts/code-locations/workspace-files) file and keep the process running:
+- [Running locally](#running-locally)
+- [Deploying the daemon](#deploying-the-daemon)
+
+### Running locally
+
+The Dagster daemon can be started locally in a few ways, which are outlined in the following tabs. Once started, the process should be kept running.
+
+<TabGroup>
+<TabItem name="From a file">
+
+The Dagster daemon can load a file directly as a code location. In the following example, we used the `-f` argument to supply the name of the file to `dagster-daemon`:
 
 ```shell
-$ dagster-daemon run
+dagster-daemon run -f my_file.py
 ```
 
-Refer to the [deployment guides](/deployment/guides) for more information on deploying the daemon in other environments, such as Docker or Kubernetes.
+This command loads the definitions in `my_file.py` as a code location in the same Python environment where the daemon resides.
+
+You can also include multiple files at a time:
+
+```shell
+dagster-daemon run -f my_file.py -f my_second_file.py
+```
+
+---
+
+</TabItem>
+<TabItem name="From a module">
+
+The Dagster daemon can also load Python modules as code locations. When this approach is used, Dagster loads the definitions defined at the top-level of the module, in a variable containing the <PyObject object="Definitions" /> object of its root `__init__.py` file. As this style of development eliminates an entire class of Python import errors, we strongly recommend it for Dagster projects deployed to production.
+
+In the following example, we used the `-m` argument to supply the name of the module to the daemon process:
+
+```shell
+dagster-daemon run -m your_module_name
+```
+
+This command loads the definitions in the variable containing the <PyObject object="Definitions" /> object in the named module - defined as the root `__init__.py` file - in the same virtual environment as the daemon.
+
+---
+
+</TabItem>
+<TabItem name="Without command line arguments">
+
+To load definitions without supplying command line arguments, you can use the `pyproject.toml` file. This file, included in all Dagster example projects, contains a `tool.dagster` section with a `module_name` variable:
+
+```shell
+[tool.dagster]
+module_name = "your_module_name"  ## name of project's Python module
+```
+
+When defined, you can run this in the same directory as the `pyproject.toml` file:
+
+```shell
+dagster-daemon run
+```
+
+Instead of this:
+
+```shell
+dagster-daemon run -m your_module_name
+```
+
+---
+
+</TabItem>
+</TabGroup>
+
+### Deploying the daemon
+
+For information on deploying the daemon to environments like Docker or Kubernetes, refer to the [deployment guides](/deployment/guides).
 
 ---
 


### PR DESCRIPTION
This PR updates the Dagster daemon concept docs for the new `Definitions` world. It also:

- Edits some copy for style / clarity
- Updates formatting
- Updates the instructions for checking daemon status in Dagit to reflect UI changes