### PR TITLE
allow upload config to pass through s3 compute log manager

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -42,6 +42,7 @@ class S3ComputeLogManager(BaseModel):
     endpointUrl: Optional[StringSource]
     skipEmptyFiles: Optional[bool]
     uploadInterval: Optional[int]
+    uploadExtraArgs: Optional[dict]
 
 
 class ComputeLogManagerConfig(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -584,6 +584,8 @@ def test_s3_compute_log_manager(template: HelmTemplate):
     endpoint_url = "endpoint.com"
     skip_empty_files = True
     upload_interval = 30
+    upload_extra_args = {"ACL": "public-read"}
+
     helm_values = DagsterHelmValues.construct(
         computeLogManager=ComputeLogManager.construct(
             type=ComputeLogManagerType.S3,
@@ -598,6 +600,7 @@ def test_s3_compute_log_manager(template: HelmTemplate):
                     endpointUrl=endpoint_url,
                     skipEmptyFiles=skip_empty_files,
                     uploadInterval=upload_interval,
+                    uploadExtraArgs=upload_extra_args,
                 )
             ),
         )
@@ -619,6 +622,7 @@ def test_s3_compute_log_manager(template: HelmTemplate):
         "endpoint_url": endpoint_url,
         "skip_empty_files": skip_empty_files,
         "upload_interval": upload_interval,
+        "upload_extra_args": upload_extra_args,
     }
 
     # Test all config fields in configurable class

--- a/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
+++ b/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
@@ -97,6 +97,10 @@ config:
   {{- if $s3ComputeLogManagerConfig.uploadInterval }}
   upload_interval: {{ $s3ComputeLogManagerConfig.uploadInterval }}
   {{- end }}
+
+  {{- if $s3ComputeLogManagerConfig.uploadExtraArgs }}
+  upload_extra_args: {{ $s3ComputeLogManagerConfig.uploadExtraArgs | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 
 {{- define "dagsterYaml.computeLogManager.custom" }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1425,6 +1425,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "uploadExtraArgs": {
+                    "title": "Uploadextraargs",
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -207,12 +207,14 @@ computeLogManager:
   #     secretKey: ~
   #     localDir: ~
   #     prefix: ~
+  #     uploadInterval: ~
   ##  Uncomment this configuration if the GCSComputeLogManager is selected
   #   gcsComputeLogManager:
   #     bucket: ~
   #     localDir: ~
   #     prefix: ~
   #     jsonCredentialsEnvvar: ~
+  #     uploadInterval: ~
   ##  Uncomment this configuration if the S3ComputeLogManager is selected
   #   s3ComputeLogManager:
   #     bucket: ~
@@ -223,6 +225,8 @@ computeLogManager:
   #     verifyCertPath: ~
   #     endpointUrl: ~
   #     skipEmptyFiles: ~
+  #     uploadInterval: ~
+  #     uploadExtraArgs: {}
   ##  Uncomment this configuration if the CustomComputeLogManager is selected.
   ##  Using this setting requires a custom Dagit image that defines the user specified
   ##  compute log manager in an installed python module.
@@ -1026,7 +1030,6 @@ dagsterDaemon:
         dequeueIntervalSeconds: ~
         dequeueUseThreads: ~
         dequeueNumWorkers: ~
-
 
     ##  Uncomment this configuration if the CustomRunCoordinator is selected.
     ##  Using this setting requires a custom Daemon image that defines the user specified

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -5,7 +5,7 @@ import boto3
 from botocore.errorfactory import ClientError
 
 import dagster._seven as seven
-from dagster import Field, StringSource
+from dagster import Field, Permissive, StringSource
 from dagster import _check as check
 from dagster._config.config_type import Noneable
 from dagster._core.storage.cloud_storage_compute_log_manager import (
@@ -73,6 +73,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         endpoint_url=None,
         skip_empty_files=False,
         upload_interval=None,
+        upload_extra_args=None,
     ):
         _verify = False if not verify else verify_cert_path
         self._s3_session = boto3.resource(
@@ -90,6 +91,8 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self._skip_empty_files = check.bool_param(skip_empty_files, "skip_empty_files")
         self._upload_interval = check.opt_int_param(upload_interval, "upload_interval")
+        check.opt_dict_param(upload_extra_args, "upload_extra_args")
+        self._upload_extra_args = upload_extra_args
 
     @property
     def inst_data(self):
@@ -107,6 +110,9 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
             "endpoint_url": Field(StringSource, is_required=False),
             "skip_empty_files": Field(bool, is_required=False, default_value=False),
             "upload_interval": Field(Noneable(int), is_required=False, default_value=None),
+            "upload_extra_args": Field(
+                Permissive(), is_required=False, description="Extra args for S3 file upload"
+            ),
         }
 
     @staticmethod
@@ -196,7 +202,9 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
 
         s3_key = self._s3_key(log_key, io_type, partial=partial)
         with open(path, "rb") as data:
-            self._s3_session.upload_fileobj(data, self._s3_bucket, s3_key)
+            self._s3_session.upload_fileobj(
+                data, self._s3_bucket, s3_key, ExtraArgs=self._upload_extra_args
+            )
 
     def download_from_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial=False


### PR DESCRIPTION
### Summary & Motivation
Finally getting around to https://github.com/dagster-io/dagster/issues/10507...

This pass through some S3 boto config from the helm chart for the S3 compute log manager all the way to the boto upload call.

### How I Tested These Changes
BK, helm checks, tested manual boto upload via compute log manager.

