### PR TITLE
Unexperimentalize LogicalVersion and quell warning messages whenever assets are materialized

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/logical_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/logical_version.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import warnings
 from hashlib import sha256
 from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional, Union
 
 from typing_extensions import Final
 
 from dagster import _check as check
-from dagster._annotations import experimental
-from dagster._utils.backcompat import ExperimentalWarning
 
 if TYPE_CHECKING:
     from dagster._core.definitions.events import (
@@ -28,14 +25,13 @@ class UnknownValue:
 UNKNOWN_VALUE: Final[UnknownValue] = UnknownValue()
 
 
-@experimental
 class LogicalVersion(
     NamedTuple(
         "_LogicalVersion",
         [("value", str)],
     )
 ):
-    """Represents a logical version for an asset.
+    """(Experimental) Represents a logical version for an asset.
 
     Args:
         value (str): An arbitrary string representing a logical version.
@@ -51,10 +47,8 @@ class LogicalVersion(
         )
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", category=ExperimentalWarning)
-    UNKNOWN_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("UNKNOWN")
-    DEFAULT_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("INITIAL")
+UNKNOWN_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("UNKNOWN")
+DEFAULT_LOGICAL_VERSION: Final[LogicalVersion] = LogicalVersion("INITIAL")
 
 
 class LogicalVersionProvenance(

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -14,6 +14,7 @@ Why not pickle?
   (in memory, not human readable, etc) just handle the json case effectively.
 """
 
+import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from inspect import Parameter, signature
@@ -424,9 +425,13 @@ def deserialize_json_to_dagster_namedtuple(
     json_str: str,
 ) -> tuple:
     """Deserialize a json encoded string in to a whitelisted named tuple"""
-    dagster_namedtuple = _deserialize_json(
-        check.str_param(json_str, "json_str"), whitelist_map=_WHITELIST_MAP
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        dagster_namedtuple = _deserialize_json(
+            check.str_param(json_str, "json_str"), whitelist_map=_WHITELIST_MAP
+        )
+
     if not isinstance(dagster_namedtuple, tuple):
         raise DeserializationError(
             f"Output of deserialized json_str was not expected type of tuple. Received type {type(dagster_namedtuple)}."

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
@@ -43,6 +43,9 @@ def _all_asset_keys(result):
 @pytest.fixture(autouse=True)
 def check_experimental_warnings():
     with warnings.catch_warnings(record=True) as record:
+        # turn off any outer warnings filters
+        warnings.resetwarnings()
+
         yield
 
         raises_warning = False

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -53,6 +53,9 @@ from dagster._utils.backcompat import ExperimentalWarning
 @pytest.fixture(autouse=True)
 def check_experimental_warnings():
     with warnings.catch_warnings(record=True) as record:
+        # turn off any outer warnings filters
+        warnings.resetwarnings()
+
         yield
 
         for w in record:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -31,6 +31,9 @@ from dagster._core.types.dagster_type import resolve_dagster_type
 @pytest.fixture(autouse=True)
 def check_experimental_warnings():
     with warnings.catch_warnings(record=True) as record:
+        # turn off any outer warnings filters
+        warnings.resetwarnings()
+
         yield
 
         for w in record:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -35,6 +35,9 @@ from dagster._core.test_utils import instance_for_test
 @pytest.fixture(autouse=True)
 def check_experimental_warnings():
     with warnings.catch_warnings(record=True) as record:
+        # turn off any outer warnings filters
+        warnings.resetwarnings()
+
         yield
 
         for w in record:
@@ -42,7 +45,7 @@ def check_experimental_warnings():
             # resource_defs and io_manager_def arguments.
             if "resource_defs" in w.message.args[0] or "io_manager_def" in w.message.args[0]:
                 continue
-            assert False, f"Unexpected warning: {w.message.args[0]}"
+            assert False, f"Unexpected warning: {str(w)}"
 
 
 def test_basic_materialize():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -39,6 +39,9 @@ from dagster._core.test_utils import assert_namedtuple_lists_equal
 @pytest.fixture(autouse=True)
 def check_experimental_warnings():
     with warnings.catch_warnings(record=True) as record:
+        # turn off any outer warnings filters
+        warnings.resetwarnings()
+
         yield
 
         for w in record:


### PR DESCRIPTION
### Summary & Motivation

I observed that we were emitting warnings whenever assets were materialized. Our tests weren't caching these because https://github.com/dagster-io/dagster/pull/9577 was masking them.

Rather than hunt for every site where we instantiate `LogicalVersion`, I elected to take off the experimental marker. I think this is safe because the places it can be used (`observable_source_asset`) are experimental.

I also filtered out deprecation warnings that occur when deserializing JSON into named tuples, which we were hitting with MetadataEntries because of the deprecated `entry_data` field.

### How I Tested These Changes
