### PR TITLE
Docs for new k8s configuration options

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/kubernetes/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/kubernetes/configuration-reference.mdx
@@ -72,13 +72,24 @@ locations:
           - name: test-volume
             config_map:
               name: test-volume-configmap
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
+        server_k8s_config: # Raw kubernetes config for code servers launched by the agent
+          pod_spec_config:
+            node_selector:
+              disktype: standard
+          container_config:
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+        run_k8s_config: # Raw kubernetes config for runs launched by the agent
+          pod_spec_config:
+            node_selector:
+              disktype: ssd
+          container_config:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1024Mi
 ```
 
 ### Environment variables and secrets
@@ -139,7 +150,7 @@ def k8s_job():
 
 ## Per-job and per-op configuration
 
-To add configuration to specific Dagster jobs or ops, use the `dagster-k8s/config` tag. For example, to specify that a job should have certain resource limits when it runs. Refer to [Customizing your Kubernetes deployment for Dagster Open Source](/deployment/guides/kubernetes/customizing-your-deployment#job-or-op-kubernetes-configuration) for more info.
+To add configuration to specific Dagster jobs or ops, use the `dagster-k8s/config` tag. For example, to specify that a job should have certain resource limits when it runs. Refer to [Customizing your Kubernetes deployment for Dagster Open Source](/deployment/guides/kubernetes/customizing-your-deployment#per-job-or-per-op-kubernetes-configuration) for more info.
 
 ---
 

--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -7,9 +7,50 @@ description: This section covers common ways to customize your Dagster Helm depl
 
 This section covers common ways to customize your Dagster Helm deployment.
 
-## Job or Op Kubernetes Configuration
+## Specifying custom Kubernetes configuration
 
-The `dagster-k8s/config` tag allows users to pass custom configuration through to the Kubernetes Jobs and Pods created by Dagster during execution.
+Dagster allows you to pass custom configuration to the Kubernetes Jobs and Pods created by Dagster during execution.
+
+### Instance-level Kubernetes Configuration
+
+If your instance is using the <PyObject module="dagster_k8s" object="K8sRunLauncher" />, you can configure custom configuration for every run launched by Dagster by setting the `k8sRunLauncher.runK8sConfig` dictionary in the Helm chart.
+
+`k8sRunLauncher.runK8sConfig` is a dictionary with the following keys:
+
+- `containerConfig`: The Pod's [Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core).
+- `podSpecConfig`: The Pod's [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podspec-v1-core).
+- `podTemplateSpecMetadata`: The Pod's [Metadata](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+- `jobSpecConfig`: The Job's [JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#jobspec-v1-batch).
+- `jobMetadata`: The Job's [Metadata](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta).
+
+The values for each of these keys is a dictionary with the YAML configuration for the underlying Kubernetes object. The Kubernetes object fields can be configured using either snake case (for example, `volume_mounts`) or camel case (`volumeMounts`). For example:
+
+```yaml file=/deploying/kubernetes/run_k8s_config.yaml
+runLauncher:
+  type: K8sRunLauncher
+  config:
+    k8sRunLauncher:
+      runK8sConfig:
+        containerConfig: # raw config for the pod's main container
+          resources:
+            cpu: 100m
+            memory: 128Mi
+        podTemplateSpecMetadata: # raw config for the pod's metadata
+          annotations:
+            mykey: myvalue
+        podSpecConfig: # raw config for the spec of the launched's pod
+          nodeSelector:
+            disktype: ssd
+        jobSpecConfig: # raw config for the kubernetes job's spec
+          ttlSecondsAfterFinished: 7200
+        jobMetadata: # raw config for the kubernetes job's metadata
+          annotations:
+            mykey: myvalue
+```
+
+### Per-job or per-op Kubernetes configuration
+
+The `dagster-k8s/config` tag allows you to pass custom configuration to the Kubernetes Jobs and Pods created by Dagster for specific jobs or ops.
 
 `dagster-k8s/config` is a dictionary with the following keys:
 
@@ -89,6 +130,10 @@ def my_job():
 ```
 
 Non-k8s run launchers and executors will ignore the `dagster-k8s/config` tag.
+
+If a Kubernetes configuration dictionary (like `container_config`) is specified at both the instance level in the Helm chart and in a specific Dagster job or op, the two dictionaries will be shallowly merged. The more specific configuration takes precedence if the same key is set in both dictionaries.
+
+For example, if `k8sRunLauncher.runK8sConfig.podSpecConfig` is set to `{"nodeSelector": {"disktype": "ssd"}, "dns_policy": "ClusterFirst"}` in the Helm chart, but a specific job has the `pod_spec_config` key in the `dagster-k8s/config` tag set to `{"nodeSelector": {"region": "east"}}`, the node selector from the job and the DNS policy from the Helm chart will be applied, since only the node selector is overridden in the job.
 
 ## Configuring an External Database
 

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/run_k8s_config.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/run_k8s_config.yaml
@@ -1,0 +1,20 @@
+runLauncher:
+  type: K8sRunLauncher
+  config:
+    k8sRunLauncher:
+      runK8sConfig:
+         containerConfig: # raw config for the pod's main container
+           resources:
+             cpu: 100m
+             memory: 128Mi
+         podTemplateSpecMetadata: # raw config for the pod's metadata
+           annotations:
+             mykey: myvalue
+         podSpecConfig: # raw config for the spec of the launched's pod
+           nodeSelector:
+             disktype: ssd
+         jobSpecConfig: # raw config for the kubernetes job's spec
+           ttlSecondsAfterFinished: 7200
+         jobMetadata: # raw config for the kubernetes job's metadata
+           annotations:
+             mykey: myvalue


### PR DESCRIPTION
Summary:
- In OSS, you can set raw config for launched runs that are applied to all jobs
- In Cloud, per-location config now includes server_k8s_config and run_k8s_config keys

### Summary & Motivation

### How I Tested These Changes
