### PR TITLE
Eliminate unused config_or_config_fn arg in copy_for_configured

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -98,14 +98,13 @@ class AnonymousConfigurableDefinition(ConfigurableDefinition):
             self, convert_user_facing_definition_config_schema(config_schema), config_or_config_fn
         )
 
-        return self.copy_for_configured(description, new_config_schema, config_or_config_fn)
+        return self.copy_for_configured(description, new_config_schema)
 
     @abstractmethod
     def copy_for_configured(
         self,
         description: Optional[str],
         config_schema: IDefinitionConfigSchema,
-        config_or_config_fn: Union[Any, Callable[[Any], Any]],
     ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
         raise NotImplementedError()
 
@@ -150,7 +149,7 @@ class NamedConfigurableDefinition(ConfigurableDefinition):
             self, convert_user_facing_definition_config_schema(config_schema), config_or_config_fn
         )
 
-        return self.copy_for_configured(name, description, new_config_schema, config_or_config_fn)
+        return self.copy_for_configured(name, description, new_config_schema)
 
     @abstractmethod
     def copy_for_configured(
@@ -158,7 +157,6 @@ class NamedConfigurableDefinition(ConfigurableDefinition):
         name: str,
         description: Optional[str],
         config_schema: IDefinitionConfigSchema,
-        config_or_config_fn: Union[Any, Callable[[Any], Any]],
     ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
         ...
 

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -127,7 +127,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
     def executor_creation_fn(self) -> Optional[ExecutorCreationFunction]:
         return self._executor_creation_fn
 
-    def copy_for_configured(self, name, description, config_schema, _) -> "ExecutorDefinition":
+    def copy_for_configured(self, name, description, config_schema) -> "ExecutorDefinition":
         return ExecutorDefinition(
             name=name,
             config_schema=config_schema,
@@ -178,9 +178,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
             self, convert_user_facing_definition_config_schema(config_schema), config_or_config_fn
         )
 
-        return self.copy_for_configured(
-            name or self.name, description, new_config_schema, config_or_config_fn
-        )
+        return self.copy_for_configured(name or self.name, description, new_config_schema)
 
 
 @overload

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -489,7 +489,6 @@ class GraphDefinition(NodeDefinition):
         name: str,
         description: Optional[str],
         config_schema: Any,
-        config_or_config_fn: Any,
     ):
         if not self.has_config_mapping:
             raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/_core/definitions/logger_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_definition.py
@@ -101,7 +101,9 @@ class LoggerDefinition(AnonymousConfigurableDefinition):
         return self._description
 
     def copy_for_configured(
-        self, description: Optional[str], config_schema: Any, _
+        self,
+        description: Optional[str],
+        config_schema: Any,
     ) -> "LoggerDefinition":
         return LoggerDefinition(
             config_schema=config_schema,

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -312,7 +312,6 @@ class OpDefinition(NodeDefinition):
         name: str,
         description: Optional[str],
         config_schema: IDefinitionConfigSchema,
-        config_or_config_fn: Any,
     ) -> "OpDefinition":
         return OpDefinition(
             name=name,

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -192,7 +192,6 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
         self,
         description: Optional[str],
         config_schema: CoercableToConfigSchema,
-        _,
     ) -> "ResourceDefinition":
         return ResourceDefinition(
             config_schema=config_schema,

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -85,7 +85,9 @@ class InputManagerDefinition(ResourceDefinition, IInputManagerDefinition):
         return self._input_config_schema
 
     def copy_for_configured(
-        self, description: Optional[str], config_schema: CoercableToConfigSchema, _
+        self,
+        description: Optional[str],
+        config_schema: CoercableToConfigSchema,
     ) -> "InputManagerDefinition":
         return InputManagerDefinition(
             config_schema=config_schema,

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -84,7 +84,6 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
         self,
         description: Optional[str],
         config_schema: CoercableToConfigSchema,
-        _,
     ) -> "IOManagerDefinition":
         return IOManagerDefinition(
             config_schema=config_schema,

--- a/python_modules/dagster/dagster/_core/storage/output_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/output_manager.py
@@ -45,7 +45,7 @@ class OutputManagerDefinition(ResourceDefinition, IOutputManagerDefinition):
     def output_config_schema(self):
         return self._output_config_schema
 
-    def copy_for_configured(self, description, config_schema, _):
+    def copy_for_configured(self, description, config_schema):
         return OutputManagerDefinition(
             config_schema=config_schema,
             description=description or self.description,

--- a/python_modules/dagster/dagster/_core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/root_input_manager.py
@@ -61,7 +61,7 @@ class RootInputManagerDefinition(ResourceDefinition, IInputManagerDefinition):
         return self._input_config_schema
 
     def copy_for_configured(
-        self, description: Optional[str], config_schema: CoercableToConfigSchema, _
+        self, description: Optional[str], config_schema: CoercableToConfigSchema
     ) -> "RootInputManagerDefinition":
         return RootInputManagerDefinition(
             config_schema=config_schema,


### PR DESCRIPTION
### Summary & Motivation

I am doing some further exploration in the configured system and doing value-add refactors as I find them. In this case the `config_or_config_fn` argument to copy_for_configured is unused and unnecessary, so I am eliminating it.

### How I Tested These Changes

BK
