### PR TITLE
[pyright] [core] standardize is_context_provided

### DIFF
--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -1,7 +1,13 @@
 import textwrap
-from typing import Any, Callable, Optional, Sequence, Set
+from typing import Any, Callable, Optional, Sequence, Set, TypeVar, Union
+
+from typing_extensions import Concatenate, ParamSpec, TypeGuard
 
 from dagster._seven import funcsigs
+
+R = TypeVar("R")
+T = TypeVar("T")
+P = ParamSpec("P")
 
 
 def get_valid_name_permutations(param_name: str) -> Set[str]:
@@ -75,3 +81,13 @@ def format_docstring_for_description(fn: Callable) -> Optional[str]:
                 )
     else:
         return None
+
+
+# Type-ignores are used throughout the codebase when this function returns False to ignore the type
+# error arising from assuming
+# When/if `StrictTypeGuard` is supported, we can drop `is_context_not_provided` since a False from
+# `is_context_provided` will be sufficient.
+def is_context_provided(
+    fn: Union[Callable[Concatenate[T, P], R], Callable[P, R]]
+) -> TypeGuard[Callable[Concatenate[T, P], R]]:
+    return len(get_function_params(fn)) >= 1

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -148,8 +148,8 @@ def schedule(
                 ScheduleExecutionError,
                 lambda: f"Error occurred during the evaluation of schedule {schedule_name}",
             ):
-                if is_context_provided(fn):
-                    result = fn(context)
+                if is_context_provided(fn):  # type: ignore  # fmt: skip
+                    result = fn(context)  # type: ignore  # fmt: skip
                 else:
                     result = fn()  # type: ignore
 
@@ -173,7 +173,7 @@ def schedule(
                     # this is a run-request based decorated function
                     yield from cast(RunRequestIterator, ensure_gen(result))
 
-        has_context_arg = is_context_provided(fn)
+        has_context_arg = is_context_provided(fn)  # type: ignore  # fmt: skip
         evaluation_fn = DecoratedScheduleFunction(
             decorated_fn=fn,
             wrapped_fn=_wrapped_fn,

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -13,7 +13,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import TypeAlias, TypeGuard
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
@@ -25,6 +25,7 @@ from dagster._utils.backcompat import experimental_arg_warning
 
 from ..decorator_utils import (
     get_function_params,
+    is_context_provided,
     is_required_param,
     positional_arg_name_list,
     validate_expected_params,
@@ -55,10 +56,6 @@ ResourceFunction: TypeAlias = Union[
     ResourceFunctionWithContext,
     ResourceFunctionWithoutContext,
 ]
-
-
-def is_context_provided(fn: ResourceFunction) -> TypeGuard[ResourceFunctionWithContext]:
-    return len(get_function_params(fn)) >= 1
 
 
 class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
@@ -202,9 +199,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
     def __call__(self, *args, **kwargs):
         from dagster._core.execution.context.init import UnboundInitResourceContext
 
-        context_provided = is_context_provided(self.resource_fn)
-
-        if context_provided:
+        if is_context_provided(self.resource_fn):
             if len(args) + len(kwargs) == 0:
                 raise DagsterInvalidInvocationError(
                     "Resource initialization function has context argument, but no context was"
@@ -270,7 +265,7 @@ class _ResourceDecoratorCallable:
     def __call__(self, resource_fn: ResourceFunction) -> ResourceDefinition:
         check.callable_param(resource_fn, "resource_fn")
 
-        any_name = ["*"] if is_context_provided(resource_fn) else []
+        any_name = ["*"] if is_context_provided(resource_fn) else []  # type: ignore  # fmt: skip
 
         params = get_function_params(resource_fn)
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -29,9 +29,9 @@ def resource_invocation_result(
 
     resource_fn = resource_def.resource_fn
     val_or_gen = (
-        resource_fn(_init_context)
-        if is_context_provided(resource_fn)
-        else resource_fn()  # type: ignore
+        resource_fn(_init_context)  # type: ignore  # fmt: skip
+        if is_context_provided(resource_fn)  # type: ignore  # fmt: skip
+        else resource_fn()  # type: ignore  # (strict type guard)
     )
     if inspect.isgenerator(val_or_gen):
 
@@ -57,7 +57,7 @@ def _check_invocation_requirements(
         build_init_resource_context,
     )
 
-    context_provided = is_context_provided(resource_def.resource_fn)
+    context_provided = is_context_provided(resource_def.resource_fn)  # type: ignore  # fmt: skip
     if context_provided and resource_def.required_resource_keys and init_context is None:
         raise DagsterInvalidInvocationError(
             "Resource has required resources, but no context was provided. Use the "

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -325,8 +325,8 @@ def single_resource_event_generator(
             try:
                 with time_execution_scope() as timer_result:
                     resource_or_gen = (
-                        resource_def.resource_fn(context)
-                        if is_context_provided(resource_def.resource_fn)
+                        resource_def.resource_fn(context)  # type: ignore  # fmt: skip
+                        if is_context_provided(resource_def.resource_fn)  # type: ignore  # fmt: skip
                         else resource_def.resource_fn()  # type: ignore[call-arg]
                     )
 

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -1,26 +1,26 @@
 from abc import ABC, abstractmethod
 from functools import update_wrapper
-from typing import TYPE_CHECKING, AbstractSet, Callable, Optional
+from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union, cast, overload
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
+from dagster._core.decorator_utils import is_context_provided
 from dagster._core.definitions.config import is_callable_valid_config_arg
 from dagster._core.definitions.definition_config_schema import (
     CoercableToConfigSchema,
     IDefinitionConfigSchema,
     convert_user_facing_definition_config_schema,
 )
-from dagster._core.definitions.resource_definition import (
-    ResourceDefinition,
-    ResourceFunction,
-    is_context_provided,
-)
+from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
 
 if TYPE_CHECKING:
     from dagster._core.execution.context.input import InputContext
 
-InputLoadFn: TypeAlias = Callable[["InputContext"], object]
+InputLoadFn: TypeAlias = Union[
+    Callable[["InputContext"], object],
+    Callable[[], object],
+]
 
 
 class InputManager(ABC):
@@ -99,6 +99,14 @@ class InputManagerDefinition(ResourceDefinition, IInputManagerDefinition):
         )
 
 
+@overload
+def input_manager(
+    config_schema: InputLoadFn,
+) -> InputManagerDefinition:
+    ...
+
+
+@overload
 def input_manager(
     config_schema: Optional[CoercableToConfigSchema] = None,
     description: Optional[str] = None,
@@ -106,6 +114,16 @@ def input_manager(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     version: Optional[str] = None,
 ) -> Callable[[InputLoadFn], InputManagerDefinition]:
+    ...
+
+
+def input_manager(
+    config_schema: Union[InputLoadFn, Optional[CoercableToConfigSchema]] = None,
+    description: Optional[str] = None,
+    input_config_schema: Optional[CoercableToConfigSchema] = None,
+    required_resource_keys: Optional[AbstractSet[str]] = None,
+    version: Optional[str] = None,
+) -> Union[InputManagerDefinition, Callable[[InputLoadFn], InputManagerDefinition]]:
     """Define an input manager.
 
     Input managers load op inputs, either from upstream outputs or by providing default values.
@@ -152,12 +170,14 @@ def input_manager(
         def csv_loader(context):
             return read_csv(context.config["path"])
     """
-    if callable(config_schema) and not is_callable_valid_config_arg(config_schema):
+    if _is_input_load_fn(config_schema):
         return _InputManagerDecoratorCallable()(config_schema)
+
+    config_schema = cast(Optional[CoercableToConfigSchema], config_schema)
 
     def _wrap(load_fn: InputLoadFn) -> InputManagerDefinition:
         return _InputManagerDecoratorCallable(
-            config_schema=config_schema,
+            config_schema=config_schema,  # type: ignore  # fmt: skip
             description=description,
             version=version,
             input_config_schema=input_config_schema,
@@ -167,8 +187,12 @@ def input_manager(
     return _wrap
 
 
+def _is_input_load_fn(obj: Union[InputLoadFn, CoercableToConfigSchema]) -> TypeGuard[InputLoadFn]:
+    return callable(obj) and not is_callable_valid_config_arg(obj)
+
+
 class InputManagerWrapper(InputManager):
-    def __init__(self, load_fn):
+    def __init__(self, load_fn: InputLoadFn):
         self._load_fn = load_fn
 
     def load_input(self, context: "InputContext") -> object:
@@ -178,8 +202,8 @@ class InputManagerWrapper(InputManager):
         intermediate = (
             # type-ignore because function being used as attribute
             self._load_fn(context)  # type: ignore  # fmt: skip
-            if is_context_provided(self._load_fn)
-            else self._load_fn()  # type: ignore
+            if is_context_provided(self._load_fn)  # type: ignore  # fmt: skip
+            else self._load_fn()  # type: ignore  # (strict type guard)
         )
 
         if isinstance(intermediate, InputManager):


### PR DESCRIPTION
### Summary & Motivation

Uses modern typing features (`TypeGuard`, `ParamSpec`) to consolidate logic used for checking if a callback provided a `context` arg, something we do in many APIs.

### How I Tested These Changes

BK