### PR TITLE
handle pure asset backfills in backfill daemon

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/graphql.ts
+++ b/js_modules/dagit/packages/core/src/graphql/graphql.ts
@@ -2000,7 +2000,7 @@ export type PartitionBackfill = {
   partitionSet: Maybe<PartitionSet>;
   partitionSetName: Scalars['String'];
   partitionStatuses: PartitionStatuses;
-  reexecutionSteps: Array<Scalars['String']>;
+  reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
   status: BulkActionStatus;
   timestamp: Scalars['Float'];

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2627,7 +2627,7 @@ type PartitionBackfill {
   numPartitions: Int!
   numCancelable: Int!
   fromFailure: Boolean!
-  reexecutionSteps: [String!]!
+  reexecutionSteps: [String!]
   assetSelection: [AssetKey!]
   partitionSetName: String!
   timestamp: Float!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -96,7 +96,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     numPartitions = graphene.NonNull(graphene.Int)
     numCancelable = graphene.NonNull(graphene.Int)
     fromFailure = graphene.NonNull(graphene.Boolean)
-    reexecutionSteps = non_null_list(graphene.String)
+    reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKey))
     partitionSetName = graphene.NonNull(graphene.String)
     timestamp = graphene.NonNull(graphene.Float)

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -71,9 +71,9 @@ class AssetGraphSubset:
                 key.to_user_string(): value.serialize()
                 for key, value in self.partitions_subsets_by_asset_key.items()
             },
-            "non_partitioned_asset_keys": {
+            "non_partitioned_asset_keys": [
                 key.to_user_string() for key in self._non_partitioned_asset_keys
-            },
+            ],
         }
 
     def __or__(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1,6 +1,17 @@
 import json
-from typing import AbstractSet, Iterable, List, NamedTuple, Optional, Sequence, Set
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    cast,
+)
 
+from dagster import _check as check
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_reconciliation_sensor import (
@@ -11,11 +22,17 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.mode import DEFAULT_MODE_NAME
 from dagster._core.definitions.run_request import RunRequest
+from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG
+from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+if TYPE_CHECKING:
+    from .backfill import PartitionBackfill
 
 
 class AssetBackfillData(NamedTuple):
@@ -93,6 +110,119 @@ class AssetBackfillData(NamedTuple):
         return json.dumps(storage_dict)
 
 
+def execute_asset_backfill_iteration(
+    backfill: "PartitionBackfill", workspace: BaseWorkspaceRequestContext, instance: DagsterInstance
+) -> Iterable[None]:
+    """
+    Runs an iteration of the backfill, including submitting runs and updating the backfill object
+    in the DB.
+
+    This is a generator so that we can return control to the daemon and let it heartbeat during
+    expensive operations.
+    """
+    from dagster._core.execution.backfill import BulkActionStatus
+
+    asset_graph = ExternalAssetGraph.from_workspace_request_context(workspace)
+    if backfill.serialized_asset_backfill_data is None:
+        check.failed("Asset backfill missing serialized_asset_backfill_data")
+
+    asset_backfill_data = AssetBackfillData.from_serialized(
+        backfill.serialized_asset_backfill_data, asset_graph
+    )
+
+    result = None
+    for result in execute_asset_backfill_iteration_inner(
+        backfill_id=backfill.backfill_id,
+        asset_backfill_data=asset_backfill_data,
+        instance=instance,
+        asset_graph=asset_graph,
+    ):
+        yield None
+
+    if not isinstance(result, AssetBackfillIterationResult):
+        check.failed(
+            "Expected execute_asset_backfill_iteration_inner to return an AssetBackfillIterationResult"
+        )
+
+    updated_backfill = backfill.with_asset_backfill_data(result.backfill_data)
+    if result.backfill_data.is_complete():
+        updated_backfill = updated_backfill.with_status(BulkActionStatus.COMPLETED)
+
+    for run_request in result.run_requests:
+        yield None
+        submit_run_request(
+            run_request=run_request, asset_graph=asset_graph, workspace=workspace, instance=instance
+        )
+
+    instance.update_backfill(updated_backfill)
+
+
+def submit_run_request(
+    asset_graph: ExternalAssetGraph,
+    run_request: RunRequest,
+    instance: DagsterInstance,
+    workspace: BaseWorkspaceRequestContext,
+) -> None:
+    """
+    Creates and submits a run for the given run request
+    """
+    repo_handle = asset_graph.get_repository_handle(
+        cast(Sequence[AssetKey], run_request.asset_selection)[0]
+    )
+    location_name = repo_handle.repository_location_origin.location_name
+    repo_location = workspace.get_repository_location(
+        repo_handle.repository_location_origin.location_name
+    )
+    job_name = _get_implicit_job_name_for_assets(
+        asset_graph, cast(Sequence[AssetKey], run_request.asset_selection)
+    )
+    if job_name is None:
+        check.failed(
+            f"Could not find an implicit asset job for the given assets: {run_request.asset_selection}"
+        )
+    pipeline_selector = PipelineSelector(
+        location_name=location_name,
+        repository_name=repo_handle.repository_name,
+        pipeline_name=job_name,
+        asset_selection=run_request.asset_selection,
+        solid_selection=None,
+    )
+    external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
+
+    external_execution_plan = repo_location.get_external_execution_plan(
+        external_pipeline,
+        {},
+        DEFAULT_MODE_NAME,
+        step_keys_to_execute=None,
+        known_state=None,
+        instance=instance,
+    )
+
+    if not run_request.asset_selection:
+        check.failed("Expected RunRequest to have an asset selection")
+
+    run = instance.create_run(
+        pipeline_snapshot=external_pipeline.pipeline_snapshot,
+        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
+        pipeline_name=external_pipeline.name,
+        run_id=None,
+        solids_to_execute=None,
+        run_config={},
+        mode=DEFAULT_MODE_NAME,
+        step_keys_to_execute=None,
+        tags=run_request.tags,
+        root_run_id=None,
+        parent_run_id=None,
+        status=DagsterRunStatus.NOT_STARTED,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+        asset_selection=frozenset(run_request.asset_selection),
+    )
+
+    instance.submit_run(run.run_id, workspace)
+
+
 def _get_implicit_job_name_for_assets(
     asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
 ) -> Optional[str]:
@@ -113,12 +243,15 @@ def execute_asset_backfill_iteration_inner(
     asset_backfill_data: AssetBackfillData,
     asset_graph: ExternalAssetGraph,
     instance: DagsterInstance,
-) -> AssetBackfillIterationResult:
+) -> Iterable[Optional[AssetBackfillIterationResult]]:
     """
     Core logic of a backfill iteration. Has no side effects.
 
     Computes which runs should be requested, if any, as well as updated bookkeeping about the status
     of asset partitions targeted by the backfill.
+
+    This is a generator so that we can return control to the daemon and let it heartbeat during
+    expensive operations.
     """
     instance_queryer = CachingInstanceQueryer(instance=instance)
 
@@ -138,6 +271,8 @@ def execute_asset_backfill_iteration_inner(
     )
     initial_candidates.update(parent_materialized_asset_partitions)
 
+    yield None
+
     recently_materialized_asset_partitions = AssetGraphSubset(asset_graph)
     for asset_key in asset_backfill_data.target_subset.asset_keys:
         records = instance_queryer.get_materialization_records(
@@ -146,6 +281,8 @@ def execute_asset_backfill_iteration_inner(
         recently_materialized_asset_partitions |= {
             AssetKeyPartitionKey(asset_key, record.partition_key) for record in records
         }
+
+        yield None
 
     updated_materialized_asset_partitions = (
         asset_backfill_data.materialized_subset | recently_materialized_asset_partitions
@@ -161,6 +298,8 @@ def execute_asset_backfill_iteration_inner(
         ),
         asset_graph,
     )
+
+    yield None
 
     asset_partitions_to_request = asset_graph.bfs_filter_asset_partitions(
         lambda unit, visited: should_backfill_atomic_asset_partitions_unit(
@@ -187,7 +326,7 @@ def execute_asset_backfill_iteration_inner(
         failed_and_downstream_subset=failed_and_downstream_subset,
         requested_subset=asset_backfill_data.requested_subset | asset_partitions_to_request,
     )
-    return AssetBackfillIterationResult(run_requests, updated_asset_backfill_data)
+    yield AssetBackfillIterationResult(run_requests, updated_asset_backfill_data)
 
 
 def should_backfill_atomic_asset_partitions_unit(

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,11 +1,17 @@
 from enum import Enum
-from typing import Mapping, NamedTuple, Optional, Sequence
+from typing import Dict, Mapping, NamedTuple, Optional, Sequence, Set
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
+
+from .asset_backfill import AssetBackfillData
 
 
 @whitelist_for_serdes
@@ -37,6 +43,8 @@ class PartitionBackfill(
             ("partition_names", Optional[Sequence[str]]),
             ("last_submitted_partition_name", Optional[str]),
             ("reexecution_steps", Optional[Sequence[str]]),
+            # only used by asset backfills
+            ("serialized_asset_backfill_data", Optional[str]),
         ],
     ),
 ):
@@ -53,11 +61,19 @@ class PartitionBackfill(
         partition_names: Optional[Sequence[str]] = None,
         last_submitted_partition_name: Optional[str] = None,
         reexecution_steps: Optional[Sequence[str]] = None,
+        serialized_asset_backfill_data: Optional[str] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
             "Can't supply both an asset_selection and reexecution_steps to a PartitionBackfill.",
         )
+
+        if serialized_asset_backfill_data is not None:
+            check.invariant(partition_set_origin is None)
+            check.invariant(partition_names is None)
+            check.invariant(last_submitted_partition_name is None)
+            check.invariant(reexecution_steps is None)
+
         return super(PartitionBackfill, cls).__new__(
             cls,
             check.str_param(backfill_id, "backfill_id"),
@@ -66,18 +82,30 @@ class PartitionBackfill(
             check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
             check.float_param(backfill_timestamp, "backfill_timestamp"),
             check.opt_inst_param(error, "error", SerializableErrorInfo),
-            check.opt_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
+            check.opt_nullable_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
             check.opt_inst_param(
                 partition_set_origin, "partition_set_origin", ExternalPartitionSetOrigin
             ),
-            check.opt_sequence_param(partition_names, "partition_names", of_type=str),
+            check.opt_nullable_sequence_param(partition_names, "partition_names", of_type=str),
             check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
-            check.opt_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
+            check.opt_nullable_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
+            check.opt_str_param(serialized_asset_backfill_data, "serialized_asset_backfill_data"),
         )
 
     @property
     def selector_id(self):
         return self.partition_set_origin.get_selector_id() if self.partition_set_origin else None
+
+    @property
+    def is_asset_backfill(self) -> bool:
+        return self.serialized_asset_backfill_data is not None
+
+    @property
+    def bulk_action_type(self) -> BulkActionType:
+        if self.is_asset_backfill:
+            return BulkActionType.MULTI_RUN_ASSET_ACTION
+        else:
+            return BulkActionType.PARTITION_BACKFILL
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)
@@ -93,6 +121,7 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
         )
 
     def with_partition_checkpoint(self, last_submitted_partition_name):
@@ -109,6 +138,7 @@ class PartitionBackfill(
             last_submitted_partition_name=last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
         )
 
     def with_error(self, error):
@@ -125,4 +155,58 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
+        )
+
+    def with_asset_backfill_data(
+        self, asset_backfill_data: AssetBackfillData
+    ) -> "PartitionBackfill":
+        return PartitionBackfill(
+            status=self.status,
+            backfill_id=self.backfill_id,
+            partition_set_origin=self.partition_set_origin,
+            partition_names=self.partition_names,
+            from_failure=self.from_failure,
+            reexecution_steps=self.reexecution_steps,
+            tags=self.tags,
+            backfill_timestamp=self.backfill_timestamp,
+            last_submitted_partition_name=self.last_submitted_partition_name,
+            error=self.error,
+            asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=asset_backfill_data.serialize(),
+        )
+
+    @classmethod
+    def from_asset_partitions(
+        cls,
+        backfill_id: str,
+        asset_graph: AssetGraph,
+        partition_names: Sequence[str],
+        asset_selection: Sequence[AssetKey],
+        backfill_timestamp: float,
+        tags: Mapping[str, str],
+    ) -> "PartitionBackfill":
+        target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        non_partitioned_asset_keys: Set[AssetKey] = set()
+        for asset_key in asset_selection:
+            partitions_def = asset_graph.get_partitions_def(asset_key)
+            if partitions_def:
+                target_subsets_by_asset_key[
+                    asset_key
+                ] = partitions_def.empty_subset().with_partition_keys(partition_names)
+            else:
+                non_partitioned_asset_keys.add(asset_key)
+
+        return cls(
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            from_failure=False,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+            serialized_asset_backfill_data=AssetBackfillData.empty(
+                AssetGraphSubset(
+                    asset_graph, target_subsets_by_asset_key, non_partitioned_asset_keys
+                )
+            ).serialize(),
         )

--- a/python_modules/dagster/dagster/_core/execution/bulk_actions.py
+++ b/python_modules/dagster/dagster/_core/execution/bulk_actions.py
@@ -6,3 +6,4 @@ from dagster._serdes import whitelist_for_serdes
 @whitelist_for_serdes
 class BulkActionType(Enum):
     PARTITION_BACKFILL = "PARTITION_BACKFILL"
+    MULTI_RUN_ASSET_ACTION = "MULTI_RUN_ASSET_ACTION"

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -6,7 +6,6 @@ from tqdm import tqdm
 import dagster._check as check
 from dagster._serdes import deserialize_as
 
-from ...execution.bulk_actions import BulkActionType
 from ...execution.job_backfill import PartitionBackfill
 from ..pipeline_run import DagsterRun, DagsterRunStatus
 from ..runs.base import RunStorage
@@ -248,7 +247,7 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn=None):
                     BulkActionsTable.update()
                     .values(
                         selector_id=backfill.selector_id,
-                        action_type=BulkActionType.PARTITION_BACKFILL.value,
+                        action_type=backfill.bulk_action_type.value,
                     )
                     .where(BulkActionsTable.c.id == storage_id)
                 )

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -33,7 +33,6 @@ from dagster._core.errors import (
 )
 from dagster._core.events import EVENT_TYPE_TO_PIPELINE_RUN_STATUS, DagsterEvent, DagsterEventType
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPipelineOrigin
 from dagster._core.snap import (
     ExecutionPlanSnapshot,
@@ -1091,7 +1090,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         if self.has_bulk_actions_selector_cols():
             values["selector_id"] = partition_backfill.selector_id
-            values["action_type"] = BulkActionType.PARTITION_BACKFILL.value
+            values["action_type"] = partition_backfill.bulk_action_type.value
 
         with self.connect() as conn:
             conn.execute(

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,10 +1,12 @@
 import logging
+import sys
 from typing import Iterable, Mapping, Optional, cast
 
+from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._utils.error import SerializableErrorInfo
+from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 
 def execute_backfill_iteration(
@@ -27,6 +29,17 @@ def execute_backfill_iteration(
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-        yield from execute_job_backfill_iteration(
-            backfill, logger, workspace, debug_crash_flags, instance
-        )
+        try:
+            if backfill.is_asset_backfill:
+                yield from execute_asset_backfill_iteration(backfill, workspace, instance)
+            else:
+                yield from execute_job_backfill_iteration(
+                    backfill, logger, workspace, debug_crash_flags, instance
+                )
+        except Exception:
+            error_info = serializable_error_info_from_exc_info(sys.exc_info())
+            instance.update_backfill(
+                backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
+            )
+            logger.error(f"Backfill failed for {backfill.backfill_id}: {error_info.to_string()}")
+            yield error_info

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -24,6 +24,7 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions import Partition, PartitionSetDefinition, StaticPartitionsDefinition
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.execution.api import execute_pipeline
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.host_representation import (
@@ -669,6 +670,53 @@ def test_backfill_with_asset_selection(instance, workspace_context, external_rep
     # not selected
     for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
         assert len(instance.run_ids_for_asset_key(asset_key)) == 0
+
+
+def test_pure_asset_backfill(instance, workspace_context, external_repo):
+    del external_repo
+
+    partition_name_list = [partition.name for partition in static_partitions.get_partitions()]
+    asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
+    instance.add_backfill(
+        PartitionBackfill.from_asset_partitions(
+            asset_graph=ExternalAssetGraph.from_workspace_request_context(
+                workspace_context.create_request_context()
+            ),
+            backfill_id="backfill_with_asset_selection",
+            tags={},
+            backfill_timestamp=pendulum.now().timestamp(),
+            asset_selection=asset_selection,
+            partition_names=partition_name_list,
+        )
+    )
+    assert instance.get_runs_count() == 0
+    assert (
+        instance.get_backfill("backfill_with_asset_selection").status == BulkActionStatus.REQUESTED
+    )
+
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    assert instance.get_runs_count() == 3
+    wait_for_all_runs_to_start(instance, timeout=30)
+    assert instance.get_runs_count() == 3
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    assert instance.get_runs_count() == 3
+    runs = reversed(instance.get_runs())
+    for run in runs:
+        assert run.tags[BACKFILL_ID_TAG] == "backfill_with_asset_selection"
+        assert step_succeeded(instance, run, "foo")
+        assert step_succeeded(instance, run, "reusable")
+        assert step_succeeded(instance, run, "bar")
+    # selected
+    for asset_key in asset_selection:
+        assert len(instance.run_ids_for_asset_key(asset_key)) == 3
+    # not selected
+    for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
+        assert len(instance.run_ids_for_asset_key(asset_key)) == 0
+
+    assert (
+        instance.get_backfill("backfill_with_asset_selection").status == BulkActionStatus.COMPLETED
+    )
 
 
 def test_backfill_from_failure_for_subselection(instance, workspace_context, external_repo):


### PR DESCRIPTION
branch-name: asset-backfill-daemon

### Summary & Motivation

Makes the backfill daemon handle pure asset backfills. Wraps the core asset backfill logic in that's implemented in https://github.com/dagster-io/dagster/pull/11377.

### How I Tested These Changes

- Added tests
- With the graphql changes in https://github.com/dagster-io/dagster/pull/11377, launched backfills manually
