### PR TITLE
Make frozentags inherit from Mapping[str, str] and correctly type _check_execute_external_pipeline_args

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -99,10 +99,10 @@ def launch_reexecution_from_parent_run(
     external_pipeline = get_external_pipeline_or_raise(graphene_info, selector)
 
     run = instance.create_reexecuted_run(
-        cast(DagsterRun, parent_run),
-        repo_location,
-        external_pipeline,
-        ReexecutionStrategy(strategy),
+        parent_run=cast(DagsterRun, parent_run),
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
+        strategy=ReexecutionStrategy(strategy),
         use_parent_run_tags=True,  # inherit whatever tags were set on the parent run at launch time
     )
     graphene_info.context.instance.submit_run(

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -25,6 +25,7 @@ from dagster._cli.workspace.cli_target import (
     python_job_target_argument,
 )
 from dagster._core.definitions.pipeline_base import IPipeline
+from dagster._core.definitions.utils import validate_tags
 from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
@@ -564,7 +565,7 @@ def _check_execute_external_pipeline_args(
     preset: Optional[str],
     tags: Optional[Mapping[str, str]],
     solid_selection: Optional[Sequence[str]],
-) -> Tuple[Mapping[str, object], str, Mapping[str, object], Optional[Sequence[str]]]:
+) -> Tuple[Mapping[str, object], str, Mapping[str, str], Optional[Sequence[str]]]:
     check.inst_param(external_pipeline, "external_pipeline", ExternalPipeline)
     run_config = check.opt_mapping_param(run_config, "run_config")
     check.opt_str_param(mode, "mode")
@@ -642,7 +643,7 @@ def _check_execute_external_pipeline_args(
     return (
         run_config,
         mode,
-        tags,
+        validate_tags(tags),
         solid_selection,
     )
 

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -269,10 +269,10 @@ def create_backfill_run(
         if not last_run or last_run.status != DagsterRunStatus.FAILURE:
             return None
         return instance.create_reexecuted_run(
-            last_run,
-            repo_location,
-            external_pipeline,
-            ReexecutionStrategy.FROM_FAILURE,
+            parent_run=last_run,
+            repo_location=repo_location,
+            external_pipeline=external_pipeline,
+            strategy=ReexecutionStrategy.FROM_FAILURE,
             extra_tags=tags,
             run_config=partition_data.run_config,
             mode=external_partition_set.mode,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1259,6 +1259,7 @@ class DagsterInstance:
 
     def create_reexecuted_run(
         self,
+        *,
         parent_run: DagsterRun,
         repo_location: "RepositoryLocation",
         external_pipeline: "ExternalPipeline",

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -124,9 +124,9 @@ def retry_run(
     strategy = get_reexecution_strategy(failed_run, instance) or DEFAULT_REEXECUTION_POLICY
 
     new_run = instance.create_reexecuted_run(
-        failed_run,
-        repo_location,
-        external_pipeline,
+        parent_run=failed_run,
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
         strategy=strategy,
         extra_tags=tags,
         use_parent_run_tags=True,

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -468,7 +468,7 @@ def datetime_as_float(dt):
 
 
 # hashable frozen string to string dict
-class frozentags(frozendict):
+class frozentags(frozendict, Mapping[str, str]):
     def __init__(self, *args, **kwargs):
         super(frozentags, self).__init__(*args, **kwargs)
         check.dict_param(self, "self", key_type=str, value_type=str)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -101,7 +101,10 @@ def test_create_reexecuted_run_from_failure(
     failed_run,
 ):
     run = instance.create_reexecuted_run(
-        failed_run, repo_location, external_pipeline, ReexecutionStrategy.FROM_FAILURE
+        parent_run=failed_run,
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
+        strategy=ReexecutionStrategy.FROM_FAILURE,
     )
 
     assert run.tags[RESUME_RETRY_TAG] == "true"
@@ -123,17 +126,20 @@ def test_create_reexecuted_run_from_failure_tags(
     failed_run,
 ):
     run = instance.create_reexecuted_run(
-        failed_run, repo_location, external_pipeline, ReexecutionStrategy.FROM_FAILURE
+        parent_run=failed_run,
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
+        strategy=ReexecutionStrategy.FROM_FAILURE,
     )
 
     assert run.tags["foo"] == "bar"
     assert "fizz" not in run.tags
 
     run = instance.create_reexecuted_run(
-        failed_run,
-        repo_location,
-        external_pipeline,
-        ReexecutionStrategy.FROM_FAILURE,
+        parent_run=failed_run,
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
+        strategy=ReexecutionStrategy.FROM_FAILURE,
         use_parent_run_tags=True,
     )
 
@@ -141,10 +147,10 @@ def test_create_reexecuted_run_from_failure_tags(
     assert run.tags["fizz"] == "buzz"
 
     run = instance.create_reexecuted_run(
-        failed_run,
-        repo_location,
-        external_pipeline,
-        ReexecutionStrategy.FROM_FAILURE,
+        parent_run=failed_run,
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
+        strategy=ReexecutionStrategy.FROM_FAILURE,
         use_parent_run_tags=True,
         extra_tags={"fizz": "not buzz!!"},
     )
@@ -157,7 +163,10 @@ def test_create_reexecuted_run_all_steps(
     instance: DagsterInstance, workspace, repo_location, external_pipeline, failed_run
 ):
     run = instance.create_reexecuted_run(
-        failed_run, repo_location, external_pipeline, ReexecutionStrategy.ALL_STEPS
+        parent_run=failed_run,
+        repo_location=repo_location,
+        external_pipeline=external_pipeline,
+        strategy=ReexecutionStrategy.ALL_STEPS,
     )
 
     assert RESUME_RETRY_TAG not in run.tags


### PR DESCRIPTION
### Summary & Motivation

Correctly typing tags as they are passed down the callstack will also be part of this workstream. In this case we are making the frozentags class returned from validate_tags inherit from Mapping[str, str] so that functions typehinted with that can accept them.

### How I Tested These Changes

BK
