### PR TITLE
Update Documentation on Input/Output Context

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -42,30 +42,6 @@ class InputContext:
     an `InputContext` for testing an IO Manager's `load_input` method, use
     :py:func:`dagster.build_input_context`.
 
-    Attributes:
-        name (Optional[str]): The name of the input that we're loading.
-        config (Optional[Any]): The config attached to the input that we're loading.
-        metadata (Optional[Dict[str, Any]]): A dict of metadata that is assigned to the
-            InputDefinition that we're loading for.
-            This property only contains metadata passed in explicitly with :py:class:`AssetIn`
-            or :py:class:`In`. To access metadata of an upstream asset or operation definition,
-            use the metadata in :py:attr:`.InputContext.upstream_output`.
-        upstream_output (Optional[OutputContext]): Info about the output that produced the object
-            we're loading.
-        dagster_type (Optional[DagsterType]): The type of this input.
-            Dagster types do not propagate from an upstream output to downstream inputs,
-            and this property only captures type information for the input that is either
-            passed in explicitly with :py:class:`AssetIn` or :py:class:`In`, or can be
-            infered from type hints. For an asset input, the Dagster type from the upstream
-            asset definition is ignored.
-        log (Optional[DagsterLogManager]): The log manager to use for this input.
-        resource_config (Optional[Dict[str, Any]]): The config associated with the resource that
-            initializes the RootInputManager.
-        resources (Optional[Resources]): The resources required by the resource that initializes the
-            input manager. If using the :py:func:`@root_input_manager` decorator, these resources
-            correspond to those requested with the `required_resource_keys` parameter.
-        op_def (Optional[OpDefinition]): The definition of the op that's loading the input.
-
     Example:
 
     .. code-block:: python
@@ -172,6 +148,7 @@ class InputContext:
     @public  # type: ignore
     @property
     def name(self) -> str:
+        """The name of the input that we’re loading."""
         if self._name is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access name, "
@@ -206,6 +183,7 @@ class InputContext:
     @public  # type: ignore
     @property
     def op_def(self) -> "OpDefinition":
+        """The definition of the op that’s loading the input."""
         from dagster._core.definitions import OpDefinition
 
         if self._solid_def is None:
@@ -219,21 +197,31 @@ class InputContext:
     @public  # type: ignore
     @property
     def config(self) -> Any:
+        """The config attached to the input that we’re loading."""
         return self._config
 
     @public  # type: ignore
     @property
     def metadata(self) -> Optional[Mapping[str, Any]]:
+        """A dict of metadata that is assigned to the InputDefinition that we’re loading for. 
+        This property only contains metadata passed in explicitly with AssetIn or In. 
+        To access metadata of an upstream asset or operation definition, 
+        use the metadata in InputContext.upstream_output."""
         return self._metadata
 
     @public  # type: ignore
     @property
     def upstream_output(self) -> Optional["OutputContext"]:
+        """Info about the output that produced the object we’re loading."""
         return self._upstream_output
 
     @public  # type: ignore
     @property
     def dagster_type(self) -> "DagsterType":
+        """The type of this input. Dagster types do not propagate from an upstream output 
+        to downstream inputs, and this property only captures type information for the input 
+        that is either passed in explicitly with AssetIn or In, or can be infered from type hints. 
+        For an asset input, the Dagster type from the upstream asset definition is ignored."""
         if self._dagster_type is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access dagster_type, "
@@ -245,6 +233,7 @@ class InputContext:
     @public  # type: ignore
     @property
     def log(self) -> "DagsterLogManager":
+        """The log manager to use for this input."""
         if self._log is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access log, "
@@ -256,11 +245,15 @@ class InputContext:
     @public  # type: ignore
     @property
     def resource_config(self) -> Optional[Mapping[str, Any]]:
+        """The config associated with the resource that initializes the RootInputManager."""
         return self._resource_config
 
     @public  # type: ignore
     @property
     def resources(self) -> Any:
+        """The resources required by the resource that initializes the input manager. 
+        If using the @root_input_manager() decorator, these resources correspond 
+        to those requested with the required_resource_keys parameter."""
         if self._resources is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access resources, "
@@ -278,11 +271,16 @@ class InputContext:
     @public  # type: ignore
     @property
     def has_asset_key(self) -> bool:
+        """Whether an asset is associated with this input."""
         return self._asset_key is not None
 
     @public  # type: ignore
     @property
     def asset_key(self) -> AssetKey:
+        """The asset key corresponding to the input asset.
+        
+        Raises an error if no asset is associated with this input.
+        """
         if self._asset_key is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access asset_key, but no asset is associated with this input"
@@ -319,7 +317,7 @@ class InputContext:
     @public  # type: ignore
     @property
     def has_partition_key(self) -> bool:
-        """Whether the current run is a partitioned run"""
+        """Whether the current run is a partitioned run."""
         return self._partition_key is not None
 
     @public  # type: ignore
@@ -339,6 +337,7 @@ class InputContext:
     @public  # type: ignore
     @property
     def has_asset_partitions(self) -> bool:
+        """Whether the input asset is a partitioned asset."""
         return self._asset_partitions_subset is not None
 
     @public  # type: ignore
@@ -459,6 +458,11 @@ class InputContext:
 
     @public
     def get_asset_identifier(self) -> Sequence[str]:
+        """Utility method to get a collection of identifiers corresponding to the input asset.
+        The collection consists of a List containing the asset key (unpacked) and the asset partition key.
+        
+        Raises an error if no asset is associated with this input.
+        """
         if self.asset_key is not None:
             if self.has_asset_partitions:
                 return [*self.asset_key.path, self.asset_partition_key]

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -141,8 +141,10 @@ class InputContext:
     @public  # type: ignore
     @property
     def has_input_name(self) -> bool:
-        """If we're the InputContext is being used to load the result of a run from outside the run,
-        then it won't have an input name."""
+        """
+        If we're the InputContext is being used to load the result of a run from outside the run,
+        then it won't have an input name.
+        """
         return self._name is not None
 
     @public  # type: ignore
@@ -203,10 +205,12 @@ class InputContext:
     @public  # type: ignore
     @property
     def metadata(self) -> Optional[Mapping[str, Any]]:
-        """A dict of metadata that is assigned to the InputDefinition that we’re loading for. 
-        This property only contains metadata passed in explicitly with AssetIn or In. 
-        To access metadata of an upstream asset or operation definition, 
-        use the metadata in InputContext.upstream_output."""
+        """
+        A dict of metadata that is assigned to the op In or asset definition that we’re loading for.
+        This property only contains metadata passed in explicitly with AssetIn or In.
+        To access metadata of an upstream asset or operation definition,
+        use the metadata in InputContext.upstream_output.
+        """
         return self._metadata
 
     @public  # type: ignore
@@ -218,10 +222,12 @@ class InputContext:
     @public  # type: ignore
     @property
     def dagster_type(self) -> "DagsterType":
-        """The type of this input. Dagster types do not propagate from an upstream output 
-        to downstream inputs, and this property only captures type information for the input 
-        that is either passed in explicitly with AssetIn or In, or can be infered from type hints. 
-        For an asset input, the Dagster type from the upstream asset definition is ignored."""
+        """
+        The Dagster type of this input. Dagster types do not propagate from an upstream output
+        to downstream inputs, and this property only captures type information for the input
+        that is either passed in explicitly with AssetIn or In, or can be infered from type hints.
+        For an asset input, the Dagster type from the upstream asset definition is ignored.
+        """
         if self._dagster_type is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access dagster_type, "
@@ -245,15 +251,17 @@ class InputContext:
     @public  # type: ignore
     @property
     def resource_config(self) -> Optional[Mapping[str, Any]]:
-        """The config associated with the resource that initializes the RootInputManager."""
+        """The config associated with the resource that initializes the IOManager or RootInputManager."""
         return self._resource_config
 
     @public  # type: ignore
     @property
     def resources(self) -> Any:
-        """The resources required by the resource that initializes the input manager. 
-        If using the @root_input_manager() decorator, these resources correspond 
-        to those requested with the required_resource_keys parameter."""
+        """
+        The resources required by the resource that initializes the input manager.
+        If using the @root_input_manager() decorator, these resources correspond
+        to those requested with the required_resource_keys parameter.
+        """
         if self._resources is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access resources, "
@@ -277,8 +285,9 @@ class InputContext:
     @public  # type: ignore
     @property
     def asset_key(self) -> AssetKey:
-        """The asset key corresponding to the input asset.
-        
+        """
+        The asset key corresponding to the input asset.
+
         Raises an error if no asset is associated with this input.
         """
         if self._asset_key is None:
@@ -343,7 +352,8 @@ class InputContext:
     @public  # type: ignore
     @property
     def asset_partition_key(self) -> str:
-        """The partition key for input asset.
+        """
+        The partition key for input asset.
 
         Raises an error if the input asset has no partitioning, or if the run covers a partition
         range for the input asset.
@@ -365,7 +375,8 @@ class InputContext:
     @public  # type: ignore
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
-        """The partition key range for input asset.
+        """
+        The partition key range for input asset.
 
         Raises an error if the input asset has no partitioning.
         """
@@ -388,7 +399,8 @@ class InputContext:
     @public  # type: ignore
     @property
     def asset_partition_keys(self) -> Sequence[str]:
-        """The partition keys for input asset.
+        """
+        The partition keys for input asset.
 
         Raises an error if the input asset has no partitioning.
         """
@@ -402,7 +414,8 @@ class InputContext:
     @public  # type: ignore
     @property
     def asset_partitions_time_window(self) -> TimeWindow:
-        """The time window for the partitions of the input asset.
+        """
+        The time window for the partitions of the input asset.
 
         Raises an error if either of the following are true:
         - The input asset has no partitioning.
@@ -431,7 +444,8 @@ class InputContext:
 
     @public
     def get_identifier(self) -> Sequence[str]:
-        """Utility method to get a collection of identifiers that as a whole represent a unique
+        """
+        Utility method to get a collection of identifiers that as a whole represent a unique
         step input.
 
         If not using memoization, the unique identifier collection consists of
@@ -458,9 +472,10 @@ class InputContext:
 
     @public
     def get_asset_identifier(self) -> Sequence[str]:
-        """Utility method to get a collection of identifiers corresponding to the input asset.
+        """
+        Utility method to get a collection of identifiers corresponding to the input asset.
         The collection consists of a List containing the asset key (unpacked) and the asset partition key.
-        
+
         Raises an error if no asset is associated with this input.
         """
         if self.asset_key is not None:
@@ -472,7 +487,8 @@ class InputContext:
             check.failed("Can't get asset identifier for an input with no asset key")
 
     def consume_events(self) -> Iterator["DagsterEvent"]:
-        """Pops and yields all user-generated events that have been recorded from this context.
+        """
+        Pops and yields all user-generated events that have been recorded from this context.
 
         If consume_events has not yet been called, this will yield all logged events since the call to `handle_input`. If consume_events has been called, it will yield all events since the last time consume_events was called. Designed for internal use. Users should never need to invoke this method.
         """
@@ -486,7 +502,8 @@ class InputContext:
         metadata: Mapping[str, Any],
         description: Optional[str] = None,
     ) -> None:
-        """Accepts a dictionary of metadata. Metadata entries will appear on the LOADED_INPUT event.
+        """
+        Accepts a dictionary of metadata. Metadata entries will appear on the LOADED_INPUT event.
         If the input is an asset, metadata will be attached to an asset observation.
 
         The asset observation will be yielded from the run and appear in the event log.
@@ -513,7 +530,8 @@ class InputContext:
     def get_observations(
         self,
     ) -> Sequence[AssetObservation]:
-        """Retrieve the list of user-generated asset observations that were observed via the context.
+        """
+        Retrieve the list of user-generated asset observations that were observed via the context.
 
         User-generated events that were yielded will not appear in this list.
 
@@ -558,7 +576,8 @@ def build_input_context(
     asset_partitions_def: Optional["PartitionsDefinition"] = None,
     instance: Optional[DagsterInstance] = None,
 ) -> "InputContext":
-    """Builds input context from provided parameters.
+    """
+    Builds input context from provided parameters.
 
     ``build_input_context`` can be used as either a function, or a context manager. If resources
     that are also context managers are provided, then ``build_input_context`` must be used as a
@@ -568,17 +587,17 @@ def build_input_context(
         name (Optional[str]): The name of the input that we're loading.
         config (Optional[Any]): The config attached to the input that we're loading.
         metadata (Optional[Dict[str, Any]]): A dict of metadata that is assigned to the
-            InputDefinition that we're loading for.
+            op In or asset definition that we're loading for.
         upstream_output (Optional[OutputContext]): Info about the output that produced the object
             we're loading.
-        dagster_type (Optional[DagsterType]): The type of this input.
+        dagster_type (Optional[DagsterType]): The Dagster type of this input.
         resource_config (Optional[Dict[str, Any]]): The resource config to make available from the
             input context. This usually corresponds to the config provided to the resource that
             loads the input manager.
         resources (Optional[Dict[str, Any]]): The resources to make available from the context.
             For a given key, you can provide either an actual instance of an object, or a resource
             definition.
-        asset_key (Optional[AssetKey]): The asset key attached to the InputDefinition.
+        asset_key (Optional[AssetKey]): The asset key corresponding to the input asset.
         op_def (Optional[OpDefinition]): The definition of the op that's loading the input.
         step_context (Optional[StepExecutionContext]): For internal use.
         partition_key (Optional[str]): String value representing partition key to execute with.

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -212,7 +212,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def metadata(self) -> Optional[Mapping[str, object]]:
-        """A dict of the metadata that is assigned to the OutputDefinition that produced the output."""
+        """A dict of the metadata that is assigned to the op Out or asset definition that produced the output."""
         return self._metadata
 
     @public  # type: ignore
@@ -244,7 +244,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def dagster_type(self) -> "DagsterType":
-        """The type of this output."""
+        """The Dagster type of this output."""
         if self._dagster_type is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access dagster_type, "
@@ -274,7 +274,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def resource_config(self) -> Optional[Mapping[str, object]]:
-        """The config associated with the resource that initializes the RootInputManager."""
+        """The config associated with the resource that initializes the IOManager or RootInputManager."""
         return self._resource_config
 
     @public  # type: ignore
@@ -308,8 +308,9 @@ class OutputContext:
     @public  # type: ignore
     @property
     def asset_key(self) -> AssetKey:
-        """The asset key corresponding to the output asset.
-        
+        """
+        The asset key corresponding to the output asset.
+
         Raises an error if no asset is associated with this output.
         """
         if self._asset_info is None:
@@ -368,7 +369,8 @@ class OutputContext:
     @public  # type: ignore
     @property
     def partition_key(self) -> str:
-        """The partition key for the current run.
+        """
+        The partition key for the current run.
 
         Raises an error if the current run is not a partitioned run.
         """
@@ -407,7 +409,8 @@ class OutputContext:
     @public  # type: ignore
     @property
     def asset_partition_key(self) -> str:
-        """The partition key for output asset.
+        """
+        The partition key for output asset.
 
         Raises an error if the output asset has no partitioning, or if the run covers a partition
         range for the output asset.
@@ -425,7 +428,8 @@ class OutputContext:
     @public  # type: ignore
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
-        """The partition key range for output asset.
+        """
+        The partition key range for output asset.
 
         Raises an error if the output asset has no partitioning.
         """
@@ -442,7 +446,8 @@ class OutputContext:
     @public  # type: ignore
     @property
     def asset_partition_keys(self) -> Sequence[str]:
-        """The partition keys for the output asset.
+        """
+        The partition keys for the output asset.
 
         Raises an error if the output asset has no partitioning.
         """
@@ -461,7 +466,8 @@ class OutputContext:
     @public  # type: ignore
     @property
     def asset_partitions_time_window(self) -> TimeWindow:
-        """The time window for the partitions of the output asset.
+        """
+        The time window for the partitions of the output asset.
 
         Raises an error if either of the following are true:
         - The output asset has no partitioning.
@@ -478,7 +484,8 @@ class OutputContext:
         return self.step_context.asset_partitions_time_window_for_output(self.name)
 
     def get_run_scoped_output_identifier(self) -> Sequence[str]:
-        """Utility method to get a collection of identifiers that as a whole represent a unique
+        """
+        Utility method to get a collection of identifiers that as a whole represent a unique
         step output.
 
         The unique identifier collection consists of
@@ -522,7 +529,8 @@ class OutputContext:
 
     @public
     def get_identifier(self) -> Sequence[str]:
-        """Utility method to get a collection of identifiers that as a whole represent a unique
+        """
+        Utility method to get a collection of identifiers that as a whole represent a unique
         step output.
 
         If not using memoization, the unique identifier collection consists of
@@ -568,9 +576,10 @@ class OutputContext:
 
     @public
     def get_asset_identifier(self) -> Sequence[str]:
-        """Utility method to get a collection of identifiers corresponding to the output asset.
+        """
+        Utility method to get a collection of identifiers corresponding to the output asset.
         The collection consists of a List containing the asset key (unpacked) and the asset partition key.
-        
+
         Raises an error if no asset is associated with this output.
         """
         if self.asset_key is not None:
@@ -593,7 +602,8 @@ class OutputContext:
     def log_event(
         self, event: Union[AssetObservation, AssetMaterialization, Materialization]
     ) -> None:
-        """Log an AssetMaterialization or AssetObservation from within the body of an io manager's `handle_output` method.
+        """
+        Log an AssetMaterialization or AssetObservation from within the body of an io manager's `handle_output` method.
 
         Events logged with this method will appear in the event log.
 
@@ -630,7 +640,8 @@ class OutputContext:
             check.failed("Unexpected event {event}".format(event=event))
 
     def consume_events(self) -> Iterator["DagsterEvent"]:
-        """Pops and yields all user-generated events that have been recorded from this context.
+        """
+        Pops and yields all user-generated events that have been recorded from this context.
 
         If consume_events has not yet been called, this will yield all logged events since the call to `handle_output`. If consume_events has been called, it will yield all events since the last time consume_events was called. Designed for internal use. Users should never need to invoke this method.
         """
@@ -642,7 +653,8 @@ class OutputContext:
     def get_logged_events(
         self,
     ) -> Sequence[Union[AssetMaterialization, Materialization, AssetObservation]]:
-        """Retrieve the list of user-generated events that were logged via the context.
+        """
+        Retrieve the list of user-generated events that were logged via the context.
 
 
         User-generated events that were yielded will not appear in this list.
@@ -670,7 +682,8 @@ class OutputContext:
 
     @public
     def add_output_metadata(self, metadata: Mapping[str, RawMetadataValue]) -> None:
-        """Add a dictionary of metadata to the handled output.
+        """
+        Add a dictionary of metadata to the handled output.
 
         Metadata entries added will show up in the HANDLED_OUTPUT and ASSET_MATERIALIZATION events for the run.
 
@@ -708,7 +721,8 @@ class OutputContext:
     def consume_logged_metadata_entries(
         self,
     ) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
-        """Pops and yields all user-generated metadata entries that have been recorded from this context.
+        """
+        Pops and yields all user-generated metadata entries that have been recorded from this context.
 
         If consume_logged_metadata_entries has not yet been called, this will yield all logged events since the call to `handle_output`. If consume_logged_metadata_entries has been called, it will yield all events since the last time consume_logged_metadata_entries was called. Designed for internal use. Users should never need to invoke this method.
         """
@@ -818,7 +832,8 @@ def build_output_context(
     asset_key: Optional[Union[AssetKey, str]] = None,
     partition_key: Optional[str] = None,
 ) -> "OutputContext":
-    """Builds output context from provided parameters.
+    """
+    Builds output context from provided parameters.
 
     ``build_output_context`` can be used as either a function, or a context manager. If resources
     that are also context managers are provided, then ``build_output_context`` must be used as a
@@ -828,10 +843,10 @@ def build_output_context(
         step_key (Optional[str]): The step_key for the compute step that produced the output.
         name (Optional[str]): The name of the output that produced the output.
         metadata (Optional[Mapping[str, Any]]): A dict of the metadata that is assigned to the
-            OutputDefinition that produced the output.
+            op Out or asset definition that produced the output.
         mapping_key (Optional[str]): The key that identifies a unique mapped output. None for regular outputs.
         config (Optional[Any]): The configuration for the output.
-        dagster_type (Optional[DagsterType]): The type of this output.
+        dagster_type (Optional[DagsterType]): The Dagster type of this output.
         version (Optional[str]): (Experimental) The version of the output.
         resource_config (Optional[Mapping[str, Any]]): The resource config to make available from the
             input context. This usually corresponds to the config provided to the resource that
@@ -841,7 +856,7 @@ def build_output_context(
             definition.
         op_def (Optional[OpDefinition]): The definition of the op that produced the output.
         asset_key: Optional[Union[AssetKey, Sequence[str], str]]: The asset key corresponding to the
-            output.
+            output asset.
         partition_key: Optional[str]: String value representing partition key to execute with.
 
     Examples:

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -52,25 +52,6 @@ class OutputContext:
     `OutputContext` for testing an IO Manager's `handle_output` method, use
     :py:func:`dagster.build_output_context`.
 
-    Attributes:
-        step_key (Optional[str]): The step_key for the compute step that produced the output.
-        name (Optional[str]): The name of the output that produced the output.
-        run_id (Optional[str]): The id of the run that produced the output.
-        metadata (Optional[Mapping[str, RawMetadataValue]]): A dict of the metadata that is assigned to the
-            OutputDefinition that produced the output.
-        mapping_key (Optional[str]): The key that identifies a unique mapped output. None for regular outputs.
-        config (Optional[Any]): The configuration for the output.
-        dagster_type (Optional[DagsterType]): The type of this output.
-        log (Optional[DagsterLogManager]): The log manager to use for this output.
-        version (Optional[str]): (Experimental) The version of the output.
-        resource_config (Optional[Mapping[str, Any]]): The config associated with the resource that
-            initializes the RootInputManager.
-        resources (Optional[Resources]): The resources required by the output manager, specified by the
-            `required_resource_keys` parameter.
-        op_def (Optional[OpDefinition]): The definition of the op that produced the output.
-        asset_info: Optional[AssetOutputInfo]: (Experimental) Asset info corresponding to the
-            output.
-
     Example:
 
     .. code-block:: python
@@ -185,6 +166,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def step_key(self) -> str:
+        """The step_key for the compute step that produced the output."""
         if self._step_key is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access step_key, "
@@ -196,6 +178,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def name(self) -> str:
+        """The name of the output that produced the output."""
         if self._name is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access name, "
@@ -217,6 +200,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def run_id(self) -> str:
+        """The id of the run that produced the output."""
         if self._run_id is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access run_id, "
@@ -228,21 +212,25 @@ class OutputContext:
     @public  # type: ignore
     @property
     def metadata(self) -> Optional[Mapping[str, object]]:
+        """A dict of the metadata that is assigned to the OutputDefinition that produced the output."""
         return self._metadata
 
     @public  # type: ignore
     @property
     def mapping_key(self) -> Optional[str]:
+        """The key that identifies a unique mapped output. None for regular outputs."""
         return self._mapping_key
 
     @public  # type: ignore
     @property
     def config(self) -> Any:
+        """The configuration for the output."""
         return self._config
 
     @public  # type: ignore
     @property
     def op_def(self) -> "OpDefinition":
+        """The definition of the op that produced the output."""
         from dagster._core.definitions import OpDefinition
 
         if self._op_def is None:
@@ -256,6 +244,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def dagster_type(self) -> "DagsterType":
+        """The type of this output."""
         if self._dagster_type is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access dagster_type, "
@@ -267,6 +256,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def log(self) -> "DagsterLogManager":
+        """The log manager to use for this output."""
         if self._log is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access log, "
@@ -278,16 +268,19 @@ class OutputContext:
     @public  # type: ignore
     @property
     def version(self) -> Optional[str]:
+        """(Experimental) The version of the output."""
         return self._version
 
     @public  # type: ignore
     @property
     def resource_config(self) -> Optional[Mapping[str, object]]:
+        """The config associated with the resource that initializes the RootInputManager."""
         return self._resource_config
 
     @public  # type: ignore
     @property
     def resources(self) -> Any:
+        """The resources required by the output manager, specified by the required_resource_keys parameter."""
         if self._resources is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access resources, "
@@ -309,11 +302,16 @@ class OutputContext:
     @public  # type: ignore
     @property
     def has_asset_key(self) -> bool:
+        """Whether an asset is associated with this output."""
         return self._asset_info is not None
 
     @public  # type: ignore
     @property
     def asset_key(self) -> AssetKey:
+        """The asset key corresponding to the output asset.
+        
+        Raises an error if no asset is associated with this output.
+        """
         if self._asset_info is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access asset_key, "
@@ -356,7 +354,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def has_partition_key(self) -> bool:
-        """Whether the current run is a partitioned run"""
+        """Whether the current run is a partitioned run."""
         if self._warn_on_step_context_use:
             warnings.warn(
                 "You are using InputContext.upstream_output.has_partition_key"
@@ -392,6 +390,7 @@ class OutputContext:
     @public  # type: ignore
     @property
     def has_asset_partitions(self) -> bool:
+        """Whether the output asset is a partitioned asset."""
         if self._warn_on_step_context_use:
             warnings.warn(
                 "You are using InputContext.upstream_output.has_asset_partitions"
@@ -569,6 +568,11 @@ class OutputContext:
 
     @public
     def get_asset_identifier(self) -> Sequence[str]:
+        """Utility method to get a collection of identifiers corresponding to the output asset.
+        The collection consists of a List containing the asset key (unpacked) and the asset partition key.
+        
+        Raises an error if no asset is associated with this output.
+        """
         if self.asset_key is not None:
             if self.has_asset_partitions:
                 return [*self.asset_key.path, self.asset_partition_key]


### PR DESCRIPTION
### Summary & Motivation
I've updated the documentation corresponding to the Input/Output Context classes. (#11338)
I have tried to maintain consistency with the descriptions already present.

1) I moved the description of the attributes (next to the class name) to the individual functions as the list of attributes was not complete and they are not attributes but properties.
2) The descriptions I wrote from scratch are the following:
**has_asset_key ([Input](https://github.com/dagster-io/dagster/pull/11376/files#diff-0a168861a69df32b202eb02ec6499fe7061c07f49c4b81337ebe22d06398cd34L280), [Output](https://github.com/dagster-io/dagster/pull/11376/files#diff-95a628854b4354c233ca450502f47561dade557000f85f33e0cc10f86c4c10efL311)), asset_key ([Input](https://github.com/dagster-io/dagster/pull/11376/files#diff-0a168861a69df32b202eb02ec6499fe7061c07f49c4b81337ebe22d06398cd34L285), [Output](https://github.com/dagster-io/dagster/pull/11376/files#diff-95a628854b4354c233ca450502f47561dade557000f85f33e0cc10f86c4c10efL316)), has_asset_partitions ([Input](https://github.com/dagster-io/dagster/pull/11376/files#diff-0a168861a69df32b202eb02ec6499fe7061c07f49c4b81337ebe22d06398cd34L341), [Output](https://github.com/dagster-io/dagster/pull/11376/files#diff-95a628854b4354c233ca450502f47561dade557000f85f33e0cc10f86c4c10efL394)), get_asset_identifier ([Input](https://github.com/dagster-io/dagster/pull/11376/files#diff-0a168861a69df32b202eb02ec6499fe7061c07f49c4b81337ebe22d06398cd34L461), [Output](https://github.com/dagster-io/dagster/pull/11376/files#diff-95a628854b4354c233ca450502f47561dade557000f85f33e0cc10f86c4c10efL571))**
3) The description I like least concerns **has_asset_key**, as I can't understand in which situation the property may return False.
I tried to keep the consistency by taking inspiration from the error coming from the **asset_key** property:

```
raise DagsterInvariantViolationError(
                "Attempting to access asset_key, but no asset is associated with this input"
            )
```

Thank you very much for your support.
I am available in case a change is required.

### How I Tested These Changes
