### PR TITLE
telemetry: add location_name in repo-level metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -395,6 +395,7 @@ def log_external_repo_stats(instance, source, external_repo, external_pipeline=N
 
         pipeline_name_hash = hash_name(external_pipeline.name) if external_pipeline else ""
         repo_hash = hash_name(external_repo.name)
+        location_name_hash = hash_name(external_repo.handle.location_name)
         num_pipelines_in_repo = len(external_repo.get_all_external_jobs())
         num_schedules_in_repo = len(external_repo.get_external_schedules())
         num_sensors_in_repo = len(external_repo.get_external_sensors())
@@ -414,6 +415,7 @@ def log_external_repo_stats(instance, source, external_repo, external_pipeline=N
                     "num_sensors_in_repo": str(num_sensors_in_repo),
                     "num_assets_in_repo": str(num_assets_in_repo),
                     "repo_hash": repo_hash,
+                    "location_name_hash": location_name_hash,
                 },
             )._asdict()
         )


### PR DESCRIPTION
### Summary & Motivation
problems in repo telemetry tracking:
1. after 1.1.7, when using `Definitions` instead of `@repository`, `repo_hash` is the same, i.e. a hash of `"__repository__"`. **This PR fixes problem 1 by logging an extra `location_name`.**
2. as we introduce more examples and more users start with our examples, `location_name` will collide more often. So note that this PR doesn't solve the entire metric problem -- ultimately this new field won't be the guiding general adoption metric but likely a proxity for example adoption since we have the known hashes of location names.

### How I Tested These Changes

ran: `dagit` in `examples/quickstart_etl`
```
{"action": "update_repo_stats", "client_time": "2023-01-04 15:51:30.241633", "event_id": "8e8cfd98-52a0-4cb3-86d1-7636a7cd8e00", "elapsed_time": "", "instance_id": "cdb8b61e-d6f1-487e-aa86-61a80bcdee77", "metadata": {"source": "dagit", "pipeline_name_hash": "", "num_pipelines_in_repo": "2", "num_schedules_in_repo": "1", "num_sensors_in_repo": "0", "num_assets_in_repo": "3", "repo_hash": "f17e9128abe12b4ff329425c469a7c5abc06bace32a2237848bc3a71cf9ef808", "location_name_hash": "08cbd8b1c4c3d099aa97fcba777539adb69e2dce88e8e02bd516b71a99d74ad5"}, "python_version": "3.8.6", "dagster_version": "1!0+dev", "os_desc": "macOS-12.5-x86_64-i386-64bit", "os_platform": "Darwin", "run_storage_id": ""}
```
ran: `dagit` in `examples/assets_dbt_python`
```
{"action": "update_repo_stats", "client_time": "2023-01-04 15:52:16.870853", "event_id": "1a6da9bf-fd67-4606-b2c9-94097ece0d7d", "elapsed_time": "", "instance_id": "cdb8b61e-d6f1-487e-aa86-61a80bcdee77", "metadata": {"source": "dagit", "pipeline_name_hash": "", "num_pipelines_in_repo": "3", "num_schedules_in_repo": "2", "num_sensors_in_repo": "0", "num_assets_in_repo": "14", "repo_hash": "f17e9128abe12b4ff329425c469a7c5abc06bace32a2237848bc3a71cf9ef808", "location_name_hash": "bf763f6bb133c31aaa293e17662b3e34fd39fea979bdf4ffb5ef3d6204b5f0d4"}, "python_version": "3.8.6", "dagster_version": "1!0+dev", "os_desc": "macOS-12.5-x86_64-i386-64bit", "os_platform": "Darwin", "run_storage_id": ""}
```

repo_hash stays the same because when using definitions, `external_repo.name` is always `__repository__` therefore all hashes are the same
location_name_hash is different because `location_name`s are set to be different among our examples
