### PR TITLE
chore(ruff): add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.212
+  hooks:
+    - id: ruff
+      # Respect `exclude` and `extend-exclude` settings.
+      args: ["--force-exclude"]


### PR DESCRIPTION
### Summary & Motivation
Check the pre-commit configuration in the repository. Using this is still optional, since you have to run pre-commit install before the git hooks are setup.

### How I Tested These Changes
```
brew install pre-commit
pre-commit install
```
