### PR TITLE
Support pydantic aliases in config schema mapping

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -310,8 +310,8 @@ def infer_schema_from_config_class(
     )
 
     fields = {}
-    for pydantic_field_name, pydantic_field in model_cls.__fields__.items():
-        fields[pydantic_field_name] = _convert_pydantic_field(pydantic_field)
+    for pydantic_field in model_cls.__fields__.values():
+        fields[pydantic_field.alias] = _convert_pydantic_field(pydantic_field)
 
     docstring = model_cls.__doc__.strip() if model_cls.__doc__ else None
     return Field(config=Shape(fields), description=description or docstring)


### PR DESCRIPTION
### Summary & Motivation

Discovered this issue while trying to put a config field `schema` into a new-style config class. Pydantic requires that you alias this, so updated the mapping to respect that alias field. This makes it so that you refer to the alias in config space, but the raw name at runtime.

For example.

```
    class ConfigWithSchema(Config):
        schema_: str = pydantic.Field(alias="schema")
```

is equivalent to the config schema: `{"schema": dagster.Field(StringSource)}`

In an op it looks like:

```
    @op
    def an_op(context, config: ConfigWithSchema):
        # use the raw property in python space
        assert config.schema_ == "bar"
        # use the alias in config space
        assert context.op_config == {"schema": "bar"}
  ```

### How I Tested These Changes

BK