### PR TITLE
Add gql pin

### DIFF
--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         "graphene>=3",
-        "gql[requests]",
+        "gql[requests]>=3.0.0",
         "requests",
         "starlette",  # used for run_in_threadpool utility fn
     ],


### PR DESCRIPTION
Summary:
We are in practice requiring at least this version since we require graphql 3 elsewhere. Users reported dagit somehow leaving them stuck on 0.1

Resolves https://github.com/dagster-io/dagster/issues/10872.

### Summary & Motivation

### How I Tested These Changes
