### PR TITLE
[dagit] Restore some metadata on Code Locations page

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
@@ -26,6 +26,7 @@ import {RepositoryLocationNonBlockingErrorDialog} from './RepositoryLocationErro
 import {WorkspaceRepositoryLocationNode} from './WorkspaceContext';
 import {buildRepoAddress} from './buildRepoAddress';
 import {repoAddressAsHumanString} from './repoAddressAsString';
+import {RootWorkspaceQuery_workspaceOrError_Workspace_locationEntries_locationOrLoadError_RepositoryLocation_repositories_displayMetadata as DisplayMetadata} from './types/RootWorkspaceQuery';
 import {workspacePathFromAddress} from './workspacePath';
 
 interface Props {
@@ -66,12 +67,19 @@ export const CodeLocationRowSet: React.FC<Props> = ({locationNode}) => {
     <>
       {repositories.map((repository) => {
         const repoAddress = buildRepoAddress(repository.name, name);
+        const allMetadata = [...locationNode.displayMetadata, ...repository.displayMetadata];
         return (
           <tr key={repoAddressAsHumanString(repoAddress)}>
-            <td style={{maxWidth: '400px', fontWeight: 500}}>
-              <Link to={workspacePathFromAddress(repoAddress)}>
-                <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
-              </Link>
+            <td style={{maxWidth: '400px'}}>
+              <Box flex={{direction: 'column', gap: 4}}>
+                <div style={{fontWeight: 500}}>
+                  <Link to={workspacePathFromAddress(repoAddress)}>
+                    <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} />
+                  </Link>
+                </div>
+                <ImageName metadata={allMetadata} />
+                <ModuleOrPackageOrFile metadata={allMetadata} />
+              </Box>
             </td>
             <td>
               <LocationStatus location={repository.name} locationOrError={locationNode} />
@@ -93,6 +101,40 @@ export const CodeLocationRowSet: React.FC<Props> = ({locationNode}) => {
       })}
     </>
   );
+};
+
+export const ImageName: React.FC<{metadata: DisplayMetadata[]}> = ({metadata}) => {
+  const imageKV = metadata.find(({key}) => key === 'image');
+  if (imageKV) {
+    return (
+      <Box
+        flex={{direction: 'row', gap: 4}}
+        style={{width: '100%', color: Colors.Gray700, fontSize: 12}}
+      >
+        <span style={{fontWeight: 500}}>image:</span>
+        <MiddleTruncate text={imageKV.value} />
+      </Box>
+    );
+  }
+  return null;
+};
+
+export const ModuleOrPackageOrFile: React.FC<{metadata: DisplayMetadata[]}> = ({metadata}) => {
+  const imageKV = metadata.find(
+    ({key}) => key === 'module_name' || key === 'package_name' || key === 'python_file',
+  );
+  if (imageKV) {
+    return (
+      <Box
+        flex={{direction: 'row', gap: 4}}
+        style={{width: '100%', color: Colors.Gray700, fontSize: 12}}
+      >
+        <span style={{fontWeight: 500}}>{imageKV.key}:</span>
+        <MiddleTruncate text={imageKV.value} />
+      </Box>
+    );
+  }
+  return null;
 };
 
 const LocationStatus: React.FC<{

--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationSource.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationSource.tsx
@@ -23,30 +23,35 @@ export const CodeLocationSource: React.FC<{metadata: Metadata[]}> = ({metadata})
     return <div>{metadataWithURL.value}</div>;
   }
 
-  if (url.hostname.includes('github.com')) {
-    return (
+  const isGithub = url.hostname.includes('github.com');
+  const isGitlab = url.hostname.includes('gitlab.com');
+
+  if (!isGithub && !isGitlab) {
+    // Unknown URL type. Just render the text.
+    return <div>{metadataWithURL.value}</div>;
+  }
+
+  const metadataWithCommit = metadata.find(({key}) => key === 'commit_hash');
+  const commitHash = () => {
+    const hashSlice = metadataWithCommit?.value.slice(0, 8);
+    return hashSlice ? (
+      <>
+        <span style={{fontWeight: 500}}>Commit:</span> {hashSlice}
+      </>
+    ) : null;
+  };
+
+  return (
+    <Box flex={{direction: 'column', gap: 4, alignItems: 'flex-start'}}>
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-        <Icon name="github" color={Colors.Link} />
+        <Icon name={isGithub ? 'github' : 'gitlab'} color={Colors.Link} />
         <a href={metadataWithURL.value} target="_blank" rel="noreferrer">
           {extractProjectName(url.pathname)}
         </a>
       </Box>
-    );
-  }
-
-  if (url.hostname.includes('gitlab.com')) {
-    return (
-      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-        <Icon name="gitlab" color={Colors.Link} />
-        <a href={metadataWithURL.value} target="_blank" rel="noreferrer">
-          {extractProjectName(url.pathname)}
-        </a>
-      </Box>
-    );
-  }
-
-  // Unknown URL type. Just render the text.
-  return <div>{metadataWithURL.value}</div>;
+      <div style={{fontSize: 12, color: Colors.Gray700}}>{commitHash()}</div>
+    </Box>
+  );
 };
 
 const extractProjectName = (pathname: string) => pathname.split('/').slice(1, 3).join('/');


### PR DESCRIPTION
### Summary & Motivation

By request, restore some metadata items to the Code Locations table.

- Show the image name (if any), as well as the `module_name`, `package_name`, or `python_file` value.
- For the associated git repository, show the commit hash.

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/2823852/208720686-2b2d7ab0-7660-47b0-80c4-fb3e207fa1b6.png">


### How I Tested These Changes

In OS Dagit, verify that my code locations render correctly, with a `module_name` displayed under the location name.

In Cloud Dagit (master), verify that everything still renders correctly, now with the commit hash.

In a new branch for Cloud that includes the metadata additions to the "Name" column, view a non-serverless deployment, verify that its code locations show the `image` metadata as well.
