### PR TITLE
[dagstermill] add retries to flaky tests

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/integrations_tests/test_dagstermill.py
+++ b/examples/docs_snippets/docs_snippets_tests/integrations_tests/test_dagstermill.py
@@ -9,7 +9,6 @@ from dagster._legacy import execute_pipeline
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
-import re
 import subprocess
 import warnings
 
@@ -19,28 +18,15 @@ import pytest
 # Dagstermill tests invoke notebooks that look for an ipython kernel called dagster -- if this is
 # not already present, then the tests fail. This fixture creates the kernel if it is not already
 # present before tests run.
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(autouse=True)
 def kernel():
-    installed_kernels = [
-        x.split(" ")[0]
-        for x in [
-            re.sub("  +", " ", x.strip(" "))
-            for x in filter(
-                lambda x: x.startswith("  "),
-                subprocess.check_output(["jupyter", "kernelspec", "list"])
-                .decode("utf-8")
-                .split("\n"),
-            )
-        ]
-    ]
-    if "dagster" not in installed_kernels:
-        warnings.warn(
-            'Jupyter kernel "dagster" not found, installing. Don\'t worry, this is noninvasive '
-            "and you can reverse it by running `jupyter kernelspec uninstall dagster`."
-        )
-        subprocess.check_output(
-            ["ipython", "kernel", "install", "--name", "dagster", "--user"]
-        )
+    warnings.warn(
+        "Installing Jupyter kernel dagster. Don't worry, this is noninvasive "
+        "and you can reverse it by running `jupyter kernelspec uninstall dagster`."
+    )
+    subprocess.check_output(
+        ["ipython", "kernel", "install", "--name", "dagster", "--user"]
+    )
 
 
 @contextmanager
@@ -63,6 +49,7 @@ def exec_for_test(module_name, fn_name, env=None, raise_on_error=True, **kwargs)
                 cleanup_result_notebook(result)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_config_asset():
     module_path = "docs_snippets.integrations.dagstermill.iris_notebook_config"
     if not IS_BUILDKITE:
@@ -75,6 +62,7 @@ def test_config_asset():
         assert result.success
 
 
+@pytest.mark.flaky(reruns=1)
 def test_iris_classify_job():
     module_path = "docs_snippets.integrations.dagstermill.iris_notebook_op"
     if not IS_BUILDKITE:
@@ -87,6 +75,7 @@ def test_iris_classify_job():
         assert result.success
 
 
+@pytest.mark.flaky(reruns=1)
 def test_outputs_job():
     module_path = "docs_snippets.integrations.dagstermill.notebook_outputs"
     if not IS_BUILDKITE:

--- a/python_modules/libraries/dagstermill/dagstermill_tests/conftest.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/conftest.py
@@ -1,30 +1,17 @@
-import re
 import subprocess
 import warnings
 
 import pytest
 
-
 # Dagstermill tests invoke notebooks that look for an ipython kernel called dagster -- if this is
 # not already present, then the tests fail. This fixture creates the kernel if it is not already
 # present before tests run.
-@pytest.fixture(scope="session", autouse=True)
+
+
+@pytest.fixture(autouse=True)
 def kernel():
-    installed_kernels = [
-        x.split(" ")[0]
-        for x in [
-            re.sub("  +", " ", x.strip(" "))
-            for x in filter(
-                lambda x: x.startswith("  "),
-                subprocess.check_output(["jupyter", "kernelspec", "list"])
-                .decode("utf-8")
-                .split("\n"),
-            )
-        ]
-    ]
-    if "dagster" not in installed_kernels:
-        warnings.warn(
-            'Jupyter kernel "dagster" not found, installing. Don\'t worry, this is noninvasive '
-            "and you can reverse it by running `jupyter kernelspec uninstall dagster`."
-        )
-        subprocess.check_output(["ipython", "kernel", "install", "--name", "dagster", "--user"])
+    warnings.warn(
+        "Installing Jupyter kernel dagster. Don't worry, this is noninvasive "
+        "and you can reverse it by running `jupyter kernelspec uninstall dagster`."
+    )
+    subprocess.check_output(["ipython", "kernel", "install", "--name", "dagster", "--user"])

--- a/python_modules/libraries/dagstermill/tox.ini
+++ b/python_modules/libraries/dagstermill/tox.ini
@@ -21,7 +21,7 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   ipython kernel install --name "dagster" --user
-  pytest -v -vv {posargs}{posargs}
+  pytest -v -vv --reruns 1 {posargs}{posargs}
 [testenv:mypy]
 commands =
   mypy --config=../../../pyproject.toml --non-interactive --install-types {posargs} .


### PR DESCRIPTION
### Summary & Motivation
The dagstermill tests suite is flaky due to the Jupyter kernel mysteriously dying. This PR makes a couple of changes that should make the test suite more resilient 

1. create the jupyter kernel for each test rather than the entire session. Running the kernel install command when the kernel already exists is a no-op, so we can rerun the command before each test to ensure that the kernel is alive when the test starts
2. add retries to the dagstermill test suite (and mark the dagstermill docs example tests as flaky so they get retried). if the kernel dies midway through a test, this should rerun the test and hopefully the kernel won't die again.

### How I Tested These Changes
gonna keep an eye on the dagstermill tests for the next few weeks and see if this helps