### PR TITLE
use run tags instead of asset tags to filter materializations within backfill

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -71,6 +71,9 @@ class CachingInstanceQueryer:
 
         return asset_key in self.get_planned_materializations_for_run(run_id=run_id)
 
+    def run_has_tag(self, run_id: str, tag_key: str, tag_value: str) -> bool:
+        return cast(DagsterRun, self._get_run_by_id(run_id)).tags.get(tag_key) == tag_value
+
     def _get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
         run_record = self._get_run_record_by_id(run_id=run_id)
         if run_record is not None:
@@ -605,3 +608,17 @@ class CachingInstanceQueryer:
             evaluation_time=evaluation_time,
             used_data_times=used_data_times,
         )
+
+    def get_latest_storage_id(self, event_type: DagsterEventType) -> Optional[int]:
+        """
+        Returns None if there are no events from that type in the event log.
+        """
+        records = list(
+            self.instance.get_event_records(
+                event_records_filter=EventRecordsFilter(event_type=event_type), limit=1
+            )
+        )
+        if records:
+            return records[0].storage_id
+        else:
+            return None


### PR DESCRIPTION
### Summary & Motivation

This is a reversal of the approach taken in https://github.com/dagster-io/dagster/pull/11506.

I realized a problem with that earlier approach: it depends on user code being upgraded.  I.e. if someone running a Dagster 1.1.8 daemon runs a backfill against user code that depends on Dagster 1.1.7 or earlier, then the asset materialization events that are created as part of that backfill won't have the expected backill tag on them.

As a consequence, if that backfill has some asset partitions that can’t be run until other materializations complete, then the backfill will fail to terminate.  This should only be a problem right now in very rare situations, but will be more of a problem when we remove restrictions that prevent users from launching backfills across different code locations and across different partitions definitions.

### How I Tested These Changes

The expected behavior is covered by existing test coverage. In an ideal world, we would write a test that makes sure backfills kicked off on later versions of host code complete successfully on earlier versions of user code, but I can't think of a way to do that that avoids a bunch of very heavy lifting.
