### PR TITLE
store repository on external asset graph

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -20,7 +20,7 @@ from dagster_graphql.schema.solids import (
 
 from dagster import AssetKey
 from dagster import _check as check
-from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.logical_version import (
     DEFAULT_LOGICAL_VERSION,
     extract_logical_version_from_entry,
@@ -517,9 +517,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_freshnessInfo(self, graphene_info) -> Optional[GrapheneAssetFreshnessInfo]:
         if self._external_asset_node.freshness_policy:
-            asset_graph = AssetGraph.from_external_assets(
-                self._external_repository.get_external_asset_nodes()
-            )
+            asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
             return get_freshness_info(
                 asset_key=self._external_asset_node.asset_key,
                 freshness_policy=self._external_asset_node.freshness_policy,

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -1,8 +1,7 @@
 import functools
-from collections import defaultdict, deque
+from collections import deque
 from heapq import heapify, heappop, heappush
 from typing import (
-    TYPE_CHECKING,
     AbstractSet,
     Callable,
     Dict,
@@ -31,18 +30,41 @@ from .partition_mapping import PartitionMapping, infer_partition_mapping
 from .source_asset import SourceAsset
 from .time_window_partitions import TimeWindowPartitionsDefinition
 
-if TYPE_CHECKING:
-    from dagster._core.host_representation.external_data import ExternalAssetNode
 
+class AssetGraph:
+    def __init__(
+        self,
+        asset_dep_graph: DependencyGraph,
+        source_asset_keys: AbstractSet[AssetKey],
+        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
+        partition_mappings_by_key: Mapping[AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]],
+        group_names_by_key: Mapping[AssetKey, Optional[str]],
+        freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]],
+        required_multi_asset_sets_by_key: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]],
+    ):
+        self._asset_dep_graph = asset_dep_graph
+        self._source_asset_keys = source_asset_keys
+        self._partitions_defs_by_key = partitions_defs_by_key
+        self._partition_mappings_by_key = partition_mappings_by_key
+        self._group_names_by_key = group_names_by_key
+        self._freshness_policies_by_key = freshness_policies_by_key
+        self._required_multi_asset_sets_by_key = required_multi_asset_sets_by_key
 
-class AssetGraph(NamedTuple):
-    asset_dep_graph: DependencyGraph
-    source_asset_keys: AbstractSet[AssetKey]
-    partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]]
-    partition_mappings_by_key: Mapping[AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]]
-    group_names_by_key: Mapping[AssetKey, Optional[str]]
-    freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]]
-    required_multi_asset_sets_by_key: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]]
+    @property
+    def asset_dep_graph(self):
+        return self._asset_dep_graph
+
+    @property
+    def group_names_by_key(self):
+        return self._group_names_by_key
+
+    @property
+    def source_asset_keys(self):
+        return self._source_asset_keys
+
+    @property
+    def freshness_policies_by_key(self):
+        return self._freshness_policies_by_key
 
     @staticmethod
     def from_assets(all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]) -> "AssetGraph":
@@ -86,70 +108,18 @@ class AssetGraph(NamedTuple):
             required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
         )
 
-    @staticmethod
-    def from_external_assets(external_asset_nodes: Sequence["ExternalAssetNode"]) -> "AssetGraph":
-        upstream = {}
-        downstream = {}
-        source_asset_keys = set()
-        partitions_defs_by_key = {}
-        partition_mappings_by_key: Dict[AssetKey, Dict[AssetKey, PartitionMapping]] = defaultdict(
-            defaultdict
-        )
-        group_names_by_key = {}
-        freshness_policies_by_key = {}
-        asset_keys_by_atomic_execution_unit_id: Dict[str, Set[AssetKey]] = defaultdict(set)
-
-        for node in external_asset_nodes:
-            if node.is_source:
-                source_asset_keys.add(node.asset_key)
-            upstream[node.asset_key] = {dep.upstream_asset_key for dep in node.dependencies}
-            downstream[node.asset_key] = {dep.downstream_asset_key for dep in node.depended_by}
-            for dep in node.dependencies:
-                if dep.partition_mapping is not None:
-                    partition_mappings_by_key[node.asset_key][
-                        dep.upstream_asset_key
-                    ] = dep.partition_mapping
-            partitions_defs_by_key[node.asset_key] = (
-                node.partitions_def_data.get_partitions_definition()
-                if node.partitions_def_data
-                else None
-            )
-            group_names_by_key[node.asset_key] = node.group_name
-            freshness_policies_by_key[node.asset_key] = node.freshness_policy
-
-            if node.atomic_execution_unit_id is not None:
-                asset_keys_by_atomic_execution_unit_id[node.atomic_execution_unit_id].add(
-                    node.asset_key
-                )
-
-        required_multi_asset_sets_by_key: Dict[AssetKey, AbstractSet[AssetKey]] = {}
-        for _, asset_keys in asset_keys_by_atomic_execution_unit_id.items():
-            if len(asset_keys) > 1:
-                for asset_key in asset_keys:
-                    required_multi_asset_sets_by_key[asset_key] = asset_keys
-
-        return AssetGraph(
-            asset_dep_graph={"upstream": upstream, "downstream": downstream},
-            source_asset_keys=source_asset_keys,
-            partitions_defs_by_key=partitions_defs_by_key,
-            partition_mappings_by_key=partition_mappings_by_key,
-            group_names_by_key=group_names_by_key,
-            freshness_policies_by_key=freshness_policies_by_key,
-            required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
-        )
-
     @property
     def all_asset_keys(self) -> AbstractSet[AssetKey]:
-        return self.asset_dep_graph["upstream"].keys()
+        return self._asset_dep_graph["upstream"].keys()
 
     def get_partitions_def(self, asset_key: AssetKey) -> Optional[PartitionsDefinition]:
-        return self.partitions_defs_by_key.get(asset_key)
+        return self._partitions_defs_by_key.get(asset_key)
 
     def get_partition_mapping(
         self, asset_key: AssetKey, in_asset_key: AssetKey
     ) -> PartitionMapping:
         partitions_def = self.get_partitions_def(asset_key)
-        partition_mappings = self.partition_mappings_by_key.get(asset_key) or {}
+        partition_mappings = self._partition_mappings_by_key.get(asset_key) or {}
         return infer_partition_mapping(partition_mappings.get(in_asset_key), partitions_def)
 
     def is_partitioned(self, asset_key: AssetKey) -> bool:
@@ -161,11 +131,11 @@ class AssetGraph(NamedTuple):
 
     def get_children(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         """Returns all assets that depend on the given asset"""
-        return self.asset_dep_graph["downstream"][asset_key]
+        return self._asset_dep_graph["downstream"][asset_key]
 
     def get_parents(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         """Returns all assets that the given asset depends on"""
-        return self.asset_dep_graph["upstream"][asset_key]
+        return self._asset_dep_graph["upstream"][asset_key]
 
     def get_children_partitions(
         self, asset_key: AssetKey, partition_key: Optional[str] = None
@@ -285,9 +255,9 @@ class AssetGraph(NamedTuple):
 
     def has_non_source_parents(self, asset_key: AssetKey) -> bool:
         """Determines if an asset has any parents which are not source assets"""
-        if asset_key in self.source_asset_keys:
+        if asset_key in self._source_asset_keys:
             return False
-        return bool(self.get_parents(asset_key) - self.source_asset_keys - {asset_key})
+        return bool(self.get_parents(asset_key) - self._source_asset_keys - {asset_key})
 
     def get_non_source_roots(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         """Returns all assets upstream of the given asset which do not consume any other
@@ -307,7 +277,7 @@ class AssetGraph(NamedTuple):
         queue = deque([asset_key])
         while queue:
             current_key = queue.popleft()
-            if current_key in self.source_asset_keys:
+            if current_key in self._source_asset_keys:
                 continue
             for parent_key in self.get_parents(current_key):
                 if parent_key not in visited:
@@ -317,17 +287,17 @@ class AssetGraph(NamedTuple):
 
     def get_required_multi_asset_keys(self, asset_key: AssetKey) -> AbstractSet[AssetKey]:
         """For a given asset_key, return the set of asset keys that must be materialized at the same time."""
-        if self.required_multi_asset_sets_by_key is None:
+        if self._required_multi_asset_sets_by_key is None:
             raise DagsterInvariantViolationError(
                 "Required neighbor information not set when creating this AssetGraph"
             )
-        if asset_key in self.required_multi_asset_sets_by_key:
-            return self.required_multi_asset_sets_by_key[asset_key]
+        if asset_key in self._required_multi_asset_sets_by_key:
+            return self._required_multi_asset_sets_by_key[asset_key]
         return set()
 
     def toposort_asset_keys(self) -> Sequence[AbstractSet[AssetKey]]:
         return [
-            {key for key in level} for level in toposort.toposort(self.asset_dep_graph["upstream"])
+            {key for key in level} for level in toposort.toposort(self._asset_dep_graph["upstream"])
         ]
 
     def has_self_dependency(self, asset_key: AssetKey) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -1,0 +1,157 @@
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
+
+from dagster._core.host_representation.external import ExternalRepository
+from dagster._core.host_representation.handle import RepositoryHandle
+from dagster._core.selector.subset_selector import DependencyGraph
+from dagster._core.workspace.context import BaseWorkspaceRequestContext
+
+from .asset_graph import AssetGraph
+from .events import AssetKey
+from .freshness_policy import FreshnessPolicy
+from .partition import PartitionsDefinition
+from .partition_mapping import PartitionMapping
+
+if TYPE_CHECKING:
+    from dagster._core.host_representation.external_data import ExternalAssetNode
+
+
+class ExternalAssetGraph(AssetGraph):
+    def __init__(
+        self,
+        asset_dep_graph: DependencyGraph,
+        source_asset_keys: AbstractSet[AssetKey],
+        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
+        partition_mappings_by_key: Mapping[AssetKey, Optional[Mapping[AssetKey, PartitionMapping]]],
+        group_names_by_key: Mapping[AssetKey, Optional[str]],
+        freshness_policies_by_key: Mapping[AssetKey, Optional[FreshnessPolicy]],
+        required_multi_asset_sets_by_key: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]],
+        repo_handles_by_key: Mapping[AssetKey, RepositoryHandle],
+        job_names_by_key: Mapping[AssetKey, Sequence[str]],
+    ):
+        super().__init__(
+            asset_dep_graph=asset_dep_graph,
+            source_asset_keys=source_asset_keys,
+            partitions_defs_by_key=partitions_defs_by_key,
+            partition_mappings_by_key=partition_mappings_by_key,
+            group_names_by_key=group_names_by_key,
+            freshness_policies_by_key=freshness_policies_by_key,
+            required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
+        )
+        self._repo_handles_by_key = repo_handles_by_key
+        self._job_names_by_key = job_names_by_key
+
+    @classmethod
+    def from_workspace_request_context(
+        cls, context: BaseWorkspaceRequestContext
+    ) -> "ExternalAssetGraph":
+        repo_locations = (
+            location_entry.repository_location
+            for location_entry in context.get_workspace_snapshot().values()
+            if location_entry.repository_location
+        )
+        repos = (
+            repo
+            for repo_location in repo_locations
+            for repo in repo_location.get_repositories().values()
+        )
+        repo_handle_external_asset_nodes: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]] = [
+            (repo.handle, external_asset_node)
+            for repo in repos
+            for external_asset_node in repo.get_external_asset_nodes()
+            if not external_asset_node.is_source
+        ]
+
+        return cls.from_repository_handles_and_external_asset_nodes(
+            repo_handle_external_asset_nodes
+        )
+
+    @classmethod
+    def from_external_repository(
+        cls, external_repository: ExternalRepository
+    ) -> "ExternalAssetGraph":
+        return cls.from_repository_handles_and_external_asset_nodes(
+            [
+                (external_repository.handle, asset_node)
+                for asset_node in external_repository.get_external_asset_nodes()
+            ]
+        )
+
+    @classmethod
+    def from_repository_handles_and_external_asset_nodes(
+        cls,
+        repo_handle_external_asset_nodes: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
+    ) -> "ExternalAssetGraph":
+        upstream = {}
+        downstream = {}
+        source_asset_keys = set()
+        partitions_defs_by_key = {}
+        partition_mappings_by_key: Dict[AssetKey, Dict[AssetKey, PartitionMapping]] = defaultdict(
+            defaultdict
+        )
+        group_names_by_key = {}
+        freshness_policies_by_key = {}
+        asset_keys_by_atomic_execution_unit_id: Dict[str, Set[AssetKey]] = defaultdict(set)
+        repo_handles_by_key = {
+            node.asset_key: repo_handle for repo_handle, node in repo_handle_external_asset_nodes
+        }
+        job_names_by_key = {
+            node.asset_key: node.job_names for _, node in repo_handle_external_asset_nodes
+        }
+
+        for repo_handle, node in repo_handle_external_asset_nodes:
+            if node.is_source:
+                source_asset_keys.add(node.asset_key)
+            upstream[node.asset_key] = {dep.upstream_asset_key for dep in node.dependencies}
+            downstream[node.asset_key] = {dep.downstream_asset_key for dep in node.depended_by}
+            for dep in node.dependencies:
+                if dep.partition_mapping is not None:
+                    partition_mappings_by_key[node.asset_key][
+                        dep.upstream_asset_key
+                    ] = dep.partition_mapping
+            partitions_defs_by_key[node.asset_key] = (
+                node.partitions_def_data.get_partitions_definition()
+                if node.partitions_def_data
+                else None
+            )
+            group_names_by_key[node.asset_key] = node.group_name
+            freshness_policies_by_key[node.asset_key] = node.freshness_policy
+
+            if node.atomic_execution_unit_id is not None:
+                asset_keys_by_atomic_execution_unit_id[node.atomic_execution_unit_id].add(
+                    node.asset_key
+                )
+
+        required_multi_asset_sets_by_key: Dict[AssetKey, AbstractSet[AssetKey]] = {}
+        for _, asset_keys in asset_keys_by_atomic_execution_unit_id.items():
+            if len(asset_keys) > 1:
+                for asset_key in asset_keys:
+                    required_multi_asset_sets_by_key[asset_key] = asset_keys
+
+        return cls(
+            asset_dep_graph={"upstream": upstream, "downstream": downstream},
+            source_asset_keys=source_asset_keys,
+            partitions_defs_by_key=partitions_defs_by_key,
+            partition_mappings_by_key=partition_mappings_by_key,
+            group_names_by_key=group_names_by_key,
+            freshness_policies_by_key=freshness_policies_by_key,
+            required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
+            repo_handles_by_key=repo_handles_by_key,
+            job_names_by_key=job_names_by_key,
+        )
+
+    def get_repository_handle(self, asset_key: AssetKey) -> RepositoryHandle:
+        return self._repo_handles_by_key[asset_key]
+
+    def get_job_names(self, asset_key: AssetKey) -> Iterable[str]:
+        return self._job_names_by_key[asset_key]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -1,4 +1,6 @@
 # pylint: disable=unused-argument
+from unittest.mock import MagicMock
+
 import pendulum
 import pytest
 
@@ -22,6 +24,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.host_representation.external_data import external_asset_graph_from_defs
 from dagster._seven.compat.pendulum import create_pendulum_time
@@ -35,7 +38,9 @@ def to_external_asset_graph(assets) -> AssetGraph:
     external_asset_nodes = external_asset_graph_from_defs(
         repo.get_all_pipelines(), source_assets_by_key={}
     )
-    return AssetGraph.from_external_assets(external_asset_nodes)
+    return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
+        [(MagicMock(), asset_node) for asset_node in external_asset_nodes]
+    )
 
 
 def test_basics():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import time
+from unittest import mock
+
+from dagster import Definitions, asset
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.host_representation import InProcessRepositoryLocationOrigin
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.workspace.context import WorkspaceRequestContext
+from dagster._core.workspace.workspace import WorkspaceLocationEntry, WorkspaceLocationLoadStatus
+
+
+@asset
+def asset1():
+    ...
+
+
+defs1 = Definitions(assets=[asset1])
+
+
+@asset
+def asset2():
+    ...
+
+
+defs2 = Definitions(assets=[asset2])
+
+
+def test_get_repository_location():
+    def make_location_entry(attr: str):
+        origin = InProcessRepositoryLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                python_file=__file__,
+                working_directory=os.path.dirname(__file__),
+                attribute=attr,
+            ),
+            container_image=None,
+            entry_point=None,
+            container_context=None,
+            location_name=None,
+        )
+
+        repo_location = origin.create_location()
+
+        return WorkspaceLocationEntry(
+            origin=origin,
+            repository_location=repo_location,
+            load_error=None,
+            load_status=WorkspaceLocationLoadStatus.LOADED,
+            display_metadata={},
+            update_timestamp=time.time(),
+        )
+
+    context = WorkspaceRequestContext(
+        instance=mock.MagicMock(),
+        workspace_snapshot={
+            "loc1": make_location_entry("defs1"),
+            "loc2": make_location_entry("defs2"),
+        },
+        process_context=mock.MagicMock(),
+        version=None,
+        source=None,
+        read_only=True,
+    )
+
+    asset_graph = ExternalAssetGraph.from_workspace_request_context(context)
+
+    assert asset_graph.get_job_names(asset1.key) == ["__ASSET_JOB"]
+    repo_handle1 = asset_graph.get_repository_handle(asset1.key)
+    assert repo_handle1.repository_name == "__repository__"
+    assert repo_handle1.repository_python_origin.code_pointer.fn_name == "defs1"
+
+    assert asset_graph.get_job_names(asset1.key) == ["__ASSET_JOB"]
+    repo_handle2 = asset_graph.get_repository_handle(asset2.key)
+    assert repo_handle2.repository_name == "__repository__"
+    assert repo_handle2.repository_python_origin.code_pointer.fn_name == "defs2"


### PR DESCRIPTION
Adds a subclass of AssetGraph called ExternalAssetGraph which stores a RepositoryHandle for each asset

branch-name: external-asset-graph-repo

### Summary & Motivation

### How I Tested These Changes
