### PR TITLE
Update license to include year and company

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2022 Elementl, Inc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The year and company name were left out from when this was copied from a template.  This update just sets them so that the project gets proper attribution in the license.

### Summary & Motivation
Was checking out the project for the first time and happened to notice this in your LICENSE file.

### How I Tested These Changes
This change does not impact any code directly, but simply gives proper author attribution in the LICENSE (IANAL).