### PR TITLE
Convert accesses using '__ASSET_JOB' to instead use the supported implicit job methods

### DIFF
--- a/examples/assets_modern_data_stack/assets_modern_data_stack_tests/test_defs.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack_tests/test_defs.py
@@ -2,6 +2,7 @@ from assets_modern_data_stack import defs
 
 
 def test_defs_can_load():
-    # Repo should have only one "default" asset group, which is represented a "__ASSET_JOB" job
-    assert defs.get_job_def("__ASSET_JOB")
+    # Repo will have a single implicit job for all the assets, since they all
+    # have the same partitioning scheme
+    assert defs.get_implicit_global_asset_job_def()
     assert defs.get_job_def("all_assets")

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
@@ -2,4 +2,4 @@ from assets_pandas_type_metadata import defs
 
 
 def test_defs_can_load():
-    assert defs.get_job_def("__ASSET_JOB")
+    assert defs.get_all_job_defs()

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_cross_code_location_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_cross_code_location_asset.py
@@ -7,5 +7,13 @@ from docs_snippets.concepts.assets.cross_cl_code_location_2 import (
 
 
 def test_repository_asset_groups():
-    assert code_location_1_defs.get_job_def("__ASSET_JOB").execute_in_process().success
-    assert code_location_2_defs.get_job_def("__ASSET_JOB").execute_in_process().success
+    assert (
+        code_location_1_defs.get_implicit_global_asset_job_def()
+        .execute_in_process()
+        .success
+    )
+    assert (
+        code_location_2_defs.get_implicit_global_asset_job_def()
+        .execute_in_process()
+        .success
+    )

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -114,7 +114,7 @@ def test_single_asset_group():
     repo_def = repository_def_from_pointer(CodePointer.from_python_file(path, symbol, None))
 
     assert isinstance(repo_def, RepositoryDefinition)
-    the_job = repo_def.get_job("__ASSET_JOB")
+    the_job = repo_def.get_implicit_global_asset_job_def()
     assert len(the_job.graph.node_defs) == 2
 
 
@@ -143,7 +143,7 @@ def test_multiple_assets():
     repo_def = repository_def_from_pointer(CodePointer.from_python_file(path, symbol, None))
 
     assert isinstance(repo_def, RepositoryDefinition)
-    the_job = repo_def.get_job("__ASSET_JOB")
+    the_job = repo_def.get_implicit_global_asset_job_def()
     assert len(the_job.graph.node_defs) == 2
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -213,7 +213,7 @@ def test_pending_repo():
     assert len(all_assets) == 1
     assert all_assets[0].key.to_user_string() == "foobar"
 
-    assert isinstance(defs.get_job_def("__ASSET_JOB"), JobDefinition)
+    assert isinstance(defs.get_implicit_global_asset_job_def(), JobDefinition)
 
 
 def test_asset_loading():
@@ -243,7 +243,7 @@ def test_io_manager_coercion():
 
     defs = Definitions(assets=[one], resources={"mem_io_manager": InMemoryIOManager()})
 
-    asset_job = defs.get_job_def("__ASSET_JOB")
+    asset_job = defs.get_implicit_global_asset_job_def()
     assert isinstance(asset_job.resource_defs["mem_io_manager"], IOManagerDefinition)
     result = asset_job.execute_in_process()
     assert result.output_for_node("one") == 1
@@ -265,7 +265,7 @@ def test_custom_executor_in_definitions():
         return 1
 
     defs = Definitions(assets=[one], executor=an_executor)
-    asset_job = defs.get_job_def("__ASSET_JOB")
+    asset_job = defs.get_implicit_global_asset_job_def()
     assert asset_job.executor_def is an_executor
 
 
@@ -280,7 +280,7 @@ def test_custom_loggers_in_definitions():
 
     defs = Definitions(assets=[one], loggers={"custom_logger": a_logger})
 
-    asset_job = defs.get_job_def("__ASSET_JOB")
+    asset_job = defs.get_implicit_global_asset_job_def()
     loggers = asset_job.loggers
     assert len(loggers) == 1
     assert "custom_logger" in loggers
@@ -361,9 +361,9 @@ def test_kitchen_sink_on_create_helper_and_definitions():
     assert isinstance(repo.get_job("a_job"), JobDefinition)
     assert repo.get_job("a_job").executor_def is an_executor
     assert repo.get_job("a_job").loggers == {"logger_key": a_logger}
-    assert isinstance(repo.get_job("__ASSET_JOB"), JobDefinition)
-    assert repo.get_job("__ASSET_JOB").executor_def is an_executor
-    assert repo.get_job("__ASSET_JOB").loggers == {"logger_key": a_logger}
+    assert isinstance(repo.get_implicit_global_asset_job_def(), JobDefinition)
+    assert repo.get_implicit_global_asset_job_def().executor_def is an_executor
+    assert repo.get_implicit_global_asset_job_def().loggers == {"logger_key": a_logger}
     assert isinstance(repo.get_job("another_asset_job"), JobDefinition)
     assert repo.get_job("another_asset_job").executor_def is an_executor
     assert repo.get_job("another_asset_job").loggers == {"logger_key": a_logger}
@@ -391,9 +391,9 @@ def test_kitchen_sink_on_create_helper_and_definitions():
     assert isinstance(defs.get_job_def("a_job"), JobDefinition)
     assert defs.get_job_def("a_job").executor_def is an_executor
     assert defs.get_job_def("a_job").loggers == {"logger_key": a_logger}
-    assert isinstance(defs.get_job_def("__ASSET_JOB"), JobDefinition)
-    assert defs.get_job_def("__ASSET_JOB").executor_def is an_executor
-    assert defs.get_job_def("__ASSET_JOB").loggers == {"logger_key": a_logger}
+    assert isinstance(defs.get_implicit_global_asset_job_def(), JobDefinition)
+    assert defs.get_implicit_global_asset_job_def().executor_def is an_executor
+    assert defs.get_implicit_global_asset_job_def().loggers == {"logger_key": a_logger}
     assert isinstance(defs.get_job_def("another_asset_job"), JobDefinition)
     assert defs.get_job_def("another_asset_job").executor_def is an_executor
     assert defs.get_job_def("another_asset_job").loggers == {"logger_key": a_logger}

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -342,7 +342,7 @@ def test_asset_materialization_accessors():
 
     with DagsterInstance.ephemeral() as instance:
         defs = Definitions(assets=[return_one])
-        defs.get_job_def("__ASSET_JOB").execute_in_process(instance=instance)
+        defs.get_implicit_global_asset_job_def().execute_in_process(instance=instance)
 
         log_entry = instance.get_latest_materialization_event(AssetKey("return_one"))
         assert log_entry

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -1100,7 +1100,7 @@ def test_instance_set_on_asset_loader():
             assets=[an_asset, another_asset],
             resources={"io_manager": AssertingContextInputOnLoadInputIOManager()},
         )
-        defs.get_job_def("__ASSET_JOB").execute_in_process(
+        defs.get_implicit_global_asset_job_def().execute_in_process(
             asset_selection=[AssetKey("an_asset")], instance=instance
         )
         # load_input not called when asset does not have any inputs


### PR DESCRIPTION
### Summary & Motivation

I had added some tests that accessed the global implicit job directly using "__ASSET_JOB". Instead use the now supported official method for accessing this.

### How I Tested These Changes

BK
