### PR TITLE
chore(dagit): remove unnecessary dependencies

### DIFF
--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -42,14 +42,10 @@ setup(
     packages=find_packages(exclude=["dagit_tests*"]),
     include_package_data=True,
     install_requires=[
-        "PyYAML",
         # cli
         "click>=7.0,<9.0",
         f"dagster{pin}",
         f"dagster-graphql{pin}",
-        "requests",
-        # watchdog
-        "watchdog>=0.8.3",
         "starlette",
         "uvicorn[standard]",
     ],


### PR DESCRIPTION
### Summary & Motivation
Was randomly investigating the potential for installing dagit via `pip install dagster[dagit]`: these dependencies aren't explicitly when spinning up the webserver. 

Remove them.

### How I Tested These Changes
bk
