### PR TITLE
[docs] - Update ECS deployment guide

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -11,13 +11,13 @@ This guide provides instructions for deploying Dagster on Amazon Web Services (A
 
 ## Hosting Dagster on EC2
 
-To host Dagster on a bare VM or in Docker on EC2, see [Running Dagster as a service](/deployment/guides/service).
+To host Dagster on a bare VM or in Docker on EC2, refer to the [Running Dagster as a service](/deployment/guides/service) guide.
 
 ---
 
 ## Using RDS for run and event log storage
 
-You can use a hosted RDS PostgreSQL database for your Dagster run/events data by configuring your `dagster.yaml` file.
+You can use a hosted RDS PostgreSQL database for your Dagster run/events data by configuring your `dagster.yaml` file:
 
 ```python file=/deploying/dagster-pg.yaml
 storage:
@@ -30,11 +30,14 @@ storage:
       port: 5432
 ```
 
-In this case, you'll want to ensure you provide the right connection strings for your RDS instance, and ensure that the node or container hosting Dagit is able to connect to RDS.
+In this case, you'll want to ensure that:
 
-Be sure that this file is present, and _DAGSTER_HOME_ is set, on the node where Dagit is running.
+- You provide the right connection strings for your RDS instance
+- The node or container hosting Dagit is able to connect to RDS
 
-Note that using RDS for run and event log storage does not require that Dagit be running in the cloud. If you are connecting a local Dagit instance to a remote RDS storage, double check that your local node is able to connect to RDS.
+Be sure that this file is present and `DAGSTER_HOME` is set on the node where Dagit is running.
+
+**Note**: Using RDS for run and event log storage doesn't require that Dagit be running in the cloud. If you're' connecting a local Dagit instance to a remote RDS storage, verify that your local node is able to connect to RDS.
 
 ---
 
@@ -42,15 +45,22 @@ Note that using RDS for run and event log storage does not require that Dagit be
 
 <CodeReferenceLink filePath="examples/deploy_ecs" />
 
-The Deploying on ECS example on GitHub demonstrates how to configure the [Docker Compose CLI integration with ECS](https://docs.docker.com/cloud/ecs-integration/) to manage all of the required AWS resources that Dagster needs to run on ECS. The example includes a Dagit container for loading and launching jobs, a `dagster-daemon` container for managing a run queue and submitting runs from schedules and sensors, a Postgres container for persistent storage, and a container with user job code. The Dagster instance uses the <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> to launch each run in its own ECS task.
+The Deploying on ECS example on GitHub demonstrates how to configure the [Docker Compose CLI integration with ECS](https://docs.docker.com/cloud/ecs-integration/) to manage all of the required AWS resources that Dagster needs to run on ECS. The example includes:
 
-### Launching Runs in ECS
+- A Dagit container for loading and launching jobs
+- A `dagster-daemon` container for managing a run queue and submitting runs from schedules and sensors
+- A Postgres container for persistent storage
+- A container with user job code. The [Dagster instance](/deployment/dagster-instance) uses the <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> to launch each run in its own ECS task.
+
+### Launching runs in ECS
 
 The <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> launches an ECS task per run. It assumes that the rest of your Dagster deployment is also running in ECS.
 
-By default, each run's task registers its own task definition. To simplify configuration, these task definitions inherit most of their configuration (networking, cpu, memory, environment, etc.) from the process that launches the run but overrides its container definition with a new command to launch a Dagster run. When using the <PyObject module="dagster._core.run_coordinator" object="DefaultRunCoordinator" />, runs launched via Dagit or GraphQL inherit their task definitions from the Dagit task; runs launched from a sensor or schedule inherit their task definitions from the Daemon task.
+By default, each run's task registers its own task definition. To simplify configuration, these task definitions inherit most of their configuration (networking, cpu, memory, environment, etc.) from the process that launches the run but overrides its container definition with a new command to launch a Dagster run.
 
-Alternatively, you can define your own task definition in your dagster.yaml:
+When using the <PyObject module="dagster._core.run_coordinator" object="DefaultRunCoordinator" />, runs launched via Dagit or GraphQL inherit their task definitions from the Dagit task while runs launched from a sensor or schedule inherit their task definitions from the daemon task.
+
+Alternatively, you can define your own task definition in your `dagster.yaml`:
 
 ```yaml
 run_launcher:
@@ -82,7 +92,7 @@ def my_job():
   my_op()
 ```
 
-[Fargate tasks only support certain combinations of CPU and Memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
+**Note**: [Fargate tasks only support certain combinations of CPU and memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
 
 ### Customizing the launched run's task
 
@@ -106,11 +116,9 @@ Refer to the [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/lates
 
 ### Secrets management in ECS
 
-[ECS can bind AWS Secrets Managers secrets as environment variables when runs launch.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html)
+ECS can bind [AWS Secrets Managers secrets as environment variables when runs launch](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html). By default, Dagster will fetch any Secrets Manager secrets tagged with the `dagster` key and set them as environment variables.
 
-By default, Dagster will fetch any Secrets Manager secrets tagged with the key `dagster` and set them as environment variables.
-
-Alternatively you can set your own tag name in your dagster.yaml:
+Alternatively, you can set your own tag name in your `dagster.yaml`:
 
 ```yaml
 run_launcher:
@@ -120,7 +128,7 @@ run_launcher:
     secrets_tag: "my-tag-name"
 ```
 
-Any secret tagged with `my-tag-name` will be included as an environment variable with the name and value as that secret.
+In this example, any secret tagged with `my-tag-name` will be included as an environment variable with the name and value as that secret.
 
 Additionally, you can pass specific secrets using the [same structure as the ECS API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html):
 
@@ -136,15 +144,15 @@ run_launcher:
         valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::"
 ```
 
-Any secret tagged with `dagster` will be included in the environment. `MY_API_TOKEN` and `MY_PASSWORD` will also be included in the environment.
+In this example, any secret tagged with `dagster` will be included in the environment. `MY_API_TOKEN` and `MY_PASSWORD` will also be included in the environment.
 
 ---
 
 ## Using S3 for I/O management
 
-To enable parallel computation (e.g., with the multiprocessing or Dagster celery executors), you will need to configure persistent [IO Managers](/concepts/io-management/io-managers) -- for instance, using an S3 bucket to store data passed between ops.
+To enable parallel computation (e.g., with the multiprocessing or Dagster celery executors), you'll need to configure persistent [I/O managers](/concepts/io-management/io-managers). For example, using an S3 bucket to store data passed between ops.
 
-You'll first need to need to use <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/> as your IO Manager or customize your own persistent io managers (see [example](/concepts/io-management/io-managers#defining-an-io-manager)).
+You'll need to use <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager"/> as your I/O Manager or customize your own persistent I/O managers. Refer to the [I/O managers documentation](/concepts/io-management/io-managers#defining-an-io-manager) for an example.
 
 ```python file=/deploying/aws/io_manager.py
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
@@ -178,6 +186,6 @@ resources:
       s3_prefix: good/prefix-for-files-
 ```
 
-The resource uses `boto` under the hood, so if you are accessing your private buckets, you will need to provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or follow one of the other boto authentication methods.
+The resource uses `boto` under the hood. If you're accessing your private buckets, you will need to provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or follow one of the other boto authentication methods.
 
 With this in place, your job runs will store data passed between ops on S3 in the location `s3://<bucket>/dagster/storage/<job run id>/<op name>.compute`.

--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -37,7 +37,7 @@ In this case, you'll want to ensure that:
 
 Be sure that this file is present and `DAGSTER_HOME` is set on the node where Dagit is running.
 
-**Note**: Using RDS for run and event log storage doesn't require that Dagit be running in the cloud. If you're' connecting a local Dagit instance to a remote RDS storage, verify that your local node is able to connect to RDS.
+**Note**: Using RDS for run and event log storage doesn't require that Dagit be running in the cloud. If you're connecting a local Dagit instance to a remote RDS storage, verify that your local node is able to connect to RDS.
 
 ---
 
@@ -50,13 +50,15 @@ The Deploying on ECS example on GitHub demonstrates how to configure the [Docker
 - A Dagit container for loading and launching jobs
 - A `dagster-daemon` container for managing a run queue and submitting runs from schedules and sensors
 - A Postgres container for persistent storage
-- A container with user job code. The [Dagster instance](/deployment/dagster-instance) uses the <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> to launch each run in its own ECS task.
+- A container with user job code
+
+The [Dagster instance](/deployment/dagster-instance) uses the <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> to launch each run in its own ECS task.
 
 ### Launching runs in ECS
 
 The <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> launches an ECS task per run. It assumes that the rest of your Dagster deployment is also running in ECS.
 
-By default, each run's task registers its own task definition. To simplify configuration, these task definitions inherit most of their configuration (networking, cpu, memory, environment, etc.) from the process that launches the run but overrides its container definition with a new command to launch a Dagster run.
+By default, each run's task registers its own task definition. To simplify configuration, these task definitions inherit most of their configuration (networking, cpu, memory, environment, etc.) from the task that launches the run but overrides its container definition with a new command to launch a Dagster run.
 
 When using the <PyObject module="dagster._core.run_coordinator" object="DefaultRunCoordinator" />, runs launched via Dagit or GraphQL inherit their task definitions from the Dagit task while runs launched from a sensor or schedule inherit their task definitions from the daemon task.
 
@@ -186,6 +188,6 @@ resources:
       s3_prefix: good/prefix-for-files-
 ```
 
-The resource uses `boto` under the hood. If you're accessing your private buckets, you will need to provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or follow one of the other boto authentication methods.
+The resource uses `boto` under the hood. If you're accessing your private buckets, you'll need to provide the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or follow [one of the other boto authentication methods](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials).
 
 With this in place, your job runs will store data passed between ops on S3 in the location `s3://<bucket>/dagster/storage/<job run id>/<op name>.compute`.

--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -1,15 +1,19 @@
 ---
-title: Deploying Dagster to AWS | Dagster
+title: Deploying Dagster to Amazon Web Services | Dagster
 description: To deploy Dagster to AWS, EC2 or ECS can host Dagit, RDS can store runs and events, and S3 can act as an IO manager.
 ---
 
-# Deploying Dagster to AWS
+# Deploying Dagster to Amazon Web Services
 
-This guide provides instructions for deploying Dagster on AWS. You can use EC2 or ECS to host Dagit and the Dagster Daemon, RDS to store runs and events, and S3 as an IO manager to store op inputs and outputs.
+This guide provides instructions for deploying Dagster on Amazon Web Services (AWS). You can use EC2 or ECS to host Dagit and the Dagster daemon, RDS to store runs and events, and S3 as an I/O manager to store op inputs and outputs.
+
+---
 
 ## Hosting Dagster on EC2
 
 To host Dagster on a bare VM or in Docker on EC2, see [Running Dagster as a service](/deployment/guides/service).
+
+---
 
 ## Using RDS for run and event log storage
 
@@ -31,6 +35,8 @@ In this case, you'll want to ensure you provide the right connection strings for
 Be sure that this file is present, and _DAGSTER_HOME_ is set, on the node where Dagit is running.
 
 Note that using RDS for run and event log storage does not require that Dagit be running in the cloud. If you are connecting a local Dagit instance to a remote RDS storage, double check that your local node is able to connect to RDS.
+
+---
 
 ## Deploying in ECS
 
@@ -55,7 +61,7 @@ run_launcher:
     container_name: "my_container_name"
 ```
 
-### Customizing CPU and Memory in ECS
+### Customizing CPU and memory in ECS
 
 You can use job tags to customize the CPU and memory of every run for a job:
 
@@ -78,7 +84,7 @@ def my_job():
 
 [Fargate tasks only support certain combinations of CPU and Memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
 
-### Customizing the Launched Run's Task
+### Customizing the launched run's task
 
 The <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> creates a new task for each run, using the current ECS task to determine network configuration. For example, the launched run will use the same ECS cluster, subnets, security groups, and launch type (e.g. Fargate or EC2).
 
@@ -98,7 +104,7 @@ Refer to the [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/lates
 - Keys are in `camelCase` as they correspond to arguments in boto's API
 - All arguments with the exception of `taskDefinition` and `overrides` can be used in `run_launcher.config.run_task_kwargs`. `taskDefinition` can be overridden by configuring the `run_launcher.config.task_definition` field instead.
 
-### Secrets Management in ECS
+### Secrets management in ECS
 
 [ECS can bind AWS Secrets Managers secrets as environment variables when runs launch.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html)
 
@@ -132,7 +138,9 @@ run_launcher:
 
 Any secret tagged with `dagster` will be included in the environment. `MY_API_TOKEN` and `MY_PASSWORD` will also be included in the environment.
 
-## Using S3 for IO Management
+---
+
+## Using S3 for I/O management
 
 To enable parallel computation (e.g., with the multiprocessing or Dagster celery executors), you will need to configure persistent [IO Managers](/concepts/io-management/io-managers) -- for instance, using an S3 bucket to store data passed between ops.
 


### PR DESCRIPTION
This PR updates the **Deploying to AWS ECS** guide with some copy editing and formatting/style changes. No content in here has changed - just formatting and editing for clarity/style.