### PR TITLE
fix asset reconciliation bug that ignores earlier partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1180,6 +1180,6 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
 
         return any(
             time_window.start >= included_time_window.start
-            and time_window.start <= included_time_window.end
+            and time_window.start < included_time_window.end
             for included_time_window in self._included_time_windows
         )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -202,6 +202,18 @@ class CachingInstanceQueryer:
         return result
 
     @cached_method
+    def get_materialization_records(
+        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+    ) -> Iterable["EventLogRecord"]:
+        return self._instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+                after_cursor=after_cursor,
+            )
+        )
+
+    @cached_method
     def is_reconciled(
         self,
         asset_partition: AssetKeyPartitionKey,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -462,6 +462,10 @@ two_assets_in_sequence_one_partition = [
     asset_def("asset1", partitions_def=one_partition_partitions_def),
     asset_def("asset2", ["asset1"], partitions_def=one_partition_partitions_def),
 ]
+two_assets_in_sequence_two_partitions = [
+    asset_def("asset1", partitions_def=two_partitions_partitions_def),
+    asset_def("asset2", ["asset1"], partitions_def=two_partitions_partitions_def),
+]
 
 two_assets_in_sequence_fan_in_partitions = [
     asset_def("asset1", partitions_def=fanned_out_partitions_def),
@@ -666,6 +670,14 @@ scenarios = {
         assets=two_assets_in_sequence_one_partition,
         unevaluated_runs=[run(["asset1", "asset2"], partition_key="a")],
         expected_run_requests=[],
+    ),
+    "two_assets_both_upstream_partitions_materialized": AssetReconciliationScenario(
+        assets=two_assets_in_sequence_two_partitions,
+        unevaluated_runs=[run(["asset1"], partition_key="a"), run(["asset1"], partition_key="b")],
+        expected_run_requests=[
+            run_request(asset_keys=["asset2"], partition_key="a"),
+            run_request(asset_keys=["asset2"], partition_key="b"),
+        ],
     ),
     "parent_one_partition_one_run": AssetReconciliationScenario(
         assets=two_assets_in_sequence_one_partition,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -529,3 +529,15 @@ def test_time_window_partiitons_deserialize_backwards_compatible():
     deserialized = partitions_def.deserialize_subset(serialized)
     assert deserialized.get_partition_keys() == ["2015-01-02", "2015-01-04"]
     assert "2015-01-02" in deserialized
+
+
+def test_time_window_partitions_contains():
+    partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
+    keys = ["2015-01-06", "2015-01-07", "2015-01-08", "2015-01-10"]
+    subset = partitions_def.empty_subset().with_partition_keys(keys)
+    for key in keys:
+        assert key in subset
+
+    assert "2015-01-05" not in subset
+    assert "2015-01-09" not in subset
+    assert "2015-01-11" not in subset


### PR DESCRIPTION
branch-name: past-partitions

### Summary & Motivation

If multiple partitions for the same asset were materialized between ticks of the reconciliation sensor, we were only observing and acting on one of them.

### How I Tested These Changes

The added test fails without the added changes.