### PR TITLE
[structured config] Allow nesting structured config resources

### DIFF
--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -462,23 +462,3 @@ def _convert_potential_field(
         return potential_field
 
     return Field(_convert_potential_type(original_root, potential_field, stack))
-
-
-def config_dictionary_from_values(
-    values: Mapping[str, Any], config_field: "Field"
-) -> Dict[str, Any]:
-    assert ConfigTypeKind.is_shape(config_field.config_type.kind)
-    new_values = {}
-    for key, value in values.items():
-        if value is None:
-            continue
-
-        if isinstance(value, EnvVar):
-            new_values[key] = {"env": str(value)}
-        else:
-            new_values[key] = value
-    return new_values
-
-
-class EnvVar(str):
-    pass

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -462,3 +462,23 @@ def _convert_potential_field(
         return potential_field
 
     return Field(_convert_potential_type(original_root, potential_field, stack))
+
+
+def config_dictionary_from_values(
+    values: Mapping[str, Any], config_field: "Field"
+) -> Dict[str, Any]:
+    assert ConfigTypeKind.is_shape(config_field.config_type.kind)
+    new_values = {}
+    for key, value in values.items():
+        if value is None:
+            continue
+
+        if isinstance(value, EnvVar):
+            new_values[key] = {"env": str(value)}
+        else:
+            new_values[key] = value
+    return new_values
+
+
+class EnvVar(str):
+    pass

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -57,7 +57,9 @@ class Resource(
         ResourceDefinition.__init__(
             self,
             resource_fn=self.resource_function,
-            config_schema=configured_resource_def.config_schema,
+            # mypy worries that configured_resource_def could be self, which
+            # has not had config_schema initialized yet, but we know that's not the case
+            config_schema=configured_resource_def.config_schema,  # type: ignore[attr-defined]
             description=self.__doc__,
         )
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,37 +1,18 @@
 import inspect
-from inspect import Parameter
-from typing import Any, Optional, Sequence, Type, TypeVar
+from typing import Any, Optional, Type
 
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_SINGLETON, ModelField
-from typing_extensions import Annotated
 
 import dagster._check as check
 from dagster import Field, Shape
 from dagster._config.field_utils import FIELD_NO_DEFAULT_PROVIDED, convert_potential_field
-from dagster._core.decorator_utils import get_function_params
-from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
 class Config(BaseModel):
     """
     Base class for Dagster configuration models.
     """
-
-
-def get_resource_args(fn) -> Sequence[Parameter]:
-
-    return [param for param in get_function_params(fn) if _is_resource_annotated(param)]
-
-
-def _is_resource_annotated(param: Parameter) -> bool:
-    return (
-        isinstance(param.annotation, type) and issubclass(param.annotation, ResourceDefinition)
-    ) or (hasattr(param.annotation, "__metadata__") and getattr(param.annotation, "__metadata__"))
-
-
-T = TypeVar("T")
-ResourceOutput = Annotated[T, "resource_output"]
 
 
 def _convert_pydantic_field(pydantic_field: ModelField) -> Field:

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,5 +1,5 @@
 import inspect
-from functools import cached_property, lru_cache
+from functools import cached_property
 from typing import Any, Optional, Type
 
 from pydantic import BaseModel
@@ -19,23 +19,6 @@ class Config(BaseModel):
     """
     Base class for Dagster configuration models.
     """
-
-
-class cached_method:
-    """
-    Caches an instance method on a structured config class using :py:method:`functools.lru_cache`.
-    """
-
-    def __init__(self, function):
-        self.function = lru_cache()(function)
-
-    def __call__(self, *args, **kwargs):
-        return self.function(*args, **kwargs)
-
-    def __get__(self, instance, _):
-        from functools import partial
-
-        return partial(self.__call__, instance)
 
 
 class Resource(
@@ -62,7 +45,7 @@ class Resource(
 
     class Config:
         arbitrary_types_allowed = True
-        keep_untouched = (cached_property, cached_method)
+        keep_untouched = (cached_property,)
         frozen = True
 
     def __init__(self, **data: Any):
@@ -91,7 +74,7 @@ class Resource(
         # config schema. Pydantic will normally raise an error if you try to set an attribute
         # that is not part of the schema.
 
-        if name.startswith("_"):
+        if name.startswith("_") or name.endswith("_cache"):
             object.__setattr__(self, name, value)
             return
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,5 +1,13 @@
 import inspect
-from functools import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+
+    class cached_property:  # type: ignore[no-redef]
+        pass
+
+
 from typing import Any, Optional, Type
 
 from pydantic import BaseModel

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -55,7 +55,9 @@ class StructuredConfigResource(
         return super().__setattr__(name, value)
 
     def resource_fn(self, context) -> Any:  # pylint: disable=unused-argument
-        pass
+        # Default behavior, for "new-style" resources, is to return the resource itself, so that
+        # initialization is a no-op
+        return self
 
 
 def _convert_pydantic_field(pydantic_field: ModelField) -> Field:

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,18 +1,37 @@
 import inspect
-from typing import Any, Optional, Type
+from inspect import Parameter
+from typing import Any, Optional, Sequence, Type, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_SINGLETON, ModelField
+from typing_extensions import Annotated
 
 import dagster._check as check
 from dagster import Field, Shape
 from dagster._config.field_utils import FIELD_NO_DEFAULT_PROVIDED, convert_potential_field
+from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
 class Config(BaseModel):
     """
     Base class for Dagster configuration models.
     """
+
+
+def get_resource_args(fn) -> Sequence[Parameter]:
+
+    return [param for param in get_function_params(fn) if _is_resource_annotated(param)]
+
+
+def _is_resource_annotated(param: Parameter) -> bool:
+    return (
+        isinstance(param.annotation, type) and issubclass(param.annotation, ResourceDefinition)
+    ) or (hasattr(param.annotation, "__metadata__") and getattr(param.annotation, "__metadata__"))
+
+
+T = TypeVar("T")
+ResourceOutput = Annotated[T, "resource_output"]
 
 
 def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
@@ -81,6 +100,7 @@ def infer_schema_from_config_class(
 
     fields = {}
     for pydantic_field_name, pydantic_field in model_cls.__fields__.items():
+
         fields[pydantic_field_name] = _convert_pydantic_field(pydantic_field)
 
     docstring = model_cls.__doc__.strip() if model_cls.__doc__ else None

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -24,6 +24,13 @@ class Config(BaseModel):
 class Resource(
     ResourceDefinition,
     Config,
+    # Various pydantic model config (https://docs.pydantic.dev/usage/model_config/)
+    # Necessary to allow for caching decorators
+    arbitrary_types_allowed=True,
+    # Avoid pydantic reading a cached property class as part of the schema
+    keep_untouched=(cached_property,),
+    # Ensure the class is serializable, for caching purposes
+    frozen=True,
 ):
     """
     Base class for Dagster resources that utilize structured config.
@@ -42,11 +49,6 @@ class Resource(
                 print(f"{self.prefix}{text}")
 
     """
-
-    class Config:
-        arbitrary_types_allowed = True
-        keep_untouched = (cached_property,)
-        frozen = True
 
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -81,7 +81,6 @@ def infer_schema_from_config_class(
 
     fields = {}
     for pydantic_field_name, pydantic_field in model_cls.__fields__.items():
-
         fields[pydantic_field_name] = _convert_pydantic_field(pydantic_field)
 
     docstring = model_cls.__doc__.strip() if model_cls.__doc__ else None

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -6,7 +6,6 @@ from typing import (
     Dict,
     Mapping,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Union,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -432,7 +432,7 @@ def multi_asset(
 
         arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
         check.param_invariant(
-            len(required_resource_keys) == 0 or len(arg_resource_keys) == 0,
+            len(required_resource_keys or []) == 0 or len(arg_resource_keys) == 0,
             "Cannot specify resource requirements in both @multi_asset decorator and as arguments to the decorated function",
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -17,9 +17,9 @@ from typing import (
 import dagster._check as check
 from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
-from dagster._config.structured_config import get_resource_args
 from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.resource_output import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._core.types.dagster_type import DagsterType

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -83,7 +83,7 @@ class _Op:
         elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
 
-        resolved_resource_keys = (self.required_resource_keys or set()).union(
+        resolved_resource_keys = set(self.required_resource_keys or []).union(
             {arg.name for arg in compute_fn.get_resource_args()}
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -83,9 +83,13 @@ class _Op:
         elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
 
-        resolved_resource_keys = set(self.required_resource_keys or []).union(
-            {arg.name for arg in compute_fn.get_resource_args()}
+        arg_resource_keys = {arg.name for arg in compute_fn.get_resource_args()}
+        decorator_resource_keys = set(self.required_resource_keys or [])
+        check.param_invariant(
+            len(decorator_resource_keys) == 0 or len(arg_resource_keys) == 0,
+            "Cannot specify resource requirements in both @op decorator and as arguments to the decorated function",
         )
+        resolved_resource_keys = decorator_resource_keys.union(arg_resource_keys)
 
         op_def = OpDefinition(
             name=self.name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -83,6 +83,10 @@ class _Op:
         elif self.out is not None:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
 
+        resolved_resource_keys = (self.required_resource_keys or set()).union(
+            {arg.name for arg in compute_fn.get_resource_args()}
+        )
+
         op_def = OpDefinition(
             name=self.name,
             ins=self.ins,
@@ -90,7 +94,7 @@ class _Op:
             compute_fn=compute_fn,
             config_schema=self.config_schema,
             description=self.description or format_docstring_for_description(fn),
-            required_resource_keys=self.required_resource_keys,
+            required_resource_keys=resolved_resource_keys,
             tags=self.tags,
             code_version=self.code_version,
             retry_policy=self.retry_policy,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -162,7 +162,7 @@ class _Solid:
         decorator_resource_keys = set(self.required_resource_keys or [])
         check.param_invariant(
             len(decorator_resource_keys) == 0 or len(arg_resource_keys) == 0,
-            "Cannot specify resource requirements in both @solid decorator and as arguments to the decorated function",
+            "Cannot specify resource requirements in both @op decorator and as arguments to the decorated function",
         )
         resolved_resource_keys = decorator_resource_keys.union(arg_resource_keys)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -13,13 +13,10 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Annotated
-
 import dagster._check as check
 from dagster._config import UserConfigSchema
-from dagster._config.structured_config import get_resource_args
 from dagster._core.decorator_utils import format_docstring_for_description
-from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.resource_output import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
 from dagster._seven import funcsigs
@@ -65,7 +62,6 @@ class DecoratedOpFunction(NamedTuple):
         check.failed("Requested config arg on function that does not have one")
 
     def get_resource_args(self) -> Sequence[funcsigs.Parameter]:
-
         return get_resource_args(self.decorated_fn)
 
     def positional_inputs(self) -> Sequence[str]:
@@ -161,7 +157,7 @@ class _Solid:
             explicit_input_defs=self.input_defs,
             exclude_nothing=True,
         )
-        resolved_resource_keys = set(self.required_resource_keys).union(
+        resolved_resource_keys = (self.required_resource_keys or set()).union(
             {arg.name for arg in compute_fn.get_resource_args()}
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -13,9 +13,13 @@ from typing import (
     overload,
 )
 
+from typing_extensions import Annotated
+
 import dagster._check as check
 from dagster._config import UserConfigSchema
+from dagster._config.structured_config import get_resource_args
 from dagster._core.decorator_utils import format_docstring_for_description
+from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
 from dagster._seven import funcsigs
@@ -60,10 +64,19 @@ class DecoratedOpFunction(NamedTuple):
 
         check.failed("Requested config arg on function that does not have one")
 
+    def get_resource_args(self) -> Sequence[funcsigs.Parameter]:
+
+        return get_resource_args(self.decorated_fn)
+
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()
         input_args = params[1:] if self.has_context_arg() else params
-        input_args_filtered = [input_arg for input_arg in input_args if input_arg.name != "config"]
+        resource_arg_names = [arg.name for arg in self.get_resource_args()]
+        input_args_filtered = [
+            input_arg
+            for input_arg in input_args
+            if input_arg.name != "config" and input_arg.name not in resource_arg_names
+        ]
         return positional_arg_name_list(input_args_filtered)
 
     def has_var_kwargs(self) -> bool:
@@ -148,6 +161,9 @@ class _Solid:
             explicit_input_defs=self.input_defs,
             exclude_nothing=True,
         )
+        resolved_resource_keys = set(self.required_resource_keys).union(
+            {arg.name for arg in compute_fn.get_resource_args()}
+        )
 
         solid_def = OpDefinition(
             name=self.name,
@@ -158,7 +174,7 @@ class _Solid:
             compute_fn=compute_fn,
             config_schema=self.config_schema,
             description=self.description or format_docstring_for_description(fn),
-            required_resource_keys=self.required_resource_keys,
+            required_resource_keys=resolved_resource_keys,
             tags=self.tags,
             version=self.version,
             retry_policy=self.retry_policy,
@@ -345,6 +361,7 @@ def resolve_checked_solid_fn_inputs(
             arguments.
     """
 
+    explicit_names = set()
     if exclude_nothing:
         explicit_names = set(
             inp.name
@@ -365,10 +382,13 @@ def resolve_checked_solid_fn_inputs(
     input_args = params[1:] if compute_fn.has_context_arg() else params
 
     # filter out config arg
-    if compute_fn.has_config_arg():
+    resource_arg_names = {arg.name for arg in compute_fn.get_resource_args()}
+    explicit_names = explicit_names - resource_arg_names
+
+    if compute_fn.has_config_arg() or resource_arg_names:
         new_input_args = []
         for input_arg in input_args:
-            if input_arg.name != "config":
+            if input_arg.name != "config" and input_arg.name not in resource_arg_names:
                 new_input_args.append(input_arg)
         input_args = new_input_args
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -157,7 +157,7 @@ class _Solid:
             explicit_input_defs=self.input_defs,
             exclude_nothing=True,
         )
-        resolved_resource_keys = (self.required_resource_keys or set()).union(
+        resolved_resource_keys = set(self.required_resource_keys or []).union(
             {arg.name for arg in compute_fn.get_resource_args()}
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -157,9 +157,14 @@ class _Solid:
             explicit_input_defs=self.input_defs,
             exclude_nothing=True,
         )
-        resolved_resource_keys = set(self.required_resource_keys or []).union(
-            {arg.name for arg in compute_fn.get_resource_args()}
+
+        arg_resource_keys = {arg.name for arg in compute_fn.get_resource_args()}
+        decorator_resource_keys = set(self.required_resource_keys or [])
+        check.param_invariant(
+            len(decorator_resource_keys) == 0 or len(arg_resource_keys) == 0,
+            "Cannot specify resource requirements in both @solid decorator and as arguments to the decorated function",
         )
+        resolved_resource_keys = decorator_resource_keys.union(arg_resource_keys)
 
         solid_def = OpDefinition(
             name=self.name,

--- a/python_modules/dagster/dagster/_core/definitions/resource_output.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_output.py
@@ -1,0 +1,22 @@
+from inspect import Parameter
+from typing import Sequence, TypeVar
+
+from typing_extensions import Annotated
+
+from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.resource_definition import ResourceDefinition
+
+
+def get_resource_args(fn) -> Sequence[Parameter]:
+
+    return [param for param in get_function_params(fn) if _is_resource_annotated(param)]
+
+
+def _is_resource_annotated(param: Parameter) -> bool:
+    return (
+        isinstance(param.annotation, type) and issubclass(param.annotation, ResourceDefinition)
+    ) or (hasattr(param.annotation, "__metadata__") and getattr(param.annotation, "__metadata__"))
+
+
+T = TypeVar("T")
+ResourceOutput = Annotated[T, "resource_output"]

--- a/python_modules/dagster/dagster/_core/definitions/resource_output.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_output.py
@@ -15,7 +15,10 @@ def get_resource_args(fn) -> Sequence[Parameter]:
 def _is_resource_annotated(param: Parameter) -> bool:
     return (
         isinstance(param.annotation, type) and issubclass(param.annotation, ResourceDefinition)
-    ) or (hasattr(param.annotation, "__metadata__") and getattr(param.annotation, "__metadata__"))
+    ) or (
+        hasattr(param.annotation, "__metadata__")
+        and getattr(param.annotation, "__metadata__") == ("resource_output",)
+    )
 
 
 T = TypeVar("T")

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -45,6 +45,7 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
     output_defs = solid_def.output_defs
     context_arg_provided = compute_fn.has_context_arg()
     config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
+    resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
 
     input_names = [
         input_def.name
@@ -64,7 +65,9 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
             or inspect.iscoroutinefunction(fn)
         ):
             # safe to execute the function, as doing so will not immediately execute user code
-            result = invoke_compute_fn(fn, context, kwargs, context_arg_provided, config_arg_cls)
+            result = invoke_compute_fn(
+                fn, context, kwargs, context_arg_provided, config_arg_cls, resource_arg_mapping
+            )
             if inspect.iscoroutine(result):
                 return _coerce_async_solid_to_async_gen(result, context, output_defs)
             # already a generator
@@ -73,7 +76,13 @@ def create_solid_compute_wrapper(solid_def: OpDefinition):
             # we have a regular function, do not execute it before we are in an iterator
             # (as we want all potential failures to happen inside iterators)
             return _coerce_solid_compute_fn_to_iterator(
-                fn, output_defs, context, context_arg_provided, kwargs, config_arg_cls
+                fn,
+                output_defs,
+                context,
+                context_arg_provided,
+                kwargs,
+                config_arg_cls,
+                resource_arg_mapping,
             )
 
     return compute
@@ -91,6 +100,7 @@ def invoke_compute_fn(
     kwargs: Dict[str, Any],
     context_arg_provided: bool,
     config_arg_cls: Optional[Type[Config]],
+    resource_args: Optional[Dict[str, str]] = None,
 ) -> Any:
     args_to_pass = kwargs
     if config_arg_cls:
@@ -99,13 +109,18 @@ def invoke_compute_fn(
             args_to_pass["config"] = config_arg_cls(**context.op_config)
         else:
             args_to_pass["config"] = context.op_config
+    if resource_args:
+        for resource_name, arg_name in resource_args.items():
+            args_to_pass[arg_name] = getattr(context.resources, resource_name)
     return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
 
 
 def _coerce_solid_compute_fn_to_iterator(
-    fn, output_defs, context, context_arg_provided, kwargs, config_arg_class
+    fn, output_defs, context, context_arg_provided, kwargs, config_arg_class, resource_arg_mapping
 ):
-    result = invoke_compute_fn(fn, context, kwargs, context_arg_provided, config_arg_class)
+    result = invoke_compute_fn(
+        fn, context, kwargs, context_arg_provided, config_arg_class, resource_arg_mapping
+    )
     for event in validate_and_coerce_op_result_to_iterator(result, context, output_defs):
         yield event
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -1,15 +1,5 @@
+from dagster import AssetsDefinition, ResourceDefinition, asset, job, op, resource, with_resources
 from dagster._core.definitions.assets_job import build_assets_job
-from dagster._core.storage.mem_io_manager import InMemoryIOManager
-
-from dagster import (
-    ResourceDefinition,
-    asset,
-    job,
-    op,
-    resource,
-    with_resources,
-    AssetsDefinition,
-)
 from dagster._core.definitions.resource_output import ResourceOutput
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -175,7 +175,7 @@ def test_both_decorator_and_argument_error():
     ):
 
         @asset(required_resource_keys={"foo"})
-        def my_asset(bar: ResourceOutput[Any]):
+        def my_asset(bar: ResourceOutput[Any]):  # pylint: disable=unused-argument
             pass
 
     with pytest.raises(
@@ -187,7 +187,7 @@ def test_both_decorator_and_argument_error():
             outs={"a": AssetOut(key="asset_a"), "b": AssetOut(key="asset_b")},
             required_resource_keys={"foo"},
         )
-        def my_assets(bar: ResourceOutput[Any]):
+        def my_assets(bar: ResourceOutput[Any]):  # pylint: disable=unused-argument
             pass
 
     with pytest.raises(
@@ -196,7 +196,7 @@ def test_both_decorator_and_argument_error():
     ):
 
         @op(required_resource_keys={"foo"})
-        def my_op(bar: ResourceOutput[Any]):
+        def my_op(bar: ResourceOutput[Any]):  # pylint: disable=unused-argument
             pass
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -1,0 +1,119 @@
+from dagster._core.definitions.assets_job import build_assets_job
+from dagster._core.storage.mem_io_manager import InMemoryIOManager
+
+from dagster import (
+    ResourceDefinition,
+    asset,
+    job,
+    op,
+    resource,
+    with_resources,
+    AssetsDefinition,
+)
+from dagster._core.definitions.resource_output import ResourceOutput
+
+
+def test_filter_out_resources():
+    @op
+    def requires_resource_a(context, a: ResourceOutput[str]):
+        assert a
+        assert context.resources.a
+        assert not hasattr(context.resources, "b")
+
+    @op
+    def requires_resource_b(context, b: ResourceOutput[str]):
+        assert b
+        assert not hasattr(context.resources, "a")
+        assert context.resources.b
+
+    @op
+    def not_resources(context):
+        assert not hasattr(context.resources, "a")
+        assert not hasattr(context.resources, "b")
+
+    @job(
+        resource_defs={
+            "a": ResourceDefinition.hardcoded_resource("foo"),
+            "b": ResourceDefinition.hardcoded_resource("bar"),
+        },
+    )
+    def room_of_requirement():
+        requires_resource_a()
+        requires_resource_b()
+        not_resources()
+
+    room_of_requirement.execute_in_process()
+
+
+def test_init_resources():
+    resources_initted = {}
+
+    @resource
+    def resource_a(_):
+        resources_initted["a"] = True
+        yield "A"
+
+    @resource
+    def resource_b(_):
+        resources_initted["b"] = True
+        yield "B"
+
+    @op
+    def consumes_resource_a(a: ResourceOutput[str]):
+        assert a == "A"
+
+    @op
+    def consumes_resource_b(b: ResourceOutput[str]):
+        assert b == "B"
+
+    @job(
+        resource_defs={
+            "a": resource_a,
+            "b": resource_b,
+        },
+    )
+    def selective_init_test_job():
+        consumes_resource_a()
+        consumes_resource_b()
+
+    assert selective_init_test_job.execute_in_process().success
+
+    assert set(resources_initted.keys()) == {"a", "b"}
+
+
+def test_with_assets():
+    @asset
+    def the_asset(context, foo: ResourceOutput[str]):
+        assert context.resources.foo == "blah"
+        assert foo == "blah"
+
+    transformed_asset = with_resources(
+        [the_asset],
+        {"foo": ResourceDefinition.hardcoded_resource("blah")},
+    )[0]
+    assert isinstance(transformed_asset, AssetsDefinition)
+
+    assert build_assets_job("the_job", [transformed_asset]).execute_in_process().success
+
+
+def test_resource_class():
+
+    resource_called = {}
+
+    class MyResource(ResourceDefinition):
+        def __init__(self):
+            super().__init__(resource_fn=lambda *_, **__: self)
+
+        def do_something(self):
+            resource_called["called"] = True
+
+    @op
+    def do_something_op(my_resource: MyResource):
+        my_resource.do_something()
+
+    @job(resource_defs={"my_resource": MyResource()})
+    def my_job():
+        do_something_op()
+
+    assert my_job.execute_in_process().success
+    assert resource_called["called"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -8,10 +8,8 @@ from dagster._config.structured_config import Config
 from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
-from dagster._core.definitions.input import In
 from dagster._core.definitions.resource_output import ResourceOutput
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._core.types.dagster_type import Nothing
 
 
 def test_filter_out_resources():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,8 +1,13 @@
+from abc import ABC, abstractmethod
 from functools import cached_property
+
+import pytest
+from pydantic import ValidationError
 
 from dagster import asset, job, op
 from dagster._config.structured_config import Resource, cached_method
 from dagster._core.definitions.assets_job import build_assets_job
+from dagster._core.definitions.resource_output import ResourceOutput
 
 
 def test_basic_structured_resource():
@@ -34,6 +39,16 @@ def test_basic_structured_resource():
 
     assert prefix_job.execute_in_process().success
     assert out_txt == ["greeting: hello, world!"]
+
+
+def test_invalid_config():
+    class MyResource(Resource):
+        foo: int
+
+    with pytest.raises(
+        ValidationError,
+    ):
+        MyResource(foo="why")
 
 
 def test_caching_within_resource():
@@ -105,3 +120,82 @@ def test_caching_within_resource():
 
     assert called["greeting"] == 1
     assert called["get_introduction"] == 2
+
+
+def test_abc_resource():
+
+    out_txt = []
+
+    class WriterResource(Resource, ABC):
+        @abstractmethod
+        def output(self, text: str) -> None:
+            pass
+
+    class PrefixedWriterResource(WriterResource):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    class RepetitiveWriterResource(WriterResource):
+        repetitions: int
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{text} " * self.repetitions)
+
+    @op
+    def hello_world_op(writer: WriterResource):
+        writer.output("hello, world!")
+
+    # Can't instantiate abstract class
+    with pytest.raises(TypeError):
+        WriterResource()
+
+    @job(resource_defs={"writer": PrefixedWriterResource(prefix="greeting: ")})
+    def prefixed_job():
+        hello_world_op()
+
+    assert prefixed_job.execute_in_process().success
+    assert out_txt == ["greeting: hello, world!"]
+
+    out_txt.clear()
+
+    @job(resource_defs={"writer": RepetitiveWriterResource(repetitions=3)})
+    def repetitive_writer_job():
+        hello_world_op()
+
+    assert repetitive_writer_job.execute_in_process().success
+    assert out_txt == ["hello, world! " * 3]
+
+
+def test_yield_in_resource_function():
+    called = []
+
+    class ResourceWithCleanup(Resource):
+        idx: int
+
+        def resource_function(self, context):
+            called.append(f"creation_{self.idx}")
+            yield True
+            called.append(f"cleanup_{self.idx}")
+
+    @op
+    def check_resource_created(
+        resource_with_cleanup_1: ResourceOutput[bool], resource_with_cleanup_2: ResourceOutput[bool]
+    ):
+        assert resource_with_cleanup_1 is True
+        assert resource_with_cleanup_2 is True
+        called.append("op")
+
+    @job(
+        resource_defs={
+            "resource_with_cleanup_1": ResourceWithCleanup(idx=1),
+            "resource_with_cleanup_2": ResourceWithCleanup(idx=2),
+        }
+    )
+    def the_job():
+        check_resource_created()
+
+    assert the_job.execute_in_process().success
+
+    assert called == ["creation_1", "creation_2", "op", "cleanup_2", "cleanup_1"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,19 +1,16 @@
-from dagster import (
-    job,
-    op,
-)
-from dagster._config.structured_config import StructuredConfigResource
+from dagster import job, op
+from dagster._config.structured_config import Resource
 
 
 def test_basic_structured_resource():
 
-    output = []
+    out_txt = []
 
-    class WriterResource(StructuredConfigResource):
+    class WriterResource(Resource):
         prefix: str
 
         def output(self, text: str) -> None:
-            output.append(f"{self.prefix}{text}")
+            out_txt.append(f"{self.prefix}{text}")
 
     @op
     def hello_world_op(writer: WriterResource):
@@ -24,13 +21,13 @@ def test_basic_structured_resource():
         hello_world_op()
 
     assert no_prefix_job.execute_in_process().success
-    assert output == ["hello, world!"]
+    assert out_txt == ["hello, world!"]
 
-    output.clear()
+    out_txt.clear()
 
     @job(resource_defs={"writer": WriterResource(prefix="greeting: ")})
     def prefix_job():
         hello_world_op()
 
     assert prefix_job.execute_in_process().success
-    assert output == ["greeting: hello, world!"]
+    assert out_txt == ["greeting: hello, world!"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -5,9 +5,10 @@ import pytest
 from pydantic import ValidationError
 
 from dagster import asset, job, op
-from dagster._config.structured_config import Resource, cached_method
+from dagster._config.structured_config import Resource
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._utils.cached_method import cached_method
 
 
 def test_basic_structured_resource():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,0 +1,36 @@
+from dagster import (
+    job,
+    op,
+)
+from dagster._config.structured_config import StructuredConfigResource
+
+
+def test_basic_structured_resource():
+
+    output = []
+
+    class WriterResource(StructuredConfigResource):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            output.append(f"{self.prefix}{text}")
+
+    @op
+    def hello_world_op(writer: WriterResource):
+        writer.output("hello, world!")
+
+    @job(resource_defs={"writer": WriterResource(prefix="")})
+    def no_prefix_job():
+        hello_world_op()
+
+    assert no_prefix_job.execute_in_process().success
+    assert output == ["hello, world!"]
+
+    output.clear()
+
+    @job(resource_defs={"writer": WriterResource(prefix="greeting: ")})
+    def prefix_job():
+        hello_world_op()
+
+    assert prefix_job.execute_in_process().success
+    assert output == ["greeting: hello, world!"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,5 +1,8 @@
-from dagster import job, op
-from dagster._config.structured_config import Resource
+from functools import cached_property
+
+from dagster import asset, job, op
+from dagster._config.structured_config import Resource, cached_method
+from dagster._core.definitions.assets_job import build_assets_job
 
 
 def test_basic_structured_resource():
@@ -31,3 +34,74 @@ def test_basic_structured_resource():
 
     assert prefix_job.execute_in_process().success
     assert out_txt == ["greeting: hello, world!"]
+
+
+def test_caching_within_resource():
+
+    called = {"greeting": 0, "get_introduction": 0}
+
+    class GreetingResource(Resource):
+        name: str
+
+        @cached_property
+        def greeting(self) -> str:
+            called["greeting"] += 1
+            return f"Hello, {self.name}"
+
+        # Custom decorator which caches an instance method
+        @cached_method
+        def get_introduction(self, verbose: bool) -> str:
+            called["get_introduction"] += 1
+            return f"My name is {self.name}" if verbose else f"I'm {self.name}"
+
+    @op
+    def hello_world_op(greeting: GreetingResource):
+        assert greeting.greeting == "Hello, Dagster"
+        assert greeting.get_introduction(verbose=True) == "My name is Dagster"
+        assert greeting.get_introduction(verbose=False) == "I'm Dagster"
+
+    @op
+    def another_op(greeting: GreetingResource):
+        assert greeting.greeting == "Hello, Dagster"
+        assert greeting.get_introduction(verbose=True) == "My name is Dagster"
+        assert greeting.get_introduction(verbose=False) == "I'm Dagster"
+
+    @job(resource_defs={"greeting": GreetingResource(name="Dagster")})
+    def hello_world_job():
+        hello_world_op()
+        another_op()
+
+    assert hello_world_job.execute_in_process().success
+
+    # Each should only be called once, because of the caching
+    assert called["greeting"] == 1
+    assert called["get_introduction"] == 2
+
+    called = {"greeting": 0, "get_introduction": 0}
+
+    @asset
+    def hello_world_asset(greeting: GreetingResource):
+        assert greeting.greeting == "Hello, Dagster"
+        assert greeting.get_introduction(verbose=True) == "My name is Dagster"
+        assert greeting.get_introduction(verbose=False) == "I'm Dagster"
+        return greeting.greeting
+
+    @asset
+    def another_asset(greeting: GreetingResource, hello_world_asset):
+        assert hello_world_asset == "Hello, Dagster"
+        assert greeting.greeting == "Hello, Dagster"
+        assert greeting.get_introduction(verbose=True) == "My name is Dagster"
+        assert greeting.get_introduction(verbose=False) == "I'm Dagster"
+
+    assert (
+        build_assets_job(
+            "blah",
+            [hello_world_asset, another_asset],
+            resource_defs={"greeting": GreetingResource(name="Dagster")},
+        )
+        .execute_in_process()
+        .success
+    )
+
+    assert called["greeting"] == 1
+    assert called["get_introduction"] == 2

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -150,7 +150,7 @@ def test_abc_resource():
 
     # Can't instantiate abstract class
     with pytest.raises(TypeError):
-        WriterResource()
+        WriterResource()  # pylint: disable=abstract-class-instantiated
 
     @job(resource_defs={"writer": PrefixedWriterResource(prefix="greeting: ")})
     def prefixed_job():


### PR DESCRIPTION
## Summary

Allows structured-config-backed resources (#11321) to require other resources as input. By default, this doesn't work because the resource class is interpreted as nested config.

```python
class WriterResource(Resource):
    prefix: str

    def output(self, text: str) -> None:
        out_txt.append(f"{self.prefix}{text}")

class JsonWriterResource(Resource):
    writer: WriterResource
    indent: int

    def output(self, obj: Any) -> None:
        self.writer.output(json.dumps(obj, indent=self.indent))

writer_resource = WriterResource(prefix="greeting: ")
json_writer_resource = JsonWriterResource(writer=writer_resource, indent=2)
```

## Test Plan

Basic unit test.