### PR TITLE
Add StructuredIOManagerAdapter

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -227,6 +227,22 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
     )
 
 
+class StructuredIOManagerAdapter(StructuredConfigIOManagerBase):
+    @property
+    @abstractmethod
+    def wrapped_io_manager(self) -> IOManagerDefinition:
+        raise NotImplementedError()
+
+    def create_io_manager_to_pass_to_user_code(self, context) -> IOManager:
+        raise NotImplementedError(
+            "Because we override resource_fn in the adapter, this is never called."
+        )
+
+    @property
+    def resource_fn(self) -> ResourceFunction:
+        return self.wrapped_io_manager.resource_fn
+
+
 def infer_schema_from_config_annotation(model_cls: Any, config_arg_default: Any) -> Field:
     """
     Parses a structured config class or primitive type and returns a corresponding Dagster config Field.


### PR DESCRIPTION
### Summary & Motivation

Similar to StructuredResourceAdapter, add StructuredIOManagerAdapter. This allows a user to take an existing @io_manager or IOManagerDefinition and use it off the shelf using "new-style" resources.

Imagine you have an existing IOManager class:

```python
    @io_manager(config_schema={"a_config_value": str})
    def an_io_manager(context: InitResourceContext) -> AnIOManagerImplementation:
        return AnIOManagerImplementation(context.resource_config["a_config_value"])
```

You can adapter it to the new style as so:

```python
    class AdapterForIOManager(StructuredIOManagerAdapter):
        a_config_value: str
        @property
        def wrapped_io_manager(self) -> IOManagerDefinition:
            return an_io_manager
```

And then use it instead of a `.configured` call.

```python
    defs = Definitions(
        assets=[an_asset],
        resources={"io_manager": AdapterForIOManager(a_config_value="passed-in-configured")},
    )
```

### How I Tested These Changes

BK
