### PR TITLE
Add StaticPartitionMapping as a built-in PartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -248,6 +248,7 @@ from dagster._core.definitions.partition_mapping import (
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
     PartitionMapping as PartitionMapping,
+    StaticPartitionMapping as StaticPartitionMapping,
 )
 from dagster._core.definitions.partitioned_schedule import (
     build_schedule_from_partitioned_job as build_schedule_from_partitioned_job,

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -330,7 +330,7 @@ class SingleDimensionDependencyMapping(PartitionMapping):
 
 class StaticPartitionMapping(PartitionMapping):
     """
-    Define an explicit correspondence between two StaticPartitionsDefinitions
+    Define an explicit correspondence between two StaticPartitionsDefinitions.
 
     Args:
         downstream_partition_keys_by_upstream_partition_key (Dict[str, str | Collection[str]]):
@@ -370,9 +370,8 @@ class StaticPartitionMapping(PartitionMapping):
         """
         validate that the mapping from upstream to downstream is only defined on upstream keys
         """
-        check.inst_param(
+        check.inst(
             upstream_partitions_def,
-            "upstream_partitions_def",
             StaticPartitionsDefinition,
             "StaticPartitionMapping can only be defined between two StaticPartitionsDefinitions",
         )
@@ -388,9 +387,8 @@ class StaticPartitionMapping(PartitionMapping):
         """
         validate that the mapping from upstream to downstream only maps to downstream keys
         """
-        check.inst_param(
+        check.inst(
             downstream_partitions_def,
-            "downstream_partitions_def",
             StaticPartitionsDefinition,
             "StaticPartitionMapping can only be defined between two StaticPartitionsDefinitions",
         )

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -1,5 +1,8 @@
+import collections
+import collections.abc
+import functools
 from abc import ABC, abstractmethod
-from typing import NamedTuple, Optional, cast
+from typing import Collection, Dict, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
 from dagster._annotations import experimental, public
@@ -7,7 +10,11 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
 )
-from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+from dagster._core.definitions.partition import (
+    PartitionsDefinition,
+    PartitionsSubset,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._serdes import whitelist_for_serdes
 
@@ -320,6 +327,122 @@ class SingleDimensionDependencyMapping(PartitionMapping):
         return downstream_partitions_def.empty_subset().with_partition_keys(set(matching_keys))
 
 
+class StaticPartitionMapping(PartitionMapping):
+    """
+    Define an explicit correspondence between two StaticPartitionDefinitions
+
+    Args:
+        mapping (Dict[str, str | Collection[str]]): The single or multi-valued
+            correspondence from upstream keys to downstream keys.
+    """
+
+    def __init__(
+        self,
+        mapping: Dict[str, Union[str, Collection[str]]],
+    ):
+        check.dict_param(
+            mapping, "mapping", key_type=str, value_type=(str, collections.abc.Collection)
+        )
+
+        # cache forward and reverse mappings
+        self._mapping = collections.defaultdict(set)
+        for upstream_key, downstream_keys in mapping.items():
+            self._mapping[upstream_key] = (
+                {downstream_keys} if isinstance(downstream_keys, str) else downstream_keys
+            )
+
+        self._inverse_mapping = collections.defaultdict(set)
+        for upstream_key, downstream_keys in self._mapping.items():
+            for downstream_key in downstream_keys:
+                self._inverse_mapping[downstream_key].add(upstream_key)
+
+        @functools.cache
+        def _check_upstream(upstream_partitions_def: StaticPartitionsDefinition):
+            """
+            validate that the mapping from upstream to downstream is only defined on upstream keys
+            """
+            check.inst_param(
+                upstream_partitions_def,
+                "upstream_partitions_def",
+                StaticPartitionsDefinition,
+                "StaticPartitionMapping can only be defined between two StaticPartitionsDefinitions",
+            )
+            upstream_keys = upstream_partitions_def.get_partition_keys()
+            extra_keys = set(self._mapping.keys()).difference(upstream_keys)
+            if extra_keys:
+                raise ValueError(
+                    f"mapping source partitions not in the upstream partitions definition: {extra_keys}"
+                )
+
+        self._check_upstream = _check_upstream
+
+        @functools.cache
+        def _check_downstream(downstream_partitions_def: StaticPartitionsDefinition):
+            """
+            validate that the mapping from upstream to downstream only maps to downstream keys
+            """
+            check.inst_param(
+                downstream_partitions_def,
+                "downstream_partitions_def",
+                StaticPartitionsDefinition,
+                "StaticPartitionMapping can only be defined between two StaticPartitionsDefinitions",
+            )
+            downstream_keys = downstream_partitions_def.get_partition_keys()
+            extra_keys = set(self._inverse_mapping.keys()).difference(downstream_keys)
+            if extra_keys:
+                raise ValueError(
+                    f"mapping target partitions not in the downstream partitions definition: {extra_keys}"
+                )
+
+        self._check_downstream = _check_downstream
+
+    def get_downstream_partitions_for_partitions(
+        self,
+        upstream_partitions_subset: PartitionsSubset,
+        downstream_partitions_def: StaticPartitionsDefinition,
+    ) -> PartitionsSubset:
+        self._check_downstream(downstream_partitions_def)
+
+        downstream_subset = downstream_partitions_def.empty_subset()
+        downstream_keys = []
+        for key in upstream_partitions_subset.get_partition_keys():
+            downstream_keys.extend(self._mapping[key])
+        return downstream_subset.with_partition_keys(downstream_keys)
+
+    def get_upstream_partitions_for_partitions(
+        self,
+        downstream_partitions_subset: Optional[PartitionsSubset],
+        upstream_partitions_def: StaticPartitionsDefinition,
+    ) -> PartitionsSubset:
+        self._check_upstream(upstream_partitions_def)
+
+        upstream_subset = upstream_partitions_def.empty_subset()
+        if downstream_partitions_subset is None:
+            return upstream_subset
+
+        upstream_keys = []
+        for key in downstream_partitions_subset.get_partition_keys():
+            upstream_keys.extend(self._inverse_mapping[key])
+
+        return upstream_subset.with_partition_keys(upstream_keys)
+
+    def get_upstream_partitions_for_partition_range(
+        self,
+        downstream_partition_key_range: Optional[PartitionKeyRange],
+        downstream_partitions_def: Optional[PartitionsDefinition],
+        upstream_partitions_def: PartitionsDefinition,
+    ) -> PartitionKeyRange:
+        raise NotImplementedError()
+
+    def get_downstream_partitions_for_partition_range(
+        self,
+        upstream_partition_key_range: PartitionKeyRange,
+        downstream_partitions_def: Optional[PartitionsDefinition],
+        upstream_partitions_def: PartitionsDefinition,
+    ) -> PartitionKeyRange:
+        raise NotImplementedError()
+
+
 def infer_partition_mapping(
     partition_mapping: Optional[PartitionMapping], partitions_def: Optional[PartitionsDefinition]
 ) -> PartitionMapping:
@@ -338,5 +461,6 @@ def get_builtin_partition_mapping_types():
         AllPartitionMapping,
         IdentityPartitionMapping,
         LastPartitionMapping,
+        StaticPartitionMapping,
         TimeWindowPartitionMapping,
     )

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -1,5 +1,4 @@
 import collections.abc
-import functools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Collection, Mapping, NamedTuple, Optional, Union, cast
@@ -366,7 +365,7 @@ class StaticPartitionMapping(PartitionMapping):
                 self._inverse_mapping[downstream_key].add(upstream_key)
 
     @cached_method
-    def _check_upstream(self, *, upstream_partitions_def: StaticPartitionsDefinition):
+    def _check_upstream(self, *, upstream_partitions_def: PartitionsDefinition):
         """
         validate that the mapping from upstream to downstream is only defined on upstream keys
         """
@@ -383,7 +382,7 @@ class StaticPartitionMapping(PartitionMapping):
             )
 
     @cached_method
-    def _check_downstream(self, *, downstream_partitions_def: StaticPartitionsDefinition):
+    def _check_downstream(self, *, downstream_partitions_def: PartitionsDefinition):
         """
         validate that the mapping from upstream to downstream only maps to downstream keys
         """
@@ -396,13 +395,14 @@ class StaticPartitionMapping(PartitionMapping):
         extra_keys = set(self._inverse_mapping.keys()).difference(downstream_keys)
         if extra_keys:
             raise ValueError(
-                f"mapping target partitions not in the downstream partitions definition: {extra_keys}"
+                "mapping target partitions not in the downstream partitions definition:"
+                f" {extra_keys}"
             )
 
     def get_downstream_partitions_for_partitions(
         self,
         upstream_partitions_subset: PartitionsSubset,
-        downstream_partitions_def: StaticPartitionsDefinition,
+        downstream_partitions_def: PartitionsDefinition,
     ) -> PartitionsSubset:
         self._check_downstream(downstream_partitions_def=downstream_partitions_def)
 
@@ -415,7 +415,7 @@ class StaticPartitionMapping(PartitionMapping):
     def get_upstream_partitions_for_partitions(
         self,
         downstream_partitions_subset: Optional[PartitionsSubset],
-        upstream_partitions_def: StaticPartitionsDefinition,
+        upstream_partitions_def: PartitionsDefinition,
     ) -> PartitionsSubset:
         self._check_upstream(upstream_partitions_def=upstream_partitions_def)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -1,0 +1,74 @@
+import pytest
+
+from dagster import StaticPartitionMapping, StaticPartitionsDefinition
+from dagster._core.definitions.partition import DefaultPartitionsSubset
+
+
+def test_single_valued_static_mapping():
+
+    upstream_parts = StaticPartitionsDefinition(["p1", "p2", "p3", "q1", "q2", "r1"])
+    downstream_parts = StaticPartitionsDefinition(["p", "q", "r"])
+    mapping = StaticPartitionMapping({"p1": "p", "p2": "p", "p3": "p", "r1": "r"})
+
+    result = mapping.get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=upstream_parts.empty_subset().with_partition_keys(
+            ["p1", "p3", "q2", "r1"]
+        ),
+        downstream_partitions_def=downstream_parts,
+    )
+
+    assert result == DefaultPartitionsSubset(downstream_parts, {"p", "r"})
+
+    result = mapping.get_upstream_partitions_for_partitions(
+        downstream_partitions_subset=downstream_parts.empty_subset().with_partition_keys(
+            ["p", "q"]
+        ),
+        upstream_partitions_def=upstream_parts,
+    )
+
+    assert result == DefaultPartitionsSubset(upstream_parts, {"p1", "p2", "p3"})
+
+
+def test_multi_valued_static_mapping():
+
+    upstream_parts = StaticPartitionsDefinition(["p", "q1", "q2", "r"])
+    downstream_parts = StaticPartitionsDefinition(["p1", "p2", "p3", "q", "r1"])
+
+    mapping = StaticPartitionMapping({"p": {"p1", "p2", "p3"}, "q1": "q", "q2": "q"})
+
+    result = mapping.get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=upstream_parts.empty_subset().with_partition_keys(["p", "r"]),
+        downstream_partitions_def=downstream_parts,
+    )
+
+    assert result == DefaultPartitionsSubset(downstream_parts, {"p1", "p2", "p3"})
+
+    result = mapping.get_upstream_partitions_for_partitions(
+        downstream_partitions_subset=downstream_parts.empty_subset().with_partition_keys(
+            ["p2", "p3", "q"]
+        ),
+        upstream_partitions_def=upstream_parts,
+    )
+
+    assert result == DefaultPartitionsSubset(upstream_parts, {"p", "q1", "q2"})
+
+
+def test_error_on_extra_keys_in_mapping():
+    upstream_parts = StaticPartitionsDefinition(["p", "q"])
+    downstream_parts = StaticPartitionsDefinition(["p", "q"])
+
+    with pytest.raises(ValueError, match="OTHER"):
+        StaticPartitionMapping(
+            {"p": "p", "q": "q", "q": "OTHER"}
+        ).get_downstream_partitions_for_partitions(
+            upstream_partitions_subset=upstream_parts.empty_subset(),
+            downstream_partitions_def=downstream_parts,
+        )
+
+    with pytest.raises(ValueError, match="OTHER"):
+        StaticPartitionMapping(
+            {"p": "p", "q": "q", "OTHER": "q"}
+        ).get_upstream_partitions_for_partitions(
+            downstream_partitions_subset=downstream_parts.empty_subset(),
+            upstream_partitions_def=upstream_parts,
+        )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -57,7 +57,7 @@ def test_error_on_extra_keys_in_mapping():
 
     with pytest.raises(ValueError, match="OTHER"):
         StaticPartitionMapping(
-            {"p": "p", "q": "q", "q": "OTHER"}
+            {"p": "p", "q": {"q", "OTHER"}}
         ).get_downstream_partitions_for_partitions(
             upstream_partitions_subset=upstream_parts.empty_subset(),
             downstream_partitions_def=downstream_parts,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -1,5 +1,4 @@
 import pytest
-
 from dagster import StaticPartitionMapping, StaticPartitionsDefinition
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -5,7 +5,6 @@ from dagster._core.definitions.partition import DefaultPartitionsSubset
 
 
 def test_single_valued_static_mapping():
-
     upstream_parts = StaticPartitionsDefinition(["p1", "p2", "p3", "q1", "q2", "r1"])
     downstream_parts = StaticPartitionsDefinition(["p", "q", "r"])
     mapping = StaticPartitionMapping({"p1": "p", "p2": "p", "p3": "p", "r1": "r"})
@@ -30,7 +29,6 @@ def test_single_valued_static_mapping():
 
 
 def test_multi_valued_static_mapping():
-
     upstream_parts = StaticPartitionsDefinition(["p", "q1", "q2", "r"])
     downstream_parts = StaticPartitionsDefinition(["p1", "p2", "p3", "q", "r1"])
 


### PR DESCRIPTION
### Summary & Motivation

https://dagster.slack.com/archives/C01U954MEER/p1672437648946139

This adds a new PartitionMapping subclass -- StaticPartitionMapping -- which allows arbitrary dependency relations between two StaticPartitionDefinitions to be expressed.

The slack thread discussed the immediate need just for rolling up upstream partitions into downstream (many-to-one), but this implementation is slightly more general in that it also allows many-to-many dependencies to be expressed.

### How I Tested These Changes

See the new `test_static_partition_mapping.py` file