### PR TITLE
docs(dagster-dbt): clarify that the integration supports arbitrary dbt profiles

### DIFF
--- a/docs/content/integrations/dbt.mdx
+++ b/docs/content/integrations/dbt.mdx
@@ -34,7 +34,7 @@ To learn how to load dbt models into Dagster as assets, check out the tutorial b
 
 ## dbt and Dagster software-defined assets tutorial
 
-In this tutorial, we'll walk you through integrating dbt with Dagster using dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a [DuckDB database](https://duckdb.org/).
+In this tutorial, we'll walk you through integrating dbt with Dagster using dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a data warehouse, such as [DuckDB](https://duckdb.org/).
 
 By the end of the tutorial, you'll have a working dbt and Dagster integration and a handful of materialized Dagster assets, including a plotly chart powered by data computed from your dbt models.
 

--- a/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster.mdx
@@ -10,7 +10,7 @@ description: Dagster can orchestrate dbt alongside other technologies.
   <a href="/integrations/dbt-cloud">dbt Cloud with Dagster guide</a>!
 </Note>
 
-In this tutorial, we'll walk you through integrating dbt with Dagster using dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a [DuckDB database](https://duckdb.org/).
+In this tutorial, we'll walk you through integrating dbt with Dagster using dbt's example [jaffle shop project](https://github.com/dbt-labs/jaffle_shop), the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt), and a data warehouse, such as [DuckDB](https://duckdb.org/).
 
 By the end of this tutorial, you will:
 

--- a/docs/content/integrations/dbt/using-dbt-with-dagster/part-one.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/part-one.mdx
@@ -18,7 +18,7 @@ First, you'll download Dagster's `tutorial_dbt_dagster` example and configure th
 In this part, you'll:
 
 - [Download the `tutorial_dbt_dagster` example](#step-1-download-the-tutorial_dbt_dagster-example)
-- [Create a DuckDB connection profile](#step-2-create-a-duckdb-profile)
+- [Create a profile](#step-2-create-a-profile)
 - [Configure dbt model data sources](#step-3-configure-dbt-model-data-sources)
 
 ---
@@ -47,9 +47,28 @@ Let's get started by downloading the [`tutorial_dbt_dagster` example](https://gi
 
 ---
 
-## Step 2: Create a DuckDB profile
+## Step 2: Create a profile
 
-In this step, you'll add a DuckDB profile to the dbt project. Profiles in dbt allow you to connect dbt to a database - in this case, that's DuckDB.
+<Note>
+  We assume you use DuckDB as your data warehouse in order to run the tutorial
+  entirely locally. If you plan on using a different data warehouse in
+  production, that's totally fine: Dagster can orchestrate dbt regardless of
+  what profile is configured. For example, we support dbt profiles for{" "}
+  <a href="https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup">
+    BigQuery
+  </a>
+  ,{" "}
+  <a href="https://docs.getdbt.com/reference/warehouse-setups/redshift-setup">
+    Redshift
+  </a>
+  ,{" "}
+  <a href="https://docs.getdbt.com/reference/warehouse-setups/snowflake-setup">
+    Snowflake
+  </a>
+  , and more.
+</Note>
+
+In this step, you'll add a profile to the dbt project. Profiles in dbt allow you to connect dbt to a database - in this case, that's DuckDB.
 
 1. Open the `profiles.yml` file, located in `/tutorial_template/jaffle_shop/config`.
 


### PR DESCRIPTION
### Summary & Motivation
In the the dbt + Dagster tutorial, we use DuckDB so that the tutorial is self contained in a local environment. But we also support whatever profiles that dbt supports.

Let's be explicit about this.

### How I Tested These Changes
read
