### PR TITLE
Update PartitionsSubset Serialization

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -24,7 +24,7 @@ from .partition import (
     StaticPartitionsDefinition,
     PartitionKeyRange,
 )
-from .time_window_partitions import TimeWindowPartitionsDefinition
+from .time_window_partitions import TimeWindowPartitionsDefinition, TimeWindowPartitionsSubset
 
 INVALID_STATIC_PARTITIONS_KEY_CHARACTERS = set(["|", ",", "[", "]"])
 
@@ -182,19 +182,6 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def partitions_defs(self) -> Sequence[PartitionDimensionDefinition]:
         return self._partitions_defs
 
-    def has_partition_key(self, partition_key: MultiPartitionKey) -> bool:
-        # Function exists for performance improvement. Scanning the entire list of partitions
-        # is expensive, so we can instead validate by dimension
-        if not set(partition_key.keys_by_dimension.keys()) == set(self.partition_dimension_names):
-            return False
-        return all(
-            [
-                partition_key.keys_by_dimension[dim_def.name]
-                in dim_def.partitions_def.get_partition_keys()
-                for dim_def in self._partitions_defs
-            ]
-        )
-
     def get_partitions(self, current_time: Optional[datetime] = None) -> Sequence[Partition]:
         partition_sequences = [
             partition_dim.partitions_def.get_partitions(current_time=current_time)
@@ -253,6 +240,25 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def __repr__(self) -> str:
         return f"{type(self).__name__}(dimensions={[str(dim) for dim in self.partitions_defs]}"
 
+    def split_partition_key_str(self, partition_key_str: str) -> Mapping[str, str]:
+        """
+        Given a string representation of a partition key, returns a list of per-dimension
+        partition keys in the supplied order.
+
+        Does not validate, relying on downstream checks to ensure that the partition key is valid
+        for performance reasons.
+        """
+        check.str_param(partition_key_str, "partition_key_str")
+
+        partition_key_strs = partition_key_str.split("|")
+        check.invariant(
+            len(partition_key_strs) == len(self.partitions_defs),
+            f"Expected {len(self.partitions_defs)} partition keys in partition key string {partition_key_str}, "
+            f"but got {len(partition_key_strs)}",
+        )
+
+        return {dim.name: partition_key_strs[i] for i, dim in enumerate(self._partitions_defs)}
+
     def get_multi_partition_key_from_str(self, partition_key_str: str) -> MultiPartitionKey:
         """
         Given a string representation of a partition key, returns a MultiPartitionKey object.
@@ -292,6 +298,9 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def _get_primary_and_secondary_dimension(
         self,
     ) -> Tuple[PartitionDimensionDefinition, PartitionDimensionDefinition]:
+        # Multipartitions subsets are serialized by primary dimension. If changing
+        # the selection of primary/secondary dimension, will need to also update the
+        # serialization of MultiPartitionsSubsets
         partition_defs = self.partitions_defs
         time_partition_defs = [
             dimension_def
@@ -316,14 +325,14 @@ class MultiPartitionsDefinition(PartitionsDefinition):
 
 
 class MultiPartitionsSubset(PartitionsSubset):
-    # TODO serialization version comment
+    # Every time we change the serialization format, we should increment the version number.
+    # This will ensure that we can deserialize old data.
     SERIALIZATION_VERSION = 1
 
     def __init__(
         self,
         partitions_def: MultiPartitionsDefinition,
-        subsets_by_primary_dimension_partition_key: Optional[Mapping[str, PartitionsSubset]] = None
-        # subset: Optional[Set[str]] = None,
+        subsets_by_primary_dimension_partition_key: Optional[Mapping[str, PartitionsSubset]] = None,
     ):
         self._partitions_def = check.inst_param(
             partitions_def, "partitions_def", MultiPartitionsDefinition
@@ -336,7 +345,7 @@ class MultiPartitionsSubset(PartitionsSubset):
             value_type=PartitionsSubset,
         )
         if not subsets_by_primary_dimension_partition_key:
-            self.subsets_by_primary_dimension_partition_key = {
+            self._subsets_by_primary_dimension_partition_key = {
                 primary_key: partitions_def.secondary_dimension.partitions_def.empty_subset()
                 for primary_key in partitions_def.primary_dimension.partitions_def.get_partition_keys()
             }
@@ -352,20 +361,9 @@ class MultiPartitionsSubset(PartitionsSubset):
                     == partitions_def.secondary_dimension.partitions_def,
                     f"Secondary dimension subset partitions definition {secondary_dim_subset.partitions_def} does not match partitions definition for dimension {partitions_def.secondary_dimension.name}",
                 )
-            self.subsets_by_primary_dimension_partition_key = (
+            self._subsets_by_primary_dimension_partition_key = (
                 subsets_by_primary_dimension_partition_key
             )
-
-        # subsets_by_primary_dimension_partition_key = defaultdict(set)
-        # for partition_key in subset:
-        #     multi_partition_key = cast(
-        #         MultiPartitionsDefinition, self._partitions_def
-        #     ).get_multi_partition_key_from_str(partition_key)
-        #     subsets_by_primary_dimension_partition_key[
-        #         multi_partition_key.keys_by_dimension[self._primary_dimension.name]
-        #     ].add(multi_partition_key.keys_by_dimension[self._secondary_dimension.name])
-
-        # super(MultiPartitionsSubset, self).__init__(partitions_def, subset)
 
     @property
     def partitions_def(self) -> MultiPartitionsDefinition:
@@ -378,7 +376,7 @@ class MultiPartitionsSubset(PartitionsSubset):
         for (
             primary_key,
             secondary_subset,
-        ) in self.subsets_by_primary_dimension_partition_key.items():
+        ) in self._subsets_by_primary_dimension_partition_key.items():
             for secondary_key in secondary_subset.get_partition_keys_not_in_subset(current_time):
                 keys_not_in_subset.add(
                     MultiPartitionKey(
@@ -395,7 +393,7 @@ class MultiPartitionsSubset(PartitionsSubset):
         for (
             primary_key,
             secondary_subset,
-        ) in self.subsets_by_primary_dimension_partition_key.items():
+        ) in self._subsets_by_primary_dimension_partition_key.items():
             for secondary_key in secondary_subset.get_partition_keys(current_time):
                 keys_in_subset.add(
                     MultiPartitionKey(
@@ -405,20 +403,42 @@ class MultiPartitionsSubset(PartitionsSubset):
                         }
                     )
                 )
+        return keys_in_subset
 
     def get_partition_key_ranges(
         self, current_time: Optional[datetime] = None
     ) -> Sequence[PartitionKeyRange]:
-        # TODO
-        pass
+        partition_keys = self._partitions_def.get_partition_keys(current_time)
+        cur_range_start = None
+        cur_range_end = None
+        result = []
+        for partition_key in partition_keys:
+            if partition_key in self:
+                if cur_range_start is None:
+                    cur_range_start = partition_key
+                cur_range_end = partition_key
+            else:
+                if cur_range_start is not None and cur_range_end is not None:
+                    result.append(PartitionKeyRange(cur_range_start, cur_range_end))
+                cur_range_start = cur_range_end = None
+
+        if cur_range_start is not None and cur_range_end is not None:
+            result.append(PartitionKeyRange(cur_range_start, cur_range_end))
+
+        return result
 
     def __eq__(self, other):
-        # TODO
-        pass
+        return (
+            isinstance(other, MultiPartitionsSubset)
+            and self.partitions_def == other.partitions_def
+            and self._subsets_by_primary_dimension_partition_key
+            == other._subsets_by_primary_dimension_partition_key
+        )
 
     def __len__(self) -> int:
-        # TODO
-        pass
+        return sum(
+            len(subset) for subset in self._subsets_by_primary_dimension_partition_key.values()
+        )
 
     def __contains__(self, partition_key: str) -> bool:
         if not isinstance(partition_key, MultiPartitionKey):
@@ -432,32 +452,54 @@ class MultiPartitionsSubset(PartitionsSubset):
         )
         return (
             primary_key is not None
-            and primary_key in self.subsets_by_primary_dimension_partition_key
+            and primary_key in self._subsets_by_primary_dimension_partition_key
             and secondary_key is not None
-            and secondary_key in self.subsets_by_primary_dimension_partition_key[primary_key]
+            and secondary_key in self._subsets_by_primary_dimension_partition_key[primary_key]
         )
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "MultiPartitionsSubset":
         new_keys_by_primary_dim_key = defaultdict(set)
-        for partition_key in partition_keys:
-            multi_partition_key = cast(
-                MultiPartitionsDefinition, self._partitions_def
-            ).get_multi_partition_key_from_str(partition_key)
+        keys_split_into_dimensions = [
+            self._partitions_def.split_partition_key_str(key) for key in partition_keys
+        ]
+
+        for dim_key_mapping in keys_split_into_dimensions:
             new_keys_by_primary_dim_key[
-                multi_partition_key.keys_by_dimension[self.partitions_def.primary_dimension.name]
-            ].add(
-                multi_partition_key.keys_by_dimension[self.partitions_def.secondary_dimension.name]
+                dim_key_mapping[self.partitions_def.primary_dimension.name]
+            ].add(dim_key_mapping[self.partitions_def.secondary_dimension.name])
+
+        if isinstance(
+            self.partitions_def.secondary_dimension.partitions_def, TimeWindowPartitionsDefinition
+        ):
+            secondary_dim_def = self.partitions_def.secondary_dimension.partitions_def
+            # Cache the valid time windows to avoid refetching them for creating each time window subset.
+            # Fetching the valid time windows is expensive.
+            _valid_time_windows = list(
+                secondary_dim_def.iterate_valid_time_windows(start=secondary_dim_def.start)
             )
 
-        return MultiPartitionsSubset(
-            self._partitions_def,
-            {
-                primary_key: secondary_dim_subset.with_partition_keys(
-                    new_keys_by_primary_dim_key[primary_key]
-                )
-                for primary_key, secondary_dim_subset in self.subsets_by_primary_dimension_partition_key.items()
-            },
-        )
+            return MultiPartitionsSubset(
+                self._partitions_def,
+                {
+                    primary_key: cast(
+                        TimeWindowPartitionsSubset, secondary_dim_subset
+                    ).with_partition_keys(
+                        new_keys_by_primary_dim_key[primary_key],
+                        _valid_time_windows=_valid_time_windows,
+                    )
+                    for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+                },
+            )
+        else:
+            return MultiPartitionsSubset(
+                self._partitions_def,
+                {
+                    primary_key: secondary_dim_subset.with_partition_keys(
+                        new_keys_by_primary_dim_key[primary_key],
+                    )
+                    for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+                },
+            )
 
     def serialize(self) -> str:
         # Serialize version number, so attempting to deserialize old versions can be handled gracefully.
@@ -467,7 +509,7 @@ class MultiPartitionsSubset(PartitionsSubset):
                 "version": self.SERIALIZATION_VERSION,
                 "serialized_subsets_by_primary_key": {
                     primary_key: secondary_dim_subset.serialize()
-                    for primary_key, secondary_dim_subset in self.subsets_by_primary_dimension_partition_key.items()
+                    for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
                 },
             }
         )
@@ -482,7 +524,6 @@ class MultiPartitionsSubset(PartitionsSubset):
     def from_serialized(
         cls, partitions_def: PartitionsDefinition, serialized: str
     ) -> "MultiPartitionsSubset":
-        # TODO add comment on serialization version
         if not isinstance(partitions_def, MultiPartitionsDefinition):
             check.failed(
                 "Must pass a MultiPartitionsDefinition object to deserialize MultiPartitionsSubset."
@@ -504,31 +545,38 @@ class MultiPartitionsSubset(PartitionsSubset):
             },
         )
 
-    # def _get_primary_and_secondary_dimension(
-    #     self, partitions_def: MultiPartitionsDefinition
-    # ) -> Tuple[PartitionDimensionDefinition, PartitionDimensionDefinition]:
-    #     partition_defs = partitions_def.partitions_defs
-    #     time_partition_defs = [
-    #         dimension_def
-    #         for dimension_def in partition_defs
-    #         if isinstance(dimension_def.partitions_def, TimeWindowPartitionsDefinition)
-    #     ]
-    #     secondary_serialization_dimension = (
-    #         next(iter(time_partition_defs)) if len(time_partition_defs) == 1 else partition_defs[1]
-    #     )
-    #     primary_serialization_dimension = next(
-    #         iter([dim for dim in partition_defs if dim != secondary_serialization_dimension])
-    #     )
-    #     return primary_serialization_dimension, secondary_serialization_dimension
-
     def get_inverse_subset(self) -> "MultiPartitionsSubset":
-        return MultiPartitionsSubset(
-            partitions_def=self._partitions_def,
-            subsets_by_primary_dimension_partition_key={
-                primary_key: secondary_dim_subset.get_inverse_subset()
-                for primary_key, secondary_dim_subset in self.subsets_by_primary_dimension_partition_key.items()
-            },
-        )
+        if isinstance(
+            self.partitions_def.secondary_dimension.partitions_def, TimeWindowPartitionsDefinition
+        ):
+            secondary_dim_def = self.partitions_def.secondary_dimension.partitions_def
+            # Cache the valid time windows to avoid refetching them for creating each time window subset.
+            # Fetching the valid time windows is expensive.
+            _valid_time_windows = list(
+                secondary_dim_def.iterate_valid_time_windows(start=secondary_dim_def.start)
+            )
+
+            return MultiPartitionsSubset(
+                partitions_def=self._partitions_def,
+                subsets_by_primary_dimension_partition_key={
+                    primary_key: cast(
+                        TimeWindowPartitionsSubset, secondary_dim_subset
+                    ).get_inverse_subset(_valid_time_windows)
+                    for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+                },
+            )
+        else:
+            return MultiPartitionsSubset(
+                partitions_def=self._partitions_def,
+                subsets_by_primary_dimension_partition_key={
+                    primary_key: secondary_dim_subset.get_inverse_subset()
+                    for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+                },
+            )
+
+    @property
+    def subsets_by_primary_dimension_partition_key(self) -> Mapping[str, PartitionsSubset]:
+        return self._subsets_by_primary_dimension_partition_key
 
 
 def get_tags_from_multi_partition_key(multi_partition_key: MultiPartitionKey) -> Mapping[str, str]:

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1090,6 +1090,13 @@ class PartitionsSubset(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def get_inverse_subset(self) -> "PartitionsSubset":
+        """
+        Returns a PartitionsSubset that represents all partitions not selected in this PartitionsSubset.
+        """
+        raise NotImplementedError()
+
 
 class DefaultPartitionsSubset(PartitionsSubset):
     # Every time we change the serialization format, we should increment the version number.
@@ -1190,3 +1197,8 @@ class DefaultPartitionsSubset(PartitionsSubset):
             )
 
         return cls(subset=set(data.get("subset")), partitions_def=partitions_def)
+
+    def get_inverse_subset(self) -> "DefaultPartitionsSubset":
+        return DefaultPartitionsSubset(
+            self.partitions_def, set(self.get_partition_keys_not_in_subset())
+        )

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -43,6 +43,7 @@ from ..errors import (
     DagsterUnknownPartitionError,
     ScheduleExecutionError,
     user_code_error_boundary,
+    DagsterInvalidDeserializationVersionError,
 )
 from ..storage.pipeline_run import DagsterRun
 from .config import ConfigMapping
@@ -1063,6 +1064,11 @@ class PartitionsSubset(ABC):
     def serialize(self) -> str:
         raise NotImplementedError()
 
+    @classmethod
+    @abstractmethod
+    def from_serialized(cls, serialized: str) -> "PartitionsSubset":
+        raise NotImplementedError()
+
     @property
     @abstractmethod
     def partitions_def(self) -> PartitionsDefinition:
@@ -1076,8 +1082,20 @@ class PartitionsSubset(ABC):
     def __contains__(self, value) -> bool:
         raise NotImplementedError()
 
+    @classmethod
+    @abstractmethod
+    def can_deserialize(cls, serialized: str) -> bool:
+        """
+        Returns True if this PartitionsSubset can deserialize the given serialized string.
+        """
+        raise NotImplementedError()
+
 
 class DefaultPartitionsSubset(PartitionsSubset):
+    # Every time we change the serialization format, we should increment the version number.
+    # This will ensure that we can gracefully degrade when deserializing old data.
+    SERIALIZATION_VERSION = 1
+
     def __init__(self, partitions_def: PartitionsDefinition, subset: Optional[Set[str]] = None):
         check.opt_set_param(subset, "subset")
         self._partitions_def = partitions_def
@@ -1123,9 +1141,6 @@ class DefaultPartitionsSubset(PartitionsSubset):
             self._partitions_def.get_partition_keys_in_range(partition_key_range)
         )
 
-    def serialize(self) -> str:
-        return json.dumps(list(self._subset))
-
     @property
     def partitions_def(self) -> PartitionsDefinition:
         return self._partitions_def
@@ -1143,15 +1158,31 @@ class DefaultPartitionsSubset(PartitionsSubset):
     def __contains__(self, value) -> bool:
         return value in self._subset
 
-    @staticmethod
-    def from_serialized(
-        partitions_def: PartitionsDefinition, serialized: str
-    ) -> "DefaultPartitionsSubset":
-        return DefaultPartitionsSubset(
-            subset=set(json.loads(serialized)), partitions_def=partitions_def
-        )
-
     def __repr__(self) -> str:
         return (
             f"DefaultPartitionsSubset(subset={self._subset}, partitions_def={self._partitions_def})"
         )
+
+    def serialize(self) -> str:
+        # Serialize version number, so attempting to deserialize old versions can be handled gracefully.
+        # Any time the serialization format changes, we should increment the version number.
+        return json.dumps({"version": self.SERIALIZATION_VERSION, "subset": list(self._subset)})
+
+    @classmethod
+    def can_deserialize(cls, serialized: str) -> bool:
+        # Check the version number to determine if the serialization format is supported
+        data = json.loads(serialized)
+        return data.get("version") == cls.SERIALIZATION_VERSION
+
+    @classmethod
+    def from_serialized(
+        cls, partitions_def: PartitionsDefinition, serialized: str
+    ) -> "DefaultPartitionsSubset":
+        # Check the version number, so only valid versions can be deserialized.
+        data = json.loads(serialized)
+        if data.get("version") != cls.SERIALIZATION_VERSION:
+            raise DagsterInvalidDeserializationVersionError(
+                f"Attempted to deserialize partition subset with version {data.get('version')}, but only version {cls.SERIALIZATION_VERSION} is supported."
+            )
+
+        return cls(subset=set(data.get("subset")), partitions_def=partitions_def)

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1099,7 +1099,7 @@ class DefaultPartitionsSubset(PartitionsSubset):
     def __init__(self, partitions_def: PartitionsDefinition, subset: Optional[Set[str]] = None):
         check.opt_set_param(subset, "subset")
         self._partitions_def = partitions_def
-        self._subset = subset or set()
+        self._subset = (subset & set(partitions_def.get_partition_keys())) if subset else set()
 
     def get_partition_keys_not_in_subset(
         self, current_time: Optional[datetime] = None
@@ -1132,7 +1132,11 @@ class DefaultPartitionsSubset(PartitionsSubset):
         return result
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "DefaultPartitionsSubset":
-        return DefaultPartitionsSubset(self._partitions_def, self._subset | set(partition_keys))
+        valid_partition_keys = set(self._partitions_def.get_partition_keys())
+        return DefaultPartitionsSubset(
+            self._partitions_def,
+            self._subset | (set(valid_partition_keys) & set(partition_keys)),
+        )
 
     def with_partition_key_range(
         self, partition_key_range: PartitionKeyRange

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1185,12 +1185,16 @@ class DefaultPartitionsSubset(PartitionsSubset):
     ) -> "DefaultPartitionsSubset":
         # Check the version number, so only valid versions can be deserialized.
         data = json.loads(serialized)
-        if data.get("version") != cls.SERIALIZATION_VERSION:
-            raise DagsterInvalidDeserializationVersionError(
-                f"Attempted to deserialize partition subset with version {data.get('version')}, but only version {cls.SERIALIZATION_VERSION} is supported."
-            )
 
-        return cls(subset=set(data.get("subset")), partitions_def=partitions_def)
+        if isinstance(data, list):
+            # backwards compatibility
+            return cls(subset=set(data), partitions_def=partitions_def)
+        else:
+            if data.get("version") != cls.SERIALIZATION_VERSION:
+                raise DagsterInvalidDeserializationVersionError(
+                    f"Attempted to deserialize partition subset with version {data.get('version')}, but only version {cls.SERIALIZATION_VERSION} is supported."
+                )
+            return cls(subset=set(data.get("subset")), partitions_def=partitions_def)
 
     def get_inverse_subset(self) -> "DefaultPartitionsSubset":
         return DefaultPartitionsSubset(

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1054,11 +1054,12 @@ class PartitionsSubset(ABC):
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "PartitionsSubset":
         raise NotImplementedError()
 
-    @abstractmethod
     def with_partition_key_range(
         self, partition_key_range: PartitionKeyRange
     ) -> "PartitionsSubset":
-        raise NotImplementedError()
+        return self.with_partition_keys(
+            self.partitions_def.get_partition_keys_in_range(partition_key_range)
+        )
 
     @abstractmethod
     def serialize(self) -> str:
@@ -1143,13 +1144,6 @@ class DefaultPartitionsSubset(PartitionsSubset):
         return DefaultPartitionsSubset(
             self._partitions_def,
             self._subset | (set(valid_partition_keys) & set(partition_keys)),
-        )
-
-    def with_partition_key_range(
-        self, partition_key_range: PartitionKeyRange
-    ) -> "PartitionsSubset":
-        return self.with_partition_keys(
-            self._partitions_def.get_partition_keys_in_range(partition_key_range)
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -179,10 +179,6 @@ class TimeWindowPartitionMapping(
         return TimeWindowPartitionsSubset(
             to_partitions_def,
             time_windows,
-            num_partitions=sum(
-                len(to_partitions_def.get_partition_keys_in_time_window(time_window))
-                for time_window in time_windows
-            ),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -178,7 +178,7 @@ class TimeWindowPartitionMapping(
 
         return TimeWindowPartitionsSubset(
             to_partitions_def,
-            time_windows,
+            to_partitions_def.build_merged_subset_time_windows(time_windows),
         )
 
 

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -65,6 +65,10 @@ class DagsterInvalidSubsetError(DagsterError):
     """
 
 
+class DagsterInvalidDeserializationVersionError(DagsterError):
+    """Indicates that a serialized value has an unsupported version and cannot be deserialized."""
+
+
 CONFIG_ERROR_VERBIAGE = """
 This value can be a:
     - Field

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -689,6 +689,9 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
     ) -> "PartitionsSubset":
         raise NotImplementedError()
 
+    def get_inverse_subset(self, current_time: Optional[datetime] = None) -> "PartitionsSubset":
+        raise NotImplementedError()
+
     @classmethod
     def can_deserialize(cls, serialized: str) -> bool:
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -683,6 +683,16 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
     def serialize(self) -> str:
         raise NotImplementedError()
 
+    @classmethod
+    def from_serialized(
+        cls, partitions_def: "PartitionsDefinition", serialized: str
+    ) -> "PartitionsSubset":
+        raise NotImplementedError()
+
+    @classmethod
+    def can_deserialize(cls, serialized: str) -> bool:
+        raise NotImplementedError()
+
     @property
     def partitions_def(self) -> "PartitionsDefinition":
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -998,7 +998,7 @@ class SqlEventLogStorage(EventLogStorage):
                     last_run_id=row[3],
                     asset_details=AssetDetails.from_db_string(row[4]),
                     cached_status=AssetStatusCacheValue.from_db_string(row[5])
-                    if self.has_asset_key_col("cached_status_data")
+                    if self.can_cache_asset_status_data()
                     else None,
                 ),
             )
@@ -1234,7 +1234,7 @@ class SqlEventLogStorage(EventLogStorage):
     def update_asset_cached_status_data(
         self, asset_key: AssetKey, cache_values: "AssetStatusCacheValue"
     ) -> None:
-        if self.has_asset_key_col("cached_status_data"):
+        if self.can_cache_asset_status_data():
             with self.index_connection() as conn:
                 conn.execute(
                     AssetKeyTable.update()  # pylint: disable=no-value-for-parameter
@@ -1544,7 +1544,7 @@ class SqlEventLogStorage(EventLogStorage):
                     wipe_timestamp=utc_datetime_from_timestamp(wipe_timestamp),
                 )
             )
-        if self.has_asset_key_col("cached_status_data"):
+        if self.can_cache_asset_status_data():
             values.update(dict(cached_status_data=None))
         return values
 

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -31,6 +31,37 @@ CACHEABLE_PARTITION_TYPES = {
 }
 
 
+class PartitionMaterializationStatus(
+    NamedTuple(
+        "_PartitionMaterializationStatus",
+        [
+            ("serialized_materialized_partition_subset", str),
+            ("serialized_unmaterialized_partition_subset", str),
+        ],
+    )
+):
+    """
+    docstring here
+    """
+
+    def __new__(
+        cls,
+        serialized_materialized_partition_subset: str,
+        serialized_unmaterialized_partition_subset: str,
+    ):
+        check.opt_str_param(
+            serialized_materialized_partition_subset, "serialized_materialized_partition_subset"
+        )
+        check.opt_str_param(
+            serialized_unmaterialized_partition_subset, "serialized_unmaterialized_partition_subset"
+        )
+        return super(PartitionMaterializationStatus, cls).__new__(
+            cls,
+            serialized_materialized_partition_subset,
+            serialized_unmaterialized_partition_subset,
+        )
+
+
 @whitelist_for_serdes
 class AssetStatusCacheValue(
     NamedTuple(
@@ -157,6 +188,7 @@ def _build_status_cache(
         )
     )
 
+    # TODO represent unmaterialized partition subset
     return AssetStatusCacheValue(
         latest_storage_id=latest_storage_id,
         partitions_def_id=partitions_def.serializable_unique_identifier,

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -96,7 +96,7 @@ class AssetStatusCacheValue(
 
 def get_materialized_multipartitions(
     instance: DagsterInstance, asset_key: AssetKey, partitions_def: MultiPartitionsDefinition
-) -> Sequence[MultiPartitionKey]:
+) -> Sequence[str]:
     dimension_names = partitions_def.partition_dimension_names
     materialized_keys: List[MultiPartitionKey] = []
     for event_tags in instance.get_event_tags_for_asset(asset_key):

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -229,6 +229,9 @@ def _get_updated_status_cache(
         current_status_cache_value.partitions_def_id
         == partitions_def.serializable_unique_identifier
     )
+
+    # TODO add checks to see if a subset can be deserialized
+
     materialized_subset: PartitionsSubset = (
         partitions_def.deserialize_subset(
             current_status_cache_value.serialized_materialized_partition_subset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -18,14 +18,11 @@ def test_get_downstream_partitions_single_key_in_range():
         ),
         downstream_partitions_def=downstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
-        {
-            MultiPartitionKey({"abc": "a", "123": "1"}),
-            MultiPartitionKey({"abc": "a", "123": "2"}),
-            MultiPartitionKey({"abc": "a", "123": "3"}),
-        },
-    )
+    assert result.get_partition_keys() == {
+        MultiPartitionKey({"abc": "a", "123": "1"}),
+        MultiPartitionKey({"abc": "a", "123": "2"}),
+        MultiPartitionKey({"abc": "a", "123": "3"}),
+    }
 
     downstream_partitions_def = MultiPartitionsDefinition(
         {"abc": upstream_partitions_def, "xyz": StaticPartitionsDefinition(["x", "y", "z"])}
@@ -39,14 +36,11 @@ def test_get_downstream_partitions_single_key_in_range():
         ),
         downstream_partitions_def=downstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
-        {
-            MultiPartitionKey({"abc": "b", "xyz": "x"}),
-            MultiPartitionKey({"abc": "b", "xyz": "y"}),
-            MultiPartitionKey({"abc": "b", "xyz": "z"}),
-        },
-    )
+    assert result.get_partition_keys() == {
+        MultiPartitionKey({"abc": "b", "xyz": "x"}),
+        MultiPartitionKey({"abc": "b", "xyz": "y"}),
+        MultiPartitionKey({"abc": "b", "xyz": "z"}),
+    }
 
 
 def test_get_downstream_partitions_multiple_keys_in_range():
@@ -63,17 +57,14 @@ def test_get_downstream_partitions_multiple_keys_in_range():
         ),
         downstream_partitions_def=downstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
-        {
-            MultiPartitionKey({"abc": "a", "123": "1"}),
-            MultiPartitionKey({"abc": "a", "123": "2"}),
-            MultiPartitionKey({"abc": "a", "123": "3"}),
-            MultiPartitionKey({"abc": "b", "123": "1"}),
-            MultiPartitionKey({"abc": "b", "123": "2"}),
-            MultiPartitionKey({"abc": "b", "123": "3"}),
-        },
-    )
+    assert result.get_partition_keys() == {
+        MultiPartitionKey({"abc": "a", "123": "1"}),
+        MultiPartitionKey({"abc": "a", "123": "2"}),
+        MultiPartitionKey({"abc": "a", "123": "3"}),
+        MultiPartitionKey({"abc": "b", "123": "1"}),
+        MultiPartitionKey({"abc": "b", "123": "2"}),
+        MultiPartitionKey({"abc": "b", "123": "3"}),
+    }
 
 
 def test_get_upstream_single_dimension_to_multi_partition_mapping():
@@ -107,4 +98,4 @@ def test_get_upstream_single_dimension_to_multi_partition_mapping():
         ),
         upstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(upstream_partitions_def, {"a", "b"})
+    assert result.get_partition_keys() == {"a", "b"}

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -1,14 +1,8 @@
-from dagster import (
-    MultiPartitionKey,
-    MultiPartitionsDefinition,
-    PartitionKeyRange,
-    StaticPartitionsDefinition,
-    DailyPartitionsDefinition,
-)
-from dagster._core.definitions.partition import DefaultPartitionsSubset
-from dagster._core.errors import DagsterInvalidDeserializationVersionError
-from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
 import pytest
+from dagster import DailyPartitionsDefinition, StaticPartitionsDefinition
+from dagster._core.definitions.partition import DefaultPartitionsSubset
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+from dagster._core.errors import DagsterInvalidDeserializationVersionError
 
 
 def test_default_subset_cannot_deserialize_invalid_version():
@@ -26,7 +20,7 @@ def test_default_subset_cannot_deserialize_invalid_version():
     class NewSerializationVersionSubset(DefaultPartitionsSubset):
         SERIALIZATION_VERSION = -1
 
-    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) == False
+    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) is False
 
     with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -1"):
         NewSerializationVersionSubset.from_serialized(static_partitions_def, serialized_subset)
@@ -45,7 +39,7 @@ def test_time_window_subset_cannot_deserialize_invalid_version():
     class NewSerializationVersionSubset(TimeWindowPartitionsSubset):
         SERIALIZATION_VERSION = -2
 
-    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) == False
+    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) is False
 
     with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -2"):
         NewSerializationVersionSubset.from_serialized(daily_partitions_def, serialized_subset)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -1,0 +1,51 @@
+from dagster import (
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
+    PartitionKeyRange,
+    StaticPartitionsDefinition,
+    DailyPartitionsDefinition,
+)
+from dagster._core.definitions.partition import DefaultPartitionsSubset
+from dagster._core.errors import DagsterInvalidDeserializationVersionError
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+import pytest
+
+
+def test_default_subset_cannot_deserialize_invalid_version():
+    static_partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
+    serialized_subset = (
+        static_partitions_def.empty_subset().with_partition_keys(["a", "c", "d"]).serialize()
+    )
+
+    assert static_partitions_def.deserialize_subset(serialized_subset).get_partition_keys() == {
+        "a",
+        "c",
+        "d",
+    }
+
+    class NewSerializationVersionSubset(DefaultPartitionsSubset):
+        SERIALIZATION_VERSION = -1
+
+    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) == False
+
+    with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -1"):
+        NewSerializationVersionSubset.from_serialized(static_partitions_def, serialized_subset)
+
+
+def test_time_window_subset_cannot_deserialize_invalid_version():
+    daily_partitions_def = DailyPartitionsDefinition(start_date="2023-01-01")
+    serialized_subset = (
+        daily_partitions_def.empty_subset().with_partition_keys(["2023-01-02"]).serialize()
+    )
+
+    assert set(daily_partitions_def.deserialize_subset(serialized_subset).get_partition_keys()) == {
+        "2023-01-02"
+    }
+
+    class NewSerializationVersionSubset(TimeWindowPartitionsSubset):
+        SERIALIZATION_VERSION = -2
+
+    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) == False
+
+    with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -2"):
+        NewSerializationVersionSubset.from_serialized(daily_partitions_def, serialized_subset)

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -822,3 +822,22 @@ def test_static_partitions_subset():
     assert len(with_some_partitions) == 2
     assert len(deserialized) == 2
     assert "bar" in with_some_partitions
+
+
+def test_static_partitions_subset_backwards_compat():
+    partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
+    serialization = '["baz", "foo"]'
+
+    deserialized = partitions.deserialize_subset(serialization)
+    assert deserialized.get_partition_keys() == {"baz", "foo"}
+
+
+def test_static_partitions_subset_current_version_serialization():
+    partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
+    serialization = partitions.empty_subset().with_partition_keys(["foo", "baz"]).serialize()
+    deserialized = partitions.deserialize_subset(serialization)
+    assert deserialized.get_partition_keys() == {"baz", "foo"}
+
+    serialization = '{"version": 1, "subset": ["foo", "baz"]}'
+    deserialized = partitions.deserialize_subset(serialization)
+    assert deserialized.get_partition_keys() == {"baz", "foo"}

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -6,17 +6,13 @@ from dagster import (
     DagsterEventType,
     DailyPartitionsDefinition,
     EventRecordsFilter,
+    MultiPartitionKey,
     StaticPartitionsDefinition,
     asset,
     define_asset_job,
     repository,
-    MultiPartitionKey,
 )
-from dagster._core.definitions.multi_dimensional_partitions import (
-    MultiPartitionKey,
-    MultiPartitionsDefinition,
-    MultiPartitionsSubset,
-)
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import get_multidimensional_partition_tag
 from dagster._core.test_utils import instance_for_test
@@ -321,7 +317,9 @@ def test_multipartitions_subset_addition(initial, added):
             current_time=datetime.strptime(current_day, "%Y-%m-%d")
         )
     ) == set(expected_keys_not_in_updated_subset)
-    # assert added_subset.get_inverse_subset().get_partition_keys(
-    #     current_time=datetime.strptime(current_day, "%Y-%m-%d")
-    # ) == set(expected_keys_not_in_updated_subset)
-    # TODO add test for inverse
+
+    assert set(
+        added_subset.get_inverse_subset(
+            current_time=datetime.strptime(current_day, daily_partitions_def.fmt)
+        ).get_partition_keys()
+    ) == set(expected_keys_not_in_updated_subset)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -167,3 +167,12 @@ def test_tags_multi_dimensional_partitions():
             )
         )
         assert len(materializations) == 1
+
+
+def test_get_primary_and_secondary_dimensions():
+    pass
+    # TODO add test to confirm that partitions subset is aligned with primary/secondary dimension
+
+
+def test_multipartitions_subset_serialization():
+    pass

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -10,10 +10,12 @@ from dagster import (
     asset,
     define_asset_job,
     repository,
+    MultiPartitionKey,
 )
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
+    MultiPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import get_multidimensional_partition_tag
@@ -169,10 +171,157 @@ def test_tags_multi_dimensional_partitions():
         assert len(materializations) == 1
 
 
+multipartitions_def = MultiPartitionsDefinition(
+    {
+        "date": DailyPartitionsDefinition(start_date="2015-01-01"),
+        "static": StaticPartitionsDefinition(["a", "b", "c", "d"]),
+    }
+)
+
+
 def test_get_primary_and_secondary_dimensions():
-    pass
-    # TODO add test to confirm that partitions subset is aligned with primary/secondary dimension
+    assert multipartitions_def.primary_dimension.name == "static"
+    assert multipartitions_def.secondary_dimension.name == "date"
+
+    assert multipartitions_def.empty_subset().with_partition_keys(
+        [MultiPartitionKey({"static": "a", "date": "2015-01-01"})]
+    ).subsets_by_primary_dimension_partition_key.keys() == set(
+        multipartitions_def.primary_dimension.partitions_def.get_partition_keys()
+    )
 
 
 def test_multipartitions_subset_serialization():
+    # TODO test serialization / deserialization
     pass
+
+
+def test_multipartitions_subset_equality():
+    assert multipartitions_def.empty_subset().with_partition_keys(
+        [
+            MultiPartitionKey({"static": "a", "date": "2015-01-01"}),
+            MultiPartitionKey({"static": "b", "date": "2015-01-05"}),
+        ]
+    ) == multipartitions_def.empty_subset().with_partition_keys(
+        [
+            MultiPartitionKey({"static": "a", "date": "2015-01-01"}),
+            MultiPartitionKey({"static": "b", "date": "2015-01-05"}),
+        ]
+    )
+
+    assert multipartitions_def.empty_subset().with_partition_keys(
+        [
+            MultiPartitionKey({"static": "c", "date": "2015-01-01"}),
+            MultiPartitionKey({"static": "b", "date": "2015-01-05"}),
+        ]
+    ) != multipartitions_def.empty_subset().with_partition_keys(
+        [
+            MultiPartitionKey({"static": "a", "date": "2015-01-01"}),
+            MultiPartitionKey({"static": "b", "date": "2015-01-05"}),
+        ]
+    )
+
+    assert multipartitions_def.empty_subset().with_partition_keys(
+        [
+            MultiPartitionKey({"static": "a", "date": "2015-01-01"}),
+            MultiPartitionKey({"static": "b", "date": "2015-01-05"}),
+        ]
+    ) != multipartitions_def.empty_subset().with_partition_keys(
+        [
+            MultiPartitionKey({"static": "a", "date": "2016-01-01"}),
+            MultiPartitionKey({"static": "b", "date": "2015-01-05"}),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "initial, added",
+    [
+        (["------", "+-----", "------", "------"], ["+-----", "+-----", "------", "------"]),
+        (
+            ["+--+--", "------", "------", "------"],
+            ["+-----", "------", "------", "------"],
+        ),
+        (
+            ["+------", "-+-----", "-++--+-", "+-+++++"],
+            ["-+-----", "-+-----", "+-+-+-+", "+++----"],
+        ),
+        (
+            ["+-----+", "------+", "-+++---", "-------"],
+            ["+++++++", "-+-+-+-", "-++----", "----+++"],
+        ),
+    ],
+)
+def test_multipartitions_subset_addition(initial, added):
+    assert len(initial) == len(added)
+
+    static_keys = ["a", "b", "c", "d"]
+    daily_partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
+    multipartitions_def = MultiPartitionsDefinition(
+        {
+            "date": daily_partitions_def,
+            "static": StaticPartitionsDefinition(static_keys),
+        }
+    )
+    full_date_set_keys = daily_partitions_def.get_partition_keys(
+        current_time=datetime(year=2015, month=1, day=30)
+    )[: max(len(keys) for keys in initial)]
+    current_day = daily_partitions_def.get_partition_keys(
+        current_time=datetime(year=2015, month=1, day=30)
+    )[: max(len(keys) for keys in initial) + 1][-1]
+
+    initial_subset_keys = []
+    added_subset_keys = []
+    expected_keys_not_in_updated_subset = []
+    for i in range(len(initial)):
+        for j in range(len(initial[i])):
+            if initial[i][j] == "+":
+                initial_subset_keys.append(
+                    MultiPartitionKey({"date": full_date_set_keys[j], "static": static_keys[i]})
+                )
+
+            if added[i][j] == "+":
+                added_subset_keys.append(
+                    MultiPartitionKey({"date": full_date_set_keys[j], "static": static_keys[i]})
+                )
+
+            if initial[i][j] != "+" and added[i][j] != "+":
+                expected_keys_not_in_updated_subset.append(
+                    MultiPartitionKey({"date": full_date_set_keys[j], "static": static_keys[i]})
+                )
+
+    initial_subset = multipartitions_def.empty_subset().with_partition_keys(initial_subset_keys)
+    added_subset = initial_subset.with_partition_keys(added_subset_keys)
+
+    for i in range(len(initial)):
+        selected_days = [
+            full_date_set_keys[j] for j in range(len(initial[i])) if initial[i][j] == "+"
+        ]
+        assert (
+            initial_subset.subsets_by_primary_dimension_partition_key[
+                static_keys[i]
+            ].get_partition_keys()
+            == daily_partitions_def.empty_subset()
+            .with_partition_keys(selected_days)
+            .get_partition_keys()
+        )
+        selected_and_added_days = [
+            full_date_set_keys[j] for j in range(len(added[i])) if added[i][j] == "+"
+        ] + selected_days
+        assert (
+            added_subset.subsets_by_primary_dimension_partition_key[
+                static_keys[i]
+            ].get_partition_keys()
+            == daily_partitions_def.empty_subset()
+            .with_partition_keys(selected_and_added_days)
+            .get_partition_keys()
+        )
+
+    assert set(
+        added_subset.get_partition_keys_not_in_subset(
+            current_time=datetime.strptime(current_day, "%Y-%m-%d")
+        )
+    ) == set(expected_keys_not_in_updated_subset)
+    # assert added_subset.get_inverse_subset().get_partition_keys(
+    #     current_time=datetime.strptime(current_day, "%Y-%m-%d")
+    # ) == set(expected_keys_not_in_updated_subset)
+    # TODO add test for inverse

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -551,3 +551,39 @@ def test_unique_identifier():
         DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
         == DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
     )
+
+
+def test_valid_partition_time_window():
+    partitions_def = DailyPartitionsDefinition(start_date="2023-01-01")
+    assert (
+        partitions_def.is_valid_partition_time_window(time_window("2023-01-01", "2023-01-02"))
+        == True
+    )
+    assert (
+        partitions_def.is_valid_partition_time_window(
+            time_window("2023-01-01", "2023-01-03"), cast(datetime, pendulum.parse("2023-01-04"))
+        )
+        == True
+    )
+    assert (
+        partitions_def.is_valid_partition_time_window(time_window("2023-01-01", "2023-01-01"))
+        == False
+    )
+    assert (
+        partitions_def.is_valid_partition_time_window(
+            time_window("2023-01-01", "2023-01-04"), cast(datetime, pendulum.parse("2023-01-03"))
+        )
+        == False
+    )
+    assert (
+        partitions_def.is_valid_partition_time_window(
+            time_window("2023-01-01", "2023-01-04"), cast(datetime, pendulum.parse("2023-01-04"))
+        )
+        == True
+    )
+    assert (
+        partitions_def.is_valid_partition_time_window(
+            time_window("2023-01-01", "2023-01-04"), cast(datetime, pendulum.parse("2023-01-01"))
+        )
+        == False
+    )

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1078,5 +1078,6 @@ def test_1_0_17_add_cached_status_data_column():
         assert get_current_alembic_version(db_path) == "958a9495162d"
         assert "cached_status_data" not in set(get_sqlite3_columns(db_path, "asset_keys"))
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
+            assert instance.can_cache_asset_status_data() is False
             instance.upgrade()
             assert "cached_status_data" in set(get_sqlite3_columns(db_path, "asset_keys"))


### PR DESCRIPTION
Following the decision to represent time window partition statuses in ranges in Dagit, this PR makes the following changes:
- For all partitions subsets:
   - Add `get_inverse_subset` methods to partitions subsets, allowing for performantly fetching the unmaterialized partition subsets from materialized subsets
   - Adds versions to the serializations. This allows for deserializing older versions of serialized subsets.
   - Adds a `can_deserialize` method, allowing for checking if a serialized subset can still be deserialized. For the partition status cache, rebuilds partition status from storage if the version is no longer supported.
- For `TimeWindowPartitionsSubset`s:
   - Restructure each stored time window to also store the number of partitions within, so Dagit can directly render the partition bar without searching for the length of each time window.
   - Performantly create `TimeWindowPartitionsSubset`s assuming that there are fewer than 10 ranges of materialized partitions
- Restructures the `MultiPartitionsSubset`. In Dagit, the "primary" key will be the static dimension (as many users want to view partition status by a static partition key). Accordingly, `MultiPartitionsSubset` now maps static partition keys to their corresponding `TimeWindowPartitionsSubset`s.

One decision in this PR is to not serialize the "unmaterialized" partition subsets. With the assumption that there will be no more than 10 ranges in a time window partitions definition, calculating the inverse should be fairly fast. I'm curious how this will perform for users, especially for the multidimensional case where the inverse must be calculated for each static partition. If users report this being slow, I'd advocate to switching to iterating through all time windows (versus partition keys) to speed up this behavior.