### PR TITLE
RFC: Change .configured to leverage default values instead of config mapping when dealing with raw config

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definition_config_schema.py
+++ b/python_modules/dagster/dagster/_core/definitions/definition_config_schema.py
@@ -123,6 +123,8 @@ class ConfiguredDefinitionConfigSchema(IDefinitionConfigSchema):
         else:
             self._config_fn = config_or_config_fn  # type: ignore
 
+        self.config_or_config_fn = config_or_config_fn
+
     def as_field(self) -> Field:
         return check.not_none(self._current_field)
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_invocation.py
@@ -112,7 +112,7 @@ def test_resource_invocation_with_config():
 
     with pytest.raises(
         DagsterInvalidConfigError,
-        match="Error when applying config mapping for resource",
+        match="Incorrect values passed to .configured",
     ):
         resource_reqs_config.configured({"foobar": "bar"})(None)
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -3,13 +3,13 @@ from abc import ABC, abstractmethod
 from typing import Callable
 
 import pytest
-from pydantic import ValidationError
 
 from dagster import asset, job, op, resource
 from dagster._config.structured_config import Resource, StructuredResourceAdapter
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.cached_method import cached_method
 
 
@@ -48,9 +48,8 @@ def test_invalid_config():
     class MyResource(Resource):
         foo: int
 
-    with pytest.raises(
-        ValidationError,
-    ):
+    with pytest.raises(DagsterInvalidConfigError):
+        # was from pydantic import ValidationError
         MyResource(foo="why")
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_logger_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_logger_invocation.py
@@ -57,9 +57,7 @@ def test_logger_with_config():
     with pytest.raises(DagsterInvalidConfigError, match="Error in config for logger"):
         int_logger(build_init_logger_context())
 
-    with pytest.raises(
-        DagsterInvalidConfigError, match="Error when applying config mapping for logger"
-    ):
+    with pytest.raises(DagsterInvalidConfigError, match="Incorrect values passed to .configured"):
         conf_logger = int_logger.configured("foo")
         conf_logger(build_init_logger_context())
 


### PR DESCRIPTION
### Summary & Motivation

This is a proposal to change how the config system works, in particular when `.configured` receives raw values and not a config mapping.

There is a current usability issue in the system that when `.configured` is used, the values essentially "disappear" from our tools. They cannot be overridden in the launchpad. They are undocumented. This ends up being a sort of worst-of-both-worlds situation where you have both the awkward API ergonomics of our config system, combined with the lack of traceability and parameterization of using vanilla Python.

Instead of having a configured values encoded in the config mapping system, this PR proposes that we jam them into the "default values" of config. In effect when you write `some_definition.configured({"foo":"bar"})` with this approach you are saying "make bar the default value for foo in this config schema."

If we combine this with some UI changes––notably automatically expanding default values in the Launchpad and expanding all defaults prior to persisting them in runs––we will have a lot more visibility. Users will have the option to see the entire config slug that (I believe this should be the default behavior) run will accept, including the defaults. And then users will see historical config slugs as well. This is more obvious, and also covers cases like when default values change over time.

This will also make it so that users can change the values they have configured for deployed code, if they so choose.

Additionally, our proposed UIs for the resources system can be implemented leverage this scheme. We can introspect the default values for a particular resource, process them, and then render them. 

### How I Tested These Changes

BK