### PR TITLE
Use Config class instead of base class kwargs in structured config to not break early pydantic versions

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -37,7 +37,7 @@ class MakeConfigCacheable(BaseModel):
     """
 
     # Pydantic config for this class
-    # Cannot use kwargs for base class as this is not support for pydnatic <1.8
+    # Cannot use kwargs for base class as this is not support for pydnatic<1.8
     class Config:
         # Various pydantic model config (https://docs.pydantic.dev/usage/model_config/)
         # Necessary to allow for caching decorators
@@ -67,7 +67,7 @@ class Config(MakeConfigCacheable):
 
 class PermissiveConfig(Config):
     # Pydantic config for this class
-    # Cannot use kwargs for base class as this is not support for pydnatic <1.8
+    # Cannot use kwargs for base class as this is not support for pydantic<1.8
     class Config:
         extra = "allow"
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -30,20 +30,22 @@ from dagster._core.definitions.resource_definition import ResourceDefinition, Re
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
 
-class MakeConfigCacheable(
-    BaseModel,
-    # Various pydantic model config (https://docs.pydantic.dev/usage/model_config/)
-    # Necessary to allow for caching decorators
-    arbitrary_types_allowed=True,
-    # Avoid pydantic reading a cached property class as part of the schema
-    keep_untouched=(cached_property,),
-    # Ensure the class is serializable, for caching purposes
-    frozen=True,
-):
+class MakeConfigCacheable(BaseModel):
     """This class centralizes and implements all the chicanery we need in order
     to support caching decorators. If we decide this is a bad idea we can remove it
     all in one go.
     """
+
+    # Pydantic config for this class
+    # Cannot use kwargs for base class as this is not support for pydnatic <1.8
+    class Config:
+        # Various pydantic model config (https://docs.pydantic.dev/usage/model_config/)
+        # Necessary to allow for caching decorators
+        arbitrary_types_allowed = True
+        # Avoid pydantic reading a cached property class as part of the schema
+        keep_untouched = (cached_property,)
+        # Ensure the class is serializable, for caching purposes
+        frozen = True
 
     def __setattr__(self, name: str, value: Any):
         # This is a hack to allow us to set attributes on the class that are not part of the
@@ -63,7 +65,12 @@ class Config(MakeConfigCacheable):
     """
 
 
-class PermissiveConfig(Config, extra="allow"):
+class PermissiveConfig(Config):
+    # Pydantic config for this class
+    # Cannot use kwargs for base class as this is not support for pydnatic <1.8
+    class Config:
+        extra = "allow"
+
     """
     Base class for Dagster configuration models that allow arbitrary extra fields.
     """

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
@@ -3,6 +3,7 @@ from dagster import job, op
 from dagster._config.config_type import ConfigTypeKind
 from dagster._config.structured_config import Config, PermissiveConfig
 from dagster._core.errors import DagsterInvalidConfigError
+from dagster._utils.cached_method import cached_method
 
 
 def test_default_config_class_non_permissive():
@@ -76,3 +77,24 @@ def test_struct_config_permissive():
     )
 
     assert executed["yes"]
+
+
+def test_struct_config_persmissive_cached_method():
+    calls = {"plus": 0}
+
+    class PlusConfig(PermissiveConfig):
+        x: int
+        y: int
+
+        @cached_method
+        def plus(self):
+            calls["plus"] += 1
+            return self.x + self.y
+
+    plus_config = PlusConfig(x=1, y=2)
+
+    assert plus_config.plus() == 3
+    assert calls["plus"] == 1
+
+    assert plus_config.plus() == 3
+    assert calls["plus"] == 1


### PR DESCRIPTION
### Summary & Motivation

We were using base class kwargs arguments in Pydantic in the structured config workstream. This breaks pydantic <1.8. Using `Config` class instead of kwargs.

### How I Tested These Changes

```
dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:script_to_assets_branching_io_manager schrockn$ pip list | grep pydantic
pydantic                            1.7.4
(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:script_to_assets_branching_io_manager schrockn$ pytest /Users/schrockn/code/dagster/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py

This error occurred:
....
TypeError: MakeConfigCacheable.__init_subclass__() takes no keyword arguments

(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:script_to_assets_branching_io_manager schrockn$ git co fix-pydantic
Switched to branch 'fix-pydantic'
(dagster-x86-3.10.3) elementl-13in-m1-mbppro-2021:script_to_assets_branching_io_manager schrockn$ !pyt
pytest /Users/schrockn/code/dagster/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
WARNING:root:Unable to detect CI environment.  No test analytics will be sent.
================================================================================= test session starts ==================================================================================
platform darwin -- Python 3.10.3, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/schrockn/code/dagster, configfile: pyproject.toml
plugins: forked-1.4.0, structlog-0.5, ddtrace-1.6.1, buildkite-test-collector-0.1.3, dependency-0.5.1, requests-mock-1.10.0, snapshottest-0.6.0, xdist-2.1.0, mock-3.3.1, cov-2.10.1, respx-0.20.0, anyio-3.6.2, rerunfailures-10.0
collected 22 items

../../../python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py ......................                                          [100%]

================================================================================== 22 passed in 0.59s ==================================================================================
```
