### PR TITLE
Add parameter invariants around external_pipeline_origin and pipeline_code_origin arguments

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1136,23 +1136,18 @@ class DagsterInstance:
         from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
         # The "python origin" arguments exist so a job can be reconstructed in memory
-        # after a DagsterRun has been fetched from the database. In all cases where
-        # external_pipeline_origin is passed, pipeline_code_origin is also passed.
+        # after a DagsterRun has been fetched from the database.
+        #
         # There are cases (notably in _logged_execute_pipeline with Reconstructable pipelines)
-        # where pipeline_code_origin and is not. But they are almost always
-        # passed together. If these are not set the created run will never be
-        # able to be relaunched from the information just in the run or in another process.
+        # where pipeline_code_origin and is not. In some cloud test cases only
+        # external_pipeline_origin is passed But they are almost always passed together.
+        # If these are not set the created run will never be able to be relaunched from
+        # the information just in the run or in another process.
 
         check.opt_inst_param(
             external_pipeline_origin, "external_pipeline_origin", ExternalPipelineOrigin
         )
         check.opt_inst_param(pipeline_code_origin, "pipeline_code_origin", PipelinePythonOrigin)
-
-        if external_pipeline_origin:
-            check.invariant(
-                pipeline_code_origin,
-                "If external_pipeline_origin is set, pipeline_code_origin must also be set",
-            )
 
         pipeline_run = self._construct_run_with_snapshots(
             pipeline_name=pipeline_name,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -49,6 +49,7 @@ from dagster._core.errors import (
     DagsterRunConflict,
     DagsterUndefinedLogicalVersionError,
 )
+from dagster._core.origin import PipelinePythonOrigin
 from dagster._core.storage.pipeline_run import (
     IN_PROGRESS_RUN_STATUSES,
     DagsterRun,
@@ -1128,9 +1129,30 @@ class DagsterInstance:
         parent_pipeline_snapshot,
         asset_selection,
         solid_selection,
-        external_pipeline_origin,
-        pipeline_code_origin,
+        external_pipeline_origin: Optional[ExternalPipelineOrigin],
+        pipeline_code_origin: Optional[PipelinePythonOrigin],
     ) -> DagsterRun:
+
+        from dagster._core.host_representation.origin import ExternalPipelineOrigin
+
+        # The "python origin" arguments exist so a job can be reconstructed in memory
+        # after a DagsterRun has been fetched from the database. In all cases where
+        # external_pipeline_origin is passed, pipeline_code_origin is also passed.
+        # There are cases (notably in _logged_execute_pipeline with Reconstructable pipelines)
+        # where pipeline_code_origin and is not. But they are almost always
+        # passed together. If these are not set the created run will never be
+        # able to be relaunched from the information just in the run or in another process.
+
+        check.opt_inst_param(
+            external_pipeline_origin, "external_pipeline_origin", ExternalPipelineOrigin
+        )
+        check.opt_inst_param(pipeline_code_origin, "pipeline_code_origin", PipelinePythonOrigin)
+
+        if external_pipeline_origin:
+            check.invariant(
+                pipeline_code_origin,
+                "If external_pipeline_origin is set, pipeline_code_origin must also be set",
+            )
 
         pipeline_run = self._construct_run_with_snapshots(
             pipeline_name=pipeline_name,
@@ -1773,8 +1795,7 @@ class DagsterInstance:
             run_id (str): The id of the run.
         """
 
-        from dagster._core.host_representation import ExternalPipelineOrigin
-        from dagster._core.origin import PipelinePythonOrigin
+        from dagster._core.host_representation.origin import ExternalPipelineOrigin
         from dagster._core.run_coordinator import SubmitRunContext
 
         run = self.get_run_by_id(run_id)


### PR DESCRIPTION
### Summary & Motivation

There are a bunch of implicit invariants in this complicated function that callsites do respected but that are unencoded in code. This is one of them. Either both of these origin parameters are passed, or neither of them are. Adding checks to verify that that is correct.

### How I Tested These Changes

BK
