### PR TITLE
Hoist schema and database to DbIOManager constructor

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -68,8 +68,11 @@ class DbClient:
 class DbIOManager(IOManager):
     def __init__(
         self,
+        *,
         type_handlers: Sequence[DbTypeHandler],
         db_client: DbClient,
+        database: str,
+        schema: Optional[str] = None,
         io_manager_name: Optional[str] = None,
     ):
         self._handlers_by_type: Dict[Optional[Type], DbTypeHandler] = {}
@@ -85,6 +88,8 @@ class DbIOManager(IOManager):
 
                 self._handlers_by_type[handled_type] = type_handler
         self._db_client = db_client
+        self._database = database
+        self._schema = schema
 
     def handle_output(self, context: OutputContext, obj: object) -> None:
         table_slice = self._get_table_slice(context, context)
@@ -136,21 +141,17 @@ class DbIOManager(IOManager):
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
             table = asset_key_path[-1]
-            if (
-                len(asset_key_path) > 1
-                and context.resource_config
-                and context.resource_config.get("schema")
-            ):
+            if len(asset_key_path) > 1 and self._schema:
                 raise DagsterInvalidDefinitionError(
                     f"Asset {asset_key_path} specifies a schema with "
                     f"its key prefixes {asset_key_path[:-1]}, but schema  "
-                    f"{context.resource_config.get('schema')} was also provided via run config. "
+                    f"{self._schema} was also provided via run config. "
                     "Schema can only be specified one way."
                 )
             elif len(asset_key_path) > 1:
                 schema = asset_key_path[-2]
-            elif context.resource_config and context.resource_config.get("schema"):
-                schema = cast(str, context.resource_config["schema"])
+            elif self._schema:
+                schema = self._schema
             else:
                 schema = "public"
             time_window = (
@@ -158,21 +159,17 @@ class DbIOManager(IOManager):
             )
         else:
             table = output_context.name
-            if (
-                output_context_metadata.get("schema")
-                and output_context.resource_config
-                and output_context.resource_config.get("schema")
-            ):
+            if output_context_metadata.get("schema") and self._schema:
                 raise DagsterInvalidDefinitionError(
                     f"Schema {output_context_metadata.get('schema')} "
                     "specified via output metadata, but conflicting schema "
-                    f"{output_context.resource_config.get('schema')} was provided via run_config. "
+                    f"{self._schema} was provided via run_config. "
                     "Schema can only be specified one way."
                 )
             elif output_context_metadata.get("schema"):
                 schema = cast(str, output_context_metadata["schema"])
-            elif output_context.resource_config and output_context.resource_config.get("schema"):
-                schema = cast(str, output_context.resource_config["schema"])
+            elif self._schema:
+                schema = self._schema
             else:
                 schema = "public"
             time_window = None
@@ -194,7 +191,7 @@ class DbIOManager(IOManager):
         return TableSlice(
             table=table,
             schema=schema,
-            database=cast(Mapping[str, str], context.resource_config).get("database"),
+            database=self._database,
             partition=partition,
             columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
         )

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -169,7 +169,7 @@ class DbIOManager(IOManager):
                     f"{output_context.resource_config.get('schema')} was provided via run_config. "
                     "Schema can only be specified one way."
                 )
-            elif output_context.resource_config and output_context_metadata.get("schema"):
+            elif output_context_metadata.get("schema"):
                 schema = cast(str, output_context_metadata["schema"])
             elif output_context.resource_config and output_context.resource_config.get("schema"):
                 schema = cast(str, output_context.resource_config["schema"])

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -83,7 +83,7 @@ def build_duckdb_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOManager
             ),
         }
     )
-    def duckdb_io_manager(_):
+    def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database
 
         Assets will be stored in the schema and table name specified by their AssetKey.
@@ -92,7 +92,11 @@ def build_duckdb_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOManager
         table of the name of the output.
         """
         return DbIOManager(
-            type_handlers=type_handlers, db_client=DuckDbClient(), io_manager_name="DuckDBIOManager"
+            type_handlers=type_handlers,
+            db_client=DuckDbClient(),
+            io_manager_name="DuckDBIOManager",
+            database=init_context.resource_config["database"],
+            schema=init_context.resource_config.get("schema"),
         )
 
     return duckdb_io_manager

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -98,11 +98,13 @@ def build_snowflake_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOMana
             "role": Field(StringSource, description="Name of the role to use", is_required=False),
         }
     )
-    def snowflake_io_manager():
+    def snowflake_io_manager(init_context):
         return DbIOManager(
             type_handlers=type_handlers,
             db_client=SnowflakeDbClient(),
             io_manager_name="SnowflakeIOManager",
+            database=init_context.resource_config["database"],
+            schema=init_context.resource_config.get("schema"),
         )
 
     return snowflake_io_manager


### PR DESCRIPTION
### Summary & Motivation

Similar to https://github.com/dagster-io/dagster/pull/11300. We should be grabbing config as early as possible and putting it into vanilla python. This makes code more safe as well as easier to understand and refactor.

### How I Tested These Changes

BK

`cd docs && make apidoc-build`

<img width="599" alt="Screen Shot 2022-12-21 at 4 47 21 PM" src="https://user-images.githubusercontent.com/28738937/209008456-d2d69322-d532-4af4-b608-131e45ec433e.png">

<img width="382" alt="Screen Shot 2022-12-21 at 4 47 32 PM" src="https://user-images.githubusercontent.com/28738937/209008465-82cb74c5-4ec9-4e25-bdfe-f5895a0665cb.png">

