### PR TITLE
Remove unused backfillStatus, which loads individual run status

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2616,7 +2616,6 @@ type PartitionRun {
 type PartitionBackfill {
   backfillId: String!
   status: BulkActionStatus!
-  backfillStatus: BackfillStatus!
   partitionNames: [String!]!
   numPartitions: Int!
   numRequested: Int!
@@ -2637,15 +2636,6 @@ enum BulkActionStatus {
   COMPLETED
   FAILED
   CANCELED
-}
-
-enum BackfillStatus {
-  REQUESTED
-  FAILED
-  CANCELED
-  IN_PROGRESS
-  COMPLETED
-  INCOMPLETE
 }
 
 union PartitionSetOrError = PartitionSet | PartitionSetNotFoundError | PythonError

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -138,7 +138,6 @@ const BACKFILLS_QUERY = gql`
         results {
           backfillId
           status
-          backfillStatus
           numRequested
           numPartitions
           timestamp

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BulkActionStatus, BackfillStatus } from "./../../types/globalTypes";
+import { BulkActionStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: InstanceBackfillsQuery
@@ -47,7 +47,6 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
-  backfillStatus: BackfillStatus;
   numRequested: number;
   numPartitions: number;
   timestamp: number;

--- a/js_modules/dagit/packages/core/src/types/globalTypes.ts
+++ b/js_modules/dagit/packages/core/src/types/globalTypes.ts
@@ -7,15 +7,6 @@
 // START Enums and Input Objects
 //==============================================================
 
-export enum BackfillStatus {
-  CANCELED = "CANCELED",
-  COMPLETED = "COMPLETED",
-  FAILED = "FAILED",
-  INCOMPLETE = "INCOMPLETE",
-  IN_PROGRESS = "IN_PROGRESS",
-  REQUESTED = "REQUESTED",
-}
-
 export enum BulkActionStatus {
   CANCELED = "CANCELED",
   COMPLETED = "COMPLETED",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -28,7 +28,6 @@ PARTITION_PROGRESS_QUERY = """
         numPartitions
         fromFailure
         reexecutionSteps
-        backfillStatus
         partitionStatuses {
           results {
             partitionName
@@ -154,7 +153,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["backfillStatus"] == "REQUESTED"
         assert result.data["partitionBackfillOrError"]["numRequested"] == 0
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
 
@@ -280,7 +278,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "CANCELED"
-        assert result.data["partitionBackfillOrError"]["backfillStatus"] == "CANCELED"
 
     def test_resume_backfill(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
@@ -385,7 +382,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
         assert result.data["partitionBackfillOrError"]["numPartitions"] == 4
-        assert result.data["partitionBackfillOrError"]["backfillStatus"] == "REQUESTED"
         run_stats = _get_run_stats(
             result.data["partitionBackfillOrError"]["partitionStatuses"]["results"]
         )
@@ -407,7 +403,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             variables={"backfillId": backfill_id},
         )
         assert result.data["partitionBackfillOrError"]["status"] == "COMPLETED"
-        assert result.data["partitionBackfillOrError"]["backfillStatus"] == "IN_PROGRESS"
 
     def test_backfill_run_completed(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
@@ -465,8 +460,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert run_stats.get("success") == 4
         assert run_stats.get("failure") == 0
 
-        assert result.data["partitionBackfillOrError"]["backfillStatus"] == "COMPLETED"
-
     def test_backfill_run_incomplete(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
         result = execute_dagster_graphql(
@@ -522,8 +515,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert run_stats.get("success") == 3
         assert run_stats.get("failure") == 0
         assert run_stats.get("canceled") == 1
-
-        assert result.data["partitionBackfillOrError"]["backfillStatus"] == "INCOMPLETE"
 
 
 class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):


### PR DESCRIPTION
### Summary & Motivation
We are spending 2/3 of the backfill query time loading unused graphql fields.

### How I Tested These Changes
BK, ran backfill page using shadow dagit, saw improvement in backfill page load time