### PR TITLE
remove pragmas in docs snippets

### DIFF
--- a/docs/next/util/codeBlockTransformer.ts
+++ b/docs/next/util/codeBlockTransformer.ts
@@ -80,6 +80,10 @@ export default ({setCodeBlockStats: setCodeBlockStats}: CodeTransformerOptions) 
           metaOptions.endbefore,
         );
 
+        // remove pragmas
+        contentWithLimit = contentWithLimit.replace(/^\s*# (type|noqa):.*$/g, '');
+        contentWithLimit = contentWithLimit.replace(/  # (type|noqa):.*$/g, '');
+
         if (metaOptions.trim) {
           contentWithLimit = contentWithLimit.trim();
         }

--- a/examples/docs_snippets/docs_snippets/concepts/logging/python_logging_file_output_config.yaml
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/python_logging_file_output_config.yaml
@@ -4,9 +4,9 @@ python_logs:
       myHandler:
         class: logging.FileHandler
         level: INFO
-        filename: 'my_dagster_logs.log'
-        mode: 'a'
+        filename: "my_dagster_logs.log"
+        mode: "a"
         formatter: timeFormatter
     formatters:
       timeFormatter:
-        format: '%(asctime)s :: %(message)s'
+        format: "%(asctime)s :: %(message)s"

--- a/examples/docs_snippets/docs_snippets/deploying/docker/run_launcher_volumes.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/docker/run_launcher_volumes.yaml
@@ -8,4 +8,4 @@ run_launcher:
       - DAGSTER_POSTGRES_DB
     container_kwargs:
       volumes:
-          - /absolute/path/to/local/repo.py:/opt/dagster/app/
+        - /absolute/path/to/local/repo.py:/opt/dagster/app/


### PR DESCRIPTION
### Summary & Motivation

Docs snippets can sometimes benefit from inline pragmas to ignore specific errors (e.g. `type: ignore`). However, we don't want these showing up in the published snippet.

This PR adds logic to remove any pragma comments when running `make mdx-format` (i.e. syncing snippet source to docs). This allows us to benefit from the pragmas in the source without showing them in the snippets.

The PR also slightly tweaks two yaml files used in code blocks which were altered by the parse/serialize loop (some indentation changed and single-quotes converted to double), causing them to always show as "updated code blocks". They were changed so that parse/serialize no longer changes them.

### How I Tested These Changes

Added a pragma to a snippet, ran `make mdx-format`, observed pragma was not present in updated code block in mdx file.
