### PR TITLE
[For 1.2] Change default run monitoring settings

### DIFF
--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -227,14 +227,15 @@ def test_run_monitoring_defaults(
 
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
 
-    assert "run_monitoring" not in instance
+    assert instance["run_monitoring"]["enabled"] is True
+    assert instance["run_monitoring"]["max_resume_run_attempts"] == 0
 
 
-def test_run_monitoring(
+def test_run_monitoring_disabled(
     instance_template: HelmTemplate,
 ):  # pylint: disable=redefined-outer-name
     helm_values = DagsterHelmValues.construct(
-        dagsterDaemon=Daemon.construct(runMonitoring={"enabled": True})
+        dagsterDaemon=Daemon.construct(runMonitoring={"enabled": False})
     )
 
     configmaps = instance_template.render(helm_values)
@@ -243,9 +244,7 @@ def test_run_monitoring(
 
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
 
-    assert instance["run_monitoring"]["enabled"] is True
-
-    assert "max_resume_run_attempts" not in instance["run_monitoring"]
+    assert "run_monitoring" not in instance
 
 
 def test_run_monitoring_no_max_resume_run_attempts(

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1082,16 +1082,16 @@ dagsterDaemon:
   # marked as failed. If a run had started but then the run worker crashed, the monitoring daemon
   # will either fail the run or attempt to resume the run with a new run worker.
   runMonitoring:
-    enabled: false
+    enabled: true
     # Timeout for runs to start (avoids runs hanging in STARTED)
-    startTimeoutSeconds: 180
+    startTimeoutSeconds: 300
     # How often to check on in progress runs
     pollIntervalSeconds: 120
     # [Experimental] Max number of times to attempt to resume a run with a new run worker instead
     # of failing the run if the run worker has crashed. Only works for runs using the
-    # `k8s_job_executor` to run each op in its own Kubernetes job. If this value is set to nil,
-    # defaults to 3 if using the K8sRunLauncher, otherwise defaults to 0.
-    maxResumeRunAttempts: ~
+    # `k8s_job_executor` to run each op in its own Kubernetes job. To enable, set this value
+    # to a value greater than 0.
+    maxResumeRunAttempts: 0
 
   runRetries:
     enabled: true

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -745,7 +745,12 @@ def helm_chart_for_k8s_run_launcher(
                 "runCoordinator": {"enabled": False},  # No run queue
                 "env": ({"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}),
                 "annotations": {"dagster-integration-tests": "daemon-pod-annotation"},
-                "runMonitoring": {"enabled": True, "pollIntervalSeconds": 5}
+                "runMonitoring": {
+                    "enabled": True,
+                    "pollIntervalSeconds": 5,
+                    "startTimeoutSeconds": 180,
+                    "maxResumeRunAttempts": 3,
+                }
                 if run_monitoring
                 else {},
             },
@@ -962,6 +967,8 @@ def _base_helm_config(system_namespace, docker_image, enable_subchart=True):
             "runMonitoring": {
                 "enabled": True,
                 "pollIntervalSeconds": 5,
+                "startTimeoutSeconds": 180,
+                "maxResumeRunAttempts": 0,
             },
         },
         # Used to set the environment variables in dagster.shared_env that determine the run config


### PR DESCRIPTION
Summary:
Proposed run monitoring changes starting in 1.2
- on by default for starting runs and failing hanging started runs
- experimental run recovery off by default

Will wait to land this until 1.2 is cut in the distant future

### Summary & Motivation

### How I Tested These Changes
