### PR TITLE
[dagit] Fresh + Stale should not show “Stale” on the Asset Graph

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
@@ -1,0 +1,244 @@
+import {Box} from '@dagster-io/ui';
+import React from 'react';
+
+import {position} from '../graph/common';
+import {RunStatus} from '../types/globalTypes';
+
+import {AssetNode, AssetNodeMinimal} from './AssetNode';
+import {LiveDataForNode} from './Utils';
+import {AssetNodeFragment} from './types/AssetNodeFragment';
+
+const ASSET_NODE_DEFINITION: AssetNodeFragment = {
+  __typename: 'AssetNode',
+  assetKey: {__typename: 'AssetKey', path: ['asset1']},
+  computeKind: null,
+  description: 'This is a test asset description',
+  graphName: null,
+  id: '["asset1"]',
+  isObservable: false,
+  isPartitioned: false,
+  isSource: false,
+  jobNames: ['job1'],
+  opNames: ['asset1'],
+  opVersion: '1',
+};
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AssetNode};
+
+export const LiveStates = () => {
+  const caseWithLiveData = (name: string, liveData?: LiveDataForNode) => {
+    return (
+      <Box flex={{direction: 'column', gap: 0, alignItems: 'flex-start'}}>
+        <div style={{position: 'relative', width: 280}}>
+          <AssetNode definition={ASSET_NODE_DEFINITION} selected={false} liveData={liveData} />
+        </div>
+        <div style={{position: 'relative', width: 280, height: 82}}>
+          <div style={{position: 'absolute', width: 280, height: 82}}>
+            <AssetNodeMinimal
+              definition={ASSET_NODE_DEFINITION}
+              selected={false}
+              liveData={liveData}
+            />
+          </div>
+        </div>
+        <code>
+          <strong>{name}</strong>
+          <pre>{JSON.stringify(liveData, null, 2)}</pre>
+        </code>
+      </Box>
+    );
+  };
+  return (
+    <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
+      {caseWithLiveData('No Live Data', undefined)}
+      {caseWithLiveData('Run Started - Not Materializing Yet', {
+        stepKey: 'asset1',
+        unstartedRunIds: ['ABCDEF'],
+        inProgressRunIds: [],
+        lastMaterialization: null,
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: null,
+        projectedLogicalVersion: null,
+        freshnessInfo: null,
+        freshnessPolicy: null,
+      })}
+      {caseWithLiveData('Run Started - Materializing', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: ['ABCDEF'],
+        lastMaterialization: null,
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: null,
+        projectedLogicalVersion: null,
+        freshnessInfo: null,
+        freshnessPolicy: null,
+      })}
+
+      {caseWithLiveData('Run Failed to Materialize', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: null,
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: {__typename: 'Run', id: 'ABCDEF', status: RunStatus.FAILURE},
+        currentLogicalVersion: null,
+        projectedLogicalVersion: null,
+        freshnessInfo: null,
+        freshnessPolicy: null,
+      })}
+
+      {caseWithLiveData('Never Materialized', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: null,
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'INITIAL',
+        projectedLogicalVersion: 'V_A',
+        freshnessInfo: null,
+        freshnessPolicy: null,
+      })}
+
+      {caseWithLiveData('Materialized', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: {
+          __typename: 'MaterializationEvent',
+          runId: 'ABCDEF',
+          timestamp: `${Date.now()}`,
+        },
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'INITIAL',
+        projectedLogicalVersion: 'V_A',
+        freshnessInfo: null,
+        freshnessPolicy: null,
+      })}
+
+      {caseWithLiveData('Materialized and Stale', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: {
+          __typename: 'MaterializationEvent',
+          runId: 'ABCDEF',
+          timestamp: `${Date.now()}`,
+        },
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'V_A',
+        projectedLogicalVersion: 'V_B',
+        freshnessInfo: null,
+        freshnessPolicy: null,
+      })}
+      {caseWithLiveData('Materialized and Stale and Late', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: {
+          __typename: 'MaterializationEvent',
+          runId: 'ABCDEF',
+          timestamp: `${Date.now()}`,
+        },
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'V_A',
+        projectedLogicalVersion: 'V_B',
+        freshnessInfo: {
+          __typename: 'AssetFreshnessInfo',
+          currentMinutesLate: 12,
+        },
+        freshnessPolicy: {
+          __typename: 'FreshnessPolicy',
+          maximumLagMinutes: 10,
+          cronSchedule: null,
+        },
+      })}
+      {caseWithLiveData('Materialized and Stale and Fresh', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: {
+          __typename: 'MaterializationEvent',
+          runId: 'ABCDEF',
+          timestamp: `${Date.now()}`,
+        },
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'V_A',
+        projectedLogicalVersion: 'V_B',
+        freshnessInfo: {
+          __typename: 'AssetFreshnessInfo',
+          currentMinutesLate: 0,
+        },
+        freshnessPolicy: {
+          __typename: 'FreshnessPolicy',
+          maximumLagMinutes: 10,
+          cronSchedule: null,
+        },
+      })}
+      {caseWithLiveData('Materialized and Fresh', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: {
+          __typename: 'MaterializationEvent',
+          runId: 'ABCDEF',
+          timestamp: `${Date.now()}`,
+        },
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'V_B',
+        projectedLogicalVersion: 'V_B',
+        freshnessInfo: {
+          __typename: 'AssetFreshnessInfo',
+          currentMinutesLate: 0,
+        },
+        freshnessPolicy: {
+          __typename: 'FreshnessPolicy',
+          maximumLagMinutes: 10,
+          cronSchedule: null,
+        },
+      })}
+      {caseWithLiveData('Materialized and Late', {
+        stepKey: 'asset1',
+        unstartedRunIds: [],
+        inProgressRunIds: [],
+        lastMaterialization: {
+          __typename: 'MaterializationEvent',
+          runId: 'ABCDEF',
+          timestamp: `${Date.now()}`,
+        },
+        lastMaterializationRunStatus: null,
+        lastObservation: null,
+        runWhichFailedToMaterialize: null,
+        currentLogicalVersion: 'V_A',
+        projectedLogicalVersion: 'V_A',
+        freshnessInfo: {
+          __typename: 'AssetFreshnessInfo',
+          currentMinutesLate: 12,
+        },
+        freshnessPolicy: {
+          __typename: 'FreshnessPolicy',
+          maximumLagMinutes: 10,
+          cronSchedule: null,
+        },
+      })}
+    </Box>
+  );
+  return;
+};

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -192,7 +192,7 @@ export const AssetNodeStatusRow: React.FC<{
     );
   }
 
-  if (isAssetStale(liveData)) {
+  if (!liveData.freshnessPolicy && isAssetStale(liveData)) {
     return (
       <AssetNodeStatusBox background={Colors.Yellow50}>
         <Caption color={Colors.Yellow700}>Stale</Caption>
@@ -218,34 +218,25 @@ export const AssetNodeMinimal: React.FC<{
   const displayName = assetKey.path[assetKey.path.length - 1];
   const materializingRunId = liveData?.inProgressRunIds?.[0] || liveData?.unstartedRunIds?.[0];
 
+  const [background, border] =
+    !liveData || definition.isSource
+      ? [Colors.Gray100, Colors.Gray300]
+      : materializingRunId
+      ? [Colors.Blue50, Colors.Blue500]
+      : liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
+      ? [Colors.Red50, Colors.Red500]
+      : !liveData?.lastMaterialization || (!liveData.freshnessPolicy && isAssetStale(liveData))
+      ? [Colors.Yellow50, Colors.Yellow500]
+      : [Colors.Green50, Colors.Green500];
+
   return (
     <AssetInsetForHoverEffect>
       <MinimalAssetNodeContainer $selected={selected}>
         <MinimalAssetNodeBox
           $selected={selected}
           $isSource={isSource}
-          $background={
-            !liveData || definition.isSource
-              ? Colors.Gray100
-              : materializingRunId
-              ? Colors.Blue50
-              : liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
-              ? Colors.Red50
-              : !liveData?.lastMaterialization || isAssetStale(liveData)
-              ? Colors.Yellow50
-              : Colors.Green50
-          }
-          $border={
-            !liveData || definition.isSource
-              ? Colors.Gray300
-              : materializingRunId
-              ? Colors.Blue500
-              : liveData?.runWhichFailedToMaterialize || isAssetLate(liveData)
-              ? Colors.Red500
-              : !liveData?.lastMaterialization || isAssetStale(liveData)
-              ? Colors.Yellow500
-              : Colors.Green500
-          }
+          $background={background}
+          $border={border}
         >
           <div style={{position: 'absolute', bottom: 6, left: 6}}>
             <AssetLatestRunSpinner liveData={liveData} purpose="section" />

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -104,6 +104,7 @@ export const AssetNodeLineageGraph: React.FC<{
                 ) : scale < MINIMAL_SCALE ? (
                   <AssetNodeMinimal
                     definition={graphNode.definition}
+                    liveData={liveDataByNode[graphNode.id]}
                     selected={graphNode.id === assetGraphId}
                   />
                 ) : (

--- a/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentMinutesLateTag.tsx
@@ -48,14 +48,10 @@ export const CurrentMinutesLateTag: React.FC<{
   if (freshnessInfo.currentMinutesLate === 0) {
     return description ? (
       <Tooltip content={freshnessPolicyDescription(freshnessPolicy)}>
-        <Tag intent="success" icon="check_circle">
-          On time
-        </Tag>
+        <Tag intent="success" icon="check_circle" />
       </Tooltip>
     ) : (
-      <Tag intent="success" icon="check_circle">
-        On time
-      </Tag>
+      <Tag intent="success" icon="check_circle" />
     );
   }
 


### PR DESCRIPTION
### Summary & Motivation

This PR makes a few small changes based on this week's UI sync:

- Assets that are Stale but are meeting their freshness policy do not show "Stale" on the graph, instead they show "Materialized"

- The word "On time" has been removed and we just show a freshness check icon you can see more info about on hover.

- I've added a storybook for seeing AssetNodes in all the various states because there are a lot of them and the ordering is fairly difficult to get right. 

### How I Tested These Changes

New storybook!

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/208512855-a345b7c4-e33e-4558-93af-26e5a8df18a1.png">
