### PR TITLE
[fix] Fix builtin type error related to resource annotations

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -306,7 +306,14 @@ def _safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:
     """Version of issubclass that returns False if cls is not a Type."""
     if not isinstance(cls, type):
         return False
-    return issubclass(cls, possible_parent_cls)
+
+    try:
+        return issubclass(cls, possible_parent_cls)
+    except TypeError:
+        # Using builtin Python types in python 3.9+ will raise a TypeError when using issubclass
+        # even though the isinstance check will succeed (as will inspect.isclass), for example
+        # list[dict[str, str]] will raise a TypeError
+        return False
 
 
 def infer_schema_from_config_class(

--- a/python_modules/dagster/dagster/_core/definitions/resource_output.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_output.py
@@ -12,9 +12,18 @@ def get_resource_args(fn) -> Sequence[Parameter]:
 
 
 def _is_resource_annotated(param: Parameter) -> bool:
-    return (
-        isinstance(param.annotation, type) and issubclass(param.annotation, ResourceDefinition)
-    ) or (
+    extends_resource_definition = False
+    try:
+        extends_resource_definition = isinstance(param.annotation, type) and issubclass(
+            param.annotation, ResourceDefinition
+        )
+    except TypeError:
+        # Using builtin Python types in python 3.9+ will raise a TypeError when using issubclass
+        # even though the isinstance check will succeed (as will inspect.isclass), for example
+        # list[dict[str, str]] will raise a TypeError
+        pass
+
+    return (extends_resource_definition) or (
         hasattr(param.annotation, "__metadata__")
         and getattr(param.annotation, "__metadata__") == ("resource_output",)
     )

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -306,6 +306,8 @@ def test_asset_with_structured_config():
     assert executed["the_asset"]
 
 
+# Disabled for Python versions <3.9 as builtin types do not support generics
+# until Python 3.9, https://peps.python.org/pep-0585/
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9")
 def test_no_err_builtin_annotations():
     # Ensures that we can use Python builtin types without causing any issues, see

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any
 
 import pytest
@@ -303,3 +304,40 @@ def test_asset_with_structured_config():
         .success
     )
     assert executed["the_asset"]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9")
+def test_no_err_builtin_annotations():
+    # Ensures that we can use Python builtin types without causing any issues, see
+    # https://github.com/dagster-io/dagster/issues/11541
+
+    # Use aliases for the builtin types so that this doesn't cause a load error on
+    # python < 3.9
+    _list = list
+    _dict = dict
+
+    executed = {}
+
+    @asset
+    def the_asset(context, foo: ResourceOutput[str]):
+        assert context.resources.foo == "blah"
+        assert foo == "blah"
+        executed["the_asset"] = True
+        return [{"hello": "world"}]
+
+    @asset
+    def the_other_asset(context, the_asset: _list[_dict[str, str]], foo: ResourceOutput[str]):
+        assert context.resources.foo == "blah"
+        assert foo == "blah"
+        assert the_asset == [{"hello": "world"}]
+        executed["the_other_asset"] = True
+        return "world"
+
+    transformed_assets = with_resources(
+        [the_asset, the_other_asset],
+        {"foo": ResourceDefinition.hardcoded_resource("blah")},
+    )
+
+    assert build_assets_job("the_job", transformed_assets).execute_in_process().success
+    assert executed["the_asset"]
+    assert executed["the_other_asset"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -311,11 +311,6 @@ def test_no_err_builtin_annotations():
     # Ensures that we can use Python builtin types without causing any issues, see
     # https://github.com/dagster-io/dagster/issues/11541
 
-    # Use aliases for the builtin types so that this doesn't cause a load error on
-    # python < 3.9
-    _list = list
-    _dict = dict
-
     executed = {}
 
     @asset
@@ -326,7 +321,7 @@ def test_no_err_builtin_annotations():
         return [{"hello": "world"}]
 
     @asset
-    def the_other_asset(context, the_asset: _list[_dict[str, str]], foo: ResourceOutput[str]):
+    def the_other_asset(context, the_asset: list[dict[str, str]], foo: ResourceOutput[str]):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         assert the_asset == [{"hello": "world"}]


### PR DESCRIPTION
### Summary & Motivation

Addresses #11541, a bug introduced in #11322.

Users who are using Python >= 3.9 may use [builtin types](https://peps.python.org/pep-0585/) for generic type annotations, e.g. `list[dict[str, str]]` rather than `typing.List[typing.Dict[str, str]]`.

Unfortunately, these builtin generics manage to get around the safety checks in our subclass code - `isinstance(list[dict[str, str]], type) == True` and `inspect.isclass(list[dict[str, str]]) == True` but `issubclass(list[dict[str, str]], Resource)` raises an error that `list[dict[str, str]]` is not a class:

```python
TypeError: issubclass() arg 1 must be a class
```

This seems to be a specific issue related to `abc._abc_subclasscheck`, since `Resource` is an ABC. The CPython implementation of the subclass check seems to have different results than the python one, which uses `isinstance(..., type)` under the hood: https://bugs.python.org/issue44847

This PR adds a try/catch guard to areas where we make a subclass call to avoid this issue.

## Test Plan

Add a test suite which is run for Python >= 3.9 to ensure builtin generics can be used.


