### PR TITLE
[structured config] Add support for default values

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -49,7 +49,12 @@ def infer_schema_from_config_annotation(model_cls: Any, config_arg_default: Any)
         return infer_schema_from_config_class(model_cls)
 
     inner_config_type = convert_potential_field(model_cls).config_type
-    return Field(config=inner_config_type, default_value=config_arg_default)
+    return Field(
+        config=inner_config_type,
+        default_value=FIELD_NO_DEFAULT_PROVIDED
+        if config_arg_default is inspect.Parameter.empty
+        else config_arg_default,
+    )
 
 
 def _safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any, Type
 
 from pydantic import BaseModel
@@ -5,7 +6,7 @@ from pydantic.fields import SHAPE_SINGLETON, ModelField
 
 import dagster._check as check
 from dagster import Field, Shape
-from dagster._config.field_utils import convert_potential_field
+from dagster._config.field_utils import FIELD_NO_DEFAULT_PROVIDED, convert_potential_field
 
 
 class Config(BaseModel):
@@ -26,18 +27,29 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
     if pydantic_field.shape != SHAPE_SINGLETON:
         raise NotImplementedError(f"Pydantic shape {pydantic_field.shape} not supported")
 
-    return convert_potential_field(dagster_type)
+    inner_config_type = convert_potential_field(dagster_type).config_type
+    return Field(
+        config=inner_config_type,
+        default_value=pydantic_field.default
+        if pydantic_field.default
+        else FIELD_NO_DEFAULT_PROVIDED,
+    )
 
 
-def infer_schema_from_config_annotation(model_cls: Any) -> Field:
+def infer_schema_from_config_annotation(model_cls: Any, config_arg_default: Any) -> Field:
     """
     Parses a structured config class or primitive type and returns a corresponding Dagster config Field.
     """
 
     if _safe_is_subclass(model_cls, Config):
+        check.invariant(
+            config_arg_default is inspect.Parameter.empty,
+            "Cannot provide a default value when using a Config class",
+        )
         return infer_schema_from_config_class(model_cls)
 
-    return convert_potential_field(model_cls)
+    inner_config_type = convert_potential_field(model_cls).config_type
+    return Field(config=inner_config_type, default_value=config_arg_default)
 
 
 def _safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -72,7 +72,10 @@ class _Op:
             # Parse schema from the type annotation of the config arg
             config_arg = compute_fn.get_config_arg()
             config_arg_type = config_arg.annotation
-            self.config_schema = infer_schema_from_config_annotation(config_arg_type)
+            config_arg_default = config_arg.default
+            self.config_schema = infer_schema_from_config_annotation(
+                config_arg_type, config_arg_default
+            )
 
         outs: Optional[Mapping[str, Out]] = None
         if self.out is not None and isinstance(self.out, Out):

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_default_values.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_default_values.py
@@ -1,0 +1,132 @@
+import pytest
+from pydantic import BaseModel
+
+from dagster import _check as check
+from dagster import job, op, validate_run_config
+from dagster._config.config_type import ConfigTypeKind
+from dagster._config.field_utils import convert_potential_field
+from dagster._config.structured_config import Config, infer_schema_from_config_class
+from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
+from dagster._core.execution.context.invocation import build_op_context
+from dagster._legacy import pipeline
+
+
+def test_default_values():
+    class ANewConfigOpConfig(Config):
+        a_string: str = "bar"
+        an_int: int = 2
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: ANewConfigOpConfig):
+        assert config.a_string == "foo"
+        assert config.an_int == 2
+        executed["yes"] = True
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_struct_config_op).has_config_arg()
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    assert a_job
+
+    with pytest.raises(AssertionError):
+        # ensure that assertion-raising default value is passed
+        a_job.execute_in_process()
+
+    a_job.execute_in_process({"ops": {"a_struct_config_op": {"config": {"a_string": "foo"}}}})
+
+    assert executed["yes"]
+
+
+def test_default_value_primitive():
+    executed = {}
+
+    @op
+    def a_primitive_config_op(config: str = "foo"):
+        assert config == "foo"
+        executed["yes"] = True
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_primitive_config_op).has_config_arg()
+
+    @job
+    def a_job():
+        a_primitive_config_op()
+
+    assert a_job
+
+    a_job.execute_in_process()
+
+    with pytest.raises(AssertionError):
+        a_job.execute_in_process({"ops": {"a_primitive_config_op": {"config": "qux"}}})
+
+    assert executed["yes"]
+
+
+def test_direct_op_invocation_default():
+    class MyBasicOpConfig(Config):
+        foo: str = "qux"
+
+    @op
+    def basic_op(context, config: MyBasicOpConfig):
+        assert config.foo == "bar"
+
+    with pytest.raises(AssertionError):
+        basic_op(build_op_context())
+
+    basic_op(build_op_context(op_config={"foo": "bar"}))
+
+    @op
+    def primitive_config_op(context, config: str = "bar"):
+        assert config == "bar"
+
+    with pytest.raises(AssertionError):
+        primitive_config_op(build_op_context(op_config="qux"))
+
+    primitive_config_op(build_op_context())
+
+
+def test_default_values_nested():
+    class ANestedOpConfig(Config):
+        an_int: int = 1
+        a_bool: bool = True
+
+    class AnotherNestedOpConfig(Config):
+        a_float: float = 1.0
+
+    class AnOpConfig(Config):
+        a_string: str = "bar"
+        a_nested: ANestedOpConfig
+        another_nested: AnotherNestedOpConfig
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: AnOpConfig):
+        assert config.a_string == "foo"
+        assert config.a_nested.an_int == 2
+        assert config.a_nested.a_bool is True
+        assert config.another_nested.a_float == 1.0
+        executed["yes"] = True
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_struct_config_op).has_config_arg()
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    assert a_job
+
+    a_job.execute_in_process(
+        {"ops": {"a_struct_config_op": {"config": {"a_string": "foo", "a_nested": {"an_int": 2}}}}}
+    )
+
+    assert executed["yes"]


### PR DESCRIPTION
## Summary

When using structured config (#11268), allows users to specify default values for config items.

This works in a very basic case with primitive config types:

```python
@op
def greet_user(config: str = "Unknown"):
    print(f"Hello, {config}")
```

When using Pydantic config types, users can specify defaults in a few ways, either by directly setting members, or by specifying a default on a Pydantic `Field`:

```python
class GreetingConfig(Config):
    name: str = "Unknown"
    should_print: bool = Field(default=True)

@op 
def greet_user(config: GreetingConfig):
    if config.should_print:
        print(f"Hello, {config.name}")
    else:
        ...
```

## Test Plan

Introduced a new set of unit tests to test default behavior.