### PR TITLE
Add .git to excludes for ruff in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,13 +86,14 @@ exclude = [
   "*/__generated__/*",
   "*/dagster_airflow/vendor/*",
   "*/snapshots/*",
+  ".git/*"
 ]
 
 ignore = [
 
   # (module level import not at top) There are several places where we use e.g.
   # warnings.filterwarings calls before imports.
-  "E402", 
+  "E402",
 
   # (line too long): This fires for comments, which black won't wrap.
   # Disabling until there is an autoformat solution available for comments.


### PR DESCRIPTION
### Summary & Motivation

Looks like ruff was parsing all the files in .git. Excluding it via pyproject.toml

### How I Tested These Changes

(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:dagster schrockn$ make ruff

Before:

```
(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:dagster schrockn$ make ruff
ruff --fix .
.git/logs/refs/remotes/origin/yuhan/12-12-convert-examples_4.2/_assets_pandas_type_metadata_repository.py_-___init__.py:1:43: E999 SyntaxError: invalid syntax. Got unexpected token 'a13b52de68dfa49916333202bf26d70ab50cb8db'
Found 1 error(s).
make: *** [ruff] Error 1
(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:dagster schrockn$
```

After
```
(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:dagster schrockn$ make ruff
ruff --fix .
(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:dagster schrockn$
```