### PR TITLE
Passthrough pydantic.ModelField.required to dagster.Field.is_required

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -1,8 +1,10 @@
 import sys
+from typing import Optional
 
 import pytest
 from pydantic import BaseModel
 
+import dagster
 from dagster import AssetOut
 from dagster import _check as check
 from dagster import asset, job, multi_asset, op, validate_run_config
@@ -467,3 +469,50 @@ def test_int_source_default():
     assert print_config_type_to_string({"an_int": IntSource}) == print_config_type_to_string(
         infer_schema_from_config_class(RawIntConfigSchema).config_type
     )
+
+
+def test_optional_string_source_default():
+    class RawStringConfigSchema(Config):
+        a_str: Optional[str]
+
+    assert print_config_type_to_string(
+        {"a_str": dagster.Field(StringSource, is_required=False)}
+    ) == print_config_type_to_string(
+        infer_schema_from_config_class(RawStringConfigSchema).config_type
+    )
+
+    assert RawStringConfigSchema(a_str=None).a_str is None
+
+
+def test_optional_string_source_with_default_none():
+    class RawStringConfigSchema(Config):
+        a_str: Optional[str] = None
+
+    assert print_config_type_to_string(
+        {"a_str": dagster.Field(StringSource, is_required=False)}
+    ) == print_config_type_to_string(
+        infer_schema_from_config_class(RawStringConfigSchema).config_type
+    )
+
+    assert RawStringConfigSchema().a_str is None
+    assert RawStringConfigSchema(a_str=None).a_str is None
+
+
+def test_optional_bool_source_default():
+    class RawBoolConfigSchema(Config):
+        a_bool: Optional[bool]
+
+    assert print_config_type_to_string(
+        {"a_bool": dagster.Field(BoolSource, is_required=False)}
+    ) == print_config_type_to_string(
+        infer_schema_from_config_class(RawBoolConfigSchema).config_type
+    )
+
+
+def test_optional_int_source_default():
+    class OptionalInt(Config):
+        an_int: Optional[int]
+
+    assert print_config_type_to_string(
+        {"an_int": dagster.Field(IntSource, is_required=False)}
+    ) == print_config_type_to_string(infer_schema_from_config_class(OptionalInt).config_type)


### PR DESCRIPTION
### Summary & Motivation

This makes dagster.config respect Pydantic's `required` field. 

This makes it so that:

```python
    class RawStringConfigSchema(Config):
        a_str: Optional[str]
```

maps to an optional field in the config schema.

Note that this does NOT support Pydantic's notion of "undefined" and explicitly errors in that case.

### How I Tested These Changes

BK
