### PR TITLE
[structured config] Fix test importing functools.cached_property on py37 tests

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,3 +1,4 @@
+import sys
 from abc import ABC, abstractmethod
 from typing import Callable
 
@@ -53,14 +54,12 @@ def test_invalid_config():
         MyResource(foo="why")
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8")
 def test_caching_within_resource():
 
     called = {"greeting": 0, "get_introduction": 0}
 
-    try:
-        from functools import cached_property
-    except ImportError:
-        return
+    from functools import cached_property
 
     class GreetingResource(Resource):
         name: str

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from functools import cached_property
 from typing import Callable
 
 import pytest
@@ -57,6 +56,11 @@ def test_invalid_config():
 def test_caching_within_resource():
 
     called = {"greeting": 0, "get_introduction": 0}
+
+    try:
+        from functools import cached_property
+    except ImportError:
+        return
 
     class GreetingResource(Resource):
         name: str


### PR DESCRIPTION
we're importing `functools.cached_property` in tests, this skips the test if we can't import it (python 3.7)

https://buildkite.com/dagster/dagster/builds/43587#01854077-8c0a-4ad5-aa24-af205e7caf82