### PR TITLE
[pyright] [core] eliminate `funcsigs`

### DIFF
--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -1,9 +1,8 @@
 import textwrap
+from inspect import Parameter, signature
 from typing import Any, Callable, Optional, Sequence, Set, TypeVar, Union
 
 from typing_extensions import Concatenate, ParamSpec, TypeGuard
-
-from dagster._seven import funcsigs
 
 R = TypeVar("R")
 T = TypeVar("T")
@@ -20,12 +19,12 @@ def get_valid_name_permutations(param_name: str) -> Set[str]:
     }
 
 
-def _is_param_valid(param: funcsigs.Parameter, expected_positional: str) -> bool:
+def _is_param_valid(param: Parameter, expected_positional: str) -> bool:
     # The "*" character indicates that we permit any name for this positional parameter.
     if expected_positional == "*":
         return True
 
-    possible_kinds = {funcsigs.Parameter.POSITIONAL_OR_KEYWORD, funcsigs.Parameter.POSITIONAL_ONLY}
+    possible_kinds = {Parameter.POSITIONAL_OR_KEYWORD, Parameter.POSITIONAL_ONLY}
 
     return (
         param.name in get_valid_name_permutations(expected_positional)
@@ -33,12 +32,12 @@ def _is_param_valid(param: funcsigs.Parameter, expected_positional: str) -> bool
     )
 
 
-def get_function_params(fn: Callable[..., Any]) -> Sequence[funcsigs.Parameter]:
-    return list(funcsigs.signature(fn).parameters.values())
+def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
+    return list(signature(fn).parameters.values())
 
 
 def validate_expected_params(
-    params: Sequence[funcsigs.Parameter], expected_params: Sequence[str]
+    params: Sequence[Parameter], expected_params: Sequence[str]
 ) -> Optional[str]:
     """Returns first missing positional, if any, otherwise None."""
     expected_idx = 0
@@ -49,20 +48,20 @@ def validate_expected_params(
     return None
 
 
-def is_required_param(param: funcsigs.Parameter) -> bool:
-    return param.default == funcsigs.Parameter.empty
+def is_required_param(param: Parameter) -> bool:
+    return param.default == Parameter.empty
 
 
-def positional_arg_name_list(params: Sequence[funcsigs.Parameter]) -> Sequence[str]:
+def positional_arg_name_list(params: Sequence[Parameter]) -> Sequence[str]:
     accepted_param_types = {
-        funcsigs.Parameter.POSITIONAL_OR_KEYWORD,
-        funcsigs.Parameter.POSITIONAL_ONLY,
+        Parameter.POSITIONAL_OR_KEYWORD,
+        Parameter.POSITIONAL_ONLY,
     }
     return [p.name for p in params if p.kind in accepted_param_types]
 
 
-def param_is_var_keyword(param: funcsigs.Parameter) -> bool:
-    return param.kind == funcsigs.Parameter.VAR_KEYWORD
+def param_is_var_keyword(param: Parameter) -> bool:
+    return param.kind == Parameter.VAR_KEYWORD
 
 
 def format_docstring_for_description(fn: Callable) -> Optional[str]:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1,4 +1,5 @@
 import warnings
+from inspect import Parameter
 from typing import (
     AbstractSet,
     Any,
@@ -22,7 +23,6 @@ from dagster._core.definitions.resource_output import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._core.types.dagster_type import DagsterType
-from dagster._seven import funcsigs
 from dagster._utils.backcompat import (
     ExperimentalWarning,
     deprecation_warning,
@@ -565,11 +565,9 @@ def build_asset_ins(
     input_params = new_input_args
 
     non_var_input_param_names = [
-        param.name
-        for param in new_input_args
-        if param.kind == funcsigs.Parameter.POSITIONAL_OR_KEYWORD
+        param.name for param in new_input_args if param.kind == Parameter.POSITIONAL_OR_KEYWORD
     ]
-    has_kwargs = any(param.kind == funcsigs.Parameter.VAR_KEYWORD for param in new_input_args)
+    has_kwargs = any(param.kind == Parameter.VAR_KEYWORD for param in new_input_args)
 
     all_input_names = set(non_var_input_param_names) | asset_ins.keys()
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -1,4 +1,5 @@
 from functools import lru_cache, update_wrapper
+from inspect import Parameter
 from typing import (
     AbstractSet,
     Any,
@@ -19,7 +20,6 @@ from dagster._core.decorator_utils import format_docstring_for_description
 from dagster._core.definitions.resource_output import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
-from dagster._seven import funcsigs
 
 from ...decorator_utils import (
     get_function_params,
@@ -44,7 +44,7 @@ class DecoratedOpFunction(NamedTuple):
         return is_context_provided(get_function_params(self.decorated_fn))
 
     @lru_cache(maxsize=1)
-    def _get_function_params(self) -> Sequence[funcsigs.Parameter]:
+    def _get_function_params(self) -> Sequence[Parameter]:
         return get_function_params(self.decorated_fn)
 
     def has_config_arg(self) -> bool:
@@ -54,14 +54,14 @@ class DecoratedOpFunction(NamedTuple):
 
         return False
 
-    def get_config_arg(self) -> funcsigs.Parameter:
+    def get_config_arg(self) -> Parameter:
         for param in get_function_params(self.decorated_fn):
             if param.name == "config":
                 return param
 
         check.failed("Requested config arg on function that does not have one")
 
-    def get_resource_args(self) -> Sequence[funcsigs.Parameter]:
+    def get_resource_args(self) -> Sequence[Parameter]:
         return get_resource_args(self.decorated_fn)
 
     def positional_inputs(self) -> Sequence[str]:
@@ -399,10 +399,10 @@ def resolve_checked_solid_fn_inputs(
     inputs_to_infer = set()
     has_kwargs = False
 
-    for param in cast(List[funcsigs.Parameter], input_args):
-        if param.kind == funcsigs.Parameter.VAR_KEYWORD:
+    for param in cast(List[Parameter], input_args):
+        if param.kind == Parameter.VAR_KEYWORD:
             has_kwargs = True
-        elif param.kind == funcsigs.Parameter.VAR_POSITIONAL:
+        elif param.kind == Parameter.VAR_POSITIONAL:
             raise DagsterInvalidDefinitionError(
                 f"{decorator_name} '{fn_name}' decorated function has positional vararg parameter "
                 f"'{param}'. {decorator_name} decorated functions should only have keyword "
@@ -469,7 +469,7 @@ def resolve_checked_solid_fn_inputs(
     return input_defs
 
 
-def is_context_provided(params: Sequence[funcsigs.Parameter]) -> bool:
+def is_context_provided(params: Sequence[Parameter]) -> bool:
     if len(params) == 0:
         return False
     return params[0].name in get_valid_name_permutations("context")

--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -23,10 +23,6 @@ from .temp_dir import get_system_temp_directory as get_system_temp_directory
 
 IS_WINDOWS = os.name == "nt"
 
-funcsigs = inspect
-
-IS_WINDOWS = os.name == "nt"
-
 # TODO implement a generic import by name -- see https://stackoverflow.com/questions/301134/how-to-import-a-module-given-its-name
 
 


### PR DESCRIPTION
### Summary & Motivation

For some reason probably having to do with previous Python 2.x support, we were accessing stdlib functionality of `inspect` through an alias `dagster._seven.funcsigs`-- this removes the indirection and just uses `inspect`.

### How I Tested These Changes

BK