### PR TITLE
[structured config] Base structured config implementation

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Any, Type
 
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_SINGLETON, ModelField
@@ -29,7 +29,7 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
     return convert_potential_field(dagster_type)
 
 
-def infer_schema_from_config_annotation(model_cls: Type) -> Field:
+def infer_schema_from_config_annotation(model_cls: Any) -> Field:
     """
     Parses a structured config class or primitive type and returns a corresponding Dagster config Field.
     """
@@ -40,12 +40,11 @@ def infer_schema_from_config_annotation(model_cls: Type) -> Field:
     return convert_potential_field(model_cls)
 
 
-def _safe_is_subclass(cls: Type, possible_parent_cls: Type) -> bool:
-    """Safe version of issubclass that returns False if cls is not a class."""
-    try:
-        return issubclass(cls, possible_parent_cls)
-    except TypeError:
+def _safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:
+    """Version of issubclass that returns False if cls is not a Type."""
+    if not isinstance(cls, Type):
         return False
+    return issubclass(cls, possible_parent_cls)
 
 
 def infer_schema_from_config_class(model_cls: Type[Config]) -> Field:

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,0 +1,65 @@
+from typing import Type
+
+from pydantic import BaseModel
+from pydantic.fields import SHAPE_SINGLETON, ModelField
+
+import dagster._check as check
+from dagster import Field, Shape
+from dagster._config.field_utils import convert_potential_field
+
+
+class Config(BaseModel):
+    """
+    Base class for Dagster configuration models.
+    """
+
+
+def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
+    """
+    Transforms a Pydantic field into a corresponding Dagster config field.
+    """
+
+    if issubclass(pydantic_field.type_, Config):
+        return infer_schema_from_config_class(pydantic_field.type_)
+
+    dagster_type = pydantic_field.type_
+    if pydantic_field.shape == SHAPE_SINGLETON:
+        pass
+    else:
+        raise NotImplementedError(f"Pydantic shape {pydantic_field.shape} not supported.")
+
+    return convert_potential_field(dagster_type)
+
+
+def infer_schema_from_config_annotation(model_cls: Type) -> Field:
+    """
+    Parses a structured config class or primitive type and returns a corresponding Dagster config Field.
+    """
+
+    try:
+        if issubclass(model_cls, Config):
+            return infer_schema_from_config_class(model_cls)
+    except TypeError:
+        # In case a user passes e.g. a Typing type, which is not a class
+        # convert_potential_field will produce a more actionable error message
+        # than the TypeError that would be raised here
+        pass
+
+    return convert_potential_field(model_cls)
+
+
+def infer_schema_from_config_class(model_cls: Type[Config]) -> Field:
+    """
+    Parses a structured config class and returns a corresponding Dagster config Field.
+    """
+
+    check.param_invariant(
+        issubclass(model_cls, Config),
+        "Config type annotation must inherit from dagster._config.structured_config.Config",
+    )
+
+    fields = {}
+    for pydantic_field_name, pydantic_field in model_cls.__fields__.items():
+        fields[pydantic_field_name] = _convert_pydantic_field(pydantic_field)
+
+    return Field(config=Shape(fields))

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -42,7 +42,7 @@ def infer_schema_from_config_annotation(model_cls: Any) -> Field:
 
 def _safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:
     """Version of issubclass that returns False if cls is not a Type."""
-    if not isinstance(cls, Type):
+    if not isinstance(cls, type):
         return False
     return issubclass(cls, possible_parent_cls)
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -23,10 +23,8 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
         return infer_schema_from_config_class(pydantic_field.type_)
 
     dagster_type = pydantic_field.type_
-    if pydantic_field.shape == SHAPE_SINGLETON:
-        pass
-    else:
-        raise NotImplementedError(f"Pydantic shape {pydantic_field.shape} not supported.")
+    if pydantic_field.shape != SHAPE_SINGLETON:
+        raise NotImplementedError(f"Pydantic shape {pydantic_field.shape} not supported")
 
     return convert_potential_field(dagster_type)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -61,6 +61,19 @@ class _Op:
             else NoContextDecoratedOpFunction(decorated_fn=fn)
         )
 
+        if compute_fn.has_config_arg():
+            check.param_invariant(
+                self.config_schema is None,
+                "If the @op has a config arg, you cannot specify a config schema",
+            )
+
+            from dagster._config.structured_config import infer_schema_from_config_annotation
+
+            # Parse schema from the type annotation of the config arg
+            config_arg = compute_fn.get_config_arg()
+            config_arg_type = config_arg.annotation
+            self.config_schema = infer_schema_from_config_annotation(config_arg_type)
+
         outs: Optional[Mapping[str, Out]] = None
         if self.out is not None and isinstance(self.out, Out):
             outs = {DEFAULT_OUTPUT: self.out}

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -58,7 +58,7 @@ class DecoratedOpFunction(NamedTuple):
             if param.name == "config":
                 return param
 
-        raise Exception("Must have config arg")
+        check.failed("Requested config arg on function that does not have one")
 
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -46,10 +46,25 @@ class DecoratedOpFunction(NamedTuple):
     def _get_function_params(self) -> Sequence[funcsigs.Parameter]:
         return get_function_params(self.decorated_fn)
 
+    def has_config_arg(self) -> bool:
+        for param in get_function_params(self.decorated_fn):
+            if param.name == "config":
+                return True
+
+        return False
+
+    def get_config_arg(self) -> funcsigs.Parameter:
+        for param in get_function_params(self.decorated_fn):
+            if param.name == "config":
+                return param
+
+        raise Exception("Must have config arg")
+
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()
         input_args = params[1:] if self.has_context_arg() else params
-        return positional_arg_name_list(input_args)
+        input_args_filtered = [input_arg for input_arg in input_args if input_arg.name != "config"]
+        return positional_arg_name_list(input_args_filtered)
 
     def has_var_kwargs(self) -> bool:
         params = self._get_function_params()
@@ -348,6 +363,14 @@ def resolve_checked_solid_fn_inputs(
     params = get_function_params(compute_fn.decorated_fn)
 
     input_args = params[1:] if compute_fn.has_context_arg() else params
+
+    # filter out config arg
+    if compute_fn.has_config_arg():
+        new_input_args = []
+        for input_arg in input_args:
+            if input_arg.name != "config":
+                new_input_args.append(input_arg)
+        input_args = new_input_args
 
     # Validate input arguments
     used_inputs = set()

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -120,7 +120,7 @@ class InputDefinition:
         input_manager_key: Optional[str] = None
         # when adding new params, make sure to update combine_with_inferred and with_dagster_type below
     ):
-        self._name = check_valid_name(name)
+        self._name = check_valid_name(name, allow_list=["config"])
 
         self._type_not_set = dagster_type is None
         self._dagster_type = check.inst(resolve_dagster_type(dagster_type), DagsterType)

--- a/python_modules/dagster/dagster/_core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_invocation.py
@@ -54,10 +54,15 @@ def op_invocation_result(
         check.failed("solid invocation only works with decorated solid fns")
 
     compute_fn = cast(DecoratedOpFunction, compute_fn)
-    result = (
-        compute_fn.decorated_fn(bound_context, **input_dict)
-        if compute_fn.has_context_arg()
-        else compute_fn.decorated_fn(**input_dict)
+
+    from ..execution.plan.compute_generator import invoke_compute_fn
+
+    result = invoke_compute_fn(
+        compute_fn.decorated_fn,
+        bound_context,
+        input_dict,
+        compute_fn.has_context_arg(),
+        compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None,
     )
 
     return _type_check_output_wrapper(op_def, result, bound_context)

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -2,7 +2,7 @@ import keyword
 import os
 import re
 from glob import glob
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 import yaml
 
@@ -50,8 +50,13 @@ def has_valid_name_chars(name: str) -> bool:
     return bool(VALID_NAME_REGEX.match(name))
 
 
-def check_valid_name(name: str) -> str:
+def check_valid_name(name: str, allow_list: List[str] = None) -> str:
+
     check.str_param(name, "name")
+
+    if allow_list and name in allow_list:
+        return name
+
     if name in DISALLOWED_NAMES:
         raise DagsterInvalidDefinitionError(
             f'"{name}" is not a valid name in Dagster. It conflicts with a Dagster or python reserved keyword.'

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -50,7 +50,7 @@ def has_valid_name_chars(name: str) -> bool:
     return bool(VALID_NAME_REGEX.match(name))
 
 
-def check_valid_name(name: str, allow_list: List[str] = None) -> str:
+def check_valid_name(name: str, allow_list: Optional[List[str]] = None) -> str:
 
     check.str_param(name, "name")
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -4,9 +4,9 @@ from functools import wraps
 from typing import (
     Any,
     Callable,
+    Dict,
     Generator,
     Iterator,
-    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -88,7 +88,7 @@ async def _coerce_async_solid_to_async_gen(awaitable, context, output_defs):
 def invoke_compute_fn(
     fn: Callable,
     context: OpExecutionContext,
-    kwargs: Mapping[str, Any],
+    kwargs: Dict[str, Any],
     context_arg_provided: bool,
     config_arg_cls: Optional[Type[Config]],
 ) -> Any:

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -1,10 +1,23 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Any, Generator, Iterator, Sequence, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from typing_extensions import get_args
 
+from dagster._config.structured_config import Config
 from dagster._core.definitions import (
     AssetMaterialization,
     DynamicOutput,
@@ -31,6 +44,7 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
     input_defs = solid_def.input_defs
     output_defs = solid_def.output_defs
     context_arg_provided = compute_fn.has_context_arg()
+    config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
 
     input_names = [
         input_def.name
@@ -39,7 +53,7 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
     ]
 
     @wraps(fn)
-    def compute(context, input_defs) -> Generator[Output, None, None]:
+    def compute(context: OpExecutionContext, input_defs) -> Generator[Output, None, None]:
         kwargs = {}
         for input_name in input_names:
             kwargs[input_name] = input_defs[input_name]
@@ -50,7 +64,7 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
             or inspect.iscoroutinefunction(fn)
         ):
             # safe to execute the function, as doing so will not immediately execute user code
-            result = fn(context, **kwargs) if context_arg_provided else fn(**kwargs)
+            result = invoke_compute_fn(fn, context, kwargs, context_arg_provided, config_arg_cls)
             if inspect.iscoroutine(result):
                 return _coerce_async_solid_to_async_gen(result, context, output_defs)
             # already a generator
@@ -59,7 +73,7 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
             # we have a regular function, do not execute it before we are in an iterator
             # (as we want all potential failures to happen inside iterators)
             return _coerce_solid_compute_fn_to_iterator(
-                fn, output_defs, context, context_arg_provided, kwargs
+                fn, output_defs, context, context_arg_provided, kwargs, config_arg_cls
             )
 
     return compute
@@ -71,8 +85,27 @@ async def _coerce_async_solid_to_async_gen(awaitable, context, output_defs):
         yield event
 
 
-def _coerce_solid_compute_fn_to_iterator(fn, output_defs, context, context_arg_provided, kwargs):
-    result = fn(context, **kwargs) if context_arg_provided else fn(**kwargs)
+def invoke_compute_fn(
+    fn: Callable,
+    context: OpExecutionContext,
+    kwargs: Mapping[str, Any],
+    context_arg_provided: bool,
+    config_arg_cls: Optional[Type[Config]],
+) -> Any:
+    args_to_pass = kwargs
+    if config_arg_cls:
+        # config_arg_cls is either a Config class or a primitive type
+        if issubclass(config_arg_cls, Config):
+            args_to_pass["config"] = config_arg_cls(**context.op_config)
+        else:
+            args_to_pass["config"] = context.op_config
+    return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
+
+
+def _coerce_solid_compute_fn_to_iterator(
+    fn, output_defs, context, context_arg_provided, kwargs, config_arg_class
+):
+    result = invoke_compute_fn(fn, context, kwargs, context_arg_provided, config_arg_class)
     for event in validate_and_coerce_op_result_to_iterator(result, context, output_defs):
         yield event
 

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -1,0 +1,300 @@
+import pytest
+from pydantic import BaseModel
+
+from dagster import _check as check
+from dagster import job, op, validate_run_config
+from dagster._config.config_type import ConfigTypeKind
+from dagster._config.field_utils import convert_potential_field
+from dagster._config.structured_config import Config, infer_schema_from_config_class
+from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
+from dagster._core.execution.context.invocation import build_op_context
+from dagster._legacy import pipeline
+
+
+def test_disallow_config_schema_conflict():
+    class ANewConfigOpConfig(Config):
+        a_string: str
+
+    with pytest.raises(check.ParameterCheckError):
+
+        @op(config_schema=str)
+        def a_double_config(config: ANewConfigOpConfig):
+            pass
+
+
+from dagster._config.type_printer import print_config_type_to_string
+
+
+def test_infer_config_schema():
+    old_schema = {"a_string": str, "an_int": int}
+
+    class ConfigClassTest(Config):
+        a_string: str
+        an_int: int
+
+    assert type_string_from_config_schema(old_schema) == type_string_from_pydantic(ConfigClassTest)
+
+    from_old_schema_field = convert_potential_field(old_schema)
+    config_class_config_field = infer_schema_from_config_class(ConfigClassTest)
+
+    assert type_string_from_config_schema(
+        from_old_schema_field.config_type
+    ) == type_string_from_config_schema(config_class_config_field)
+
+
+def type_string_from_config_schema(config_schema):
+    return print_config_type_to_string(convert_potential_field(config_schema).config_type)
+
+
+def type_string_from_pydantic(cls):
+    return print_config_type_to_string(infer_schema_from_config_class(cls).config_type)
+
+
+def test_decorated_op_function():
+    class ANewConfigOpConfig(Config):
+        a_string: str
+
+    @op
+    def a_struct_config_op(config: ANewConfigOpConfig):
+        pass
+
+    @op(config_schema={"a_string": str})
+    def an_old_config_op():
+        pass
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert not DecoratedOpFunction(an_old_config_op).has_config_arg()
+    assert DecoratedOpFunction(a_struct_config_op).has_config_arg()
+
+    config_param = DecoratedOpFunction(a_struct_config_op).get_config_arg()
+    assert config_param.name == "config"
+
+
+def test_struct_config():
+    class ANewConfigOpConfig(Config):
+        a_string: str
+        an_int: int
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: ANewConfigOpConfig):
+        executed["yes"] = True
+        assert config.a_string == "foo"
+        assert config.an_int == 2
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_struct_config_op).has_config_arg()
+
+    # test fields are inferred correctly
+    assert a_struct_config_op.config_schema.config_type.kind == ConfigTypeKind.STRICT_SHAPE
+    assert list(a_struct_config_op.config_schema.config_type.fields.keys()) == [
+        "a_string",
+        "an_int",
+    ]
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    assert a_job
+
+    from dagster._core.errors import DagsterInvalidConfigError
+
+    with pytest.raises(DagsterInvalidConfigError):
+        # ensure that config schema actually works
+        a_job.execute_in_process(
+            {"ops": {"a_struct_config_op": {"config": {"a_string_mispelled": "foo", "an_int": 2}}}}
+        )
+
+    a_job.execute_in_process(
+        {"ops": {"a_struct_config_op": {"config": {"a_string": "foo", "an_int": 2}}}}
+    )
+
+    assert executed["yes"]
+
+
+def test_primitive_struct_config():
+
+    executed = {}
+
+    @op
+    def a_str_op(config: str):
+        executed["yes"] = True
+        assert config == "foo"
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_str_op).has_config_arg()
+
+    @job
+    def a_job():
+        a_str_op()
+
+    assert a_job
+
+    from dagster._core.errors import DagsterInvalidConfigError
+
+    with pytest.raises(DagsterInvalidConfigError):
+        # ensure that config schema actually works
+        a_job.execute_in_process({"ops": {"a_str_op": {"config": 1}}})
+
+    a_job.execute_in_process({"ops": {"a_str_op": {"config": "foo"}}})
+
+    assert executed["yes"]
+
+    @op
+    def a_bool_op(config: bool):
+        assert not config
+
+    @op
+    def a_int_op(config: int):
+        assert config == 1
+
+    @op
+    def a_dict_op(config: dict):
+        assert config == {"foo": 1}
+
+    @op
+    def a_list_op(config: list):
+        assert config == [1, 2, 3]
+
+    @job
+    def a_larger_job():
+        a_str_op()
+        a_bool_op()
+        a_int_op()
+        a_dict_op()
+        a_list_op()
+
+    a_larger_job.execute_in_process(
+        {
+            "ops": {
+                "a_str_op": {"config": "foo"},
+                "a_bool_op": {"config": False},
+                "a_int_op": {"config": 1},
+                "a_dict_op": {"config": {"foo": 1}},
+                "a_list_op": {"config": [1, 2, 3]},
+            }
+        }
+    )
+
+
+def test_invalid_struct_config():
+    # Config should extend Config, not BaseModel
+    with pytest.raises(DagsterInvalidConfigDefinitionError):
+
+        class BaseModelExtendingConfig(BaseModel):
+            a_string: str
+            an_int: int
+
+        @op
+        def a_basemodel_config_op(config: BaseModelExtendingConfig):
+            pass
+
+
+def test_nested_struct_config():
+    class ANestedConfig(Config):
+        a_string: str
+        an_int: int
+
+    class ANewConfigOpConfig(Config):
+        a_nested_value: ANestedConfig
+        a_bool: bool
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: ANewConfigOpConfig):
+        executed["yes"] = True
+        assert config.a_nested_value.a_string == "foo"
+        assert config.a_nested_value.an_int == 2
+        assert config.a_bool == True
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_struct_config_op).has_config_arg()
+
+    # test fields are inferred correctly
+    assert a_struct_config_op.config_schema.config_type.kind == ConfigTypeKind.STRICT_SHAPE
+    assert list(a_struct_config_op.config_schema.config_type.fields.keys()) == [
+        "a_nested_value",
+        "a_bool",
+    ]
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    assert a_job
+
+    a_job.execute_in_process(
+        {
+            "ops": {
+                "a_struct_config_op": {
+                    "config": {"a_bool": True, "a_nested_value": {"a_string": "foo", "an_int": 2}}
+                }
+            }
+        }
+    )
+
+    assert executed["yes"]
+
+
+def test_direct_op_invocation():
+    class MyBasicOpConfig(Config):
+        foo: str
+
+    # Limitation: for now direct invocation still requires the op to have a context argument.
+    @op
+    def basic_op(context, config: MyBasicOpConfig):
+        assert config.foo == "bar"
+
+    basic_op(build_op_context(op_config={"foo": "bar"}))
+
+    with pytest.raises(AssertionError):
+        basic_op(build_op_context(op_config={"foo": "qux"}))
+
+    with pytest.raises(DagsterInvalidConfigError):
+        basic_op(build_op_context(op_config={"baz": "qux"}))
+
+
+def test_validate_run_config():
+    class MyBasicOpConfig(Config):
+        foo: str
+
+    @op()
+    def requires_config(config: MyBasicOpConfig):
+        pass
+
+    @pipeline
+    def pipeline_requires_config():
+        requires_config()
+
+    result = validate_run_config(
+        pipeline_requires_config, {"solids": {"requires_config": {"config": {"foo": "bar"}}}}
+    )
+
+    assert result == {
+        "solids": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
+        "execution": {"in_process": {"retries": {"enabled": {}}}},
+        "resources": {"io_manager": {"config": None}},
+        "loggers": {},
+    }
+
+    result_with_storage = validate_run_config(
+        pipeline_requires_config,
+        {"solids": {"requires_config": {"config": {"foo": "bar"}}}},
+    )
+
+    assert result_with_storage == {
+        "solids": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
+        "execution": {"in_process": {"retries": {"enabled": {}}}},
+        "resources": {"io_manager": {"config": None}},
+        "loggers": {},
+    }
+
+    with pytest.raises(DagsterInvalidConfigError):
+        validate_run_config(pipeline_requires_config)

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -6,6 +6,7 @@ from dagster import job, op, validate_run_config
 from dagster._config.config_type import ConfigTypeKind
 from dagster._config.field_utils import convert_potential_field
 from dagster._config.structured_config import Config, infer_schema_from_config_class
+from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
 from dagster._core.execution.context.invocation import build_op_context
 from dagster._legacy import pipeline
@@ -20,9 +21,6 @@ def test_disallow_config_schema_conflict():
         @op(config_schema=str)
         def a_double_config(config: ANewConfigOpConfig):
             pass
-
-
-from dagster._config.type_printer import print_config_type_to_string
 
 
 def test_infer_config_schema():

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -99,6 +99,7 @@ setup(
         'pywin32 != 226; platform_system=="Windows"',
         "docstring-parser",
         "universal_pathlib",
+        "pydantic",
     ],
     extras_require={
         "docker": ["docker"],

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -42,4 +42,6 @@ commands =
 
 [testenv:pylint]
 commands =
+  # Additional arg to allow pylint to build AST from pydantic module, see
+  # https://github.com/pydantic/pydantic/issues/1961#issuecomment-729288794
   pylint -j0 --rcfile=../../pyproject.toml {posargs} dagster dagster_tests --extension-pkg-whitelist='pydantic'

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -42,4 +42,4 @@ commands =
 
 [testenv:pylint]
 commands =
-  pylint -j0 --rcfile=../../pyproject.toml {posargs} dagster dagster_tests
+  pylint -j0 --rcfile=../../pyproject.toml {posargs} dagster dagster_tests --extension-pkg-whitelist='pydantic'


### PR DESCRIPTION
## Summary

Introduces the capability to specify config types for an Op or Asset by applying a type annotation to the new `config` keyword, e.g.

```python
@op
def greet_user(config: str):
    print(f"Hello, {config}")
```

For more complex config schema, users can build a Pydantic type ("structured config") extending the new `Config` base class. This provides type hinting when using config in an asset or op body:

```python
class GreetingConfig(Config):
    name: str
    should_print: bool

@op 
def greet_user(config: GreetingConfig):
    if config.should_print:
        print(f"Hello, {config.name}")
    else:
        ...
```

## Limitations

This PR only handles the case of structured config which has primitive types. More complex config (defaults, descriptions, Permissive, Selector/Unions, etc) will be handled in stacked diffs.

## Test Plan

Introduced a set of unit tests to cover basic config classes using primitives + nested structured config.