### PR TITLE
[dagit] Utility for timezone-aware date/time formatting

### DIFF
--- a/js_modules/dagit/packages/core/src/app/time/TimezoneContext.tsx
+++ b/js_modules/dagit/packages/core/src/app/time/TimezoneContext.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import {useStateWithStorage} from '../../hooks/useStateWithStorage';
 
-const TimezoneStorageKey = 'TimezonePreference';
+export const TimezoneStorageKey = 'TimezonePreference';
 
 export const TimezoneContext = React.createContext<
   [string, React.Dispatch<React.SetStateAction<string | undefined>>]

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -14,13 +14,12 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {TimezoneContext} from '../app/time/TimezoneContext';
-import {browserTimezone} from '../app/time/browserTimezone';
 import {OVERVIEW_COLLAPSED_KEY} from '../overview/OverviewExpansionKey';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {RunStatus} from '../types/globalTypes';
 import {AnchorButton} from '../ui/AnchorButton';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
+import {useFormatDateTime} from '../ui/useFormatDateTime';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
@@ -311,43 +310,32 @@ interface TimeDividersProps {
   range: [number, number];
 }
 
+const dateTimeOptions: Intl.DateTimeFormatOptions = {
+  month: 'numeric',
+  day: 'numeric',
+  year: 'numeric',
+};
+
+const dateTimeOptionsWithTimezone: Intl.DateTimeFormatOptions = {
+  month: 'numeric',
+  day: 'numeric',
+  year: 'numeric',
+  timeZoneName: 'short',
+};
+
+const timeOnlyOptions: Intl.DateTimeFormatOptions = {
+  hour: 'numeric',
+};
+
 const TimeDividers = (props: TimeDividersProps) => {
   const {interval, range, height} = props;
   const [start, end] = range;
-  const locale = navigator.language;
-  const [tz] = React.useContext(TimezoneContext);
-  const timeZone = tz === 'Automatic' ? browserTimezone() : tz;
-
-  const dateFormat = React.useMemo(() => {
-    return new Intl.DateTimeFormat(locale, {
-      month: 'numeric',
-      day: 'numeric',
-      year: 'numeric',
-      timeZone,
-    });
-  }, [locale, timeZone]);
-
-  const dateFormatWithTimezone = React.useMemo(() => {
-    return Intl.DateTimeFormat(locale, {
-      month: 'numeric',
-      day: 'numeric',
-      year: 'numeric',
-      timeZone,
-      timeZoneName: 'short',
-    });
-  }, [locale, timeZone]);
-
-  const timeFormat = React.useMemo(() => {
-    return new Intl.DateTimeFormat(locale, {
-      hour: 'numeric',
-      timeZone,
-    });
-  }, [locale, timeZone]);
+  const formatDateTime = useFormatDateTime();
 
   const dateMarkers: DateMarker[] = React.useMemo(() => {
     const totalTime = end - start;
     const startDate = new Date(start);
-    const startDateStringWithTimezone = dateFormatWithTimezone.format(startDate);
+    const startDateStringWithTimezone = formatDateTime(startDate, dateTimeOptionsWithTimezone);
 
     const dayBoundaries = [];
 
@@ -371,13 +359,13 @@ const TimeDividers = (props: TimeDividersProps) => {
       const right = Math.min(100, (endRight / totalTime) * 100);
 
       return {
-        label: dateFormat.format(date),
+        label: formatDateTime(date, dateTimeOptions),
         key: date.toString(),
         left,
         width: right - left,
       };
     });
-  }, [dateFormat, dateFormatWithTimezone, end, start]);
+  }, [end, formatDateTime, start]);
 
   const timeMarkers: TimeMarker[] = React.useMemo(() => {
     const totalTime = end - start;
@@ -388,7 +376,7 @@ const TimeDividers = (props: TimeDividersProps) => {
       .map((_, ii) => {
         const time = firstMarker + ii * interval;
         const date = new Date(time);
-        const label = timeFormat.format(date).replace(' ', '');
+        const label = formatDateTime(date, timeOnlyOptions).replace(' ', '');
         return {
           label,
           key: date.toString(),
@@ -396,7 +384,7 @@ const TimeDividers = (props: TimeDividersProps) => {
         };
       })
       .filter((marker) => marker.left > 0);
-  }, [end, start, interval, timeFormat]);
+  }, [end, start, interval, formatDateTime]);
 
   const now = Date.now();
   const nowLeft = `${(((now - start) / (end - start)) * 100).toPrecision(3)}%`;

--- a/js_modules/dagit/packages/core/src/ui/useFormatDateTime.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useFormatDateTime.test.tsx
@@ -1,0 +1,134 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {TimezoneProvider, TimezoneStorageKey} from '../app/time/TimezoneContext';
+
+import {useFormatDateTime} from './useFormatDateTime';
+
+jest.mock('../app/time/browserTimezone', () => ({
+  browserTimezone: jest.fn(() => 'Pacific/Honolulu'),
+}));
+
+const NYD_2023_CST = 1672552800000;
+
+describe('useFormatDateTime', () => {
+  interface Props {
+    date: Date;
+    options: Intl.DateTimeFormatOptions;
+  }
+
+  const Test: React.FC<Props> = ({date, options}) => {
+    const formatDateTime = useFormatDateTime();
+    return <div>{formatDateTime(date, options)}</div>;
+  };
+
+  afterEach(() => {
+    window.localStorage.removeItem(TimezoneStorageKey);
+  });
+
+  describe('Automatic timezone', () => {
+    // Timezone has not been set in localStorage, so it should be an `Automatic` timezone, and
+    // we should end up using `browserTimezone()` as mocked above.
+    it('renders with Pacific/Honolulu as the automatic timezone', async () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{month: 'long', day: 'numeric', year: 'numeric', timeZoneName: 'short'}}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/December 31, 2022(.+) HST/)).toBeVisible();
+    });
+
+    it('renders both time and date', async () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{
+              month: 'long',
+              day: 'numeric',
+              year: 'numeric',
+              hour: 'numeric',
+              minute: 'numeric',
+              timeZoneName: 'short',
+            }}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/December 31, 2022(.+) 8:00 PM HST/)).toBeVisible();
+    });
+
+    it('can render just time', async () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{
+              hour: 'numeric',
+              minute: 'numeric',
+              timeZoneName: 'short',
+            }}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/^8:00 PM HST/)).toBeVisible();
+    });
+  });
+
+  // Set the timezone in localStorage, test that it is retrieved and used correctly
+  // for the formatted string.
+  describe('Saved timezone', () => {
+    beforeEach(() => {
+      window.localStorage.setItem(TimezoneStorageKey, 'Europe/Rome');
+    });
+
+    it('renders with Europe/Rome as the timezone', async () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{month: 'long', day: 'numeric', year: 'numeric', timeZoneName: 'short'}}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/January 1, 2023(.+) GMT\+1/)).toBeVisible();
+    });
+
+    it('renders both time and date', async () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{
+              month: 'long',
+              day: 'numeric',
+              year: 'numeric',
+              hour: 'numeric',
+              minute: 'numeric',
+              timeZoneName: 'short',
+            }}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/January 1, 2023(.+) 7:00 AM GMT\+1/)).toBeVisible();
+    });
+
+    it('can render just time', async () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{
+              hour: 'numeric',
+              minute: 'numeric',
+              timeZoneName: 'short',
+            }}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/^7:00 AM GMT\+1/)).toBeVisible();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/ui/useFormatDateTime.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useFormatDateTime.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import {TimezoneContext} from '../app/time/TimezoneContext';
+import {browserTimezone} from '../app/time/browserTimezone';
+
+/**
+ * Return a date/time formatter function that takes the user's stored timezone into
+ * account. Useful for rendering arbitrary non-typical date/time formats.
+ *
+ * @returns string
+ */
+export const useFormatDateTime = () => {
+  const [storedTimezone] = React.useContext(TimezoneContext);
+  const timeZone = storedTimezone === 'Automatic' ? browserTimezone() : storedTimezone;
+  return React.useCallback(
+    (date: Date, options: Intl.DateTimeFormatOptions) => {
+      return Intl.DateTimeFormat(navigator.language, {timeZone, ...options}).format(date);
+    },
+    [timeZone],
+  );
+};


### PR DESCRIPTION
### Summary & Motivation

Create a utility hook for generating formatted date/time strings with awareness of the user's timezone.

The hook returns a memoized function that accepts a date and an `Intl.DateTimeOptions` object, and produces a formatted string with the user's timezone applied to it.

I wrote a test and updated `RunTimeline` to make use of it. Most of the use cases look like they'll be in Cloud.

### How I Tested These Changes

Jest, load Dagit and view run timeline. Verify that the date and time labels look correct.
