### PR TITLE
dagster-graphql tests for permissions failures

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
@@ -2,17 +2,34 @@ import time
 from typing import Any
 
 from dagster_graphql import ShutdownRepositoryLocationStatus
+from dagster_graphql.client.client_queries import SHUTDOWN_REPOSITORY_LOCATION_MUTATION
+from dagster_graphql.test.utils import execute_dagster_graphql
 
 from dagster._core.errors import DagsterUserCodeUnreachableError
 
 from ..graphql.graphql_context_test_suite import (
     GraphQLContextVariant,
+    ReadonlyGraphQLContextTestMatrix,
     make_graphql_context_test_suite,
 )
 
 BaseTestSuite: Any = make_graphql_context_test_suite(
     context_variants=[GraphQLContextVariant.non_launchable_sqlite_instance_deployed_grpc_env()]
 )
+
+
+class TestShutdownRepositoryLocationReadOnly(ReadonlyGraphQLContextTestMatrix):
+    def test_shutdown_repository_location_permission_failure(self, graphql_context):
+        result = execute_dagster_graphql(
+            graphql_context,
+            SHUTDOWN_REPOSITORY_LOCATION_MUTATION,
+            {"repositoryLocationName": "test"},
+        )
+
+        assert result
+        assert result.data
+        assert result.data["shutdownRepositoryLocation"]
+        assert result.data["shutdownRepositoryLocation"]["__typename"] == "UnauthorizedError"
 
 
 class TestShutdownRepositoryLocation(BaseTestSuite):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -915,8 +915,6 @@ def get_step_output_event(logs, step_key, output_name="result"):
 
 class TestExecutePipelineReadonlyFailure(ReadonlyGraphQLContextTestMatrix):
     def test_start_pipeline_execution_readonly_failure(self, graphql_context):
-        assert graphql_context.read_only is True
-
         selector = infer_pipeline_selector(graphql_context, "csv_hello_world")
         result = execute_dagster_graphql(
             graphql_context,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1,4 +1,5 @@
 import os
+import time
 from typing import List, Tuple
 
 from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
@@ -8,13 +9,18 @@ from dagster_graphql.test.utils import (
     infer_repository_selector,
 )
 
-from dagster._core.execution.backfill import BulkActionStatus
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import create_run_for_test
+from dagster._core.utils import make_new_backfill_id
 from dagster._legacy import DagsterRun, DagsterRunStatus
 from dagster._seven import get_system_temp_directory
 
-from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
+from .graphql_context_test_suite import (
+    ExecutingGraphQLContextTestMatrix,
+    ReadonlyGraphQLContextTestMatrix,
+)
 
 PARTITION_PROGRESS_QUERY = """
   query PartitionProgressQuery($backfillId: String!) {
@@ -46,8 +52,8 @@ PARTITION_PROGRESS_QUERY = """
 CANCEL_BACKFILL_MUTATION = """
   mutation($backfillId: String!) {
     cancelPartitionBackfill(backfillId: $backfillId) {
+      __typename
       ... on CancelBackfillSuccess {
-        __typename
         backfillId
       }
       ... on PythonError {
@@ -61,8 +67,8 @@ CANCEL_BACKFILL_MUTATION = """
 RESUME_BACKFILL_MUTATION = """
   mutation($backfillId: String!) {
     resumePartitionBackfill(backfillId: $backfillId) {
+      __typename
       ... on ResumeBackfillSuccess {
-        __typename
         backfillId
       }
       ... on PythonError {
@@ -119,6 +125,72 @@ def _get_run_stats(partition_statuses):
             [status for status in partition_statuses if status["runStatus"] == "CANCELED"]
         ),
     }
+
+
+class TestPartitionBackillReadonlyFailure(ReadonlyGraphQLContextTestMatrix):
+    def _create_backfill(self, graphql_context):
+        repository_location = graphql_context.get_repository_location("test")
+        repository = repository_location.get_repository("test_repo")
+
+        backfill = PartitionBackfill(
+            backfill_id=make_new_backfill_id(),
+            partition_set_origin=ExternalPartitionSetOrigin(
+                external_repository_origin=repository.get_external_origin(),
+                partition_set_name="integer_partition",
+            ),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["one", "two", "three"],
+            from_failure=False,
+            reexecution_steps=None,
+            tags=None,
+            backfill_timestamp=time.time(),
+        )
+        graphql_context.instance.add_backfill(backfill)
+        return backfill.backfill_id
+
+    def test_launch_backill_failure(self, graphql_context):
+        repository_selector = infer_repository_selector(graphql_context)
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PARTITION_BACKFILL_MUTATION,
+            variables={
+                "backfillParams": {
+                    "selector": {
+                        "repositorySelector": repository_selector,
+                        "partitionSetName": "integer_partition",
+                    },
+                    "partitionNames": ["2", "3"],
+                }
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert result.data["launchPartitionBackfill"]["__typename"] == "UnauthorizedError"
+
+    def test_cancel_backfill_failure(self, graphql_context):
+        backfill_id = self._create_backfill(graphql_context)
+        result = execute_dagster_graphql(
+            graphql_context,
+            CANCEL_BACKFILL_MUTATION,
+            variables={"backfillId": backfill_id},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["cancelPartitionBackfill"]["__typename"] == "UnauthorizedError"
+
+    def test_resume_backfill_failure(self, graphql_context):
+        backfill_id = self._create_backfill(graphql_context)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            RESUME_BACKFILL_MUTATION,
+            variables={"backfillId": backfill_id},
+        )
+        assert result.data
+        assert result.data["resumePartitionBackfill"]["__typename"] == "UnauthorizedError", str(
+            result.data
+        )
 
 
 class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -16,11 +16,14 @@ from dagster_graphql.test.utils import (
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
-from dagster._core.test_utils import poll_for_finished_run
+from dagster._core.test_utils import create_run_for_test, poll_for_finished_run
 from dagster._core.utils import make_new_run_id
 from dagster._seven.temp_dir import get_system_temp_directory
 
-from .graphql_context_test_suite import ExecutingGraphQLContextTestMatrix
+from .graphql_context_test_suite import (
+    ExecutingGraphQLContextTestMatrix,
+    ReadonlyGraphQLContextTestMatrix,
+)
 from .repo import csv_hello_world_solids_config, get_retry_multi_execution_params, retry_config
 from .utils import (
     get_all_logs_for_finished_run_via_subscription,
@@ -57,6 +60,41 @@ def get_step_output_event(logs, step_key, output_name="result"):
             return log
 
     return None
+
+
+class TestRetryExecutionReadonly(ReadonlyGraphQLContextTestMatrix):
+    def test_retry_execution_permission_failure(self, graphql_context):
+        selector = infer_pipeline_selector(graphql_context, "eventually_successful")
+
+        repository_location = graphql_context.get_repository_location("test")
+        repository = repository_location.get_repository("test_repo")
+        external_pipeline_origin = repository.get_full_external_job(
+            "eventually_successful"
+        ).get_external_origin()
+
+        run_id = create_run_for_test(
+            graphql_context.instance,
+            "eventually_successful",
+            external_pipeline_origin=external_pipeline_origin,
+        ).run_id
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+            variables={
+                "executionParams": {
+                    "mode": "default",
+                    "selector": selector,
+                    "runConfigData": {},
+                    "executionMetadata": {
+                        "rootRunId": run_id,
+                        "parentRunId": run_id,
+                        "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}],
+                    },
+                }
+            },
+        )
+        assert result.data["launchPipelineReexecution"]["__typename"] == "UnauthorizedError"
 
 
 class TestRetryExecution(ExecutingGraphQLContextTestMatrix):


### PR DESCRIPTION
Tests that will let us more safely alter codepaths for permissions failures in graphql.