### PR TITLE
Export RunRecord in the public API

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -516,6 +516,7 @@ from dagster._core.storage.pipeline_run import (
     DagsterRun as DagsterRun,
     DagsterRunStatus as DagsterRunStatus,
     RunsFilter as RunsFilter,
+    RunRecord as RunRecord,
 )
 from dagster._core.storage.root_input_manager import (
     RootInputManager as RootInputManager,


### PR DESCRIPTION
Summary:
Since we point users at get_run_records (and RunRecord has information not available on DagsterRun) I think we should export it.

### Summary & Motivation

### How I Tested These Changes
