### PR TITLE
backfill perf: swap backfill requested for num cancelable

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2618,7 +2618,7 @@ type PartitionBackfill {
   status: BulkActionStatus!
   partitionNames: [String!]!
   numPartitions: Int!
-  numRequested: Int!
+  numCancelable: Int!
   fromFailure: Boolean!
   reexecutionSteps: [String!]!
   assetSelection: [AssetKey!]

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -176,8 +176,7 @@ const BackfillMenu = ({
         <Menu>
           {canCancelPartitionBackfill.enabled ? (
             <>
-              {backfill.numRequested < statusData.results.length &&
-              backfill.status === BulkActionStatus.REQUESTED ? (
+              {backfill.numCancelable > 0 ? (
                 <MenuItem
                   text="Cancel backfill submission"
                   icon="cancel"

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -129,7 +129,7 @@ export const BACKFILL_TABLE_FRAGMENT = gql`
   fragment BackfillTableFragment on PartitionBackfill {
     backfillId
     status
-    numRequested
+    numCancelable
     partitionNames
     numPartitions
     timestamp

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -53,7 +53,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     return null;
   }
 
-  const numUnscheduled = (backfill.numPartitions || 0) - (backfill.numRequested || 0);
+  const numUnscheduled = backfill.numCancelable;
   const cancel = async () => {
     setIsSubmitting(true);
     await cancelBackfill({variables: {backfillId: backfill.backfillId}});

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -138,7 +138,6 @@ const BACKFILLS_QUERY = gql`
         results {
           backfillId
           status
-          numRequested
           numPartitions
           timestamp
           partitionSetName

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTableFragment.ts
@@ -47,7 +47,7 @@ export interface BackfillTableFragment {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
-  numRequested: number;
+  numCancelable: number;
   partitionNames: string[];
   numPartitions: number;
   timestamp: number;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfillsQuery.ts
@@ -47,12 +47,12 @@ export interface InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackf
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
-  numRequested: number;
   numPartitions: number;
   timestamp: number;
   partitionSetName: string;
   partitionSet: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_partitionSet | null;
   error: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_error | null;
+  numCancelable: number;
   partitionNames: string[];
   assetSelection: InstanceBackfillsQuery_partitionBackfillsOrError_PartitionBackfills_results_assetSelection[] | null;
 }

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsQuery.ts
@@ -51,7 +51,7 @@ export interface JobBackfillsQuery_partitionSetOrError_PartitionSet_backfills {
   __typename: "PartitionBackfill";
   backfillId: string;
   status: BulkActionStatus;
-  numRequested: number;
+  numCancelable: number;
   partitionNames: string[];
   numPartitions: number;
   timestamp: number;

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -23,7 +23,7 @@ PARTITION_PROGRESS_QUERY = """
         __typename
         backfillId
         status
-        numRequested
+        numCancelable
         partitionNames
         numPartitions
         fromFailure
@@ -153,7 +153,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["numRequested"] == 0
+        assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
 
     def test_get_partition_backfills(self, graphql_context):
@@ -223,7 +223,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["numRequested"] == 0
+        assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
         assert result.data["partitionBackfillOrError"]["reexecutionSteps"] == ["after_failure"]
 
@@ -258,7 +258,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["numRequested"] == 0
+        assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
 
         result = execute_dagster_graphql(
@@ -310,7 +310,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["numRequested"] == 0
+        assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
 
         # manually mark as failed
@@ -576,7 +576,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["numRequested"] == 0
+        assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
         assert result.data["partitionBackfillOrError"]["fromFailure"]
 
@@ -612,5 +612,5 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["numRequested"] == 0
+        assert result.data["partitionBackfillOrError"]["numCancelable"] == 10
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 10


### PR DESCRIPTION
### Summary & Motivation
Context: this is the last step to bring backfill page loads to a reasonable spot, after https://github.com/dagster-io/dagster/pull/11205 and https://github.com/dagster-io/dagster/pull/11246

Looking at a slow backfill page load on speedscope, it looks like we're still doing slow multi-run fetches just to calculate the count of "cancelable" runs, where "cancelable" is the number of partitions requested in the backfill that never had corresponding runs launched.  This value was only used to cancel a backfill via the action menu.

Previously, we were comparing the number of runs with the backfill tag on it to the total count of partitions requested.

In this PR, instead, we directly look at the checkpoint value on the backfill object (e.g. how the backfill daemon checkpoints its own progress in terms of requesting runs) and the backfill status to get a `numCancelable` field.  This has the advantage of never having to query the runs table.

### How I Tested These Changes
Loaded slow backfill page in shadow dagit, saw the `InstanceBackfillQuery` load time go from >15s down to 3s.

Launched a backfill, saw that I could successfully cancel.