### PR TITLE
Fix issues with a SerializableErrorInfo being coerced to a GraphenePythonError

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -229,7 +229,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
         return GrapheneExecutionStepSkippedEvent(**basic_params)
     elif dagster_event.event_type == DagsterEventType.STEP_UP_FOR_RETRY:
         return GrapheneExecutionStepUpForRetryEvent(
-            error=dagster_event.step_retry_data.error,
+            error=GraphenePythonError(dagster_event.step_retry_data.error),
             secondsToWait=dagster_event.step_retry_data.seconds_to_wait,
             **basic_params,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -139,7 +139,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
             timestamp=tick.timestamp,
             runIds=tick.run_ids,
             runKeys=tick.run_keys,
-            error=tick.error,
+            error=GraphenePythonError(tick.error) if tick.error else None,
             skipReason=tick.skip_reason,
             originRunIds=tick.origin_run_ids,
             cursor=tick.cursor,
@@ -237,7 +237,11 @@ class GrapheneTickEvaluation(graphene.ObjectType):
             "schedule_data",
             (ScheduleExecutionData, SerializableErrorInfo),
         )
-        error = schedule_data if isinstance(schedule_data, SerializableErrorInfo) else None
+        error = (
+            GraphenePythonError(schedule_data)
+            if isinstance(schedule_data, SerializableErrorInfo)
+            else None
+        )
         skip_reason = (
             schedule_data.skip_message if isinstance(schedule_data, ScheduleExecutionData) else None
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/ticks.py
@@ -33,7 +33,7 @@ def tick_specific_data_from_dagster_tick(graphene_info, tick):
         return GrapheneScheduleTickSuccessData(run=None)
     elif tick.status == TickStatus.FAILURE:
         error = tick.error
-        return GrapheneScheduleTickFailureData(error=error)
+        return GrapheneScheduleTickFailureData(error=GraphenePythonError(error))
 
 
 class GrapheneScheduleTickSpecificData(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -542,7 +542,10 @@ def naughty_programmer_pipeline():
     def throw_a_thing():
         try:
             try:
-                raise Exception("bad programmer, bad")
+                try:
+                    raise Exception("The inner sanctum")
+                except:
+                    raise Exception("bad programmer, bad")
             except Exception as e:
                 raise Exception("Outer exception") from e
         except Exception as e:
@@ -1298,6 +1301,10 @@ def define_sensors():
         )
 
     @sensor(job_name="no_config_pipeline")
+    def always_error_sensor(_):
+        raise Exception("OOPS")
+
+    @sensor(job_name="no_config_pipeline")
     def once_no_config_sensor(_):
         return RunRequest(
             run_key="once",
@@ -1334,6 +1341,7 @@ def define_sensors():
 
     return [
         always_no_config_sensor,
+        always_error_sensor,
         once_no_config_sensor,
         never_no_config_sensor,
         multi_no_config_sensor,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
@@ -7,161 +7,27 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestSensors.test_get_sensor[non_launchable_postgres_instance_lazy_repository] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_postgres_instance_multi_location] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_lazy_repository] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_managed_grpc_env] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
-snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_multi_location] 1'] = {
-    '__typename': 'Sensor',
-    'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
-    'nextTick': None,
-    'sensorState': {
-        'runs': [
-        ],
-        'runsCount': 0,
-        'status': 'STOPPED',
-        'ticks': [
-        ]
-    },
-    'targets': [
-        {
-            'mode': 'default',
-            'pipelineName': 'no_config_pipeline',
-            'solidSelection': None
-        }
-    ]
-}
-
 snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_lazy_repository] 1'] = [
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
     {
         'description': None,
         'minIntervalSeconds': 30,
@@ -308,6 +174,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_managed
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'always_no_config_sensor',
         'sensorState': {
             'runs': [
@@ -448,6 +334,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_managed
 ]
 
 snapshots['TestSensors.test_get_sensors[non_launchable_postgres_instance_multi_location] 1'] = [
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
     {
         'description': None,
         'minIntervalSeconds': 30,
@@ -594,6 +500,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'always_no_config_sensor',
         'sensorState': {
             'runs': [
@@ -734,6 +660,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
 ]
 
 snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repository] 1'] = [
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
     {
         'description': None,
         'minIntervalSeconds': 30,
@@ -880,6 +826,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'always_no_config_sensor',
         'sensorState': {
             'runs': [
@@ -1020,6 +986,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
 ]
 
 snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_location] 1'] = [
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
     {
         'description': None,
         'minIntervalSeconds': 30,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_python_error.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_python_error.py
@@ -22,10 +22,11 @@ def test_python_error():
         python_error = GraphenePythonError(serializable_error_info_from_exc_info(sys.exc_info()))
 
     assert python_error
-    assert isinstance(python_error.message, str)
-    assert isinstance(python_error.stack, list)
-    assert len(python_error.stack) == 2
-    assert "bar" in python_error.stack[1]
+    assert isinstance(python_error.resolve_message(None), str)  #
+    stack = python_error.resolve_stack(None)
+    assert isinstance(stack, list)
+    assert len(stack) == 2
+    assert "bar" in stack[1]
 
 
 def test_error_capture(graphql_context):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -112,6 +112,12 @@ query SensorQuery($sensorSelector: SensorSelector!) {
             error {
                 message
                 stack
+                errorChain {
+                    error {
+                        message
+                        stack
+                    }
+                }
             }
         }
       }
@@ -494,12 +500,24 @@ def test_sensor_next_ticks(graphql_context):
     next_tick = result.data["sensorOrError"]["nextTick"]
     assert not next_tick
 
+    error_sensor_name = "always_error_sensor"
+    external_error_sensor = external_repository.get_external_sensor(error_sensor_name)
+    error_sensor_selector = infer_sensor_selector(graphql_context, error_sensor_name)
+
     # test default sensor with no tick
     graphql_context.instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_external_origin(), InstigatorType.SENSOR, InstigatorStatus.RUNNING
         )
     )
+    graphql_context.instance.add_instigator_state(
+        InstigatorState(
+            external_error_sensor.get_external_origin(),
+            InstigatorType.SENSOR,
+            InstigatorStatus.RUNNING,
+        )
+    )
+
     result = execute_dagster_graphql(
         graphql_context, GET_SENSOR_QUERY, variables={"sensorSelector": sensor_selector}
     )
@@ -515,11 +533,22 @@ def test_sensor_next_ticks(graphql_context):
     result = execute_dagster_graphql(
         graphql_context, GET_SENSOR_QUERY, variables={"sensorSelector": sensor_selector}
     )
-    assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
     assert result.data
     assert result.data["sensorOrError"]["__typename"] == "Sensor"
+
+    assert len(result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
+    assert not result.data["sensorOrError"]["sensorState"]["ticks"][0].get("error")
+
     next_tick = result.data["sensorOrError"]["nextTick"]
     assert next_tick
+
+    error_result = execute_dagster_graphql(
+        graphql_context, GET_SENSOR_QUERY, variables={"sensorSelector": error_sensor_selector}
+    )
+    assert error_result.data
+    assert error_result.data["sensorOrError"]["__typename"] == "Sensor"
+    assert len(error_result.data["sensorOrError"]["sensorState"]["ticks"]) == 1
+    assert error_result.data["sensorOrError"]["sensorState"]["ticks"][0]["error"]
 
 
 def _create_tick(graphql_context):


### PR DESCRIPTION
Summary:
I stumbled on a bit of a landmine on a separate PR by adding logic to GraphenePythonError that assumes that it's a GraphenePythonError - normally a valid assumption, but if you pass a namedtuple where Graphene is expecting a GrapheneObjectType, it appears that it coerces it into the object without ever calling the constructor. So we were calling GraphenePythonError methods on a SerializableErrorInfo.

I'll audit other callsites of GraphenePythonError for places we might have been doing this, but this is the only one i've found so far.

Test Plan: New test that would fail in master

### Summary & Motivation

### How I Tested These Changes
