### PR TITLE
[structured config] Add support for Selectors w/ pydantic discriminated unions

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -829,9 +829,8 @@ def _convert_pydantic_descriminated_union_field(pydantic_field: ModelField) -> F
     })
     """
     sub_fields_mapping = pydantic_field.sub_fields_mapping
-    assert sub_fields_mapping
 
-    if not all(
+    if not sub_fields_mapping or not all(
         issubclass(pydantic_field.type_, Config) for pydantic_field in sub_fields_mapping.values()
     ):
         raise NotImplementedError("Descriminated unions with non-Config types are not supported.")
@@ -840,6 +839,7 @@ def _convert_pydantic_descriminated_union_field(pydantic_field: ModelField) -> F
     # Dagster config fields that correspond to them. We strip the descriminator key
     # from the fields, since the user should not have to specify it.
 
+    assert pydantic_field.sub_fields_mapping
     dagster_config_field_mapping = {
         descriminator_value: infer_schema_from_config_class(
             field.type_,

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -38,7 +38,6 @@ except ImportError:
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Mapping, Optional, Set, Type, cast
 
 from pydantic import BaseModel, Extra
 from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_MAPPING, SHAPE_SINGLETON, ModelField

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -829,7 +829,6 @@ def _convert_pydantic_descriminated_union_field(pydantic_field: ModelField) -> F
     })
     """
     sub_fields_mapping = pydantic_field.sub_fields_mapping
-
     if not sub_fields_mapping or not all(
         issubclass(pydantic_field.type_, Config) for pydantic_field in sub_fields_mapping.values()
     ):

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -103,7 +103,7 @@ class Config(MakeConfigCacheable):
         """
         This constructor is overridden to handle any remapping of raw config dicts to
         the appropriate config classes. For example, discriminated unions are represented
-        in Dagster config as dicts with a single key, which is the descriminator value.
+        in Dagster config as dicts with a single key, which is the discriminator value.
         """
         modified_data = {}
         for key, value in config_dict.items():
@@ -834,23 +834,23 @@ def _convert_pydantic_descriminated_union_field(pydantic_field: ModelField) -> F
     ):
         raise NotImplementedError("Descriminated unions with non-Config types are not supported.")
 
-    # First, we generate a mapping between the various descriminator values and the
-    # Dagster config fields that correspond to them. We strip the descriminator key
+    # First, we generate a mapping between the various discriminator values and the
+    # Dagster config fields that correspond to them. We strip the discriminator key
     # from the fields, since the user should not have to specify it.
 
     assert pydantic_field.sub_fields_mapping
     dagster_config_field_mapping = {
-        descriminator_value: infer_schema_from_config_class(
+        discriminator_value: infer_schema_from_config_class(
             field.type_,
             fields_to_omit={pydantic_field.field_info.discriminator}
             if pydantic_field.field_info.discriminator
             else None,
         )
-        for descriminator_value, field in sub_fields_mapping.items()
+        for discriminator_value, field in sub_fields_mapping.items()
     }
 
     # We then nest the union fields under a Selector. The keys for the selector
-    # are the various descriminator values
+    # are the various discriminator values
     return Field(config=Selector(fields=dagster_config_field_mapping))
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Mapping, Optional, Type, Union
+from typing import Any, Dict, List, Mapping, Optional, Type, Union
 
 import pytest
 from dagster import job, op
@@ -7,6 +7,7 @@ from dagster._config.structured_config import Config, PermissiveConfig
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.cached_method import cached_method
 from pydantic import Field
+from typing_extensions import Literal
 
 
 def test_default_config_class_non_permissive():


### PR DESCRIPTION
## Summary

When using structured config (#11268), enables the use of Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions), which under the hood are converted into `Selectors`. Since the structure of a selector and a discriminated union varies slightly, there is some coercing of config dicts done under the hood.

For example, given the config:

```python
class Cat(Config):
    pet_type: Literal["cat"]
    meows: int

class Dog(Config):
    pet_type: Literal["dog"]
    barks: float

class PetConfig(Config):
    pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")

@op 
def print_pet_info(config: PetConfig):
    if config.pet.pet_type == "cat":
        print(f"Meows: {config.pet.meows})
    else:
        print(f"Barks: {config.pet.barks})
```

The Dagster config structure moves the union field to a `Selector`, with the key acting as the discriminator value. A valid input to the above config is:

```json
{
  "pet": {
    "dog": {
      "barks": 3.0,
    },
  },
}
```

## Test Plan

Introduced a new set of unit tests.