### PR TITLE
[structured config] Fix env vars not working with direct Resource instantiation

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_top_level_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_top_level_resources.py
@@ -7,57 +7,104 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_fetch_top_level_resource 1"] = {
-    "topLevelResourceDetailsOrError": {
-        "__typename": "ResourceDetails",
-        "configFields": [
-            {"configType": {"key": "BoolSourceType"}, "description": None, "name": "a_bool"},
-            {"configType": {"key": "StringSourceType"}, "description": None, "name": "a_string"},
+snapshots['test_fetch_top_level_resource 1'] = {
+    'topLevelResourceDetailsOrError': {
+        '__typename': 'ResourceDetails',
+        'configFields': [
             {
-                "configType": {"key": "StringSourceType"},
-                "description": None,
-                "name": "an_unset_string",
+                'configType': {
+                    'key': 'BoolSourceType'
+                },
+                'description': None,
+                'name': 'a_bool'
             },
+            {
+                'configType': {
+                    'key': 'StringSourceType'
+                },
+                'description': None,
+                'name': 'a_string'
+            },
+            {
+                'configType': {
+                    'key': 'StringSourceType'
+                },
+                'description': None,
+                'name': 'an_unset_string'
+            }
         ],
-        "configuredValues": [
-            {"key": "a_bool", "value": "true"},
-            {"key": "a_string", "value": '"foo"'},
+        'configuredValues': [
+            {
+                'key': 'a_bool',
+                'value': 'true'
+            },
+            {
+                'key': 'a_string',
+                'value': '"foo"'
+            },
+            {
+                'key': 'an_unset_string',
+                'value': '"defaulted"'
+            }
         ],
-        "description": "my description",
-        "name": "my_resource",
+        'description': 'my description',
+        'name': 'my_resource'
     }
 }
 
-snapshots["test_fetch_top_level_resources 1"] = {
-    "allTopLevelResourceDetailsOrError": {
-        "__typename": "ResourceDetailsList",
-        "results": [
-            {"configFields": [], "configuredValues": [], "description": None, "name": "foo"},
+snapshots['test_fetch_top_level_resources 1'] = {
+    'allTopLevelResourceDetailsOrError': {
+        '__typename': 'ResourceDetailsList',
+        'results': [
             {
-                "configFields": [
-                    {
-                        "configType": {"key": "BoolSourceType"},
-                        "description": None,
-                        "name": "a_bool",
-                    },
-                    {
-                        "configType": {"key": "StringSourceType"},
-                        "description": None,
-                        "name": "a_string",
-                    },
-                    {
-                        "configType": {"key": "StringSourceType"},
-                        "description": None,
-                        "name": "an_unset_string",
-                    },
+                'configFields': [
                 ],
-                "configuredValues": [
-                    {"key": "a_bool", "value": "true"},
-                    {"key": "a_string", "value": '"foo"'},
+                'configuredValues': [
                 ],
-                "description": "my description",
-                "name": "my_resource",
+                'description': None,
+                'name': 'foo'
             },
-        ],
+            {
+                'configFields': [
+                    {
+                        'configType': {
+                            'key': 'BoolSourceType'
+                        },
+                        'description': None,
+                        'name': 'a_bool'
+                    },
+                    {
+                        'configType': {
+                            'key': 'StringSourceType'
+                        },
+                        'description': None,
+                        'name': 'a_string'
+                    },
+                    {
+                        'configType': {
+                            'key': 'StringSourceType'
+                        },
+                        'description': None,
+                        'name': 'an_unset_string'
+                    }
+                ],
+                'configuredValues': [
+                    {
+                        'key': 'a_bool',
+                        'value': 'true'
+                    },
+                    {
+                        'key': 'a_string',
+                        'value': '"foo"'
+                    },
+                    {
+                        'key': 'an_unset_string',
+                        'value': '"defaulted"'
+                    }
+                ],
+                'description': 'my description',
+                'name': 'my_resource'
+            }
+        ]
     }
 }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
@@ -111,6 +111,10 @@ def test_fetch_top_level_resource(definitions_graphql_context, snapshot):
             "key": "a_string",
             "value": '"foo"',
         },
+        {
+            "key": "an_unset_string",
+            "value": '"defaulted"',
+        },
     ]
 
     snapshot.assert_match(result.data)

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -4,10 +4,11 @@ from typing import Generic, TypeVar, Union
 from typing_extensions import TypeAlias
 
 from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType
+from dagster._config.field_utils import config_dictionary_from_values
 from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.structured_config.typing_utils import TypecheckAllowPartialResourceInitParams
-from dagster._config.validate import validate_config
+from dagster._config.validate import process_config, validate_config
 from dagster._core.definitions.definition_config_schema import (
     DefinitionConfigSchema,
     IDefinitionConfigSchema,
@@ -24,7 +25,7 @@ except ImportError:
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Type, cast
+from typing import Any, Dict, Mapping, Optional, Type, cast
 
 from pydantic import BaseModel, Extra
 from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_MAPPING, SHAPE_SINGLETON, ModelField
@@ -143,6 +144,22 @@ def copy_with_default(old_field: Field, new_config_value: Any) -> Field:
     )
 
 
+def _post_process_values(schema_field: Field, data: Mapping[str, Any]) -> Mapping[str, Any]:
+    post_processed_config = process_config(
+        schema_field.config_type, config_dictionary_from_values(data, schema_field)
+    )
+
+    if not post_processed_config.success:
+        raise DagsterInvalidConfigError(
+            "Error in config mapping ",
+            post_processed_config.errors,
+            data,
+        )
+    assert post_processed_config.value is not None
+
+    return post_processed_config.value
+
+
 def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSchema:
     """Return a new config schema configured with the passed in data"""
     return DefinitionConfigSchema(_apply_defaults_to_schema_field(schema_field, data))
@@ -176,11 +193,12 @@ class Resource(
 
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)
-        Config.__init__(self, **data)
+        post_processed_data = _post_process_values(schema, data)
+        Config.__init__(self, **post_processed_data)
         ResourceDefinition.__init__(
             self,
             resource_fn=self.create_object_to_pass_to_user_code,
-            config_schema=_curry_config_schema(schema, data),
+            config_schema=_curry_config_schema(schema, post_processed_data),
             description=self.__doc__,
         )
 
@@ -285,7 +303,8 @@ class StructuredConfigIOManagerBase(Resource[IOManager], IOManagerDefinition):
     """
 
     def __init__(self, **data: Any):
-        Resource.__init__(self, **data)
+        schema = infer_schema_from_config_class(self.__class__)
+        Resource.__init__(self, **_post_process_values(schema, data))
         IOManagerDefinition.__init__(
             self,
             resource_fn=self.create_io_manager_to_pass_to_user_code,

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,9 +1,11 @@
+import os
 import sys
 from abc import ABC, abstractmethod
 from typing import Callable
 
 import pytest
 from dagster import IOManager, asset, job, op, resource
+from dagster._config.field_utils import EnvVar
 from dagster._config.structured_config import (
     Resource,
     StructuredConfigIOManagerBase,
@@ -14,11 +16,11 @@ from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
 from dagster._utils.cached_method import cached_method
-from pydantic import ValidationError
 
 
 def test_basic_structured_resource():
@@ -56,7 +58,7 @@ def test_invalid_config():
         foo: int
 
     with pytest.raises(
-        ValidationError,
+        DagsterInvalidConfigError,
     ):
         MyResource(foo="why")
 
@@ -349,3 +351,79 @@ def test_structured_resource_runtime_config():
         .success
     )
     assert out_txt == ["greeting: hello, world!"]
+
+
+def test_env_var():
+    os.environ["ENV_VARIABLE_FOR_TEST"] = "SOME_VALUE"
+    os.environ["ENV_VARIABLE_FOR_TEST_INT"] = "3"
+    try:
+
+        class ResourceWithString(Resource):
+            a_str: str
+            a_int: int
+
+        executed = {}
+
+        @asset
+        def an_asset(a_resource: ResourceWithString):
+            assert a_resource.a_str == "SOME_VALUE"
+            assert a_resource.a_int == 3
+            executed["yes"] = True
+
+        defs = Definitions(
+            assets=[an_asset],
+            resources={
+                "a_resource": ResourceWithString(
+                    a_str=EnvVar("ENV_VARIABLE_FOR_TEST"), a_int=EnvVar("ENV_VARIABLE_FOR_TEST_INT")
+                )
+            },
+        )
+
+        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert executed["yes"]
+    finally:
+        del os.environ["ENV_VARIABLE_FOR_TEST"]
+        del os.environ["ENV_VARIABLE_FOR_TEST_INT"]
+
+
+def test_env_var_err():
+    if "UNSET_ENV_VAR" in os.environ:
+        del os.environ["UNSET_ENV_VAR"]
+
+    class ResourceWithString(Resource):
+        a_str: str
+
+    with pytest.raises(DagsterInvalidConfigError):
+        ResourceWithString(a_str=EnvVar("UNSET_ENV_VAR"))
+
+
+def test_runtime_config_env_var():
+    out_txt = []
+
+    class WriterResource(Resource):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    @asset
+    def hello_world_asset(writer: WriterResource):
+        writer.output("hello, world!")
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={"writer": WriterResource.configure_at_launch()},
+    )
+
+    os.environ["MY_PREFIX_FOR_TEST"] = "greeting: "
+    try:
+        assert (
+            defs.get_implicit_global_asset_job_def()
+            .execute_in_process(
+                {"resources": {"writer": {"config": {"prefix": EnvVar("MY_PREFIX_FOR_TEST")}}}}
+            )
+            .success
+        )
+        assert out_txt == ["greeting: hello, world!"]
+    finally:
+        del os.environ["MY_PREFIX_FOR_TEST"]

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from typing import Optional
 
@@ -570,3 +571,45 @@ def test_schema_aliased_field():
     # use the alias in config space
     assert a_job.execute_in_process({"ops": {"an_op": {"config": {"schema": "bar"}}}}).success
     assert executed["yes"]
+
+
+def test_env_var():
+    os.environ["ENV_VARIABLE_FOR_TEST"] = "foo"
+    os.environ["ENV_VARIABLE_FOR_TEST_INT"] = "2"
+    try:
+
+        class AnAssetConfig(Config):
+            a_string: str
+            an_int: int
+
+        executed = {}
+
+        @asset
+        def my_asset(config: AnAssetConfig):
+            assert config.a_string == "foo"
+            assert config.an_int == 2
+            executed["yes"] = True
+
+        assert (
+            build_assets_job(
+                "blah",
+                [my_asset],
+                config={
+                    "ops": {
+                        "my_asset": {
+                            "config": {
+                                "a_string": {"env": "ENV_VARIABLE_FOR_TEST"},
+                                "an_int": {"env": "ENV_VARIABLE_FOR_TEST_INT"},
+                            }
+                        }
+                    }
+                },
+            )
+            .execute_in_process()
+            .success
+        )
+
+        assert executed["yes"]
+    finally:
+        del os.environ["ENV_VARIABLE_FOR_TEST"]
+        del os.environ["ENV_VARIABLE_FOR_TEST_INT"]


### PR DESCRIPTION
## Summary

As shown in #11466, supplying config via env var when directly constructing a (new, structured-config-based) Resource or IO Manager is broken. This is because, unlike the Op/Asset case, we never process the config, meaning the post-processing which evaluates env var values is never called.

This PR explicitly processes the input config when a user constructs a resource or I/O manager.

## Test Plan

New unit tests.