### PR TITLE
Docs for new ECS resource options

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference.mdx
@@ -38,6 +38,12 @@ locations:
             valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::"
         secrets_tags:
           - "my_tag_name"
+        server_resources: # Resources for code servers launched by the agent for this location
+          cpu: 256
+          memory: 512
+        run_resources: # Resources for runs launched by the agent for this location
+          cpu: 4096
+          memory: 16384
 ```
 
 ### Environment variables and secrets
@@ -74,6 +80,8 @@ def my_job():
 
 [Fargate tasks only support certain combinations of CPU and memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
 
+If the `ecs/cpu` or `ecs/memory` tags are set, they will override any defaults set on the code location or the deployment.
+
 ---
 
 ## Per-deployment configuration
@@ -108,6 +116,12 @@ user_code_launcher:
     log_group: <Log Group Name>
     launch_type: <"FARGATE"|"EC2">
     server_process_startup_timeout: <Timeout in seconds>
+    server_resources:
+      cpu: <CPU value>
+      memory: <Memory value>
+    run_resources:
+      cpu: <CPU value>
+      memory: <Memory value>
 ```
 
 ### dagster_cloud_api properties
@@ -188,5 +202,13 @@ user_code_launcher:
   <ul>
   <li><strong>Default</strong> - 180 (seconds)</li>
   </ul>
+  </ReferenceTableItem>
+  <ReferenceTableItem
+  propertyName="config.server_resources">
+  The resources that the agent should allocate to the ECS service for each code location that it creates. If set, must be a dictionary with a <code>cpu</code> and/or <code>memory</code> key. <strong>Note</strong>: <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html">Fargate tasks only support certain combinations of CPU and memory</a>.
+  </ReferenceTableItem>
+  <ReferenceTableItem
+  propertyName="config.run_resources">
+  The resources that the agent should allocate to the ECS task that it creates for each run. If set, must be a dictionary with a <code>cpu</code> and/or <code>memory</code> key. <strong>Note</strong>: <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html">Fargate tasks only support certain combinations of CPU and memory</a>.
   </ReferenceTableItem>
 </ReferenceTable>

--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -75,7 +75,19 @@ run_launcher:
 
 ### Customizing CPU and memory in ECS
 
-You can use job tags to customize the CPU and memory of every run for a job:
+You can set the `run_launcher.config.run_resources` field to customize the default memory and CPU resources for Dagster runs. For example:
+
+```yaml
+run_launcher:
+  module: "dagster_aws.ecs"
+  class: "EcsRunLauncher"
+  config:
+    run_resources:
+      cpu: 256
+      memory: 512
+```
+
+You can also use job tags to customize the CPU and memory of every run for a particular job:
 
 ```py
 from dagster import job, op
@@ -93,6 +105,8 @@ def my_op(context):
 def my_job():
   my_op()
 ```
+
+If the `ecs/cpu` or `ecs/memory` tags are set, they will override any defaults set on the run launcher.
 
 **Note**: [Fargate tasks only support certain combinations of CPU and memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
 


### PR DESCRIPTION
Summary:
- In OSS, you can set 'run_resources' and have it apply to all launched runs - no more tags for each job
- In cloud, you can set `server_resources` or `run_resources` at the deployment or code location level.

### Summary & Motivation

### How I Tested These Changes
