### PR TITLE
[dagster-dbt] add DbtManifestAssetSelection

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -1,6 +1,7 @@
 from dagster._core.utils import check_dagster_package_version
 
 from .asset_defs import load_assets_from_dbt_manifest, load_assets_from_dbt_project
+from .asset_selection import DbtManifestAssetSelection
 from .cli import DbtCliOutput, DbtCliResource, dbt_cli_resource
 from .cloud import (
     DbtCloudOutput,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
@@ -14,18 +14,34 @@ from dagster._core.definitions.asset_graph import AssetGraph
 
 @experimental
 class DbtManifestAssetSelection(AssetSelection):
-    """Defines a selection of assets from a parsed dbt manifest.json file and a dbt-syntax slection
+    """Defines a selection of assets from a parsed dbt manifest.json file and a dbt-syntax selection
     string.
 
     Args:
         manifest_json (Mapping[str, Any]): The parsed manifest.json file from your dbt project.
-        select (str): A dbt-syntax selection string, e.g. tag:foo or config.materilized:table.
+        select (str): A dbt-syntax selection string, e.g. tag:foo or config.materialized:table.
         exclude (str): A dbt-syntax exclude string. Defaults to "".
         resource_types (Sequence[str]): The resource types to select. Defaults to ["model"].
         node_info_to_asset_key (Callable[[Mapping[str, Any]], AssetKey]): A function that takes a
             dictionary of dbt metadata and returns the AssetKey that you want to represent a given
             model or source. If you pass in a custom function to `load_assets_from_dbt_manifest`,
             you must also pass in the same function here.
+
+    Example:
+
+            .. code-block:: python
+
+            my_dbt_assets = load_assets_from_dbt_manifest(
+                manifest_json,
+                node_info_to_asset_key=my_node_info_to_asset_key_fn,
+            )
+
+            # This will select all assets that have the tag "foo" and are in the path "marts/finance"
+            my_selection = DbtManifestAssetSelection(
+                manifest_json,
+                select="tag:foo,path:marts/finance",
+                node_info_to_asset_key=my_node_info_to_asset_key_fn,
+            )
     """
 
     def __init__(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
@@ -1,0 +1,59 @@
+from typing import AbstractSet, Any, Callable, Mapping, Optional, Sequence
+
+from dagster_dbt.asset_defs import (
+    _get_node_asset_key,
+    _is_non_asset_node,
+    _select_unique_ids_from_manifest_json,
+)
+
+import dagster._check as check
+from dagster import AssetKey, AssetSelection
+from dagster._annotations import experimental
+from dagster._core.definitions.asset_graph import AssetGraph
+
+
+@experimental
+class DbtManifestAssetSelection(AssetSelection):
+    """Defines a selection of assets from a parsed dbt manifest.json file and a dbt-syntax slection
+    string.
+
+    Args:
+        manifest_json (Mapping[str, Any]): The parsed manifest.json file from your dbt project.
+        select (str): A dbt-syntax selection string, e.g. tag:foo or config.materilized:table.
+        exclude (str): A dbt-syntax exclude string. Defaults to "".
+        resource_types (Sequence[str]): The resource types to select. Defaults to ["model"].
+        node_info_to_asset_key (Callable[[Mapping[str, Any]], AssetKey]): A function that takes a
+            dictionary of dbt metadata and returns the AssetKey that you want to represent a given
+            model or source. If you pass in a custom function to `load_assets_from_dbt_manifest`,
+            you must also pass in the same function here.
+    """
+
+    def __init__(
+        self,
+        manifest_json: Mapping[str, Any],
+        select: str,
+        exclude: str = "",
+        resource_types: Optional[Sequence[str]] = None,
+        node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
+    ):
+        self.manifest_json = check.dict_param(manifest_json, "manifest_json")
+        self.select = check.str_param(select, "select")
+        self.exclude = check.str_param(exclude, "exclude")
+        self.resource_types = check.opt_list_param(
+            resource_types, "resource_types", of_type=str
+        ) or ["model"]
+        self.node_info_to_asset_key = check.callable_param(
+            node_info_to_asset_key, "node_info_to_asset_key"
+        )
+
+    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        keys = set()
+        for unique_id in _select_unique_ids_from_manifest_json(
+            manifest_json=self.manifest_json, select=self.select, exclude=self.exclude
+        ):
+            node_info = self.manifest_json["nodes"][unique_id]
+            if node_info["resource_type"] in self.resource_types and not _is_non_asset_node(
+                node_info
+            ):
+                keys.add(self.node_info_to_asset_key(node_info))
+        return keys

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_selection.py
@@ -1,0 +1,90 @@
+import json
+
+import pytest
+from dagster_dbt import DbtManifestAssetSelection
+from dagster_dbt.asset_defs import load_assets_from_dbt_manifest
+
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.events import AssetKey
+from dagster._utils import file_relative_path
+
+
+@pytest.mark.parametrize(
+    "select,exclude,expected_asset_names",
+    [
+        (
+            "*",
+            None,
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+                "sort_hot_cereals_by_calories",
+            },
+        ),
+        (
+            "+least_caloric",
+            None,
+            {"sort_by_calories", "subdir_schema/least_caloric"},
+        ),
+        (
+            "sort_by_calories least_caloric",
+            None,
+            {"sort_by_calories", "subdir_schema/least_caloric"},
+        ),
+        (
+            "tag:bar+",
+            None,
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+                "sort_hot_cereals_by_calories",
+            },
+        ),
+        (
+            "tag:foo",
+            None,
+            {"sort_by_calories", "cold_schema/sort_cold_cereals_by_calories"},
+        ),
+        (
+            "tag:foo,tag:bar",
+            None,
+            {"sort_by_calories"},
+        ),
+        (
+            None,
+            "sort_hot_cereals_by_calories",
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+            },
+        ),
+        (
+            None,
+            "+least_caloric",
+            {"cold_schema/sort_cold_cereals_by_calories", "sort_hot_cereals_by_calories"},
+        ),
+        (
+            None,
+            "sort_by_calories least_caloric",
+            {"cold_schema/sort_cold_cereals_by_calories", "sort_hot_cereals_by_calories"},
+        ),
+        (None, "tag:foo", {"subdir_schema/least_caloric", "sort_hot_cereals_by_calories"}),
+    ],
+)
+def test_dbt_asset_selection(select, exclude, expected_asset_names):
+    manifest_path = file_relative_path(__file__, "sample_manifest.json")
+    with open(manifest_path, "r", encoding="utf8") as f:
+        manifest_json = json.load(f)
+
+    expected_keys = {AssetKey(key.split("/")) for key in expected_asset_names}
+
+    dbt_assets = load_assets_from_dbt_manifest(manifest_json=manifest_json)
+    asset_graph = AssetGraph.from_assets(dbt_assets)
+    actual_keys = DbtManifestAssetSelection(
+        manifest_json=manifest_json, select=select or "*", exclude=exclude or ""
+    ).resolve_inner(asset_graph)
+
+    assert expected_keys == actual_keys


### PR DESCRIPTION
### Summary & Motivation

dbt has a very expressive selection syntax, which people might want to use to describe sections of their overall asset graph. This PR adds the ability to do that.

This only works if you're using `load_assets_from_dbt_manifest` because a) if you don't have a compiled manifest available to you, you'll need to run `dbt ls` which can take a long time and b) if you have a large enough dbt graph to make you want to describe things in terms of dbt selections, you probably should be using `load_assets_from_dbt_manifest` anyway.

### How I Tested These Changes
