### PR TITLE
[structured config] Add support for Permissive fields

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -13,13 +13,14 @@ except ImportError:
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Type, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 from pydantic.fields import SHAPE_SINGLETON, ModelField
 
 import dagster._check as check
 from dagster import Field, Shape
 from dagster._config.field_utils import (
     FIELD_NO_DEFAULT_PROVIDED,
+    Permissive,
     config_dictionary_from_values,
     convert_potential_field,
 )
@@ -57,6 +58,12 @@ class MakeConfigCacheable(
 class Config(MakeConfigCacheable):
     """
     Base class for Dagster configuration models.
+    """
+
+
+class PermissiveConfig(Config, extra="allow"):
+    """
+    Base class for Dagster configuration models that allow arbitrary extra fields.
     """
 
 
@@ -271,5 +278,7 @@ def infer_schema_from_config_class(
     for pydantic_field_name, pydantic_field in model_cls.__fields__.items():
         fields[pydantic_field_name] = _convert_pydantic_field(pydantic_field)
 
+    shape_cls = Permissive if model_cls.__config__.extra == Extra.allow else Shape
+
     docstring = model_cls.__doc__.strip() if model_cls.__doc__ else None
-    return Field(config=Shape(fields), description=description or docstring)
+    return Field(config=shape_cls(fields), description=description or docstring)

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
@@ -1,0 +1,79 @@
+import pytest
+
+from dagster import job, op
+from dagster._config.config_type import ConfigTypeKind
+from dagster._config.structured_config import Config, PermissiveConfig
+from dagster._core.errors import DagsterInvalidConfigError
+
+
+def test_default_config_class_non_permissive():
+    class AnOpConfig(Config):
+        a_string: str
+        an_int: int
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: AnOpConfig):
+        executed["yes"] = True
+        assert config.a_string == "foo"
+        assert config.an_int == 2
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    with pytest.raises(DagsterInvalidConfigError):
+        a_job.execute_in_process(
+            {
+                "ops": {
+                    "a_struct_config_op": {
+                        "config": {"a_string": "foo", "an_int": 2, "a_bool": True}
+                    }
+                }
+            }
+        )
+
+
+def test_struct_config_permissive():
+    class AnOpConfig(PermissiveConfig):
+        a_string: str
+        an_int: int
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: AnOpConfig):
+        executed["yes"] = True
+        assert config.a_string == "foo"
+        assert config.an_int == 2
+
+        # Can pull out config dict to access permissive fields
+        assert config.dict() == {"a_string": "foo", "an_int": 2, "a_bool": True}
+
+    from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
+
+    assert DecoratedOpFunction(a_struct_config_op).has_config_arg()
+
+    # test fields are inferred correctly
+    assert a_struct_config_op.config_schema.config_type.kind == ConfigTypeKind.PERMISSIVE_SHAPE
+    assert list(a_struct_config_op.config_schema.config_type.fields.keys()) == [
+        "a_string",
+        "an_int",
+    ]
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    assert a_job
+
+    a_job.execute_in_process(
+        {
+            "ops": {
+                "a_struct_config_op": {"config": {"a_string": "foo", "an_int": 2, "a_bool": True}}
+            }
+        }
+    )
+
+    assert executed["yes"]


### PR DESCRIPTION
## Summary

When using structured config (#11268), adds a new `PermissiveConfig` base class that allows a user to specify config values beyond what is defined in the config class.

These values can be accessed by name, or by retrieving the config dict using `config.dict()`:

```python
class KeyValueConfig(PermissiveConfig):
    pass

@op 
def print_key_value(config: KeyValueConfig):
    for key, value in config.dict():
        print(f"{key}: {value}")
```

## Test Plan

Introduced a new set of unit tests.