### PR TITLE
[dagit] Add GraphQL configuration for VSCode

### DIFF
--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -1,0 +1,4 @@
+projects:
+  dagit:
+    schema: "./js_modules/dagit/packages/core/src/graphql/schema.graphql"
+    documents: "./js_modules/dagit/packages/core/src/**/*.{tsx}"


### PR DESCRIPTION
### Summary & Motivation

Picking this back up from https://github.com/dagster-io/dagster/pull/11500.

Add a `.graphqlrc.yml` to the `dagster` root to allow the VSCode GraphQL language extension (https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) to find the `dagit` schema for autocompletion and validation.

### How I Tested These Changes

Open `VersionNumber.tsx`, mess around with its query.

<img width="568" alt="Screenshot 2023-01-06 at 4 17 04 PM" src="https://user-images.githubusercontent.com/2823852/211109434-50045504-3743-45cc-b917-898e9e95ea33.png">
<img width="336" alt="Screenshot 2023-01-06 at 4 17 16 PM" src="https://user-images.githubusercontent.com/2823852/211109438-fb196f66-b5bc-4739-89c1-029d6df8d26f.png">
<img width="614" alt="Screenshot 2023-01-06 at 4 18 17 PM" src="https://user-images.githubusercontent.com/2823852/211109440-ed90b399-d202-4abd-9e93-4a6bd73baefd.png">

