### PR TITLE
Eliminate default values for solid_selection, external_pipeline_origin, and pipeline_code_origin on create_run

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1127,9 +1127,9 @@ class DagsterInstance:
         execution_plan_snapshot,
         parent_pipeline_snapshot,
         asset_selection,
-        solid_selection=None,
-        external_pipeline_origin=None,
-        pipeline_code_origin=None,
+        solid_selection,
+        external_pipeline_origin,
+        pipeline_code_origin,
     ) -> DagsterRun:
 
         pipeline_run = self._construct_run_with_snapshots(

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -239,6 +239,7 @@ def create_run_for_test(
         external_pipeline_origin=external_pipeline_origin,
         pipeline_code_origin=pipeline_code_origin,
         asset_selection=None,
+        solid_selection=None,
     )
 
 

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -221,6 +221,7 @@ def test_successful_run_from_pending(
         external_pipeline_origin=external_pipeline.get_external_origin(),
         pipeline_code_origin=external_pipeline.get_python_origin(),
         asset_selection=None,
+        solid_selection=None,
     )
 
     run_id = created_pipeline_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -148,6 +148,7 @@ def test_run_from_pending_repository():
                     external_pipeline_origin=external_pipeline.get_external_origin(),
                     pipeline_code_origin=external_pipeline.get_python_origin(),
                     asset_selection=None,
+                    solid_selection=None,
                 )
 
                 run_id = pipeline_run.run_id


### PR DESCRIPTION
### Summary & Motivation

Continuing create_run refactors in preparation for changing the application of config defaults in this codepath. Here we make the remaining arguments to create_run requireed.

### How I Tested These Changes

BK
