### PR TITLE
Allow AssetIn(dagster_type=Nothing)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -559,8 +559,11 @@ def build_asset_ins(
     all_input_names = set(non_var_input_param_names) | asset_ins.keys()
 
     if not has_kwargs:
-        for in_key in asset_ins.keys():
-            if in_key not in non_var_input_param_names:
+        for in_key, asset_in in asset_ins.items():
+            if in_key not in non_var_input_param_names and (
+                not isinstance(asset_in.dagster_type, DagsterType)
+                or not asset_in.dagster_type.is_nothing
+            ):
                 raise DagsterInvalidDefinitionError(
                     f"Key '{in_key}' in provided ins dict does not correspond to any of the names "
                     "of the arguments to the decorated function"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -7,11 +7,14 @@ from dagster import (
     AssetKey,
     AssetOut,
     DagsterInvalidDefinitionError,
+    DailyPartitionsDefinition,
+    Nothing,
     OpExecutionContext,
     Out,
     Output,
     StaticPartitionsDefinition,
     String,
+    TimeWindowPartitionMapping,
 )
 from dagster import _check as check
 from dagster import build_op_context, io_manager, materialize_to_memory, resource
@@ -703,8 +706,6 @@ def test_multi_asset_retry_policy():
 
 
 def test_invalid_self_dep():
-    from dagster import DailyPartitionsDefinition, TimeWindowPartitionMapping
-
     with pytest.raises(DagsterInvalidDefinitionError):
 
         @asset
@@ -732,3 +733,35 @@ def test_invalid_self_dep():
         )
         def c(c):
             del c
+
+
+def test_asset_in_nothing():
+    @asset(ins={"upstream": AssetIn(dagster_type=Nothing)})
+    def asset1():
+        ...
+
+    assert AssetKey("upstream") in asset1.keys_by_input_name.values()
+    assert materialize_to_memory([asset1]).success
+
+
+def test_asset_in_nothing_and_something():
+    @asset
+    def other_upstream():
+        ...
+
+    @asset(ins={"upstream": AssetIn(dagster_type=Nothing)})
+    def asset1(other_upstream):
+        del other_upstream
+
+    assert AssetKey("upstream") in asset1.keys_by_input_name.values()
+    assert AssetKey("other_upstream") in asset1.keys_by_input_name.values()
+    assert materialize_to_memory([other_upstream, asset1]).success
+
+
+def test_asset_in_nothing_context():
+    @asset(ins={"upstream": AssetIn(dagster_type=Nothing)})
+    def asset1(context):
+        del context
+
+    assert AssetKey("upstream") in asset1.keys_by_input_name.values()
+    assert materialize_to_memory([asset1]).success


### PR DESCRIPTION
### Summary & Motivation

Prior, there was no way to set a partition mapping on a non-argument dep.

This enables:
```python
@asset(ins={"upstream": AssetIn(dagster_type=Nothing, partition_mapping=TimeWindowPartitionMapping())})
def asset1():
    ...
```

Something awkward about this approach is that it gets kind of unnecessarily hairy if you want to specify a multi-component asset key:

```python
@asset(ins={"upstream": AssetIn(key_prefix=["other_component"], dagster_type=Nothing, partition_mapping=TimeWindowPartitionMapping())})
def asset1():
    ...
```

I considered a couple other options too:
```python
@asset(non_argument_deps={AssetIn("upstream", partition_mapping=TimeWindowPartitionMapping())})
def asset1():
    ...
```
I found this one a little weird because the `dagster_type`, `input_manager_key`, and `key_prefix` parameters on the `AssetIn` wouldn't be applicable.

```python
@asset(non_argument_deps={AssetDep("upstream", partition_mapping=TimeWindowPartitionMapping())})
def asset1():
    ...
```
I kind of like this one, but was hesitant to introduce a new class. I figured we can always add this later.


### How I Tested These Changes
