### PR TITLE
Move env var injection earlier in step command

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -379,6 +379,14 @@ def _execute_step_command_body(
             "Pipeline run with id '{}' does not include an origin.".format(args.pipeline_run_id),
         )
 
+        location_name = (
+            pipeline_run.external_pipeline_origin.location_name
+            if pipeline_run.external_pipeline_origin
+            else None
+        )
+
+        instance.inject_env_vars(location_name)
+
         log_manager = create_context_free_log_manager(instance, pipeline_run)
 
         yield DagsterEvent.step_worker_started(
@@ -393,14 +401,6 @@ def _execute_step_command_body(
             ),
             step_key=single_step_key,
         )
-
-        location_name = (
-            pipeline_run.external_pipeline_origin.location_name
-            if pipeline_run.external_pipeline_origin
-            else None
-        )
-
-        instance.inject_env_vars(location_name)
 
         if args.should_verify_step:
             success = verify_step(

--- a/python_modules/dagster/dagster_tests/cli_tests/fake_python_logger_module/__init__.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/fake_python_logger_module/__init__.py
@@ -1,0 +1,9 @@
+import logging
+import os
+
+if not os.getenv("REQUIRED_LOGGER_ENV_VAR") == "LOGGER_ENV_VAR_VALUE":
+    raise Exception("Missing env var REQUIRED_LOGGER_ENV_VAR")
+
+
+class FakeHandler(logging.StreamHandler):
+    pass


### PR DESCRIPTION
Summary:
If you have custom python handlers, you can end up loading code that requires env vars while setting up the log handler here. Move the env var loading code earlier to facilitate that.

### Summary & Motivation

### How I Tested These Changes
