### PR TITLE
Add asset_materialization property to EventLogEntry

### DIFF
--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -56,16 +56,7 @@ class EventLogRecord(NamedTuple):
 
     @property
     def asset_materialization(self) -> Optional[AssetMaterialization]:
-        dagster_event = self.event_log_entry.dagster_event
-        if (
-            dagster_event
-            and dagster_event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION
-        ):
-            materialization = dagster_event.step_materialization_data.materialization
-            if isinstance(materialization, AssetMaterialization):
-                return materialization
-
-        return None
+        return self.event_log_entry.asset_materialization
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -2,8 +2,9 @@ from typing import Any, Dict, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
+from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.events import DagsterEvent
+from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.utils import coerce_valid_log_level
 from dagster._serdes.serdes import (
     DefaultNamedTupleSerializer,
@@ -150,6 +151,18 @@ class EventLogEntry(
                 return msg
 
         return self.user_message
+
+    @property
+    def asset_materialization(self) -> Optional[AssetMaterialization]:
+        if (
+            self.dagster_event
+            and self.dagster_event.event_type_value == DagsterEventType.ASSET_MATERIALIZATION
+        ):
+            materialization = self.dagster_event.step_materialization_data.materialization
+            if isinstance(materialization, AssetMaterialization):
+                return materialization
+
+        return None
 
 
 def construct_event_record(logger_message: StructuredLoggerMessage) -> EventLogEntry:


### PR DESCRIPTION
### Summary & Motivation

It is awkward to access a user-created AssetMaterialization when faced with having an EventLogEntry. Wrapping up all the object tree navigation one needs to do in a property.

### How I Tested These Changes

Unit tests
