### PR TITLE
asset backfill core logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -1,0 +1,190 @@
+from collections import defaultdict
+from typing import AbstractSet, Any, Dict, Iterable, Mapping, Optional, Set, Union, cast
+
+from dagster import _check as check
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+
+from .asset_graph import AssetGraph
+from .events import AssetKey, AssetKeyPartitionKey
+
+
+class AssetGraphSubset:
+    def __init__(
+        self,
+        asset_graph: AssetGraph,
+        partitions_subsets_by_asset_key: Optional[Mapping[AssetKey, PartitionsSubset]] = None,
+        non_partitioned_asset_keys: Optional[AbstractSet[AssetKey]] = None,
+    ):
+        self._asset_graph = asset_graph
+        self._partitions_subsets_by_asset_key = partitions_subsets_by_asset_key or {}
+        self._non_partitioned_asset_keys = non_partitioned_asset_keys or set()
+
+    @property
+    def asset_graph(self):
+        return self._asset_graph
+
+    @property
+    def partitions_subsets_by_asset_key(self):
+        return self._partitions_subsets_by_asset_key
+
+    @property
+    def non_partitioned_asset_keys(self):
+        return self._non_partitioned_asset_keys
+
+    @property
+    def asset_keys(self) -> Iterable[AssetKey]:
+        return self.partitions_subsets_by_asset_key.keys() | self._non_partitioned_asset_keys
+
+    @property
+    def num_partitions_and_non_partitioned_assets(self):
+        return len(self._non_partitioned_asset_keys) + sum(
+            len(subset) for subset in self._partitions_subsets_by_asset_key.values()
+        )
+
+    def get_partitions_subset(self, asset_key: AssetKey) -> PartitionsSubset:
+        partitions_def = self.asset_graph.get_partitions_def(asset_key)
+        if partitions_def is None:
+            check.failed("Can only call get_partitions_subset on a partitioned asset")
+
+        return self.partitions_subsets_by_asset_key.get(asset_key, partitions_def.empty_subset())
+
+    def iterate_asset_partitions(self) -> Iterable[AssetKeyPartitionKey]:
+        for asset_key, partitions_subset in self.partitions_subsets_by_asset_key.items():
+            for partition_key in partitions_subset.get_partition_keys():
+                yield AssetKeyPartitionKey(asset_key, partition_key)
+
+        for asset_key in self._non_partitioned_asset_keys:
+            yield AssetKeyPartitionKey(asset_key, None)
+
+    def __contains__(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        if asset_partition.partition_key is None:
+            return asset_partition.asset_key in self._non_partitioned_asset_keys
+        else:
+            partitions_subset = self.partitions_subsets_by_asset_key.get(asset_partition.asset_key)
+            return (
+                partitions_subset is not None and asset_partition.partition_key in partitions_subset
+            )
+
+    def to_storage_dict(self) -> Mapping[str, object]:
+        return {
+            "partitions_subsets_by_asset_key": {
+                key.to_user_string(): value.serialize()
+                for key, value in self.partitions_subsets_by_asset_key.items()
+            },
+            "non_partitioned_asset_keys": {
+                key.to_user_string() for key in self._non_partitioned_asset_keys
+            },
+        }
+
+    def __or__(
+        self, other: Union["AssetGraphSubset", AbstractSet[AssetKeyPartitionKey]]
+    ) -> "AssetGraphSubset":
+        result_partition_subsets_by_asset_key = {**self.partitions_subsets_by_asset_key}
+        result_non_partitioned_asset_keys = set(self._non_partitioned_asset_keys)
+
+        if not isinstance(other, AssetGraphSubset):
+            other = AssetGraphSubset.from_asset_partition_set(other, self.asset_graph)
+
+        for asset_key in other.asset_keys:
+            if asset_key in other.non_partitioned_asset_keys:
+                check.invariant(asset_key not in self.partitions_subsets_by_asset_key)
+                result_non_partitioned_asset_keys.add(asset_key)
+            else:
+                subset = self.get_partitions_subset(asset_key)
+                check.invariant(asset_key not in self.non_partitioned_asset_keys)
+                result_partition_subsets_by_asset_key[asset_key] = subset.with_partition_keys(
+                    other.get_partitions_subset(asset_key).get_partition_keys()
+                )
+
+        return AssetGraphSubset(
+            self.asset_graph,
+            result_partition_subsets_by_asset_key,
+            result_non_partitioned_asset_keys,
+        )
+
+    def filter_asset_keys(self, asset_keys: AbstractSet[AssetKey]) -> "AssetGraphSubset":
+        return AssetGraphSubset(
+            self.asset_graph,
+            {
+                asset_key: subset
+                for asset_key, subset in self.partitions_subsets_by_asset_key.items()
+                if asset_key in asset_keys
+            },
+            self._non_partitioned_asset_keys & asset_keys,
+        )
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, AssetGraphSubset)
+            and self.asset_graph == other.asset_graph
+            and self.partitions_subsets_by_asset_key == other.partitions_subsets_by_asset_key
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "AssetGraphSubset("
+            f"non_partitioned_asset_keys={self.non_partitioned_asset_keys}, "
+            f"partitions_subset_by_asset_key={self.partitions_subsets_by_asset_key}"
+            ")"
+        )
+
+    @classmethod
+    def from_asset_partition_set(
+        cls, asset_partitions_set: AbstractSet[AssetKeyPartitionKey], asset_graph: AssetGraph
+    ) -> "AssetGraphSubset":
+        partitions_by_asset_key = defaultdict(set)
+        non_partitioned_asset_keys = set()
+        for asset_key, partition_key in asset_partitions_set:
+            if partition_key is not None:
+                partitions_by_asset_key[asset_key].add(partition_key)
+            else:
+                non_partitioned_asset_keys.add(asset_key)
+
+        return AssetGraphSubset(
+            partitions_subsets_by_asset_key={
+                asset_key: cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+                .empty_subset()
+                .with_partition_keys(partition_keys)
+                for asset_key, partition_keys in partitions_by_asset_key.items()
+            },
+            non_partitioned_asset_keys=non_partitioned_asset_keys,
+            asset_graph=asset_graph,
+        )
+
+    @classmethod
+    def from_storage_dict(
+        cls, serialized_dict: Mapping[str, Any], asset_graph: AssetGraph
+    ) -> "AssetGraphSubset":
+        partitions_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for key, value in serialized_dict["partitions_subsets_by_asset_key"].items():
+            asset_key = AssetKey.from_user_string(key)
+            partitions_def = cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+            partitions_subsets_by_asset_key[asset_key] = partitions_def.deserialize_subset(value)
+
+        non_partitioned_asset_keys = {
+            AssetKey.from_user_string(key) for key in serialized_dict["non_partitioned_asset_keys"]
+        }
+
+        return AssetGraphSubset(
+            asset_graph, partitions_subsets_by_asset_key, non_partitioned_asset_keys
+        )
+
+    @classmethod
+    def all(cls, asset_graph: AssetGraph) -> "AssetGraphSubset":
+        partitions_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        non_partitioned_asset_keys: Set[AssetKey] = set()
+
+        for asset_key in asset_graph.all_asset_keys:
+            partitions_def = asset_graph.get_partitions_def(asset_key)
+            if partitions_def:
+                partitions_subsets_by_asset_key[
+                    asset_key
+                ] = partitions_def.empty_subset().with_partition_keys(
+                    partitions_def.get_partition_keys()
+                )
+            else:
+                non_partitioned_asset_keys.add(asset_key)
+
+        return AssetGraphSubset(
+            asset_graph, partitions_subsets_by_asset_key, non_partitioned_asset_keys
+        )

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -168,6 +168,9 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
             return AssetKey(asset_key["path"])
         return None
 
+    def to_graphql_input(self) -> Mapping[str, Sequence[str]]:
+        return {"path": self.path}
+
     @staticmethod
     def from_coerceable(arg: "CoercibleToAssetKey") -> "AssetKey":
         if isinstance(arg, AssetKey):

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1,0 +1,265 @@
+import json
+from typing import AbstractSet, Iterable, List, NamedTuple, Optional, Sequence, Set
+
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    build_run_requests,
+    find_parent_materialized_asset_partitions,
+)
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.assets_job import is_base_asset_job_name
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.run_request import RunRequest
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
+from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+
+class AssetBackfillData(NamedTuple):
+    """Has custom serialization instead of standard Dagster NamedTuple serialization because the
+    asset graph is required to build the AssetGraphSubset objects.
+    """
+
+    target_subset: AssetGraphSubset
+    requested_runs_for_target_roots: bool
+    latest_storage_id: Optional[int]
+    materialized_subset: AssetGraphSubset
+    requested_subset: AssetGraphSubset
+    failed_and_downstream_subset: AssetGraphSubset
+
+    def is_complete(self) -> bool:
+        return (
+            (
+                self.requested_subset | self.failed_and_downstream_subset
+            ).num_partitions_and_non_partitioned_assets
+            == self.target_subset.num_partitions_and_non_partitioned_assets
+        )
+
+    def get_target_root_asset_partitions(self) -> Iterable[AssetKeyPartitionKey]:
+        root_asset_keys = (
+            AssetSelection.keys(*self.target_subset.asset_keys)
+            .sources()
+            .resolve(self.target_subset.asset_graph)
+        )
+        return list(
+            self.target_subset.filter_asset_keys(root_asset_keys).iterate_asset_partitions()
+        )
+
+    @classmethod
+    def empty(cls, target_subset: AssetGraphSubset) -> "AssetBackfillData":
+        asset_graph = target_subset.asset_graph
+        return cls(
+            target_subset=target_subset,
+            requested_runs_for_target_roots=False,
+            requested_subset=AssetGraphSubset(asset_graph),
+            materialized_subset=AssetGraphSubset(asset_graph),
+            failed_and_downstream_subset=AssetGraphSubset(asset_graph),
+            latest_storage_id=None,
+        )
+
+    @classmethod
+    def from_serialized(cls, serialized: str, asset_graph: AssetGraph) -> "AssetBackfillData":
+        storage_dict = json.loads(serialized)
+
+        return cls(
+            target_subset=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_target_subset"], asset_graph
+            ),
+            requested_runs_for_target_roots=storage_dict["requested_runs_for_target_roots"],
+            requested_subset=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_requested_subset"], asset_graph
+            ),
+            materialized_subset=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_materialized_subset"], asset_graph
+            ),
+            failed_and_downstream_subset=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_failed_subset"], asset_graph
+            ),
+            latest_storage_id=storage_dict["latest_storage_id"],
+        )
+
+    def serialize(self) -> str:
+        storage_dict = {
+            "requested_runs_for_target_roots": self.requested_runs_for_target_roots,
+            "serialized_target_subset": self.target_subset.to_storage_dict(),
+            "latest_storage_id": self.latest_storage_id,
+            "serialized_requested_subset": self.requested_subset.to_storage_dict(),
+            "serialized_materialized_subset": self.materialized_subset.to_storage_dict(),
+            "serialized_failed_subset": self.failed_and_downstream_subset.to_storage_dict(),
+        }
+        return json.dumps(storage_dict)
+
+
+def _get_implicit_job_name_for_assets(
+    asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
+) -> Optional[str]:
+    job_names = set(asset_graph.get_job_names(asset_keys[0]))
+    for asset_key in asset_keys[1:]:
+        job_names &= set(asset_graph.get_job_names(asset_key))
+
+    return next(job_name for job_name in job_names if is_base_asset_job_name(job_name))
+
+
+class AssetBackfillIterationResult(NamedTuple):
+    run_requests: Sequence[RunRequest]
+    backfill_data: AssetBackfillData
+
+
+def execute_asset_backfill_iteration_inner(
+    backfill_id: str,
+    asset_backfill_data: AssetBackfillData,
+    asset_graph: ExternalAssetGraph,
+    instance: DagsterInstance,
+) -> AssetBackfillIterationResult:
+    """
+    Core logic of a backfill iteration. Has no side effects.
+
+    Computes which runs should be requested, if any, as well as updated bookkeeping about the status
+    of asset partitions targeted by the backfill.
+    """
+    instance_queryer = CachingInstanceQueryer(instance=instance)
+
+    initial_candidates: Set[AssetKeyPartitionKey] = set()
+    request_roots = not asset_backfill_data.requested_runs_for_target_roots
+    if request_roots:
+        initial_candidates.update(asset_backfill_data.get_target_root_asset_partitions())
+
+    (
+        parent_materialized_asset_partitions,
+        next_latest_storage_id,
+    ) = find_parent_materialized_asset_partitions(
+        asset_graph=asset_graph,
+        instance_queryer=instance_queryer,
+        target_asset_selection=AssetSelection.keys(*asset_backfill_data.target_subset.asset_keys),
+        latest_storage_id=asset_backfill_data.latest_storage_id,
+    )
+    initial_candidates.update(parent_materialized_asset_partitions)
+
+    recently_materialized_asset_partitions = AssetGraphSubset(asset_graph)
+    for asset_key in asset_backfill_data.target_subset.asset_keys:
+        records = instance_queryer.get_materialization_records(
+            asset_key=asset_key, after_cursor=asset_backfill_data.latest_storage_id
+        )
+        recently_materialized_asset_partitions |= {
+            AssetKeyPartitionKey(asset_key, record.partition_key) for record in records
+        }
+
+    updated_materialized_asset_partitions = (
+        asset_backfill_data.materialized_subset | recently_materialized_asset_partitions
+    )
+
+    failed_and_downstream_subset = AssetGraphSubset.from_asset_partition_set(
+        asset_graph.bfs_filter_asset_partitions(
+            lambda asset_partitions, _: any(
+                asset_partition in asset_backfill_data.target_subset
+                for asset_partition in asset_partitions
+            ),
+            _get_failed_asset_partitions(instance_queryer, backfill_id),
+        ),
+        asset_graph,
+    )
+
+    asset_partitions_to_request = asset_graph.bfs_filter_asset_partitions(
+        lambda unit, visited: should_backfill_atomic_asset_partitions_unit(
+            candidates_unit=unit,
+            asset_partitions_to_request=visited,
+            asset_graph=asset_graph,
+            materialized_subset=updated_materialized_asset_partitions,
+            target_subset=asset_backfill_data.target_subset,
+            failed_and_downstream_subset=failed_and_downstream_subset,
+        ),
+        initial_asset_partitions=initial_candidates,
+    )
+
+    run_requests = build_run_requests(
+        asset_partitions_to_request, asset_graph, {BACKFILL_ID_TAG: backfill_id}
+    )
+
+    updated_asset_backfill_data = AssetBackfillData(
+        target_subset=asset_backfill_data.target_subset,
+        latest_storage_id=next_latest_storage_id or asset_backfill_data.latest_storage_id,
+        requested_runs_for_target_roots=asset_backfill_data.requested_runs_for_target_roots
+        or request_roots,
+        materialized_subset=updated_materialized_asset_partitions,
+        failed_and_downstream_subset=failed_and_downstream_subset,
+        requested_subset=asset_backfill_data.requested_subset | asset_partitions_to_request,
+    )
+    return AssetBackfillIterationResult(run_requests, updated_asset_backfill_data)
+
+
+def should_backfill_atomic_asset_partitions_unit(
+    asset_graph: ExternalAssetGraph,
+    candidates_unit: Iterable[AssetKeyPartitionKey],
+    asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
+    target_subset: AssetGraphSubset,
+    materialized_subset: AssetGraphSubset,
+    failed_and_downstream_subset: AssetGraphSubset,
+) -> bool:
+    """
+    Args:
+        candidates_unit: A set of asset partitions that must all be materialized if any is
+            materialized.
+    """
+    for candidate in candidates_unit:
+        if (
+            candidate not in target_subset
+            or candidate in failed_and_downstream_subset
+            or candidate in materialized_subset
+        ):
+            return False
+
+        for parent in asset_graph.get_parents_partitions(*candidate):
+            can_run_with_parent = (
+                parent in asset_partitions_to_request
+                and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
+                and parent.partition_key == candidate.partition_key
+                and asset_graph.get_repository_handle(candidate.asset_key)
+                is asset_graph.get_repository_handle(parent.asset_key)
+            )
+
+            if (
+                parent in target_subset
+                and not can_run_with_parent
+                and parent not in materialized_subset
+            ):
+                return False
+
+    return True
+
+
+def _get_failed_asset_partitions(
+    instance_queryer: CachingInstanceQueryer, backfill_id: str
+) -> Sequence[AssetKeyPartitionKey]:
+    """
+    Returns asset partitions that materializations were requested for as part of the backfill, but
+    will not be materialized.
+
+    Includes canceled asset partitions. Implementation assumes that successful runs won't have any
+    failed partitions.
+    """
+    runs = instance_queryer.instance.get_runs(
+        filters=RunsFilter(
+            tags={BACKFILL_ID_TAG: backfill_id},
+            statuses=[DagsterRunStatus.CANCELED, DagsterRunStatus.FAILURE],
+        )
+    )
+
+    result: List[AssetKeyPartitionKey] = []
+
+    for run in runs:
+        partition_key = run.tags.get(PARTITION_NAME_TAG)
+        planned_asset_keys = instance_queryer.get_planned_materializations_for_run(
+            run_id=run.run_id
+        )
+        completed_asset_keys = instance_queryer.get_current_materializations_for_run(
+            run_id=run.run_id
+        )
+        result.extend(
+            AssetKeyPartitionKey(asset_key, partition_key)
+            for asset_key in planned_asset_keys - completed_asset_keys
+        )
+
+    return result

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1,0 +1,253 @@
+from typing import AbstractSet, Mapping, NamedTuple, Optional, Sequence, Set, Union
+from unittest.mock import MagicMock, patch
+
+import pendulum
+import pytest
+from dagster_tests.definitions_tests.test_asset_reconciliation_sensor import (
+    RunSpec,
+    do_run,
+    non_partitioned_after_partitioned,
+    one_asset_one_partition,
+    one_asset_self_dependency,
+    one_asset_two_partitions,
+    partitioned_after_non_partitioned,
+    two_assets_in_sequence_fan_in_partitions,
+    two_assets_in_sequence_fan_out_partitions,
+    two_assets_in_sequence_one_partition,
+    two_assets_in_sequence_two_partitions,
+)
+
+from dagster import (
+    AssetSelection,
+    AssetsDefinition,
+    DagsterInstance,
+    Definitions,
+    RunRequest,
+    SourceAsset,
+)
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.execution.asset_backfill import (
+    AssetBackfillData,
+    execute_asset_backfill_iteration_inner,
+)
+from dagster._core.host_representation.external_data import external_asset_graph_from_defs
+from dagster._seven.compat.pendulum import create_pendulum_time
+
+
+class AssetBackfillScenario(NamedTuple):
+    assets: Sequence[Union[SourceAsset, AssetsDefinition]]
+    unevaluated_runs: Sequence[RunSpec] = []
+    expected_run_requests: Optional[Sequence[RunRequest]] = None
+    expected_iterations: Optional[int] = None
+
+
+assets_by_repo_name_by_scenario_name: Mapping[str, Mapping[str, Sequence[AssetsDefinition]]] = {
+    "one_asset_one_partition": {"repo": one_asset_one_partition},
+    "one_asset_two_partitions": {"repo": one_asset_two_partitions},
+    "two_assets_in_sequence_one_partition": {"repo": two_assets_in_sequence_one_partition},
+    "two_assets_in_sequence_one_partition_cross_repo": {
+        "repo1": [two_assets_in_sequence_one_partition[0]],
+        "repo2": [two_assets_in_sequence_one_partition[1]],
+    },
+    "two_assets_in_sequence_two_partitions": {"repo": two_assets_in_sequence_two_partitions},
+    "two_assets_in_sequence_fan_in_partitions": {"repo": two_assets_in_sequence_fan_in_partitions},
+    "two_assets_in_sequence_fan_out_partitions": {
+        "repo": two_assets_in_sequence_fan_out_partitions
+    },
+    "one_asset_self_dependency": {"repo": one_asset_self_dependency},
+    "non_partitioned_after_partitioned": {"repo": non_partitioned_after_partitioned},
+    "partitioned_after_non_partitioned": {"repo": partitioned_after_non_partitioned},
+}
+
+
+@pytest.mark.parametrize("some_or_all", ["all", "some"])
+@pytest.mark.parametrize("failures", ["no_failures", "root_failures", "random_half_failures"])
+@pytest.mark.parametrize("scenario_name", list(assets_by_repo_name_by_scenario_name.keys()))
+def test_scenario_to_completion(scenario_name: str, failures: str, some_or_all: str):
+    with pendulum.test(create_pendulum_time(year=2020, month=1, day=7, hour=4)):
+        assets_by_repo_name = assets_by_repo_name_by_scenario_name[scenario_name]
+
+        with patch(
+            "dagster._core.host_representation.external_data.get_builtin_partition_mapping_types"
+        ) as get_builtin_partition_mapping_types:
+            get_builtin_partition_mapping_types.return_value = tuple(
+                assets_def.infer_partition_mapping(dep_key).__class__
+                for assets in assets_by_repo_name.values()
+                for assets_def in assets
+                for dep_key in assets_def.dependency_keys
+            )
+            asset_graph = external_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
+
+        asset_keys = asset_graph.all_asset_keys
+        root_asset_keys = AssetSelection.keys(*asset_keys).sources().resolve(asset_graph)
+
+        if some_or_all == "all":
+            target_subset = AssetGraphSubset.all(asset_graph)
+        elif some_or_all == "some":
+            # all partitions downstream of half of the partitions in each partitioned root asset
+            root_asset_partitions: Set[AssetKeyPartitionKey] = set()
+            for i, root_asset_key in enumerate(sorted(root_asset_keys)):
+                partitions_def = asset_graph.get_partitions_def(root_asset_key)
+
+                if partitions_def is not None:
+                    partition_keys = list(partitions_def.get_partition_keys())
+                    start_index = len(partition_keys) // 2
+                    chosen_partition_keys = partition_keys[start_index:]
+                    root_asset_partitions.update(
+                        AssetKeyPartitionKey(root_asset_key, partition_key)
+                        for partition_key in chosen_partition_keys
+                    )
+                else:
+                    if i % 2 == 0:
+                        root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
+
+            target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+                lambda _a, _b: True, root_asset_partitions
+            )
+
+            target_subset = AssetGraphSubset.from_asset_partition_set(
+                target_asset_partitions, asset_graph
+            )
+
+        else:
+            assert False
+
+        if failures == "no_failures":
+            fail_asset_partitions: Set[AssetKeyPartitionKey] = set()
+        elif failures == "root_failures":
+            fail_asset_partitions = set(
+                (target_subset.filter_asset_keys(root_asset_keys)).iterate_asset_partitions()
+            )
+        elif failures == "random_half_failures":
+            fail_asset_partitions = {
+                asset_partition
+                for asset_partition in target_subset.iterate_asset_partitions()
+                if hash(str(asset_partition.asset_key) + str(asset_partition.partition_key)) % 2
+                == 0
+            }
+
+        else:
+            assert False
+
+        backfill = AssetBackfillData.empty(target_subset)
+        run_backfill_to_completion(
+            asset_graph, assets_by_repo_name, "backfillid_x", backfill, fail_asset_partitions
+        )
+
+
+def run_backfill_to_completion(
+    asset_graph: ExternalAssetGraph,
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
+    backfill_id: str,
+    backfill_data: AssetBackfillData,
+    fail_asset_partitions: AbstractSet[AssetKeyPartitionKey],
+) -> None:
+    iteration_count = 0
+    instance = DagsterInstance.ephemeral()
+
+    # assert each asset partition only targeted once
+    requested_asset_partitions: Set[AssetKeyPartitionKey] = set()
+
+    fail_and_downstream_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+        lambda _a, _b: True, fail_asset_partitions
+    )
+
+    while not backfill_data.is_complete():
+        iteration_count += 1
+        result1 = execute_asset_backfill_iteration_inner(
+            backfill_id=backfill_id,
+            asset_backfill_data=backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
+        # iteration_count += 1
+        assert result1.backfill_data != backfill_data
+
+        # if nothing changes, nothing should happen in the iteration
+        result2 = execute_asset_backfill_iteration_inner(
+            backfill_id=backfill_id,
+            asset_backfill_data=result1.backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
+        assert result2.backfill_data == result1.backfill_data
+        assert result2.run_requests == []
+
+        backfill_data = result2.backfill_data
+
+        for asset_partition in backfill_data.materialized_subset.iterate_asset_partitions():
+            assert asset_partition not in fail_and_downstream_asset_partitions
+
+            for parent_asset_partition in asset_graph.get_parents_partitions(*asset_partition):
+                if (
+                    parent_asset_partition in backfill_data.target_subset
+                    and parent_asset_partition not in backfill_data.materialized_subset
+                ):
+                    assert (
+                        False
+                    ), f"{asset_partition} was materialized before its parent {parent_asset_partition},"
+
+        for run_request in result1.run_requests:
+            asset_keys = run_request.asset_selection
+            assert asset_keys is not None
+
+            for asset_key in asset_keys:
+                asset_partition = AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                assert (
+                    asset_partition not in requested_asset_partitions
+                ), f"{asset_partition} requested twice. Requested: {requested_asset_partitions}."
+                requested_asset_partitions.add(asset_partition)
+
+            assert all(
+                asset_graph.get_repository_handle(asset_keys[0])
+                == asset_graph.get_repository_handle(asset_key)
+                for asset_key in asset_keys
+            )
+            assets = assets_by_repo_name[
+                asset_graph.get_repository_handle(asset_keys[0]).repository_name
+            ]
+
+            do_run(
+                all_assets=assets,
+                asset_keys=asset_keys,
+                partition_key=run_request.partition_key,
+                instance=instance,
+                failed_asset_keys=[
+                    asset_key
+                    for asset_key in asset_keys
+                    if AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                    in fail_asset_partitions
+                ],
+                tags=run_request.tags,
+            )
+
+        assert iteration_count <= len(requested_asset_partitions) + 1
+
+    assert (
+        len(requested_asset_partitions | fail_and_downstream_asset_partitions)
+        == backfill_data.target_subset.num_partitions_and_non_partitioned_assets
+    )
+
+
+def external_asset_graph_from_assets_by_repo_name(
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
+) -> ExternalAssetGraph:
+    from_repository_handles_and_external_asset_nodes = []
+
+    for repo_name, assets in assets_by_repo_name.items():
+
+        repo = Definitions(assets=assets).get_repository_def()
+
+        external_asset_nodes = external_asset_graph_from_defs(
+            repo.get_all_pipelines(), source_assets_by_key=repo.source_assets_by_key
+        )
+        repo_handle = MagicMock(repository_name=repo_name)
+        from_repository_handles_and_external_asset_nodes.extend(
+            [(repo_handle, asset_node) for asset_node in external_asset_nodes]
+        )
+
+    return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
+        from_repository_handles_and_external_asset_nodes
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -482,6 +482,17 @@ two_assets_in_sequence_fan_out_partitions = [
 ]
 one_asset_daily_partitions = [asset_def("asset1", partitions_def=daily_partitions_def)]
 
+partitioned_after_non_partitioned = [
+    asset_def("asset1"),
+    asset_def(
+        "asset2", ["asset1"], partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")
+    ),
+]
+non_partitioned_after_partitioned = [
+    asset_def("asset1", partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")),
+    asset_def("asset2", ["asset1"]),
+]
+
 one_asset_self_dependency = [
     asset_def(
         "asset1",


### PR DESCRIPTION
branch-name: asset-backfill-core

### Summary & Motivation

Adds the core logic for pure asset backfills. Gets hooked up to the [daemon](https://github.com/dagster-io/dagster/pull/11378) and [graphql](https://github.com/dagster-io/dagster/pull/11379) in later PRs.

### How I Tested These Changes
