### PR TITLE
telemetry: add num_assets_in_repo in log_repo_stats metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -435,6 +435,10 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
             num_pipelines_in_repo = len(repository.pipeline_names)
             num_schedules_in_repo = len(repository.schedule_defs)
             num_sensors_in_repo = len(repository.sensor_defs)
+            all_assets = list(
+                repository._assets_defs_by_key.values()
+            )  # pylint: disable=protected-access
+            num_assets_in_repo = len(all_assets)
         elif isinstance(repo, ReconstructableRepository):
             pipeline_name_hash = ""
             repository = repo.get_definition()
@@ -442,12 +446,17 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
             num_pipelines_in_repo = len(repository.pipeline_names)
             num_schedules_in_repo = len(repository.schedule_defs)
             num_sensors_in_repo = len(repository.sensor_defs)
+            all_assets = list(
+                repository._assets_defs_by_key.values()
+            )  # pylint: disable=protected-access
+            num_assets_in_repo = len(all_assets)
         else:
             pipeline_name_hash = hash_name(pipeline.get_definition().name)
             repo_hash = hash_name(get_ephemeral_repository_name(pipeline.get_definition().name))
             num_pipelines_in_repo = 1
             num_schedules_in_repo = 0
             num_sensors_in_repo = 0
+            num_assets_in_repo = 0
 
         write_telemetry_log_line(
             TelemetryEntry(
@@ -461,6 +470,7 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
                     "num_pipelines_in_repo": str(num_pipelines_in_repo),
                     "num_schedules_in_repo": str(num_schedules_in_repo),
                     "num_sensors_in_repo": str(num_sensors_in_repo),
+                    "num_assets_in_repo": str(num_assets_in_repo),
                     "repo_hash": repo_hash,
                 },
             )._asdict()

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -436,8 +436,8 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
             num_schedules_in_repo = len(repository.schedule_defs)
             num_sensors_in_repo = len(repository.sensor_defs)
             all_assets = list(
-                repository._assets_defs_by_key.values()
-            )  # pylint: disable=protected-access
+                repository._assets_defs_by_key.values()  # pylint: disable=protected-access
+            )
             num_assets_in_repo = len(all_assets)
         elif isinstance(repo, ReconstructableRepository):
             pipeline_name_hash = ""
@@ -447,8 +447,8 @@ def log_repo_stats(instance, source, pipeline=None, repo=None):
             num_schedules_in_repo = len(repository.schedule_defs)
             num_sensors_in_repo = len(repository.sensor_defs)
             all_assets = list(
-                repository._assets_defs_by_key.values()
-            )  # pylint: disable=protected-access
+                repository._assets_defs_by_key.values()  # pylint: disable=protected-access
+            )
             num_assets_in_repo = len(all_assets)
         else:
             pipeline_name_hash = hash_name(pipeline.get_definition().name)


### PR DESCRIPTION
### Summary & Motivation

### How I Tested These Changes
ran `execute_job` got:
```
{"action": "update_repo_stats", "client_time": "2023-01-04 15:03:11.344601", "event_id": "b2a515cd-f6cf-43be-85d6-fb2696c67659", "elapsed_time": "", "instance_id": "cdb8b61e-d6f1-487e-aa86-61a80bcdee77", "metadata": {"source": "execute_pipeline", "pipeline_name_hash": "50cd11031b497599d0e8d4b57b32ceb2ab60133b63909007e485af4d255b0759", "num_pipelines_in_repo": "1", "num_schedules_in_repo": "0", "num_sensors_in_repo": "0", "num_assets_in_repo": "0", "repo_hash": "c097d855f90cf8b5d841965dc22c79ee3ab46270d567cb7b59947717dfb0cba2"}, "python_version": "3.8.6", "dagster_version": "1!0+dev", "os_desc": "macOS-12.5-x86_64-i386-64bit", "os_platform": "Darwin", "run_storage_id": ""}
```
