### PR TITLE
graphql for pure asset backfills

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/graphql.ts
+++ b/js_modules/dagit/packages/core/src/graphql/graphql.ts
@@ -1594,7 +1594,7 @@ export type LaunchBackfillParams = {
   fromFailure?: InputMaybe<Scalars['Boolean']>;
   partitionNames?: InputMaybe<Array<Scalars['String']>>;
   reexecutionSteps?: InputMaybe<Array<Scalars['String']>>;
-  selector: PartitionSetSelector;
+  selector?: InputMaybe<PartitionSetSelector>;
   tags?: InputMaybe<Array<ExecutionTag>>;
 };
 
@@ -1998,7 +1998,7 @@ export type PartitionBackfill = {
   numPartitions: Scalars['Int'];
   partitionNames: Array<Scalars['String']>;
   partitionSet: Maybe<PartitionSet>;
-  partitionSetName: Scalars['String'];
+  partitionSetName: Maybe<Scalars['String']>;
   partitionStatuses: PartitionStatuses;
   reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
@@ -3675,7 +3675,7 @@ export type LaunchAssetCheckUpstreamQueryQuery = { __typename: 'DagitQuery', ass
 export type RunningBackfillsNoticeQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type RunningBackfillsNoticeQueryQuery = { __typename: 'DagitQuery', partitionBackfillsOrError: { __typename: 'PartitionBackfills', results: Array<{ __typename: 'PartitionBackfill', partitionSetName: string, backfillId: string }> } | { __typename: 'PythonError' } };
+export type RunningBackfillsNoticeQueryQuery = { __typename: 'DagitQuery', partitionBackfillsOrError: { __typename: 'PartitionBackfills', results: Array<{ __typename: 'PartitionBackfill', partitionSetName: string | null, backfillId: string }> } | { __typename: 'PythonError' } };
 
 export type PartitionHealthQueryQueryVariables = Exact<{
   assetKey: AssetKeyInput;
@@ -3789,7 +3789,7 @@ export type SingleBackfillQueryQuery = { __typename: 'DagitQuery', partitionBack
 
 export type PartitionStatusesForBackfillFragment = { __typename: 'PartitionStatuses', results: Array<{ __typename: 'PartitionStatus', id: string, partitionName: string, runId: string | null, runStatus: RunStatus | null }> };
 
-export type BackfillTableFragmentFragment = { __typename: 'PartitionBackfill', backfillId: string, status: BulkActionStatus, numCancelable: number, partitionNames: Array<string>, numPartitions: number, timestamp: number, partitionSetName: string, partitionSet: { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } } | null, assetSelection: Array<{ __typename: 'AssetKey', path: Array<string> }> | null, error: { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } | null };
+export type BackfillTableFragmentFragment = { __typename: 'PartitionBackfill', backfillId: string, status: BulkActionStatus, numCancelable: number, partitionNames: Array<string>, numPartitions: number, timestamp: number, partitionSetName: string | null, partitionSet: { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } } | null, assetSelection: Array<{ __typename: 'AssetKey', path: Array<string> }> | null, error: { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } | null };
 
 export type PartitionSetForBackfillTableFragment = { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } };
 
@@ -3829,7 +3829,7 @@ export type InstanceBackfillsQueryQueryVariables = Exact<{
 }>;
 
 
-export type InstanceBackfillsQueryQuery = { __typename: 'DagitQuery', partitionBackfillsOrError: { __typename: 'PartitionBackfills', results: Array<{ __typename: 'PartitionBackfill', backfillId: string, status: BulkActionStatus, numPartitions: number, timestamp: number, partitionSetName: string, numCancelable: number, partitionNames: Array<string>, partitionSet: { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } } | null, error: { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } | null, assetSelection: Array<{ __typename: 'AssetKey', path: Array<string> }> | null }> } | { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } };
+export type InstanceBackfillsQueryQuery = { __typename: 'DagitQuery', partitionBackfillsOrError: { __typename: 'PartitionBackfills', results: Array<{ __typename: 'PartitionBackfill', backfillId: string, status: BulkActionStatus, numPartitions: number, timestamp: number, partitionSetName: string | null, numCancelable: number, partitionNames: Array<string>, partitionSet: { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } } | null, error: { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } | null, assetSelection: Array<{ __typename: 'AssetKey', path: Array<string> }> | null }> } | { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } };
 
 export type InstanceConfigQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4185,7 +4185,7 @@ export type JobBackfillsQueryQueryVariables = Exact<{
 }>;
 
 
-export type JobBackfillsQueryQuery = { __typename: 'DagitQuery', partitionSetOrError: { __typename: 'PartitionSet', id: string, pipelineName: string, backfills: Array<{ __typename: 'PartitionBackfill', backfillId: string, status: BulkActionStatus, numCancelable: number, partitionNames: Array<string>, numPartitions: number, timestamp: number, partitionSetName: string, partitionSet: { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } } | null, assetSelection: Array<{ __typename: 'AssetKey', path: Array<string> }> | null, error: { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } | null }> } | { __typename: 'PartitionSetNotFoundError' } | { __typename: 'PythonError' } };
+export type JobBackfillsQueryQuery = { __typename: 'DagitQuery', partitionSetOrError: { __typename: 'PartitionSet', id: string, pipelineName: string, backfills: Array<{ __typename: 'PartitionBackfill', backfillId: string, status: BulkActionStatus, numCancelable: number, partitionNames: Array<string>, numPartitions: number, timestamp: number, partitionSetName: string | null, partitionSet: { __typename: 'PartitionSet', id: string, name: string, mode: string, pipelineName: string, repositoryOrigin: { __typename: 'RepositoryOrigin', id: string, repositoryName: string, repositoryLocationName: string } } | null, assetSelection: Array<{ __typename: 'AssetKey', path: Array<string> }> | null, error: { __typename: 'PythonError', message: string, stack: Array<string>, errorChain: Array<{ __typename: 'ErrorChainLink', isExplicitLink: boolean, error: { __typename: 'PythonError', message: string, stack: Array<string> } }> } | null }> } | { __typename: 'PartitionSetNotFoundError' } | { __typename: 'PythonError' } };
 
 export type PartitionsStatusQueryQueryVariables = Exact<{
   partitionSetName: Scalars['String'];

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2248,7 +2248,7 @@ input MarshalledOutput {
 }
 
 input LaunchBackfillParams {
-  selector: PartitionSetSelector!
+  selector: PartitionSetSelector
   partitionNames: [String!]
   reexecutionSteps: [String!]
   assetSelection: [AssetKeyInput!]
@@ -2629,7 +2629,7 @@ type PartitionBackfill {
   fromFailure: Boolean!
   reexecutionSteps: [String!]
   assetSelection: [AssetKey!]
-  partitionSetName: String!
+  partitionSetName: String
   timestamp: Float!
   partitionSet: PartitionSet
   runs(limit: Int): [Run!]!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -1,6 +1,9 @@
+from typing import TYPE_CHECKING, Any, List, Mapping, Union, cast
+
 import pendulum
 
 import dagster._check as check
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.errors import DagsterError
 from dagster._core.events import AssetKey
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -13,85 +16,124 @@ from ..utils import capture_error
 BACKFILL_CHUNK_SIZE = 25
 
 
-@capture_error
-def create_and_launch_partition_backfill(graphene_info, backfill_params):
+if TYPE_CHECKING:
     from ...schema.backfill import GrapheneLaunchBackfillSuccess
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
-    partition_set_selector = backfill_params.get("selector")
-    partition_set_name = partition_set_selector.get("partitionSetName")
-    repository_selector = RepositorySelector.from_graphql_input(
-        partition_set_selector.get("repositorySelector")
-    )
-    location = graphene_info.context.get_repository_location(repository_selector.location_name)
-    repository = location.get_repository(repository_selector.repository_name)
-    matches = [
-        partition_set
-        for partition_set in repository.get_external_partition_sets()
-        if partition_set.name == partition_set_selector.get("partitionSetName")
-    ]
-    if not matches:
-        return GraphenePartitionSetNotFoundError(partition_set_name)
 
-    check.invariant(
-        len(matches) == 1,
-        "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
-            num=len(matches), partition_set_name=partition_set_name
-        ),
-    )
-
-    external_partition_set = next(iter(matches))
-
-    if backfill_params.get("allPartitions"):
-        result = graphene_info.context.get_external_partition_names(external_partition_set)
-        partition_names = result.partition_names
-    elif backfill_params.get("partitionNames"):
-        partition_names = backfill_params.get("partitionNames")
-    else:
-        raise DagsterError(
-            'Backfill requested without specifying either "allPartitions" or "partitionNames" '
-            "arguments"
-        )
+@capture_error
+def create_and_launch_partition_backfill(
+    graphene_info, backfill_params: Mapping[str, Any]
+) -> Union["GrapheneLaunchBackfillSuccess", "GraphenePartitionSetNotFoundError"]:
+    from ...schema.backfill import GrapheneLaunchBackfillSuccess
+    from ...schema.errors import GraphenePartitionSetNotFoundError
 
     backfill_id = make_new_backfill_id()
-    backfill = PartitionBackfill(
-        backfill_id=backfill_id,
-        partition_set_origin=external_partition_set.get_external_origin(),
-        status=BulkActionStatus.REQUESTED,
-        partition_names=partition_names,
-        from_failure=bool(backfill_params.get("fromFailure")),
-        reexecution_steps=backfill_params.get("reexecutionSteps"),
-        tags={t["key"]: t["value"] for t in backfill_params.get("tags", [])},
-        backfill_timestamp=pendulum.now("UTC").timestamp(),
-        asset_selection=[
-            AssetKey.from_graphql_input(asset_key)
-            for asset_key in backfill_params.get("assetSelection")
+
+    asset_selection = (
+        [
+            cast(AssetKey, AssetKey.from_graphql_input(asset_key))
+            for asset_key in backfill_params["assetSelection"]
         ]
         if backfill_params.get("assetSelection")
-        else None,
+        else None
     )
 
-    if backfill_params.get("forceSynchronousSubmission"):
-        # should only be used in a test situation
-        to_submit = [name for name in partition_names]
-        submitted_run_ids = []
+    tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
+    backfill_timestamp = pendulum.now("UTC").timestamp()
 
-        while to_submit:
-            chunk = to_submit[:BACKFILL_CHUNK_SIZE]
-            to_submit = to_submit[BACKFILL_CHUNK_SIZE:]
-            submitted_run_ids.extend(
-                run_id
-                for run_id in submit_backfill_runs(
-                    graphene_info.context.instance,
-                    workspace=graphene_info.context,
-                    repo_location=location,
-                    backfill_job=backfill,
-                    partition_names=chunk,
-                )
-                if run_id != None
+    if backfill_params.get("selector") is not None:  # job backfill
+        partition_set_selector = backfill_params["selector"]
+        partition_set_name = partition_set_selector.get("partitionSetName")
+        repository_selector = RepositorySelector.from_graphql_input(
+            partition_set_selector.get("repositorySelector")
+        )
+        location = graphene_info.context.get_repository_location(repository_selector.location_name)
+        repository = location.get_repository(repository_selector.repository_name)
+        matches = [
+            partition_set
+            for partition_set in repository.get_external_partition_sets()
+            if partition_set.name == partition_set_selector.get("partitionSetName")
+        ]
+        if not matches:
+            return GraphenePartitionSetNotFoundError(partition_set_name)
+
+        check.invariant(
+            len(matches) == 1,
+            "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
+                num=len(matches), partition_set_name=partition_set_name
+            ),
+        )
+        external_partition_set = next(iter(matches))
+
+        if backfill_params.get("allPartitions"):
+            result = graphene_info.context.get_external_partition_names(external_partition_set)
+            partition_names = result.partition_names
+        elif backfill_params.get("partitionNames"):
+            partition_names = backfill_params["partitionNames"]
+        else:
+            raise DagsterError(
+                'Backfill requested without specifying either "allPartitions" or "partitionNames" '
+                "arguments"
             )
-        return GrapheneLaunchBackfillSuccess(
-            backfill_id=backfill_id, launched_run_ids=submitted_run_ids
+
+        backfill = PartitionBackfill(
+            backfill_id=backfill_id,
+            partition_set_origin=external_partition_set.get_external_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=partition_names,
+            from_failure=bool(backfill_params.get("fromFailure")),
+            reexecution_steps=backfill_params.get("reexecutionSteps"),
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+        )
+
+        if backfill_params.get("forceSynchronousSubmission"):
+            # should only be used in a test situation
+            to_submit = [name for name in partition_names]
+            submitted_run_ids: List[str] = []
+
+            while to_submit:
+                chunk = to_submit[:BACKFILL_CHUNK_SIZE]
+                to_submit = to_submit[BACKFILL_CHUNK_SIZE:]
+                submitted_run_ids.extend(
+                    run_id
+                    for run_id in submit_backfill_runs(
+                        graphene_info.context.instance,
+                        workspace=graphene_info.context,
+                        repo_location=location,
+                        backfill_job=backfill,
+                        partition_names=chunk,
+                    )
+                    if run_id is not None
+                )
+            return GrapheneLaunchBackfillSuccess(
+                backfill_id=backfill_id, launched_run_ids=submitted_run_ids
+            )
+    elif asset_selection is not None:  # pure asset backfill
+        if backfill_params.get("forceSynchronousSubmission"):
+            raise DagsterError(
+                "forceSynchronousSubmission is not supported for pure asset backfills"
+            )
+
+        if backfill_params.get("fromFailure"):
+            raise DagsterError("fromFailure is not supported for pure asset backfills")
+
+        if backfill_params.get("allPartitions"):
+            raise DagsterError("allPartitions is not supported for pure asset backfills")
+
+        backfill = PartitionBackfill.from_asset_partitions(
+            asset_graph=ExternalAssetGraph.from_workspace(graphene_info.context),
+            backfill_id=backfill_id,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+            partition_names=backfill_params["partitionNames"],
+        )
+    else:
+        raise DagsterError(
+            "Backfill requested without specifying partition set selector or asset selection"
         )
 
     graphene_info.context.instance.add_backfill(backfill)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from graphene import ResolveInfo
 
 import dagster._check as check
@@ -196,7 +198,7 @@ def get_partition_set_partition_statuses(graphene_info, external_partition_set):
 
 
 def partition_statuses_from_run_partition_data(
-    partition_set_name, run_partition_data, partition_names, backfill_id=None
+    partition_set_name: Optional[str], run_partition_data, partition_names, backfill_id=None
 ):
     from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
 
@@ -208,7 +210,7 @@ def partition_statuses_from_run_partition_data(
 
     results = []
     for name in partition_names:
-        partition_id = f"{partition_set_name}:{name}{suffix}"
+        partition_id = f'{partition_set_name or "__NO_PARTITION_SET__"}:{name}{suffix}'
         if not partition_data_by_name.get(name):
             results.append(
                 GraphenePartitionStatus(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -1,7 +1,7 @@
 import graphene
 
 import dagster._check as check
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 
@@ -98,7 +98,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     fromFailure = graphene.NonNull(graphene.Boolean)
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.List(graphene.NonNull(GrapheneAssetKey))
-    partitionSetName = graphene.NonNull(graphene.String)
+    partitionSetName = graphene.Field(graphene.String)
     timestamp = graphene.NonNull(graphene.Float)
     partitionSet = graphene.Field("dagster_graphql.schema.partition_sets.GraphenePartitionSet")
     runs = graphene.Field(
@@ -122,16 +122,18 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
         super().__init__(
             backfillId=backfill_job.backfill_id,
-            partitionSetName=backfill_job.partition_set_origin.partition_set_name,
+            partitionSetName=backfill_job.partition_set_name,
             status=backfill_job.status.value,
             fromFailure=bool(backfill_job.from_failure),
             reexecutionSteps=backfill_job.reexecution_steps,
-            partitionNames=backfill_job.partition_names,
             timestamp=backfill_job.backfill_timestamp,
             assetSelection=backfill_job.asset_selection,
         )
 
     def _get_partition_set(self, graphene_info):
+        if self._backfill_job.partition_set_origin is None:
+            return None
+
         origin = self._backfill_job.partition_set_origin
         location_name = origin.external_repository_origin.repository_location_origin.location_name
         repository_name = origin.external_repository_origin.repository_name
@@ -186,21 +188,14 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         records = self._get_records(graphene_info)
         return [GrapheneRun(record) for record in records]
 
+    def resolve_partitionNames(self, _graphene_info):
+        return self._backfill_job.get_partition_names(_graphene_info.context)
+
     def resolve_numPartitions(self, _graphene_info):
-        return len(self._backfill_job.partition_names)
+        return self._backfill_job.get_num_partitions(_graphene_info.context)
 
     def resolve_numCancelable(self, _graphene_info):
-        if self._backfill_job.status != BulkActionStatus.REQUESTED:
-            return 0
-
-        checkpoint = self._backfill_job.last_submitted_partition_name
-        total_count = len(self._backfill_job.partition_names)
-        checkpoint_idx = (
-            self._backfill_job.partition_names.index(checkpoint) + 1
-            if checkpoint and checkpoint in self._backfill_job.partition_names
-            else 0
-        )
-        return max(0, total_count - checkpoint_idx)
+        return self._backfill_job.get_num_cancelable()
 
     def resolve_partitionSet(self, graphene_info):
         from ..schema.partition_sets import GraphenePartitionSet
@@ -216,12 +211,15 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         )
 
     def resolve_partitionStatuses(self, graphene_info):
-        partition_set_name = self._backfill_job.partition_set_origin.partition_set_name
+        partition_set_origin = self._backfill_job.partition_set_origin
+        partition_set_name = (
+            partition_set_origin.partition_set_name if partition_set_origin else None
+        )
         partition_run_data = self._get_partition_run_data(graphene_info)
         return partition_statuses_from_run_partition_data(
             partition_set_name,
             partition_run_data,
-            self._backfill_job.partition_names,
+            self._backfill_job.get_partition_names(graphene_info.context),
             backfill_id=self._backfill_job.backfill_id,
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -143,7 +143,7 @@ class GraphenePartitionSetSelector(graphene.InputObjectType):
 
 
 class GrapheneLaunchBackfillParams(graphene.InputObjectType):
-    selector = graphene.NonNull(GraphenePartitionSetSelector)
+    selector = graphene.InputField(GraphenePartitionSetSelector)
     partitionNames = graphene.List(graphene.NonNull(graphene.String))
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.InputField(graphene.List(graphene.NonNull(GrapheneAssetKeyInput)))

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -259,7 +259,9 @@ class GraphenePartitionSet(graphene.ObjectType):
             for backfill in graphene_info.context.instance.get_backfills(
                 cursor=kwargs.get("cursor"),
             )
-            if backfill.partition_set_origin.partition_set_name == self._external_partition_set.name
+            if backfill.partition_set_origin
+            and backfill.partition_set_origin.partition_set_name
+            == self._external_partition_set.name
             and backfill.partition_set_origin.external_repository_origin.repository_name
             == self._external_repository_handle.repository_name
         ]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1,0 +1,137 @@
+from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
+
+from dagster import Definitions, StaticPartitionsDefinition, asset
+from dagster._core.execution.asset_backfill import AssetBackfillData
+from dagster._core.test_utils import instance_for_test
+
+GET_PARTITION_BACKFILLS_QUERY = """
+  query InstanceBackfillsQuery($cursor: String, $limit: Int) {
+    partitionBackfillsOrError(cursor: $cursor, limit: $limit) {
+      ... on PartitionBackfills {
+        results {
+          backfillId
+          status
+          numPartitions
+          timestamp
+          partitionNames
+          partitionSetName
+          partitionSet {
+            id
+            name
+            mode
+            pipelineName
+            repositoryOrigin {
+              id
+              repositoryName
+              repositoryLocationName
+            }
+          }
+        }
+      }
+    }
+  }
+"""
+
+SINGLE_BACKFILL_QUERY = """
+  query SingleBackfillQuery($backfillId: String!) {
+    partitionBackfillOrError(backfillId: $backfillId) {
+      ... on PartitionBackfill {
+        partitionStatuses {
+          results {
+            id
+            partitionName
+            runId
+            runStatus
+          }
+        }
+      }
+    }
+  }
+"""
+
+
+def get_repo():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        ...
+
+    @asset(partitions_def=partitions_def)
+    def asset2():
+        ...
+
+    return Definitions(assets=[asset1, asset2]).get_repository_def()
+
+
+def test_launch_asset_backfill():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.all_asset_keys
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            # launchPartitionBackfill
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            assert launch_backfill_result
+            assert launch_backfill_result.data
+            error_msg = (
+                (
+                    "".join(launch_backfill_result.data["launchPartitionBackfill"]["stack"])
+                    + launch_backfill_result.data["launchPartitionBackfill"]["message"]
+                )
+                if "message" in launch_backfill_result.data["launchPartitionBackfill"]
+                else None
+            )
+            assert "backfillId" in launch_backfill_result.data["launchPartitionBackfill"], error_msg
+
+            backfill_id = launch_backfill_result.data["launchPartitionBackfill"]["backfillId"]
+            assert launch_backfill_result.data["launchPartitionBackfill"]["launchedRunIds"] is None
+
+            backfills = instance.get_backfills()
+            assert len(backfills) == 1
+            backfill = backfills[0]
+            assert backfill.backfill_id == backfill_id
+            assert backfill.serialized_asset_backfill_data
+            asset_backfill_data = AssetBackfillData.from_serialized(
+                backfill.serialized_asset_backfill_data, repo.asset_graph
+            )
+            assert asset_backfill_data.target_subset.asset_keys == all_asset_keys
+
+            # on PartitionBackfills
+            get_backfills_result = execute_dagster_graphql(
+                context, GET_PARTITION_BACKFILLS_QUERY, variables={}
+            )
+            assert not get_backfills_result.errors
+            assert get_backfills_result.data
+            backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
+            assert len(backfill_results) == 1
+            assert backfill_results[0]["numPartitions"] == 2
+            assert backfill_results[0]["backfillId"] == backfill_id
+            assert backfill_results[0]["partitionSet"] is None
+            assert backfill_results[0]["partitionSetName"] is None
+            assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
+
+            # on PartitionBackfill
+            single_backfill_result = execute_dagster_graphql(
+                context, SINGLE_BACKFILL_QUERY, variables={"backfillId": backfill_id}
+            )
+            assert not single_backfill_result.errors
+            assert single_backfill_result.data
+            partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
+                "partitionStatuses"
+            ]["results"]
+            assert len(partition_status_results) == 2
+            assert {
+                partition_status_result["partitionName"]
+                for partition_status_result in partition_status_results
+            } == {"a", "b"}

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -14,7 +14,7 @@ from typing import (
 from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.host_representation.handle import RepositoryHandle
 from dagster._core.selector.subset_selector import DependencyGraph
-from dagster._core.workspace.context import BaseWorkspaceRequestContext
+from dagster._core.workspace.workspace import IWorkspace
 
 from .asset_graph import AssetGraph
 from .events import AssetKey
@@ -52,9 +52,7 @@ class ExternalAssetGraph(AssetGraph):
         self._job_names_by_key = job_names_by_key
 
     @classmethod
-    def from_workspace_request_context(
-        cls, context: BaseWorkspaceRequestContext
-    ) -> "ExternalAssetGraph":
+    def from_workspace(cls, context: IWorkspace) -> "ExternalAssetGraph":
         repo_locations = (
             location_entry.repository_location
             for location_entry in context.get_workspace_snapshot().values()

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -5,9 +5,11 @@ from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
+from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
@@ -106,6 +108,56 @@ class PartitionBackfill(
             return BulkActionType.MULTI_RUN_ASSET_ACTION
         else:
             return BulkActionType.PARTITION_BACKFILL
+
+    @property
+    def partition_set_name(self) -> Optional[str]:
+        if self.partition_set_origin is None:
+            return None
+
+        return self.partition_set_origin.partition_set_name
+
+    def get_num_partitions(self, workspace: IWorkspace) -> int:
+        if self.serialized_asset_backfill_data is not None:
+            asset_backfill_data = AssetBackfillData.from_serialized(
+                self.serialized_asset_backfill_data, ExternalAssetGraph.from_workspace(workspace)
+            )
+            return asset_backfill_data.get_num_partitions()
+        else:
+            if self.partition_names is None:
+                check.failed("Non-asset backfills should have a non-null partition_names field")
+
+            return len(self.partition_names)
+
+    def get_partition_names(self, workspace: IWorkspace) -> Sequence[str]:
+        if self.serialized_asset_backfill_data is not None:
+            asset_backfill_data = AssetBackfillData.from_serialized(
+                self.serialized_asset_backfill_data, ExternalAssetGraph.from_workspace(workspace)
+            )
+            return asset_backfill_data.get_partition_names()
+        else:
+            if self.partition_names is None:
+                check.failed("Non-asset backfills should have a non-null partition_names field")
+
+            return self.partition_names
+
+    def get_num_cancelable(self) -> int:
+        if self.is_asset_backfill:
+            return 0
+
+        if self.status != BulkActionStatus.REQUESTED:
+            return 0
+
+        if self.partition_names is None:
+            check.failed("Expected partition_names to not be None for job backfill")
+
+        checkpoint = self.last_submitted_partition_name
+        total_count = len(self.partition_names)
+        checkpoint_idx = (
+            self.partition_names.index(checkpoint) + 1
+            if checkpoint and checkpoint in self.partition_names
+            else 0
+        )
+        return max(0, total_count - checkpoint_idx)
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -84,9 +84,7 @@ def make_context(defs_attrs):
 
 
 def test_get_repository_handle():
-    asset_graph = ExternalAssetGraph.from_workspace_request_context(
-        make_context(["defs1", "defs2"])
-    )
+    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "defs2"]))
 
     assert asset_graph.get_job_names(asset1.key) == ["__ASSET_JOB"]
     repo_handle1 = asset_graph.get_repository_handle(asset1.key)
@@ -100,9 +98,7 @@ def test_get_repository_handle():
 
 
 def test_cross_repo_dep_with_source_asset():
-    asset_graph = ExternalAssetGraph.from_workspace_request_context(
-        make_context(["defs1", "downstream_defs"])
-    )
+    asset_graph = ExternalAssetGraph.from_workspace(make_context(["defs1", "downstream_defs"]))
     assert len(asset_graph.source_asset_keys) == 0
     assert asset_graph.get_parents(AssetKey("downstream")) == {AssetKey("asset1")}
     assert asset_graph.get_children(AssetKey("asset1")) == {AssetKey("downstream")}
@@ -121,7 +117,7 @@ def test_cross_repo_dep_with_source_asset():
 
 
 def test_cross_repo_dep_no_source_asset():
-    asset_graph = ExternalAssetGraph.from_workspace_request_context(
+    asset_graph = ExternalAssetGraph.from_workspace(
         make_context(["defs1", "downstream_defs_no_source"])
     )
     assert len(asset_graph.source_asset_keys) == 0

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -679,7 +679,7 @@ def test_pure_asset_backfill(instance, workspace_context, external_repo):
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=ExternalAssetGraph.from_workspace_request_context(
+            asset_graph=ExternalAssetGraph.from_workspace(
                 workspace_context.create_request_context()
             ),
             backfill_id="backfill_with_asset_selection",


### PR DESCRIPTION
branch-name: asset-backfill-graphql

### Summary & Motivation

Enables launching pure asset backfills via graphql.

Sits atop https://github.com/dagster-io/dagster/pull/11378.

### How I Tested These Changes
