### PR TITLE
Fix graphql permisisons checks, fix black

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -53,7 +53,6 @@ def _force_mark_as_canceled(instance: DagsterInstance, run_id):
     return GrapheneTerminateRunSuccess(GrapheneRun(reloaded_record))
 
 
-@capture_error
 def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
     from ...schema.errors import GrapheneRunNotFoundError
     from ...schema.pipelines.pipeline import GrapheneRun
@@ -74,6 +73,7 @@ def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
     )
 
     if not records:
+        assert_permission(graphene_info, Permissions.TERMINATE_PIPELINE_EXECUTION)
         return GrapheneRunNotFoundError(run_id)
 
     record = records[0]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -69,7 +69,6 @@ def test_launch_asset_backfill():
     all_asset_keys = repo.asset_graph.all_asset_keys
 
     with instance_for_test() as instance:
-
         # read-only context fails
         with define_out_of_process_context(
             __file__, "get_repo", instance, read_only=True


### PR DESCRIPTION
Summary:
- fix black
- fix unneeded cpature_error causing an error to be returned prematurely
- still check a permission instead of returning a RunNotFoundError (probably good to do anyways so that you're not leaking the non-existance of a run)

### Summary & Motivation

### How I Tested These Changes
