### PR TITLE
[3/n] Display top-level resources in Dagit sidebar

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -10,6 +10,7 @@ export const FeatureFlag = {
   flagDebugConsoleLogging: 'flagDebugConsoleLogging' as const,
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,
+  flagSidebarResources: 'flagSidebarResources' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 

--- a/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
@@ -16,4 +16,8 @@ export const getVisibleFeatureFlagRows = () => [
     key: 'Experimental schedule/sensor logging view',
     flagType: FeatureFlag.flagSensorScheduleLogging,
   },
+  {
+    key: 'Experimental resource view',
+    flagType: FeatureFlag.flagSidebarResources,
+  },
 ];

--- a/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
@@ -38,6 +38,34 @@ export const getAssetGroupItemsForOption = (option: DagsterRepoOption) => {
   return items.sort((a, b) => a.name.localeCompare(b.name));
 };
 
+export const getTopLevelResourceItemsForOption = (option: DagsterRepoOption) => {
+  const items: LeftNavItemType[] = [];
+
+  const {repository, repositoryLocation} = option;
+  const address = buildRepoAddress(repository.name, repositoryLocation.name);
+
+  for (const resource of repository.topLevelResources) {
+    items.push({
+      name: resource.name,
+      leftIcon: 'resource',
+      isJob: false,
+      schedules: [],
+      sensors: [],
+      repoAddress: address,
+      path: workspacePathFromAddress(address, `/resources/${resource.name}`),
+      label: (
+        <Label $hasIcon={false}>
+          <TruncatingName data-tooltip={resource.name} data-tooltip-style={LabelTooltipStyles}>
+            {resource.name}
+          </TruncatingName>
+        </Label>
+      ),
+    });
+  }
+
+  return items;
+};
+
 export const getJobItemsForOption = (option: DagsterRepoOption) => {
   const items: LeftNavItemType[] = [];
 

--- a/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
@@ -38,13 +38,13 @@ export const getAssetGroupItemsForOption = (option: DagsterRepoOption) => {
   return items.sort((a, b) => a.name.localeCompare(b.name));
 };
 
-export const getTopLevelResourceItemsForOption = (option: DagsterRepoOption) => {
+export const gettopLevelResourceDetailsItemsForOption = (option: DagsterRepoOption) => {
   const items: LeftNavItemType[] = [];
 
   const {repository, repositoryLocation} = option;
   const address = buildRepoAddress(repository.name, repositoryLocation.name);
 
-  for (const resource of repository.topLevelResources) {
+  for (const resource of repository.allTopLevelResourceDetails) {
     items.push({
       name: resource.name,
       leftIcon: 'resource',

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -62,8 +62,6 @@ export const ResourceRoot: React.FC<Props> = (props) => {
     notifyOnNetworkStatusChange: true,
   });
 
-  console.log(queryResult);
-
   return (
     <Page>
       <PageHeader

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -30,11 +30,11 @@ interface Props {
 }
 
 const remapName = (inName: string): string => {
-  if (inName == 'StringSourceType') {
+  if (inName === 'StringSourceType') {
     return 'String';
-  } else if (inName == 'IntSourceType') {
+  } else if (inName === 'IntSourceType') {
     return 'Int';
-  } else if (inName == 'BoolSourceType') {
+  } else if (inName === 'BoolSourceType') {
     return 'Bool';
   }
   return inName;
@@ -103,7 +103,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
                       const defaultValue = field.defaultValueAsJson;
                       const actualValue = configuredValues[field.name];
 
-                      const isDefault = defaultValue == actualValue;
+                      const isDefault = defaultValue === actualValue;
 
                       return (
                         <tr key={field.name}>

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -1,0 +1,207 @@
+import {gql, useQuery} from '@apollo/client';
+import {
+  Box,
+  Colors,
+  Heading,
+  Page,
+  PageHeader,
+  SplitPanelContainer,
+  Table,
+  Tag,
+  Tooltip,
+} from '@dagster-io/ui';
+import * as React from 'react';
+import {useParams} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {useTrackPageView} from '../app/analytics';
+import {ResourceRootQueryQuery} from '../graphql/graphql';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {RepositoryLink} from '../nav/RepositoryLink';
+import {SidebarSection} from '../pipelines/SidebarComponents';
+import {Loading} from '../ui/Loading';
+import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
+import {RepoAddress} from '../workspace/types';
+
+interface Props {
+  repoAddress: RepoAddress;
+}
+
+const remapName = (inName: string): string => {
+  if (inName == 'StringSourceType') {
+    return 'String';
+  } else if (inName == 'IntSourceType') {
+    return 'Int';
+  } else if (inName == 'BoolSourceType') {
+    return 'Bool';
+  }
+  return inName;
+};
+
+export const ResourceRoot: React.FC<Props> = (props) => {
+  useTrackPageView();
+
+  const {repoAddress} = props;
+
+  const {resourceName} = useParams<{resourceName: string}>();
+
+  useDocumentTitle(`Resource: ${resourceName}`);
+
+  const resourceSelector = {
+    ...repoAddressToSelector(repoAddress),
+    resourceName,
+  };
+  const queryResult = useQuery<ResourceRootQueryQuery>(RESOURCE_ROOT_QUERY, {
+    variables: {
+      resourceSelector,
+    },
+    fetchPolicy: 'cache-and-network',
+    partialRefetch: true,
+    notifyOnNetworkStatusChange: true,
+  });
+
+  console.log(queryResult);
+
+  return (
+    <Page>
+      <PageHeader
+        title={
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
+            <Heading>{resourceName}</Heading>
+          </Box>
+        }
+      />
+      <Loading queryResult={queryResult} allowStaleData={true}>
+        {({topLevelResourceOrError}) => {
+          if (topLevelResourceOrError.__typename !== 'TopLevelResource') {
+            return null;
+          }
+
+          const configuredValues = Object.fromEntries(
+            topLevelResourceOrError.configuredValues.map((cv) => [cv.key, cv.value]),
+          );
+
+          return (
+            <SplitPanelContainer
+              identifier="explorer"
+              firstInitialPercent={70}
+              firstMinSize={400}
+              height="calc(100% - 60px)"
+              first={
+                <Table>
+                  <thead>
+                    <tr>
+                      <th style={{width: 120}}>Key</th>
+                      <th style={{width: 90}}>Type</th>
+                      <th style={{width: 90}}>Value</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {topLevelResourceOrError.configFields.map((field) => {
+                      const defaultValue = field.defaultValueAsJson;
+                      const actualValue = configuredValues[field.name];
+
+                      const isDefault = defaultValue == actualValue;
+
+                      return (
+                        <tr key={field.name}>
+                          <td>
+                            <Box flex={{direction: 'column', gap: 4, alignItems: 'flex-start'}}>
+                              <strong>{field.name}</strong>
+                              <div style={{fontSize: 12, color: Colors.Gray700}}>
+                                {field.description}
+                              </div>
+                            </Box>
+                          </td>
+                          <td>{remapName(field.configTypeKey)}</td>
+                          <td>
+                            <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+                              <Tooltip content={<>Default: {defaultValue}</>} canShow={!isDefault}>
+                                {actualValue}
+                              </Tooltip>
+                              {isDefault && <Tag>Default</Tag>}
+                            </Box>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </Table>
+              }
+              second={
+                <RightInfoPanel>
+                  <RightInfoPanelContent>
+                    <Box
+                      flex={{gap: 4, direction: 'column'}}
+                      margin={{left: 24, right: 12, vertical: 16}}
+                    >
+                      <Heading>{resourceName}</Heading>
+                    </Box>
+
+                    <SidebarSection title="Definition">
+                      <Box padding={{vertical: 16, horizontal: 24}}>
+                        <Tag icon="resource">
+                          Resource in{' '}
+                          <RepositoryLink repoAddress={repoAddress} showRefresh={false} />
+                        </Tag>
+                      </Box>
+                    </SidebarSection>
+                    {topLevelResourceOrError.description ? (
+                      <SidebarSection title="Description">
+                        <Box padding={{vertical: 16, horizontal: 24}}>
+                          {topLevelResourceOrError.description}
+                        </Box>
+                      </SidebarSection>
+                    ) : null}
+                  </RightInfoPanelContent>
+                </RightInfoPanel>
+              }
+            />
+          );
+        }}
+      </Loading>
+    </Page>
+  );
+};
+
+export const RightInfoPanel = styled.div`
+  // Fixes major perofmance hit. To reproduce, add enough content to
+  // the sidebar that it scrolls (via overflow-y below) and then try
+  // to pan the DAG.
+  position: relative;
+
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: ${Colors.White};
+`;
+
+export const RightInfoPanelContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+`;
+
+const RESOURCE_ROOT_QUERY = gql(`
+  query ResourceRootQuery($resourceSelector: ResourceSelector!) {
+    topLevelResourceOrError(resourceSelector: $resourceSelector) {
+      ... on TopLevelResource {
+        name
+        description
+        configFields {
+          name
+          description
+          configTypeKey
+          isRequired
+          defaultValueAsJson
+        }
+        configuredValues {
+          key
+          value
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+`);

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -14,14 +14,16 @@ import * as React from 'react';
 import {useParams} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {useTrackPageView} from '../app/analytics';
-import {ResourceRootQueryQuery} from '../graphql/graphql';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {Loading} from '../ui/Loading';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
+
+import {ResourceRootQuery} from './types/ResourceRoot.types';
 
 interface Props {
   repoAddress: RepoAddress;
@@ -51,7 +53,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
     ...repoAddressToSelector(repoAddress),
     resourceName,
   };
-  const queryResult = useQuery<ResourceRootQueryQuery>(RESOURCE_ROOT_QUERY, {
+  const queryResult = useQuery<ResourceRootQuery>(RESOURCE_ROOT_QUERY, {
     variables: {
       resourceSelector,
     },
@@ -183,7 +185,7 @@ export const RightInfoPanelContent = styled.div`
   overflow-y: auto;
 `;
 
-const RESOURCE_ROOT_QUERY = gql(`
+const RESOURCE_ROOT_QUERY = gql`
   query ResourceRootQuery($resourceSelector: ResourceSelector!) {
     topLevelResourceOrError(resourceSelector: $resourceSelector) {
       ... on TopLevelResource {
@@ -204,4 +206,5 @@ const RESOURCE_ROOT_QUERY = gql(`
       ...PythonErrorFragment
     }
   }
-`);
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -67,11 +67,11 @@ export const ResourceRoot: React.FC<Props> = (props) => {
     <Page style={{height: '100%', overflow: 'hidden'}}>
       <PageHeader title={<Heading>{resourceName}</Heading>} />
       <Loading queryResult={queryResult} allowStaleData={true}>
-        {({topLevelResourceOrError}) => {
-          if (topLevelResourceOrError.__typename !== 'TopLevelResource') {
+        {({topLevelResourceDetailsOrError}) => {
+          if (topLevelResourceDetailsOrError.__typename !== 'topLevelResourceDetails') {
             let message: string | null = null;
-            if (topLevelResourceOrError.__typename === 'PythonError') {
-              message = topLevelResourceOrError.message;
+            if (topLevelResourceDetailsOrError.__typename === 'PythonError') {
+              message = topLevelResourceDetailsOrError.message;
             }
 
             return (
@@ -101,7 +101,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
           }
 
           const configuredValues = Object.fromEntries(
-            topLevelResourceOrError.configuredValues.map((cv) => [cv.key, cv.value]),
+            topLevelResourceDetailsOrError.configuredValues.map((cv) => [cv.key, cv.value]),
           );
 
           return (
@@ -120,7 +120,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
                       </tr>
                     </thead>
                     <tbody>
-                      {topLevelResourceOrError.configFields.map((field) => {
+                      {topLevelResourceDetailsOrError.configFields.map((field) => {
                         const defaultValue = field.defaultValueAsJson;
                         const actualValue =
                           field.name in configuredValues
@@ -175,10 +175,10 @@ export const ResourceRoot: React.FC<Props> = (props) => {
                           </Tag>
                         </Box>
                       </SidebarSection>
-                      {topLevelResourceOrError.description ? (
+                      {topLevelResourceDetailsOrError.description ? (
                         <SidebarSection title="Description">
                           <Box padding={{vertical: 16, horizontal: 24}}>
-                            {topLevelResourceOrError.description}
+                            {topLevelResourceDetailsOrError.description}
                           </Box>
                         </SidebarSection>
                       ) : null}
@@ -212,8 +212,8 @@ export const RightInfoPanelContent = styled.div`
 
 const RESOURCE_ROOT_QUERY = gql`
   query ResourceRootQuery($resourceSelector: ResourceSelector!) {
-    topLevelResourceOrError(resourceSelector: $resourceSelector) {
-      ... on TopLevelResource {
+    topLevelResourceDetailsOrError(resourceSelector: $resourceSelector) {
+      ... on ResourceDetails {
         name
         description
         configFields {

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -68,7 +68,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
       <PageHeader title={<Heading>{resourceName}</Heading>} />
       <Loading queryResult={queryResult} allowStaleData={true}>
         {({topLevelResourceDetailsOrError}) => {
-          if (topLevelResourceDetailsOrError.__typename !== 'topLevelResourceDetails') {
+          if (topLevelResourceDetailsOrError.__typename !== 'ResourceDetails') {
             let message: string | null = null;
             if (topLevelResourceDetailsOrError.__typename === 'PythonError') {
               message = topLevelResourceDetailsOrError.message;

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -1,0 +1,37 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type ResourceRootQueryVariables = Types.Exact<{
+  resourceSelector: Types.ResourceSelector;
+}>;
+
+export type ResourceRootQuery = {
+  __typename: 'DagitQuery';
+  topLevelResourceOrError:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {__typename: 'ResourceNotFoundError'}
+    | {
+        __typename: 'TopLevelResource';
+        name: string;
+        description: string | null;
+        configFields: Array<{
+          __typename: 'ConfigTypeField';
+          name: string;
+          description: string | null;
+          configTypeKey: string;
+          isRequired: boolean;
+          defaultValueAsJson: string | null;
+        }>;
+        configuredValues: Array<{__typename: 'ConfiguredValue'; key: string; value: string}>;
+      };
+};

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -8,7 +8,7 @@ export type ResourceRootQueryVariables = Types.Exact<{
 
 export type ResourceRootQuery = {
   __typename: 'DagitQuery';
-  topLevelResourceOrError:
+  topLevelResourceDetailsOrError:
     | {
         __typename: 'PythonError';
         message: string;
@@ -19,9 +19,8 @@ export type ResourceRootQuery = {
           error: {__typename: 'PythonError'; message: string; stack: Array<string>};
         }>;
       }
-    | {__typename: 'ResourceNotFoundError'}
     | {
-        __typename: 'TopLevelResource';
+        __typename: 'ResourceDetails';
         name: string;
         description: string | null;
         configFields: Array<{
@@ -33,5 +32,6 @@ export type ResourceRootQuery = {
           defaultValueAsJson: string | null;
         }>;
         configuredValues: Array<{__typename: 'ConfiguredValue'; key: string; value: string}>;
-      };
+      }
+    | {__typename: 'ResourceNotFoundError'};
 };

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -4,6 +4,7 @@ import {useRouteMatch} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {AppContext} from '../app/AppContext';
+import {useFeatureFlags} from '../app/Flags';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {LeftNavItem} from '../nav/LeftNavItem';
@@ -143,7 +144,13 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
 
   const jobItems = React.useMemo(() => getJobItemsForOption(option), [option]);
   const assetGroupItems = React.useMemo(() => getAssetGroupItemsForOption(option), [option]);
-  const resourceItems = React.useMemo(() => getTopLevelResourceItemsForOption(option), [option]);
+
+  const {flagSidebarResources} = useFeatureFlags();
+  const resourceItems = React.useMemo(
+    () => (flagSidebarResources ? getTopLevelResourceItemsForOption(option) : []),
+    [option, flagSidebarResources],
+  );
+
   const empty = jobItems.length === 0 && assetGroupItems.length === 0 && resourceItems.length === 0;
   const showTypeLabels =
     expanded &&

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -12,7 +12,7 @@ import {LeftNavItemType} from '../nav/LeftNavItemType';
 import {
   getAssetGroupItemsForOption,
   getJobItemsForOption,
-  getTopLevelResourceItemsForOption,
+  gettopLevelResourceDetailsItemsForOption,
 } from '../nav/getLeftNavItemsForOption';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
 import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
@@ -147,7 +147,7 @@ export const Section: React.FC<SectionProps> = React.memo((props) => {
 
   const {flagSidebarResources} = useFeatureFlags();
   const resourceItems = React.useMemo(
-    () => (flagSidebarResources ? getTopLevelResourceItemsForOption(option) : []),
+    () => (flagSidebarResources ? gettopLevelResourceDetailsItemsForOption(option) : []),
     [option, flagSidebarResources],
   );
 

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -122,6 +122,9 @@ const ROOT_WORKSPACE_QUERY = gql`
     assetGroups {
       groupName
     }
+    topLevelResources {
+      name
+    }
     ...RepositoryInfoFragment
   }
 

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -122,7 +122,7 @@ const ROOT_WORKSPACE_QUERY = gql`
     assetGroups {
       groupName
     }
-    topLevelResources {
+    allTopLevelResourceDetails {
       name
     }
     ...RepositoryInfoFragment

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -4,6 +4,7 @@ import {Route, Switch, useParams} from 'react-router-dom';
 
 import {AssetGroupRoot} from '../assets/AssetGroupRoot';
 import {PipelineRoot} from '../pipelines/PipelineRoot';
+import {ResourceRoot} from '../resources/ResourceRoot';
 import {ScheduleRoot} from '../schedules/ScheduleRoot';
 import {SensorRoot} from '../sensors/SensorRoot';
 
@@ -115,6 +116,9 @@ const RepoRouteContainer = () => {
       </Route>
       <Route path="/locations/:repoPath/sensors/:sensorName">
         <SensorRoot repoAddress={addressForPath} />
+      </Route>
+      <Route path="/locations/:repoPath/resources/:resourceName">
+        <ResourceRoot repoAddress={addressForPath} />
       </Route>
       <Route path={['/locations/:repoPath/asset-groups/:groupName/list(/?.*)']}>
         <AssetGroupRoot repoAddress={addressForPath} tab="list" />

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
@@ -94,6 +94,7 @@ export type RootWorkspaceQuery = {
                     pipelineName: string;
                   }>;
                   assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
+                  topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
                   location: {__typename: 'RepositoryLocation'; id: string; name: string};
                   displayMetadata: Array<{
                     __typename: 'RepositoryMetadata';
@@ -178,6 +179,7 @@ export type WorkspaceLocationNodeFragment = {
             pipelineName: string;
           }>;
           assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
+          topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
           location: {__typename: 'RepositoryLocation'; id: string; name: string};
           displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
         }>;
@@ -244,6 +246,7 @@ export type WorkspaceLocationFragment = {
       pipelineName: string;
     }>;
     assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
+    topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
     displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
   }>;
@@ -296,6 +299,7 @@ export type WorkspaceRepositoryFragment = {
     pipelineName: string;
   }>;
   assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
+  topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
   location: {__typename: 'RepositoryLocation'; id: string; name: string};
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
 };

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
@@ -94,7 +94,7 @@ export type RootWorkspaceQuery = {
                     pipelineName: string;
                   }>;
                   assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
-                  topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
+                  allTopLevelResourceDetails: Array<{__typename: 'ResourceDetails'; name: string}>;
                   location: {__typename: 'RepositoryLocation'; id: string; name: string};
                   displayMetadata: Array<{
                     __typename: 'RepositoryMetadata';
@@ -179,7 +179,7 @@ export type WorkspaceLocationNodeFragment = {
             pipelineName: string;
           }>;
           assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
-          topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
+          allTopLevelResourceDetails: Array<{__typename: 'ResourceDetails'; name: string}>;
           location: {__typename: 'RepositoryLocation'; id: string; name: string};
           displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
         }>;
@@ -246,7 +246,7 @@ export type WorkspaceLocationFragment = {
       pipelineName: string;
     }>;
     assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
-    topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
+    allTopLevelResourceDetails: Array<{__typename: 'ResourceDetails'; name: string}>;
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
     displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
   }>;
@@ -299,7 +299,7 @@ export type WorkspaceRepositoryFragment = {
     pipelineName: string;
   }>;
   assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
-  topLevelResources: Array<{__typename: 'TopLevelResource'; name: string}>;
+  allTopLevelResourceDetails: Array<{__typename: 'ResourceDetails'; name: string}>;
   location: {__typename: 'RepositoryLocation'; id: string; name: string};
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
 };

--- a/js_modules/dagit/packages/ui/src/components/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/ui/src/components/SplitPanelContainer.tsx
@@ -15,7 +15,6 @@ interface SplitPanelContainerProps {
   firstInitialPercent: number;
   firstMinSize?: number;
   second: React.ReactNode | null; // Note: pass null to hide / animate away the second panel
-  height?: string;
 }
 
 interface SplitPanelContainerState {
@@ -65,12 +64,7 @@ export class SplitPanelContainer extends React.Component<
     }
 
     return (
-      <Container
-        axis={axis}
-        id="split-panel-container"
-        resizing={resizing}
-        height={this.props.height}
-      >
+      <Container axis={axis} id="split-panel-container" resizing={resizing}>
         <div className="split-panel" style={firstPaneStyles}>
           {first}
         </div>
@@ -269,7 +263,6 @@ const DividerHitArea = {
 const Container = styled.div<{
   axis?: 'horizontal' | 'vertical';
   resizing: boolean;
-  height?: string;
 }>`
   display: flex;
   overflow: hidden;
@@ -278,7 +271,6 @@ const Container = styled.div<{
   width: 100%;
   min-width: 0;
   min-height: 0;
-  height: ${({height}) => (height ? height : 'auto')};
 
   .split-panel {
     position: relative;

--- a/js_modules/dagit/packages/ui/src/components/SplitPanelContainer.tsx
+++ b/js_modules/dagit/packages/ui/src/components/SplitPanelContainer.tsx
@@ -15,6 +15,7 @@ interface SplitPanelContainerProps {
   firstInitialPercent: number;
   firstMinSize?: number;
   second: React.ReactNode | null; // Note: pass null to hide / animate away the second panel
+  height?: string;
 }
 
 interface SplitPanelContainerState {
@@ -64,7 +65,12 @@ export class SplitPanelContainer extends React.Component<
     }
 
     return (
-      <Container axis={axis} id="split-panel-container" resizing={resizing}>
+      <Container
+        axis={axis}
+        id="split-panel-container"
+        resizing={resizing}
+        height={this.props.height}
+      >
         <div className="split-panel" style={firstPaneStyles}>
           {first}
         </div>
@@ -263,6 +269,7 @@ const DividerHitArea = {
 const Container = styled.div<{
   axis?: 'horizontal' | 'vertical';
   resizing: boolean;
+  height?: string;
 }>`
   display: flex;
   overflow: hidden;
@@ -271,6 +278,7 @@ const Container = styled.div<{
   width: 100%;
   min-width: 0;
   min-height: 0;
+  height: ${({height}) => (height ? height : 'auto')};
 
   .split-panel {
     position: relative;


### PR DESCRIPTION
## Summary

Adds a basic frontend layer to display top-level resources in the Dagit sidebar, and a resource page to display their details:

<img width="1573" alt="Screen Shot 2023-01-09 at 11 10 16 AM" src="https://user-images.githubusercontent.com/10215173/211388481-9b8c5551-f518-4de9-a5a4-f01311232692.png">

This is currently gated behind a user-visible feature flag - by default does not affect what a user is presented with.

## Test Plan

tested locally
