### PR TITLE
[dagster-databricks] handle execution interrupts

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -222,17 +222,16 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         if self.permissions:
             self._grant_permissions(log, databricks_run_id)
 
-        completed = False
         try:
             # If this is being called within a `capture_interrupts` context, allow interrupts while
             # waiting for the  execution to complete, so that we can terminate slow or hanging steps
             with raise_execution_interrupts():
                 yield from self.step_events_iterator(step_context, step_key, databricks_run_id)
-            completed = True
+        except:
+            # if executon is interrupted before the step is completed, cancel the run
+            self.databricks_runner.client.client.jobs.cancel_run(databricks_run_id)
+            raise
         finally:
-            # if execution is interrupted before the step is completed, cancel the run
-            if not completed:
-                self.databricks_runner.client.client.jobs.cancel_run(databricks_run_id)
             self.log_compute_logs(log, run_id, step_key)
             # this is somewhat obsolete
             if self.wait_for_logs:


### PR DESCRIPTION
### Summary & Motivation

When a user cancels execution from dagit, you'd expect computation to cease on the remote cluster. Instead, the op would be marked as failed within dagit, but no cancellation signal would be sent to the remote database cluster, so computation would continue, which is wasteful of compute resources.

### How I Tested These Changes

Started a long-running step using the databricks_pyspark_step_launcher, then cancelled it from the UI, confirmed that the job was cancelled on the cluster. Did the same thing without cancelling, no cancellation signal sent. Also tried adding an error to the step so that it would fail on the remote cluster, and no cancellation signal was sent (as expected)
