### PR TITLE
fix remote captured log manager complete check

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -112,7 +112,10 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
         self.upload_to_cloud_storage(log_key, ComputeIOType.STDERR)
 
     def is_capture_complete(self, log_key: Sequence[str]) -> bool:
-        return self.local_manager.is_capture_complete(log_key)
+        if self.local_manager.is_capture_complete(log_key):
+            return True
+        # check remote storage
+        return self.cloud_storage_has_logs(log_key, ComputeIOType.STDERR)
 
     def _log_data_for_type(self, log_key, io_type, offset, max_bytes):
         if self._has_local_file(log_key, io_type):

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
@@ -108,7 +108,7 @@ class TestCapturedLogManager:
             pytest.skip("does not support streaming")
 
         now = pendulum.now("UTC")
-        log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
+        log_key = ["streaming", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):
             print("hello stdout")  # pylint: disable=print-call
             print("hello stderr", file=sys.stderr)  # pylint: disable=print-call
@@ -145,7 +145,7 @@ class TestCapturedLogManager:
             pytest.skip("unnecessary check since write/read manager should have the same behavior")
 
         now = pendulum.now("UTC")
-        log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
+        log_key = ["complete", "test", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):
             print("hello stdout")  # pylint: disable=print-call
             print("hello stderr", file=sys.stderr)  # pylint: disable=print-call

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
@@ -45,7 +45,8 @@ class TestCapturedLogManager:
         should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
     )
     def test_capture(self, captured_log_manager):
-        log_key = ["foo"]
+        now = pendulum.now("UTC")
+        log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
 
         with captured_log_manager.capture_logs(log_key) as context:
             print("HELLO WORLD")  # pylint: disable=print-call
@@ -134,6 +135,15 @@ class TestCapturedLogManager:
         should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
     )
     def test_complete_checks(self, write_manager, read_manager):
+        from dagster._core.storage.cloud_storage_compute_log_manager import (
+            CloudStorageComputeLogManager,
+        )
+
+        if not isinstance(write_manager, CloudStorageComputeLogManager) or not isinstance(
+            read_manager, CloudStorageComputeLogManager
+        ):
+            pytest.skip("unnecessary check since write/read manager should have the same behavior")
+
         now = pendulum.now("UTC")
         log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):


### PR DESCRIPTION
### Summary & Motivation
We should be checking to see if the capture is complete by checking remote storage, not just local storage so that the read-side compute log manager can report download links accurately.

This should ensure that download links can be constructed properly

### How I Tested These Changes
BK