### PR TITLE
Docs release backfill 1.1.7

### DIFF
--- a/docs/next/.versioned_content/_versioned_navigation.json
+++ b/docs/next/.versioned_content/_versioned_navigation.json
@@ -66551,20 +66551,6 @@
         {
           "children": [
             {
-              "children": [
-                {
-                  "path": "/dagster-cloud/getting-started/getting-started-with-serverless-deployment",
-                  "title": "Serverless Deployment"
-                },
-                {
-                  "path": "/dagster-cloud/getting-started/getting-started-with-hybrid-deployment",
-                  "title": "Hybrid Deployment"
-                },
-                {
-                  "path": "/dagster-cloud/developing-testing/environment-variables-and-secrets",
-                  "title": "Environment variables and secrets"
-                }
-              ],
               "path": "/dagster-cloud/getting-started",
               "title": "Getting started"
             },
@@ -66786,6 +66772,14 @@
             {
               "path": "/integrations/airflow/from-airflow-to-dagster",
               "title": "Learning Dagster from Airflow"
+            },
+            {
+              "path": "/integrations/airflow/migrating-to-dagster",
+              "title": "Airflow Migration Guide"
+            },
+            {
+              "path": "/integrations/airflow/reference",
+              "title": "Reference"
             }
           ],
           "path": "/integrations/airflow",
@@ -66866,6 +66860,10 @@
             {
               "path": "/integrations/snowflake/using-snowflake-with-dagster",
               "title": "Snowflake+ Dagster tutorial"
+            },
+            {
+              "path": "/integrations/snowflake/reference",
+              "title": "Reference"
             }
           ],
           "path": "/integrations/snowflake",


### PR DESCRIPTION
### Summary & Motivation
This PR needs to be merged in, in order to update the 1.1.7 nav using the current master.

This PR also shows how the docs backfill is done:

Backfill procedure:

<details>
<summary>1. cut docs backfill branch off of master</summary>

```bash
~/dev/dagster master
dagster-3.8.6 $ git checkout -b docs-release-backfill-1.1.7
Switched to a new branch 'docs-release-backfill-1.1.7'

~/dev/dagster docs-release-backfill-1.1.7
dagster-3.8.6 $ git sl
* commit: ec387055c5 <ec387055c57b7a1152fa33c32d32afa8aa82224e>  (HEAD -> docs-release-backfill-1.1.7, origin>
  date: Wed Dec 21 18:39:58 2022 -0500 8 minutes ago
  author: Erin Cochran <erin.k.cochran@gmail.com>
  [docs] - [definitions] Update Dagster daemon docs (#11226)
```

</details>

2. backfill 1.1.7 nav using the current master
3. test in preview 
4. replace 1.1.7 docs contents and images ([source code](https://github.com/dagster-io/dagster/blob/master/docs/next/pages/%5B...page%5D.tsx#L107)) with the docs/content dir in this branch
5. redeploy docs build https://vercel.com/elementl/dagster/84QPrXZvf8DYNG9amk57kvk7rFs1

### How I Tested These Changes
test in preview
pages which weren't released with 1.1.7 should show up in 1.1.7 now:
- https://dagster-git-docs-release-backfill-117-elementl.vercel.app/1.1.7/integrations/airflow/migrating-to-dagster 
- changes in https://dagster-git-docs-release-backfill-117-elementl.vercel.app/1.1.7/concepts/resources#providing-resources-to-software-defined-assets
- https://dagster-git-docs-release-backfill-117-elementl.vercel.app/1.1.7/integrations/snowflake/reference