### PR TITLE
Eliminating unnecessary output_context.resource_config check

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -169,7 +169,7 @@ class DbIOManager(IOManager):
                     f"{output_context.resource_config.get('schema')} was provided via run_config. "
                     "Schema can only be specified one way."
                 )
-            elif output_context.resource_config and output_context_metadata.get("schema"):
+            elif output_context_metadata.get("schema"):
                 schema = cast(str, output_context_metadata["schema"])
             elif output_context.resource_config and output_context.resource_config.get("schema"):
                 schema = cast(str, output_context.resource_config["schema"])


### PR DESCRIPTION
### Summary & Motivation

This appears to be a useless clause in this check, as resource_config always has a value and it doesn't make sense to logically gate this check on the existence of resource_config. output_context_metadata guaranted to have a dict at the top of this function so the bare call to `get` should be fine

### How I Tested These Changes

BK
