### PR TITLE
Be more resilient to user code errors when dequeuing runs

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -820,7 +820,16 @@ def test_compute_log_manager_has_schema(json_schema_model, compute_log_manager_c
 )
 def test_run_coordinator_has_schema(json_schema_model, run_coordinator_class):
     json_schema_fields = json_schema_model.schema()["properties"].keys()
-    run_coordinator_fields = set(map(to_camel_case, run_coordinator_class.config_type().keys()))
+    run_coordinator_fields = set(
+        map(
+            to_camel_case,
+            {
+                key
+                for key in run_coordinator_class.config_type().keys()
+                if key not in {"user_code_failure_retry_delay", "max_user_code_failure_retries"}
+            },
+        )
+    )
 
     assert json_schema_fields == run_coordinator_fields
 

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -17,10 +17,25 @@ class RunQueueConfig(
         [
             ("max_concurrent_runs", int),
             ("tag_concurrency_limits", Optional[Sequence[Mapping[str, Any]]]),
+            ("max_user_code_failure_retries", int),
+            ("user_code_failure_retry_delay", int),
         ],
     )
 ):
-    pass
+    def __new__(
+        cls,
+        max_concurrent_runs,
+        tag_concurrency_limits,
+        max_user_code_failure_retries=0,
+        user_code_failure_retry_delay=60,
+    ):
+        return super(RunQueueConfig, cls).__new__(
+            cls,
+            check.int_param(max_concurrent_runs, "max_concurrent_runs"),
+            check.opt_sequence_param(tag_concurrency_limits, "tag_concurrency_limits"),
+            check.int_param(max_user_code_failure_retries, "max_user_code_failure_retries"),
+            check.int_param(user_code_failure_retry_delay, "user_code_failure_retry_delay"),
+        )
 
 
 class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
@@ -36,6 +51,8 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
         dequeue_interval_seconds=None,
         dequeue_use_threads=None,
         dequeue_num_workers=None,
+        max_user_code_failure_retries=None,
+        user_code_failure_retry_delay=None,
         inst_data=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
@@ -57,6 +74,12 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
             dequeue_use_threads, "dequeue_use_threads", False
         )
         self._dequeue_num_workers = check.opt_int_param(dequeue_num_workers, "dequeue_num_workers")
+        self._max_user_code_failure_retries = check.opt_int_param(
+            max_user_code_failure_retries, "max_user_code_failure_retries", 0
+        )
+        self._user_code_failure_retry_delay = check.opt_int_param(
+            user_code_failure_retry_delay, "user_code_failure_retry_delay", 60
+        )
         self._logger = logging.getLogger("dagster.run_coordinator.queued_run_coordinator")
         super().__init__()
 
@@ -68,6 +91,8 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
         return RunQueueConfig(
             max_concurrent_runs=self._max_concurrent_runs,
             tag_concurrency_limits=self._tag_concurrency_limits,
+            max_user_code_failure_retries=self._max_user_code_failure_retries,
+            user_code_failure_retry_delay=self._user_code_failure_retry_delay,
         )
 
     @property
@@ -133,6 +158,24 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
                 is_required=False,
                 description="If dequeue_use_threads is true, limit the number of concurrent worker threads.",
             ),
+            "max_user_code_failure_retries": Field(
+                config=IntSource,
+                is_required=False,
+                default_value=0,
+                description="If there is an error reaching a Dagster gRPC server while dequeuing "
+                "the run, how many times to retry the dequeue before failing it. The only run "
+                "launcher that requires the gRPC server to be running is the DefaultRunLauncher, "
+                "so setting this will have no effect unless that run launcher is being used.",
+            ),
+            "user_code_failure_retry_delay": Field(
+                config=IntSource,
+                is_required=False,
+                default_value=60,
+                description="If there is an error reaching a Dagster gRPC server while dequeuing "
+                "the run, how long to wait before retrying any runs from that same code location. The only run "
+                "launcher that requires the gRPC server to be running is the DefaultRunLauncher, "
+                "so setting this will have no effect unless that run launcher is being used.",
+            ),
         }
 
     @classmethod
@@ -144,6 +187,8 @@ class QueuedRunCoordinator(RunCoordinator, ConfigurableClass):
             dequeue_interval_seconds=config_value.get("dequeue_interval_seconds"),
             dequeue_use_threads=config_value.get("dequeue_use_threads"),
             dequeue_num_workers=config_value.get("dequeue_num_workers"),
+            max_user_code_failure_retries=config_value.get("max_user_code_failure_retries"),
+            user_code_failure_retry_delay=config_value.get("user_code_failure_retry_delay"),
         )
 
     def submit_run(self, context: SubmitRunContext) -> DagsterRun:

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -1,12 +1,20 @@
 import sys
+import threading
+import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 from typing import Dict, List, Optional, Tuple
 
 from dagster import _check as check
+from dagster._core.errors import DagsterRepositoryLocationLoadError, DagsterUserCodeUnreachableError
+from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
 from dagster._core.instance import DagsterInstance
-from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
+from dagster._core.launcher import LaunchRunContext
+from dagster._core.run_coordinator.queued_run_coordinator import (
+    QueuedRunCoordinator,
+    RunQueueConfig,
+)
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
@@ -15,8 +23,9 @@ from dagster._core.storage.pipeline_run import (
 )
 from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._core.workspace.context import IWorkspaceProcessContext
+from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import IntervalDaemon, TDaemonGenerator
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+from dagster._utils.error import serializable_error_info_from_exc_info
 
 
 class _TagConcurrencyLimitsCounter:
@@ -107,6 +116,8 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
     def __init__(self, interval_seconds):
         self._exit_stack = ExitStack()
         self._executor = None
+        self._location_timeouts_lock = threading.Lock()
+        self._location_timeouts: Dict[str, float] = {}
         super().__init__(interval_seconds)
 
     def _get_executor(self, max_workers) -> ThreadPoolExecutor:
@@ -132,51 +143,88 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
     def run_iteration(
         self,
         workspace_process_context: IWorkspaceProcessContext,
+        fixed_iteration_time: Optional[float] = None,  # used for tests
     ) -> TDaemonGenerator:
-        instance = workspace_process_context.instance
-        runs_to_dequeue = self._get_runs_to_dequeue(instance)
-        yield from self._dequeue_runs_iter(workspace_process_context, runs_to_dequeue)
-
-    def _dequeue_runs_iter(
-        self,
-        workspace_process_context: IWorkspaceProcessContext,
-        runs_to_dequeue: List[DagsterRun],
-    ):
         run_coordinator = workspace_process_context.instance.run_coordinator
         if not isinstance(run_coordinator, QueuedRunCoordinator):
             check.failed(f"Expected QueuedRunCoordinator, got {run_coordinator}")
 
+        run_queue_config = run_coordinator.get_run_queue_config()
+
+        instance = workspace_process_context.instance
+        runs_to_dequeue = self._get_runs_to_dequeue(
+            instance, run_queue_config, fixed_iteration_time=fixed_iteration_time
+        )
+        yield from self._dequeue_runs_iter(
+            workspace_process_context,
+            run_coordinator,
+            runs_to_dequeue,
+            run_queue_config,
+            fixed_iteration_time=fixed_iteration_time,
+        )
+
+    def _dequeue_runs_iter(
+        self,
+        workspace_process_context: IWorkspaceProcessContext,
+        run_coordinator: QueuedRunCoordinator,
+        runs_to_dequeue: List[DagsterRun],
+        run_queue_config: RunQueueConfig,
+        fixed_iteration_time: Optional[float],
+    ):
         if run_coordinator.dequeue_use_threads:
             yield from self._dequeue_runs_iter_threaded(
                 workspace_process_context,
                 runs_to_dequeue,
                 run_coordinator.dequeue_num_workers,
+                run_queue_config,
+                fixed_iteration_time=fixed_iteration_time,
             )
         else:
             yield from self._dequeue_runs_iter_loop(
                 workspace_process_context,
                 runs_to_dequeue,
+                run_queue_config,
+                fixed_iteration_time=fixed_iteration_time,
             )
+
+    def _dequeue_run_thread(
+        self,
+        workspace_process_context: IWorkspaceProcessContext,
+        run: DagsterRun,
+        run_queue_config: RunQueueConfig,
+        fixed_iteration_time: Optional[float],
+    ) -> bool:
+        return self._dequeue_run(
+            workspace_process_context.instance,
+            workspace_process_context.create_request_context(),
+            run,
+            run_queue_config,
+            fixed_iteration_time,
+        )
 
     def _dequeue_runs_iter_threaded(
         self,
         workspace_process_context: IWorkspaceProcessContext,
         runs_to_dequeue: List[DagsterRun],
         max_workers: Optional[int],
+        run_queue_config: RunQueueConfig,
+        fixed_iteration_time: Optional[float],
     ):
         num_dequeued_runs = 0
 
         for future in as_completed(
             self._get_executor(max_workers).submit(
-                self._dequeue_run_guarded,
+                self._dequeue_run_thread,
                 workspace_process_context,
                 run,
+                run_queue_config,
+                fixed_iteration_time=fixed_iteration_time,
             )
             for run in runs_to_dequeue
         ):
-            err_or_none = future.result()
-            yield err_or_none
-            if err_or_none is None:
+            run_launched = future.result()
+            yield None
+            if run_launched:
                 num_dequeued_runs += 1
 
         if num_dequeued_runs > 0:
@@ -186,22 +234,34 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         self,
         workspace_process_context: IWorkspaceProcessContext,
         runs_to_dequeue: List[DagsterRun],
+        run_queue_config: RunQueueConfig,
+        fixed_iteration_time: Optional[float],
     ):
         num_dequeued_runs = 0
+        workspace = workspace_process_context.create_request_context()
         for run in runs_to_dequeue:
-            err_or_none = self._dequeue_run_guarded(workspace_process_context, run)
-            yield err_or_none
-            if err_or_none is None:
+            run_launched = self._dequeue_run(
+                workspace_process_context.instance,
+                workspace,
+                run,
+                run_queue_config,
+                fixed_iteration_time=fixed_iteration_time,
+            )
+            yield None
+            if run_launched:
                 num_dequeued_runs += 1
 
         if num_dequeued_runs > 0:
             self._logger.info("Launched %d runs.", num_dequeued_runs)
 
-    def _get_runs_to_dequeue(self, instance: DagsterInstance) -> List[DagsterRun]:
+    def _get_runs_to_dequeue(
+        self,
+        instance: DagsterInstance,
+        run_queue_config: RunQueueConfig,
+        fixed_iteration_time: Optional[float],
+    ) -> List[DagsterRun]:
         if not isinstance(instance.run_coordinator, QueuedRunCoordinator):
             check.failed(f"Expected QueuedRunCoordinator, got {instance.run_coordinator}")
-
-        run_queue_config = instance.run_coordinator.get_run_queue_config()
 
         max_concurrent_runs = run_queue_config.max_concurrent_runs
         tag_concurrency_limits = run_queue_config.tag_concurrency_limits
@@ -225,8 +285,27 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
 
         if not queued_runs:
             self._logger.debug("Poll returned no queued runs.")
-        else:
-            self._logger.info("Retrieved %d queued runs, checking limits.", len(queued_runs))
+            return []
+
+        now = fixed_iteration_time or time.time()
+
+        with self._location_timeouts_lock:
+            paused_location_names = {
+                location_name
+                for location_name in self._location_timeouts
+                if self._location_timeouts[location_name] > now
+            }
+
+        locations_clause = ""
+        if paused_location_names:
+            locations_clause = (
+                " Temporarily skipping runs from the following locations due to a user code error: "
+                + ",".join(list(paused_location_names))
+            )
+
+        self._logger.info(
+            f"Retrieved %d queued runs, checking limits.{locations_clause}", len(queued_runs)
+        )
 
         # place in order
         sorted_runs = self._priority_sort(queued_runs)
@@ -242,6 +321,12 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
             if tag_concurrency_limits_counter.is_run_blocked(run):
                 continue
 
+            location_name = (
+                run.external_pipeline_origin.location_name if run.external_pipeline_origin else None
+            )
+            if location_name and location_name in paused_location_names:
+                continue
+
             tag_concurrency_limits_counter.update_counters_with_launched_run(run)
             batch.append(run)
 
@@ -251,12 +336,10 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         queued_runs_filter = RunsFilter(statuses=[DagsterRunStatus.QUEUED])
 
         # Reversed for fifo ordering
-        # Note: should add a maximum fetch limit https://github.com/dagster-io/dagster/issues/3339
         runs = instance.get_runs(filters=queued_runs_filter)[::-1]
         return runs
 
     def _get_in_progress_runs(self, instance):
-        # Note: should add a maximum fetch limit https://github.com/dagster-io/dagster/issues/3339
         return instance.get_runs(filters=RunsFilter(statuses=IN_PROGRESS_RUN_STATUSES))
 
     def _priority_sort(self, runs):
@@ -270,48 +353,133 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         # sorted is stable, so fifo is maintained
         return sorted(runs, key=get_priority, reverse=True)
 
-    def _dequeue_run_guarded(
-        self,
-        workspace_process_context: IWorkspaceProcessContext,
-        run: DagsterRun,
-    ) -> Optional[SerializableErrorInfo]:
-        instance = workspace_process_context.instance
-        error_info = None
-
-        try:
-            self._dequeue_run(workspace_process_context, run)
-        except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-
-            message = (
-                f"Caught an error for run {run.run_id} while removing it from the queue."
-                " Marking the run as failed and dropping it from the queue"
+    def _is_location_pausing_dequeues(self, location_name, now):
+        with self._location_timeouts_lock:
+            return (
+                location_name in self._location_timeouts
+                and self._location_timeouts[location_name] > now
             )
-            message_with_full_error = f"{message}: {error_info.to_string()}"
-
-            self._logger.error(message_with_full_error)
-            instance.report_run_failed(run, message_with_full_error)
-
-            # modify the original error, so that the extra message appears in heartbeats
-            error_info = error_info._replace(message=f"{message}: {error_info.message}")
-
-        return error_info
 
     def _dequeue_run(
         self,
-        workspace_process_context: IWorkspaceProcessContext,
+        instance: DagsterInstance,
+        workspace: IWorkspace,
         run: DagsterRun,
-    ) -> None:
-        instance = workspace_process_context.instance
-        # double check that the run is still queued before dequeing
-        reloaded_run = check.not_none(instance.get_run_by_id(run.run_id))
+        run_queue_config: RunQueueConfig,
+        fixed_iteration_time: Optional[float],
+    ) -> bool:
 
-        if reloaded_run.status != DagsterRunStatus.QUEUED:
+        # double check that the run is still queued before dequeing
+        run = check.not_none(instance.get_run_by_id(run.run_id))
+
+        now = fixed_iteration_time or time.time()
+
+        if run.status != DagsterRunStatus.QUEUED:
             self._logger.info(
                 "Run %s is now %s instead of QUEUED, skipping",
-                reloaded_run.run_id,
-                reloaded_run.status,
+                run.run_id,
+                run.status,
             )
-            return
+            return False
 
-        instance.launch_run(run.run_id, workspace_process_context.create_request_context())
+        # Very old (pre 0.10.0) runs and programatically submitted runs may not have an
+        # attached code location name
+        location_name = (
+            run.external_pipeline_origin.location_name if run.external_pipeline_origin else None
+        )
+
+        if location_name and self._is_location_pausing_dequeues(location_name, now):
+            self._logger.info(
+                "Pausing dequeues for runs from code location %s to give its code server time to recover",
+                location_name,
+            )
+            return False
+
+        launch_started_event = DagsterEvent(
+            event_type_value=DagsterEventType.PIPELINE_STARTING.value,
+            pipeline_name=run.pipeline_name,
+        )
+
+        instance.report_dagster_event(launch_started_event, run_id=run.run_id)
+
+        run = check.not_none(instance.get_run_by_id(run.run_id))
+
+        try:
+            instance.run_launcher.launch_run(
+                LaunchRunContext(pipeline_run=run, workspace=workspace)
+            )
+        except Exception as e:
+            error = serializable_error_info_from_exc_info(sys.exc_info())
+
+            run = check.not_none(instance.get_run_by_id(run.run_id))
+            # Make sure we don't re-enqueue a run if it has already finished or moved into STARTED:
+            if run.status not in (DagsterRunStatus.QUEUED, DagsterRunStatus.STARTING):
+                self._logger.info(
+                    f"Run {run.run_id} failed while being dequeued, but has already advanced to {run.status} - moving on. Error: {error.to_string()}"
+                )
+                return False
+            elif run_queue_config.max_user_code_failure_retries and isinstance(
+                e, (DagsterUserCodeUnreachableError, DagsterRepositoryLocationLoadError)
+            ):
+
+                if location_name:
+                    with self._location_timeouts_lock:
+                        # Don't try to dequeue runs from this location for another N seconds
+                        self._location_timeouts[location_name] = (
+                            now + run_queue_config.user_code_failure_retry_delay
+                        )
+
+                enqueue_event_records = instance.get_records_for_run(
+                    run_id=run.run_id, of_type=DagsterEventType.PIPELINE_ENQUEUED
+                ).records
+
+                check.invariant(len(enqueue_event_records), "Could not find enqueue event for run")
+
+                num_retries_so_far = len(enqueue_event_records) - 1
+
+                if num_retries_so_far >= run_queue_config.max_user_code_failure_retries:
+                    message = f"Run dequeue failed to reach the user code server after {run_queue_config.max_user_code_failure_retries} attempts, failing run"
+                    message_with_full_error = f"{message}: {error.to_string()}"
+                    self._logger.error(message_with_full_error)
+                    instance.report_engine_event(
+                        message,
+                        run,
+                        EngineEventData.engine_error(error),
+                    )
+                    instance.report_run_failed(run)
+                    return False
+                else:
+                    retries_left = (
+                        run_queue_config.max_user_code_failure_retries - num_retries_so_far
+                    )
+                    retries_str = "retr" + ("y" if retries_left == 1 else "ies")
+                    message = f"Run dequeue failed to reach the user code server, re-submitting the run into the queue ({retries_left} {retries_str} remaining)"
+                    message_with_full_error = f"{message}: {error.to_string()}"
+                    self._logger.warning(message_with_full_error)
+
+                    instance.report_engine_event(
+                        message,
+                        run,
+                        EngineEventData.engine_error(error),
+                    )
+                    # Re-submit the run into the queue
+                    enqueued_event = DagsterEvent(
+                        event_type_value=DagsterEventType.PIPELINE_ENQUEUED.value,
+                        pipeline_name=run.pipeline_name,
+                    )
+                    instance.report_dagster_event(enqueued_event, run_id=run.run_id)
+                    return False
+            else:
+                message = "Caught an unrecoverable error while dequeuing the run. Marking the run as failed and dropping it from the queue"
+                message_with_full_error = f"{message}: {error.to_string()}"
+                self._logger.error(message_with_full_error)
+
+                instance.report_engine_event(
+                    message,
+                    run,
+                    EngineEventData.engine_error(error),
+                )
+
+                instance.report_run_failed(run)
+                return False
+        return True

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -1,10 +1,12 @@
 # pylint: disable=redefined-outer-name
 
+import time
 from contextlib import contextmanager
 
 import pytest
 from dagster_tests.api_tests.utils import get_foo_job_handle
 
+from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.host_representation.repository_location import GrpcServerRepositoryLocation
 from dagster._core.storage.pipeline_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus
 from dagster._core.storage.tags import PRIORITY_TAG
@@ -18,29 +20,20 @@ from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import Queued
 
 
 @contextmanager
-def instance_for_queued_run_coordinator(
-    max_concurrent_runs=None, tag_concurrency_limits=None, use_threads=False
-):
-    max_concurrent_runs = (
-        {"max_concurrent_runs": max_concurrent_runs} if max_concurrent_runs else {}
-    )
-    tag_concurrency_limits = (
-        {"tag_concurrency_limits": tag_concurrency_limits} if tag_concurrency_limits else {}
-    )
+def instance_for_queued_run_coordinator(**kwargs):
     overrides = {
         "run_coordinator": {
             "module": "dagster._core.run_coordinator",
             "class": "QueuedRunCoordinator",
-            "config": {
-                **max_concurrent_runs,
-                **tag_concurrency_limits,
-                "dequeue_use_threads": use_threads,
-            },
+            "config": {**kwargs},
         },
         "run_launcher": {
             "module": "dagster._core.test_utils",
             "class": "MockedRunLauncher",
-            "config": {"bad_run_ids": ["bad-run"]},
+            "config": {
+                "bad_run_ids": ["bad-run"],
+                "bad_user_code_run_ids": ["bad-user-code-run"],
+            },
         },
     }
 
@@ -73,6 +66,17 @@ def pipeline_handle():
         yield handle
 
 
+@pytest.fixture(scope="module")
+def other_location_pipeline_handle(pipeline_handle):
+    return pipeline_handle._replace(
+        repository_handle=pipeline_handle.repository_handle._replace(
+            repository_location_origin=pipeline_handle.repository_handle.repository_location_origin._replace(
+                location_name="other_location_name"
+            )
+        )
+    )
+
+
 def create_run(instance, pipeline_handle, **kwargs):
     create_run_for_test(
         instance,
@@ -83,16 +87,32 @@ def create_run(instance, pipeline_handle, **kwargs):
     )
 
 
+def create_queued_run(instance, pipeline_handle, **kwargs):
+    run = create_run_for_test(
+        instance,
+        external_pipeline_origin=pipeline_handle.get_external_origin(),
+        pipeline_code_origin=pipeline_handle.get_python_origin(),
+        pipeline_name="foo",
+        status=DagsterRunStatus.NOT_STARTED,
+        **kwargs,
+    )
+    enqueued_event = DagsterEvent(
+        event_type_value=DagsterEventType.PIPELINE_ENQUEUED.value,
+        pipeline_name=run.pipeline_name,
+    )
+    instance.report_dagster_event(enqueued_event, run_id=run.run_id)
+    return instance.get_run_by_id(run.run_id)
+
+
 def get_run_ids(runs_queue):
     return [run.run_id for run in runs_queue]
 
 
 def test_attempt_to_launch_runs_filter(instance, workspace_context, daemon, pipeline_handle):
-    create_run(
+    create_queued_run(
         instance,
         pipeline_handle,
         run_id="queued-run",
-        status=DagsterRunStatus.QUEUED,
     )
     create_run(
         instance,
@@ -142,7 +162,7 @@ def test_get_queued_runs_max_runs(
 ):
     max_runs = 4
     with instance_for_queued_run_coordinator(
-        max_concurrent_runs=max_runs, use_threads=use_threads
+        max_concurrent_runs=max_runs, dequeue_use_threads=use_threads
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
         # fill run store with ongoing runs
@@ -160,11 +180,10 @@ def test_get_queued_runs_max_runs(
         # add more queued runs than should be launched
         queued_run_ids = ["queued-run-{}".format(i) for i in range(max_runs + 1)]
         for run_id in queued_run_ids:
-            create_run(
+            create_queued_run(
                 instance,
                 pipeline_handle,
                 run_id=run_id,
-                status=DagsterRunStatus.QUEUED,
             )
 
         list(daemon.run_iteration(bounded_ctx))
@@ -178,7 +197,7 @@ def test_get_queued_runs_max_runs(
 )
 def test_disable_max_concurrent_runs_limit(use_threads, workspace_context, pipeline_handle, daemon):
     with instance_for_queued_run_coordinator(
-        max_concurrent_runs=-1, use_threads=use_threads
+        max_concurrent_runs=-1, dequeue_use_threads=use_threads
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
@@ -197,11 +216,10 @@ def test_disable_max_concurrent_runs_limit(use_threads, workspace_context, pipel
         # add more queued runs
         queued_run_ids = ["queued-run-{}".format(i) for i in range(6)]
         for run_id in queued_run_ids:
-            create_run(
+            create_queued_run(
                 instance,
                 pipeline_handle,
                 run_id=run_id,
-                status=DagsterRunStatus.QUEUED,
             )
 
         list(daemon.run_iteration(bounded_ctx))
@@ -211,18 +229,16 @@ def test_disable_max_concurrent_runs_limit(use_threads, workspace_context, pipel
 
 def test_priority(instance, workspace_context, pipeline_handle, daemon):
     create_run(instance, pipeline_handle, run_id="default-pri-run", status=DagsterRunStatus.QUEUED)
-    create_run(
+    create_queued_run(
         instance,
         pipeline_handle,
         run_id="low-pri-run",
-        status=DagsterRunStatus.QUEUED,
         tags={PRIORITY_TAG: "-1"},
     )
-    create_run(
+    create_queued_run(
         instance,
         pipeline_handle,
         run_id="hi-pri-run",
-        status=DagsterRunStatus.QUEUED,
         tags={PRIORITY_TAG: "3"},
     )
 
@@ -236,11 +252,10 @@ def test_priority(instance, workspace_context, pipeline_handle, daemon):
 
 
 def test_priority_on_malformed_tag(instance, workspace_context, pipeline_handle, daemon):
-    create_run(
+    create_queued_run(
         instance,
         pipeline_handle,
         run_id="bad-pri-run",
-        status=DagsterRunStatus.QUEUED,
         tags={PRIORITY_TAG: "foobar"},
     )
 
@@ -257,29 +272,26 @@ def test_tag_limits(use_threads, workspace_context, pipeline_handle, daemon):
     with instance_for_queued_run_coordinator(
         max_concurrent_runs=10,
         tag_concurrency_limits=[{"key": "database", "value": "tiny", "limit": 1}],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="tiny-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="tiny-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="large-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "large"},
         )
 
@@ -299,29 +311,26 @@ def test_tag_limits_just_key(use_threads, workspace_context, pipeline_handle, da
         tag_concurrency_limits=[
             {"key": "database", "value": {"applyLimitPerUniqueValue": False}, "limit": 2}
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="tiny-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="tiny-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="large-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "large"},
         )
 
@@ -347,36 +356,32 @@ def test_multiple_tag_limits(
             {"key": "database", "value": "tiny", "limit": 1},
             {"key": "user", "value": "johann", "limit": 2},
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny", "user": "johann"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"database": "tiny"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=DagsterRunStatus.QUEUED,
             tags={"user": "johann"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=DagsterRunStatus.QUEUED,
             tags={"user": "johann"},
         )
 
@@ -397,36 +402,32 @@ def test_overlapping_tag_limits(use_threads, workspace_context, daemon, pipeline
             {"key": "foo", "limit": 2},
             {"key": "foo", "value": "bar", "limit": 1},
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
 
@@ -446,38 +447,34 @@ def test_limits_per_unique_value(use_threads, workspace_context, pipeline_handle
         tag_concurrency_limits=[
             {"key": "foo", "limit": 1, "value": {"applyLimitPerUniqueValue": True}},
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
         list(daemon.run_iteration(bounded_ctx))
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
 
@@ -503,36 +500,32 @@ def test_limits_per_unique_value_overlapping_limits(
             {"key": "foo", "limit": 1, "value": {"applyLimitPerUniqueValue": True}},
             {"key": "foo", "limit": 2},
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "other-2"},
         )
 
@@ -547,43 +540,38 @@ def test_limits_per_unique_value_overlapping_limits(
             {"key": "foo", "limit": 2, "value": {"applyLimitPerUniqueValue": True}},
             {"key": "foo", "limit": 1, "value": "bar"},
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "baz"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-3",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "bar"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-4",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "baz"},
         )
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-5",
-            status=DagsterRunStatus.QUEUED,
             tags={"foo": "baz"},
         )
 
@@ -598,18 +586,16 @@ def test_locations_not_created(instance, monkeypatch, workspace_context, daemon,
     Verifies that no repository location is created when runs are dequeued
     """
 
-    create_run(
+    create_queued_run(
         instance,
         pipeline_handle,
         run_id="queued-run",
-        status=DagsterRunStatus.QUEUED,
     )
 
-    create_run(
+    create_queued_run(
         instance,
         pipeline_handle,
         run_id="queued-run-2",
-        status=DagsterRunStatus.QUEUED,
     )
 
     original_method = GrpcServerRepositoryLocation.__init__
@@ -652,28 +638,174 @@ def test_locations_not_created(instance, monkeypatch, workspace_context, daemon,
     assert len(method_calls) == 0
 
 
-def test_skip_error_runs(instance, pipeline_handle, workspace_context, daemon):
-    create_run(
-        instance,
-        pipeline_handle,
-        run_id="bad-run",
-        status=DagsterRunStatus.QUEUED,
-    )
+@pytest.mark.parametrize(
+    "use_threads",
+    [False, True],
+)
+def test_skip_error_runs(pipeline_handle, daemon, use_threads):
+    with instance_for_queued_run_coordinator(
+        max_concurrent_runs=10, dequeue_use_threads=use_threads
+    ) as instance:
+        with create_test_daemon_workspace_context(
+            workspace_load_target=EmptyWorkspaceTarget(), instance=instance
+        ) as workspace_context:
+            create_queued_run(
+                instance,
+                pipeline_handle,
+                run_id="bad-run",
+            )
 
-    create_run(
-        instance,
-        pipeline_handle,
-        run_id="good-run",
-        status=DagsterRunStatus.QUEUED,
-    )
+            create_queued_run(
+                instance,
+                pipeline_handle,
+                run_id="good-run",
+            )
 
-    errors = [error for error in list(daemon.run_iteration(workspace_context)) if error]
+            create_queued_run(
+                instance,
+                pipeline_handle,
+                run_id="bad-user-code-run",
+            )
 
-    assert len(errors) == 1
-    assert "Bad run bad-run" in errors[0].message
+            list(daemon.run_iteration(workspace_context))
 
-    assert get_run_ids(instance.run_launcher.queue()) == ["good-run"]
-    assert instance.get_run_by_id("bad-run").status == DagsterRunStatus.FAILURE
+            assert get_run_ids(instance.run_launcher.queue()) == ["good-run"]
+            assert instance.get_run_by_id("bad-run").status == DagsterRunStatus.FAILURE
+            assert instance.get_run_by_id("bad-user-code-run").status == DagsterRunStatus.FAILURE
+
+
+@pytest.mark.parametrize(
+    "use_threads",
+    [False, True],
+)
+def test_retry_user_code_error_run(
+    pipeline_handle, other_location_pipeline_handle, daemon, use_threads
+):
+    with instance_for_queued_run_coordinator(
+        max_concurrent_runs=10,
+        dequeue_use_threads=use_threads,
+        max_user_code_failure_retries=2,
+        user_code_failure_retry_delay=120,
+    ) as instance:
+        with create_test_daemon_workspace_context(
+            workspace_load_target=EmptyWorkspaceTarget(), instance=instance
+        ) as workspace_context:
+            fixed_iteration_time = time.time() - 3600 * 24 * 365
+
+            create_queued_run(instance, pipeline_handle, run_id="bad-run")
+            create_queued_run(instance, pipeline_handle, run_id="good-run")
+            create_queued_run(
+                instance,
+                pipeline_handle,
+                run_id="bad-user-code-run",
+            )
+
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert get_run_ids(instance.run_launcher.queue()) == ["good-run"]
+            assert instance.get_run_by_id("bad-run").status == DagsterRunStatus.FAILURE
+
+            # Run was put back into the queue due to the user code failure
+            assert instance.get_run_by_id("bad-user-code-run").status == DagsterRunStatus.QUEUED
+
+            # Other runs in the same location are skipped
+            create_queued_run(
+                instance,
+                pipeline_handle,
+                run_id="good-run-same-location",
+                tags={
+                    "dagster/priority": "5",
+                },
+            )
+            create_queued_run(
+                instance,
+                other_location_pipeline_handle,
+                run_id="good-run-other-location",
+            )
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert get_run_ids(instance.run_launcher.queue()) == [
+                "good-run",
+                "good-run-other-location",
+            ]
+
+            fixed_iteration_time = fixed_iteration_time + 10
+
+            # Add more runs, one in the same location, one in another location - the former is
+            # skipped, the other launches. The original failed run is also skipped
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert instance.get_run_by_id("bad-user-code-run").status == DagsterRunStatus.QUEUED
+            assert (
+                instance.get_run_by_id("good-run-same-location").status == DagsterRunStatus.QUEUED
+            )
+
+            fixed_iteration_time = fixed_iteration_time + 121
+
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert instance.get_run_by_id("bad-user-code-run").status == DagsterRunStatus.QUEUED
+
+            fixed_iteration_time = fixed_iteration_time + 121
+
+            # Gives up after max_user_code_failure_retries retries - the good run from that
+            # location succeeds
+
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert instance.get_run_by_id("bad-user-code-run").status == DagsterRunStatus.FAILURE
+
+            fixed_iteration_time = fixed_iteration_time + 121
+
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            # good run is now free to launch (since it is dequeud before the bad run due to), bad run does its second retry
+            assert get_run_ids(instance.run_launcher.queue()) == [
+                "good-run",
+                "good-run-other-location",
+                "good-run-same-location",
+            ]
+
+
+@pytest.mark.parametrize(
+    "use_threads",
+    [False, True],
+)
+def test_retry_user_code_error_recovers(pipeline_handle, daemon, use_threads):
+    with instance_for_queued_run_coordinator(
+        max_concurrent_runs=10,
+        dequeue_use_threads=use_threads,
+        max_user_code_failure_retries=1,
+        user_code_failure_retry_delay=5,
+    ) as instance:
+        with create_test_daemon_workspace_context(
+            workspace_load_target=EmptyWorkspaceTarget(), instance=instance
+        ) as workspace_context:
+            fixed_iteration_time = time.time() - 3600 * 24 * 365
+
+            create_queued_run(
+                instance,
+                pipeline_handle,
+                run_id="bad-user-code-run",
+            )
+
+            # fails on initial dequeue
+
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert instance.get_run_by_id("bad-user-code-run").status == DagsterRunStatus.QUEUED
+
+            fixed_iteration_time = fixed_iteration_time + 6
+
+            # Passes on retry
+
+            instance.run_launcher.bad_user_code_run_ids = set()
+
+            list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
+
+            assert get_run_ids(instance.run_launcher.queue()) == [
+                "bad-user-code-run",
+            ]
 
 
 @pytest.mark.parametrize(
@@ -686,23 +818,21 @@ def test_key_limit_with_extra_tags(use_threads, workspace_context, daemon, pipel
         tag_concurrency_limits=[
             {"key": "test", "limit": 1},
         ],
-        use_threads=use_threads,
+        dequeue_use_threads=use_threads,
     ) as instance:
         bounded_ctx = workspace_context.copy_for_test_instance(instance)
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-1",
-            status=DagsterRunStatus.QUEUED,
             tags={"other-tag": "value", "test": "value"},
         )
 
-        create_run(
+        create_queued_run(
             instance,
             pipeline_handle,
             run_id="run-2",
-            status=DagsterRunStatus.QUEUED,
             tags={"other-tag": "value", "test": "value"},
         )
 


### PR DESCRIPTION
Summary:
Right now if the user code server is unreachable while a run is being dequeued - e.g. you're using the default run launcher and the grpc server is down, or you're using cloud and the run is launched via the agent - the dequeue will immediately give up.

This is a work-in-progress solution that instead:
- Retries up to N times by re-enqueing the run
- Puts the last user code failure timestamp for that code location in a map to make it wait to try again for a while, so we don't race through the N retries right away

The other missing piece here would be to add a hook on each iteration to optionally check that all user code servers are unavailable - that would cover cases in cloud like the agent being in the middle of being upgraded for an extended period of time.

### Summary & Motivation

### How I Tested These Changes
