### PR TITLE
change version placeholder 0+dev -> 1!0+dev

### DIFF
--- a/docs/dagit-screenshot/setup.py
+++ b/docs/dagit-screenshot/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dagit-screenshot",
-    version="0+dev",
+    version="1!0+dev",
     author_email="hello@elementl.com",
     packages=find_packages(exclude=["dagit_screenshot_tests*"]),  # same as name
     install_requires=["click>=6", "selenium", "pyyaml", "typing-extensions>=4"],  # external packages as dependencies

--- a/examples/development_to_production/setup.py
+++ b/examples/development_to_production/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup  # type: ignore
 
 setup(
     name="development_to_production",
-    version="0+dev",
+    version="1!0+dev",
     author_email="hello@elementl.com",
     packages=["development_to_production"],  # same as name
     install_requires=[

--- a/examples/project_fully_featured/setup.py
+++ b/examples/project_fully_featured/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="project_fully_featured",
-    version="0+dev",
+    version="1!0+dev",
     author="Elementl",
     author_email="hello@elementl.com",
     classifiers=[

--- a/python_modules/automation/automation/docker/images/README.md
+++ b/python_modules/automation/automation/docker/images/README.md
@@ -23,7 +23,7 @@ which they are served to Buildkite etc. The command for building an image is:
 This will build images for all Python versions specified in the corresponding
 `versions.yaml`. Note that when building images for use in Buildkite (i.e.
 `buildkite-test`, used for testing the tips of branches), you should specify
-the version for the editable install of dagster, `0+dev`. Note also that the
+the version for the editable install of dagster, `1!0+dev`. Note also that the
 `--platform=linux/amd64` might not always be necessary, but in the past it has
 solved issues when building on an M1 mac.
 

--- a/python_modules/dagit/dagit/version.py
+++ b/python_modules/dagit/dagit/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -20,7 +20,7 @@ def get_version():
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagit",
     version=ver,

--- a/python_modules/dagster-graphql/dagster_graphql/version.py
+++ b/python_modules/dagster-graphql/dagster_graphql/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-graphql",
     version=ver,

--- a/python_modules/dagster-test/setup.py
+++ b/python_modules/dagster-test/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dagster-test",
-    version="0+dev",
+    version="1!0+dev",
     author="Elementl",
     author_email="hello@elementl.com",
     license="Apache-2.0",

--- a/python_modules/dagster/dagster/version.py
+++ b/python_modules/dagster/dagster/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/version.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-airbyte",
     version=ver,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/version.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-airflow",
     version=ver,

--- a/python_modules/libraries/dagster-aws/dagster_aws/version.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-aws",
     version=ver,

--- a/python_modules/libraries/dagster-azure/dagster_azure/version.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-azure/setup.py
+++ b/python_modules/libraries/dagster-azure/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-azure",
     version=ver,

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/version.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-celery-docker",
     version=ver,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/version.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-celery-k8s",
     version=ver,

--- a/python_modules/libraries/dagster-celery/dagster_celery/version.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-celery/setup.py
+++ b/python_modules/libraries/dagster-celery/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-celery",
     version=ver,

--- a/python_modules/libraries/dagster-census/dagster_census/version.py
+++ b/python_modules/libraries/dagster-census/dagster_census/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-census/setup.py
+++ b/python_modules/libraries/dagster-census/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-census",
     version=ver,

--- a/python_modules/libraries/dagster-dask/dagster_dask/version.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-dask",
     version=ver,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/version.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-databricks",
     version=ver,

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/version.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-datadog",
     version=ver,

--- a/python_modules/libraries/dagster-datahub/dagster_datahub/version.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-datahub",
     version=ver,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/version.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-dbt",
     version=ver,

--- a/python_modules/libraries/dagster-docker/dagster_docker/version.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-docker",
     version=ver,

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/version.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-duckdb-pandas",
     version=ver,

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/version.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-duckdb-pyspark",
     version=ver,

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/version.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-duckdb",
     version=ver,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/version.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-fivetran",
     version=ver,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/version.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-gcp",
     version=ver,

--- a/python_modules/libraries/dagster-ge/dagster_ge/version.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-ge",
     version=ver,

--- a/python_modules/libraries/dagster-github/dagster_github/version.py
+++ b/python_modules/libraries/dagster-github/dagster_github/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-github",
     version=ver,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/version.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-k8s",
     version=ver,

--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/version.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-managed-elements/setup.py
+++ b/python_modules/libraries/dagster-managed-elements/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-managed-elements",
     version=ver,

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/version.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/version.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/version.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-mysql/setup.py
+++ b/python_modules/libraries/dagster-mysql/setup.py
@@ -13,7 +13,7 @@ def get_version():
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-mysql",
     version=ver,

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/version.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-pagerduty",
     version=ver,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/version.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -21,7 +21,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-pandas",
     version=ver,

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/version.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-pandera",
     version=ver,

--- a/python_modules/libraries/dagster-papertrail/dagster_papertrail/version.py
+++ b/python_modules/libraries/dagster-papertrail/dagster_papertrail/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-papertrail",
     version=ver,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/version.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-postgres",
     version=ver,

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/version.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-prometheus",
     version=ver,

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/version.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-pyspark",
     version=ver,

--- a/python_modules/libraries/dagster-shell/dagster_shell/version.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-shell",
     version=ver,

--- a/python_modules/libraries/dagster-slack/dagster_slack/version.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -13,7 +13,7 @@ def get_version():
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-slack",
     version=ver,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/version.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-snowflake-pandas",
     version=ver,

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/version.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-snowflake",
     version=ver,

--- a/python_modules/libraries/dagster-spark/dagster_spark/version.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-spark",
     version=ver,

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/version.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-ssh",
     version=ver,

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/version.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagster-twilio",
     version=ver,

--- a/python_modules/libraries/dagstermill/dagstermill/version.py
+++ b/python_modules/libraries/dagstermill/dagstermill/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -14,7 +14,7 @@ def get_version() -> str:
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "0+dev" else f"=={ver}"
+pin = "" if ver == "1!0+dev" else f"=={ver}"
 setup(
     name="dagstermill",
     version=ver,


### PR DESCRIPTION
### Summary & Motivation

Changes the placeholder version from `0+dev` to `1!0+dev`.

The motivation here is to guarantee that the placeholder version is always greater than any published version. This is accomplished by the `1!`, which is an "epoch" specifier (the implicit epoch on published versions is 0).

This means our local versions of packages can satisfy any lower-bounded dagster requirement. This recently became an issue with https://github.com/dagster-io/internal/pull/4420, which added the external package [dagster-hex](https://github.com/hex-inc/dagster-hex) as a dependency to some of our tests. `dagster-hex` depends on `dagster>1`, which was not being satisfied by our usual editable installs (which have version `0+dev`). Using `1!0+dev` fixes this problem.

### How I Tested These Changes

BK
