### PR TITLE
Use dark mode logo on README.md

### DIFF
--- a/python_modules/dagster/README.md
+++ b/python_modules/dagster/README.md
@@ -1,6 +1,10 @@
 <p align="center">
   <a target="_blank" href="https://dagster.io" style="background:none">
-    <img alt="dagster logo" src="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/dagster-logo-light.svg" width="auto" height="120">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/dagster-logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/dagster-logo-light.svg">
+      <img alt="dagster logo" src="https://raw.githubusercontent.com/dagster-io/dagster/master/.github/dagster-logo-light.svg" width="auto" height="120">
+    </picture>
   </a>
   <br /><br />
   <a target="_blank" href="https://twitter.com/dagster" style="background:none">


### PR DESCRIPTION
### Summary & Motivation

Based on recommendations in https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to.

<img width="710" alt="Screenshot 2022-12-21 at 4 30 33 PM" src="https://user-images.githubusercontent.com/2823852/209015012-f30b4328-5590-4928-a57b-3f16b08aa3af.png">
<img width="679" alt="Screenshot 2022-12-21 at 4 30 57 PM" src="https://user-images.githubusercontent.com/2823852/209015013-00e728fd-c5c2-45c3-be50-4f97c61ca05c.png">


### How I Tested These Changes

Preview with GH dark mode, then with GH light mode.
