### PR TITLE
feat: add retry number and url to integration api call failure

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -121,6 +121,7 @@ class AirbyteResource:
             Optional[Dict[str, Any]]: Parsed json data from the response to this request
         """
 
+        url = self.api_base_url + endpoint
         headers = {"accept": "application/json"}
 
         num_retries = 0
@@ -130,7 +131,7 @@ class AirbyteResource:
                     **deep_merge_dicts(  # type: ignore
                         dict(
                             method="POST",
-                            url=self.api_base_url + endpoint,
+                            url=url,
                             headers=headers,
                             json=data,
                             timeout=self._request_timeout,
@@ -152,7 +153,7 @@ class AirbyteResource:
                 num_retries += 1
                 time.sleep(self._request_retry_delay)
 
-        raise Failure("Exceeded max number of retries.")
+        raise Failure(f"Max retries ({self._request_max_retries}) exceeded with url: {url}.")
 
     def cancel_job(self, job_id: int):
         self.make_request(endpoint="/jobs/cancel", data={"id": job_id})

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import responses
 from dagster_airbyte import AirbyteOutput, AirbyteState, airbyte_resource
@@ -34,7 +36,12 @@ def test_trigger_connection_fail():
     ab_resource = airbyte_resource(
         build_init_resource_context(config={"host": "some_host", "port": "8000"})
     )
-    with pytest.raises(Failure, match="Exceeded max number of retries"):
+    with pytest.raises(
+        Failure,
+        match=re.escape(
+            "Max retries (3) exceeded with url: http://some_host:8000/api/v1/connections/get."
+        ),
+    ):
         ab_resource.sync_and_poll("some_connection")
 
 

--- a/python_modules/libraries/dagster-census/dagster_census/resources.py
+++ b/python_modules/libraries/dagster-census/dagster_census/resources.py
@@ -61,6 +61,7 @@ class CensusResource:
         Returns:
             Dict[str, Any]: JSON data from the response to this request
         """
+        url = f"{self.api_base_url}/{endpoint}"
         headers = {
             "User-Agent": f"dagster-census/{__version__}",
             "Content-Type": "application/json;version=2",
@@ -71,7 +72,7 @@ class CensusResource:
             try:
                 response = requests.request(
                     method=method,
-                    url=f"{self.api_base_url}/{endpoint}",
+                    url=url,
                     headers=headers,
                     auth=HTTPBasicAuth("bearer", self._api_key),
                     data=data,
@@ -85,7 +86,7 @@ class CensusResource:
                 num_retries += 1
                 time.sleep(self._request_retry_delay)
 
-        raise Failure("Exceeded max number of retries.")
+        raise Failure(f"Max retries ({self._request_max_retries}) exceeded with url: {url}.")
 
     def get_sync(self, sync_id: int) -> Mapping[str, Any]:
         """

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/resources.py
@@ -126,7 +126,7 @@ class DbtCloudResourceV2:
                 num_retries += 1
                 time.sleep(self._request_retry_delay)
 
-        raise Failure("Exceeded max number of retries.")
+        raise Failure(f"Max retries ({self._request_max_retries}) exceeded with url: {url}.")
 
     def get_job(self, job_id: int) -> Mapping[str, Any]:
         """

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import responses
 from dagster_dbt import dbt_cloud_resource
@@ -130,7 +132,12 @@ def test_request_flake(max_retries, n_flakes):
             return dc_resource.get_run(SAMPLE_RUN_ID)
 
     if n_flakes > max_retries:
-        with pytest.raises(Failure, match="Exceeded max number of retries."):
+        with pytest.raises(
+            Failure,
+            match=re.escape(
+                f"Max retries ({max_retries}) exceeded with url: https://cloud.getdbt.com/api/v2/accounts/30000/runs/5000000/."
+            ),
+        ):
             _mock_interaction()
     else:
         assert _mock_interaction() == sample_run_details()["data"]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -73,7 +73,7 @@ class FivetranResource:
         Returns:
             Dict[str, Any]: Parsed json data from the response to this request
         """
-
+        url = urljoin(self.api_base_url, endpoint)
         headers = {
             "User-Agent": f"dagster-fivetran/{__version__}",
             "Content-Type": "application/json;version=2",
@@ -84,7 +84,7 @@ class FivetranResource:
             try:
                 response = requests.request(
                     method=method,
-                    url=urljoin(self.api_base_url, endpoint),
+                    url=url,
                     headers=headers,
                     auth=self._auth,
                     data=data,
@@ -99,7 +99,7 @@ class FivetranResource:
                 num_retries += 1
                 time.sleep(self._request_retry_delay)
 
-        raise Failure("Exceeded max number of retries.")
+        raise Failure(f"Max retries ({self._request_max_retries}) exceeded with url: {url}.")
 
     def get_connector_details(self, connector_id: str) -> Mapping[str, Any]:
         """

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_resources.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 import pytest
 import responses
@@ -70,7 +71,12 @@ def test_get_connector_details_flake(max_retries, n_flakes):
             return ft_resource.get_connector_details(DEFAULT_CONNECTOR_ID)
 
     if n_flakes > max_retries:
-        with pytest.raises(Failure, match="Exceeded max number of retries."):
+        with pytest.raises(
+            Failure,
+            match=re.escape(
+                f"Max retries ({max_retries}) exceeded with url: https://api.fivetran.com/v1/connectors/some_connector."
+            ),
+        ):
             _mock_interaction()
     else:
         assert _mock_interaction() == get_sample_connector_response()["data"]


### PR DESCRIPTION
### Summary & Motivation
Something like this message is a little insufficient. Add the number of retries that occurred, as well as the specific url that was being requested.
```
dagster._core.errors.DagsterUserCodeUnreachableError: dagster._core.errors.DagsterUserCodeUnreachableError: Failure loading server endpoint for prod:purina:
dagster._core.definitions.events.Failure: Exceeded max number of retries.
```

### How I Tested These Changes
TODO: pytest
