### PR TITLE
enable filtering by asset tag when asset tags table is not present

### DIFF
--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict, NamedTuple, Optional, Union
+from typing import Any, Dict, Mapping, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
-from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.utils import coerce_valid_log_level
@@ -161,6 +161,30 @@ class EventLogEntry(
             materialization = self.dagster_event.step_materialization_data.materialization
             if isinstance(materialization, AssetMaterialization):
                 return materialization
+
+        return None
+
+    @property
+    def asset_observation(self) -> Optional[AssetObservation]:
+        if (
+            self.dagster_event
+            and self.dagster_event.event_type_value == DagsterEventType.ASSET_OBSERVATION
+        ):
+            observation = self.dagster_event.asset_observation_data.asset_observation
+            if isinstance(observation, AssetObservation):
+                return observation
+
+        return None
+
+    @property
+    def tags(self) -> Optional[Mapping[str, str]]:
+        materialization = self.asset_materialization
+        if materialization:
+            return materialization.tags
+
+        observation = self.asset_observation
+        if observation:
+            return observation.tags
 
         return None
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -803,13 +803,8 @@ class SqlEventLogStorage(EventLogStorage):
         if event_records_filter.storage_ids:
             query = query.where(SqlEventLogStorageTable.c.id.in_(event_records_filter.storage_ids))
 
-        if event_records_filter.tags:
-            if not self.has_table(AssetEventTagsTable.name):
-                raise DagsterInvalidInvocationError(
-                    "Cannot filter by asset event tags because AssetEventTags table does not "
-                    "exist. Run `dagster instance migrate` to create the table."
-                )
-
+        if event_records_filter.tags and self.has_table(AssetEventTagsTable.name):
+            # If we don't have the tags table, we'll filter the results after the query
             check.invariant(
                 isinstance(event_records_filter.asset_key, AssetKey),
                 "Asset key must be set in event records filter to filter by tags.",
@@ -869,7 +864,11 @@ class SqlEventLogStorage(EventLogStorage):
         else:
             asset_details = None
 
-        if event_records_filter.tags and not self.supports_intersect:
+        if (
+            event_records_filter.tags
+            and not self.supports_intersect
+            and self.has_table(AssetEventTagsTable.name)
+        ):
             table = self._apply_tags_table_joins(
                 SqlEventLogStorageTable, event_records_filter.tags, event_records_filter.asset_key
             )
@@ -905,10 +904,24 @@ class SqlEventLogStorage(EventLogStorage):
                         "Could not resolve event record as EventLogEntry for id `%s`.", row_id
                     )
                     continue
-                else:
-                    event_records.append(
-                        EventLogRecord(storage_id=row_id, event_log_entry=event_record)
-                    )
+
+                if event_records_filter.tags and not self.has_table(AssetEventTagsTable.name):
+                    # If we can't filter tags via the tags table, filter the returned records
+                    if limit is not None:
+                        raise DagsterInvalidInvocationError(
+                            "Cannot filter events on tags with a limit, without the asset event "
+                            "tags table. To fix, run `dagster instance migrate`."
+                        )
+
+                    event_record_tags = event_record.tags
+                    if not event_record_tags or any(
+                        event_record_tags.get(k) != v for k, v in event_records_filter.tags.items()
+                    ):
+                        continue
+
+                event_records.append(
+                    EventLogRecord(storage_id=row_id, event_log_entry=event_record)
+                )
             except seven.JSONDecodeError:
                 logging.warning("Could not parse event record id `%s`.", row_id)
 


### PR DESCRIPTION
### Summary & Motivation

Prior to this change, you get a `DagsterInvalidInvocationError` if you try to pass `get_event_records` an `EventRecordsFilter` with the `tags` attr set.

### How I Tested These Changes
