### PR TITLE
pydantic 1.7.x fix for structured config

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -30,16 +30,16 @@ from dagster._core.definitions.resource_definition import ResourceDefinition, Re
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
 
-class MakeConfigCacheable(
-    BaseModel,
+class MakeConfigCacheable(BaseModel):
     # Various pydantic model config (https://docs.pydantic.dev/usage/model_config/)
-    # Necessary to allow for caching decorators
-    arbitrary_types_allowed=True,
-    # Avoid pydantic reading a cached property class as part of the schema
-    keep_untouched=(cached_property,),
-    # Ensure the class is serializable, for caching purposes
-    frozen=True,
-):
+    class Config:
+        # Necessary to allow for caching decorators
+        arbitrary_types_allowed = True
+        # Avoid pydantic reading a cached property class as part of the schema
+        keep_untouched = (cached_property,)
+        # Ensure the class is serializable, for caching purposes
+        frozen = True
+
     """This class centralizes and implements all the chicanery we need in order
     to support caching decorators. If we decide this is a bad idea we can remove it
     all in one go.
@@ -63,10 +63,13 @@ class Config(MakeConfigCacheable):
     """
 
 
-class PermissiveConfig(Config, extra="allow"):
+class PermissiveConfig(Config):
     """
     Base class for Dagster configuration models that allow arbitrary extra fields.
     """
+
+    class Config(Config.Config):
+        extra = "allow"
 
 
 def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSchema:


### PR DESCRIPTION
Summary:
kwargs for basemodels were added in 1.8 apparently

### Summary & Motivation

### How I Tested These Changes
