### PR TITLE
support non-partitioned assets in backfills

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -1,6 +1,9 @@
+from typing import TYPE_CHECKING, Any, Mapping, Union
+
 import pendulum
 
 import dagster._check as check
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.errors import DagsterError
 from dagster._core.events import AssetKey
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -13,85 +16,122 @@ from ..utils import capture_error
 BACKFILL_CHUNK_SIZE = 25
 
 
-@capture_error
-def create_and_launch_partition_backfill(graphene_info, backfill_params):
+if TYPE_CHECKING:
     from ...schema.backfill import GrapheneLaunchBackfillSuccess
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
-    partition_set_selector = backfill_params.get("selector")
-    partition_set_name = partition_set_selector.get("partitionSetName")
-    repository_selector = RepositorySelector.from_graphql_input(
-        partition_set_selector.get("repositorySelector")
-    )
-    location = graphene_info.context.get_repository_location(repository_selector.location_name)
-    repository = location.get_repository(repository_selector.repository_name)
-    matches = [
-        partition_set
-        for partition_set in repository.get_external_partition_sets()
-        if partition_set.name == partition_set_selector.get("partitionSetName")
-    ]
-    if not matches:
-        return GraphenePartitionSetNotFoundError(partition_set_name)
 
-    check.invariant(
-        len(matches) == 1,
-        "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
-            num=len(matches), partition_set_name=partition_set_name
-        ),
-    )
-
-    external_partition_set = next(iter(matches))
-
-    if backfill_params.get("allPartitions"):
-        result = graphene_info.context.get_external_partition_names(external_partition_set)
-        partition_names = result.partition_names
-    elif backfill_params.get("partitionNames"):
-        partition_names = backfill_params.get("partitionNames")
-    else:
-        raise DagsterError(
-            'Backfill requested without specifying either "allPartitions" or "partitionNames" '
-            "arguments"
-        )
+@capture_error
+def create_and_launch_partition_backfill(
+    graphene_info, backfill_params: Mapping[str, Any]
+) -> Union["GrapheneLaunchBackfillSuccess", "GraphenePartitionSetNotFoundError"]:
+    from ...schema.backfill import GrapheneLaunchBackfillSuccess
+    from ...schema.errors import GraphenePartitionSetNotFoundError
 
     backfill_id = make_new_backfill_id()
-    backfill = PartitionBackfill(
-        backfill_id=backfill_id,
-        partition_set_origin=external_partition_set.get_external_origin(),
-        status=BulkActionStatus.REQUESTED,
-        partition_names=partition_names,
-        from_failure=bool(backfill_params.get("fromFailure")),
-        reexecution_steps=backfill_params.get("reexecutionSteps"),
-        tags={t["key"]: t["value"] for t in backfill_params.get("tags", [])},
-        backfill_timestamp=pendulum.now("UTC").timestamp(),
-        asset_selection=[
-            AssetKey.from_graphql_input(asset_key)
-            for asset_key in backfill_params.get("assetSelection")
-        ]
+
+    asset_selection = (
+        [AssetKey.from_graphql_input(asset_key) for asset_key in backfill_params["assetSelection"]]
         if backfill_params.get("assetSelection")
-        else None,
+        else None
     )
 
-    if backfill_params.get("forceSynchronousSubmission"):
-        # should only be used in a test situation
-        to_submit = [name for name in partition_names]
-        submitted_run_ids = []
+    tags = {t["key"]: t["value"] for t in backfill_params.get("tags", [])}
+    backfill_timestamp = pendulum.now("UTC").timestamp()
 
-        while to_submit:
-            chunk = to_submit[:BACKFILL_CHUNK_SIZE]
-            to_submit = to_submit[BACKFILL_CHUNK_SIZE:]
-            submitted_run_ids.extend(
-                run_id
-                for run_id in submit_backfill_runs(
-                    graphene_info.context.instance,
-                    workspace=graphene_info.context,
-                    repo_location=location,
-                    backfill_job=backfill,
-                    partition_names=chunk,
-                )
-                if run_id != None
+    if backfill_params.get("selector") is not None:  # job backfill
+        partition_set_selector = backfill_params["selector"]
+        partition_set_name = partition_set_selector.get("partitionSetName")
+        repository_selector = RepositorySelector.from_graphql_input(
+            partition_set_selector.get("repositorySelector")
+        )
+        location = graphene_info.context.get_repository_location(repository_selector.location_name)
+        repository = location.get_repository(repository_selector.repository_name)
+        matches = [
+            partition_set
+            for partition_set in repository.get_external_partition_sets()
+            if partition_set.name == partition_set_selector.get("partitionSetName")
+        ]
+        if not matches:
+            return GraphenePartitionSetNotFoundError(partition_set_name)
+
+        check.invariant(
+            len(matches) == 1,
+            "Partition set names must be unique: found {num} matches for {partition_set_name}".format(
+                num=len(matches), partition_set_name=partition_set_name
+            ),
+        )
+        external_partition_set = next(iter(matches))
+
+        if backfill_params.get("allPartitions"):
+            result = graphene_info.context.get_external_partition_names(external_partition_set)
+            partition_names = result.partition_names
+        elif backfill_params.get("partitionNames"):
+            partition_names = backfill_params["partitionNames"]
+        else:
+            raise DagsterError(
+                'Backfill requested without specifying either "allPartitions" or "partitionNames" '
+                "arguments"
             )
-        return GrapheneLaunchBackfillSuccess(
-            backfill_id=backfill_id, launched_run_ids=submitted_run_ids
+
+        backfill = PartitionBackfill(
+            backfill_id=backfill_id,
+            partition_set_origin=external_partition_set.get_external_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=partition_names,
+            from_failure=bool(backfill_params.get("fromFailure")),
+            reexecution_steps=backfill_params.get("reexecutionSteps"),
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+        )
+
+        if backfill_params.get("forceSynchronousSubmission"):
+            # should only be used in a test situation
+            to_submit = [name for name in partition_names]
+            submitted_run_ids = []
+
+            while to_submit:
+                chunk = to_submit[:BACKFILL_CHUNK_SIZE]
+                to_submit = to_submit[BACKFILL_CHUNK_SIZE:]
+                submitted_run_ids.extend(
+                    run_id
+                    for run_id in submit_backfill_runs(
+                        graphene_info.context.instance,
+                        workspace=graphene_info.context,
+                        repo_location=location,
+                        backfill_job=backfill,
+                        partition_names=chunk,
+                    )
+                    if run_id != None
+                )
+            return GrapheneLaunchBackfillSuccess(
+                backfill_id=backfill_id, launched_run_ids=submitted_run_ids
+            )
+    elif asset_selection is not None:  # pure asset backfill
+        if backfill_params.get("forceSynchronousSubmission"):
+            raise DagsterError(
+                "forceSynchronousSubmission is not supported for pure asset backfills"
+            )
+
+        if backfill_params.get("fromFailure"):
+            raise DagsterError("fromFailure is not supported for pure asset backfills")
+
+        if backfill_params.get("allPartitions"):
+            raise DagsterError("allPartitions is not supported for pure asset backfills")
+
+        backfill = PartitionBackfill.from_asset_partitions(
+            asset_graph=ExternalAssetGraph.from_workspace_request_context(graphene_info.context),
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+            partition_names=backfill_params["partitionNames"],
+        )
+    else:
+        raise DagsterError(
+            "Backfill requested without specifying partition set selector or asset selection"
         )
 
     graphene_info.context.instance.add_backfill(backfill)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -143,7 +143,7 @@ class GraphenePartitionSetSelector(graphene.InputObjectType):
 
 
 class GrapheneLaunchBackfillParams(graphene.InputObjectType):
-    selector = graphene.NonNull(GraphenePartitionSetSelector)
+    selector = GraphenePartitionSetSelector
     partitionNames = graphene.List(graphene.NonNull(graphene.String))
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
     assetSelection = graphene.InputField(graphene.List(graphene.NonNull(GrapheneAssetKeyInput)))

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1,0 +1,62 @@
+from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
+
+from dagster import Definitions, StaticPartitionsDefinition, asset
+from dagster._core.execution.asset_backfill import AssetBackfillData
+from dagster._core.test_utils import instance_for_test
+
+
+def get_repo():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        ...
+
+    @asset(partitions_def=partitions_def)
+    def asset2():
+        ...
+
+    return Definitions(assets=[asset1, asset2]).get_repository_def()
+
+
+def test_launch_asset_backfill():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.all_asset_keys
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            assert result
+            assert result.data
+            error_msg = (
+                (
+                    "".join(result.data["launchPartitionBackfill"]["stack"])
+                    + result.data["launchPartitionBackfill"]["message"]
+                )
+                if "message" in result.data["launchPartitionBackfill"]
+                else None
+            )
+            assert "backfillId" in result.data["launchPartitionBackfill"], error_msg
+
+            backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
+            assert result.data["launchPartitionBackfill"]["launchedRunIds"] is None
+
+            backfills = instance.get_backfills()
+            assert len(backfills) == 1
+            backfill = backfills[0]
+            assert backfill.backfill_id == backfill_id
+            assert backfill.serialized_asset_backfill_data
+            asset_backfill_data = AssetBackfillData.from_serialized(
+                backfill.serialized_asset_backfill_data, repo.asset_graph
+            )
+            assert asset_backfill_data.target_subsets_by_asset_key.keys() == all_asset_keys

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import AbstractSet, Dict, Iterable, Mapping, cast
+from typing import AbstractSet, Any, Dict, Iterable, Mapping, Optional, Set, cast
 
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 
@@ -11,10 +11,12 @@ class AssetGraphSubset:
     def __init__(
         self,
         partitions_subsets_by_asset_key: Mapping[AssetKey, PartitionsSubset],
+        non_partitioned_asset_keys: AbstractSet[AssetKey],
         asset_graph: AssetGraph,
     ):
         self._partitions_subsets_by_asset_key = partitions_subsets_by_asset_key
         self._asset_graph = asset_graph
+        self._non_partitioned_asset_keys = non_partitioned_asset_keys
 
     @property
     def asset_graph(self):
@@ -26,7 +28,7 @@ class AssetGraphSubset:
 
     @property
     def asset_keys(self) -> Iterable[AssetKey]:
-        return self.partitions_subsets_by_asset_key.keys()
+        return self.partitions_subsets_by_asset_key.keys() | self._non_partitioned_asset_keys
 
     def get_partitions_subset(self, asset_key: AssetKey) -> PartitionsSubset:
         partitions_def = cast(PartitionsDefinition, self.asset_graph.get_partitions_def(asset_key))
@@ -37,55 +39,119 @@ class AssetGraphSubset:
             for partition_key in partitions_subset.get_partition_keys():
                 yield AssetKeyPartitionKey(asset_key, partition_key)
 
+        for asset_key in self._non_partitioned_asset_keys:
+            yield AssetKeyPartitionKey(asset_key, None)
+
     def __contains__(self, asset_partition: AssetKeyPartitionKey) -> bool:
-        partitions_subset = self.partitions_subsets_by_asset_key.get(asset_partition.asset_key)
-        return partitions_subset is not None and asset_partition.partition_key in partitions_subset
-
-    def to_storage_dict(self) -> Mapping[str, str]:
-        return {
-            key.to_user_string(): value.serialize()
-            for key, value in self.partitions_subsets_by_asset_key.items()
-        }
-
-    def __or__(self, other: Mapping[AssetKey, AbstractSet[str]]) -> "AssetGraphSubset":
-        result_partition_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
-        for asset_key in self.partitions_subsets_by_asset_key.keys() | other.keys():
-            subset = self.get_partitions_subset(asset_key)
-            result_partition_subsets_by_asset_key[asset_key] = subset.with_partition_keys(
-                other.get(asset_key, [])
+        if asset_partition.partition_key is None:
+            return asset_partition.asset_key in self._non_partitioned_asset_keys
+        else:
+            partitions_subset = self.partitions_subsets_by_asset_key.get(asset_partition.asset_key)
+            return (
+                partitions_subset is not None and asset_partition.partition_key in partitions_subset
             )
 
-        return AssetGraphSubset(result_partition_subsets_by_asset_key, self.asset_graph)
+    def to_storage_dict(self) -> Mapping[str, object]:
+        return {
+            "partitions_subsets_by_asset_key": {
+                key.to_user_string(): value.serialize()
+                for key, value in self.partitions_subsets_by_asset_key.items()
+            },
+            "non_partitioned_asset_keys": {
+                key.to_user_string() for key in self._non_partitioned_asset_keys
+            },
+        }
+
+    def __or__(self, other: Mapping[AssetKey, Optional[AbstractSet[str]]]) -> "AssetGraphSubset":
+        result_partition_subsets_by_asset_key = {**self.partitions_subsets_by_asset_key}
+        result_non_partitioned_asset_keys = set(self._non_partitioned_asset_keys)
+
+        for asset_key, partition_keys in other.items():
+            if partition_keys is None:
+                result_non_partitioned_asset_keys.add(asset_key)
+            else:
+                subset = self.get_partitions_subset(asset_key)
+                result_partition_subsets_by_asset_key[asset_key] = subset.with_partition_keys(
+                    partition_keys
+                )
+
+        return AssetGraphSubset(
+            result_partition_subsets_by_asset_key,
+            result_non_partitioned_asset_keys,
+            self.asset_graph,
+        )
+
+    def __and__(self, other: AbstractSet[AssetKey]) -> "AssetGraphSubset":
+        return AssetGraphSubset(
+            {
+                asset_key: subset
+                for asset_key, subset in self.partitions_subsets_by_asset_key.items()
+                if asset_key in other
+            },
+            self._non_partitioned_asset_keys & other,
+            self.asset_graph,
+        )
 
     @classmethod
     def from_asset_partition_set(
         cls, asset_partitions_set: AbstractSet[AssetKeyPartitionKey], asset_graph: AssetGraph
     ) -> "AssetGraphSubset":
         partitions_by_asset_key = defaultdict(set)
+        non_partitioned_asset_keys = set()
         for asset_key, partition_key in asset_partitions_set:
-            partitions_by_asset_key[asset_key].add(cast(str, partition_key))
+            if partition_key is not None:
+                partitions_by_asset_key[asset_key].add(cast(str, partition_key))
+            else:
+                non_partitioned_asset_keys.add(asset_key)
 
         return AssetGraphSubset(
-            {
+            partitions_subsets_by_asset_key={
                 asset_key: cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
                 .empty_subset()
                 .with_partition_keys(partition_keys)
                 for asset_key, partition_keys in partitions_by_asset_key.items()
             },
-            asset_graph,
+            non_partitioned_asset_keys=non_partitioned_asset_keys,
+            asset_graph=asset_graph,
         )
 
     @classmethod
     def from_storage_dict(
-        cls, serialized_dict: Mapping[str, str], asset_graph: AssetGraph
+        cls, serialized_dict: Mapping[str, Any], asset_graph: AssetGraph
     ) -> "AssetGraphSubset":
-        result: Dict[AssetKey, PartitionsSubset] = {}
-        for key, value in serialized_dict.items():
+        partitions_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for key, value in serialized_dict["partitions_subsets_by_asset_key"].items():
             asset_key = AssetKey.from_user_string(key)
             partitions_def = cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
-            result[asset_key] = partitions_def.deserialize_subset(value)
+            partitions_subsets_by_asset_key[asset_key] = partitions_def.deserialize_subset(value)
 
-        return AssetGraphSubset(result, asset_graph)
+        non_partitioned_asset_keys = {
+            AssetKey.from_user_string(key) for key in serialized_dict["non_partitioned_asset_keys"]
+        }
+
+        return AssetGraphSubset(
+            partitions_subsets_by_asset_key, non_partitioned_asset_keys, asset_graph
+        )
+
+    @classmethod
+    def all(cls, asset_graph: AssetGraph) -> "AssetGraphSubset":
+        partitions_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        non_partitioned_asset_keys: Set[AssetKey] = set()
+
+        for asset_key in asset_graph.all_asset_keys:
+            partitions_def = asset_graph.get_partitions_def(asset_key)
+            if partitions_def:
+                partitions_subsets_by_asset_key[
+                    asset_key
+                ] = partitions_def.empty_subset().with_partition_keys(
+                    partitions_def.get_partition_keys()
+                )
+            else:
+                non_partitioned_asset_keys.add(asset_key)
+
+        return AssetGraphSubset(
+            partitions_subsets_by_asset_key, non_partitioned_asset_keys, asset_graph
+        )
 
     def __eq__(self, other) -> bool:
         return (
@@ -96,3 +162,8 @@ class AssetGraphSubset:
 
     def __repr__(self) -> str:
         return f"AssetGraphSubset(partitions_subset_by_asset_key={self.partitions_subsets_by_asset_key})"
+
+    def __len__(self) -> int:
+        return len(self._non_partitioned_asset_keys) + sum(
+            len(subset) for subset in self._partitions_subsets_by_asset_key.values()
+        )

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -1,0 +1,98 @@
+from collections import defaultdict
+from typing import AbstractSet, Dict, Iterable, Mapping, cast
+
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+
+from .asset_graph import AssetGraph
+from .events import AssetKey, AssetKeyPartitionKey
+
+
+class AssetGraphSubset:
+    def __init__(
+        self,
+        partitions_subsets_by_asset_key: Mapping[AssetKey, PartitionsSubset],
+        asset_graph: AssetGraph,
+    ):
+        self._partitions_subsets_by_asset_key = partitions_subsets_by_asset_key
+        self._asset_graph = asset_graph
+
+    @property
+    def asset_graph(self):
+        return self._asset_graph
+
+    @property
+    def partitions_subsets_by_asset_key(self):
+        return self._partitions_subsets_by_asset_key
+
+    @property
+    def asset_keys(self) -> Iterable[AssetKey]:
+        return self.partitions_subsets_by_asset_key.keys()
+
+    def get_partitions_subset(self, asset_key: AssetKey) -> PartitionsSubset:
+        partitions_def = cast(PartitionsDefinition, self.asset_graph.get_partitions_def(asset_key))
+        return self.partitions_subsets_by_asset_key.get(asset_key, partitions_def.empty_subset())
+
+    def iterate_asset_partitions(self) -> Iterable[AssetKeyPartitionKey]:
+        for asset_key, partitions_subset in self.partitions_subsets_by_asset_key.items():
+            for partition_key in partitions_subset.get_partition_keys():
+                yield AssetKeyPartitionKey(asset_key, partition_key)
+
+    def __contains__(self, asset_partition: AssetKeyPartitionKey) -> bool:
+        partitions_subset = self.partitions_subsets_by_asset_key.get(asset_partition.asset_key)
+        return partitions_subset is not None and asset_partition.partition_key in partitions_subset
+
+    def to_storage_dict(self) -> Mapping[str, str]:
+        return {
+            key.to_user_string(): value.serialize()
+            for key, value in self.partitions_subsets_by_asset_key.items()
+        }
+
+    def __or__(self, other: Mapping[AssetKey, AbstractSet[str]]) -> "AssetGraphSubset":
+        result_partition_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for asset_key in self.partitions_subsets_by_asset_key.keys() | other.keys():
+            subset = self.get_partitions_subset(asset_key)
+            result_partition_subsets_by_asset_key[asset_key] = subset.with_partition_keys(
+                other.get(asset_key, [])
+            )
+
+        return AssetGraphSubset(result_partition_subsets_by_asset_key, self.asset_graph)
+
+    @classmethod
+    def from_asset_partition_set(
+        cls, asset_partitions_set: AbstractSet[AssetKeyPartitionKey], asset_graph: AssetGraph
+    ) -> "AssetGraphSubset":
+        partitions_by_asset_key = defaultdict(set)
+        for asset_key, partition_key in asset_partitions_set:
+            partitions_by_asset_key[asset_key].add(cast(str, partition_key))
+
+        return AssetGraphSubset(
+            {
+                asset_key: cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+                .empty_subset()
+                .with_partition_keys(partition_keys)
+                for asset_key, partition_keys in partitions_by_asset_key.items()
+            },
+            asset_graph,
+        )
+
+    @classmethod
+    def from_storage_dict(
+        cls, serialized_dict: Mapping[str, str], asset_graph: AssetGraph
+    ) -> "AssetGraphSubset":
+        result: Dict[AssetKey, PartitionsSubset] = {}
+        for key, value in serialized_dict.items():
+            asset_key = AssetKey.from_user_string(key)
+            partitions_def = cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+            result[asset_key] = partitions_def.deserialize_subset(value)
+
+        return AssetGraphSubset(result, asset_graph)
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, AssetGraphSubset)
+            and self.asset_graph == other.asset_graph
+            and self.partitions_subsets_by_asset_key == other.partitions_subsets_by_asset_key
+        )
+
+    def __repr__(self) -> str:
+        return f"AssetGraphSubset(partitions_subset_by_asset_key={self.partitions_subsets_by_asset_key})"

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -168,6 +168,9 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
             return AssetKey(asset_key["path"])
         return None
 
+    def to_graphql_input(self) -> Mapping[str, Sequence[str]]:
+        return {"path": self.path}
+
     @staticmethod
     def from_coerceable(arg: "CoercibleToAssetKey") -> "AssetKey":
         if isinstance(arg, AssetKey):

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1,0 +1,266 @@
+import json
+from typing import AbstractSet, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, cast
+
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    build_run_requests,
+    find_parent_materialized_asset_partitions,
+)
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.assets_job import is_base_asset_job_name
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.definitions.run_request import RunRequest
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
+from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+
+
+class AssetBackfillData(NamedTuple):
+    """Has custom serialization instead of standard Dagster NamedTuple serialization because the
+    asset graph is required to build the AssetGraphSubset objects.
+    """
+
+    target_asset_partitions: AssetGraphSubset
+    roots_were_requested: bool
+    latest_storage_id: Optional[int]
+    materialized_asset_partitions: AssetGraphSubset
+    # also includes asset partitions within the backfill that are downstream of failed asset
+    # partitions
+    failed_asset_partitions: AssetGraphSubset
+
+    def is_complete(self) -> bool:
+        return all(
+            len(self.materialized_asset_partitions.get_partitions_subset(asset_key))
+            + len(self.failed_asset_partitions.get_partitions_subset(asset_key))
+            == len(self.target_asset_partitions.get_partitions_subset(asset_key))
+            for asset_key in self.target_asset_partitions.asset_keys
+        )
+
+    def get_target_root_asset_partitions(self) -> Iterable[AssetKeyPartitionKey]:
+        root_asset_keys = (
+            AssetSelection.keys(*self.target_asset_partitions.asset_keys)
+            .sources()
+            .resolve(self.target_asset_partitions.asset_graph)
+        )
+        return [
+            AssetKeyPartitionKey(asset_key, partition_key)
+            for asset_key in root_asset_keys
+            for partition_key in self.target_asset_partitions.get_partitions_subset(
+                asset_key
+            ).get_partition_keys()
+        ]
+
+    @classmethod
+    def empty(
+        cls,
+        target_subsets_by_asset_key: Mapping[AssetKey, PartitionsSubset],
+        asset_graph: AssetGraph,
+    ) -> "AssetBackfillData":
+        return cls(
+            target_asset_partitions=AssetGraphSubset(target_subsets_by_asset_key, asset_graph),
+            roots_were_requested=False,
+            materialized_asset_partitions=AssetGraphSubset({}, asset_graph),
+            failed_asset_partitions=AssetGraphSubset({}, asset_graph),
+            latest_storage_id=None,
+        )
+
+    @classmethod
+    def from_serialized(cls, serialized: str, asset_graph: AssetGraph) -> "AssetBackfillData":
+        storage_dict = json.loads(serialized)
+
+        return cls(
+            target_asset_partitions=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_target_asset_partitions"], asset_graph
+            ),
+            roots_were_requested=storage_dict["roots_were_requested"],
+            materialized_asset_partitions=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_materialized_asset_partitions"], asset_graph
+            ),
+            failed_asset_partitions=AssetGraphSubset.from_storage_dict(
+                storage_dict["serialized_failed_asset_partitions"], asset_graph
+            ),
+            latest_storage_id=storage_dict["latest_storage_id"],
+        )
+
+    def serialize(self) -> str:
+        storage_dict = {
+            "roots_were_requested": self.roots_were_requested,
+            "serialized_target_asset_partitions": self.target_asset_partitions.to_storage_dict(),
+            "latest_storage_id": self.latest_storage_id,
+            "serialized_materialized_asset_partitions": self.materialized_asset_partitions.to_storage_dict(),
+            "serialized_failed_asset_partitions": self.failed_asset_partitions.to_storage_dict(),
+        }
+        return json.dumps(storage_dict)
+
+
+def _get_implicit_job_name_for_assets(
+    asset_graph: ExternalAssetGraph, asset_keys: Sequence[AssetKey]
+) -> Optional[str]:
+    job_names = set(asset_graph.get_job_names(asset_keys[0]))
+    for asset_key in asset_keys[1:]:
+        job_names &= set(asset_graph.get_job_names(asset_key))
+
+    return next(job_name for job_name in job_names if is_base_asset_job_name(job_name))
+
+
+class AssetBackfillIterationResult(NamedTuple):
+    run_requests: Sequence[RunRequest]
+    backfill_data: AssetBackfillData
+
+
+def execute_asset_backfill_iteration_inner(
+    backfill_id: str,
+    asset_backfill_data: AssetBackfillData,
+    asset_graph: ExternalAssetGraph,
+    instance: "DagsterInstance",
+) -> AssetBackfillIterationResult:
+    """Core logic of a backfill iteration. Has no side effects."""
+    instance_queryer = CachingInstanceQueryer(instance=instance)
+
+    initial_candidates: Set[AssetKeyPartitionKey] = set()
+    request_roots = not asset_backfill_data.roots_were_requested
+    if request_roots:
+        initial_candidates.update(asset_backfill_data.get_target_root_asset_partitions())
+
+    (
+        parent_materialized_asset_partitions,
+        next_latest_storage_id,
+    ) = find_parent_materialized_asset_partitions(
+        asset_graph=asset_graph,
+        instance_queryer=instance_queryer,
+        target_asset_selection=AssetSelection.keys(
+            *asset_backfill_data.target_asset_partitions.asset_keys
+        ),
+        latest_storage_id=asset_backfill_data.latest_storage_id,
+    )
+    initial_candidates.update(parent_materialized_asset_partitions)
+
+    recently_materialized_partitions_by_asset_key: Mapping[AssetKey, AbstractSet[str]] = {
+        asset_key: {
+            cast(str, record.partition_key)
+            for record in instance_queryer.get_materialization_records(
+                asset_key=asset_key, after_cursor=asset_backfill_data.latest_storage_id
+            )
+        }
+        for asset_key in asset_backfill_data.target_asset_partitions.asset_keys
+    }
+
+    updated_materialized_asset_partitions = (
+        asset_backfill_data.materialized_asset_partitions
+        | recently_materialized_partitions_by_asset_key
+    )
+
+    failed_asset_partitions = AssetGraphSubset.from_asset_partition_set(
+        asset_graph.bfs_filter_asset_partitions(
+            lambda asset_partitions, _: any(
+                asset_partition in asset_backfill_data.target_asset_partitions
+                for asset_partition in asset_partitions
+            ),
+            _get_failed_asset_partitions(instance_queryer, backfill_id),
+        ),
+        asset_graph,
+    )
+
+    asset_partitions_to_request = asset_graph.bfs_filter_asset_partitions(
+        lambda unit, visited: should_backfill_atomic_asset_partitions_unit(
+            candidates_unit=unit,
+            asset_partitions_to_request=visited,
+            asset_graph=asset_graph,
+            materialized_asset_partitions=updated_materialized_asset_partitions,
+            target_asset_partitions=asset_backfill_data.target_asset_partitions,
+            failed_asset_partitions=failed_asset_partitions,
+        ),
+        initial_asset_partitions=initial_candidates,
+    )
+
+    run_requests = build_run_requests(
+        asset_partitions_to_request, asset_graph, {BACKFILL_ID_TAG: backfill_id}
+    )
+
+    updated_asset_backfill_data = AssetBackfillData(
+        target_asset_partitions=asset_backfill_data.target_asset_partitions,
+        latest_storage_id=next_latest_storage_id or asset_backfill_data.latest_storage_id,
+        roots_were_requested=asset_backfill_data.roots_were_requested or request_roots,
+        materialized_asset_partitions=updated_materialized_asset_partitions,
+        failed_asset_partitions=failed_asset_partitions,
+    )
+    return AssetBackfillIterationResult(run_requests, updated_asset_backfill_data)
+
+
+def should_backfill_atomic_asset_partitions_unit(
+    asset_graph: ExternalAssetGraph,
+    candidates_unit: Iterable[AssetKeyPartitionKey],
+    asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
+    target_asset_partitions: AssetGraphSubset,
+    materialized_asset_partitions: AssetGraphSubset,
+    failed_asset_partitions: AssetGraphSubset,
+) -> bool:
+    """
+    Args:
+        candidates_unit: A set of asset partitions that must all be materialized if any is
+            materialized.
+    """
+    for candidate in candidates_unit:
+        if (
+            candidate not in target_asset_partitions
+            or candidate in failed_asset_partitions
+            or candidate in materialized_asset_partitions
+        ):
+            return False
+
+        for parent in asset_graph.get_parents_partitions(*candidate):
+            can_run_with_parent = (
+                parent in asset_partitions_to_request
+                and asset_graph.have_same_partitioning(parent.asset_key, candidate.asset_key)
+                and parent.partition_key == candidate.partition_key
+                and asset_graph.get_repository_handle(candidate.asset_key)
+                is asset_graph.get_repository_handle(parent.asset_key)
+            )
+
+            if (
+                parent in target_asset_partitions
+                and not can_run_with_parent
+                and parent not in materialized_asset_partitions
+            ):
+                return False
+
+    return True
+
+
+def _get_failed_asset_partitions(
+    instance_queryer: CachingInstanceQueryer, backfill_id: str
+) -> Sequence[AssetKeyPartitionKey]:
+    """
+    Returns asset partitions that materializations were requested for as part of the backfill, but
+    will not be materialized.
+
+    Includes canceled asset partitions. Implementation assumes that successful runs won't have any
+    failed partitions.
+    """
+    runs = instance_queryer.instance.get_runs(
+        filters=RunsFilter(
+            tags={BACKFILL_ID_TAG: backfill_id},
+            statuses=[DagsterRunStatus.CANCELED, DagsterRunStatus.FAILURE],
+        )
+    )
+
+    result: List[AssetKeyPartitionKey] = []
+
+    for run in runs:
+        partition_key = run.tags[PARTITION_NAME_TAG]
+        planned_asset_keys = instance_queryer.get_planned_materializations_for_run_from_events(
+            run_id=run.run_id
+        )
+        completed_asset_keys = instance_queryer.get_current_materializations_for_run(
+            run_id=run.run_id
+        )
+        result.extend(
+            AssetKeyPartitionKey(asset_key, partition_key)
+            for asset_key in planned_asset_keys - completed_asset_keys
+        )
+
+    return result

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,11 +1,16 @@
 from enum import Enum
-from typing import Mapping, NamedTuple, Optional, Sequence
+from typing import Dict, Mapping, NamedTuple, Optional, Sequence, cast
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
+
+from .asset_backfill import AssetBackfillData
 
 
 @whitelist_for_serdes
@@ -37,6 +42,8 @@ class PartitionBackfill(
             ("partition_names", Optional[Sequence[str]]),
             ("last_submitted_partition_name", Optional[str]),
             ("reexecution_steps", Optional[Sequence[str]]),
+            # only used by asset backfills
+            ("serialized_asset_backfill_data", Optional[str]),
         ],
     ),
 ):
@@ -53,11 +60,19 @@ class PartitionBackfill(
         partition_names: Optional[Sequence[str]] = None,
         last_submitted_partition_name: Optional[str] = None,
         reexecution_steps: Optional[Sequence[str]] = None,
+        serialized_asset_backfill_data: Optional[str] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
             "Can't supply both an asset_selection and reexecution_steps to a PartitionBackfill.",
         )
+
+        if serialized_asset_backfill_data is not None:
+            check.invariant(partition_set_origin is None)
+            check.invariant(partition_names is None)
+            check.invariant(last_submitted_partition_name is None)
+            check.invariant(reexecution_steps is None)
+
         return super(PartitionBackfill, cls).__new__(
             cls,
             check.str_param(backfill_id, "backfill_id"),
@@ -66,18 +81,30 @@ class PartitionBackfill(
             check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
             check.float_param(backfill_timestamp, "backfill_timestamp"),
             check.opt_inst_param(error, "error", SerializableErrorInfo),
-            check.opt_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
+            check.opt_nullable_sequence_param(asset_selection, "asset_selection", of_type=AssetKey),
             check.opt_inst_param(
                 partition_set_origin, "partition_set_origin", ExternalPartitionSetOrigin
             ),
-            check.opt_sequence_param(partition_names, "partition_names", of_type=str),
+            check.opt_nullable_sequence_param(partition_names, "partition_names", of_type=str),
             check.opt_str_param(last_submitted_partition_name, "last_submitted_partition_name"),
-            check.opt_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
+            check.opt_nullable_sequence_param(reexecution_steps, "reexecution_steps", of_type=str),
+            check.opt_str_param(serialized_asset_backfill_data, "serialized_asset_backfill_data"),
         )
 
     @property
     def selector_id(self):
         return self.partition_set_origin.get_selector_id() if self.partition_set_origin else None
+
+    @property
+    def is_asset_backfill(self) -> bool:
+        return self.serialized_asset_backfill_data is not None
+
+    @property
+    def bulk_action_type(self) -> BulkActionType:
+        if self.is_asset_backfill:
+            return BulkActionType.MULTI_RUN_ASSET_ACTION
+        else:
+            return BulkActionType.PARTITION_BACKFILL
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)
@@ -93,6 +120,7 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
         )
 
     def with_partition_checkpoint(self, last_submitted_partition_name):
@@ -109,6 +137,7 @@ class PartitionBackfill(
             last_submitted_partition_name=last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
         )
 
     def with_error(self, error):
@@ -125,4 +154,52 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=error,
             asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=self.serialized_asset_backfill_data,
+        )
+
+    def with_asset_backfill_data(
+        self, asset_backfill_data: AssetBackfillData
+    ) -> "PartitionBackfill":
+        return PartitionBackfill(
+            status=self.status,
+            backfill_id=self.backfill_id,
+            partition_set_origin=self.partition_set_origin,
+            partition_names=self.partition_names,
+            from_failure=self.from_failure,
+            reexecution_steps=self.reexecution_steps,
+            tags=self.tags,
+            backfill_timestamp=self.backfill_timestamp,
+            last_submitted_partition_name=self.last_submitted_partition_name,
+            error=self.error,
+            asset_selection=self.asset_selection,
+            serialized_asset_backfill_data=asset_backfill_data.serialize(),
+        )
+
+    @classmethod
+    def from_asset_partitions(
+        cls,
+        backfill_id: str,
+        asset_graph: AssetGraph,
+        partition_names: Sequence[str],
+        asset_selection: Sequence[AssetKey],
+        backfill_timestamp: float,
+        tags: Mapping[str, str],
+    ) -> "PartitionBackfill":
+        target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+        for asset_key in asset_selection:
+            partitions_def = cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
+            target_subsets_by_asset_key[
+                asset_key
+            ] = partitions_def.empty_subset().with_partition_keys(partition_names)
+
+        return cls(
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            from_failure=False,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            asset_selection=asset_selection,
+            serialized_asset_backfill_data=AssetBackfillData.empty(
+                target_subsets_by_asset_key, asset_graph
+            ).serialize(),
         )

--- a/python_modules/dagster/dagster/_core/execution/bulk_actions.py
+++ b/python_modules/dagster/dagster/_core/execution/bulk_actions.py
@@ -6,3 +6,4 @@ from dagster._serdes import whitelist_for_serdes
 @whitelist_for_serdes
 class BulkActionType(Enum):
     PARTITION_BACKFILL = "PARTITION_BACKFILL"
+    MULTI_RUN_ASSET_ACTION = "MULTI_RUN_ASSET_ACTION"

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -6,7 +6,6 @@ from tqdm import tqdm
 import dagster._check as check
 from dagster._serdes import deserialize_as
 
-from ...execution.bulk_actions import BulkActionType
 from ...execution.job_backfill import PartitionBackfill
 from ..pipeline_run import DagsterRun, DagsterRunStatus
 from ..runs.base import RunStorage
@@ -246,10 +245,7 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn=None):
                 storage_id = row[1]
                 conn.execute(
                     BulkActionsTable.update()
-                    .values(
-                        selector_id=backfill.selector_id,
-                        action_type=BulkActionType.PARTITION_BACKFILL.value,
-                    )
+                    .values(selector_id=backfill.selector_id, action_type=backfill.bulk_action_type)
                     .where(BulkActionsTable.c.id == storage_id)
                 )
                 cursor = storage_id

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -33,7 +33,6 @@ from dagster._core.errors import (
 )
 from dagster._core.events import EVENT_TYPE_TO_PIPELINE_RUN_STATUS, DagsterEvent, DagsterEventType
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPipelineOrigin
 from dagster._core.snap import (
     ExecutionPlanSnapshot,
@@ -1091,7 +1090,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         if self.has_bulk_actions_selector_cols():
             values["selector_id"] = partition_backfill.selector_id
-            values["action_type"] = BulkActionType.PARTITION_BACKFILL.value
+            values["action_type"] = partition_backfill.bulk_action_type.value
 
         with self.connect() as conn:
             conn.execute(

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -1,10 +1,12 @@
 import logging
+import sys
 from typing import Iterable, Mapping, Optional, cast
 
+from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._utils.error import SerializableErrorInfo
+from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 
 def execute_backfill_iteration(
@@ -27,6 +29,17 @@ def execute_backfill_iteration(
 
         # refetch, in case the backfill was updated in the meantime
         backfill = cast(PartitionBackfill, instance.get_backfill(backfill_id))
-        yield from execute_job_backfill_iteration(
-            backfill, logger, workspace, debug_crash_flags, instance
-        )
+        try:
+            if backfill.is_asset_backfill:
+                execute_asset_backfill_iteration(backfill, workspace, instance)
+            else:
+                yield from execute_job_backfill_iteration(
+                    backfill, logger, workspace, debug_crash_flags, instance
+                )
+        except Exception:
+            error_info = serializable_error_info_from_exc_info(sys.exc_info())
+            instance.update_backfill(
+                backfill.with_status(BulkActionStatus.FAILED).with_error(error_info)
+            )
+            logger.error(f"Backfill failed for {backfill.backfill_id}: {error_info.to_string()}")
+            yield error_info

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1,0 +1,260 @@
+from typing import AbstractSet, Dict, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
+from unittest.mock import MagicMock, patch
+
+import pendulum
+import pytest
+from dagster_tests.definitions_tests.test_asset_reconciliation_sensor import (
+    RunSpec,
+    do_run,
+    one_asset_one_partition,
+    one_asset_self_dependency,
+    one_asset_two_partitions,
+    two_assets_in_sequence_fan_in_partitions,
+    two_assets_in_sequence_fan_out_partitions,
+    two_assets_in_sequence_one_partition,
+    two_assets_in_sequence_two_partitions,
+)
+
+from dagster import (
+    AssetKey,
+    AssetSelection,
+    AssetsDefinition,
+    DagsterInstance,
+    Definitions,
+    PartitionsDefinition,
+    RunRequest,
+    SourceAsset,
+)
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.execution.asset_backfill import (
+    AssetBackfillData,
+    execute_asset_backfill_iteration_inner,
+)
+from dagster._core.host_representation.external_data import external_asset_graph_from_defs
+from dagster._seven.compat.pendulum import create_pendulum_time
+
+
+class AssetBackfillScenario(NamedTuple):
+    assets: Sequence[Union[SourceAsset, AssetsDefinition]]
+    unevaluated_runs: Sequence[RunSpec] = []
+    expected_run_requests: Optional[Sequence[RunRequest]] = None
+    expected_iterations: Optional[int] = None
+
+
+assets_by_repo_name_by_scenario_name: Mapping[str, Mapping[str, Sequence[AssetsDefinition]]] = {
+    "one_asset_one_partition": {"repo": one_asset_one_partition},
+    "one_asset_two_partitions": {"repo": one_asset_two_partitions},
+    "two_assets_in_sequence_one_partition": {"repo": two_assets_in_sequence_one_partition},
+    "two_assets_in_sequence_one_partition_cross_repo": {
+        "repo1": [two_assets_in_sequence_one_partition[0]],
+        "repo2": [two_assets_in_sequence_one_partition[1]],
+    },
+    "two_assets_in_sequence_two_partitions": {"repo": two_assets_in_sequence_two_partitions},
+    "two_assets_in_sequence_fan_in_partitions": {"repo": two_assets_in_sequence_fan_in_partitions},
+    "two_assets_in_sequence_fan_out_partitions": {
+        "repo": two_assets_in_sequence_fan_out_partitions
+    },
+    "one_asset_self_dependency": {"repo": one_asset_self_dependency},
+}
+
+
+@pytest.mark.parametrize("some_or_all", ["all", "some"])
+@pytest.mark.parametrize("failures", ["no_failures", "root_failures", "random_half_failures"])
+@pytest.mark.parametrize("scenario_name", list(assets_by_repo_name_by_scenario_name.keys()))
+def test_scenario_to_completion(scenario_name: str, failures: str, some_or_all: str):
+    with pendulum.test(create_pendulum_time(year=2020, month=1, day=7, hour=4)):
+        assets_by_repo_name = assets_by_repo_name_by_scenario_name[scenario_name]
+
+        with patch(
+            "dagster._core.host_representation.external_data.get_builtin_partition_mapping_types"
+        ) as get_builtin_partition_mapping_types:
+            get_builtin_partition_mapping_types.return_value = tuple(
+                assets_def.infer_partition_mapping(dep_key).__class__
+                for assets in assets_by_repo_name.values()
+                for assets_def in assets
+                for dep_key in assets_def.dependency_keys
+            )
+            asset_graph = external_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
+
+        asset_keys = asset_graph.all_asset_keys
+        root_asset_keys = AssetSelection.keys(*asset_keys).sources().resolve(asset_graph)
+
+        if some_or_all == "all":
+            target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+            for assets in assets_by_repo_name.values():
+                for asset_def in assets:
+                    partitions_def = cast(PartitionsDefinition, asset_def.partitions_def)
+                    target_subsets_by_asset_key[
+                        asset_def.key
+                    ] = partitions_def.empty_subset().with_partition_keys(
+                        partitions_def.get_partition_keys()
+                    )
+        elif some_or_all == "some":
+            # all partitions downstream of half of the partitions in each root asset
+            root_asset_partitions: Set[AssetKeyPartitionKey] = set()
+            for root_asset_key in root_asset_keys:
+                partitions_def = asset_graph.get_partitions_def(root_asset_key)
+                assert partitions_def is not None
+                partition_keys = list(partitions_def.get_partition_keys())
+                start_index = len(partition_keys) // 2
+                chosen_partition_keys = partition_keys[start_index:]
+                root_asset_partitions.update(
+                    AssetKeyPartitionKey(root_asset_key, partition_key)
+                    for partition_key in chosen_partition_keys
+                )
+
+            target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+                lambda _a, _b: True, root_asset_partitions
+            )
+
+            target_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
+            for asset_key, partition_key in target_asset_partitions:
+                assert partition_key is not None
+                partitions_def = asset_graph.get_partitions_def(asset_key)
+                assert partitions_def is not None
+                subset = target_subsets_by_asset_key.get(asset_key, partitions_def.empty_subset())
+                target_subsets_by_asset_key[asset_key] = subset.with_partition_keys([partition_key])
+
+        else:
+            assert False
+
+        if failures == "no_failures":
+            fail_asset_partitions: Set[AssetKeyPartitionKey] = set()
+        elif failures == "root_failures":
+            fail_asset_partitions: Set[AssetKeyPartitionKey] = {
+                AssetKeyPartitionKey(root_asset_key, partition_key)
+                for root_asset_key in root_asset_keys
+                for partition_key in target_subsets_by_asset_key[
+                    root_asset_key
+                ].get_partition_keys()
+            }
+        elif failures == "random_half_failures":
+            fail_asset_partitions: Set[AssetKeyPartitionKey] = {
+                AssetKeyPartitionKey(asset_key, partition_key)
+                for asset_key, subset in target_subsets_by_asset_key.items()
+                for partition_key in subset.get_partition_keys()
+                if hash(str(asset_key) + partition_key) % 2 == 0
+            }
+
+        else:
+            assert False
+
+        backfill = AssetBackfillData.empty(target_subsets_by_asset_key, asset_graph)
+        run_backfill_to_completion(
+            asset_graph, assets_by_repo_name, "backfillid_x", backfill, fail_asset_partitions
+        )
+
+
+def run_backfill_to_completion(
+    asset_graph: ExternalAssetGraph,
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
+    backfill_id: str,
+    backfill_data: AssetBackfillData,
+    fail_asset_partitions: AbstractSet[AssetKeyPartitionKey],
+) -> None:
+    iteration_count = 0
+    instance = DagsterInstance.ephemeral()
+
+    # assert each asset partition only targeted once
+    requested_asset_partitions: Set[AssetKeyPartitionKey] = set()
+
+    fail_and_downstream_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+        lambda _a, _b: True, fail_asset_partitions
+    )
+
+    while not backfill_data.is_complete():
+        iteration_count += 1
+        result1 = execute_asset_backfill_iteration_inner(
+            backfill_id=backfill_id,
+            asset_backfill_data=backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
+        # iteration_count += 1
+        assert result1.backfill_data != backfill_data
+
+        # if nothing changes, nothing should happen in the iteration
+        result2 = execute_asset_backfill_iteration_inner(
+            backfill_id=backfill_id,
+            asset_backfill_data=result1.backfill_data,
+            asset_graph=asset_graph,
+            instance=instance,
+        )
+        assert result2.backfill_data == result1.backfill_data
+        assert result2.run_requests == []
+
+        backfill_data = result2.backfill_data
+
+        for (
+            asset_partition
+        ) in backfill_data.materialized_asset_partitions.iterate_asset_partitions():
+            assert asset_partition not in fail_and_downstream_asset_partitions
+
+            for parent_asset_partition in asset_graph.get_parents_partitions(*asset_partition):
+                if (
+                    parent_asset_partition in backfill_data.target_asset_partitions
+                    and parent_asset_partition not in backfill_data.materialized_asset_partitions
+                ):
+                    assert (
+                        False
+                    ), f"{asset_partition} was materialized before its parent {parent_asset_partition},"
+
+        for run_request in result1.run_requests:
+            asset_keys = run_request.asset_selection
+            assert asset_keys is not None
+
+            for asset_key in asset_keys:
+                asset_partition = AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                assert (
+                    asset_partition not in requested_asset_partitions
+                ), f"{asset_partition} requested twice. Requested: {requested_asset_partitions}."
+                requested_asset_partitions.add(asset_partition)
+
+            assert all(
+                asset_graph.get_repository_handle(asset_keys[0])
+                == asset_graph.get_repository_handle(asset_key)
+                for asset_key in asset_keys
+            )
+            assets = assets_by_repo_name[
+                asset_graph.get_repository_handle(asset_keys[0]).repository_name
+            ]
+
+            do_run(
+                all_assets=assets,
+                asset_keys=asset_keys,
+                partition_key=run_request.partition_key,
+                instance=instance,
+                failed_asset_keys=[
+                    asset_key
+                    for asset_key in asset_keys
+                    if AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                    in fail_asset_partitions
+                ],
+                tags=run_request.tags,
+            )
+
+    assert iteration_count <= len(requested_asset_partitions) + 1
+
+
+def external_asset_graph_from_assets_by_repo_name(
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
+) -> ExternalAssetGraph:
+    from_repository_handles_and_external_asset_nodes = []
+
+    for repo_name, assets in assets_by_repo_name.items():
+
+        repo = Definitions(assets=assets).get_repository_def()
+
+        external_asset_nodes = external_asset_graph_from_defs(
+            repo.get_all_pipelines(), source_assets_by_key=repo.source_assets_by_key
+        )
+        repo_handle = MagicMock(repository_name=repo_name)
+        from_repository_handles_and_external_asset_nodes.extend(
+            [(repo_handle, asset_node) for asset_node in external_asset_nodes]
+        )
+
+    return ExternalAssetGraph.from_repository_handles_and_external_asset_nodes(
+        from_repository_handles_and_external_asset_nodes
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -482,6 +482,17 @@ two_assets_in_sequence_fan_out_partitions = [
 ]
 one_asset_daily_partitions = [asset_def("asset1", partitions_def=daily_partitions_def)]
 
+partitioned_after_non_partitioned = [
+    asset_def("asset1"),
+    asset_def(
+        "asset2", ["asset1"], partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")
+    ),
+]
+non_partitioned_after_partitioned = [
+    asset_def("asset1", partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")),
+    asset_def("asset2", ["asset1"]),
+]
+
 one_asset_self_dependency = [
     asset_def(
         "asset1",


### PR DESCRIPTION
branch-name: backfill-non-partitioned

### Summary & Motivation

This allows launching backfill runs that include non-partitioned assets.

### How I Tested These Changes
