### PR TITLE
[structured config] Structured-config-backed IO managers

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -21,7 +21,12 @@ from dagster._config.field_utils import (
     config_dictionary_from_values,
     convert_potential_field,
 )
+from dagster._core.definitions.definition_config_schema import (
+    IDefinitionConfigSchema,
+    convert_user_facing_definition_config_schema,
+)
 from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
+from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
 
 class Config(BaseModel):
@@ -137,6 +142,101 @@ class StructuredResourceAdapter(Resource, ABC):
 
     def __call__(self, *args, **kwargs):
         return self.wrapped_resource(*args, **kwargs)
+
+
+class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
+    """
+    Base class for Dagster IO managers that utilize structured config. This base class
+    is useful for cases in which the returned IO manager is not the same as the class itself
+    (e.g. when it is a wrapper around the actual IO manager implementation).
+
+    This class is a subclass of both :py:class:`IOManagerDefinition` and :py:class:`Config`.
+    Implementers should provide an implementation of the :py:meth:`resource_function` method,
+    which should return an instance of :py:class:`IOManager`.
+
+    To specify the input and output config schemas, implementers should provide an inner class
+    named ``InputConfigSchema`` and/or ``OutputConfigSchema``. These classes should be subclasses
+    of :py:class:`Config`.
+    """
+
+    class InputConfigSchema(Config):
+        pass
+
+    class OutputConfigSchema(Config):
+        pass
+
+    def __init__(self, **data: Any):
+        schema = infer_schema_from_config_class(self.__class__)
+
+        inner_resource_def = ResourceDefinition(self.resource_function, schema)
+        configured_resource_def = inner_resource_def.configured(
+            config_dictionary_from_values(
+                data,
+                schema,
+            ),
+        )
+
+        Config.__init__(self, **data)
+        IOManagerDefinition.__init__(
+            self,
+            resource_fn=self.resource_function,
+            # mypy worries that configured_resource_def could be self, which
+            # has not had config_schema initialized yet, but we know that's not the case
+            config_schema=configured_resource_def.config_schema,  # type: ignore[attr-defined]
+            description=self.__doc__,
+        )
+
+    def __setattr__(self, name: str, value: Any):
+        # This is a hack to allow us to set attributes on the class that are not part of the
+        # config schema. Pydantic will normally raise an error if you try to set an attribute
+        # that is not part of the schema.
+
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+
+        return super().__setattr__(name, value)
+
+    @property
+    def _input_config_schema_from_inner_class(self) -> IDefinitionConfigSchema:
+        input_schema = infer_schema_from_config_class(self.InputConfigSchema)
+        return convert_user_facing_definition_config_schema(input_schema)
+
+    @property
+    def _output_config_schema_from_inner_class(self) -> IDefinitionConfigSchema:
+        output_schema = infer_schema_from_config_class(self.OutputConfigSchema)
+        return (
+            convert_user_facing_definition_config_schema(output_schema) if output_schema else None
+        )
+
+    @property
+    def input_config_schema(self) -> IDefinitionConfigSchema:
+        return self._input_config_schema_from_inner_class
+
+    @property
+    def output_config_schema(self) -> Optional[IDefinitionConfigSchema]:
+        return self._output_config_schema_from_inner_class
+
+    @abstractmethod
+    def resource_function(self, context) -> IOManager:
+        raise NotImplementedError()
+
+
+class StructuredConfigIOManager(StructuredConfigIOManagerBase, IOManager):
+    """
+    Base class for Dagster IO managers that utilize structured config.
+
+    This class is a subclass of both :py:class:`IOManagerDefinition`, :py:class:`Config`,
+    and :py:class:`IOManager`. Implementers must provide an implementation of the
+    :py:meth:`handle_output` and :py:meth:`load_input` methods.
+
+    To specify the input and output config schemas, implementers should provide an inner class
+    named ``InputConfigSchema`` and/or ``OutputConfigSchema``. These classes should be subclasses
+    of :py:class:`Config`.
+    """
+
+    def resource_function(self, context) -> IOManager:
+        return self
 
 
 def _convert_pydantic_field(pydantic_field: ModelField) -> Field:

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -21,10 +21,6 @@ from dagster._config.field_utils import (
     config_dictionary_from_values,
     convert_potential_field,
 )
-from dagster._core.definitions.definition_config_schema import (
-    IDefinitionConfigSchema,
-    convert_user_facing_definition_config_schema,
-)
 from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
@@ -153,17 +149,7 @@ class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
     This class is a subclass of both :py:class:`IOManagerDefinition` and :py:class:`Config`.
     Implementers should provide an implementation of the :py:meth:`resource_function` method,
     which should return an instance of :py:class:`IOManager`.
-
-    To specify the input and output config schemas, implementers should provide an inner class
-    named ``InputConfigSchema`` and/or ``OutputConfigSchema``. These classes should be subclasses
-    of :py:class:`Config`.
     """
-
-    class InputConfigSchema(Config):
-        pass
-
-    class OutputConfigSchema(Config):
-        pass
 
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)
@@ -197,26 +183,6 @@ class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
 
         return super().__setattr__(name, value)
 
-    @property
-    def _input_config_schema_from_inner_class(self) -> IDefinitionConfigSchema:
-        input_schema = infer_schema_from_config_class(self.InputConfigSchema)
-        return convert_user_facing_definition_config_schema(input_schema)
-
-    @property
-    def _output_config_schema_from_inner_class(self) -> Optional[IDefinitionConfigSchema]:
-        output_schema = infer_schema_from_config_class(self.OutputConfigSchema)
-        return (
-            convert_user_facing_definition_config_schema(output_schema) if output_schema else None
-        )
-
-    @property
-    def input_config_schema(self) -> IDefinitionConfigSchema:
-        return self._input_config_schema_from_inner_class
-
-    @property
-    def output_config_schema(self) -> Optional[IDefinitionConfigSchema]:
-        return self._output_config_schema_from_inner_class
-
     @abstractmethod
     def resource_function(self, context) -> IOManager:
         raise NotImplementedError()
@@ -229,10 +195,6 @@ class StructuredConfigIOManager(StructuredConfigIOManagerBase, IOManager):
     This class is a subclass of both :py:class:`IOManagerDefinition`, :py:class:`Config`,
     and :py:class:`IOManager`. Implementers must provide an implementation of the
     :py:meth:`handle_output` and :py:meth:`load_input` methods.
-
-    To specify the input and output config schemas, implementers should provide an inner class
-    named ``InputConfigSchema`` and/or ``OutputConfigSchema``. These classes should be subclasses
-    of :py:class:`Config`.
     """
 
     def resource_function(self, context) -> IOManager:

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -203,7 +203,7 @@ class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
         return convert_user_facing_definition_config_schema(input_schema)
 
     @property
-    def _output_config_schema_from_inner_class(self) -> IDefinitionConfigSchema:
+    def _output_config_schema_from_inner_class(self) -> Optional[IDefinitionConfigSchema]:
         output_schema = infer_schema_from_config_class(self.OutputConfigSchema)
         return (
             convert_user_facing_definition_config_schema(output_schema) if output_schema else None

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_iomanagers.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_iomanagers.py
@@ -1,0 +1,108 @@
+from typing import Callable, Optional
+
+from dagster import job, op, resource, io_manager, In, DagsterInvalidConfigError
+import pytest
+from dagster._config.field_utils import convert_potential_field
+from dagster._config.structured_config import (
+    Config,
+    Resource,
+    StructuredConfigIOManagerBase,
+    StructuredConfigIOManager,
+)
+from dagster._config.type_printer import print_config_type_to_string
+from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
+from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._core.storage.io_manager import IOManagerDefinition
+
+
+def test_config_schemas():
+    # Decorator-based IO manager definition
+    @io_manager(
+        config_schema={"base_dir": str},
+        output_config_schema={"path": str},
+        input_config_schema={"format": str},
+    )
+    def an_io_manager():
+        pass
+
+    # Equivalent class-based IO manager definition
+    class AnIoManager(StructuredConfigIOManagerBase):
+        base_dir: str
+
+        class OutputConfigSchema(Config):
+            path: str
+
+        class InputConfigSchema(Config):
+            format: str
+
+        def resource_function(self, _):
+            pass
+
+    configured_io_manager = AnIoManager(base_dir="/a/b/c")
+
+    assert isinstance(configured_io_manager, IOManagerDefinition)
+    assert type_string_from_config_schema(
+        configured_io_manager.output_config_schema
+    ) == type_string_from_config_schema(an_io_manager.output_config_schema)
+    assert type_string_from_config_schema(
+        configured_io_manager.input_config_schema
+    ) == type_string_from_config_schema(an_io_manager.input_config_schema)
+
+
+def type_string_from_config_schema(config_schema: IDefinitionConfigSchema):
+    return print_config_type_to_string(config_schema.config_type)
+
+
+def test_load_input_handle_output():
+    class MyIOManager(StructuredConfigIOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            assert False, "should not be called"
+
+    class MyInputManager(MyIOManager):
+        class InputConfigSchema(Config):
+            config_value: int
+
+        def load_input(self, context):
+            if context.upstream_output is None:
+                assert False, "upstream output should not be None"
+            else:
+                return context.config["config_value"]
+
+    did_run = {}
+
+    @op
+    def first_op():
+        did_run["first_op"] = True
+        return 1
+
+    @op(ins={"an_input": In(input_manager_key="my_input_manager")})
+    def second_op(an_input):
+        assert an_input == 6
+        did_run["second_op"] = True
+
+    @job(
+        resource_defs={
+            "io_manager": MyIOManager(),
+            "my_input_manager": MyInputManager(),
+        }
+    )
+    def check_input_managers():
+        out = first_op()
+        second_op(out)
+
+    check_input_managers.execute_in_process(
+        run_config={"ops": {"second_op": {"inputs": {"an_input": {"config_value": 6}}}}}
+    )
+    assert did_run["first_op"]
+    assert did_run["second_op"]
+
+    with pytest.raises(DagsterInvalidConfigError):
+        check_input_managers.execute_in_process(
+            run_config={
+                "ops": {"second_op": {"inputs": {"an_input": {"config_value": "a_string"}}}}
+            }
+        )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -1,18 +1,14 @@
-from typing import Callable, Optional
-
-from dagster import job, op, resource, io_manager, In, DagsterInvalidConfigError
+# pylint: disable=unused-argument
 import pytest
-from dagster._config.field_utils import convert_potential_field
+
+from dagster import DagsterInvalidConfigError, In, io_manager, job, op
 from dagster._config.structured_config import (
     Config,
-    Resource,
-    StructuredConfigIOManagerBase,
     StructuredConfigIOManager,
+    StructuredConfigIOManagerBase,
 )
 from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
-from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.definitions.resource_output import ResourceOutput
 from dagster._core.storage.io_manager import IOManagerDefinition
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -1,53 +1,7 @@
 # pylint: disable=unused-argument
-import pytest
 
-from dagster import DagsterInvalidConfigError, In, io_manager, job, op
-from dagster._config.structured_config import (
-    Config,
-    StructuredConfigIOManager,
-    StructuredConfigIOManagerBase,
-)
-from dagster._config.type_printer import print_config_type_to_string
-from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
-from dagster._core.storage.io_manager import IOManagerDefinition
-
-
-def test_config_schemas():
-    # Decorator-based IO manager definition
-    @io_manager(
-        config_schema={"base_dir": str},
-        output_config_schema={"path": str},
-        input_config_schema={"format": str},
-    )
-    def an_io_manager():
-        pass
-
-    # Equivalent class-based IO manager definition
-    class AnIoManager(StructuredConfigIOManagerBase):
-        base_dir: str
-
-        class OutputConfigSchema(Config):
-            path: str
-
-        class InputConfigSchema(Config):
-            format: str
-
-        def resource_function(self, _):
-            pass
-
-    configured_io_manager = AnIoManager(base_dir="/a/b/c")
-
-    assert isinstance(configured_io_manager, IOManagerDefinition)
-    assert type_string_from_config_schema(
-        configured_io_manager.output_config_schema
-    ) == type_string_from_config_schema(an_io_manager.output_config_schema)
-    assert type_string_from_config_schema(
-        configured_io_manager.input_config_schema
-    ) == type_string_from_config_schema(an_io_manager.input_config_schema)
-
-
-def type_string_from_config_schema(config_schema: IDefinitionConfigSchema):
-    return print_config_type_to_string(config_schema.config_type)
+from dagster import In, job, op
+from dagster._config.structured_config import StructuredConfigIOManager
 
 
 def test_load_input_handle_output():
@@ -59,14 +13,11 @@ def test_load_input_handle_output():
             assert False, "should not be called"
 
     class MyInputManager(MyIOManager):
-        class InputConfigSchema(Config):
-            config_value: int
-
         def load_input(self, context):
             if context.upstream_output is None:
                 assert False, "upstream output should not be None"
             else:
-                return context.config["config_value"]
+                return 6
 
     did_run = {}
 
@@ -90,15 +41,6 @@ def test_load_input_handle_output():
         out = first_op()
         second_op(out)
 
-    check_input_managers.execute_in_process(
-        run_config={"ops": {"second_op": {"inputs": {"an_input": {"config_value": 6}}}}}
-    )
+    check_input_managers.execute_in_process()
     assert did_run["first_op"]
     assert did_run["second_op"]
-
-    with pytest.raises(DagsterInvalidConfigError):
-        check_input_managers.execute_in_process(
-            run_config={
-                "ops": {"second_op": {"inputs": {"an_input": {"config_value": "a_string"}}}}
-            }
-        )


### PR DESCRIPTION
## Summary

Allows defining IO managers using structured config (#11268), using a same strategy as #11321 . There are two classes introduced here: `StructuredConfigIOManagerBase`, for cases where the class itself doesn't implement `IOManager` (ie wrapping construction of a legacy IO manager), and `StructuredConfigIOManager` where everything is defined in one place.

IO manager config, similar to with resources, is defined at the top-level. Input and output config schema is defined by including a nested `InputConfigSchema` or `OutputConfigSchema` class, as follows:

```python
class MyIOManager(StructuredConfigIOManager):
    config_value: str

    class InputConfigSchema(Config):
        input_config_value: int

    def handle_output(self, context, obj):
        pass

    # TODO: make typed config available as a param, here
    def load_input(self, context):
        if context.upstream_output is None:
            assert False, "upstream output should not be None"
        else:
            return context.config["input_config_value"]
```



## Test Plan

Small unit test, more forthcoming