### PR TITLE
Allow setting raw k8s config at the run launcher / container context level

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Extra, Field
 
@@ -52,6 +52,17 @@ class CeleryK8sRunLauncherConfig(BaseModel):
         extra = Extra.forbid
 
 
+class RunK8sConfig(BaseModel):
+    containerConfig: Optional[Dict[str, Any]]
+    podSpecConfig: Optional[Dict[str, Any]]
+    podTemplateSpecMetadata: Optional[Dict[str, Any]]
+    jobSpecConfig: Optional[Dict[str, Any]]
+    jobMetadata: Optional[Dict[str, Any]]
+
+    class Config:
+        extra = Extra.forbid
+
+
 class K8sRunLauncherConfig(BaseModel):
     image: Optional[kubernetes.Image]
     imagePullPolicy: kubernetes.PullPolicy
@@ -68,6 +79,7 @@ class K8sRunLauncherConfig(BaseModel):
     resources: Optional[kubernetes.ResourceRequirements]
     schedulerName: Optional[str]
     securityContext: Optional[kubernetes.SecurityContext]
+    runK8sConfig: Optional[RunK8sConfig]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -124,11 +124,30 @@ config:
   {{- end }}
 
   {{- if $k8sRunLauncherConfig.schedulerName }}
-  schedulerName: {{ $k8sRunLauncherConfig.schedulerName | quote }}
+  scheduler_name: {{ $k8sRunLauncherConfig.schedulerName | quote }}
   {{- end }}
 
   {{- if $k8sRunLauncherConfig.securityContext }}
-  securityContext: {{- $k8sRunLauncherConfig.securityContext | toYaml | nindent 4 }}
+  security_context: {{- $k8sRunLauncherConfig.securityContext | toYaml | nindent 4 }}
+  {{- end }}
+
+  {{- if $k8sRunLauncherConfig.runK8sConfig }}
+  run_k8s_config:
+    {{- if $k8sRunLauncherConfig.runK8sConfig.containerConfig }}
+    container_config: {{- $k8sRunLauncherConfig.runK8sConfig.containerConfig | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $k8sRunLauncherConfig.runK8sConfig.podSpecConfig }}
+    pod_spec_config: {{- $k8sRunLauncherConfig.runK8sConfig.podSpecConfig | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $k8sRunLauncherConfig.runK8sConfig.podTemplateSpecMetadata }}
+    pod_template_spec_metadata: {{- $k8sRunLauncherConfig.runK8sConfig.podTemplateSpecMetadata | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $k8sRunLauncherConfig.runK8sConfig.jobSpecConfig }}
+    job_spec_config: {{- $k8sRunLauncherConfig.runK8sConfig.jobSpecConfig | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $k8sRunLauncherConfig.runK8sConfig.jobMetadata }}
+    job_metadata: {{- $k8sRunLauncherConfig.runK8sConfig.jobMetadata | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
 
 {{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1905,6 +1905,68 @@
             "properties": {},
             "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         },
+        "RunK8sConfig": {
+            "title": "RunK8sConfig",
+            "type": "object",
+            "properties": {
+                "containerConfig": {
+                    "title": "Containerconfig",
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "podSpecConfig": {
+                    "title": "Podspecconfig",
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "podTemplateSpecMetadata": {
+                    "title": "Podtemplatespecmetadata",
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "jobSpecConfig": {
+                    "title": "Jobspecconfig",
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "jobMetadata": {
+                    "title": "Jobmetadata",
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
         "K8sRunLauncherConfig": {
             "title": "K8sRunLauncherConfig",
             "type": "object",
@@ -2036,6 +2098,17 @@
                     "anyOf": [
                         {
                             "$ref": "#/definitions/SecurityContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "runK8sConfig": {
+                    "title": "RunK8sConfig",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RunK8sConfig"
                         },
                         {
                             "type": "null"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -550,6 +550,28 @@ runLauncher:
       # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
       securityContext: ~
 
+      # Raw k8s configuration for the Kubernetes Job and Pod created for the run.
+      # See: https://docs.dagster.io/deployment/guides/kubernetes/customizing-your-deployment
+      #
+      # Example:
+      # runK8sConfig:
+      #   containerConfig: # raw config for the pod's main container
+      #     resources:
+      #       cpu: 100m
+      #       memory: 128Mi
+      #   podTemplateSpecMetadata: # raw config for the pod's metadata
+      #     annotations:
+      #       mykey: myvalue
+      #   podSpecConfig: # raw config for the spec of the launched's pod
+      #     nodeSelector:
+      #       disktype: ssd
+      #   jobSpecConfig: # raw config for the kubernetes job's spec
+      #     ttlSecondsAfterFinished: 7200
+      #   jobMetadata: # raw config for the kubernetes job's metadata
+      #     annotations:
+      #       mykey: myvalue
+      runK8sConfig: {}
+
     # This configuration will only be used if the CeleryK8sRunLauncher is selected
     celeryK8sRunLauncher:
       # Change with caution! If you're using a fixed tag for pipeline run images, changing the

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -8,12 +8,12 @@ from dagster._core.container_context import process_shared_container_context_con
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.utils import parse_env_var
-from dagster._utils import make_readonly_value
+from dagster._utils import frozentags, make_readonly_value
 
 if TYPE_CHECKING:
     from . import K8sRunLauncher
 
-from .job import DagsterK8sJobConfig
+from .job import DagsterK8sJobConfig, UserDefinedDagsterK8sConfig, get_user_defined_k8s_config
 from .models import k8s_snake_case_dict
 
 
@@ -38,6 +38,8 @@ class K8sContainerContext(
             ("resources", Mapping[str, Any]),
             ("scheduler_name", Optional[str]),
             ("security_context", Mapping[str, Any]),
+            ("server_k8s_config", Mapping[str, Any]),
+            ("run_k8s_config", Mapping[str, Any]),
         ],
     )
 ):
@@ -61,6 +63,8 @@ class K8sContainerContext(
         resources: Optional[Mapping[str, Any]] = None,
         scheduler_name: Optional[str] = None,
         security_context: Optional[Mapping[str, Any]] = None,
+        server_k8s_config: Optional[Mapping[str, Any]] = None,
+        run_k8s_config: Optional[Mapping[str, Any]] = None,
     ):
         return super(K8sContainerContext, cls).__new__(
             cls,
@@ -83,7 +87,22 @@ class K8sContainerContext(
             resources=check.opt_mapping_param(resources, "resources"),
             scheduler_name=check.opt_str_param(scheduler_name, "scheduler_name"),
             security_context=check.opt_mapping_param(security_context, "security_context"),
+            server_k8s_config=UserDefinedDagsterK8sConfig(
+                **check.opt_mapping_param(server_k8s_config, "server_k8s_config")
+            ).to_dict(),
+            run_k8s_config=UserDefinedDagsterK8sConfig(
+                **check.opt_mapping_param(run_k8s_config, "run_k8s_config")
+            ).to_dict(),
         )
+
+    def _merge_k8s_config(
+        self, first_config: Mapping[str, Any], second_config: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+
+        # Keys are always the same and initialized in constructor
+        assert set(first_config) == set(second_config)
+
+        return {key: {**first_config[key], **second_config[key]} for key in first_config}
 
     def merge(self, other: "K8sContainerContext") -> "K8sContainerContext":
         # Lists of attributes that can be combined are combined, scalar values are replaced
@@ -107,9 +126,13 @@ class K8sContainerContext(
             namespace=other.namespace if other.namespace else self.namespace,
             resources=other.resources if other.resources else self.resources,
             scheduler_name=other.scheduler_name if other.scheduler_name else self.scheduler_name,
-            security_context=other.security_context
-            if other.security_context
-            else self.security_context,
+            security_context=(
+                other.security_context if other.security_context else self.security_context
+            ),
+            server_k8s_config=self._merge_k8s_config(
+                self.server_k8s_config, other.server_k8s_config
+            ),
+            run_k8s_config=self._merge_k8s_config(self.run_k8s_config, other.run_k8s_config),
         )
 
     def get_environment_dict(self) -> Mapping[str, str]:
@@ -138,19 +161,27 @@ class K8sContainerContext(
                     resources=run_launcher.resources,
                     scheduler_name=run_launcher.scheduler_name,
                     security_context=run_launcher.security_context,
+                    run_k8s_config=run_launcher.run_k8s_config,
                 )
             )
 
-        run_container_context = (
-            pipeline_run.pipeline_code_origin.repository_origin.container_context
-            if pipeline_run.pipeline_code_origin
-            else None
+        if pipeline_run.pipeline_code_origin:
+            run_container_context = (
+                pipeline_run.pipeline_code_origin.repository_origin.container_context
+            )
+
+            if run_container_context:
+                context = context.merge(
+                    K8sContainerContext.create_from_config(run_container_context)
+                )
+
+        user_defined_k8s_config = get_user_defined_k8s_config(frozentags(pipeline_run.tags))
+
+        context = context.merge(
+            K8sContainerContext(run_k8s_config=user_defined_k8s_config.to_dict())
         )
 
-        if not run_container_context:
-            return context
-
-        return context.merge(K8sContainerContext.create_from_config(run_container_context))
+        return context
 
     @staticmethod
     def create_from_config(run_container_context) -> "K8sContainerContext":
@@ -196,6 +227,8 @@ class K8sContainerContext(
                 resources=processed_context_value.get("resources"),
                 scheduler_name=processed_context_value.get("scheduler_name"),
                 security_context=processed_context_value.get("security_context"),
+                server_k8s_config=processed_context_value.get("server_k8s_config"),
+                run_k8s_config=processed_context_value.get("run_k8s_config"),
             )
         )
 
@@ -218,3 +251,9 @@ class K8sContainerContext(
             scheduler_name=self.scheduler_name,
             security_context=self.security_context,
         )
+
+    def get_run_user_defined_k8s_config(self) -> UserDefinedDagsterK8sConfig:
+        return UserDefinedDagsterK8sConfig(**self.run_k8s_config)
+
+    def get_server_user_defined_k8s_config(self) -> UserDefinedDagsterK8sConfig:
+        return UserDefinedDagsterK8sConfig(**self.server_k8s_config)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -362,6 +362,11 @@ class DagsterK8sJobConfig(
                     is_required=False,
                     description="Whether the launched Kubernetes Jobs and Pods should fail if the Dagster run fails",
                 ),
+                "run_k8s_config": Field(
+                    USER_DEFINED_K8S_CONFIG_SCHEMA,
+                    is_required=False,
+                    description="Raw Kubernetes configuration for launched runs.",
+                ),
             },
         )
 
@@ -502,6 +507,22 @@ class DagsterK8sJobConfig(
                     description="The namespace into which to launch Kubernetes resources. Note that any "
                     "other required resources (such as the service account) must be "
                     "present in this namespace.",
+                ),
+                "run_k8s_config": Field(
+                    USER_DEFINED_K8S_CONFIG_SCHEMA,
+                    is_required=False,
+                    description="Raw Kubernetes configuration for launched runs.",
+                ),
+                "server_k8s_config": Field(
+                    Shape(
+                        {
+                            "container_config": Permissive(),
+                            "pod_spec_config": Permissive(),
+                            "pod_template_spec_metadata": Permissive(),
+                        }
+                    ),
+                    is_required=False,
+                    description="Raw Kubernetes configuration for launched code servers.",
                 ),
             },
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -13,17 +13,12 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._grpc.types import ResumeRunArgs
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
-from dagster._utils import frozentags, merge_dicts
+from dagster._utils import merge_dicts
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from .client import DagsterKubernetesClient
 from .container_context import K8sContainerContext
-from .job import (
-    DagsterK8sJobConfig,
-    construct_dagster_k8s_job,
-    get_job_name_from_run_id,
-    get_user_defined_k8s_config,
-)
+from .job import DagsterK8sJobConfig, construct_dagster_k8s_job, get_job_name_from_run_id
 
 
 class K8sRunLauncher(RunLauncher, ConfigurableClass):
@@ -71,6 +66,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         resources=None,
         scheduler_name=None,
         security_context=None,
+        run_k8s_config=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.job_namespace = check.str_param(job_namespace, "job_namespace")
@@ -121,6 +117,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         self._resources: Mapping[str, Any] = check.opt_mapping_param(resources, "resources")
         self._scheduler_name = check.opt_str_param(scheduler_name, "scheduler_name")
         self._security_context = check.opt_dict_param(security_context, "security_context")
+        self._run_k8s_config = check.opt_dict_param(run_k8s_config, "run_k8s_config")
         super().__init__()
 
     @property
@@ -176,6 +173,10 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         return self._labels
 
     @property
+    def run_k8s_config(self) -> Mapping[str, str]:
+        return self._run_k8s_config
+
+    @property
     def fail_pod_on_run_failure(self) -> Optional[bool]:
         return self._fail_pod_on_run_failure
 
@@ -208,7 +209,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         pod_name = job_name
 
         pipeline_origin = run.pipeline_code_origin
-        user_defined_k8s_config = get_user_defined_k8s_config(frozentags(run.tags))
+        user_defined_k8s_config = container_context.get_run_user_defined_k8s_config()
         repository_origin = pipeline_origin.repository_origin
 
         job_config = container_context.get_k8s_job_config(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -9,12 +9,7 @@ from dagster._utils import merge_dicts
 
 from ..client import DagsterKubernetesClient
 from ..container_context import K8sContainerContext
-from ..job import (
-    DagsterK8sJobConfig,
-    UserDefinedDagsterK8sConfig,
-    construct_dagster_k8s_job,
-    get_k8s_job_name,
-)
+from ..job import DagsterK8sJobConfig, construct_dagster_k8s_job, get_k8s_job_name
 from ..launcher import K8sRunLauncher
 
 K8S_JOB_OP_CONFIG = merge_dicts(
@@ -186,6 +181,10 @@ def execute_k8s_job(
         else None,
     )
 
+    container_config = container_config or {}
+    if command:
+        container_config["command"] = command
+
     op_container_context = K8sContainerContext(
         image_pull_policy=image_pull_policy,
         image_pull_secrets=image_pull_secrets,
@@ -199,23 +198,20 @@ def execute_k8s_job(
         namespace=namespace,
         resources=resources,
         scheduler_name=scheduler_name,
+        run_k8s_config={
+            "container_config": container_config,
+            "pod_template_spec_metadata": pod_template_spec_metadata,
+            "pod_spec_config": pod_spec_config,
+            "job_metadata": job_metadata,
+            "job_spec_config": job_spec_config,
+        },
     )
 
     container_context = run_container_context.merge(op_container_context)
 
     namespace = container_context.namespace
 
-    container_config = container_config or {}
-    if command:
-        container_config["command"] = command
-
-    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config=container_config,
-        pod_template_spec_metadata=pod_template_spec_metadata,
-        pod_spec_config=pod_spec_config,
-        job_metadata=job_metadata,
-        job_spec_config=job_spec_config,
-    )
+    user_defined_k8s_config = container_context.get_run_user_defined_k8s_config()
 
     k8s_job_config = DagsterK8sJobConfig(
         job_image=image,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -37,6 +37,19 @@ def container_context_config():
                 "limits": {"memory": "128Mi", "cpu": "500m"},
             },
             "scheduler_name": "my_scheduler",
+            "server_k8s_config": {
+                "container_config": {"command": ["echo", "SERVER"]},
+                "pod_template_spec_metadata": {"namespace": "my_pod_server_amespace"},
+            },
+            "run_k8s_config": {
+                "container_config": {"command": ["echo", "RUN"], "tty": True},
+                "pod_template_spec_metadata": {"namespace": "my_pod_namespace"},
+                "pod_spec_config": {"dns_policy": "value"},
+                "job_metadata": {
+                    "namespace": "my_job_value",
+                },
+                "job_spec_config": {"backoff_limit": 120},
+            },
         },
     }
 
@@ -70,6 +83,20 @@ def other_container_context_config():
                 "limits": {"memory": "64Mi", "cpu": "250m"},
             },
             "scheduler_name": "my_other_scheduler",
+            "run_k8s_config": {
+                "container_config": {
+                    "command": ["REPLACED"],
+                    "stdin": True,
+                },  # container_config is merged shallowly
+                "pod_template_spec_metadata": {"namespace": "my_other_namespace"},
+                "pod_spec_config": {
+                    "dnsPolicy": "other_value"
+                },  # camel case and snake case are reconciled and merged
+                "job_metadata": {
+                    "namespace": "my_other_job_value",
+                },
+                "job_spec_config": {"backoffLimit": 240},
+            },
         },
     }
 
@@ -137,6 +164,14 @@ def test_empty_container_context(empty_container_context):
     assert empty_container_context.namespace is None
     assert empty_container_context.resources == {}
     assert empty_container_context.scheduler_name == None
+    assert all(
+        empty_container_context.server_k8s_config[key] == {}
+        for key in empty_container_context.server_k8s_config
+    )
+    assert all(
+        empty_container_context.run_k8s_config[key] == {}
+        for key in empty_container_context.run_k8s_config
+    )
 
 
 def test_invalid_config():
@@ -257,5 +292,21 @@ def test_merge(empty_container_context, container_context, other_container_conte
     }
     assert merged.scheduler_name == "my_other_scheduler"
 
+    assert merged.run_k8s_config == {
+        "container_config": {
+            "command": ["REPLACED"],
+            "stdin": True,
+            "tty": True,
+        },
+        "pod_template_spec_metadata": {"namespace": "my_other_namespace"},
+        "pod_spec_config": {"dns_policy": "other_value"},
+        "job_metadata": {
+            "namespace": "my_other_job_value",
+        },
+        "job_spec_config": {"backoff_limit": 240},
+        "job_config": {},
+    }
+
     assert container_context.merge(empty_container_context) == container_context
     assert empty_container_context.merge(container_context) == container_context
+    assert other_container_context.merge(empty_container_context) == other_container_context


### PR DESCRIPTION
Summary:
This will allow users to set raw k8s config in the helm chart that applies to all launched runs - no more setting tags on every job just to e.g. set a TTL globally - and no more adding helm chart params one by one as people request them.

Also adds a container_context hook which will let us in the future vary raw config like this per-code location. The hook covers both runs and servers (currently unused in OSS since we don't have a way to programatically spin up gRPC servers in OSS).

Test Plan: New automated tests
