### PR TITLE
[dagit] Fix line height and size of timestamps on the asset graph

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
@@ -22,23 +22,38 @@ const ASSET_NODE_DEFINITION: AssetNodeFragment = {
   opVersion: '1',
 };
 
+const SOURCE_ASSET_NODE_DEFINITION: AssetNodeFragment = {
+  __typename: 'AssetNode',
+  assetKey: {__typename: 'AssetKey', path: ['source_asset']},
+  computeKind: null,
+  description: 'This is a test source asset',
+  graphName: null,
+  id: '["source_asset"]',
+  isObservable: true,
+  isPartitioned: false,
+  isSource: true,
+  jobNames: [],
+  opNames: [],
+  opVersion: '1',
+};
+
 // eslint-disable-next-line import/no-default-export
 export default {component: AssetNode};
 
 export const LiveStates = () => {
-  const caseWithLiveData = (name: string, liveData?: LiveDataForNode) => {
+  const caseWithLiveData = (
+    name: string,
+    liveData: LiveDataForNode | undefined = undefined,
+    def: AssetNodeFragment = ASSET_NODE_DEFINITION,
+  ) => {
     return (
       <Box flex={{direction: 'column', gap: 0, alignItems: 'flex-start'}}>
         <div style={{position: 'relative', width: 280}}>
-          <AssetNode definition={ASSET_NODE_DEFINITION} selected={false} liveData={liveData} />
+          <AssetNode definition={def} selected={false} liveData={liveData} />
         </div>
         <div style={{position: 'relative', width: 280, height: 82}}>
           <div style={{position: 'absolute', width: 280, height: 82}}>
-            <AssetNodeMinimal
-              definition={ASSET_NODE_DEFINITION}
-              selected={false}
-              liveData={liveData}
-            />
+            <AssetNodeMinimal definition={def} selected={false} liveData={liveData} />
           </div>
         </div>
         <code>
@@ -237,6 +252,92 @@ export const LiveStates = () => {
           cronSchedule: null,
         },
       })}
+      {caseWithLiveData('Source Asset - No Live Data', undefined, SOURCE_ASSET_NODE_DEFINITION)}
+
+      {caseWithLiveData('Source Asset - Not Observable', undefined, {
+        ...SOURCE_ASSET_NODE_DEFINITION,
+        isObservable: false,
+      })}
+
+      {caseWithLiveData(
+        'Source Asset - Never Observed',
+        {
+          stepKey: 'source_asset',
+          unstartedRunIds: [],
+          inProgressRunIds: [],
+          lastMaterialization: null,
+          lastMaterializationRunStatus: null,
+          lastObservation: null,
+          runWhichFailedToMaterialize: null,
+          currentLogicalVersion: 'INITIAL',
+          projectedLogicalVersion: null,
+          freshnessInfo: null,
+          freshnessPolicy: null,
+        },
+        SOURCE_ASSET_NODE_DEFINITION,
+      )}
+
+      {caseWithLiveData(
+        'Source Asset - Observation Running',
+        {
+          stepKey: 'source_asset',
+          unstartedRunIds: [],
+          inProgressRunIds: ['12345'],
+          lastMaterialization: null,
+          lastMaterializationRunStatus: null,
+          lastObservation: null,
+          runWhichFailedToMaterialize: null,
+          currentLogicalVersion: 'INITIAL',
+          projectedLogicalVersion: null,
+          freshnessInfo: null,
+          freshnessPolicy: null,
+        },
+        SOURCE_ASSET_NODE_DEFINITION,
+      )}
+
+      {caseWithLiveData(
+        'Source Asset - Observed, Stale',
+        {
+          stepKey: 'source_asset',
+          unstartedRunIds: [],
+          inProgressRunIds: ['12345'],
+          lastMaterialization: null,
+          lastMaterializationRunStatus: null,
+          lastObservation: {
+            __typename: 'ObservationEvent',
+            runId: 'ABCDEF',
+            timestamp: `${Date.now()}`,
+          },
+          runWhichFailedToMaterialize: null,
+          currentLogicalVersion: 'INITIAL',
+          projectedLogicalVersion: 'DIFFERENT',
+          freshnessInfo: null,
+          freshnessPolicy: null,
+        },
+        SOURCE_ASSET_NODE_DEFINITION,
+      )}
+
+      {caseWithLiveData(
+        'Source Asset - Observed, Up To Date',
+        {
+          stepKey: 'source_asset',
+          unstartedRunIds: [],
+          inProgressRunIds: [],
+          lastMaterialization: null,
+          lastMaterializationRunStatus: null,
+          lastObservation: {
+            __typename: 'ObservationEvent',
+            runId: 'ABCDEF',
+            timestamp: `${Date.now()}`,
+          },
+          runWhichFailedToMaterialize: null,
+          currentLogicalVersion: 'DIFFERENT',
+          projectedLogicalVersion: 'DIFFERENT',
+          freshnessInfo: null,
+          freshnessPolicy: null,
+        },
+        SOURCE_ASSET_NODE_DEFINITION,
+      )}
     </Box>
   );
   return;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -158,17 +158,17 @@ export const AssetNodeStatusRow: React.FC<{
   }
 
   const lastMaterializationLink = lastMaterialization ? (
-    <AssetRunLink
-      runId={lastMaterialization.runId}
-      event={{stepKey, timestamp: lastMaterialization.timestamp}}
-    >
-      <Caption>
+    <Caption>
+      <AssetRunLink
+        runId={lastMaterialization.runId}
+        event={{stepKey, timestamp: lastMaterialization.timestamp}}
+      >
         <TimestampDisplay
           timestamp={Number(lastMaterialization.timestamp) / 1000}
           timeFormat={{showSeconds: false, showTimezone: false}}
         />
-      </Caption>
-    </AssetRunLink>
+      </AssetRunLink>
+    </Caption>
   ) : undefined;
 
   if (runWhichFailedToMaterialize || late) {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Colors, Icon, FontFamily, Box, CaptionMono, Caption, Spinner} from '@dagster-io/ui';
+import {Colors, Icon, FontFamily, Box, Caption, Spinner} from '@dagster-io/ui';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 import styled from 'styled-components/macro';
@@ -57,7 +57,7 @@ export const AssetNode: React.FC<{
               <StatsRow>
                 <span>Observed</span>
                 {liveData?.lastObservation ? (
-                  <CaptionMono style={{textAlign: 'right'}}>
+                  <Caption style={{textAlign: 'right'}}>
                     <AssetRunLink
                       runId={liveData.lastObservation.runId}
                       event={{stepKey, timestamp: liveData.lastObservation.timestamp}}
@@ -67,7 +67,7 @@ export const AssetNode: React.FC<{
                         timeFormat={{showSeconds: false, showTimezone: false}}
                       />
                     </AssetRunLink>
-                  </CaptionMono>
+                  </Caption>
                 ) : (
                   <span>–</span>
                 )}
@@ -105,7 +105,7 @@ export const AssetNodeStatusBox: React.FC<{background: string}> = ({background, 
       borderBottomLeftRadius: 6,
       borderBottomRightRadius: 6,
       whiteSpace: 'nowrap',
-      lineHeight: 12,
+      lineHeight: '12px',
       height: 24,
     }}
     flex={{justifyContent: 'space-between', alignItems: 'center', gap: 6}}
@@ -162,10 +162,12 @@ export const AssetNodeStatusRow: React.FC<{
       runId={lastMaterialization.runId}
       event={{stepKey, timestamp: lastMaterialization.timestamp}}
     >
-      <TimestampDisplay
-        timestamp={Number(lastMaterialization.timestamp) / 1000}
-        timeFormat={{showSeconds: false, showTimezone: false}}
-      />
+      <Caption>
+        <TimestampDisplay
+          timestamp={Number(lastMaterialization.timestamp) / 1000}
+          timeFormat={{showSeconds: false, showTimezone: false}}
+        />
+      </Caption>
     </AssetRunLink>
   ) : undefined;
 


### PR DESCRIPTION
### Summary & Motivation

This PR adds a missing <Caption> sizing and changes the source asset "observation" timestamp from CaptionMono to Caption so it matches (I think Caption looks nicer in this case?) I also fixed a small issue with line heights causing the clickable region to be way too large.

Before:
<img width="1728" alt="Screen Shot 2023-01-02 at 8 00 46 PM" src="https://user-images.githubusercontent.com/1037212/210291337-220212df-de16-4e05-80b2-feadca1407c5.png">
<img width="1728" alt="Screen Shot 2023-01-02 at 8 00 52 PM" src="https://user-images.githubusercontent.com/1037212/210291340-dd569b3e-de5f-4dde-a1bd-fceef733b698.png">


After:

<img width="1728" alt="Screen Shot 2023-01-02 at 7 59 29 PM" src="https://user-images.githubusercontent.com/1037212/210291332-d3e088b2-a74c-41b4-bad1-88a4fd6270be.png">
<img width="1728" alt="Screen Shot 2023-01-02 at 7 59 36 PM" src="https://user-images.githubusercontent.com/1037212/210291334-b91d0cfd-3604-4258-832d-431872aa9bf8.png">


### How I Tested These Changes
