### PR TITLE
[pyright] [core] misc

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -167,13 +167,15 @@ def is_callable(obj: object, additional_message: Optional[str] = None) -> Callab
 # ##### CLASS
 # ########################
 
+T_Type = TypeVar("T_Type", bound=type)
+
 
 def class_param(
-    obj: object,
+    obj: T_Type,
     param_name: str,
     superclass: Optional[type] = None,
     additional_message: Optional[str] = None,
-) -> type:
+) -> T_Type:
     if not isinstance(obj, type):
         raise _param_class_mismatch_exception(
             obj, param_name, superclass, False, additional_message

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -540,7 +540,7 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
     )
     package_name = check.opt_str_elem(kwargs, "package_name")
     working_directory = get_working_directory_from_kwargs(kwargs)
-    attribute = kwargs.get("attribute")
+    attribute = check.opt_str_elem(kwargs, "attribute")
     if python_file:
         _check_cli_arguments_none(kwargs, "module_name", "package_name")
         return {

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -404,7 +404,9 @@ class ScalarUnion(ConfigType):
     ):
         from .field import resolve_to_config_type
 
-        self.scalar_type = resolve_to_config_type(scalar_type)
+        self.scalar_type = check.inst(
+            cast(ConfigType, resolve_to_config_type(scalar_type)), ConfigType
+        )
         self.non_scalar_type = resolve_to_config_type(non_scalar_schema)
 
         check.param_invariant(self.scalar_type.kind == ConfigTypeKind.SCALAR, "scalar_type")
@@ -426,7 +428,7 @@ class ScalarUnion(ConfigType):
         )
 
     def type_iterator(self) -> Iterator["ConfigType"]:
-        yield from self.scalar_type.type_iterator()
+        yield from self.scalar_type.type_iterator()  # type: ignore
         yield from self.non_scalar_type.type_iterator()
         yield from super().type_iterator()
 

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -68,7 +68,7 @@ def resolve_to_config_type(obj: object) -> Union[ConfigType, bool]:
                         )
                     )
 
-                if not key_type.kind == ConfigTypeKind.SCALAR:
+                if not key_type.kind == ConfigTypeKind.SCALAR:  # type: ignore
                     raise DagsterInvalidDefinitionError(
                         "Non-scalar key in map specification: {key} in map {collection}".format(
                             key=repr(key), collection=obj

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -333,7 +333,7 @@ class PendingNodeInvocation:
         if is_in_composition():
             current_context().add_pending_invocation(self)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Any:
         from ..execution.context.invocation import UnboundOpExecutionContext
         from .decorators.solid_decorator import DecoratedOpFunction
         from .solid_invocation import op_invocation_result
@@ -374,7 +374,15 @@ class PendingNodeInvocation:
                 return op_invocation_result(self, None, *args, **kwargs)
 
         assert_in_composition(node_name, self.node_def)
-        input_bindings = {}
+        input_bindings: Dict[
+            str,
+            Union[
+                InvokedNodeOutputHandle,
+                InputMappingNode,
+                DynamicFanIn,
+                List[Union[InvokedNodeOutputHandle, InputMappingNode]],
+            ],
+        ] = {}
 
         # handle *args
         for idx, output_node in enumerate(args):
@@ -448,7 +456,9 @@ class PendingNodeInvocation:
                 )
 
         outputs = [output_def for output_def in self.node_def.output_defs]
-        invoked_output_handles = {}
+        invoked_output_handles: Dict[
+            str, Union[InvokedNodeDynamicOutputWrapper, InvokedNodeOutputHandle]
+        ] = {}
         for output_def in outputs:
             if output_def.is_dynamic:
                 invoked_output_handles[output_def.name] = InvokedNodeDynamicOutputWrapper(

--- a/python_modules/dagster/dagster/_core/definitions/config.py
+++ b/python_modules/dagster/dagster/_core/definitions/config.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, Mapping, NamedTuple, Optional, Union, cast
 
+from typing_extensions import TypeAlias
+
 import dagster._check as check
 from dagster._builtins import BuiltinEnum
 from dagster._config import (
@@ -13,6 +15,8 @@ from dagster._core.definitions.definition_config_schema import IDefinitionConfig
 from dagster._core.errors import DagsterInvalidConfigError
 
 from .definition_config_schema import convert_user_facing_definition_config_schema
+
+ConfigMappingFn: TypeAlias = Callable[[Any], Any]
 
 
 def is_callable_valid_config_arg(config: Union[Callable[..., Any], Mapping[str, object]]) -> bool:
@@ -51,7 +55,7 @@ class ConfigMapping(
 
     def __new__(
         cls,
-        config_fn: Callable[[Any], Any],
+        config_fn: ConfigMappingFn,
         config_schema: Optional[Any] = None,
         receive_processed_config_values: Optional[bool] = None,
     ):

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Mapping, Optional, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from typing_extensions import Self
 
@@ -8,6 +8,7 @@ from dagster import (
     _check as check,
 )
 from dagster._config import EvaluateValueResult
+from dagster._config.config_schema import UserConfigSchema
 
 from .definition_config_schema import (
     CoercableToConfigSchema,
@@ -117,7 +118,7 @@ class NamedConfigurableDefinition(ConfigurableDefinition):
         self,
         config_or_config_fn: Any,
         name: str,
-        config_schema: Optional[Mapping[str, Any]] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         description: Optional[str] = None,
     ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
         """
@@ -196,7 +197,7 @@ T_Configurable = TypeVar(
 
 def configured(
     configurable: T_Configurable,
-    config_schema: Optional[Mapping[str, Any]] = None,
+    config_schema: Optional[UserConfigSchema] = None,
     **kwargs: Any,
 ) -> Callable[[object], T_Configurable]:
     """

--- a/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional, Union, overload
 import dagster._check as check
 from dagster._config import UserConfigSchema
 
-from ..config import ConfigMapping
+from ..config import ConfigMapping, ConfigMappingFn
 
 
 class _ConfigMapping:
@@ -29,7 +29,7 @@ class _ConfigMapping:
 
 @overload
 def config_mapping(
-    config_fn: Callable[..., Any],
+    config_fn: ConfigMappingFn,
 ) -> ConfigMapping:
     ...
 
@@ -39,7 +39,7 @@ def config_mapping(
     *,
     config_schema: UserConfigSchema = ...,
     receive_processed_config_values: Optional[bool] = ...,
-) -> Union[_ConfigMapping, ConfigMapping]:
+) -> Callable[[ConfigMappingFn], ConfigMapping]:
     ...
 
 
@@ -48,7 +48,7 @@ def config_mapping(
     *,
     config_schema: Optional[UserConfigSchema] = None,
     receive_processed_config_values: Optional[bool] = None,
-) -> Union[ConfigMapping, _ConfigMapping]:
+) -> Union[Callable[[ConfigMappingFn], ConfigMapping], ConfigMapping]:
     """Create a config mapping with the specified parameters from the decorated function.
 
     The config schema will be inferred from the type signature of the decorated function if not explicitly provided.

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -1,5 +1,17 @@
 from functools import update_wrapper
-from typing import Any, Callable, List, Mapping, Optional, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    overload,
+)
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
@@ -21,8 +33,10 @@ from ..schedule_definition import ScheduleDefinition
 from ..sensor_definition import SensorDefinition
 from ..unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
+T = TypeVar("T")
 
-def _flatten(items):
+
+def _flatten(items: Iterable[Union[T, List[T]]]) -> Iterator[T]:
     for x in items:
         if isinstance(x, List):
             # switch to `yield from _flatten(x)` to support multiple layers of nesting
@@ -49,7 +63,7 @@ class _Repository:
         )
 
     def __call__(
-        self, fn: Callable[[], Any]
+        self, fn: Callable[[], Sequence[Any]]
     ) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
         from dagster._core.definitions import AssetGroup, AssetsDefinition, SourceAsset
         from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
@@ -157,7 +171,7 @@ class _Repository:
 
 
 @overload
-def repository(definitions_fn: Callable[..., Any]) -> RepositoryDefinition:
+def repository(definitions_fn: Callable[..., Sequence[Any]]) -> RepositoryDefinition:
     ...
 
 
@@ -173,7 +187,7 @@ def repository(
 
 
 def repository(
-    definitions_fn: Optional[Callable[..., Any]] = None,
+    definitions_fn: Optional[Callable[..., Sequence[Any]]] = None,
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -492,7 +492,7 @@ class NodeHandle(
         return NodeHandle.from_path(path)
 
     @classmethod
-    def from_dict(cls, dict_repr: Dict[str, Any]) -> Optional["NodeHandle"]:
+    def from_dict(cls, dict_repr: Mapping[str, Any]) -> "NodeHandle":
         """This method makes it possible to load a potentially nested NodeHandle after a
         roundtrip through json.loads(json.dumps(NodeHandle._asdict())).
         """
@@ -505,14 +505,16 @@ class NodeHandle(
         )
 
         if isinstance(dict_repr["parent"], (list, tuple)):
-            dict_repr["parent"] = NodeHandle.from_dict(
+            parent = NodeHandle.from_dict(
                 {
                     "name": dict_repr["parent"][0],
                     "parent": dict_repr["parent"][1],
                 }
             )
+        else:
+            parent = dict_repr["parent"]
 
-        return NodeHandle(**{k: dict_repr[k] for k in ["name", "parent"]})
+        return NodeHandle(name=dict_repr["name"], parent=parent)
 
 
 class NodeInputHandle(

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -2,7 +2,7 @@ from enum import Enum as PyEnum
 from functools import update_wrapper
 from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional, Sequence, Union, overload
 
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
@@ -146,9 +146,9 @@ class ExecutorDefinition(NamedConfigurableDefinition):
         self,
         config_or_config_fn: Any,
         name: Optional[str] = None,
-        config_schema: Optional[Mapping[str, Any]] = None,
+        config_schema: Optional[UserConfigSchema] = None,
         description: Optional[str] = None,
-    ):
+    ) -> Self:  # type: ignore  # fmt: skip
         """
         Wraps this object in an object of the same type that provides configuration to the inner
         object.

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -173,8 +173,10 @@ class FreshnessPolicy(
                 self.cron_schedule, evaluation_time, ret_type=datetime.datetime, is_prev=True
             )
             evaluation_tick = next(schedule_ticks)
-        else:
+        elif evaluation_time is not None:
             evaluation_tick = evaluation_time
+        else:
+            check.failed("Must provide an evaluation time if not using a cron schedule")
 
         minutes_late = 0.0
         for used_data_time in used_data_times.values():

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 from collections import OrderedDict, defaultdict
 from typing import (
     TYPE_CHECKING,
@@ -64,6 +62,8 @@ if TYPE_CHECKING:
     from .job_definition import JobDefinition
     from .op_definition import OpDefinition
     from .partition import PartitionedConfig, PartitionsDefinition
+
+T = TypeVar("T")
 
 
 def _check_node_defs_arg(
@@ -195,8 +195,8 @@ class GraphDefinition(NodeDefinition):
         input_mappings: Optional[Sequence[InputMapping]] = None,
         output_mappings: Optional[Sequence[OutputMapping]] = None,
         config: Optional[ConfigMapping] = None,
-        tags: Optional[Mapping[str, Any]] = None,
-        **kwargs,
+        tags: Optional[Mapping[str, str]] = None,
+        **kwargs: object,
     ):
         self._node_defs = _check_node_defs_arg(name, node_defs)
         self._dependencies = validate_dependency_dict(dependencies)
@@ -230,7 +230,7 @@ class GraphDefinition(NodeDefinition):
             input_defs=input_defs,
             output_defs=output_defs,
             tags=tags,
-            **kwargs,
+            **kwargs,  # type: ignore  # fmt: skip
         )
 
         # must happen after base class construction as properties are assumed to be there
@@ -253,7 +253,7 @@ class GraphDefinition(NodeDefinition):
     def get_inputs_must_be_resolved_top_level(
         self, asset_layer: "AssetLayer", handle: Optional[NodeHandle] = None
     ) -> Sequence[InputDefinition]:
-        unresolveable_input_defs = []
+        unresolveable_input_defs: List[InputDefinition] = []
         for node in self.node_dict.values():
             cur_handle = NodeHandle(node.name, handle)
             for input_def in node.definition.get_inputs_must_be_resolved_top_level(
@@ -486,7 +486,7 @@ class GraphDefinition(NodeDefinition):
         name: str,
         description: Optional[str],
         config_schema: Any,
-    ):
+    ) -> "GraphDefinition":
         if not self.has_config_mapping:
             raise DagsterInvalidDefinitionError(
                 "Only graphs utilizing config mapping can be pre-configured. The graph "
@@ -508,7 +508,7 @@ class GraphDefinition(NodeDefinition):
             ),
         )
 
-    def node_names(self):
+    def node_names(self) -> Sequence[str]:
         return list(self._node_dict.keys())
 
     @public
@@ -517,7 +517,7 @@ class GraphDefinition(NodeDefinition):
         name: Optional[str] = None,
         description: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-        config: Optional[Union[ConfigMapping, Mapping[str, object], "PartitionedConfig"]] = None,
+        config: Optional[Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]"]] = None,
         tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
@@ -526,7 +526,7 @@ class GraphDefinition(NodeDefinition):
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
         op_selection: Optional[Sequence[str]] = None,
-        partitions_def: Optional["PartitionsDefinition"] = None,
+        partitions_def: Optional["PartitionsDefinition[T]"] = None,
         asset_layer: Optional["AssetLayer"] = None,
         input_values: Optional[Mapping[str, object]] = None,
         _asset_selection_data: Optional[AssetSelectionData] = None,
@@ -613,7 +613,7 @@ class GraphDefinition(NodeDefinition):
             _metadata_entries=_metadata_entries,
         ).get_job_def_for_subset_selection(op_selection)
 
-    def coerce_to_job(self):
+    def coerce_to_job(self) -> "JobDefinition":
         # attempt to coerce a Graph in to a Job, raising a useful error if it doesn't work
         try:
             return self.to_job()
@@ -685,7 +685,7 @@ class GraphDefinition(NodeDefinition):
         run_config = run_config if run_config is not None else {}
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)
 
-        return ephemeral_job.execute_in_process(
+        return ephemeral_job.execute_in_process(  # type: ignore  # fmt: skip
             run_config=run_config,
             instance=instance,
             raise_on_error=raise_on_error,
@@ -805,13 +805,13 @@ def _validate_in_mappings(
     from .composition import MappedInputPlaceholder
 
     input_defs_by_name: Dict[str, InputDefinition] = OrderedDict()
-    mapping_keys = set()
+    mapping_keys: Set[str] = set()
 
     target_input_types_by_graph_input_name: Dict[str, Set[DagsterType]] = defaultdict(set)
 
     for mapping in input_mappings:
         # handle incorrect objects passed in as mappings
-        if not isinstance(mapping, InputMapping):
+        if not isinstance(mapping, InputMapping):  # type: ignore  # (isinstance check for error)
             if isinstance(mapping, InputDefinition):
                 raise DagsterInvalidDefinitionError(
                     f"In {class_name} '{name}' you passed an InputDefinition "

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -17,6 +17,8 @@ from typing import (
     cast,
 )
 
+from typing_extensions import Self
+
 import dagster._check as check
 from dagster._annotations import public
 from dagster._config import Field, Shape, StringSource
@@ -428,7 +430,7 @@ class JobDefinition(PipelineDefinition):
         self,
         op_selection: Optional[Sequence[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ):
+    ) -> Self:  # type: ignore  # fmt: skip
         check.invariant(
             not (op_selection and asset_selection),
             (
@@ -438,7 +440,7 @@ class JobDefinition(PipelineDefinition):
         )
         if op_selection:
             return self._get_job_def_for_op_selection(op_selection)
-        if asset_selection:  # asset_selection:
+        if asset_selection:
             return self._get_job_def_for_asset_selection(asset_selection)
         else:
             return self
@@ -446,7 +448,7 @@ class JobDefinition(PipelineDefinition):
     def _get_job_def_for_asset_selection(
         self,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ) -> "JobDefinition":
+    ) -> Self:  # type: ignore  # fmt: skip
         asset_selection = check.opt_set_param(asset_selection, "asset_selection", AssetKey)
 
         nonexistent_assets = [
@@ -492,7 +494,7 @@ class JobDefinition(PipelineDefinition):
     def _get_job_def_for_op_selection(
         self,
         op_selection: Optional[Sequence[str]] = None,
-    ) -> "JobDefinition":
+    ) -> Self:  # type: ignore  # fmt: skip
         if not op_selection:
             return self
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -138,7 +138,7 @@ def normalize_metadata(
     ]
 
 
-def normalize_metadata_value(raw_value: RawMetadataValue):
+def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue":
     from dagster._core.definitions.events import AssetKey
 
     if isinstance(raw_value, MetadataValue):

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -148,7 +148,7 @@ class OutputDefinition:
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -805,6 +805,7 @@ def _create_run_config_schema(
     # When executing with a subset pipeline, include the missing solids
     # from the original pipeline as ignored to allow execution with
     # run config that is valid for the original
+    ignored_solids: Sequence[Node] = []
     if isinstance(pipeline_def, JobDefinition) and pipeline_def.is_subset_pipeline:
         if isinstance(pipeline_def.graph, SubselectedGraphDefinition):  # op selection provided
             ignored_solids = pipeline_def.graph.get_top_level_omitted_nodes()

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -84,14 +84,14 @@ def _check_invocation_requirements(
 
     # Construct a context if None was provided. This will initialize an ephemeral instance, and
     # console log manager.
-    init_context = init_context or build_init_resource_context()
+    _init_context = init_context or build_init_resource_context()
 
     return InitResourceContext(
         resource_config=resource_config,
-        resources=init_context.resources,
+        resources=_init_context.resources,
         resource_def=resource_def,
-        instance=init_context.instance,
-        log_manager=init_context.log,
+        instance=_init_context.instance,
+        log_manager=_init_context.log,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -1,9 +1,20 @@
 import logging
 import warnings
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Sequence, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterator,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+    overload,
+)
 
 import pendulum
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
@@ -51,6 +62,15 @@ if TYPE_CHECKING:
         JobSelector,
         RepositorySelector,
     )
+
+RunStatusSensorEvaluationFunction: TypeAlias = Union[
+    Callable[[], RawSensorEvaluationFunctionReturn],
+    Callable[["RunStatusSensorContext"], RawSensorEvaluationFunctionReturn],
+]
+RunFailureSensorEvaluationFn: TypeAlias = Union[
+    Callable[[], RawSensorEvaluationFunctionReturn],
+    Callable[["RunFailureSensorContext"], RawSensorEvaluationFunctionReturn],
+]
 
 
 @whitelist_for_serdes
@@ -216,8 +236,16 @@ def build_run_status_sensor_context(
     )
 
 
+@overload
 def run_failure_sensor(
-    name: Optional[Union[Callable[..., Any], str]] = None,
+    name: RunFailureSensorEvaluationFn,
+) -> SensorDefinition:
+    ...
+
+
+@overload
+def run_failure_sensor(
+    name: Optional[str] = None,
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,
     monitored_jobs: Optional[
@@ -248,10 +276,43 @@ def run_failure_sensor(
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     request_job: Optional[Union[GraphDefinition, JobDefinition]] = None,
     request_jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
-) -> Callable[
-    [Callable[[RunFailureSensorContext], Union[SkipReason, PipelineRunReaction]]],
-    SensorDefinition,
-]:
+) -> Callable[[RunFailureSensorEvaluationFn], SensorDefinition,]:
+    ...
+
+
+def run_failure_sensor(
+    name: Optional[Union[RunFailureSensorEvaluationFn, str]] = None,
+    minimum_interval_seconds: Optional[int] = None,
+    description: Optional[str] = None,
+    monitored_jobs: Optional[
+        Sequence[
+            Union[
+                PipelineDefinition,
+                GraphDefinition,
+                UnresolvedAssetJobDefinition,
+                "RepositorySelector",
+                "JobSelector",
+                "CodeLocationSelector",
+            ]
+        ]
+    ] = None,
+    job_selection: Optional[
+        Sequence[
+            Union[
+                PipelineDefinition,
+                GraphDefinition,
+                UnresolvedAssetJobDefinition,
+                "RepositorySelector",
+                "JobSelector",
+                "CodeLocationSelector",
+            ]
+        ]
+    ] = None,
+    monitor_all_repositories: bool = False,
+    default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+    request_job: Optional[Union[GraphDefinition, JobDefinition]] = None,
+    request_jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
+) -> Union[SensorDefinition, Callable[[RunFailureSensorEvaluationFn], SensorDefinition,]]:
     """
     Creates a sensor that reacts to job failure events, where the decorated function will be
     run when a run fails.
@@ -284,7 +345,7 @@ def run_failure_sensor(
     """
 
     def inner(
-        fn: Callable[[RunFailureSensorContext], Union[SkipReason, PipelineRunReaction]]
+        fn: RunFailureSensorEvaluationFn,
     ) -> SensorDefinition:
         check.callable_param(fn, "fn")
         if name is None or callable(name):
@@ -308,7 +369,7 @@ def run_failure_sensor(
             request_jobs=request_jobs,
         )
         def _run_failure_sensor(context: RunStatusSensorContext):
-            return fn(context.for_run_failure())
+            return fn(context.for_run_failure())  # type: ignore  # fmt: skip
 
         return _run_failure_sensor
 
@@ -351,7 +412,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         self,
         name: str,
         run_status: DagsterRunStatus,
-        run_status_sensor_fn: Callable[[RunStatusSensorContext], RawSensorEvaluationFunctionReturn],
+        run_status_sensor_fn: RunStatusSensorEvaluationFunction,
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
         monitored_jobs: Optional[
@@ -426,7 +487,9 @@ class RunStatusSensorDefinition(SensorDefinition):
             else []
         )
 
-        def _wrapped_fn(context: SensorEvaluationContext):
+        def _wrapped_fn(
+            context: SensorEvaluationContext,
+        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction]]:
             # initiate the cursor to (most recent event id, current timestamp) when:
             # * it's the first time starting the sensor
             # * or, the cursor isn't in valid format (backcompt)
@@ -558,7 +621,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                         lambda: f'Error occurred during the execution sensor "{name}".',
                     ):
                         # one user code invocation maps to one failure event
-                        sensor_return = run_status_sensor_fn(
+                        sensor_return = run_status_sensor_fn(  # type: ignore  # fmt: skip
                             RunStatusSensorContext(
                                 sensor_name=name,
                                 dagster_run=pipeline_run,
@@ -690,10 +753,7 @@ def run_status_sensor(
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     request_job: Optional[Union[GraphDefinition, JobDefinition]] = None,
     request_jobs: Optional[Sequence[Union[GraphDefinition, JobDefinition]]] = None,
-) -> Callable[
-    [Callable[[RunStatusSensorContext], RawSensorEvaluationFunctionReturn]],
-    RunStatusSensorDefinition,
-]:
+) -> Callable[[RunStatusSensorEvaluationFunction], RunStatusSensorDefinition,]:
     """
     Creates a sensor that reacts to a given status of pipeline execution, where the decorated
     function will be run when a pipeline is at the given status.
@@ -727,7 +787,7 @@ def run_status_sensor(
     """
 
     def inner(
-        fn: Callable[["RunStatusSensorContext"], RawSensorEvaluationFunctionReturn]
+        fn: RunStatusSensorEvaluationFunction,
     ) -> RunStatusSensorDefinition:
         check.callable_param(fn, "fn")
         sensor_name = name or fn.__name__

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -216,7 +216,7 @@ class SensorEvaluationContext:
 
 
 RawSensorEvaluationFunctionReturn = Union[
-    Iterator[Union[SkipReason, RunRequest]],
+    Iterator[Union[SkipReason, RunRequest, PipelineRunReaction]],
     Sequence[RunRequest],
     SkipReason,
     RunRequest,

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -754,9 +754,9 @@ class DagsterEvent(
         return self.event_specific_data
 
     @property
-    def logs_captured_data(self):
+    def logs_captured_data(self) -> "ComputeLogsCaptureData":
         _assert_type("logs_captured_data", DagsterEventType.LOGS_CAPTURED, self.event_type)
-        return self.event_specific_data
+        return cast(ComputeLogsCaptureData, self.event_specific_data)
 
     @staticmethod
     def step_output_event(

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -22,21 +22,25 @@ from dagster._core.storage.pipeline_run import DagsterRun
 
 class ExecutionResult(ABC):
     @property
+    @abstractmethod
     def job_def(self) -> JobDefinition:
-        raise NotImplementedError()
+        ...
 
     @property
+    @abstractmethod
     def dagster_run(self) -> DagsterRun:
-        raise NotImplementedError()
+        ...
 
     @property
+    @abstractmethod
     def all_events(self) -> Sequence[DagsterEvent]:
-        raise NotImplementedError()
+        ...
 
     @property
+    @abstractmethod
     def run_id(self) -> str:
         """The unique identifier of the executed run."""
-        raise NotImplementedError()
+        ...
 
     @property
     def success(self) -> bool:

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -37,7 +37,6 @@ from .outputs import StepOutputHandle, UnresolvedStepOutputHandle
 from .utils import build_resources_for_manager, op_execution_error_boundary
 
 if TYPE_CHECKING:
-    from dagster._core.events import DagsterEvent
     from dagster._core.execution.context.input import InputContext
     from dagster._core.execution.context.system import StepExecutionContext
     from dagster._core.storage.input_manager import InputManager
@@ -115,7 +114,9 @@ class StepInputSource(ABC):
         return []
 
     @abstractmethod
-    def load_input_object(self, step_context: "StepExecutionContext", input_def: InputDefinition):
+    def load_input_object(
+        self, step_context: "StepExecutionContext", input_def: InputDefinition
+    ) -> Iterator[object]:
         ...
 
     def required_resource_keys(self, _pipeline_def: PipelineDefinition) -> AbstractSet[str]:
@@ -158,7 +159,7 @@ class FromSourceAsset(
         self,
         step_context: "StepExecutionContext",
         input_def: InputDefinition,
-    ) -> Iterator["DagsterEvent"]:
+    ) -> Iterator[object]:
         from dagster._core.definitions.asset_layer import AssetOutputInfo
         from dagster._core.events import DagsterEvent
         from dagster._core.execution.context.output import OutputContext
@@ -219,14 +220,15 @@ class FromSourceAsset(
         from ..resolve_versions import check_valid_version, resolve_config_version
 
         op = pipeline_def.get_solid(self.solid_handle)
-        io_manager_key = op.input_def_named(self.input_name).io_manager_key
+        input_manager_key = check.not_none(op.input_def_named(self.input_name).input_manager_key)  # type: ignore  # fmt: skip
         io_manager_def = pipeline_def.get_mode_definition(resolved_run_config.mode).resource_defs[
-            io_manager_key
+            input_manager_key
         ]
 
-        op_config = resolved_run_config.solids.get(op.name)
+        op_config = check.not_none(resolved_run_config.solids.get(op.name))  # type: ignore  # fmt: skip
         input_config = op_config.inputs.get(self.input_name)
-        resource_config = resolved_run_config.resources.get(io_manager_key).config
+        resource_entry = check.not_none(resolved_run_config.resources.get(input_manager_key))  # type: ignore  # fmt: skip
+        resource_config = resource_entry.config
 
         version_context = ResourceVersionContext(
             resource_def=io_manager_def,
@@ -293,7 +295,7 @@ class FromRootInputManager(
         self,
         step_context: "StepExecutionContext",
         input_def: InputDefinition,
-    ) -> Iterator["DagsterEvent"]:
+    ) -> Iterator[object]:
         from dagster._core.events import DagsterEvent
 
         check.invariant(
@@ -478,7 +480,7 @@ class FromStepOutput(
         self,
         step_context: "StepExecutionContext",
         input_def: InputDefinition,
-    ) -> Iterator["DagsterEvent"]:
+    ) -> Iterator[object]:
         from dagster._core.events import DagsterEvent
         from dagster._core.storage.input_manager import InputManager
 
@@ -849,7 +851,9 @@ class FromMultipleSources(
         ]
 
 
-def _load_input_with_input_manager(input_manager: "InputManager", context: "InputContext"):
+def _load_input_with_input_manager(
+    input_manager: "InputManager", context: "InputContext"
+) -> Iterator[object]:
     from dagster._core.execution.context.system import StepExecutionContext
 
     step_context = cast(StepExecutionContext, context.step_context)

--- a/python_modules/dagster/dagster/_core/executor/base.py
+++ b/python_modules/dagster/dagster/_core/executor/base.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Iterator
 
 from dagster._annotations import public
 from dagster._core.execution.retries import RetryMode
 
+if TYPE_CHECKING:
+    from dagster._core.events import DagsterEvent
 
-class Executor(ABC):  # pylint: disable=no-init
+
+class Executor(ABC):
     @public
     @abstractmethod
-    def execute(self, plan_context, execution_plan):
+    def execute(self, plan_context, execution_plan) -> Iterator["DagsterEvent"]:
         """
         For the given context and execution plan, orchestrate a series of sub plan executions in a way that satisfies the whole plan being executed.
 

--- a/python_modules/dagster/dagster/_core/executor/child_process_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/child_process_executor.py
@@ -7,7 +7,9 @@ import sys
 from abc import ABC, abstractmethod
 from multiprocessing import Queue
 from multiprocessing.context import BaseContext as MultiprocessingBaseContext
-from typing import TYPE_CHECKING, Iterator, NamedTuple, Union
+from typing import TYPE_CHECKING, Iterator, NamedTuple, Optional, Union
+
+from typing_extensions import Literal
 
 import dagster._check as check
 from dagster._core.errors import DagsterExecutionInterruptedError
@@ -97,7 +99,9 @@ PROCESS_DEAD_AND_QUEUE_EMPTY = "PROCESS_DEAD_AND_QUEUE_EMPTY"
 """Sentinel value."""
 
 
-def _poll_for_event(process, event_queue):
+def _poll_for_event(
+    process, event_queue
+) -> Optional[Union["DagsterEvent", Literal["PROCESS_DEAD_AND_QUEUE_EMPTY"]]]:
     try:
         return event_queue.get(block=True, timeout=TICK)
     except queue.Empty:
@@ -110,14 +114,13 @@ def _poll_for_event(process, event_queue):
             except queue.Empty:
                 # If the queue empty we know that there are no more events
                 # and that the process has died.
-                return PROCESS_DEAD_AND_QUEUE_EMPTY
-
+                return PROCESS_DEAD_AND_QUEUE_EMPTY  # type: ignore  # fmt: skip
     return None
 
 
 def execute_child_process_command(
     multiprocessing_ctx: MultiprocessingBaseContext, command: ChildProcessCommand
-) -> Iterator["DagsterEvent"]:
+) -> Iterator[Optional["DagsterEvent"]]:
     """Execute a ChildProcessCommand in a new process.
 
     This function starts a new process whose execution target is a ChildProcessCommand wrapped by
@@ -161,7 +164,7 @@ def execute_child_process_command(
             if event == PROCESS_DEAD_AND_QUEUE_EMPTY:
                 break
 
-            yield event
+            yield event  # type: ignore  # fmt: skip
 
             if isinstance(event, (ChildProcessDoneEvent, ChildProcessSystemErrorEvent)):
                 completed_properly = True

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -190,7 +190,7 @@ class MultiprocessExecutor(Executor):
                 max_concurrent=limit,
                 tag_concurrency_limits=tag_concurrency_limits,
             ) as active_execution:
-                active_iters: Dict[str, Iterator[DagsterEvent]] = {}
+                active_iters: Dict[str, Iterator[Optional[DagsterEvent]]] = {}
                 errors: Dict[int, SerializableErrorInfo] = {}
                 term_events: Dict[str, Any] = {}
                 stopping: bool = False
@@ -335,7 +335,7 @@ def execute_step_out_of_process(
     retries: RetryMode,
     known_state: KnownExecutionState,
     repository_load_data: Optional[RepositoryLoadData],
-) -> Iterator[DagsterEvent]:
+) -> Iterator[Optional[DagsterEvent]]:
     command = MultiprocessExecutorChildProcessCommand(
         run_config=step_context.run_config,
         pipeline_run=step_context.pipeline_run,

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -36,6 +36,7 @@ from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
 from dagster._core.utils import toposort
 from dagster._serdes import create_snapshot_id
+from dagster._utils import iter_to_list
 from dagster._utils.cached_method import cached_method
 from dagster._utils.schedules import schedule_execution_time_iterator
 
@@ -129,7 +130,7 @@ class ExternalRepository:
         return self._external_schedules[schedule_name]
 
     def get_external_schedules(self) -> Sequence[ExternalSchedule]:
-        return self._external_schedules.values()
+        return iter_to_list(self._external_schedules.values())
 
     @property
     @cached_method
@@ -146,7 +147,7 @@ class ExternalRepository:
         return self._external_sensors[sensor_name]
 
     def get_external_sensors(self) -> Sequence[ExternalSensor]:
-        return self._external_sensors.values()
+        return iter_to_list(self._external_sensors.values())
 
     @property
     @cached_method
@@ -165,7 +166,7 @@ class ExternalRepository:
         return self._external_partition_sets[partition_set_name]
 
     def get_external_partition_sets(self) -> Sequence[ExternalPartitionSet]:
-        return self._external_partition_sets.values()
+        return iter_to_list(self._external_partition_sets.values())
 
     def has_external_job(self, job_name: str) -> bool:
         return job_name in self._job_map

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -326,7 +326,7 @@ class DagsterLogManager(logging.Logger):
         python_log_level = logging.NOTSET
 
         if instance:
-            handlers += instance.get_handlers()
+            handlers = [*handlers, *instance.get_handlers()]
             managed_loggers += [
                 logging.getLogger(lname) if lname != "root" else logging.getLogger()
                 for lname in instance.managed_python_loggers

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -8,6 +8,8 @@ from typing import (
     Callable,
     Dict,
     FrozenSet,
+    Generic,
+    Hashable,
     Iterable,
     List,
     Mapping,
@@ -35,8 +37,9 @@ if TYPE_CHECKING:
 
 MAX_NUM = sys.maxsize
 
-T = TypeVar("T")
-DependencyGraph: TypeAlias = Mapping[str, Mapping[T, AbstractSet[T]]]
+T_Hashable = TypeVar("T_Hashable", bound=Hashable)
+Direction: TypeAlias = Literal["downstream", "upstream"]
+DependencyGraph: TypeAlias = Mapping[Direction, Mapping[T_Hashable, AbstractSet[T_Hashable]]]
 
 
 class OpSelectionData(
@@ -126,7 +129,7 @@ def generate_asset_dep_graph(
     return {"upstream": upstream, "downstream": downstream}
 
 
-def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
+def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph[str]:
     """Pipeline to dependency graph. It currently only supports top-level solids.
 
     Args:
@@ -157,7 +160,7 @@ def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
     item_names = [i.name for i in pipeline_def.solids]
 
     # defaultdict isn't appropriate because we also want to include items without dependencies
-    graph: Dict[str, Dict[str, MutableSet[str]]] = {"upstream": {}, "downstream": {}}
+    graph: Dict[Direction, Dict[str, MutableSet[str]]] = {"upstream": {}, "downstream": {}}
     for item_name in item_names:
         graph["upstream"][item_name] = set()
         upstream_dep = dependency_structure.input_to_upstream_outputs_for_node(item_name)
@@ -174,18 +177,17 @@ def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph:
     return graph
 
 
-Direction = Literal["downstream", "upstream"]
-
-
-class Traverser:
-    def __init__(self, graph: DependencyGraph):
+class Traverser(Generic[T_Hashable]):
+    def __init__(self, graph: DependencyGraph[T_Hashable]):
         self.graph = graph
 
     # `depth=None` is infinite depth
-    def _fetch_items(self, item_name: T, depth: int, direction: Direction) -> AbstractSet[T]:
+    def _fetch_items(
+        self, item_name: T_Hashable, depth: int, direction: Direction
+    ) -> AbstractSet[T_Hashable]:
         dep_graph = self.graph[direction]
         stack = deque([item_name])
-        result: Set[T] = set()
+        result: Set[T_Hashable] = set()
         curr_depth = 0
         while stack:
             # stop when reach the given depth
@@ -195,7 +197,7 @@ class Traverser:
             while stack and curr_level_len > 0:
                 curr_item = stack.popleft()
                 curr_level_len -= 1
-                empty_set: Set[str] = set()
+                empty_set: Set[T_Hashable] = set()
                 for item in dep_graph.get(curr_item, empty_set):
                     if item not in result:
                         stack.append(item)
@@ -203,22 +205,22 @@ class Traverser:
             curr_depth += 1
         return result
 
-    def fetch_upstream(self, item_name: T, depth: int) -> AbstractSet[T]:
+    def fetch_upstream(self, item_name: T_Hashable, depth: int) -> AbstractSet[T_Hashable]:
         # return a set of ancestors of the given item, up to the given depth
         return self._fetch_items(item_name, depth, "upstream")
 
-    def fetch_downstream(self, item_name: T, depth: int) -> AbstractSet[T]:
+    def fetch_downstream(self, item_name: T_Hashable, depth: int) -> AbstractSet[T_Hashable]:
         # return a set of descendants of the given item, down to the given depth
         return self._fetch_items(item_name, depth, "downstream")
 
 
 def fetch_connected(
-    item: T,
+    item: T_Hashable,
     graph: DependencyGraph,
     *,
     direction: Direction,
     depth: Optional[int] = None,
-) -> AbstractSet[T]:
+) -> AbstractSet[T_Hashable]:
     if depth is None:
         depth = MAX_NUM
     if direction == "downstream":
@@ -227,13 +229,15 @@ def fetch_connected(
         return Traverser(graph).fetch_upstream(item, depth)
 
 
-def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[T]) -> AbstractSet[T]:
+def fetch_sinks(
+    graph: DependencyGraph, within_selection: AbstractSet[T_Hashable]
+) -> AbstractSet[T_Hashable]:
     """
     A sink is an asset that has no downstream dependencies within the provided selection.
     It can have other dependencies outside of the selection.
     """
     traverser = Traverser(graph)
-    sinks: Set[T] = set()
+    sinks: Set[T_Hashable] = set()
     for item in within_selection:
         downstream = traverser.fetch_downstream(item, depth=MAX_NUM) & within_selection
         if len(downstream) == 0 or downstream == {item}:
@@ -241,7 +245,9 @@ def fetch_sinks(graph: DependencyGraph, within_selection: AbstractSet[T]) -> Abs
     return sinks
 
 
-def fetch_sources(graph: DependencyGraph, within_selection: AbstractSet[T]) -> AbstractSet[T]:
+def fetch_sources(
+    graph: DependencyGraph, within_selection: AbstractSet[T_Hashable]
+) -> AbstractSet[T_Hashable]:
     """
     A source is a node that has no upstream dependencies within the provided selection.
     It can have other dependencies outside of the selection.
@@ -307,8 +313,8 @@ def parse_items_from_selection(selection: Sequence[str]) -> Sequence[str]:
 
 
 def clause_to_subset(
-    graph: DependencyGraph, clause: str, item_name_to_item_fn: Callable[[str], T]
-) -> Sequence[T]:
+    graph: DependencyGraph, clause: str, item_name_to_item_fn: Callable[[str], T_Hashable]
+) -> Sequence[T_Hashable]:
     """Take a selection query and return a list of the selected and qualified items.
 
     Args:
@@ -334,7 +340,7 @@ def clause_to_subset(
     if item not in graph["upstream"]:
         return []
 
-    subset_list: List[T] = []
+    subset_list: List[T_Hashable] = []
     traverser = Traverser(graph=graph)
     subset_list.append(item)
     # traverse graph to get up/downsteam items
@@ -470,7 +476,7 @@ def parse_step_selection(
             downstream_deps[step_key].add(downstream_key)
 
     # generate dep graph
-    graph = {"upstream": step_deps, "downstream": downstream_deps}
+    graph: DependencyGraph[str] = {"upstream": step_deps, "downstream": downstream_deps}
     steps_set: Set[str] = set()
 
     step_keys = parse_items_from_selection(step_selection)

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.resource_definition import (
 if TYPE_CHECKING:
     from dagster._core.execution.context.input import InputContext
 
-InputLoadFn: TypeAlias = Callable[["InputContext", object], object]
+InputLoadFn: TypeAlias = Callable[["InputContext"], object]
 
 
 class InputManager(ABC):
@@ -171,13 +171,13 @@ class InputManagerWrapper(InputManager):
     def __init__(self, load_fn):
         self._load_fn = load_fn
 
-    def load_input(self, context):
+    def load_input(self, context: "InputContext") -> object:
         # the @input_manager decorated function (self._load_fn) may return a direct value that
         # should be used or an instance of an InputManager. So we call self._load_fn and see if the
         # result is an InputManager. If so we call it's load_input method
         intermediate = (
             # type-ignore because function being used as attribute
-            self._load_fn(context)
+            self._load_fn(context)  # type: ignore  # fmt: skip
             if is_context_provided(self._load_fn)
             else self._load_fn()  # type: ignore
         )

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -16,6 +16,8 @@ from typing import (
     Union,
 )
 
+from typing_extensions import Self
+
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.events import AssetKey
@@ -44,6 +46,7 @@ from .tags import (
 )
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.partition import Partition, PartitionSetDefinition
     from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
 
@@ -424,7 +427,7 @@ class DagsterRun(
             ),
         )
 
-    def with_status(self, status):
+    def with_status(self, status: DagsterRunStatus) -> Self:  # type: ignore  # fmt: skip
         if status == DagsterRunStatus.QUEUED:
             # Placing this with the other imports causes a cyclic import
             # https://github.com/dagster-io/dagster/issues/3181
@@ -438,16 +441,16 @@ class DagsterRun(
 
         return self._replace(status=status)
 
-    def with_job_origin(self, origin):
+    def with_job_origin(self, origin: "ExternalPipelineOrigin") -> Self:  # type: ignore  # fmt: skip
         from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
         check.inst_param(origin, "origin", ExternalPipelineOrigin)
         return self._replace(external_pipeline_origin=origin)
 
-    def with_mode(self, mode):
+    def with_mode(self, mode: str) -> Self:  # type: ignore  # fmt: skip
         return self._replace(mode=mode)
 
-    def with_tags(self, tags):
+    def with_tags(self, tags: Mapping[str, str]) -> Self:  # type: ignore  # fmt: skip
         return self._replace(tags=tags)
 
     def get_root_run_id(self):
@@ -477,12 +480,12 @@ class DagsterRun(
 
     @public  # type: ignore
     @property
-    def is_success(self):
+    def is_success(self) -> bool:
         return self.status == DagsterRunStatus.SUCCESS
 
     @public  # type: ignore
     @property
-    def is_failure(self):
+    def is_failure(self) -> bool:
         return self.status == DagsterRunStatus.FAILURE
 
     @public  # type: ignore
@@ -492,11 +495,11 @@ class DagsterRun(
 
     @public  # type: ignore
     @property
-    def is_resume_retry(self):
+    def is_resume_retry(self) -> bool:
         return self.tags.get(RESUME_RETRY_TAG) == "true"
 
     @property
-    def previous_run_id(self):
+    def previous_run_id(self) -> Optional[str]:
         # Compat
         return self.parent_run_id
 
@@ -506,19 +509,21 @@ class DagsterRun(
         return self.pipeline_name
 
     @staticmethod
-    def tags_for_schedule(schedule):
+    def tags_for_schedule(schedule) -> Mapping[str, str]:
         return {SCHEDULE_NAME_TAG: schedule.name}
 
     @staticmethod
-    def tags_for_sensor(sensor):
+    def tags_for_sensor(sensor) -> Mapping[str, str]:
         return {SENSOR_NAME_TAG: sensor.name}
 
     @staticmethod
-    def tags_for_backfill_id(backfill_id):
+    def tags_for_backfill_id(backfill_id: str) -> Mapping[str, str]:
         return {BACKFILL_ID_TAG: backfill_id}
 
     @staticmethod
-    def tags_for_partition_set(partition_set, partition):
+    def tags_for_partition_set(
+        partition_set: "PartitionSetDefinition", partition: "Partition"
+    ) -> Mapping[str, str]:
         from dagster._core.definitions.multi_dimensional_partitions import (
             MultiPartitionKey,
             get_tags_from_multi_partition_key,

--- a/python_modules/dagster/dagster/_core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/root_input_manager.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from functools import update_wrapper
-from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union, cast, overload
 
 import dagster._check as check
 from dagster._annotations import experimental
@@ -91,9 +91,27 @@ class RootInputManager(InputManager):
         """
 
 
+@overload
+def root_input_manager(
+    config_schema: InputLoadFn,
+) -> RootInputManagerDefinition:
+    ...
+
+
+@overload
+def root_input_manager(
+    config_schema: Optional[CoercableToConfigSchema] = None,
+    description: Optional[str] = None,
+    input_config_schema: Optional[CoercableToConfigSchema] = None,
+    required_resource_keys: Optional[AbstractSet[str]] = None,
+    version: Optional[str] = None,
+) -> Callable[[InputLoadFn], RootInputManagerDefinition]:
+    ...
+
+
 @experimental
 def root_input_manager(
-    config_schema: Optional[Union[Callable, CoercableToConfigSchema]] = None,
+    config_schema: Optional[Union[InputLoadFn, CoercableToConfigSchema]] = None,
     description: Optional[str] = None,
     input_config_schema: CoercableToConfigSchema = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Callable, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Iterator, Optional, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from dagster._core.execution.context.system import (
         DagsterTypeLoaderContext,
         DagsterTypeMaterializerContext,
-        StepExecutionContext,
     )
 
 
@@ -185,7 +184,7 @@ def _create_type_loader_for_decorator(
     )
 
 
-DagsterTypeLoaderFn: TypeAlias = Callable[["StepExecutionContext", object], object]
+DagsterTypeLoaderFn: TypeAlias = Callable[["DagsterTypeLoaderContext", Any], Any]
 
 
 def dagster_type_loader(

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -4,6 +4,7 @@ from enum import Enum as PythonEnum
 from functools import partial
 from typing import (
     AbstractSet as TypingAbstractSet,
+    AnyStr,
     Iterator as TypingIterator,
     Mapping,
     Optional as TypingOptional,
@@ -40,7 +41,7 @@ if t.TYPE_CHECKING:
     from dagster._core.definitions.node_definition import NodeDefinition
     from dagster._core.execution.context.system import DagsterTypeLoaderContext, TypeCheckContext
 
-TypeCheckFn = t.Callable[["TypeCheckContext", object], t.Union[TypeCheck, bool]]
+TypeCheckFn = t.Callable[["TypeCheckContext", AnyStr], t.Union[TypeCheck, bool]]
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -7,6 +7,8 @@ from contextlib import ExitStack
 from itertools import count
 from typing import TYPE_CHECKING, Dict, Mapping, Optional, Sequence, Set, Union, cast
 
+from typing_extensions import Self
+
 import dagster._check as check
 from dagster._core.errors import (
     DagsterRepositoryLocationLoadError,
@@ -200,7 +202,7 @@ class BaseWorkspaceRequestContext(IWorkspace):
     def shutdown_repository_location(self, name: str):
         self.process_context.shutdown_repository_location(name)
 
-    def reload_workspace(self) -> "BaseWorkspaceRequestContext":
+    def reload_workspace(self) -> Self:  # type: ignore  # fmt: skip
         self.process_context.reload_workspace()
         return self.process_context.create_request_context()
 

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -3,7 +3,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence
 
 from dagster import (
     DagsterEvent,
@@ -28,6 +28,7 @@ from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import IntervalDaemon, TDaemonGenerator
+from dagster._utils import len_iter
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
@@ -194,14 +195,13 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         in_progress_runs = self._get_in_progress_runs(instance)
 
         max_concurrent_runs_enabled = max_concurrent_runs != -1  # setting to -1 disables the limit
+        max_runs_to_launch = max_concurrent_runs - len_iter(in_progress_runs)
         if max_concurrent_runs_enabled:
-            max_runs_to_launch = max_concurrent_runs - len(in_progress_runs)
-
             # Possibly under 0 if runs were launched without queuing
             if max_runs_to_launch <= 0:
                 self._logger.info(
                     "{} runs are currently in progress. Maximum is {}, won't launch more.".format(
-                        len(in_progress_runs), max_concurrent_runs
+                        len_iter(in_progress_runs), max_concurrent_runs
                     )
                 )
                 return []
@@ -264,10 +264,10 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         runs = instance.get_runs(filters=queued_runs_filter)[::-1]
         return runs
 
-    def _get_in_progress_runs(self, instance):
+    def _get_in_progress_runs(self, instance: DagsterInstance) -> Iterable[DagsterRun]:
         return instance.get_runs(filters=RunsFilter(statuses=IN_PROGRESS_RUN_STATUSES))
 
-    def _priority_sort(self, runs):
+    def _priority_sort(self, runs: Iterable[DagsterRun]) -> Sequence[DagsterRun]:
         def get_priority(run):
             priority_tag_value = run.tags.get(PRIORITY_TAG, "0")
             try:

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -42,7 +42,7 @@ class BaseDaemonWorkspace(IWorkspace):
     def get_workspace_snapshot(self) -> Mapping[str, WorkspaceLocationEntry]:
         if self._location_entries is None:
             self._location_entries = self._load_workspace()
-        return self._location_entries.copy()
+        return dict(self._location_entries)
 
     def get_location_statuses(self) -> Sequence[WorkspaceLocationStatusEntry]:
         if self._location_entries is None:

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -3,9 +3,11 @@ import subprocess
 import sys
 import warnings
 from contextlib import contextmanager
-from typing import Iterator, Optional, Sequence, Tuple
+from threading import Event
+from typing import Any, Iterator, Optional, Sequence, Tuple
 
 import grpc
+from google.protobuf.reflection import GeneratedProtocolMessageType
 from grpc_health.v1 import health_pb2
 from grpc_health.v1.health_pb2_grpc import HealthStub
 
@@ -40,7 +42,7 @@ CLIENT_HEARTBEAT_INTERVAL = 1
 DEFAULT_GRPC_TIMEOUT = default_grpc_timeout()
 
 
-def client_heartbeat_thread(client, shutdown_event):
+def client_heartbeat_thread(client: "DagsterGrpcClient", shutdown_event: Event) -> None:
     while True:
         shutdown_event.wait(CLIENT_HEARTBEAT_INTERVAL)
         if shutdown_event.is_set():
@@ -55,10 +57,10 @@ def client_heartbeat_thread(client, shutdown_event):
 class DagsterGrpcClient:
     def __init__(
         self,
-        port=None,
-        socket=None,
-        host="localhost",
-        use_ssl=False,
+        port: Optional[int] = None,
+        socket: Optional[str] = None,
+        host: str = "localhost",
+        use_ssl: bool = False,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
     ):
         self.port = check.opt_int_param(port, "port")
@@ -86,6 +88,7 @@ class DagsterGrpcClient:
         if port:
             self._server_address = host + ":" + str(port)
         else:
+            socket = check.not_none(socket)
             self._server_address = "unix:" + os.path.abspath(socket)
 
     @property
@@ -97,7 +100,7 @@ class DagsterGrpcClient:
         return self._use_ssl
 
     @contextmanager
-    def _channel(self):
+    def _channel(self) -> Iterator[grpc.Channel]:
         options = [
             ("grpc.max_receive_message_length", max_rx_bytes()),
             ("grpc.max_send_message_length", max_send_bytes()),
@@ -120,9 +123,9 @@ class DagsterGrpcClient:
 
     def _get_response(
         self,
-        method,
-        request,
-        timeout=DEFAULT_GRPC_TIMEOUT,
+        method: str,
+        request: str,
+        timeout: int = DEFAULT_GRPC_TIMEOUT,
     ):
         with self._channel() as channel:
             stub = DagsterApiStub(channel)
@@ -144,8 +147,8 @@ class DagsterGrpcClient:
 
     def _query(
         self,
-        method,
-        request_type,
+        method: str,
+        request_type: GeneratedProtocolMessageType,
         timeout=DEFAULT_GRPC_TIMEOUT,
         custom_timeout_message=None,
         **kwargs,
@@ -159,10 +162,10 @@ class DagsterGrpcClient:
 
     def _get_streaming_response(
         self,
-        method,
-        request,
-        timeout=DEFAULT_GRPC_TIMEOUT,
-    ):
+        method: str,
+        request: str,
+        timeout: int = DEFAULT_GRPC_TIMEOUT,
+    ) -> Iterator[Any]:
         with self._channel() as channel:
             stub = DagsterApiStub(channel)
             yield from getattr(stub, method)(request, metadata=self._metadata, timeout=timeout)
@@ -174,7 +177,7 @@ class DagsterGrpcClient:
         timeout=DEFAULT_GRPC_TIMEOUT,
         custom_timeout_message=None,
         **kwargs,
-    ):
+    ) -> Iterator[Any]:
         try:
             yield from self._get_streaming_response(
                 method, request=request_type(**kwargs), timeout=timeout
@@ -184,17 +187,17 @@ class DagsterGrpcClient:
                 e, timeout=timeout, custom_timeout_message=custom_timeout_message
             )
 
-    def ping(self, echo):
+    def ping(self, echo: str):
         check.str_param(echo, "echo")
         res = self._query("Ping", api_pb2.PingRequest, echo=echo)
         return res.echo
 
-    def heartbeat(self, echo=""):
+    def heartbeat(self, echo: str = ""):
         check.str_param(echo, "echo")
         res = self._query("Heartbeat", api_pb2.PingRequest, echo=echo)
         return res.echo
 
-    def streaming_ping(self, sequence_length, echo):
+    def streaming_ping(self, sequence_length: int, echo: str):
         check.int_param(sequence_length, "sequence_length")
         check.str_param(echo, "echo")
 
@@ -209,11 +212,11 @@ class DagsterGrpcClient:
                 "echo": res.echo,
             }
 
-    def get_server_id(self, timeout=None):
+    def get_server_id(self, timeout: int = DEFAULT_GRPC_TIMEOUT) -> str:
         res = self._query("GetServerId", api_pb2.Empty, timeout=timeout)
         return res.server_id
 
-    def execution_plan_snapshot(self, execution_plan_snapshot_args):
+    def execution_plan_snapshot(self, execution_plan_snapshot_args: ExecutionPlanSnapshotArgs):
         check.inst_param(
             execution_plan_snapshot_args, "execution_plan_snapshot_args", ExecutionPlanSnapshotArgs
         )
@@ -436,7 +439,11 @@ class DagsterGrpcClient:
 
         return res.serialized_cancel_execution_result
 
-    def can_cancel_execution(self, can_cancel_execution_request, timeout=None):
+    def can_cancel_execution(
+        self,
+        can_cancel_execution_request: CanCancelExecutionRequest,
+        timeout: int = DEFAULT_GRPC_TIMEOUT,
+    ):
         check.inst_param(
             can_cancel_execution_request,
             "can_cancel_execution_request",
@@ -454,7 +461,7 @@ class DagsterGrpcClient:
 
         return res.serialized_can_cancel_execution_result
 
-    def start_run(self, execute_run_args):
+    def start_run(self, execute_run_args) -> ExecuteExternalPipelineArgs:
         check.inst_param(execute_run_args, "execute_run_args", ExecuteExternalPipelineArgs)
 
         with DagsterInstance.from_ref(execute_run_args.instance_ref) as instance:
@@ -511,7 +518,7 @@ class EphemeralDagsterGrpcClient(DagsterGrpcClient):
         self._server_process = check.inst_param(server_process, "server_process", subprocess.Popen)
         super(EphemeralDagsterGrpcClient, self).__init__(*args, **kwargs)
 
-    def cleanup_server(self):
+    def cleanup_server(self) -> None:
         if self._server_process:
             if self._server_process.poll() is None:
                 try:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import multiprocessing
 import os
@@ -8,9 +10,10 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.synchronize import Event as MPEvent
+from subprocess import Popen
 from threading import Event as ThreadingEventType
 from time import sleep
-from typing import Dict, List, Mapping, NamedTuple, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Sequence, Tuple, cast
 
 import grpc
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
@@ -30,6 +33,7 @@ from dagster._core.host_representation.origin import ExternalRepositoryOrigin
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.workspace.autodiscovery import LoadableTarget
 from dagster._serdes import deserialize_as, serialize_dagster_namedtuple, whitelist_for_serdes
 from dagster._serdes.ipc import IPCErrorMessage, ipc_write_stream, open_ipc_subprocess
 from dagster._utils import (
@@ -139,11 +143,11 @@ class LoadedRepositories:
             )
 
     @property
-    def loadable_repository_symbols(self):
+    def loadable_repository_symbols(self) -> Sequence[LoadableRepositorySymbol]:
         return self._loadable_repository_symbols
 
     @property
-    def code_pointers_by_repo_name(self):
+    def code_pointers_by_repo_name(self) -> Mapping[str, CodePointer]:
         return self._code_pointers_by_repo_name
 
     @property
@@ -155,7 +159,10 @@ class LoadedRepositories:
         return self._recon_repos_by_name
 
 
-def _get_code_pointer(loadable_target_origin, loadable_repository_symbol):
+def _get_code_pointer(
+    loadable_target_origin: LoadableTargetOrigin,
+    loadable_repository_symbol: LoadableTarget,
+) -> CodePointer:
     if loadable_target_origin.python_file:
         return CodePointer.from_python_file(
             loadable_target_origin.python_file,
@@ -168,12 +175,14 @@ def _get_code_pointer(loadable_target_origin, loadable_repository_symbol):
             loadable_repository_symbol.attribute,
             loadable_target_origin.working_directory,
         )
-    else:
+    elif loadable_target_origin.module_name:
         return CodePointer.from_module(
             loadable_target_origin.module_name,
             loadable_repository_symbol.attribute,
             loadable_target_origin.working_directory,
         )
+    else:
+        check.failed("Invalid loadable target origin")
 
 
 class DagsterApiServer(DagsterApiServicer):
@@ -219,7 +228,7 @@ class DagsterApiServer(DagsterApiServicer):
         # termination event once all current executions have finished, which will stop the server)
         self._shutdown_once_executions_finish_event = threading.Event()
 
-        self._executions: Dict[str, Tuple[multiprocessing.Process, DagsterInstance]] = {}
+        self._executions: Dict[str, Tuple[multiprocessing.Process, InstanceRef]] = {}
         self._termination_events: Dict[str, MPEvent] = {}
         self._termination_times: Dict[str, float] = {}
         self._execution_lock = threading.Lock()
@@ -274,12 +283,12 @@ class DagsterApiServer(DagsterApiServicer):
 
         self.__cleanup_thread.start()
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         if self.__heartbeat_thread:
             self.__heartbeat_thread.join()
         self.__cleanup_thread.join()
 
-    def _heartbeat_thread(self, heartbeat_timeout):
+    def _heartbeat_thread(self, heartbeat_timeout: float) -> None:
         while True:
             self._shutdown_once_executions_finish_event.wait(heartbeat_timeout)
             if self._shutdown_once_executions_finish_event.is_set():
@@ -288,7 +297,7 @@ class DagsterApiServer(DagsterApiServicer):
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
                 self._shutdown_once_executions_finish_event.set()
 
-    def _cleanup_thread(self):
+    def _cleanup_thread(self) -> None:
         while True:
             self._server_termination_event.wait(CLEANUP_TICK)
             if self._server_termination_event.is_set():
@@ -296,7 +305,7 @@ class DagsterApiServer(DagsterApiServicer):
 
             self._check_for_orphaned_runs()
 
-    def _check_for_orphaned_runs(self):
+    def _check_for_orphaned_runs(self) -> None:
         with self._execution_lock:
             runs_to_clear = []
             for run_id, (process, instance_ref) in self._executions.items():
@@ -310,7 +319,7 @@ class DagsterApiServer(DagsterApiServicer):
 
                         message = get_run_crash_explanation(
                             prefix=f"Run execution process for {run.run_id}",
-                            exit_code=process.exitcode,
+                            exit_code=check.not_none(process.exitcode),
                         )
 
                         instance.report_engine_event(message, run, cls=self.__class__)
@@ -326,7 +335,7 @@ class DagsterApiServer(DagsterApiServicer):
                     self._server_termination_event.set()
 
     # Assumes execution lock is being held
-    def _clear_run(self, run_id):
+    def _clear_run(self, run_id: str) -> None:
         del self._executions[run_id]
         del self._termination_events[run_id]
         if run_id in self._termination_times:
@@ -343,22 +352,22 @@ class DagsterApiServer(DagsterApiServicer):
             )
         return loaded_repos.definitions_by_name[external_repo_origin.repository_name]
 
-    def Ping(self, request, _context):
+    def Ping(self, request, _context) -> api_pb2.PingReply:  # type: ignore  # fmt: skip
         echo = request.echo
         return api_pb2.PingReply(echo=echo)
 
-    def StreamingPing(self, request, _context):
+    def StreamingPing(self, request, _context) -> Iterator[api_pb2.StreamingPingEvent]:  # type: ignore  # fmt: skip
         sequence_length = request.sequence_length
         echo = request.echo
         for sequence_number in range(sequence_length):
             yield api_pb2.StreamingPingEvent(sequence_number=sequence_number, echo=echo)
 
-    def Heartbeat(self, request, _context):
+    def Heartbeat(self, request, _context) -> api_pb2.PingReply:  # type: ignore  # fmt: skip
         self.__last_heartbeat_time = time.time()
         echo = request.echo
         return api_pb2.PingReply(echo=echo)
 
-    def GetServerId(self, _request, _context):
+    def GetServerId(self, _request, _context) -> api_pb2.GetServerIdReply:  # type: ignore  # fmt: skip
         return api_pb2.GetServerIdReply(server_id=self._server_id)
 
     def ExecutionPlanSnapshot(self, request, _context):
@@ -380,20 +389,22 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ListRepositories(self, request, _context):
+    def ListRepositories(
+        self, request, _context
+    ) -> api_pb2.ListRepositoriesReply:  # type: ignore  # fmt: skip
         if self._serializable_load_error:
             return api_pb2.ListRepositoriesReply(
                 serialized_list_repositories_response_or_error=serialize_dagster_namedtuple(
                     self._serializable_load_error
                 )
             )
-
+        loaded_repositories = check.not_none(self._loaded_repositories)
         response = ListRepositoriesResponse(
-            self._loaded_repositories.loadable_repository_symbols,
+            loaded_repositories.loadable_repository_symbols,
             executable_path=self._loadable_target_origin.executable_path
             if self._loadable_target_origin
             else None,
-            repository_code_pointer_dict=self._loaded_repositories.code_pointers_by_repo_name,
+            repository_code_pointer_dict=loaded_repositories.code_pointers_by_repo_name,
             entry_point=self._entry_point,
             container_image=self._container_image,
             container_context=self._container_context,
@@ -403,7 +414,9 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_list_repositories_response_or_error=serialize_dagster_namedtuple(response)
         )
 
-    def ExternalPartitionNames(self, request, _context):
+    def ExternalPartitionNames(
+        self, request, _context
+    ) -> api_pb2.ExternalPartitionNamesReply:  # type: ignore  # fmt: skip
         partition_names_args = deserialize_as(
             request.serialized_partition_names_args,
             PartitionNamesArgs,
@@ -417,7 +430,9 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ExternalNotebookData(self, request, _context):
+    def ExternalNotebookData(
+        self, request, _context
+    ) -> api_pb2.ExternalNotebookDataReply:  # type: ignore  # fmt: skip
         notebook_path = request.notebook_path
         check.str_param(notebook_path, "notebook_path")
         return api_pb2.ExternalNotebookDataReply(content=get_notebook_data(notebook_path))
@@ -451,7 +466,9 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ExternalPartitionTags(self, request, _context):
+    def ExternalPartitionTags(
+        self, request, _context
+    ) -> api_pb2.ExternalPartitionTagsReply:  # type: ignore  # fmt: skip
         partition_args = deserialize_as(request.serialized_partition_args, PartitionArgs)
 
         return api_pb2.ExternalPartitionTagsReply(
@@ -464,7 +481,9 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ExternalPipelineSubsetSnapshot(self, request, _context):
+    def ExternalPipelineSubsetSnapshot(
+        self, request: Any, _context
+    ) -> api_pb2.ExternalPipelineSubsetSnapshotReply:  # type: ignore  # fmt: skip
         pipeline_subset_snapshot_args = deserialize_as(
             request.serialized_pipeline_subset_snapshot_args,
             PipelineSubsetSnapshotArgs,
@@ -507,7 +526,9 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_external_repository_data=serialized_external_repository_data,
         )
 
-    def ExternalJob(self, request, _context):
+    def ExternalJob(
+        self, request, _context
+    ) -> api_pb2.ExternalJobReply:  # type: ignore  # fmt: skip
         try:
             repository_origin = deserialize_as(
                 request.serialized_repository_origin,
@@ -595,7 +616,7 @@ class DagsterApiServer(DagsterApiServicer):
 
         yield from self._split_serialized_data_into_chunk_events(serialized_sensor_data)
 
-    def ShutdownServer(self, request, _context):
+    def ShutdownServer(self, request, _context) -> api_pb2.ShutdownServerReply:  # type: ignore  # fmt: skip
         try:
             self._shutdown_once_executions_finish_event.set()
             return api_pb2.ShutdownServerReply(
@@ -643,7 +664,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def CanCancelExecution(self, request, _context):
+    def CanCancelExecution(self, request, _context) -> api_pb2.CanCancelExecutionReply:  # type: ignore  # fmt: skip
         can_cancel_execution_request = deserialize_as(
             request.serialized_can_cancel_execution_request,
             CanCancelExecutionRequest,
@@ -660,7 +681,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def StartRun(self, request, _context):
+    def StartRun(self, request, _context) -> api_pb2.StartRunReply:  # type: ignore  # fmt: skip
         if self._shutdown_once_executions_finish_event.is_set():
             return api_pb2.StartRunReply(
                 serialized_start_run_result=serialize_dagster_namedtuple(
@@ -715,8 +736,10 @@ class DagsterApiServer(DagsterApiServicer):
         with self._execution_lock:
             execution_process.start()
             self._executions[run_id] = (
-                execution_process,
-                execute_external_pipeline_args.instance_ref,
+                # Cast here to convert `SpawnProcess` from event into regular `Process`-- not sure
+                # why not recognized as subclass, multiprocessing typing is a little rough.
+                cast(multiprocessing.Process, execution_process),
+                check.not_none(execute_external_pipeline_args.instance_ref),
             )
             self._termination_events[run_id] = termination_event
 
@@ -783,7 +806,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def GetCurrentRuns(self, request, context):
+    def GetCurrentRuns(self, request, context) -> api_pb2.GetCurrentRunsReply:  # type: ignore  # fmt: skip
         with self._execution_lock:
             return api_pb2.GetCurrentRunsReply(
                 serialized_current_runs=serialize_dagster_namedtuple(
@@ -1110,9 +1133,10 @@ def _open_server_process_on_dynamic_port(
     cwd: Optional[str] = None,
     log_level: str = "INFO",
     env: Optional[Dict[str, str]] = None,
-):
+) -> Tuple[Optional[Popen[str]], Optional[int]]:
     server_process = None
     retries = 0
+    port = None
     while server_process is None and retries < max_retries:
         port = find_free_port()
         try:

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -682,7 +682,7 @@ def _get_existing_run_for_request(
     external_schedule: ExternalSchedule,
     schedule_time,
     run_request: RunRequest,
-):
+) -> Optional[DagsterRun]:
     tags = merge_dicts(
         DagsterRun.tags_for_schedule(external_schedule),
         {
@@ -720,7 +720,7 @@ def _create_scheduler_run(
     external_schedule: ExternalSchedule,
     external_pipeline: ExternalPipeline,
     run_request: RunRequest,
-):
+) -> DagsterRun:
     from dagster._daemon.daemon import get_telemetry_daemon_session_id
 
     run_config = run_request.run_config

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -346,7 +346,9 @@ def serialize_dagster_namedtuple(nt: tuple, **json_kwargs) -> str:
     return _serialize_dagster_namedtuple(nt, whitelist_map=_WHITELIST_MAP, **json_kwargs)
 
 
-def _serialize_dagster_namedtuple(nt: tuple, whitelist_map: WhitelistMap, **json_kwargs) -> str:
+def _serialize_dagster_namedtuple(
+    nt: Tuple[Any, ...], whitelist_map: WhitelistMap, **json_kwargs
+) -> str:
     return seven.json.dumps(pack_inner_value(nt, whitelist_map, _root(nt)), **json_kwargs)
 
 

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -26,11 +26,13 @@ from typing import (
     Dict,
     Generator,
     Generic,
+    Iterable,
     Iterator,
     List,
     Mapping,
     Optional,
     Sequence,
+    Sized,
     Tuple,
     Type,
     TypeVar,
@@ -482,10 +484,10 @@ class frozentags(frozendict, Mapping[str, str]):
         return frozentags(updated)
 
 
-GeneratedContext = TypeVar("GeneratedContext")
+T_GeneratedContext = TypeVar("T_GeneratedContext")
 
 
-class EventGenerationManager(Generic[GeneratedContext]):
+class EventGenerationManager(Generic[T_GeneratedContext]):
     """Utility class that wraps an event generator function, that also yields a single instance of
     a typed object.  All events yielded before the typed object are yielded through the method
     `generate_setup_events` and all events yielded after the typed object are yielded through the
@@ -501,14 +503,14 @@ class EventGenerationManager(Generic[GeneratedContext]):
 
     def __init__(
         self,
-        generator: Generator[Union["DagsterEvent", GeneratedContext], None, None],
-        object_cls: Type[GeneratedContext],
+        generator: Generator[Union["DagsterEvent", T_GeneratedContext], None, None],
+        object_cls: Type[T_GeneratedContext],
         require_object: Optional[bool] = True,
     ):
         self.generator = check.generator(generator)
-        self.object_cls: Type[GeneratedContext] = check.class_param(object_cls, "object_cls")
+        self.object_cls: Type[T_GeneratedContext] = check.class_param(object_cls, "object_cls")
         self.require_object = check.bool_param(require_object, "require_object")
-        self.object: Optional[GeneratedContext] = None
+        self.object: Optional[T_GeneratedContext] = None
         self.did_setup = False
         self.did_teardown = False
 
@@ -530,10 +532,10 @@ class EventGenerationManager(Generic[GeneratedContext]):
                     "generator never yielded object of type {}".format(self.object_cls.__name__),
                 )
 
-    def get_object(self) -> GeneratedContext:
+    def get_object(self) -> T_GeneratedContext:
         if not self.did_setup:
             check.failed("Called `get_object` before `generate_setup_events`")
-        return cast(GeneratedContext, self.object)
+        return cast(T_GeneratedContext, self.object)
 
     def generate_teardown_events(self) -> Iterator["DagsterEvent"]:
         self.did_teardown = True
@@ -710,3 +712,15 @@ def get_run_crash_explanation(prefix: str, exit_code: int):
         exit_clause = f"unexpectedly exited with code {exit_code}."
 
     return prefix + " " + exit_clause
+
+
+def len_iter(iterable: Iterable[object]) -> int:
+    if isinstance(iterable, Sized):
+        return len(iterable)
+    return sum(1 for _ in iterable)
+
+
+def iter_to_list(iterable: Iterable[T]) -> List[T]:
+    if isinstance(iterable, List):
+        return iterable
+    return list(iterable)

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -573,9 +573,9 @@ class CachingInstanceQueryer:
         ):
             return {}
 
-        run_failure_time = datetime.datetime.utcfromtimestamp(latest_run_record.end_time).replace(
-            tzinfo=datetime.timezone.utc
-        )
+        run_failure_time = datetime.datetime.utcfromtimestamp(
+            check.not_none(latest_run_record.end_time)
+        ).replace(tzinfo=datetime.timezone.utc)
         return {
             key: min(run_failure_time, data_time) if data_time is not None else None
             for key, data_time in self._get_in_progress_data_times_for_key_in_run(

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Mapping, Optional, Union, overload
+from typing import TYPE_CHECKING, AbstractSet, Any, Dict, Mapping, Optional, Union, cast, overload
 
 # top-level include is dangerous in terms of incurring circular deps
 from dagster import (
@@ -424,8 +424,11 @@ class FilesystemTestScheduler(Scheduler, ConfigurableClass):
         return {"base_dir": str}
 
     @staticmethod
-    def from_config_value(inst_data: object, config_value):
-        return FilesystemTestScheduler(artifacts_dir=config_value["base_dir"], inst_data=inst_data)
+    def from_config_value(
+        inst_data: object, config_value: Mapping[str, object]
+    ) -> "FilesystemTestScheduler":
+        artifacts_dir = cast(str, config_value["base_dir"])
+        return FilesystemTestScheduler(artifacts_dir=artifacts_dir, inst_data=inst_data)
 
     def debug_info(self) -> str:
         return ""

--- a/python_modules/dagster/dagster/_utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/_utils/yaml_utils.py
@@ -142,7 +142,7 @@ def load_yaml_from_path(
         return yaml.load(ff, Loader=loader)
 
 
-def load_run_config_yaml(yaml_str: str) -> object:
+def load_run_config_yaml(yaml_str: str) -> Mapping[str, object]:
     return yaml.load(yaml_str, Loader=DagsterRunConfigYamlLoader)
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
@@ -1200,7 +1200,7 @@ def test_add_asset_groups_different_resources():
     )
 
     with pytest.raises(DagsterInvalidDefinitionError):
-        group1 + group2  # pylint: disable=pointless-statement
+        group1 + group2  # type: ignore  # (test error)
 
 
 def test_add_asset_groups_different_executors():
@@ -1222,7 +1222,7 @@ def test_add_asset_groups_different_executors():
     )
 
     with pytest.raises(DagsterInvalidDefinitionError):
-        group1 + group2  # pylint: disable=pointless-statement
+        group1 + group2  # type: ignore  # (test error)
 
 
 def test_to_source_assets():

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_op_selection.py
@@ -682,7 +682,7 @@ def test_nested_op_selection_with_config_mapping():
 def test_op_selection_unsatisfied_input_failure():
     @op
     def basic() -> datetime:
-        return 5
+        return 5  # type: ignore  # (test error)
 
     @op
     def ingest(x: datetime) -> str:

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
@@ -125,14 +125,14 @@ def test_success_hook_with_resources(hook_decorator, is_event_list_hook):
     decorator = hook_decorator(required_resource_keys={"foo", "bar"})
     if is_event_list_hook:
 
-        def my_hook_reqs_resources(context, _):
+        def my_hook_reqs_resources(context, _):  # type: ignore  # (test rename)
             assert context.resources.foo == "foo"
             assert context.resources.bar == "bar"
 
         hook = decorator(my_hook_reqs_resources)
     else:
 
-        def my_hook_reqs_resources(context):  # type: ignore[misc]
+        def my_hook_reqs_resources(context):  # type: ignore  # (test rename)
             assert context.resources.foo == "foo"
             assert context.resources.bar == "bar"
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
@@ -55,7 +55,9 @@ def test_simple_parent_sensor(executor):
 
             evaluate_sensors(workspace_ctx, executor)
 
-            ticks = instance.get_ticks(y_sensor.get_external_origin_id(), y_sensor.selector_id)
+            ticks = list(
+                instance.get_ticks(y_sensor.get_external_origin_id(), y_sensor.selector_id)
+            )
             assert len(ticks) == 1
             validate_tick(
                 ticks[0],

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -756,7 +756,7 @@ def test_generic_output_op():
 
     @op
     def the_op_bad_type_match() -> Output[int]:
-        return Output("foo")  # type: ignore
+        return Output("foo")  # type: ignore  # (test error)
 
     with pytest.raises(
         DagsterTypeCheckDidNotPass,
@@ -780,7 +780,7 @@ def test_generic_output_op():
 def test_output_generic_correct_inner_type():
     @op
     def the_op_not_using_output() -> Output[int]:
-        return 42
+        return 42  # type: ignore  # (test error)
 
     with pytest.raises(
         DagsterInvariantViolationError,
@@ -803,7 +803,7 @@ def test_output_generic_correct_inner_type():
 
     @op
     def the_op_annotation_not_using_output() -> int:
-        return Output(42)
+        return Output(42)  # type: ignore  # (test error)
 
     with pytest.raises(
         DagsterInvariantViolationError,
@@ -1313,7 +1313,7 @@ def test_output_return_no_annotation():
 def test_output_mismatch_tuple_lengths():
     @op(out={"out1": Out(), "out2": Out()})
     def the_op() -> Tuple[int, int]:
-        return (1, 2, 3)
+        return (1, 2, 3)  # type: ignore  # (test error)
 
     with pytest.raises(DagsterInvariantViolationError, match="Length mismatch"):
         execute_op_in_graph(the_op)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -162,7 +162,7 @@ def test_reconstructable_module():
     original_sys_path = sys.path
     try:
         sys.path.insert(0, file_relative_path(__file__, "."))
-        from foo import bar_job  # pylint: disable=import-error
+        from foo import bar_job  # type: ignore
 
         reconstructable(bar_job)
 

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
@@ -77,7 +77,7 @@ def test_multi_composite_out():
         @job
         def _should_fail():
             def _complex(item):
-                composed_echo().map(lambda y: add(y, item))
+                composed_echo().map(lambda y: add(y, item))  # type: ignore  # (test error)
 
             dynamic_solid().map(_complex)
 

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -105,7 +105,7 @@ def _define_failing_job(has_policy: bool, is_explicit: bool = True):
             if is_explicit:
                 raise Failure(description="some failure description", metadata={"foo": 1.23})
             else:
-                _ = "x" + 1
+                _ = "x" + 1  # type: ignore
         return context.retry_number
 
     @job(

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_with_local_import.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo_with_local_import.py
@@ -1,3 +1,3 @@
-import dummy_local_file as dummy_local_file  # pylint:disable=import-error,unused-import
+import dummy_local_file as dummy_local_file  # type: ignore
 
 from dagster_tests.general_tests.grpc_tests.grpc_repo import bar_repo as bar_repo

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -64,7 +64,7 @@ def test_descent_path():
         buzz: int
 
     ser = _serialize_dagster_namedtuple(
-        {"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map
+        {"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map  # type: ignore
     )
 
     with pytest.raises(DeserializationError, match=re.escape("Descent path: <root:dict>.a.b[2].c")):
@@ -75,9 +75,9 @@ def test_forward_compat_serdes_new_field_with_default():
     test_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=test_map)
-    class Quux(namedtuple("_Quux", "foo bar")):
+    class Quux(namedtuple("_Quux", "foo bar")):  # type: ignore [reportGeneralTypeIssues]
         def __new__(cls, foo, bar):
-            return super(Quux, cls).__new__(cls, foo, bar)  # pylint: disable=bad-super-call
+            return super(Quux, cls).__new__(cls, foo, bar)  # type: ignore
 
     assert test_map.has_tuple_entry("Quux")
     klass, _, _ = test_map.get_tuple_entry("Quux")
@@ -87,9 +87,8 @@ def test_forward_compat_serdes_new_field_with_default():
 
     serialized = _serialize_dagster_namedtuple(quux, whitelist_map=test_map)
 
-    # pylint: disable=function-redefined
-    @_whitelist_for_serdes(whitelist_map=test_map)
-    class Quux(namedtuple("_Quux", "foo bar baz")):  # pylint: disable=bad-super-call
+    @_whitelist_for_serdes(whitelist_map=test_map)  # type: ignore [reportGeneralTypeIssues]
+    class Quux(namedtuple("_Quux", "foo bar baz")):
         def __new__(cls, foo, bar, baz=None):
             return super(Quux, cls).__new__(cls, foo, bar, baz=baz)
 
@@ -110,7 +109,7 @@ def test_forward_compat_serdes_new_enum_field():
     test_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=test_map)
-    class Corge(Enum):
+    class Corge(Enum):  # type: ignore [reportGeneralTypeIssues]
         FOO = 1
         BAR = 2
 
@@ -138,7 +137,7 @@ def test_serdes_enum_backcompat():
     test_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=test_map)
-    class Corge(Enum):
+    class Corge(Enum):  # type: ignore
         FOO = 1
         BAR = 2
 
@@ -175,9 +174,9 @@ def test_backward_compat_serdes():
     test_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=test_map)
-    class Quux(namedtuple("_Quux", "foo bar baz")):
+    class Quux(namedtuple("_Quux", "foo bar baz")):  # type: ignore
         def __new__(cls, foo, bar, baz):
-            return super(Quux, cls).__new__(cls, foo, bar, baz)  # pylint: disable=bad-super-call
+            return super(Quux, cls).__new__(cls, foo, bar, baz)  # type: ignore
 
     quux = Quux("zip", "zow", "whoopie")
 
@@ -241,8 +240,8 @@ def test_wrong_first_arg():
 
         @serdes_test_class
         class NotCls(namedtuple("NotCls", "field_one field_two")):
-            def __new__(not_cls, field_two, field_one):
-                return super(NotCls, not_cls).__new__(field_one, field_two)
+            def __new__(not_cls, field_two, field_one):  # type: ignore
+                return super(NotCls, not_cls).__new__(field_one, field_two)  # type: ignore
 
     assert (
         str(exc_info.value)
@@ -256,7 +255,7 @@ def test_incorrect_order():
         @serdes_test_class
         class WrongOrder(namedtuple("WrongOrder", "field_one field_two")):
             def __new__(cls, field_two, field_one):
-                return super(WrongOrder, cls).__new__(field_one, field_two)
+                return super(WrongOrder, cls).__new__(field_one, field_two)  # type: ignore
 
     assert (
         str(exc_info.value)
@@ -273,7 +272,9 @@ def test_missing_one_parameter():
         @serdes_test_class
         class MissingFieldInNew(namedtuple("MissingFieldInNew", "field_one field_two field_three")):
             def __new__(cls, field_one, field_two):
-                return super(MissingFieldInNew, cls).__new__(field_one, field_two, None)
+                return super(MissingFieldInNew, cls).__new__(
+                    field_one, field_two, None
+                )  # type: ignore
 
     assert (
         str(exc_info.value)
@@ -406,7 +407,7 @@ def test_from_storage_dict():
     old_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=old_map)
-    class MyThing(NamedTuple):
+    class MyThing(NamedTuple):  # type: ignore
         orig_name: str
 
     serialized_old = _serialize_dagster_namedtuple(MyThing("old"), whitelist_map=old_map)
@@ -468,9 +469,9 @@ def test_skip_when_empty():
     test_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=test_map)
-    class SameSnapshotTuple(namedtuple("_Tuple", "foo")):
+    class SameSnapshotTuple(namedtuple("_Tuple", "foo")):  # type: ignore
         def __new__(cls, foo):
-            return super(SameSnapshotTuple, cls).__new__(cls, foo)  # pylint: disable=bad-super-call
+            return super(SameSnapshotTuple, cls).__new__(cls, foo)  # type: ignore
 
     old_tuple = SameSnapshotTuple(foo="A")
     old_serialized = _serialize_dagster_namedtuple(old_tuple, whitelist_map=test_map)
@@ -479,7 +480,7 @@ def test_skip_when_empty():
     # Without setting skip_when_empty, the ID changes
 
     @_whitelist_for_serdes(whitelist_map=test_map)
-    class SameSnapshotTuple(namedtuple("_Tuple", "foo bar")):
+    class SameSnapshotTuple(namedtuple("_Tuple", "foo bar")):  # type: ignore
         def __new__(cls, foo, bar=None):
             return super(SameSnapshotTuple, cls).__new__(  # pylint: disable=bad-super-call
                 cls, foo, bar


### PR DESCRIPTION
### Summary & Motivation

Miscellaneous assortment of typing fixes required to pass `pyright` in core `dagster`. This PR contains all of the fixes that did not fit into any more coherent theme:

- Adding/updating assorted annotations
- Facotring out certain callback types into reusable type aliases
- Guaranteeing certain local variables are defined on access
- A few calls to e.g. `check.not_none` to fix type inference

### How I Tested These Changes

Pyright, BK