### PR TITLE
Make it more likely that we hit our lock

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -245,9 +245,6 @@ def test_task_definition_registration(
     assert len(ecs.list_task_definitions()["taskDefinitionArns"]) == len(task_definitions) + 1
 
 
-@pytest.mark.skip(
-    "https://buildkite.com/dagster/dagster/builds/42816#018530eb-8d74-4934-bbbc-4acb6db1cdaf"
-)
 def test_task_definition_registration_race_condition(ecs, instance, workspace, run):
     initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
     initial_tasks = ecs.list_tasks()["taskArns"]

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -300,7 +300,7 @@ class StubbedEcs:
             )
         else:
             # Sleep for long enough that we hit the lock
-            time.sleep(0.01)
+            time.sleep(0.2)
             # Family must be <= 255 characters. Alphanumeric, dash, and underscore only.
             if len(family) > 255 or not re.match(r"^[\w\-]+$", family):
                 self.stubber.add_client_error(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -188,9 +188,6 @@ def test_put_account_setting(ecs):
     assert task_arn_format_setting["value"] == "disabled"
 
 
-@pytest.mark.skip(
-    "https://buildkite.com/dagster/dagster/builds/42823#0185311c-dba8-4b27-88e5-2e6d3348c0ab"
-)
 def test_register_task_definition(ecs):
     # Without memory
     with pytest.raises(ClientError):


### PR DESCRIPTION
We started seeing flakes on our race condition tests as soon as we merged. I wasn't able to reproduce locally but I suspect .01 doesn't give us enough margin for error to hit our lock.

I'm bumping this a bit to see if it helps.
