### PR TITLE
[dagit] Use cache-and-network as default watchQuery fetch policy

### DIFF
--- a/js_modules/dagit/packages/core/src/CapturedLogPanel.tsx
+++ b/js_modules/dagit/packages/core/src/CapturedLogPanel.tsx
@@ -224,7 +224,6 @@ export const CapturedLogPanel: React.FC<CapturedLogProps> = React.memo(
     const {availability, disabled} = React.useContext(WebSocketContext);
     const queryResult = useQuery(CAPTURED_LOGS_METADATA_QUERY, {
       variables: {logKey},
-      fetchPolicy: 'cache-and-network',
     });
 
     React.useEffect(() => {

--- a/js_modules/dagit/packages/core/src/TickLogDialog.tsx
+++ b/js_modules/dagit/packages/core/src/TickLogDialog.tsx
@@ -21,7 +21,6 @@ export const TickLogDialog: React.FC<{
 }> = ({tick, instigationSelector, onClose}) => {
   const {data} = useQuery(TICK_LOG_EVENTS_QUERY, {
     variables: {instigationSelector, timestamp: tick.timestamp},
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -150,6 +150,11 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     return new ApolloClient({
       cache: appCache,
       link: ApolloLink.from([...apolloLinks, splitLink]),
+      defaultOptions: {
+        watchQuery: {
+          fetchPolicy: 'cache-and-network',
+        },
+      },
     });
   }, [apolloLinks, appCache, graphqlPath, headerObject, websocketClient]);
 

--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -80,7 +80,9 @@ export const PermissionsContext = React.createContext<{
 }>({data: [], loading: true});
 
 export const PermissionsProvider: React.FC = (props) => {
-  const {data, loading} = useQuery(PERMISSIONS_QUERY);
+  const {data, loading} = useQuery(PERMISSIONS_QUERY, {
+    fetchPolicy: 'cache-first', // Not expected to change after initial load.
+  });
   const value = React.useMemo(
     () => ({
       data: data?.permissions || [],

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphJobSidebar.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphJobSidebar.tsx
@@ -12,7 +12,6 @@ export const AssetGraphJobSidebar: React.FC<{
   pipelineSelector: PipelineSelector;
 }> = ({pipelineSelector}) => {
   const queryResult = useQuery(ASSET_GRAPH_JOB_SIDEBAR, {
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     variables: {pipelineSelector},
   });

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -31,7 +31,6 @@ export const SidebarAssetInfo: React.FC<{
   const partitionHealthData = usePartitionHealthData([assetKey]);
   const {data} = useQuery(SIDEBAR_ASSET_QUERY, {
     variables: {assetKey: {path: assetKey.path}},
-    fetchPolicy: 'cache-and-network',
   });
 
   const {lastMaterialization} = liveData || {};

--- a/js_modules/dagit/packages/core/src/assets/RunningBackfillsNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/RunningBackfillsNotice.tsx
@@ -8,9 +8,7 @@ import {graphql} from '../graphql';
 export const RunningBackfillsNotice: React.FC<{partitionSetName: string}> = ({
   partitionSetName,
 }) => {
-  const {data} = useQuery(RUNNING_BACKFILLS_NOTICE_QUERY, {
-    fetchPolicy: 'cache-and-network',
-  });
+  const {data} = useQuery(RUNNING_BACKFILLS_NOTICE_QUERY);
 
   const runningBackfills =
     data?.partitionBackfillsOrError.__typename === 'PartitionBackfills'

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -26,7 +26,6 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
 }) => {
   const queryResult = useQuery(RUN_GROUP_PANEL_QUERY, {
     variables: {runId},
-    fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
   });
 

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -53,7 +53,6 @@ export const BackfillRow = ({
 }) => {
   const history = useHistory();
   const [queryBackfill, queryResult] = useLazyQuery(SINGLE_BACKFILL_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       backfillId: backfill.backfillId,
     },

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -17,7 +17,6 @@ interface Props {
 export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props) => {
   const [cancelBackfill] = useMutation(CANCEL_BACKFILL_MUTATION);
   const {data} = useQuery(SINGLE_BACKFILL_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       backfillId: backfill?.backfillId || '',
     },

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -39,7 +39,6 @@ export const InstanceConfig = React.memo(() => {
 
   const {pageTitle} = React.useContext(InstancePageContext);
   const queryResult = useQuery(INSTANCE_CONFIG_QUERY, {
-    fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
   });
 

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -15,7 +15,6 @@ export const InstanceHealthPage = () => {
 
   const {pageTitle} = React.useContext(InstancePageContext);
   const queryData = useQuery(INSTANCE_HEALTH_QUERY, {
-    fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
   });
   const refreshState = useQueryRefreshAtInterval(queryData, FIFTEEN_SECONDS);

--- a/js_modules/dagit/packages/core/src/instance/StepSummaryForRun.tsx
+++ b/js_modules/dagit/packages/core/src/instance/StepSummaryForRun.tsx
@@ -14,7 +14,9 @@ interface Props {
 
 export const StepSummaryForRun = (props: Props) => {
   const {runId} = props;
-  const {data} = useQuery(STEP_SUMMARY_FOR_RUN_QUERY, {variables: {runId}});
+  const {data} = useQuery(STEP_SUMMARY_FOR_RUN_QUERY, {
+    variables: {runId},
+  });
 
   const run = data?.pipelineRunOrError;
   const status = run?.__typename === 'Run' ? run.status : null;

--- a/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
@@ -10,7 +10,6 @@ import {StatusAndMessage} from './DeploymentStatusType';
 export const useDaemonStatus = (skip = false): StatusAndMessage | null => {
   const {options} = useRepositoryOptions();
   const queryResult = useQuery(INSTANCE_WARNING_QUERY, {
-    fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
     skip,
   });

--- a/js_modules/dagit/packages/core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickDetailsDialog.tsx
@@ -18,7 +18,6 @@ export const TickDetailsDialog: React.FC<{
 }> = ({timestamp, instigationSelector, onClose}) => {
   const {data} = useQuery(JOB_SELECTED_TICK_QUERY, {
     variables: {instigationSelector, timestamp: timestamp || 0},
-    fetchPolicy: 'cache-and-network',
     skip: !timestamp,
     partialRefetch: true,
   });

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -291,7 +291,6 @@ export const TickHistoryTimeline = ({
   const instigationSelector = {...repoAddressToSelector(repoAddress), name};
   const queryResult = useQuery(JOB_TICK_HISTORY_QUERY, {
     variables: {instigationSelector, limit: 15},
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -101,7 +101,6 @@ const LaunchpadAllowedRoot: React.FC<Props> = (props) => {
 
   const result = useQuery(PIPELINE_EXECUTION_ROOT_QUERY, {
     variables: {repositoryName, repositoryLocationName, pipelineName},
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
   });
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -185,7 +185,6 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
 
   const configResult = useQuery(PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY, {
     variables: {selector: pipelineSelector, mode: currentSession?.mode},
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
   });
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSetupFromRunRoot.tsx
@@ -63,7 +63,9 @@ const LaunchpadSetupFromRunAllowedRoot: React.FC<Props> = (props) => {
 
   const [storageData, onSave] = useExecutionSessionStorage(repoAddress, pipelineName);
 
-  const {data, loading} = useQuery(CONFIG_FOR_RUN_QUERY, {variables: {runId}});
+  const {data, loading} = useQuery(CONFIG_FOR_RUN_QUERY, {
+    variables: {runId},
+  });
   const runOrError = data?.runOrError;
   const run = runOrError?.__typename === 'Run' ? runOrError : null;
 

--- a/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
@@ -66,7 +66,6 @@ export const OpSelector = (props: IOpSelectorProps) => {
   const isJob = isThisThingAJob(repo, pipelineName);
   const {data, loading} = useQuery(SOLID_SELECTOR_QUERY, {
     variables: {selector, requestScopeHandleID: flattenGraphs ? undefined : ''},
-    fetchPolicy: 'cache-and-network',
   });
 
   const query = props.query || '*';

--- a/js_modules/dagit/packages/core/src/nav/VersionNumber.tsx
+++ b/js_modules/dagit/packages/core/src/nav/VersionNumber.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro';
 import {graphql} from '../graphql';
 
 export const VersionNumber = () => {
-  const {data} = useQuery(VERSION_NUMBER_QUERY, {fetchPolicy: 'cache-and-network'});
+  const {data} = useQuery(VERSION_NUMBER_QUERY);
   return <Version>{data?.version || <span>&nbsp;</span>}</Version>;
 };
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionsBackfill.tsx
@@ -107,6 +107,7 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
   }, [onLaunch]);
 
   const {loading, data} = useQuery(PARTITIONS_BACKFILL_SELECTOR_QUERY, {
+    fetchPolicy: 'network-only',
     variables: {
       repositorySelector,
       partitionSetName,
@@ -115,7 +116,6 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
         pipelineName,
       },
     },
-    fetchPolicy: 'network-only',
   });
 
   const [queryStatuses, {loading: statusesLoading, data: statusesData}] = useLazyQuery(
@@ -125,7 +125,6 @@ export const PartitionsBackfillPartitionSelector: React.FC<{
         repositorySelector,
         partitionSetName,
       },
-      fetchPolicy: 'cache-and-network',
     },
   );
 

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOp.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOp.tsx
@@ -40,7 +40,6 @@ const useSidebarOpQuery = (
       },
       handleID,
     },
-    fetchPolicy: 'cache-and-network',
     skip: isGraph,
   });
 
@@ -53,7 +52,6 @@ const useSidebarOpQuery = (
       },
       handleID,
     },
-    fetchPolicy: 'cache-and-network',
     skip: !isGraph,
   });
 

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -33,7 +33,6 @@ export const SidebarOpExecutionGraphs: React.FC<{
         pipelineName,
       },
     },
-    fetchPolicy: 'cache-and-network',
   });
   const stepStats =
     result.data?.pipelineOrError.__typename === 'Pipeline'

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -26,7 +26,6 @@ export const RunRoot = () => {
   const {runId} = useParams<{runId: string}>();
 
   const {data, loading} = useQuery(RUN_ROOT_QUERY, {
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     variables: {runId},
   });

--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -18,7 +18,6 @@ export const ScheduledRunListRoot = () => {
   useDocumentTitle('Scheduled runs');
 
   const queryResult = useQuery(SCHEDULER_INFO_QUERY, {
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });

--- a/js_modules/dagit/packages/core/src/runs/useCursorPaginatedQuery.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useCursorPaginatedQuery.tsx
@@ -39,7 +39,6 @@ export function useCursorPaginatedQuery<T, TVars extends CursorPaginationQueryVa
   };
 
   const queryResult = useQuery<T, TVars>(options.query, {
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     variables: queryVars,
     notifyOnNetworkStatusChange: true,

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -20,7 +20,6 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
   const endSec = end / 1000.0;
 
   const queryData = useQuery(RUN_TIMELINE_QUERY, {
-    fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
     variables: {
       inProgressFilter: {

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -41,7 +41,6 @@ export const ScheduleRoot: React.FC<Props> = (props) => {
     variables: {
       scheduleSelector,
     },
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });
@@ -100,7 +99,6 @@ export const SchedulePreviousRuns: React.FC<{
   highlightedIds?: string[];
 }> = ({schedule, highlightedIds, tabs}) => {
   const queryResult = useQuery(PREVIOUS_RUNS_FOR_SCHEDULE_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       limit: 20,
       filter: {

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesRoot.tsx
@@ -29,7 +29,6 @@ export const SchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
       repositorySelector,
       instigationType: InstigationType.SCHEDULE,
     },
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -126,17 +126,12 @@ const secondaryDataToSearchResults = (data?: SearchSecondaryQueryQuery) => {
 export const useRepoSearch = () => {
   const [performBootstrapQuery, {data: bootstrapData, loading: bootstrapLoading}] = useLazyQuery(
     SEARCH_BOOTSTRAP_QUERY,
-    {
-      fetchPolicy: 'cache-and-network',
-    },
   );
 
   const [
     performSecondaryQuery,
     {data: secondaryData, loading: secondaryLoading, called: secondaryQueryCalled},
-  ] = useLazyQuery(SEARCH_SECONDARY_QUERY, {
-    fetchPolicy: 'cache-and-network',
-  });
+  ] = useLazyQuery(SEARCH_SECONDARY_QUERY);
 
   const bootstrapFuse = React.useMemo(() => bootstrapDataToSearchResults(bootstrapData), [
     bootstrapData,

--- a/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
@@ -17,7 +17,6 @@ export const SensorPreviousRuns: React.FC<{
   highlightedIds?: string[];
 }> = ({sensor, highlightedIds, tabs}) => {
   const {data} = useQuery(PREVIOUS_RUNS_FOR_SENSOR_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       limit: RUNS_LIMIT,
       filter: {

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -31,7 +31,6 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
   const [selectedTab, setSelectedTab] = React.useState<string>('ticks');
   const queryResult = useQuery(SENSOR_ROOT_QUERY, {
     variables: {sensorSelector},
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });

--- a/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorsRoot.tsx
@@ -34,7 +34,6 @@ export const SensorsRoot = (props: Props) => {
       repositorySelector,
       instigationType: InstigationType.SENSOR,
     },
-    fetchPolicy: 'cache-and-network',
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });

--- a/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.test.tsx
+++ b/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.test.tsx
@@ -11,9 +11,7 @@ const typeDefs = loader('../graphql/schema.graphql');
 
 describe('ApolloTestProvider', () => {
   const Thing = () => {
-    const {data} = useQuery(INSTANCE_CONFIG_QUERY, {
-      fetchPolicy: 'cache-and-network',
-    });
+    const {data} = useQuery(INSTANCE_CONFIG_QUERY);
     return (
       <>
         <div>Version: {data?.version || ''}</div>

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorerContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorerContainer.tsx
@@ -22,7 +22,6 @@ export const TypeExplorerContainer: React.FC<ITypeExplorerContainerProps> = ({
 }) => {
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
   const queryResult = useQuery(TYPE_EXPLORER_CONTAINER_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       pipelineSelector,
       dagsterTypeName: typeName,

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
@@ -38,7 +38,6 @@ export const TypeListContainer: React.FC<ITypeListContainerProps> = ({
   }, [options, pipelineName, repoAddress, snapshotId]);
 
   const queryResult = useQuery(TYPE_LIST_CONTAINER_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {pipelineSelector: pipelineSelector!},
     skip: !pipelineSelector,
   });

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryAssetsList.tsx
@@ -55,7 +55,6 @@ export const RepositoryAssetsList: React.FC<Props> = (props) => {
   const repositorySelector = repoAddressToSelector(repoAddress);
 
   const {data, error, loading} = useQuery(REPOSITORY_ASSETS_LIST_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {repositorySelector},
   });
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryGraphsList.tsx
@@ -71,7 +71,6 @@ export const RepositoryGraphsList: React.FC<Props> = (props) => {
   const repositorySelector = repoAddressToSelector(repoAddress);
 
   const {data, error, loading} = useQuery(REPOSITORY_GRAPHS_LIST_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {repositorySelector},
   });
 

--- a/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/RepositoryPipelinesList.tsx
@@ -41,7 +41,6 @@ export const RepositoryPipelinesList: React.FC<Props> = (props) => {
   const repositorySelector = repoAddressToSelector(repoAddress);
 
   const {data, error, loading} = useQuery(REPOSITORY_PIPELINES_LIST_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {repositorySelector},
   });
 

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -54,7 +54,6 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
   } = props;
 
   const [queryAsset, queryResult] = useLazyQuery(SINGLE_ASSET_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {input: {path}},
   });
 

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedGraphTable.tsx
@@ -83,7 +83,6 @@ const GraphRow = (props: GraphRowProps) => {
   const {name, path, description, repoAddress, start, height} = props;
 
   const [queryGraph, queryResult] = useLazyQuery(SINGLE_GRAPH_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       selector: {
         repositoryName: repoAddress.name,

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedJobRow.tsx
@@ -31,7 +31,6 @@ export const VirtualizedJobRow = (props: JobRowProps) => {
   const {name, isJob, repoAddress, start, height} = props;
 
   const [queryJob, queryResult] = useLazyQuery(SINGLE_JOB_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       selector: buildPipelineSelector(repoAddress, name),
     },

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -47,7 +47,6 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
   const repo = useRepository(repoAddress);
 
   const [querySchedule, queryResult] = useLazyQuery(SINGLE_SCHEDULE_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       selector: {
         repositoryName: repoAddress.name,

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedSensorRow.tsx
@@ -35,7 +35,6 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
   const repo = useRepository(repoAddress);
 
   const [querySensor, queryResult] = useLazyQuery(SINGLE_SENSOR_QUERY, {
-    fetchPolicy: 'cache-and-network',
     variables: {
       selector: {
         repositoryName: repoAddress.name,

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -160,10 +160,7 @@ const ROOT_WORKSPACE_QUERY = graphql(`
  * in the workspace, and loading/error state for the relevant query.
  */
 const useWorkspaceState = (): WorkspaceState => {
-  const {data, loading, refetch} = useQuery(ROOT_WORKSPACE_QUERY, {
-    fetchPolicy: 'cache-and-network',
-  });
-
+  const {data, loading, refetch} = useQuery(ROOT_WORKSPACE_QUERY);
   const workspaceOrError = data?.workspaceOrError;
 
   const locationEntries = React.useMemo(


### PR DESCRIPTION
### Summary & Motivation

Modify our ApolloClient defaults to use `cache-and-network` as the default fetch policy on watched queries, instead of `cache-first`.

This should ideally resolve issues where the backend has changed (e.g. a code change for a job) and needs to be re-queried. We use `cache-and-network` pretty aggressively already to get this behavior, and my hunch is that we don't actually want `cache-first` very often since the backend is always going to be a more appropriate source of truth for anything that needs requerying.

I have gone through our existing `useQuery` calls to add `cache-first` as the fetch policy on any that haven't specified it, though we should audit these to see which of them should actually be `cache-and-network`. I've added comments to each.

I have also removed any `fetchPolicy: 'cache-and-network'` settings from `useQuery` since this will now be the default.

The end result is that all queries should keep the exact same behavior they currently have (to avoid unexpected breakages) and we can go through and fix any queries that are incorrectly configured.

### How I Tested These Changes

Load Dagit and sanity check that all queries are still performed as expected.

Verify fix for the issue @gibsondan ran into, now that the query in `PipelineExplorerRoot` now uses the `cache-and-network` default:

- Load Dagit. Navigate to Deployments page.
- Change `fails_job` to have another op in Python.
- Kill the dagit backend, then restart it.
- Wait until Dagit says that definitions are reloaded.
- Navigate to `fails_job` in Dagit, verify that it now has the op that I added. This is because navigating to the job page led to a fresh query of the backend, as expected with `cache-and-network`.
