### PR TITLE
Default new-style config mappings to *Source equivalents rather than raw scalars

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,5 +1,6 @@
 import inspect
 
+from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 
 try:
@@ -213,18 +214,30 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
             pydantic_field.type_, description=pydantic_field.field_info.description
         )
 
-    dagster_type = pydantic_field.type_
     if pydantic_field.shape != SHAPE_SINGLETON:
         raise NotImplementedError(f"Pydantic shape {pydantic_field.shape} not supported")
 
-    inner_config_type = convert_potential_field(dagster_type).config_type
     return Field(
-        config=inner_config_type,
+        config=_config_type_for_pydantic_field(pydantic_field),
         description=pydantic_field.field_info.description,
         default_value=pydantic_field.default
         if pydantic_field.default
         else FIELD_NO_DEFAULT_PROVIDED,
     )
+
+
+def _config_type_for_pydantic_field(pydantic_field: ModelField):
+    potential_dagster_type = pydantic_field.type_
+
+    # special case raw python literals to their source equivalents
+    if potential_dagster_type is str:
+        return StringSource
+    elif potential_dagster_type is int:
+        return IntSource
+    elif potential_dagster_type is bool:
+        return BoolSource
+    else:
+        return convert_potential_field(potential_dagster_type).config_type
 
 
 class StructuredIOManagerAdapter(StructuredConfigIOManagerBase):

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -8,6 +8,7 @@ from dagster import _check as check
 from dagster import asset, job, multi_asset, op, validate_run_config
 from dagster._config.config_type import ConfigTypeKind
 from dagster._config.field_utils import convert_potential_field
+from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.structured_config import Config, infer_schema_from_config_class
 from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.definitions.assets_job import build_assets_job
@@ -29,7 +30,7 @@ def test_disallow_config_schema_conflict():
 
 
 def test_infer_config_schema():
-    old_schema = {"a_string": str, "an_int": int}
+    old_schema = {"a_string": StringSource, "an_int": IntSource}
 
     class ConfigClassTest(Config):
         a_string: str
@@ -439,3 +440,30 @@ def test_cached_method():
 
     assert counts["plus"] == 1
     assert counts["mult"] == 1
+
+
+def test_string_source_default():
+    class RawStringConfigSchema(Config):
+        a_str: str
+
+    assert print_config_type_to_string({"a_str": StringSource}) == print_config_type_to_string(
+        infer_schema_from_config_class(RawStringConfigSchema).config_type
+    )
+
+
+def test_bool_source_default():
+    class RawBoolConfigSchema(Config):
+        a_bool: bool
+
+    assert print_config_type_to_string({"a_bool": BoolSource}) == print_config_type_to_string(
+        infer_schema_from_config_class(RawBoolConfigSchema).config_type
+    )
+
+
+def test_int_source_default():
+    class RawIntConfigSchema(Config):
+        an_int: int
+
+    assert print_config_type_to_string({"an_int": IntSource}) == print_config_type_to_string(
+        infer_schema_from_config_class(RawIntConfigSchema).config_type
+    )


### PR DESCRIPTION
### Summary & Motivation

We default to the respective Source types (e.g. `IntSource`, `StringSource`) in config space for those scalars with source types. This makes it so that users can always use `EnvVar` in the config space.

### How I Tested These Changes

BK
