### PR TITLE
[1/n] Serialize top-level resources into repository data

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_repository.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/repositories_workspaces_tests/test_repository.py
@@ -22,6 +22,7 @@ def test_my_repository():
     assert len(my_repository.schedule_defs) == 1
     assert len(my_repository.sensor_defs) == 1
     assert len(my_repository.get_all_jobs()) == 4
+    assert len(my_repository.get_top_level_resources()) == 0
 
 
 def test_my_lazy_repository():
@@ -30,3 +31,4 @@ def test_my_lazy_repository():
     assert len(my_lazy_repository.schedule_defs) == 1
     assert len(my_lazy_repository.sensor_defs) == 1
     assert len(my_lazy_repository.get_all_jobs()) == 1
+    assert len(my_lazy_repository.get_top_level_resources()) == 0

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -127,19 +127,6 @@ def copy_with_default(old_field: Field, new_config_value: Any) -> Field:
 
 def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSchema:
     """Return a new config schema configured with the passed in data"""
-    # # We don't do anything with this resource definition, other than
-    # # use it to construct configured schema
-    # inner_resource_def = ResourceDefinition(lambda _: None, schema_field)
-    # configured_resource_def = inner_resource_def.configured(
-    #     config_dictionary_from_values(
-    #         data,
-    #         schema_field,
-    #     ),
-    # )
-    # # this cast required to make mypy happy, which does not support Self
-    # configured_resource_def = cast(ResourceDefinition, configured_resource_def)
-    # return configured_resource_def.config_schema
-
     return DefinitionConfigSchema(_apply_defaults_to_schema_field(schema_field, data))
 
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -127,7 +127,6 @@ def copy_with_default(old_field: Field, new_config_value: Any) -> Field:
 
 def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSchema:
     """Return a new config schema configured with the passed in data"""
-
     # # We don't do anything with this resource definition, other than
     # # use it to construct configured schema
     # inner_resource_def = ResourceDefinition(lambda _: None, schema_field)

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -1,8 +1,14 @@
 import inspect
 
 from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType
+from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
-from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
+from dagster._config.validate import validate_config
+from dagster._core.definitions.definition_config_schema import (
+    DefinitionConfigSchema,
+    IDefinitionConfigSchema,
+)
+from dagster._core.errors import DagsterInvalidConfigError
 
 try:
     from functools import cached_property  # type: ignore  # (py37 compat)
@@ -13,16 +19,10 @@ except ImportError:
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Type, cast
+from typing import Any, Optional, Type
 
 from pydantic import BaseModel, Extra
-from pydantic.fields import (
-    SHAPE_DICT,
-    SHAPE_LIST,
-    SHAPE_MAPPING,
-    SHAPE_SINGLETON,
-    ModelField,
-)
+from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_MAPPING, SHAPE_SINGLETON, ModelField
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -31,7 +31,6 @@ from dagster._config.field_utils import (
     FIELD_NO_DEFAULT_PROVIDED,
     Map,
     Permissive,
-    config_dictionary_from_values,
     convert_potential_field,
 )
 from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
@@ -84,20 +83,65 @@ class PermissiveConfig(Config):
     """
 
 
+# This is from https://github.com/dagster-io/dagster/pull/11470
+def _apply_defaults_to_schema_field(field: Field, additional_default_values: Any) -> Field:
+    # This work by validating the top-level config and then
+    # just setting it at that top-level field. Config fields
+    # can actually take nested values so we only need to set it
+    # at a single level
+
+    evr = validate_config(field.config_type, additional_default_values)
+
+    if not evr.success:
+        raise DagsterInvalidConfigError(
+            "Incorrect values passed to .configured",
+            evr.errors,
+            additional_default_values,
+        )
+
+    if field.default_provided:
+        # In the case where there is already a default config value
+        # we can apply "additional" defaults by actually invoking
+        # the config machinery. Meaning we pass the new_additional_default_values
+        # and then resolve the existing defaults over them. This preserves the default
+        # values that are not specified in new_additional_default_values and then
+        # applies the new value as the default value of the field in question.
+        defaults_processed_evr = resolve_defaults(field.config_type, additional_default_values)
+        check.invariant(
+            defaults_processed_evr.success, "Since validation passed, this should always work."
+        )
+        default_to_pass = defaults_processed_evr.value
+        return copy_with_default(field, default_to_pass)
+    else:
+        return copy_with_default(field, additional_default_values)
+
+
+def copy_with_default(old_field: Field, new_config_value: Any) -> Field:
+    return Field(
+        config=old_field.config_type,
+        default_value=new_config_value,
+        is_required=False,
+        description=old_field.description,
+    )
+
+
 def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSchema:
     """Return a new config schema configured with the passed in data"""
-    # We don't do anything with this resource definition, other than
-    # use it to construct configured schema
-    inner_resource_def = ResourceDefinition(lambda _: None, schema_field)
-    configured_resource_def = inner_resource_def.configured(
-        config_dictionary_from_values(
-            data,
-            schema_field,
-        ),
-    )
-    # this cast required to make mypy happy, which does not support Self
-    configured_resource_def = cast(ResourceDefinition, configured_resource_def)
-    return configured_resource_def.config_schema
+
+    # # We don't do anything with this resource definition, other than
+    # # use it to construct configured schema
+    # inner_resource_def = ResourceDefinition(lambda _: None, schema_field)
+    # configured_resource_def = inner_resource_def.configured(
+    #     config_dictionary_from_values(
+    #         data,
+    #         schema_field,
+    #     ),
+    # )
+    # # this cast required to make mypy happy, which does not support Self
+    # configured_resource_def = cast(ResourceDefinition, configured_resource_def)
+    # return configured_resource_def.config_schema
+
+    return DefinitionConfigSchema(_apply_defaults_to_schema_field(schema_field, data))
 
 
 class Resource(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -15,6 +15,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 from ..executor_definition import ExecutorDefinition
@@ -53,6 +54,7 @@ class _Repository:
         description: Optional[str] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
+        top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
@@ -61,6 +63,9 @@ class _Repository:
         )
         self.default_logger_defs = check.opt_mapping_param(
             default_logger_defs, "default_logger_defs", key_type=str, value_type=LoggerDefinition
+        )
+        self.top_level_resources = check.opt_mapping_param(
+            top_level_resources, "top_level_resources", key_type=str, value_type=ResourceDefinition
         )
 
     def __call__(
@@ -125,6 +130,7 @@ class _Repository:
                     repository_defns,
                     default_executor_def=self.default_executor_def,
                     default_logger_defs=self.default_logger_defs,
+                    top_level_resources=self.top_level_resources,
                 )
             )
 
@@ -160,6 +166,7 @@ class _Repository:
                 description=self.description,
                 default_executor_def=self.default_executor_def,
                 default_logger_defs=self.default_logger_defs,
+                top_level_resources=self.top_level_resources,
             )
         else:
             repository_def = RepositoryDefinition(
@@ -195,6 +202,7 @@ def repository(
     description: Optional[str] = None,
     default_executor_def: Optional[ExecutorDefinition] = None,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
+    top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Union[RepositoryDefinition, PendingRepositoryDefinition, _Repository]:
     """Create a repository from the decorated function.
 
@@ -226,6 +234,8 @@ def repository(
         name (Optional[str]): The name of the repository. Defaults to the name of the decorated
             function.
         description (Optional[str]): A string description of the repository.
+        top_level_resources (Optional[Mapping[str, ResourceDefinition]]): A dict of top-level
+            resource keys to defintions, for resources which should be displayed in the UI.
 
     Example:
         .. code-block:: python
@@ -329,4 +339,5 @@ def repository(
         description=description,
         default_executor_def=default_executor_def,
         default_logger_defs=default_logger_defs,
+        top_level_resources=top_level_resources,
     )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -191,6 +191,7 @@ def repository(
     description: Optional[str] = ...,
     default_executor_def: Optional[ExecutorDefinition] = ...,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
+    top_level_resources: Optional[Mapping[str, ResourceDefinition]] = ...,
 ) -> _Repository:
     ...
 

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -99,6 +99,7 @@ def _create_repository_using_definitions_args(
         name=name,
         default_executor_def=executor_def,
         default_logger_defs=loggers,
+        top_level_resources=resource_defs,
     )
     def created_repo():
         return [

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -486,6 +486,10 @@ class RepositoryData(ABC):
     def get_source_assets_by_key(self) -> Mapping[AssetKey, SourceAsset]:
         return {}
 
+    @public
+    def get_assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
+        return {}
+
     def load_all_definitions(self):
         # force load of all lazy constructed code artifacts
         self.get_all_pipelines()

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -718,7 +718,7 @@ class CachingRepositoryData(RepositoryData):
                 )
 
         return CachingRepositoryData(
-            **repository_definitions, source_assets_by_key={}, assets_defs_by_key={}
+            **repository_definitions, source_assets_by_key={}, assets_defs_by_key={}, top_level_resources={}
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -718,7 +718,10 @@ class CachingRepositoryData(RepositoryData):
                 )
 
         return CachingRepositoryData(
-            **repository_definitions, source_assets_by_key={}, assets_defs_by_key={}, top_level_resources={}
+            **repository_definitions,
+            source_assets_by_key={},
+            assets_defs_by_key={},
+            top_level_resources={},
         )
 
     @classmethod
@@ -947,7 +950,7 @@ class CachingRepositoryData(RepositoryData):
             sensors=sensors,
             source_assets_by_key=source_assets_by_key,
             assets_defs_by_key=assets_defs_by_key,
-            top_level_resources=top_level_resources,
+            top_level_resources=top_level_resources or {},
         )
 
     def get_pipeline_names(self) -> Sequence[str]:

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -187,6 +187,36 @@ class ScheduleSelector(
         )
 
 
+class ResourceSelector(
+    NamedTuple(
+        "_ResourceSelector",
+        [("location_name", str), ("repository_name", str), ("resource_name", str)],
+    )
+):
+    def __new__(cls, location_name: str, repository_name: str, resource_name: str):
+        return super(ResourceSelector, cls).__new__(
+            cls,
+            location_name=check.str_param(location_name, "location_name"),
+            repository_name=check.str_param(repository_name, "repository_name"),
+            resource_name=check.str_param(resource_name, "resource_name"),
+        )
+
+    def to_graphql_input(self):
+        return {
+            "repositoryLocationName": self.location_name,
+            "repositoryName": self.repository_name,
+            "resourceName": self.resource_name,
+        }
+
+    @staticmethod
+    def from_graphql_input(graphql_data):
+        return ResourceSelector(
+            location_name=graphql_data["repositoryLocationName"],
+            repository_name=graphql_data["repositoryName"],
+            resource_name=graphql_data["resourceName"],
+        )
+
+
 class SensorSelector(
     NamedTuple(
         "_SensorSelector", [("location_name", str), ("repository_name", str), ("sensor_name", str)]

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -187,19 +187,10 @@ class ScheduleSelector(
         )
 
 
-class ResourceSelector(
-    NamedTuple(
-        "_ResourceSelector",
-        [("location_name", str), ("repository_name", str), ("resource_name", str)],
-    )
-):
-    def __new__(cls, location_name: str, repository_name: str, resource_name: str):
-        return super(ResourceSelector, cls).__new__(
-            cls,
-            location_name=check.str_param(location_name, "location_name"),
-            repository_name=check.str_param(repository_name, "repository_name"),
-            resource_name=check.str_param(resource_name, "resource_name"),
-        )
+class ResourceSelector(NamedTuple):
+    location_name: str
+    repository_name: str
+    resource_name: str
 
     def to_graphql_input(self):
         return {

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -139,7 +139,9 @@ class ExternalRepository:
     def _external_resources(self) -> Dict[str, ExternalResource]:
         return {
             external_resource_data.name: ExternalResource(external_resource_data, self._handle)
-            for external_resource_data in self.external_repository_data.external_resource_data
+            for external_resource_data in (
+                self.external_repository_data.external_resource_data or []
+            )
         }
 
     def has_external_resource(self, resource_name: str) -> bool:

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
 from dagster._core.definitions.run_request import InstigatorType
@@ -48,6 +49,7 @@ from .external_data import (
     ExternalPipelineData,
     ExternalPresetData,
     ExternalRepositoryData,
+    ExternalResourceData,
     ExternalScheduleData,
     ExternalSensorData,
     ExternalSensorMetadata,
@@ -131,6 +133,23 @@ class ExternalRepository:
 
     def get_external_schedules(self) -> Sequence[ExternalSchedule]:
         return iter_to_list(self._external_schedules.values())
+
+    @property
+    @cached_method
+    def _external_resources(self) -> Dict[str, ExternalResource]:
+        return {
+            external_resource_data.name: ExternalResource(external_resource_data, self._handle)
+            for external_resource_data in self.external_repository_data.external_resource_data
+        }
+
+    def has_external_resource(self, resource_name: str) -> bool:
+        return resource_name in self._external_resources
+
+    def get_external_resource(self, resource_name: str) -> ExternalResource:
+        return self._external_resources[resource_name]
+
+    def get_external_resources(self) -> Sequence[ExternalResource]:
+        return self._external_resources.values()
 
     @property
     @cached_method
@@ -506,6 +525,40 @@ class ExternalExecutionPlan:
             ]
 
         return self._topological_step_levels
+
+
+class ExternalResource:
+    """
+    Represents a top-level resource in a repository, e.g. one passed through the Definitions API.
+    """
+
+    def __init__(self, external_resource_data: ExternalResourceData, handle: RepositoryHandle):
+        self._external_resource_data = check.inst_param(
+            external_resource_data, "external_resource_data", ExternalResourceData
+        )
+        self._handle = InstigatorHandle(
+            self._external_resource_data.name, check.inst_param(handle, "handle", RepositoryHandle)
+        )
+
+    @property
+    def name(self) -> str:
+        return self._external_resource_data.name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._external_resource_data.resource_snapshot.description
+
+    @property
+    def config_field_snaps(self) -> List[ConfigFieldSnap]:
+        return self._external_resource_data.config_field_snaps
+
+    @property
+    def configured_values(self) -> Dict[str, str]:
+        return self._external_resource_data.configured_values
+
+    @property
+    def config_schema_snap(self) -> ConfigSchemaSnapshot:
+        return self._external_resource_data.config_schema_snap
 
 
 class ExternalSchedule:

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1288,7 +1288,10 @@ def external_resource_data_from_def(
     # we parse the JSON and break it out into defaults for each individual nested Field
     # for display in the UI
     configured_values_expanded = cast(
-        Mapping[str, Any], json.loads(resource_def.config_schema.default_value_as_json_str)
+        Mapping[str, Any],
+        json.loads(resource_def.config_schema.default_value_as_json_str)
+        if resource_def.config_schema.default_provided
+        else {},
     )
     configured_values = {k: json.dumps(v) for k, v in configured_values_expanded.items()}
 
@@ -1296,7 +1299,7 @@ def external_resource_data_from_def(
         name=name,
         resource_snapshot=build_resource_def_snap(name, resource_def),
         configured_values=configured_values,
-        config_field_snaps=unconfigured_config_type_snap.fields,
+        config_field_snaps=unconfigured_config_type_snap.fields or [],
         config_schema_snap=ConfigSchemaSnapshot(
             {unconfigured_config_schema.config_type.key: unconfigured_config_type_snap}
         ),

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1280,9 +1280,14 @@ def external_resource_data_from_def(
     # longer visible. We walk up the list of parent schemas to find the base, unconfigured
     # schema so we can display all fields in the UI.
     unconfigured_config_schema = resource_def.config_schema
-    while isinstance(unconfigured_config_schema, ConfiguredDefinitionConfigSchema):
+    while (
+        isinstance(unconfigured_config_schema, ConfiguredDefinitionConfigSchema)
+        and unconfigured_config_schema.parent_def.config_schema
+    ):
         unconfigured_config_schema = unconfigured_config_schema.parent_def.config_schema
-    unconfigured_config_type_snap = snap_from_config_type(unconfigured_config_schema.config_type)
+
+    config_type = check.not_none(unconfigured_config_schema.config_type)
+    unconfigured_config_type_snap = snap_from_config_type(config_type)
 
     # Right now, .configured sets the default value of the top-level Field
     # we parse the JSON and break it out into defaults for each individual nested Field
@@ -1300,9 +1305,7 @@ def external_resource_data_from_def(
         resource_snapshot=build_resource_def_snap(name, resource_def),
         configured_values=configured_values,
         config_field_snaps=unconfigured_config_type_snap.fields or [],
-        config_schema_snap=ConfigSchemaSnapshot(
-            {unconfigured_config_schema.config_type.key: unconfigured_config_type_snap}
-        ),
+        config_schema_snap=ConfigSchemaSnapshot({config_type.key: unconfigured_config_type_snap}),
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -43,6 +43,9 @@ class TestDynamicRepositoryData(RepositoryData):
         self._num_calls = self._num_calls + 1
         return [define_foo_pipeline(self._num_calls)]
 
+    def get_top_level_resources(self):
+        return {}
+
 
 @repository
 def bar_repo():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['test_external_pipeline_data 1'] = '''{
@@ -3851,6 +3852,7 @@ snapshots['test_external_repository_data 1'] = '''{
       }
     }
   ],
+  "external_resource_data": [],
   "external_schedule_datas": [
     {
       "__class__": "ExternalScheduleData",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -1,4 +1,11 @@
-from dagster import job, op, repository
+from dagster import Definitions, asset, job, op, repository
+from dagster._config.structured_config import Resource
+from dagster._core.definitions.repository_definition import (
+    PendingRepositoryDefinition,
+    RepositoryDefinition,
+)
+from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.resource_output import ResourceOutput
 from dagster._core.host_representation import (
     ExternalPipelineData,
     external_repository_data_from_def,
@@ -32,6 +39,78 @@ def test_repository_snap_all_props():
     assert pipeline_snapshot.tags == {}
 
 
+def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefinition:
+    repo_or_caching_repo = definitions.get_inner_repository_for_loading_process()
+    return (
+        repo_or_caching_repo.compute_repository_definition()
+        if isinstance(repo_or_caching_repo, PendingRepositoryDefinition)
+        else repo_or_caching_repo
+    )
+
+
+def test_repository_snap_definitions_resources_basic():
+    @asset
+    def my_asset(foo: ResourceOutput[str]):
+        pass
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={"foo": ResourceDefinition.hardcoded_resource("wrapped")},
+    )
+
+    repo = resolve_pending_repo_if_required(defs)
+    external_repo_data = external_repository_data_from_def(repo)
+
+    assert len(external_repo_data.external_resource_data) == 1
+    assert external_repo_data.external_resource_data[0].name == "foo"
+    assert external_repo_data.external_resource_data[0].resource_snapshot.name == "foo"
+    assert external_repo_data.external_resource_data[0].resource_snapshot.description is None
+    assert external_repo_data.external_resource_data[0].configured_values == {}
+
+
+def test_repository_snap_definitions_resources_complex():
+    class MyStringResource(Resource):
+        """my description"""
+
+        my_string: str = "bar"
+
+    @asset
+    def my_asset(foo: MyStringResource):
+        pass
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "foo": MyStringResource(
+                my_string="baz",
+            )
+        },
+    )
+
+    repo = resolve_pending_repo_if_required(defs)
+    external_repo_data = external_repository_data_from_def(repo)
+
+    assert len(external_repo_data.external_resource_data) == 1
+    assert external_repo_data.external_resource_data[0].name == "foo"
+    assert external_repo_data.external_resource_data[0].resource_snapshot.name == "foo"
+    assert (
+        external_repo_data.external_resource_data[0].resource_snapshot.description
+        == "my description"
+    )
+
+    # Ensure we get config snaps for the resource's fields
+    assert len(external_repo_data.external_resource_data[0].config_field_snaps) == 1
+    snap = external_repo_data.external_resource_data[0].config_field_snaps[0]
+    assert snap.name == "my_string"
+    assert not snap.is_required
+    assert snap.default_value_as_json_str == '"bar"'
+
+    # Ensure we get the configured values for the resource
+    assert external_repo_data.external_resource_data[0].configured_values == {
+        "my_string": '"baz"',
+    }
+
+
 def test_repository_snap_empty():
     @repository
     def empty_repo():
@@ -40,3 +119,4 @@ def test_repository_snap_empty():
     external_repo_data = external_repository_data_from_def(empty_repo)
     assert external_repo_data.name == "empty_repo"
     assert len(external_repo_data.external_pipeline_datas) == 0
+    assert len(external_repo_data.external_resource_data) == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -145,6 +145,10 @@ def test_with_resource_binding():
         resources={"foo": ResourceDefinition.hardcoded_resource("wrapped")},
     )
     repo = resolve_pending_repo_if_required(defs)
+
+    assert len(repo.get_top_level_resources()) == 1
+    assert "foo" in repo.get_top_level_resources()
+
     asset_job = repo.get_all_jobs()[0]
     asset_job.execute_in_process()
     assert executed["yes"]
@@ -163,6 +167,10 @@ def test_resource_coercion():
         resources={"foo": "object-to-coerce"},
     )
     repo = resolve_pending_repo_if_required(defs)
+
+    assert len(repo.get_top_level_resources()) == 1
+    assert "foo" in repo.get_top_level_resources()
+
     asset_job = repo.get_all_jobs()[0]
     asset_job.execute_in_process()
     assert executed["yes"]


### PR DESCRIPTION
## Summary

Incorporates top-level resources into the Repository object, serializing them and sending them as part of external repository data so that they can be displayed in the UI (see stacked PRs).

Also incorporates the change from #11470 to copy values into default values when configuring structured resources.

## Test Plan

Unit tests.