### PR TITLE
only count materializations within backfill

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -63,6 +63,13 @@ class AssetGraph:
         return self._source_asset_keys
 
     @property
+    def root_asset_keys(self) -> AbstractSet[AssetKey]:
+        """Non-source asset keys that have no non-source parents."""
+        from .asset_selection import AssetSelection
+
+        return AssetSelection.keys(*self.all_asset_keys).sources().resolve(self)
+
+    @property
     def freshness_policies_by_key(self):
         return self._freshness_policies_by_key
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -28,6 +28,7 @@ from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG
+from dagster._core.utils import frozendict
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -315,7 +316,9 @@ def execute_asset_backfill_iteration_inner(
     recently_materialized_asset_partitions = AssetGraphSubset(asset_graph)
     for asset_key in asset_backfill_data.target_subset.asset_keys:
         records = instance_queryer.get_materialization_records(
-            asset_key=asset_key, after_cursor=asset_backfill_data.latest_storage_id
+            asset_key=asset_key,
+            after_cursor=asset_backfill_data.latest_storage_id,
+            tags=frozendict({BACKFILL_ID_TAG: backfill_id}),
         )
         recently_materialized_asset_partitions |= {
             AssetKeyPartitionKey(asset_key, record.partition_key) for record in records

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -64,7 +64,7 @@ from dagster._core.execution.plan.inputs import StepInputData
 from dagster._core.execution.plan.objects import StepSuccessData, TypeCheckData
 from dagster._core.execution.plan.outputs import StepOutputData, StepOutputHandle
 from dagster._core.execution.resolve_versions import resolve_step_output_versions
-from dagster._core.storage.tags import MEMOIZED_RUN_TAG
+from dagster._core.storage.tags import BACKFILL_ID_TAG, MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils import ensure_gen, iterate_with_context
 from dagster._utils.backcompat import ExperimentalWarning, experimental_functionality_warning
@@ -516,6 +516,10 @@ def _get_output_asset_materializations(
         step_context.record_logical_version(asset_key, logical_version)
     else:
         tags = {}
+
+    backfill_id = step_context.get_tag(BACKFILL_ID_TAG)
+    if backfill_id:
+        tags[BACKFILL_ID_TAG] = backfill_id
 
     if asset_partitions:
         metadata_mapping: Dict[

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -206,13 +206,17 @@ class CachingInstanceQueryer:
 
     @cached_method
     def get_materialization_records(
-        self, asset_key: AssetKey, after_cursor: Optional[int] = None
+        self,
+        asset_key: AssetKey,
+        after_cursor: Optional[int] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ) -> Iterable["EventLogRecord"]:
         return self._instance.get_event_records(
             EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,
                 asset_key=asset_key,
                 after_cursor=after_cursor,
+                tags=tags,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, Mapping, NamedTuple, Optional, Sequence, Set, Union
+from typing import AbstractSet, Mapping, NamedTuple, Optional, Sequence, Set, Union, cast
 from unittest.mock import MagicMock, patch
 
 import pendulum
@@ -18,10 +18,10 @@ from dagster_tests.definitions_tests.test_asset_reconciliation_sensor import (
 )
 
 from dagster import (
-    AssetSelection,
     AssetsDefinition,
     DagsterInstance,
     Definitions,
+    PartitionsDefinition,
     RunRequest,
     SourceAsset,
 )
@@ -70,61 +70,21 @@ def test_scenario_to_completion(scenario_name: str, failures: str, some_or_all: 
     with pendulum.test(create_pendulum_time(year=2020, month=1, day=7, hour=4)):
         assets_by_repo_name = assets_by_repo_name_by_scenario_name[scenario_name]
 
-        with patch(
-            "dagster._core.host_representation.external_data.get_builtin_partition_mapping_types"
-        ) as get_builtin_partition_mapping_types:
-            get_builtin_partition_mapping_types.return_value = tuple(
-                assets_def.infer_partition_mapping(dep_key).__class__
-                for assets in assets_by_repo_name.values()
-                for assets_def in assets
-                for dep_key in assets_def.dependency_keys
-            )
-            asset_graph = external_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
-
-        asset_keys = asset_graph.all_asset_keys
-        root_asset_keys = AssetSelection.keys(*asset_keys).sources().resolve(asset_graph)
-
-        if some_or_all == "all":
-            target_subset = AssetGraphSubset.all(asset_graph)
-        elif some_or_all == "some":
-            # all partitions downstream of half of the partitions in each partitioned root asset
-            root_asset_partitions: Set[AssetKeyPartitionKey] = set()
-            for i, root_asset_key in enumerate(sorted(root_asset_keys)):
-                partitions_def = asset_graph.get_partitions_def(root_asset_key)
-
-                if partitions_def is not None:
-                    partition_keys = list(partitions_def.get_partition_keys())
-                    start_index = len(partition_keys) // 2
-                    chosen_partition_keys = partition_keys[start_index:]
-                    root_asset_partitions.update(
-                        AssetKeyPartitionKey(root_asset_key, partition_key)
-                        for partition_key in chosen_partition_keys
-                    )
-                else:
-                    if i % 2 == 0:
-                        root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
-
-            target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
-                lambda _a, _b: True, root_asset_partitions
-            )
-
-            target_subset = AssetGraphSubset.from_asset_partition_set(
-                target_asset_partitions, asset_graph
-            )
-
-        else:
-            assert False
+        asset_graph = get_asset_graph(assets_by_repo_name)
+        backfill_data = make_backfill_data(some_or_all=some_or_all, asset_graph=asset_graph)
 
         if failures == "no_failures":
             fail_asset_partitions: Set[AssetKeyPartitionKey] = set()
         elif failures == "root_failures":
             fail_asset_partitions = set(
-                (target_subset.filter_asset_keys(root_asset_keys)).iterate_asset_partitions()
+                (
+                    backfill_data.target_subset.filter_asset_keys(asset_graph.root_asset_keys)
+                ).iterate_asset_partitions()
             )
         elif failures == "random_half_failures":
             fail_asset_partitions = {
                 asset_partition
-                for asset_partition in target_subset.iterate_asset_partitions()
+                for asset_partition in backfill_data.target_subset.iterate_asset_partitions()
                 if hash(str(asset_partition.asset_key) + str(asset_partition.partition_key)) % 2
                 == 0
             }
@@ -132,10 +92,84 @@ def test_scenario_to_completion(scenario_name: str, failures: str, some_or_all: 
         else:
             assert False
 
-        backfill = AssetBackfillData.empty(target_subset)
         run_backfill_to_completion(
-            asset_graph, assets_by_repo_name, "backfillid_x", backfill, fail_asset_partitions
+            asset_graph, assets_by_repo_name, backfill_data, fail_asset_partitions
         )
+
+
+def test_materializations_outside_of_backfill():
+    assets_by_repo_name = {"repo": one_asset_one_partition}
+    asset_graph = get_asset_graph(assets_by_repo_name)
+
+    instance = DagsterInstance.ephemeral()
+
+    do_run(
+        all_assets=one_asset_one_partition,
+        asset_keys=[one_asset_one_partition[0].key],
+        partition_key=cast(
+            PartitionsDefinition, one_asset_one_partition[0].partitions_def
+        ).get_partition_keys()[0],
+        instance=instance,
+        tags={},
+    )
+
+    run_backfill_to_completion(
+        instance=instance,
+        asset_graph=asset_graph,
+        assets_by_repo_name=assets_by_repo_name,
+        backfill_data=make_backfill_data("all", asset_graph),
+        fail_asset_partitions=set(),
+    )
+
+
+def make_backfill_data(some_or_all: str, asset_graph: ExternalAssetGraph) -> AssetBackfillData:
+    if some_or_all == "all":
+        target_subset = AssetGraphSubset.all(asset_graph)
+    elif some_or_all == "some":
+        # all partitions downstream of half of the partitions in each partitioned root asset
+        root_asset_partitions: Set[AssetKeyPartitionKey] = set()
+        for i, root_asset_key in enumerate(sorted(asset_graph.root_asset_keys)):
+            partitions_def = asset_graph.get_partitions_def(root_asset_key)
+
+            if partitions_def is not None:
+                partition_keys = list(partitions_def.get_partition_keys())
+                start_index = len(partition_keys) // 2
+                chosen_partition_keys = partition_keys[start_index:]
+                root_asset_partitions.update(
+                    AssetKeyPartitionKey(root_asset_key, partition_key)
+                    for partition_key in chosen_partition_keys
+                )
+            else:
+                if i % 2 == 0:
+                    root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
+
+        target_asset_partitions = asset_graph.bfs_filter_asset_partitions(
+            lambda _a, _b: True, root_asset_partitions
+        )
+
+        target_subset = AssetGraphSubset.from_asset_partition_set(
+            target_asset_partitions, asset_graph
+        )
+
+    else:
+        assert False
+
+    return AssetBackfillData.empty(target_subset)
+
+
+def get_asset_graph(
+    assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]]
+) -> ExternalAssetGraph:
+    with patch(
+        "dagster._core.host_representation.external_data.get_builtin_partition_mapping_types"
+    ) as get_builtin_partition_mapping_types:
+        get_builtin_partition_mapping_types.return_value = tuple(
+            assets_def.infer_partition_mapping(dep_key).__class__
+            for assets in assets_by_repo_name.values()
+            for assets_def in assets
+            for dep_key in assets_def.dependency_keys
+        )
+        return external_asset_graph_from_assets_by_repo_name(assets_by_repo_name)
 
 
 def execute_asset_backfill_iteration_consume_generator(
@@ -159,12 +193,13 @@ def execute_asset_backfill_iteration_consume_generator(
 def run_backfill_to_completion(
     asset_graph: ExternalAssetGraph,
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
-    backfill_id: str,
     backfill_data: AssetBackfillData,
     fail_asset_partitions: AbstractSet[AssetKeyPartitionKey],
+    instance: Optional[DagsterInstance] = None,
 ) -> None:
     iteration_count = 0
-    instance = DagsterInstance.ephemeral()
+    instance = instance or DagsterInstance.ephemeral()
+    backfill_id = "backfillid_x"
 
     # assert each asset partition only targeted once
     requested_asset_partitions: Set[AssetKeyPartitionKey] = set()


### PR DESCRIPTION
### Summary & Motivation

Asset backfills look at what asset partitions have already been materialized to decide what partitions need to be submitted.

Prior to this change, the backfill code would look at all materializations of the asset, independent of whether they were part of the backfill. This meant that any materialization prior to the backfill would stop the backfill from submitting runs.

This change filters to only materializations that were part of the backfill. It functions by adding a backfill tag to the relevant materializations

An alternative way to implement this would have been to look for the backfill tag on the runs, instead of on the asset materializations. This would have required joining the event log with the run tags table.

### How I Tested These Changes

Added a test that fails before the change