### PR TITLE
Use persist_run_for_production in dagster cli pathways; add explicit_run_id parameter

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/persist_run.py
+++ b/python_modules/dagster/dagster/_core/instance/persist_run.py
@@ -16,6 +16,7 @@ def persist_run(
     run_config: Mapping[str, object],
     run_tags: Mapping[str, str],
     explicit_mode: Optional[str],
+    explicit_run_id: Optional[str],
 ) -> DagsterRun:
     """
     Creates a run suitable for production using host process (i.e. External*) APIs.
@@ -33,6 +34,8 @@ def persist_run(
             specific to their context (e.g. users can specify ad hoc tags for runs in UI-driven cases).
             This set of tags will be merged with the tags on the pipeline itself.
         explicit_mode Optional[str]: Explicitly override the default mode for the pipeline.
+        explicit_run_id Optional[str]: Explicitly override run_id. If not specified run created
+            using make_new_run_id
     """
     external_pipeline = repository_location.get_external_pipeline(pipeline_selector)
     mode = explicit_mode or external_pipeline.get_default_mode_name()
@@ -51,7 +54,7 @@ def persist_run(
         parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
         execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
         pipeline_name=external_pipeline.name,
-        run_id=make_new_run_id(),
+        run_id=explicit_run_id or make_new_run_id(),
         asset_selection=frozenset(pipeline_selector.asset_selection)
         if pipeline_selector.asset_selection
         else None,

--- a/python_modules/dagster/dagster/_core/instance/persist_run.py
+++ b/python_modules/dagster/dagster/_core/instance/persist_run.py
@@ -1,8 +1,8 @@
 from typing import Mapping, Optional
 
+from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.definitions.utils import validate_tags
 from dagster._core.host_representation.repository_location import RepositoryLocation
-from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.utils import make_new_run_id

--- a/python_modules/dagster/dagster/_core/instance/persist_run.py
+++ b/python_modules/dagster/dagster/_core/instance/persist_run.py
@@ -1,0 +1,69 @@
+from typing import Mapping, Optional
+
+from dagster._core.definitions.utils import validate_tags
+from dagster._core.host_representation.repository_location import RepositoryLocation
+from dagster._core.host_representation.selector import PipelineSelector
+from dagster._core.instance import DagsterInstance
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
+from dagster._core.utils import make_new_run_id
+
+
+def persist_run(
+    *,
+    instance: DagsterInstance,
+    repository_location: RepositoryLocation,
+    pipeline_selector: PipelineSelector,
+    run_config: Mapping[str, object],
+    run_tags: Mapping[str, str],
+    explicit_mode: Optional[str],
+) -> DagsterRun:
+    """
+    Creates a run suitable for production using host process (i.e. External*) APIs.
+    This orchestrates necessary interactions with the user process (such as
+    fetching the external pipeline appropriate to the passed subset and
+    compiling the execution plan). This persists a run in instance with the
+    NOT_STARTED state.
+
+    Parameters:
+        instance (DagsterInstance): Instace to execute against
+        repository_location (RepositoryLocation): RepositoryLocation corresponding to user code
+        pipeline_selector (PipelineSelector): Selector that encapsulates subset of pipeline that will be executed
+        run_config (Mapping[str, object]): Run configuration for this run
+        run_tags (Mapping[str, str]): Callsites typically have tags
+            specific to their context (e.g. users can specify ad hoc tags for runs in UI-driven cases).
+            This set of tags will be merged with the tags on the pipeline itself.
+        explicit_mode Optional[str]: Explicitly override the default mode for the pipeline.
+    """
+    external_pipeline = repository_location.get_external_pipeline(pipeline_selector)
+    mode = explicit_mode or external_pipeline.get_default_mode_name()
+
+    external_execution_plan = repository_location.get_external_execution_plan(
+        external_pipeline=external_pipeline,
+        run_config=run_config,
+        mode=mode,
+        step_keys_to_execute=None,
+        known_state=None,
+        instance=instance,
+    )
+
+    return instance.create_run(
+        pipeline_snapshot=external_pipeline.pipeline_snapshot,
+        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
+        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+        pipeline_name=external_pipeline.name,
+        run_id=make_new_run_id(),
+        asset_selection=frozenset(pipeline_selector.asset_selection)
+        if pipeline_selector.asset_selection
+        else None,
+        solid_selection=pipeline_selector.solid_selection,
+        solids_to_execute=external_pipeline.solids_to_execute,
+        run_config=run_config,
+        mode=mode,
+        step_keys_to_execute=external_execution_plan.step_keys_in_plan,
+        tags=validate_tags({**external_pipeline.tags, **run_tags}),
+        root_run_id=None,
+        parent_run_id=None,
+        status=DagsterRunStatus.NOT_STARTED,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -839,4 +839,5 @@ def _create_sensor_run(
             **({RUN_KEY_TAG: run_request.run_key} if run_request.run_key else {}),
         },
         explicit_mode=external_sensor.mode,
+        explicit_run_id=None,
     )

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -16,12 +16,12 @@ import dagster._seven as seven
 from dagster._core.definitions.run_request import InstigatorType, RunRequest
 from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorExecutionData
-from dagster._core.definitions.utils import validate_tags
 from dagster._core.errors import DagsterError
-from dagster._core.host_representation.external import ExternalPipeline, ExternalSensor
+from dagster._core.host_representation.external import ExternalSensor
 from dagster._core.host_representation.external_data import ExternalTargetData
 from dagster._core.host_representation.repository_location import RepositoryLocation
 from dagster._core.instance import DagsterInstance
+from dagster._core.instance.persist_run import persist_run
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -36,7 +36,6 @@ from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._scheduler.stale import resolve_stale_or_unknown_assets
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
-from dagster._utils.merger import merge_dicts
 
 MIN_INTERVAL_LOOP_TIME = 5
 
@@ -649,16 +648,14 @@ def _evaluate_sensor(
             solid_selection=target_data.solid_selection,
             asset_selection=run_request.asset_selection,
         )
-        external_pipeline = repo_location.get_external_pipeline(pipeline_selector)
         run = _get_or_create_sensor_run(
-            context,
-            instance,
-            repo_location,
-            external_sensor,
-            external_pipeline,
-            run_request,
-            target_data,
-            existing_runs_by_key,
+            context=context,
+            instance=instance,
+            repo_location=repo_location,
+            external_sensor=external_sensor,
+            run_request=run_request,
+            existing_runs_by_key=existing_runs_by_key,
+            pipeline_selector=pipeline_selector,
         )
 
         if isinstance(run, SkippedSensorRun):
@@ -767,18 +764,22 @@ def _fetch_existing_runs(
 
 
 def _get_or_create_sensor_run(
+    *,
     context: SensorLaunchContext,
     instance: DagsterInstance,
     repo_location: RepositoryLocation,
     external_sensor: ExternalSensor,
-    external_pipeline: ExternalPipeline,
     run_request: RunRequest,
-    target_data: ExternalTargetData,
     existing_runs_by_key: Mapping[str, DagsterRun],
+    pipeline_selector: PipelineSelector,
 ):
     if not run_request.run_key:
         return _create_sensor_run(
-            instance, repo_location, external_sensor, external_pipeline, run_request, target_data
+            instance=instance,
+            repo_location=repo_location,
+            external_sensor=external_sensor,
+            run_request=run_request,
+            pipeline_selector=pipeline_selector,
         )
 
     run = existing_runs_by_key.get(run_request.run_key)
@@ -798,37 +799,23 @@ def _get_or_create_sensor_run(
     context.logger.info(f"Creating new run for {external_sensor.name}")
 
     return _create_sensor_run(
-        instance, repo_location, external_sensor, external_pipeline, run_request, target_data
+        instance=instance,
+        repo_location=repo_location,
+        external_sensor=external_sensor,
+        run_request=run_request,
+        pipeline_selector=pipeline_selector,
     )
 
 
 def _create_sensor_run(
+    *,
     instance: DagsterInstance,
     repo_location: RepositoryLocation,
     external_sensor: ExternalSensor,
-    external_pipeline: ExternalPipeline,
     run_request: RunRequest,
-    target_data: ExternalTargetData,
+    pipeline_selector: PipelineSelector,
 ):
     from dagster._daemon.daemon import get_telemetry_daemon_session_id
-
-    external_execution_plan = repo_location.get_external_execution_plan(
-        external_pipeline,
-        run_request.run_config,
-        target_data.mode,
-        step_keys_to_execute=None,
-        known_state=None,
-        instance=instance,
-    )
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
-
-    pipeline_tags = validate_tags(external_pipeline.tags or {}, allow_reserved_tags=False)
-    tags = merge_dicts(
-        merge_dicts(pipeline_tags, run_request.tags),
-        DagsterRun.tags_for_sensor(external_sensor),
-    )
-    if run_request.run_key:
-        tags[RUN_KEY_TAG] = run_request.run_key
 
     log_action(
         instance,
@@ -836,29 +823,20 @@ def _create_sensor_run(
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
             "SENSOR_NAME_HASH": hash_name(external_sensor.name),
-            "pipeline_name_hash": hash_name(external_pipeline.name),
+            "pipeline_name_hash": hash_name(pipeline_selector.pipeline_name),
             "repo_hash": hash_name(repo_location.name),
         },
     )
 
-    return instance.create_run(
-        pipeline_name=target_data.pipeline_name,
-        run_id=None,
+    return persist_run(
+        instance=instance,
+        repository_location=repo_location,
+        pipeline_selector=pipeline_selector,
         run_config=run_request.run_config,
-        mode=target_data.mode,
-        solids_to_execute=external_pipeline.solids_to_execute,
-        step_keys_to_execute=None,
-        status=DagsterRunStatus.NOT_STARTED,
-        solid_selection=target_data.solid_selection,
-        root_run_id=None,
-        parent_run_id=None,
-        tags=tags,
-        pipeline_snapshot=external_pipeline.pipeline_snapshot,
-        execution_plan_snapshot=execution_plan_snapshot,
-        parent_pipeline_snapshot=external_pipeline.parent_pipeline_snapshot,
-        external_pipeline_origin=external_pipeline.get_external_origin(),
-        pipeline_code_origin=external_pipeline.get_python_origin(),
-        asset_selection=frozenset(run_request.asset_selection)
-        if run_request.asset_selection
-        else None,
+        run_tags={
+            **run_request.tags,
+            **DagsterRun.tags_for_sensor(external_sensor),
+            **({RUN_KEY_TAG: run_request.run_key} if run_request.run_key else {}),
+        },
+        explicit_mode=external_sensor.mode,
     )

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -744,4 +744,5 @@ def _create_scheduler_run(
             **({RUN_KEY_TAG: run_request.run_key} if run_request.run_key else {}),
         },
         explicit_mode=external_schedule.mode,
+        explicit_run_id=None,
     )


### PR DESCRIPTION
### Summary & Motivation

Continue to convert callsites. To support the CLI needed to add an explicit_run_id parameter.

Note that I made this required so that callsites must make an explicit decision whether to support it or not.

### How I Tested These Changes

BK
