### PR TITLE
[dagster-airflow] warn on airflow dataset

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -178,7 +178,6 @@ def make_dagster_repo_from_airflow_dag_bag(
 
     job_defs = []
     schedule_defs = []
-    asset_defs = []
     count = 0
     # To enforce predictable iteration order
     sorted_dag_ids = sorted(dag_bag.dag_ids)
@@ -218,8 +217,11 @@ def make_dagster_repo_from_airflow_dag_bag(
             dag=dag,
             job_def=job_def,
         )
-        if isinstance(dag.normalized_schedule_interval, str) and dag.normalized_schedule_interval == "Dataset":
-            logging.warn(
+        if (
+            isinstance(dag.normalized_schedule_interval, str)
+            and dag.normalized_schedule_interval == "Dataset"
+        ):
+            logging.warning(
                 f"({dag.dag_id}) transforming airflow dataset data-aware schedule dependencies into Dagster SDA definitions is not currently supported in dagster-airflow"
             )
         if schedule_def:

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -271,7 +271,7 @@ def make_dagster_asset_from_airflow_dag(dag, job_def):
     cron_schedule = dag.normalized_schedule_interval
     if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == "Dataset":
         # TODO: add support for asset tags
-        logging.warn(f"({dag.dag_id}) transforming airflow datasets dependencies into SDA definitions is not currently supported in dagster-airflow")
+        logging.warn(f"({dag.dag_id}) transforming airflow dataset data-aware schedule dependencies into Dagster SDA definitions is not currently supported in dagster-airflow")
         return
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -271,6 +271,7 @@ def make_dagster_asset_from_airflow_dag(dag, job_def):
     cron_schedule = dag.normalized_schedule_interval
     if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == "Dataset":
         # TODO: add support for asset tags
+        logging.warn(f"({dag.dag_id}) transforming airflow datasets dependencies into SDA definitions is not currently supported in dagster-airflow")
         return
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -271,7 +271,9 @@ def make_dagster_asset_from_airflow_dag(dag, job_def):
     cron_schedule = dag.normalized_schedule_interval
     if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == "Dataset":
         # TODO: add support for asset tags
-        logging.warn(f"({dag.dag_id}) transforming airflow dataset data-aware schedule dependencies into Dagster SDA definitions is not currently supported in dagster-airflow")
+        logging.warn(
+            f"({dag.dag_id}) transforming airflow dataset data-aware schedule dependencies into Dagster SDA definitions is not currently supported in dagster-airflow"
+        )
         return
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -218,11 +218,12 @@ def make_dagster_repo_from_airflow_dag_bag(
             dag=dag,
             job_def=job_def,
         )
-        asset_def = make_dagster_asset_from_airflow_dag(dag=dag, job_def=job_def)
+        if isinstance(dag.normalized_schedule_interval, str) and dag.normalized_schedule_interval == "Dataset":
+            logging.warn(
+                f"({dag.dag_id}) transforming airflow dataset data-aware schedule dependencies into Dagster SDA definitions is not currently supported in dagster-airflow"
+            )
         if schedule_def:
             schedule_defs.append(schedule_def)
-        elif asset_def:
-            asset_defs.append(asset_def)
         else:
             job_defs.append(job_def)
 
@@ -253,28 +254,6 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
         return ScheduleDefinition(
             job=job_def, cron_schedule=cron_schedule, description=schedule_description
         )
-
-
-def make_dagster_asset_from_airflow_dag(dag, job_def):
-    """Construct a Dagster asset corresponding to an Airflow DAG.
-
-    Args:
-        dag (DAG): Airflow DAG
-        job_def (JobDefinition): Dagster pipeline corresponding to Airflow DAG
-
-    Returns:
-        AssetDefinition
-    """
-    check.inst_param(dag, "dag", DAG)
-    check.inst_param(job_def, "job_def", JobDefinition)
-
-    cron_schedule = dag.normalized_schedule_interval
-    if isinstance(dag.normalized_schedule_interval, str) and cron_schedule == "Dataset":
-        # TODO: add support for asset tags
-        logging.warn(
-            f"({dag.dag_id}) transforming airflow dataset data-aware schedule dependencies into Dagster SDA definitions is not currently supported in dagster-airflow"
-        )
-        return
 
 
 def make_dagster_repo_from_airflow_example_dags(


### PR DESCRIPTION
### Summary & Motivation
dagster-airflow currently will not create SDAs from airflow datasets, it could in the future but there's a bit of complexity in implementing it (each dag can produce and depend on N number of datasets, hard to map cleanly) and for such a new feature its unclear that migrating teams will need it. So for now dagster-airflow is not able to migrate the data-aware schedules for datasets but it is able to migrate the actual dag that produces them. In the case a user is using an airflow dataset it would be possible for them to layer ontop their own schedule/sensor for running that (if we still haven't implemented a clean transform).

This pr adds a warning that will log whenever a airflow dataset is encountered.
