### PR TITLE
[structured config] Add support for class, field descriptions

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -30,7 +30,6 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
         raise NotImplementedError(f"Pydantic shape {pydantic_field.shape} not supported")
 
     inner_config_type = convert_potential_field(dagster_type).config_type
-    print(pydantic_field.field_info)
     return Field(
         config=inner_config_type,
         description=pydantic_field.field_info.description,

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_descriptions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_descriptions.py
@@ -1,13 +1,9 @@
 from pydantic import Field
+from typing_extensions import Annotated
 
 from dagster import op
 from dagster._config.config_type import ConfigTypeKind
 from dagster._config.structured_config import Config
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
 
 
 def test_new_config_descriptions_and_defaults():

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_descriptions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_descriptions.py
@@ -1,0 +1,44 @@
+from pydantic import Field
+
+from dagster import op
+from dagster._config.config_type import ConfigTypeKind
+from dagster._config.structured_config import Config
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+
+def test_new_config_descriptions_and_defaults():
+    class ANestedOpConfig(Config):
+        an_int: Annotated[int, Field(description="An int")]
+
+    class AnOpConfig(Config):
+        """
+        Config for my new op
+        """
+
+        a_string: str = Field(description="A string")
+        nested: ANestedOpConfig = Field(description="A nested config")
+
+    executed = {}
+
+    @op
+    def a_new_config_op(config: AnOpConfig):
+        pass
+
+    # test fields are inferred correctly
+    assert a_new_config_op.config_schema.config_type.kind == ConfigTypeKind.STRICT_SHAPE
+    assert list(a_new_config_op.config_schema.config_type.fields.keys()) == ["a_string", "nested"]
+    assert a_new_config_op.config_schema.description == "Config for my new op"
+    assert a_new_config_op.config_schema.config_type.fields["a_string"].description == "A string"
+    assert (
+        a_new_config_op.config_schema.config_type.fields["nested"].description == "A nested config"
+    )
+    assert (
+        a_new_config_op.config_schema.config_type.fields["nested"]
+        .config_type.fields["an_int"]
+        .description
+        == "An int"
+    )


### PR DESCRIPTION
## Summary

When using structured config (#11268), reads descriptions into the Dagster config system.

Descriptions can either be specified on a Pydantic `Field` or by using docstring on a config class:

```python
class GreetingConfig(Config):
    """
    Configures how to greet the user.
    """
    name: str = Field(default="Unknown", description="The name to greet the user by")
    should_print: Annotated[bool, Field(description="Whether to print the name to the console or to logs")] = True
```

## Test Plan

Introduced a new set of unit tests.