### PR TITLE
Make JsonMetadataValue accept lists

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -8,7 +8,9 @@ from dagster import (
     DagsterEventType,
     FloatMetadataValue,
     IntMetadataValue,
+    JsonMetadataValue,
     MetadataValue,
+    NullMetadataValue,
     PathMetadataValue,
     PythonArtifactMetadataValue,
     TextMetadataValue,
@@ -18,7 +20,6 @@ from dagster._check import CheckError
 from dagster._core.definitions.metadata import (
     DagsterInvalidMetadata,
     MetadataEntry,
-    NullMetadataValue,
     normalize_metadata,
 )
 from dagster._core.definitions.metadata.table import (
@@ -159,6 +160,13 @@ def test_parse_null_metadata():
     entries = normalize_metadata(metadata, [])
     assert entries[0].label == "foo"
     assert entries[0].value == NullMetadataValue()
+
+
+def test_parse_list_metadata():
+    metadata = {"foo": ["bar"]}
+    entries = normalize_metadata(metadata, [])
+    assert entries[0].label == "foo"
+    assert entries[0].value == JsonMetadataValue(["bar"])
 
 
 def test_parse_invalid_metadata():


### PR DESCRIPTION
### Summary & Motivation

This allows the `JsonMetadataValue` type to accept lists as well as dicts, and automatically maps lists passed to normalize metadata to the json type.

I don't think any change is required in dagit, since in dagit the value is received as a string and later run through a JSON parser.

### How I Tested These Changes

Modified appropriate metadata unit tests.
