### PR TITLE
Rename _resolve_bound_config to resolve_bound_config

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/logger_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_invocation.py
@@ -1,12 +1,12 @@
 from ..execution.context.logger import InitLoggerContext, UnboundInitLoggerContext
 from .logger_definition import LoggerDefinition
-from .resource_invocation import _resolve_bound_config
+from .resource_invocation import resolve_bound_config
 
 
 def logger_invocation_result(logger_def: LoggerDefinition, init_context: UnboundInitLoggerContext):
     """Using the provided context, call the underlying `logger_fn` and return created logger."""
 
-    logger_config = _resolve_bound_config(init_context.logger_config, logger_def)
+    logger_config = resolve_bound_config(init_context.logger_config, logger_def)
 
     bound_context = InitLoggerContext(
         logger_config, logger_def, init_context.pipeline_def, init_context.run_id

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -78,7 +78,7 @@ def _check_invocation_requirements(
             "Use the `build_init_resource_context` function to create a context with config."
         )
 
-    resource_config = _resolve_bound_config(
+    resource_config = resolve_bound_config(
         init_context.resource_config if init_context else None, resource_def
     )
 
@@ -110,7 +110,7 @@ def _get_friendly_string(configurable_def: ConfigurableDefinition) -> str:
     check.failed(f"Invalid definition type {configurable_def}")
 
 
-def _resolve_bound_config(config: Any, configurable_def: ConfigurableDefinition) -> Any:
+def resolve_bound_config(config: Any, configurable_def: ConfigurableDefinition) -> Any:
     from dagster._config import process_config
 
     outer_config_shape = Shape({"config": configurable_def.get_config_field()})

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -239,9 +239,9 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
         _validate_resource_requirements(self._resource_defs, op_def)
 
-        from dagster._core.definitions.resource_invocation import _resolve_bound_config
+        from dagster._core.definitions.resource_invocation import resolve_bound_config
 
-        solid_config = _resolve_bound_config(self.solid_config, op_def)
+        solid_config = resolve_bound_config(self.solid_config, op_def)
 
         return BoundOpExecutionContext(
             op_def=op_def,


### PR DESCRIPTION
### Summary & Motivation

_resolve_bound_config is accessed across module boundaries, so rename to resolve_bound_config

### How I Tested These Changes

BK
