### PR TITLE
telemetry: add num_assets_in_repo in repo-level metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -398,6 +398,7 @@ def log_external_repo_stats(instance, source, external_repo, external_pipeline=N
         num_pipelines_in_repo = len(external_repo.get_all_external_jobs())
         num_schedules_in_repo = len(external_repo.get_external_schedules())
         num_sensors_in_repo = len(external_repo.get_external_sensors())
+        num_assets_in_repo = len(external_repo.get_external_asset_nodes())
 
         write_telemetry_log_line(
             TelemetryEntry(
@@ -411,6 +412,7 @@ def log_external_repo_stats(instance, source, external_repo, external_pipeline=N
                     "num_pipelines_in_repo": str(num_pipelines_in_repo),
                     "num_schedules_in_repo": str(num_schedules_in_repo),
                     "num_sensors_in_repo": str(num_sensors_in_repo),
+                    "num_assets_in_repo": str(num_assets_in_repo),
                     "repo_hash": repo_hash,
                 },
             )._asdict()


### PR DESCRIPTION
### Summary & Motivation
add tracking for how many assets declared

### How I Tested These Changes
```
dagster-3.8.6 $  cat /Users/yuhan/dev/local/dagster_home/.logs_queue/event.log
{"action": "update_repo_stats", "client_time": "2023-01-04 01:29:48.113597", "event_id": "99ef6a5c-0108-4efb-ac7c-47be90d87474", "elapsed_time": "", "instance_id": "cdb8b61e-d6f1-487e-aa86-61a80bcdee77", "metadata": {"source": "dagit", "pipeline_name_hash": "", "num_pipelines_in_repo": "2", "num_schedules_in_repo": "1", "num_sensors_in_repo": "0", "num_assets_in_repo": "3", "repo_hash": "f17e9128abe12b4ff329425c469a7c5abc06bace32a2237848bc3a71cf9ef808"}, "python_version": "3.8.6", "dagster_version": "1!0+dev", "os_desc": "macOS-12.5-x86_64-i386-64bit", "os_platform": "Darwin", "run_storage_id": ""}
```

