### PR TITLE
[dagit] Stop generating docblocks on schema.graphql and codegen

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -6,10 +6,6 @@ schema {
 
 type ComputeLogFile {
   path: String!
-
-  """
-  The data output captured from step computation at query time
-  """
   data: String
   cursor: Int!
   size: Int!
@@ -54,9 +50,6 @@ interface ErrorEvent {
   error: PythonError
 }
 
-"""
-The types of events that may be yielded by solid and pipeline execution.
-"""
 enum DagsterEventType {
   STEP_OUTPUT
   STEP_INPUT
@@ -118,9 +111,6 @@ type ExecutionStepFailureEvent implements MessageEvent & StepEvent & ErrorEvent 
   failureMetadata: FailureMetadata
 }
 
-"""
-An enumeration.
-"""
 enum ErrorSource {
   FRAMEWORK_ERROR
   USER_CODE_ERROR
@@ -767,11 +757,6 @@ type EvaluationStackMapKeyEntry {
   mapKey: GenericScalar!
 }
 
-"""
-The `GenericScalar` scalar type represents a generic
-GraphQL scalar value that could be:
-String, Boolean, Int, Float, List or Object.
-"""
 scalar GenericScalar
 
 type EvaluationStackMapValueEntry {
@@ -903,12 +888,6 @@ type PipelinePreset {
   tags: [PipelineTag!]!
 }
 
-"""
-This interface supports the case where we can look up a pipeline successfully in the
-repository available to the DagsterInstance/graphql context, as well as the case where we know
-that a pipeline exists/existed thanks to materialized data such as logs and run metadata, but
-where we can't look the concrete pipeline up.
-"""
 interface PipelineReference {
   name: String!
   solidSelection: [String!]
@@ -926,15 +905,7 @@ interface PipelineRun {
   solidSelection: [String!]
   stats: RunStatsSnapshotOrError!
   stepStats: [RunStepStats!]!
-
-  """
-  Compute logs are the stdout/stderr logs for a given solid step computation
-  """
   computeLogs(stepKey: String!): ComputeLogs!
-
-  """
-  Captured logs are the stdout/stderr logs for a given file key within the run
-  """
   capturedLogs(fileKey: String!): CapturedLogs!
   executionPlan: ExecutionPlan
   stepKeysToExecute: [String!]
@@ -1095,53 +1066,15 @@ type RunStatsSnapshot implements PipelineRunStatsSnapshot {
   endTime: Float
 }
 
-"""
-The status of run execution.
-"""
 enum RunStatus {
-  """
-  Runs waiting to be launched by the Dagster Daemon.
-  """
   QUEUED
-
-  """
-  Runs that have been created, but not yet submitted for launch.
-  """
   NOT_STARTED
-
-  """
-  Runs that are managed outside of the Dagster control plane.
-  """
   MANAGED
-
-  """
-  Runs that have been launched, but execution has not yet started.
-  """
   STARTING
-
-  """
-  Runs that have been launched and execution has started.
-  """
   STARTED
-
-  """
-  Runs that have successfully completed.
-  """
   SUCCESS
-
-  """
-  Runs that have failed to complete.
-  """
   FAILURE
-
-  """
-  Runs that are in-progress and pending to be canceled.
-  """
   CANCELING
-
-  """
-  Runs that have been canceled before completion.
-  """
   CANCELED
 }
 
@@ -1198,15 +1131,7 @@ type Run implements PipelineRun {
   solidSelection: [String!]
   stats: RunStatsSnapshotOrError!
   stepStats: [RunStepStats!]!
-
-  """
-  Compute logs are the stdout/stderr logs for a given solid step computation
-  """
   computeLogs(stepKey: String!): ComputeLogs!
-
-  """
-  Captured logs are the stdout/stderr logs for a given file key within the run
-  """
   capturedLogs(fileKey: String!): CapturedLogs!
   executionPlan: ExecutionPlan
   stepKeysToExecute: [String!]
@@ -1249,25 +1174,16 @@ union AssetOrError = Asset | AssetNotFoundError
 
 union AssetsOrError = AssetConnection | PythonError
 
-"""
-The output from deleting a run.
-"""
 union DeletePipelineRunResult =
     DeletePipelineRunSuccess
   | UnauthorizedError
   | PythonError
   | RunNotFoundError
 
-"""
-Output indicating that a run was deleted.
-"""
 type DeletePipelineRunSuccess {
   runId: String!
 }
 
-"""
-Deletes a run from storage.
-"""
 type DeleteRunMutation {
   Output: DeletePipelineRunResult!
 }
@@ -1279,39 +1195,24 @@ union ExecutionPlanOrError =
   | InvalidSubsetError
   | PythonError
 
-"""
-Launches a set of partition backfill runs.
-"""
 type LaunchBackfillMutation {
   Output: LaunchBackfillResult!
 }
 
-"""
-Launches a job run.
-"""
 type LaunchRunMutation {
   Output: LaunchRunResult!
 }
 
-"""
-Re-executes a job run.
-"""
 type LaunchRunReexecutionMutation {
   Output: LaunchRunReexecutionResult!
 }
 
 union PipelineOrError = Pipeline | PipelineNotFoundError | InvalidSubsetError | PythonError
 
-"""
-Reloads a code location server.
-"""
 type ReloadRepositoryLocationMutation {
   Output: ReloadRepositoryLocationMutationResult!
 }
 
-"""
-The output from reloading a code location server.
-"""
 union ReloadRepositoryLocationMutationResult =
     WorkspaceLocationEntry
   | ReloadNotSupported
@@ -1342,78 +1243,48 @@ type Permission {
   disabledReason: String
 }
 
-"""
-Reloads the workspace and its code location servers.
-"""
 type ReloadWorkspaceMutation {
   Output: ReloadWorkspaceMutationResult!
 }
 
-"""
-The output from reloading the workspace.
-"""
 union ReloadWorkspaceMutationResult = Workspace | UnauthorizedError | PythonError
 
 type Workspace {
   locationEntries: [WorkspaceLocationEntry!]!
 }
 
-"""
-Shuts down a code location server.
-"""
 type ShutdownRepositoryLocationMutation {
   Output: ShutdownRepositoryLocationMutationResult!
 }
 
-"""
-The output from shutting down a code location server.
-"""
 union ShutdownRepositoryLocationMutationResult =
     ShutdownRepositoryLocationSuccess
   | RepositoryLocationNotFound
   | UnauthorizedError
   | PythonError
 
-"""
-Output indicating that a code location server was shut down.
-"""
 type ShutdownRepositoryLocationSuccess {
   repositoryLocationName: String!
 }
 
-"""
-Interface indicating that a run failed to terminate.
-"""
 interface TerminatePipelineExecutionFailure {
   run: Run!
   message: String!
 }
 
-"""
-Interface indicating that a run was terminated.
-"""
 interface TerminatePipelineExecutionSuccess {
   run: Run!
 }
 
-"""
-Output indicating that a run failed to terminate.
-"""
 type TerminateRunFailure implements TerminatePipelineExecutionFailure {
   run: Run!
   message: String!
 }
 
-"""
-Terminates a run.
-"""
 type TerminateRunMutation {
   Output: TerminateRunResult!
 }
 
-"""
-The output from a run termination.
-"""
 union TerminateRunResult =
     TerminateRunSuccess
   | TerminateRunFailure
@@ -1421,16 +1292,10 @@ union TerminateRunResult =
   | UnauthorizedError
   | PythonError
 
-"""
-Output indicating that a run was terminated.
-"""
 type TerminateRunSuccess implements TerminatePipelineExecutionSuccess {
   run: Run!
 }
 
-"""
-The type of termination policy to use for a run.
-"""
 enum TerminateRunPolicy {
   SAFE_TERMINATE
   MARK_AS_CANCELED_IMMEDIATELY
@@ -1501,16 +1366,10 @@ type ScheduleTickSuccessData {
   run: Run
 }
 
-"""
-Enable a schedule to launch runs for a job at a fixed interval.
-"""
 type StartScheduleMutation {
   Output: ScheduleMutationResult!
 }
 
-"""
-Disable a schedule from launching runs for a job.
-"""
 type StopRunningScheduleMutation {
   Output: ScheduleMutationResult!
 }
@@ -1550,30 +1409,7 @@ union ConfigTypeOrError =
 type ArrayConfigType implements ConfigType & WrappingConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   ofType: ConfigType!
@@ -1582,30 +1418,7 @@ type ArrayConfigType implements ConfigType & WrappingConfigType {
 type CompositeConfigType implements ConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   fields: [ConfigTypeField!]!
@@ -1614,30 +1427,7 @@ type CompositeConfigType implements ConfigType {
 interface ConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
 }
@@ -1654,30 +1444,7 @@ type ConfigTypeField {
 type EnumConfigType implements ConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   values: [EnumConfigValue!]!
@@ -1692,65 +1459,16 @@ type EnumConfigValue {
 type NullableConfigType implements ConfigType & WrappingConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   ofType: ConfigType!
 }
 
-"""
-Regular is an odd name in this context. It really means Scalar or Any.
-"""
 type RegularConfigType implements ConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   givenName: String!
@@ -1759,30 +1477,7 @@ type RegularConfigType implements ConfigType {
 type ScalarUnionConfigType implements ConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   scalarType: ConfigType!
@@ -1798,30 +1493,7 @@ interface WrappingConfigType {
 type MapConfigType implements ConfigType {
   key: String!
   description: String
-
-  """
-  This is an odd and problematic field. It recursively goes down to
-  get all the types contained within a type. The case where it is horrible
-  are dictionaries and it recurses all the way down to the leaves. This means
-  that in a case where one is fetching all the types and then all the inner
-  types keys for those types, we are returning O(N^2) type keys, which
-  can cause awful performance for large schemas. When you have access
-  to *all* the types, you should instead only use the type_param_keys
-  field for closed generic types and manually navigate down the to
-  field types client-side.
-
-  Where it is useful is when you are fetching types independently and
-  want to be able to render them, but without fetching the entire schema.
-
-  We use this capability when rendering the sidebar.
-  """
   recursiveConfigTypes: [ConfigType!]!
-
-  """
-  This returns the keys for type parameters of any closed generic type,
-  (e.g. List, Optional). This should be used for reconstructing and
-  navigating the full schema client-side and not innerTypes.
-  """
   typeParamKeys: [String!]!
   isSelector: Boolean!
   keyType: ConfigType!
@@ -2068,19 +1740,8 @@ type ExecutionStepOutput {
 }
 
 enum StepKind {
-  """
-  This is a user-defined computation step
-  """
   COMPUTE
-
-  """
-  This is a mapped step that has not yet been resolved
-  """
   UNRESOLVED_MAPPED
-
-  """
-  This is a collect step that is not yet resolved
-  """
   UNRESOLVED_COLLECT
 }
 
@@ -2172,55 +1833,19 @@ input AssetKeyInput {
 input ExecutionMetadata {
   runId: String
   tags: [ExecutionTag!]
-
-  """
-  The ID of the run at the root of the run group. All partial /
-          full re-executions should use the first run as the rootRunID so they are
-          grouped together.
-  """
   rootRunId: String
-
-  """
-  The ID of the run serving as the parent within the run group.
-          For the first re-execution, this will be the same as the `rootRunId`. For
-          subsequent runs, the root or a previous re-execution could be the parent run.
-  """
   parentRunId: String
 }
 
 input ExecutionParams {
-  """
-  Defines the job / pipeline and solid subset that should be executed.
-          All subsequent executions in the same run group (for example, a single-step
-          re-execution) are scoped to the original run's selector and solid
-          subset.
-  """
   selector: JobOrPipelineSelector!
   runConfigData: RunConfigData
   mode: String
-
-  """
-  Defines run tags and parent / root relationships.
-
-  Note: To
-          'restart from failure', provide a `parentRunId` and pass the
-          'dagster/is_resume_retry' tag. Dagster's automatic step key selection will
-          override any stepKeys provided.
-  """
   executionMetadata: ExecutionMetadata
-
-  """
-  Defines step keys to execute within the execution plan defined
-          by the pipeline `selector`. To execute the entire execution plan, you can omit
-          this parameter, provide an empty array, or provide every step name.
-  """
   stepKeys: [String!]
   preset: String
 }
 
-"""
-This type represents the fields necessary to identify a job or pipeline
-"""
 input JobOrPipelineSelector {
   pipelineName: String
   jobName: String
@@ -2235,9 +1860,6 @@ input ExecutionTag {
   value: String!
 }
 
-"""
-This type represents the fields necessary to identify a schedule or sensor.
-"""
 input InstigationSelector {
   repositoryName: String!
   repositoryLocationName: String!
@@ -2265,18 +1887,11 @@ input LaunchBackfillParams {
   forceSynchronousSubmission: Boolean
 }
 
-"""
-This type represents the fields necessary to identify a
-        pipeline or pipeline subset.
-"""
 input PartitionSetSelector {
   partitionSetName: String!
   repositorySelector: RepositorySelector!
 }
 
-"""
-This type represents a filter on Dagster runs.
-"""
 input RunsFilter {
   runIds: [String]
   pipelineName: String
@@ -2288,10 +1903,6 @@ input RunsFilter {
   mode: String
 }
 
-"""
-This type represents the fields necessary to identify a
-        pipeline or pipeline subset.
-"""
 input PipelineSelector {
   pipelineName: String!
   repositoryName: String!
@@ -2300,26 +1911,17 @@ input PipelineSelector {
   assetSelection: [AssetKeyInput!]
 }
 
-"""
-This type represents the fields necessary to identify a repository.
-"""
 input RepositorySelector {
   repositoryName: String!
   repositoryLocationName: String!
 }
 
-"""
-This type represents the fields necessary to identify a schedule.
-"""
 input ScheduleSelector {
   repositoryName: String!
   repositoryLocationName: String!
   scheduleName: String!
 }
 
-"""
-This type represents the fields necessary to identify a sensor.
-"""
 input SensorSelector {
   repositoryName: String!
   repositoryLocationName: String!
@@ -2506,15 +2108,7 @@ type FloatMetadataEntry implements MetadataEntry {
 type IntMetadataEntry implements MetadataEntry {
   label: String!
   description: String
-
-  """
-  Nullable to allow graceful degrade on > 32 bit numbers
-  """
   intValue: Int
-
-  """
-  String representation of the int to support greater than 32 bit
-  """
   intRepr: String!
 }
 
@@ -2699,35 +2293,9 @@ type RepositoryMetadata {
   value: String!
 }
 
-"""
-The run config schema represents the all the config type
-        information given a certain execution selection and mode of execution of that
-        selection. All config interactions (e.g. checking config validity, fetching
-        all config types, fetching in a particular config type) should be done
-        through this type
-"""
 type RunConfigSchema {
-  """
-  Fetch the root environment type. Concretely this is the type that
-          is in scope at the root of configuration document for a particular execution selection.
-          It is the type that is in scope initially with a blank config editor.
-  """
   rootConfigType: ConfigType!
-
-  """
-  Fetch all the named config types that are in the schema. Useful
-          for things like a type browser UI, or for fetching all the types are in the
-          scope of a document so that the index can be built for the autocompleting editor.
-  """
   allConfigTypes: [ConfigType!]!
-
-  """
-  Parse a particular run config result. The return value
-          either indicates that the validation succeeded by returning
-          `PipelineConfigValidationValid` or that there are configuration errors
-          by returning `RunConfigValidationInvalid' which containers a list errors
-          so that can be rendered for the user
-  """
   isRunConfigValid(runConfigData: RunConfigData): PipelineConfigValidationResult!
 }
 
@@ -2786,12 +2354,6 @@ interface PipelineRuns {
   count: Int
 }
 
-"""
-This type is used when passing in a configuration object
-        for pipeline configuration. Can either be passed in as a string (the
-        YAML configuration object) or as the configuration object itself. In
-        either case, the object must conform to the constraints of the dagster config type system.
-"""
 scalar RunConfigData
 
 type RunGroup {
@@ -2845,16 +2407,10 @@ type StopSensorMutationResult {
 
 union StopSensorMutationResultOrError = StopSensorMutationResult | UnauthorizedError | PythonError
 
-"""
-Disable a sensor from launching runs for a job.
-"""
 type StopSensorMutation {
   Output: StopSensorMutationResultOrError!
 }
 
-"""
-Set a cursor for a sensor to track state across evaluations.
-"""
 type SetSensorCursorMutation {
   Output: SensorOrError!
 }
@@ -3006,259 +2562,87 @@ type PipelineTag {
   value: String!
 }
 
-"""
-A run tag and the free-form values that have been associated
-        with it so far.
-"""
 type PipelineTagAndValues {
   key: String!
   values: [String!]!
 }
 
-"""
-An invocation of a solid within a repo.
-"""
 type NodeInvocationSite {
   pipeline: Pipeline!
   solidHandle: SolidHandle!
 }
 
-"""
-A solid definition and its invocations within the repo.
-"""
 type UsedSolid {
   definition: ISolidDefinition!
   invocations: [NodeInvocationSite!]!
 }
 
-"""
-The root for all queries to retrieve data from the Dagster instance.
-"""
 type DagitQuery {
-  """
-  Retrieve the version of Dagster running in the Dagster deployment.
-  """
   version: String!
-
-  """
-  Retrieve all the repositories.
-  """
   repositoriesOrError(repositorySelector: RepositorySelector): RepositoriesOrError!
-
-  """
-  Retrieve a repository by its location name and repository name.
-  """
   repositoryOrError(repositorySelector: RepositorySelector!): RepositoryOrError!
-
-  """
-  Retrieve the workspace and its locations.
-  """
   workspaceOrError: WorkspaceOrError!
-
-  """
-  Retrieve location status for workspace locations
-  """
   locationStatusesOrError: WorkspaceLocationStatusEntriesOrError!
-
-  """
-  Retrieve a job by its location name, repository name, and job name.
-  """
   pipelineOrError(params: PipelineSelector!): PipelineOrError!
-
-  """
-  Retrieve a job snapshot by its id or location name, repository name, and job name.
-  """
   pipelineSnapshotOrError(
     snapshotId: String
     activePipelineSelector: PipelineSelector
   ): PipelineSnapshotOrError!
-
-  """
-  Retrieve a graph by its location name, repository name, and graph name.
-  """
   graphOrError(selector: GraphSelector): GraphOrError!
-
-  """
-  Retrieve the name of the scheduler running in the Dagster deployment.
-  """
   scheduler: SchedulerOrError!
-
-  """
-  Retrieve a schedule by its location name, repository name, and schedule name.
-  """
   scheduleOrError(scheduleSelector: ScheduleSelector!): ScheduleOrError!
-
-  """
-  Retrieve all the schedules.
-  """
   schedulesOrError(repositorySelector: RepositorySelector!): SchedulesOrError!
-
-  """
-  Retrieve a sensor by its location name, repository name, and sensor name.
-  """
   sensorOrError(sensorSelector: SensorSelector!): SensorOrError!
-
-  """
-  Retrieve all the sensors.
-  """
   sensorsOrError(repositorySelector: RepositorySelector!): SensorsOrError!
-
-  """
-  Retrieve the state for a schedule or sensor by its location name, repository name, and schedule/sensor name.
-  """
   instigationStateOrError(instigationSelector: InstigationSelector!): InstigationStateOrError!
-
-  """
-  Retrieve the running schedules and sensors that are missing from the workspace.
-  """
   unloadableInstigationStatesOrError(instigationType: InstigationType): InstigationStatesOrError!
-
-  """
-  Retrieve the partition sets for a job by its location name, repository name, and job name.
-  """
   partitionSetsOrError(
     repositorySelector: RepositorySelector!
     pipelineName: String!
   ): PartitionSetsOrError!
-
-  """
-  Retrieve a partition set by its location name, repository name, and partition set name.
-  """
   partitionSetOrError(
     repositorySelector: RepositorySelector!
     partitionSetName: String
   ): PartitionSetOrError!
-
-  """
-  Retrieve runs after applying a filter, cursor, and limit.
-  """
   pipelineRunsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
-
-  """
-  Retrieve a run by its run id.
-  """
   pipelineRunOrError(runId: ID!): RunOrError!
-
-  """
-  Retrieve runs after applying a filter, cursor, and limit.
-  """
   runsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
-
-  """
-  Retrieve a run by its run id.
-  """
   runOrError(runId: ID!): RunOrError!
-
-  """
-  Retrieve all the distinct key-value tags from all runs.
-  """
   pipelineRunTags: [PipelineTagAndValues!]!
-
-  """
-  Retrieve a group of runs with the matching root run id.
-  """
   runGroupOrError(runId: ID!): RunGroupOrError!
-
-  """
-  Retrieve groups of runs after applying a filter, cursor, and limit.
-  """
   runGroupsOrError(filter: RunsFilter, cursor: String, limit: Int): RunGroupsOrError!
-
-  """
-  Retrieve whether the run configuration is valid or invalid.
-  """
   isPipelineConfigValid(
     pipeline: PipelineSelector!
     runConfigData: RunConfigData
     mode: String!
   ): PipelineConfigValidationResult!
-
-  """
-  Retrieve the execution plan for a job and its run configuration.
-  """
   executionPlanOrError(
     pipeline: PipelineSelector!
     runConfigData: RunConfigData
     mode: String!
   ): ExecutionPlanOrError!
-
-  """
-  Retrieve the run configuration schema for a job.
-  """
   runConfigSchemaOrError(selector: PipelineSelector!, mode: String): RunConfigSchemaOrError!
-
-  """
-  Retrieve the instance configuration for the Dagster deployment.
-  """
   instance: Instance!
-
-  """
-  Retrieve assets after applying a prefix filter, cursor, and limit.
-  """
   assetsOrError(prefix: [String!], cursor: String, limit: Int): AssetsOrError!
-
-  """
-  Retrieve an asset by asset key.
-  """
   assetOrError(assetKey: AssetKeyInput!): AssetOrError!
-
-  """
-  Retrieve asset nodes after applying a filter on asset group, job, and asset keys.
-  """
   assetNodes(
     group: AssetGroupSelector
     pipeline: PipelineSelector
     assetKeys: [AssetKeyInput!]
     loadMaterializations: Boolean = false
   ): [AssetNode!]!
-
-  """
-  Retrieve an asset node by asset key.
-  """
   assetNodeOrError(assetKey: AssetKeyInput!): AssetNodeOrError!
-
-  """
-  Retrieve a list of asset keys where two or more repos provide an asset definition. Note: Assets should not be defined in more than one repository - this query is used to present warnings and errors in Dagit.
-  """
   assetNodeDefinitionCollisions(assetKeys: [AssetKeyInput!]): [AssetNodeDefinitionCollision!]!
-
-  """
-  Retrieve a backfill by backfill id.
-  """
   partitionBackfillOrError(backfillId: String!): PartitionBackfillOrError!
-
-  """
-  Retrieve backfills after applying a status filter, cursor, and limit.
-  """
   partitionBackfillsOrError(
     status: BulkActionStatus
     cursor: String
     limit: Int
   ): PartitionBackfillsOrError!
-
-  """
-  Retrieve the set of permissions for the Dagster deployment.
-  """
   permissions: [Permission!]!
-
-  """
-  Retrieve the latest materializations for a set of assets by asset keys.
-  """
   assetsLatestInfo(assetKeys: [AssetKeyInput!]!): [AssetLatestInfo!]!
-
-  """
-  Retrieve event logs after applying a run id filter, cursor, and limit.
-  """
   logsForRun(runId: ID!, afterCursor: String, limit: Int): EventConnectionOrError!
-
-  """
-  Retrieve the captured log metadata for a given log key.
-  """
   capturedLogsMetadata(logKey: [String!]!): CapturedLogsMetadata!
-
-  """
-  Captured logs are the stdout/stderr logs for a given log key
-  """
   capturedLogs(logKey: [String!]!, cursor: String, limit: Int): CapturedLogs!
 }
 
@@ -3296,20 +2680,12 @@ type GraphNotFoundError implements Error {
   repositoryLocationName: String!
 }
 
-"""
-This type represents the fields necessary to identify a
-        graph
-"""
 input GraphSelector {
   graphName: String!
   repositoryName: String!
   repositoryLocationName: String!
 }
 
-"""
-This type represents the fields necessary to identify
-        an asset group.
-"""
 input AssetGroupSelector {
   groupName: String!
   repositoryName: String!
@@ -3348,127 +2724,41 @@ type CapturedLogsMetadata {
   stderrLocation: String
 }
 
-"""
-The root for all mutations to modify data in your Dagster instance.
-"""
 type DagitMutation {
-  """
-  Launches a job run.
-  """
   launchPipelineExecution(executionParams: ExecutionParams!): LaunchRunResult!
-
-  """
-  Launches a job run.
-  """
   launchRun(executionParams: ExecutionParams!): LaunchRunResult!
-
-  """
-  Re-executes a job run.
-  """
   launchPipelineReexecution(
     executionParams: ExecutionParams
     reexecutionParams: ReexecutionParams
   ): LaunchRunReexecutionResult!
-
-  """
-  Re-executes a job run.
-  """
   launchRunReexecution(
     executionParams: ExecutionParams
     reexecutionParams: ReexecutionParams
   ): LaunchRunReexecutionResult!
-
-  """
-  Enable a schedule to launch runs for a job at a fixed interval.
-  """
   startSchedule(scheduleSelector: ScheduleSelector!): ScheduleMutationResult!
-
-  """
-  Disable a schedule from launching runs for a job.
-  """
   stopRunningSchedule(
     scheduleOriginId: String!
     scheduleSelectorId: String!
   ): ScheduleMutationResult!
-
-  """
-  Enable a sensor to launch runs for a job based on external state change.
-  """
   startSensor(sensorSelector: SensorSelector!): SensorOrError!
-
-  """
-  Set a cursor for a sensor to track state across evaluations.
-  """
   setSensorCursor(cursor: String, sensorSelector: SensorSelector!): SensorOrError!
-
-  """
-  Disable a sensor from launching runs for a job.
-  """
   stopSensor(jobOriginId: String!, jobSelectorId: String!): StopSensorMutationResultOrError!
-
-  """
-  Terminates a run.
-  """
   terminatePipelineExecution(
     runId: String!
     terminatePolicy: TerminateRunPolicy
   ): TerminateRunResult!
-
-  """
-  Terminates a run.
-  """
   terminateRun(runId: String!, terminatePolicy: TerminateRunPolicy): TerminateRunResult!
-
-  """
-  Deletes a run from storage.
-  """
   deletePipelineRun(runId: String!): DeletePipelineRunResult!
-
-  """
-  Deletes a run from storage.
-  """
   deleteRun(runId: String!): DeletePipelineRunResult!
-
-  """
-  Reloads a code location server.
-  """
   reloadRepositoryLocation(repositoryLocationName: String!): ReloadRepositoryLocationMutationResult!
-
-  """
-  Reloads the workspace and its code location servers.
-  """
   reloadWorkspace: ReloadWorkspaceMutationResult!
-
-  """
-  Shuts down a code location server.
-  """
   shutdownRepositoryLocation(
     repositoryLocationName: String!
   ): ShutdownRepositoryLocationMutationResult!
-
-  """
-  Deletes asset history from storage.
-  """
   wipeAssets(assetKeys: [AssetKeyInput!]!): AssetWipeMutationResult!
-
-  """
-  Launches a set of partition backfill runs.
-  """
   launchPartitionBackfill(backfillParams: LaunchBackfillParams!): LaunchBackfillResult!
-
-  """
-  Retries a set of partition backfill runs.
-  """
   resumePartitionBackfill(backfillId: String!): ResumeBackfillResult!
-
-  """
-  Cancels a set of partition backfill runs.
-  """
   cancelPartitionBackfill(backfillId: String!): CancelBackfillResult!
-
-  """
-  Log telemetry about the Dagster instance.
-  """
   logTelemetry(
     action: String!
     clientId: String!
@@ -3487,18 +2777,12 @@ enum ReexecutionStrategy {
   ALL_STEPS
 }
 
-"""
-The output from deleting asset history.
-"""
 union AssetWipeMutationResult =
     AssetNotFoundError
   | UnauthorizedError
   | PythonError
   | AssetWipeSuccess
 
-"""
-Output indicating that asset history was deleted.
-"""
 type AssetWipeSuccess {
   assetKeys: [AssetKey!]!
 }
@@ -3515,47 +2799,16 @@ type CancelBackfillSuccess {
   backfillId: String!
 }
 
-"""
-The output from logging telemetry.
-"""
 union LogTelemetryMutationResult = LogTelemetrySuccess | PythonError
 
-"""
-Output indicating that telemetry was logged.
-"""
 type LogTelemetrySuccess {
   action: String!
 }
 
-"""
-The root for all subscriptions to retrieve real-time data from the Dagster instance.
-"""
 type DagitSubscription {
-  """
-  Retrieve real-time event logs after applying a filter on run id and cursor.
-  """
-  pipelineRunLogs(
-    runId: ID!
-
-    """
-    A cursor retrieved from the API. Pass 'HEAD' to stream from the current event onward.
-    """
-    cursor: String
-  ): PipelineRunLogsSubscriptionPayload!
-
-  """
-  Retrieve real-time compute logs after applying a filter on run id, step name, log type, and cursor.
-  """
+  pipelineRunLogs(runId: ID!, cursor: String): PipelineRunLogsSubscriptionPayload!
   computeLogs(runId: ID!, stepKey: String!, ioType: ComputeIOType!, cursor: String): ComputeLogFile!
-
-  """
-  Retrieve real-time compute logs.
-  """
   capturedLogs(logKey: [String!]!, cursor: String): CapturedLogs!
-
-  """
-  Retrieve real-time events when a location in the workspace undergoes a state change.
-  """
   locationStateChangeEvents: LocationStateChangeSubscription!
 }
 

--- a/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
+++ b/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
@@ -7,9 +7,7 @@ console.log('Downloading schema...');
 
 const TARGET_FILE = './src/graphql/schema.graphql';
 
-// https://github.com/dagster-io/dagster/issues/2623
-// Initially, write schema.graphql in the SDL format, without descriptions
-// Otherwise, the generated types in Typescript would also have descriptions.
+// Write schema.graphql in the SDL format, without descriptions. We don't need them here.
 const result = execSync(
   `dagster-graphql --ephemeral-instance --empty-workspace -t '${getIntrospectionQuery({
     descriptions: false,
@@ -19,9 +17,11 @@ const result = execSync(
 const schemaJson = JSON.parse(result).data;
 const sdl = printSchema(buildClientSchema(schemaJson));
 
-console.log('Generating schema.graphql without descriptions...');
+console.log('Generating schema.graphql...');
 
 writeFileSync(TARGET_FILE, sdl);
+
+execSync(`yarn prettier --loglevel silent --write ${TARGET_FILE}`, {stdio: 'inherit'});
 
 // Write `possibleTypes.generated.json`, used in prod for `AppCache` and in tests for creating
 // a mocked schema.
@@ -40,20 +40,5 @@ writeFileSync('./src/graphql/possibleTypes.generated.json', JSON.stringify(possi
 console.log('Generating TypeScript types...');
 
 execSync('yarn graphql-codegen', {stdio: 'inherit'});
-
-// https://github.com/dagster-io/dagster/issues/2623
-// Finally, write schema.graphql in the SDL format, with descriptions
-const resultWithDescriptions = execSync(
-  `dagster-graphql --ephemeral-instance --empty-workspace -t '${getIntrospectionQuery()}'`,
-  {cwd: '../../../../examples/docs_snippets/'},
-).toString();
-const schemaJsonWithDescriptions = JSON.parse(resultWithDescriptions).data;
-const sdlWithDescriptions = printSchema(buildClientSchema(schemaJsonWithDescriptions));
-
-console.log('Generating schema.graphql with descriptions...');
-
-writeFileSync(TARGET_FILE, sdlWithDescriptions);
-
-execSync(`yarn prettier --loglevel silent --write ${TARGET_FILE}`, {stdio: 'inherit'});
 
 console.log('Done!');


### PR DESCRIPTION
### Summary & Motivation

There is a discrepancy between `yarn generate-graphql` and `yarn graphql-codegen` (e.g. for `--watch`):

- For `generate-graphql`, we create `schema.graphql` in `generateGraphQLTypes.ts` twice: once without description docblocks for the generated type file, and once with descriptions to restore them for humans. The produced `graphql.ts` does not have docblocks.
- For `graphql-codegen`, which doesn't go through this script, only the version of `schema.graphql` *with* descriptions is created. The produced `graphql.ts` **does** have docblocks.

This is likely to cause confusion for users that use both commands (e.g. during development vs. when regenerating outside of immediate query development, regenerating permissions json, etc). In my opinion, we don't really need the docblocks on `schema.graphql` at all -- I've never even looked at them.

To simplify everything -- and speed up `generate-graphql` because we don't have to build the `schema.graphql` twice! -- let's just not ever include description docblocks.

### How I Tested These Changes

`yarn generate-graphql` and `yarn graphql-codegen`, verify that they produce the same `graphql.ts` output.
