### PR TITLE
Add persist_run_for_production; Use it in sensor run creation pathways

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/persist_run.py
+++ b/python_modules/dagster/dagster/_core/instance/persist_run.py
@@ -1,0 +1,68 @@
+from typing import Mapping, Optional
+
+from dagster._core.definitions.selector import PipelineSelector
+from dagster._core.definitions.utils import validate_tags
+from dagster._core.host_representation.code_location import CodeLocation
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
+from dagster._core.utils import make_new_run_id
+
+
+def persist_run(
+    *,
+    instance: DagsterInstance,
+    code_location: CodeLocation,
+    pipeline_selector: PipelineSelector,
+    run_config: Mapping[str, object],
+    run_tags: Mapping[str, str],
+    explicit_mode: Optional[str],
+) -> DagsterRun:
+    """Creates a run suitable for production using host process (i.e. External*) APIs.
+    This orchestrates necessary interactions with the user process (such as
+    fetching the external pipeline appropriate to the passed subset and
+    compiling the execution plan). This persists a run in instance with the
+    NOT_STARTED state.
+
+    Parameters:
+        instance (DagsterInstance): Instace to execute against
+        code_location (CodeLocation): RepositoryLocation corresponding to user code
+        pipeline_selector (PipelineSelector): Selector that encapsulates subset of pipeline that will be executed
+        run_config (Mapping[str, object]): Run configuration for this run
+        run_tags (Mapping[str, str]): Callsites typically have tags
+            specific to their context (e.g. users can specify ad hoc tags for runs in UI-driven cases).
+            This set of tags will be merged with the tags on the pipeline itself.
+        explicit_mode Optional[str]: Explicitly override the default mode for the pipeline.
+    """
+    external_pipeline = code_location.get_external_pipeline(pipeline_selector)
+    mode = explicit_mode or external_pipeline.get_default_mode_name()
+
+    external_execution_plan = code_location.get_external_execution_plan(
+        external_pipeline=external_pipeline,
+        run_config=run_config,
+        mode=mode,
+        step_keys_to_execute=None,
+        known_state=None,
+        instance=instance,
+    )
+
+    return instance.create_run(
+        pipeline_snapshot=external_pipeline.pipeline_snapshot,
+        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
+        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+        pipeline_name=external_pipeline.name,
+        run_id=make_new_run_id(),
+        asset_selection=frozenset(pipeline_selector.asset_selection)
+        if pipeline_selector.asset_selection
+        else None,
+        solid_selection=pipeline_selector.solid_selection,
+        solids_to_execute=external_pipeline.solids_to_execute,
+        run_config=run_config,
+        mode=mode,
+        step_keys_to_execute=external_execution_plan.step_keys_in_plan,
+        tags=validate_tags({**external_pipeline.tags, **run_tags}),
+        root_run_id=None,
+        parent_run_id=None,
+        status=DagsterRunStatus.NOT_STARTED,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -29,12 +29,12 @@ import dagster._seven as seven
 from dagster._core.definitions.run_request import InstigatorType, RunRequest
 from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorExecutionData
-from dagster._core.definitions.utils import validate_tags
 from dagster._core.errors import DagsterError
 from dagster._core.host_representation.code_location import CodeLocation
-from dagster._core.host_representation.external import ExternalPipeline, ExternalSensor
+from dagster._core.host_representation.external import ExternalSensor
 from dagster._core.host_representation.external_data import ExternalTargetData
 from dagster._core.instance import DagsterInstance
+from dagster._core.instance.persist_run import persist_run
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -50,7 +50,6 @@ from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
-from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
     from pendulum.datetime import DateTime
@@ -669,16 +668,26 @@ def _evaluate_sensor(
             solid_selection=target_data.solid_selection,
             asset_selection=run_request.asset_selection,
         )
-        external_pipeline = code_location.get_external_pipeline(pipeline_selector)
+        # <<<<<<< HEAD
+        #         external_pipeline = code_location.get_external_pipeline(pipeline_selector)
+        #         run = _get_or_create_sensor_run(
+        #             context,
+        #             instance,
+        #             code_location,
+        #             external_sensor,
+        #             external_pipeline,
+        #             run_request,
+        #             target_data,
+        #             existing_runs_by_key,
+        # # =======
         run = _get_or_create_sensor_run(
-            context,
-            instance,
-            code_location,
-            external_sensor,
-            external_pipeline,
-            run_request,
-            target_data,
-            existing_runs_by_key,
+            context=context,
+            instance=instance,
+            code_location=code_location,
+            external_sensor=external_sensor,
+            run_request=run_request,
+            existing_runs_by_key=existing_runs_by_key,
+            pipeline_selector=pipeline_selector,
         )
 
         if isinstance(run, SkippedSensorRun):
@@ -785,18 +794,22 @@ def _fetch_existing_runs(
 
 
 def _get_or_create_sensor_run(
+    *,
     context: SensorLaunchContext,
     instance: DagsterInstance,
     code_location: CodeLocation,
     external_sensor: ExternalSensor,
-    external_pipeline: ExternalPipeline,
     run_request: RunRequest,
-    target_data: ExternalTargetData,
     existing_runs_by_key: Mapping[str, DagsterRun],
+    pipeline_selector: PipelineSelector,
 ) -> Union[DagsterRun, SkippedSensorRun]:
     if not run_request.run_key:
         return _create_sensor_run(
-            instance, code_location, external_sensor, external_pipeline, run_request, target_data
+            instance=instance,
+            code_location=code_location,
+            external_sensor=external_sensor,
+            run_request=run_request,
+            pipeline_selector=pipeline_selector,
         )
 
     run = existing_runs_by_key.get(run_request.run_key)
@@ -816,37 +829,23 @@ def _get_or_create_sensor_run(
     context.logger.info(f"Creating new run for {external_sensor.name}")
 
     return _create_sensor_run(
-        instance, code_location, external_sensor, external_pipeline, run_request, target_data
+        instance=instance,
+        code_location=code_location,
+        external_sensor=external_sensor,
+        run_request=run_request,
+        pipeline_selector=pipeline_selector,
     )
 
 
 def _create_sensor_run(
+    *,
     instance: DagsterInstance,
     code_location: CodeLocation,
     external_sensor: ExternalSensor,
-    external_pipeline: ExternalPipeline,
     run_request: RunRequest,
-    target_data: ExternalTargetData,
-) -> DagsterRun:
+    pipeline_selector: PipelineSelector,
+):
     from dagster._daemon.daemon import get_telemetry_daemon_session_id
-
-    external_execution_plan = code_location.get_external_execution_plan(
-        external_pipeline,
-        run_request.run_config,
-        target_data.mode,
-        step_keys_to_execute=None,
-        known_state=None,
-        instance=instance,
-    )
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
-
-    pipeline_tags = validate_tags(external_pipeline.tags or {}, allow_reserved_tags=False)
-    tags = merge_dicts(
-        merge_dicts(pipeline_tags, run_request.tags),
-        DagsterRun.tags_for_sensor(external_sensor),
-    )
-    if run_request.run_key:
-        tags[RUN_KEY_TAG] = run_request.run_key
 
     log_action(
         instance,
@@ -854,29 +853,20 @@ def _create_sensor_run(
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
             "SENSOR_NAME_HASH": hash_name(external_sensor.name),
-            "pipeline_name_hash": hash_name(external_pipeline.name),
+            "pipeline_name_hash": hash_name(pipeline_selector.pipeline_name),
             "repo_hash": hash_name(code_location.name),
         },
     )
 
-    return instance.create_run(
-        pipeline_name=target_data.pipeline_name,
-        run_id=None,
+    return persist_run(
+        instance=instance,
+        code_location=code_location,
+        pipeline_selector=pipeline_selector,
         run_config=run_request.run_config,
-        mode=target_data.mode,
-        solids_to_execute=external_pipeline.solids_to_execute,
-        step_keys_to_execute=None,
-        status=DagsterRunStatus.NOT_STARTED,
-        solid_selection=target_data.solid_selection,
-        root_run_id=None,
-        parent_run_id=None,
-        tags=tags,
-        pipeline_snapshot=external_pipeline.pipeline_snapshot,
-        execution_plan_snapshot=execution_plan_snapshot,
-        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
-        external_pipeline_origin=external_pipeline.get_external_origin(),
-        pipeline_code_origin=external_pipeline.get_python_origin(),
-        asset_selection=frozenset(run_request.asset_selection)
-        if run_request.asset_selection
-        else None,
+        run_tags={
+            **run_request.tags,
+            **DagsterRun.tags_for_sensor(external_sensor),
+            **({RUN_KEY_TAG: run_request.run_key} if run_request.run_key else {}),
+        },
+        explicit_mode=external_sensor.mode,
     )


### PR DESCRIPTION
### Summary & Motivation

This adds a higher level function, persist_run_for_production, to encapsulate run creation pathways. As laid out in https://github.com/dagster-io/dagster/pull/11446 the run creation pathways are in a tough spot. Here we introduce a higher level API to persist new runs suitable for production. I will be adding call sites to this function and introducing new features incrementally as needed (e.g. setting root_run_id, parent_run_id, and explicit run ids)  

Note that I am changing validate_tags to allow for reserved tag names. At this layer in the stack it seems unnecessary and some legitimate tests rely on it (`test_launch_using_memoization`).

### How I Tested These Changes

BK
