### PR TITLE
[dagster-airbyte] Allow specifying freshness policies on Airbyte assets

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -2,7 +2,14 @@ import pytest
 import responses
 from dagster_airbyte import airbyte_resource, build_airbyte_assets
 
-from dagster import AssetKey, MetadataEntry, TableColumn, TableSchema, build_init_resource_context
+from dagster import (
+    AssetKey,
+    FreshnessPolicy,
+    MetadataEntry,
+    TableColumn,
+    TableSchema,
+    build_init_resource_context,
+)
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._legacy import build_assets_job
 
@@ -97,7 +104,8 @@ def test_assets(schema_prefix):
 @responses.activate
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix_"])
 @pytest.mark.parametrize("source_asset", [None, "my_source_asset_key"])
-def test_assets_with_normalization(schema_prefix, source_asset):
+@pytest.mark.parametrize("freshness_policy", [None, FreshnessPolicy(maximum_lag_minutes=60)])
+def test_assets_with_normalization(schema_prefix, source_asset, freshness_policy):
 
     ab_resource = airbyte_resource(
         build_init_resource_context(
@@ -118,7 +126,11 @@ def test_assets_with_normalization(schema_prefix, source_asset):
         normalization_tables={destination_tables[1]: bar_normalization_tables},
         asset_key_prefix=["some", "prefix"],
         upstream_assets={AssetKey(source_asset)} if source_asset else None,
+        freshness_policy=freshness_policy,
     )
+
+    freshness_policies = ab_assets[0].freshness_policies_by_key
+    assert all(freshness_policies[key] == freshness_policy for key in freshness_policies)
 
     assert ab_assets[0].keys == {AssetKey(["some", "prefix", t]) for t in destination_tables} | {
         AssetKey(["some", "prefix", t]) for t in bar_normalization_tables

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -3,7 +3,15 @@ import responses
 from dagster_airbyte import airbyte_resource
 from dagster_airbyte.asset_defs import AirbyteConnectionMetadata, load_assets_from_airbyte_instance
 
-from dagster import AssetKey, IOManager, asset, build_init_resource_context, io_manager, materialize
+from dagster import (
+    AssetKey,
+    FreshnessPolicy,
+    IOManager,
+    asset,
+    build_init_resource_context,
+    io_manager,
+    materialize,
+)
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.execution.with_resources import with_resources
@@ -16,6 +24,8 @@ from .utils import (
     get_project_job_json,
 )
 
+TEST_FRESHNESS_POLICY = FreshnessPolicy(maximum_lag_minutes=60)
+
 
 @responses.activate
 @pytest.mark.parametrize("use_normalization_tables", [True, False])
@@ -24,11 +34,15 @@ from .utils import (
 @pytest.mark.parametrize(
     "connection_to_asset_key_fn", [None, lambda conn, name: AssetKey([f"{conn.name[0]}_{name}"])]
 )
+@pytest.mark.parametrize(
+    "connection_to_freshness_policy_fn", [None, lambda _: TEST_FRESHNESS_POLICY]
+)
 def test_load_from_instance(
     use_normalization_tables,
     connection_to_group_fn,
     filter_connection,
     connection_to_asset_key_fn,
+    connection_to_freshness_policy_fn,
 ):
 
     load_calls = []
@@ -86,6 +100,7 @@ def test_load_from_instance(
             connection_filter=(lambda _: False) if filter_connection else None,
             connection_to_io_manager_key_fn=(lambda _: "test_io_manager"),
             connection_to_asset_key_fn=connection_to_asset_key_fn,
+            connection_to_freshness_policy_fn=connection_to_freshness_policy_fn,
         )
     else:
         ab_cacheable_assets = load_assets_from_airbyte_instance(
@@ -94,6 +109,7 @@ def test_load_from_instance(
             connection_filter=(lambda _: False) if filter_connection else None,
             io_manager_key="test_io_manager",
             connection_to_asset_key_fn=connection_to_asset_key_fn,
+            connection_to_freshness_policy_fn=connection_to_freshness_policy_fn,
         )
     ab_assets = ab_cacheable_assets.build_definitions(ab_cacheable_assets.compute_cacheable_data())
     ab_assets = with_resources(ab_assets, {"test_io_manager": test_io_manager})
@@ -191,6 +207,10 @@ def test_load_from_instance(
         ]
     )
     assert len(ab_assets[0].op.output_defs) == len(tables)
+
+    expected_freshness_policy = TEST_FRESHNESS_POLICY if connection_to_freshness_policy_fn else None
+    freshness_policies = ab_assets[0].freshness_policies_by_key
+    assert all(freshness_policies[key] == expected_freshness_policy for key in freshness_policies)
 
     responses.add(
         method=responses.POST,


### PR DESCRIPTION
## Summary

Adds the ability to attach freshness policies to Airbyte assets. Users can specify a `freshness_policy` when constructing individual connection assets, or provide a `connection_to_freshness_policy_fn` mapping when loading from an instance or project.

## Test Plan

Added unit tests.
