### PR TITLE
relax matching criteria for TimeWindowPartitionMappings w/offsets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -122,17 +122,19 @@ class TimeWindowPartitionMapping(
         start_offset: int,
         end_offset: int,
     ) -> PartitionsSubset:
-        if start_offset != 0 or end_offset != 0:
-            check.invariant(from_partitions_def == to_partitions_def)
-
         if not isinstance(from_partitions_def, TimeWindowPartitionsDefinition) or not isinstance(
-            from_partitions_def, TimeWindowPartitionsDefinition
+            to_partitions_def, TimeWindowPartitionsDefinition
         ):
             raise DagsterInvalidDefinitionError(
                 "TimeWindowPartitionMappings can only operate on TimeWindowPartitionsDefinitions"
             )
+
+        # mypy requires this for some reason
         from_partitions_def = cast(TimeWindowPartitionsDefinition, from_partitions_def)
         to_partitions_def = cast(TimeWindowPartitionsDefinition, to_partitions_def)
+
+        if start_offset != 0 or end_offset != 0:
+            check.invariant(from_partitions_def.cron_schedule == to_partitions_def.cron_schedule)
 
         if to_partitions_def.timezone != from_partitions_def.timezone:
             raise DagsterInvalidDefinitionError("Timezones don't match")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -207,3 +207,17 @@ def test_daily_to_daily_lag():
         subset_with_key_range(downstream_partitions_def, "2021-05-05", "2021-05-07"),
         upstream_partitions_def,
     ).get_partition_keys() == ["2021-05-05", "2021-05-06"]
+
+
+def test_daily_to_daily_lag_different_start_date():
+    upstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-05")
+    downstream_partitions_def = DailyPartitionsDefinition(start_date="2021-05-06")
+    mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+
+    assert mapping.get_upstream_partitions_for_partitions(
+        subset_with_key(downstream_partitions_def, "2021-05-06"), upstream_partitions_def
+    ).get_partition_keys() == ["2021-05-05"]
+
+    assert mapping.get_downstream_partitions_for_partitions(
+        subset_with_key(upstream_partitions_def, "2021-05-05"), downstream_partitions_def
+    ).get_partition_keys() == ["2021-05-06"]


### PR DESCRIPTION
### Summary & Motivation

If two TimeWindowPartitionsDefinitions have different start dates, we should still let you use TimeWindowPartitionMappings with start and end offsets

More context here: https://github.com/dagster-io/dagster/issues/11420#issuecomment-1367478966.

### How I Tested These Changes
