### PR TITLE
Rename and refactor in structured_config.py for clarity

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,5 +1,7 @@
 import inspect
 
+from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
+
 try:
     from functools import cached_property
 except ImportError:
@@ -9,7 +11,7 @@ except ImportError:
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, cast
 
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_SINGLETON, ModelField
@@ -29,6 +31,23 @@ class Config(BaseModel):
     """
     Base class for Dagster configuration models.
     """
+
+
+def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSchema:
+    """Return a new config schema configured with the passed in data"""
+
+    # We don't do anything with this resource definition, other than
+    # use it to construct configured schema
+    inner_resource_def = ResourceDefinition(lambda _: None, schema_field)
+    configured_resource_def = inner_resource_def.configured(
+        config_dictionary_from_values(
+            data,
+            schema_field,
+        ),
+    )
+    # this cast required to make mypy happy, with does not support Self
+    configured_resource_def = cast(ResourceDefinition, configured_resource_def)
+    return configured_resource_def.config_schema
 
 
 class Resource(
@@ -62,22 +81,11 @@ class Resource(
 
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)
-
-        inner_resource_def = ResourceDefinition(self.resource_function, schema)
-        configured_resource_def = inner_resource_def.configured(
-            config_dictionary_from_values(
-                data,
-                schema,
-            ),
-        )
-
         Config.__init__(self, **data)
         ResourceDefinition.__init__(
             self,
-            resource_fn=self.resource_function,
-            # mypy worries that configured_resource_def could be self, which
-            # has not had config_schema initialized yet, but we know that's not the case
-            config_schema=configured_resource_def.config_schema,  # type: ignore[attr-defined]
+            resource_fn=self.create_object_to_pass_to_user_code,
+            config_schema=_curry_config_schema(schema, data),
             description=self.__doc__,
         )
 
@@ -92,9 +100,11 @@ class Resource(
 
         return super().__setattr__(name, value)
 
-    def resource_function(self, context) -> Any:  # pylint: disable=unused-argument
-        # Default behavior, for "new-style" resources, is to return the resource itself, so that
-        # initialization is a no-op
+    def create_object_to_pass_to_user_code(self, context) -> Any:  # pylint: disable=unused-argument
+        # This acts identically to the function decorator with @resource in the old style
+        #
+        # Default behavior, for "new-style" resources, is to return itself, passing
+        # the actual resource object to user code.
         return self
 
 
@@ -153,22 +163,11 @@ class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
 
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)
-
-        inner_resource_def = ResourceDefinition(self.resource_function, schema)
-        configured_resource_def = inner_resource_def.configured(
-            config_dictionary_from_values(
-                data,
-                schema,
-            ),
-        )
-
         Config.__init__(self, **data)
         IOManagerDefinition.__init__(
             self,
-            resource_fn=self.resource_function,
-            # mypy worries that configured_resource_def could be self, which
-            # has not had config_schema initialized yet, but we know that's not the case
-            config_schema=configured_resource_def.config_schema,  # type: ignore[attr-defined]
+            resource_fn=self.create_io_manager_to_pass_to_user_code,
+            config_schema=_curry_config_schema(schema, data),
             description=self.__doc__,
         )
 
@@ -184,7 +183,8 @@ class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
         return super().__setattr__(name, value)
 
     @abstractmethod
-    def resource_function(self, context) -> IOManager:
+    def create_io_manager_to_pass_to_user_code(self, context) -> IOManager:
+        """Implement as one would implement a @io_manager decorator function"""
         raise NotImplementedError()
 
 
@@ -197,7 +197,7 @@ class StructuredConfigIOManager(StructuredConfigIOManagerBase, IOManager):
     :py:meth:`handle_output` and :py:meth:`load_input` methods.
     """
 
-    def resource_function(self, context) -> IOManager:
+    def create_io_manager_to_pass_to_user_code(self, context) -> IOManager:
         return self
 
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -45,7 +45,7 @@ def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSch
             schema_field,
         ),
     )
-    # this cast required to make mypy happy, with does not support Self
+    # this cast required to make mypy happy, which does not support Self
     configured_resource_def = cast(ResourceDefinition, configured_resource_def)
     return configured_resource_def.config_schema
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -101,10 +101,14 @@ class Resource(
         return super().__setattr__(name, value)
 
     def create_object_to_pass_to_user_code(self, context) -> Any:  # pylint: disable=unused-argument
-        # This acts identically to the function decorator with @resource in the old style
-        #
-        # Default behavior, for "new-style" resources, is to return itself, passing
-        # the actual resource object to user code.
+        """
+        Returns the object that this resource hands to user code, accessible by ops or assets
+        through the context or resource parameters. This works like the function decorated
+        with @resource when using function-based resources.
+        
+        Default behavior for new class-based resources is to return itself, passing
+        the actual resource object to user code.
+        """
         return self
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -180,7 +180,7 @@ def test_yield_in_resource_function():
     class ResourceWithCleanup(Resource):
         idx: int
 
-        def resource_function(self, context):
+        def create_object_to_pass_to_user_code(self, context):
             called.append(f"creation_{self.idx}")
             yield True
             called.append(f"cleanup_{self.idx}")


### PR DESCRIPTION
### Summary & Motivation

I was adding some functionality here and I thought a couple changes made this quite a bit clearer.

1) Consolidate the logic to create the configured config schema into a single function `_curry_config_schema`. This removes code duplication and makes it clear that the "inner resource" is solely for this purpose.  Passing `self.resource_function` to this placeholder made this particularly confusing.

2) Rename `resource_function` to make it distinct from `resource_fn` on the base class. I'm proposing the verbose but explicit name `create_object_to_pass_to_user_code`. Open to feedback.

### How I Tested These Changes

BK