### PR TITLE
[structured config] Fix usage with Assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -521,12 +521,18 @@ def build_asset_ins(
         "context"
     )
     input_params = params[1:] if is_context_provided else params
+
+    # Filter config
+    filtered_input_params = [param for param in input_params if param.name != "config"]
+
     non_var_input_param_names = [
         param.name
-        for param in input_params
+        for param in filtered_input_params
         if param.kind == funcsigs.Parameter.POSITIONAL_OR_KEYWORD
     ]
-    has_kwargs = any(param.kind == funcsigs.Parameter.VAR_KEYWORD for param in input_params)
+    has_kwargs = any(
+        param.kind == funcsigs.Parameter.VAR_KEYWORD for param in filtered_input_params
+    )
 
     all_input_names = set(non_var_input_param_names) | asset_ins.keys()
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -63,7 +63,7 @@ class _Op:
 
         if compute_fn.has_config_arg():
             check.param_invariant(
-                self.config_schema is None,
+                self.config_schema is None or self.config_schema == {},
                 "If the @op has a config arg, you cannot specify a config schema",
             )
 

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -121,10 +121,13 @@ def test_with_assets():
         a_string: str
         an_int: int
 
+    executed = {}
+
     @asset
     def my_asset(config: AnAssetConfig):
         assert config.a_string == "foo"
         assert config.an_int == 2
+        executed["yes"] = True
 
     assert (
         build_assets_job(
@@ -136,16 +139,21 @@ def test_with_assets():
         .success
     )
 
+    assert executed["yes"]
+
 
 def test_multi_asset():
     class AMultiAssetConfig(Config):
         a_string: str
         an_int: int
 
+    executed = {}
+
     @multi_asset(outs={"a": AssetOut(key="asset_a"), "b": AssetOut(key="asset_b")})
     def two_assets(config: AMultiAssetConfig):
         assert config.a_string == "foo"
         assert config.an_int == 2
+        executed["yes"] = True
         return 1, 2
 
     assert (
@@ -157,6 +165,8 @@ def test_multi_asset():
         .execute_in_process()
         .success
     )
+
+    assert executed["yes"]
 
 
 def test_primitive_struct_config():


### PR DESCRIPTION
## Summary

Since asset inputs flow through a separate code path, the `config` parameter wasn't being stripped out properly when using structured config with assets. Fixes + adds test.
