### PR TITLE
Elminate PIPELINE_DEQUEUED event

### DIFF
--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_queued_run_coordinator.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_queued_run_coordinator.py
@@ -62,5 +62,5 @@ def test_execute_queued_run_on_celery_k8s(  # pylint: disable=redefined-outer-na
     logs = dagster_instance_for_daemon.all_logs(run_id)
     assert_events_in_order(
         logs,
-        ["PIPELINE_ENQUEUED", "PIPELINE_DEQUEUED", "PIPELINE_STARTING", "PIPELINE_SUCCESS"],
+        ["PIPELINE_ENQUEUED", "PIPELINE_STARTING", "PIPELINE_SUCCESS"],
     )

--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -52,7 +52,6 @@ def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_exa
                 logs,
                 [
                     "PIPELINE_ENQUEUED",
-                    "PIPELINE_DEQUEUED",
                     "PIPELINE_STARTING",
                     "PIPELINE_START",
                     "PIPELINE_SUCCESS",
@@ -75,7 +74,6 @@ def test_queued_runs(instance, foo_example_workspace, foo_example_repo):
             logs,
             [
                 "PIPELINE_ENQUEUED",
-                "PIPELINE_DEQUEUED",
                 "PIPELINE_STARTING",
                 "PIPELINE_START",
                 "PIPELINE_SUCCESS",

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -4,7 +4,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 from typing import Dict, List, Optional, Tuple
 
-from dagster import DagsterEvent, DagsterEventType
 from dagster import _check as check
 from dagster._core.instance import DagsterInstance
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
@@ -315,9 +314,4 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
             )
             return
 
-        dequeued_event = DagsterEvent(
-            event_type_value=DagsterEventType.PIPELINE_DEQUEUED.value,
-            pipeline_name=run.pipeline_name,
-        )
-        instance.report_dagster_event(dequeued_event, run_id=run.run_id)
         instance.launch_run(run.run_id, workspace_process_context.create_request_context())


### PR DESCRIPTION
Summary:
This event is always immediately followed by PIPELINE_STARTING - seems noisy to show both immediately one after the other. Also likely will make failure recovery more complicated to have to worry about yet another state the run can be in.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
