### PR TITLE
monitored_assets param for multi-asset sensor

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/asset-sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/asset-sensors.mdx
@@ -99,7 +99,7 @@ In the body of the sensor, you have access to the materialization event records 
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/asset_sensors.py startafter=start_multi_asset_sensor_marker endbefore=end_multi_asset_sensor_marker
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+    monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
     job=my_job,
 )
 def asset_a_and_b_sensor(context):
@@ -115,7 +115,7 @@ You can also return a <PyObject object="SkipReason" /> to document why the senso
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/asset_sensors.py startafter=start_multi_asset_sensor_w_skip_reason endbefore=end_multi_asset_sensor_w_skip_reason
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+    monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
     job=my_job,
 )
 def asset_a_and_b_sensor_with_skip_reason(context):
@@ -156,7 +156,10 @@ The example below monitors two assets with the same daily partitions definition.
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/asset_sensors.py startafter=start_multi_asset_sensor_AND endbefore=end_multi_asset_sensor_AND
 @multi_asset_sensor(
-    asset_keys=[AssetKey("upstream_daily_1"), AssetKey("upstream_daily_2")],
+    monitored_assets=[
+        AssetKey("upstream_daily_1"),
+        AssetKey("upstream_daily_2"),
+    ],
     job=downstream_daily_job,
 )
 def trigger_daily_asset_if_both_upstream_partitions_materialized(context):
@@ -189,7 +192,10 @@ The following example monitors two upstream daily-partitioned assets, kicking of
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/asset_sensors.py startafter=start_multi_asset_sensor_OR endbefore=end_multi_asset_sensor_OR
 @multi_asset_sensor(
-    asset_keys=[AssetKey("upstream_daily_1"), AssetKey("upstream_daily_2")],
+    monitored_assets=[
+        AssetKey("upstream_daily_1"),
+        AssetKey("upstream_daily_2"),
+    ],
     job=downstream_daily_job,
 )
 def trigger_daily_asset_when_any_upstream_partitions_have_new_materializations(context):
@@ -308,7 +314,9 @@ If the <PyObject object="PartitionsDefinition"/> of the monitored assets differs
 If a partition mapping is not defined, Dagster will use the default partition mapping, which is the <PyObject object="TimeWindowPartitionMapping"/> for time window partitions definitions and the <PyObject object="IdentityPartitionMapping"/> for other partitions definitions. The <PyObject object="TimeWindowPartitionMapping"/> will map an upstream partition to the downstream partitions that overlap with it.
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/asset_sensors.py startafter=start_daily_asset_to_weekly_asset endbefore=end_daily_asset_to_weekly_asset
-@multi_asset_sensor(asset_keys=[AssetKey("upstream_daily_1")], job=weekly_asset_job)
+@multi_asset_sensor(
+    monitored_assets=[AssetKey("upstream_daily_1")], job=weekly_asset_job
+)
 def trigger_weekly_asset_from_daily_asset(context):
     run_requests_by_partition = {}
     materializations_by_partition = context.latest_materialization_records_by_partition(

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
@@ -68,7 +68,7 @@ def my_freshness_alerting_sensor(context: FreshnessPolicySensorContext):
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+    monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
     job=my_job,
 )
 def asset_a_and_b_sensor(context):
@@ -84,7 +84,7 @@ def asset_a_and_b_sensor(context):
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+    monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
     job=my_job,
 )
 def asset_a_and_b_sensor_with_skip_reason(context):
@@ -149,7 +149,9 @@ weekly_asset_job = define_asset_job(
 # start_daily_asset_to_weekly_asset
 
 
-@multi_asset_sensor(asset_keys=[AssetKey("upstream_daily_1")], job=weekly_asset_job)
+@multi_asset_sensor(
+    monitored_assets=[AssetKey("upstream_daily_1")], job=weekly_asset_job
+)
 def trigger_weekly_asset_from_daily_asset(context):
     run_requests_by_partition = {}
     materializations_by_partition = context.latest_materialization_records_by_partition(
@@ -188,7 +190,10 @@ def trigger_weekly_asset_from_daily_asset(context):
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("upstream_daily_1"), AssetKey("upstream_daily_2")],
+    monitored_assets=[
+        AssetKey("upstream_daily_1"),
+        AssetKey("upstream_daily_2"),
+    ],
     job=downstream_daily_job,
 )
 def trigger_daily_asset_if_both_upstream_partitions_materialized(context):
@@ -211,7 +216,10 @@ def trigger_daily_asset_if_both_upstream_partitions_materialized(context):
 
 # start_multi_asset_sensor_OR
 @multi_asset_sensor(
-    asset_keys=[AssetKey("upstream_daily_1"), AssetKey("upstream_daily_2")],
+    monitored_assets=[
+        AssetKey("upstream_daily_1"),
+        AssetKey("upstream_daily_2"),
+    ],
     job=downstream_daily_job,
 )
 def trigger_daily_asset_when_any_upstream_partitions_have_new_materializations(context):

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_asset_sensors.py
@@ -41,7 +41,7 @@ def test_asset_sensors():
     instance = DagsterInstance.ephemeral()
     materialize([asset_a, asset_b], instance=instance)
     ctx = build_multi_asset_sensor_context(
-        asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+        monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
         instance=instance,
         repository_def=my_repo,
     )
@@ -51,7 +51,7 @@ def test_asset_sensors():
         materialize([asset_c], instance=instance)
 
     ctx = build_multi_asset_sensor_context(
-        asset_keys=[AssetKey("asset_c")],
+        monitored_assets=[AssetKey("asset_c")],
         instance=instance,
         repository_def=my_repo,
     )
@@ -78,7 +78,10 @@ def test_multi_asset_sensor_AND():
             partition_key="2022-08-01",
         )
         and_ctx = build_multi_asset_sensor_context(
-            asset_keys=[AssetKey("upstream_daily_1"), AssetKey("upstream_daily_2")],
+            monitored_assets=[
+                AssetKey("upstream_daily_1"),
+                AssetKey("upstream_daily_2"),
+            ],
             instance=instance,
             repository_def=my_repo,
         )
@@ -116,7 +119,10 @@ def test_multi_asset_sensor_OR():
             partition_key="2022-08-01",
         )
         or_ctx = build_multi_asset_sensor_context(
-            asset_keys=[AssetKey("upstream_daily_1"), AssetKey("upstream_daily_2")],
+            monitored_assets=[
+                AssetKey("upstream_daily_1"),
+                AssetKey("upstream_daily_2"),
+            ],
             instance=instance,
             repository_def=my_repo,
         )
@@ -151,7 +157,7 @@ def test_multi_asset_sensor_weekly_from_daily():
         ]:
             materialize([upstream_daily_1], instance=instance, partition_key=date)
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[AssetKey("upstream_daily_1")],
+            monitored_assets=[AssetKey("upstream_daily_1")],
             instance=instance,
             repository_def=my_repo,
         )

--- a/python_modules/dagster-test/dagster_test/toys/asset_sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_sensors.py
@@ -56,7 +56,7 @@ def log_asset_sensor_job():
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+    monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
     job=log_asset_sensor_job,
 )
 def asset_a_and_b_sensor(context):
@@ -76,7 +76,7 @@ def asset_a_and_b_sensor(context):
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_c"), AssetKey("asset_d")],
+    monitored_assets=[AssetKey("asset_c"), AssetKey("asset_d")],
     job=log_asset_sensor_job,
 )
 def asset_c_or_d_sensor(context):
@@ -96,7 +96,7 @@ def asset_c_or_d_sensor(context):
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("my_string_asset"), AssetKey("my_int_asset")],
+    monitored_assets=[AssetKey("my_string_asset"), AssetKey("my_int_asset")],
     job=log_asset_sensor_job,
 )
 def asset_string_and_int_sensor(context):
@@ -114,7 +114,7 @@ def asset_string_and_int_sensor(context):
 
 
 @multi_asset_sensor(
-    asset_keys=[AssetKey("asset_a")],
+    monitored_assets=[AssetKey("asset_a")],
     job=log_asset_sensor_job,
 )
 def every_fifth_materialization_sensor(context):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -1,6 +1,7 @@
+import collections.abc
 import inspect
 from functools import update_wrapper
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
@@ -187,8 +188,7 @@ def asset_sensor(
 
 @experimental
 def multi_asset_sensor(
-    asset_keys: Optional[Sequence[AssetKey]] = None,
-    asset_selection: Optional[AssetSelection] = None,
+    monitored_assets: Union[Sequence[AssetKey], AssetSelection],
     *,
     job_name: Optional[str] = None,
     name: Optional[str] = None,
@@ -208,17 +208,14 @@ def multi_asset_sensor(
     2. Return a list of `RunRequest` objects.
     3. Return a `SkipReason` object, providing a descriptive message of why no runs were requested.
     4. Return nothing (skipping without providing a reason)
-    5. Yield a `SkipReason` or yield one ore more `RunRequest` objects.
+    5. Yield a `SkipReason` or yield one or more `RunRequest` objects.
 
     Takes a :py:class:`~dagster.MultiAssetSensorEvaluationContext`.
 
     Args:
-        asset_keys (Optional[Sequence[AssetKey]]): The asset keys this sensor monitors. If not
-            provided, asset_selection argument must be provided. To monitor assets that aren't defined
-            in the repository that this sensor is part of, you must use asset_keys.
-        asset_selection (Optional[AssetSelection]): The asset selection this sensor monitors. If not
-            provided, asset_keys argument must be provided. If you use asset_selection, all assets that
-            are part of the selection must be in the repository that this sensor is part of.
+        monitored_assets (Union[Sequence[AssetKey], AssetSelection]): The assets this
+            sensor monitors. If an AssetSelection object is provided, it will only apply to assets
+            within the Definitions that this sensor is part of.
         name (Optional[str]): The name of the sensor. Defaults to the name of the decorated
             function.
         minimum_interval_seconds (Optional[int]): The minimum number of seconds that will elapse
@@ -233,14 +230,22 @@ def multi_asset_sensor(
     """
     check.opt_str_param(name, "name")
 
+    if not isinstance(monitored_assets, AssetSelection) and not (
+        isinstance(monitored_assets, collections.abc.Sequence)
+        and all(isinstance(el, AssetKey) for el in monitored_assets)
+    ):
+        check.failed(
+            "The value passed to monitored_assets param must be either an AssetSelection"
+            f" or a Sequence of AssetKeys, but was a {type(monitored_assets)}"
+        )
+
     def inner(fn: MultiAssetMaterializationFunction) -> MultiAssetSensorDefinition:
         check.callable_param(fn, "fn")
         sensor_name = name or fn.__name__
 
         sensor_def = MultiAssetSensorDefinition(
             name=sensor_name,
-            asset_keys=asset_keys,
-            asset_selection=asset_selection,
+            monitored_assets=monitored_assets,
             job_name=job_name,
             asset_materialization_fn=fn,
             minimum_interval_seconds=minimum_interval_seconds,

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -178,7 +178,9 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
     `advance_all_cursors`.
 
     Attributes:
-        asset_keys (Sequence[AssetKey]): The asset keys that the sensor is configured to monitor.
+        monitored_assets (Union[Sequence[AssetKey], AssetSelection]): The assets monitored
+            by the sensor. If an AssetSelection object is provided, it will only apply to assets
+            within the Definitions that this sensor is part of.
         repository_def (RepositoryDefinition): The repository that the sensor belongs to.
         instance_ref (Optional[InstanceRef]): The serialized instance configured to run the schedule
         cursor (Optional[str]): The cursor, passed back from the last sensor evaluation via
@@ -198,7 +200,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
 
         from dagster import multi_asset_sensor, MultiAssetSensorEvaluationContext
 
-        @multi_asset_sensor(asset_keys=[AssetKey("asset_1), AssetKey("asset_2)])
+        @multi_asset_sensor(monitored_assets=[AssetKey("asset_1), AssetKey("asset_2)])
         def the_sensor(context: MultiAssetSensorEvaluationContext):
             ...
 
@@ -212,25 +214,21 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         cursor: Optional[str],
         repository_name: Optional[str],
         repository_def: "RepositoryDefinition",
-        asset_selection: Optional[AssetSelection],
-        asset_keys: Optional[Sequence[AssetKey]],
+        monitored_assets: Union[Sequence[AssetKey], AssetSelection],
         instance: Optional[DagsterInstance] = None,
     ):
         from dagster._core.storage.event_log.base import EventLogRecord
 
         self._repository_def = repository_def
-        if asset_selection is not None:
+        self._monitored_asset_keys: Sequence[AssetKey]
+        if isinstance(monitored_assets, AssetSelection):
             repo_assets = self._repository_def._assets_defs_by_key.values()
             repo_source_assets = self._repository_def.source_assets_by_key.values()
             self._monitored_asset_keys = list(
-                asset_selection.resolve([*repo_assets, *repo_source_assets])
+                monitored_assets.resolve([*repo_assets, *repo_source_assets])
             )
-        elif asset_keys is not None:
-            self._monitored_asset_keys = list(asset_keys)
         else:
-            raise DagsterInvalidDefinitionError(
-                "MultiAssetSensorDefinition requires one of asset_selection or asset_keys"
-            )
+            self._monitored_asset_keys = monitored_assets
 
         self._assets_by_key: Dict[AssetKey, Optional[AssetsDefinition]] = {}
         for asset_key in self._monitored_asset_keys:
@@ -928,8 +926,7 @@ def get_cursor_from_latest_materializations(
 @experimental
 def build_multi_asset_sensor_context(
     repository_def: "RepositoryDefinition",
-    asset_keys: Optional[Sequence[AssetKey]] = None,
-    asset_selection: Optional[AssetSelection] = None,
+    monitored_assets: Union[Sequence[AssetKey], AssetSelection],
     instance: Optional[DagsterInstance] = None,
     cursor: Optional[str] = None,
     repository_name: Optional[str] = None,
@@ -943,10 +940,9 @@ def build_multi_asset_sensor_context(
 
     Args:
         repository_def (RepositoryDefinition): The repository definition that the sensor belongs to.
-        asset_keys (Optional[Sequence[AssetKey]]): The list of asset keys monitored by the sensor.
-            If not provided, asset_selection argument must be provided.
-        asset_selection (Optional[AssetSelection]): The asset selection monitored by the sensor.
-            If not provided, asset_keys argument must be provided.
+        monitored_assets (Union[Sequence[AssetKey], AssetSelection]): The assets monitored
+            by the sensor. If an AssetSelection object is provided, it will only apply to assets
+            within the Definitions that this sensor is part of.
         instance (Optional[DagsterInstance]): The dagster instance configured to run the sensor.
         cursor (Optional[str]): A string cursor to provide to the evaluation of the sensor. Must be
             a dictionary of asset key strings to ints that has been converted to a json string
@@ -958,7 +954,10 @@ def build_multi_asset_sensor_context(
         .. code-block:: python
 
             with instance_for_test() as instance:
-                context = build_multi_asset_sensor_context(asset_keys=[AssetKey("asset_1"), AssetKey("asset_2")], instance=instance)
+                context = build_multi_asset_sensor_context(
+                    monitored_assets=[AssetKey("asset_1"), AssetKey("asset_2")],
+                    instance=instance,
+                )
                 my_asset_sensor(context)
 
     """
@@ -968,15 +967,6 @@ def build_multi_asset_sensor_context(
     check.opt_str_param(cursor, "cursor")
     check.opt_str_param(repository_name, "repository_name")
     check.inst_param(repository_def, "repository_def", RepositoryDefinition)
-    check.invariant(asset_keys or asset_selection, "Must provide asset_keys or asset_selection")
-
-    if asset_selection:
-        asset_selection = check.inst_param(asset_selection, "asset_selection", AssetSelection)
-        asset_keys = None
-    else:  # asset keys provided
-        asset_keys = check.opt_sequence_param(asset_keys, "asset_keys", of_type=AssetKey)
-        check.invariant(len(asset_keys) > 0, "Must provide at least one asset key")
-        asset_selection = None
 
     check.bool_param(cursor_from_latest_materializations, "cursor_from_latest_materializations")
 
@@ -993,11 +983,12 @@ def build_multi_asset_sensor_context(
                 " instance."
             )
 
-        if asset_selection:
+        asset_keys: Sequence[AssetKey]
+        if isinstance(monitored_assets, AssetSelection):
             asset_keys = cast(
                 List[AssetKey],
                 list(
-                    asset_selection.resolve(
+                    monitored_assets.resolve(
                         list(
                             set(
                                 repository_def._assets_defs_by_key.values()  # pylint: disable=protected-access
@@ -1006,9 +997,8 @@ def build_multi_asset_sensor_context(
                     )
                 ),
             )
-
-        if asset_keys is None:
-            asset_keys = []
+        else:
+            asset_keys = monitored_assets
 
         cursor = get_cursor_from_latest_materializations(asset_keys, instance)
 
@@ -1019,8 +1009,7 @@ def build_multi_asset_sensor_context(
         cursor=cursor,
         repository_name=repository_name,
         instance=instance,
-        asset_selection=asset_selection,
-        asset_keys=asset_keys,
+        monitored_assets=monitored_assets,
         repository_def=repository_def,
     )
 
@@ -1071,8 +1060,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
     def __init__(
         self,
         name: str,
-        asset_keys: Optional[Sequence[AssetKey]],
-        asset_selection: Optional[AssetSelection],
+        monitored_assets: Union[Sequence[AssetKey], AssetSelection],
         job_name: Optional[str],
         asset_materialization_fn: MultiAssetMaterializationFunction,
         minimum_interval_seconds: Optional[int] = None,
@@ -1081,17 +1069,6 @@ class MultiAssetSensorDefinition(SensorDefinition):
         jobs: Optional[Sequence[ExecutableDefinition]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     ):
-        check.invariant(asset_keys or asset_selection, "Must provide asset_keys or asset_selection")
-        self._monitored_asset_selection: Optional[AssetSelection] = None
-        self._monitored_asset_keys: Optional[Sequence[AssetKey]] = None
-        if asset_selection:
-            self._monitored_asset_selection = check.inst_param(
-                asset_selection, "asset_selection", AssetSelection
-            )
-        else:  # asset keys provided
-            asset_keys = check.opt_sequence_param(asset_keys, "asset_keys", of_type=AssetKey)
-            self._monitored_asset_keys = asset_keys
-
         def _wrap_asset_fn(materialization_fn):
             def _fn(context):
                 multi_asset_sensor_context = MultiAssetSensorEvaluationContext(
@@ -1101,8 +1078,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     cursor=context.cursor,
                     repository_name=context.repository_def.name,
                     repository_def=context.repository_def,
-                    asset_selection=self._monitored_asset_selection,
-                    asset_keys=self._monitored_asset_keys,
+                    monitored_assets=monitored_assets,
                     instance=context.instance,
                 )
 
@@ -1200,13 +1176,3 @@ class MultiAssetSensorDefinition(SensorDefinition):
 
         context.update_cursor_after_evaluation()
         return result
-
-    @public  # type: ignore
-    @property
-    def monitored_asset_selection(self) -> Optional[AssetSelection]:
-        return self._monitored_asset_selection
-
-    @public  # type: ignore
-    @property
-    def monitored_asset_keys(self) -> Optional[Sequence[AssetKey]]:
-        return self._monitored_asset_keys

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -236,7 +236,7 @@ def asset_c(asset_b):  # pylint: disable=unused-argument
     return 3
 
 
-@multi_asset_sensor(asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
+@multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
 def asset_a_and_b_sensor(context):
     asset_events = context.latest_materialization_records_by_key()
     if all(asset_events.values()):
@@ -244,7 +244,7 @@ def asset_a_and_b_sensor(context):
         return RunRequest(run_key=f"{context.cursor}", run_config={})
 
 
-@multi_asset_sensor(asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
+@multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
 def doesnt_update_cursor_sensor(context):
     asset_events = context.latest_materialization_records_by_key()
     if any(asset_events.values()):
@@ -252,7 +252,7 @@ def doesnt_update_cursor_sensor(context):
         return RunRequest(run_key=f"{context.cursor}", run_config={})
 
 
-@multi_asset_sensor(asset_keys=[AssetKey("asset_a")], job=the_job)
+@multi_asset_sensor(monitored_assets=[AssetKey("asset_a")], job=the_job)
 def backlog_sensor(context):
     asset_events = context.materialization_records_for_key(asset_key=AssetKey("asset_a"), limit=2)
     if len(asset_events) == 2:
@@ -260,7 +260,7 @@ def backlog_sensor(context):
         return RunRequest(run_key=f"{context.cursor}", run_config={})
 
 
-@multi_asset_sensor(asset_selection=AssetSelection.keys("asset_c").upstream(include_self=False))
+@multi_asset_sensor(monitored_assets=AssetSelection.keys("asset_c").upstream(include_self=False))
 def asset_selection_sensor(context):
     assert context.asset_keys == [AssetKey("asset_b")]
     assert context.latest_materialization_records_by_key().keys() == {AssetKey("asset_b")}
@@ -309,7 +309,7 @@ weekly_asset_job = define_asset_job(
 )
 
 
-@multi_asset_sensor(asset_keys=[hourly_asset.key], job=weekly_asset_job)
+@multi_asset_sensor(monitored_assets=[hourly_asset.key], job=weekly_asset_job)
 def multi_asset_sensor_hourly_to_weekly(context):
     for partition, materialization in context.latest_materialization_records_by_partition(
         hourly_asset.key
@@ -323,7 +323,7 @@ def multi_asset_sensor_hourly_to_weekly(context):
         context.advance_cursor({hourly_asset.key: materialization})
 
 
-@multi_asset_sensor(asset_keys=[hourly_asset.key], job=hourly_asset_job)
+@multi_asset_sensor(monitored_assets=[hourly_asset.key], job=hourly_asset_job)
 def multi_asset_sensor_hourly_to_hourly(context):
     materialization_by_partition = context.latest_materialization_records_by_partition(
         hourly_asset.key
@@ -670,7 +670,7 @@ def with_source_asset_repo():
     return [a_source_asset]
 
 
-@multi_asset_sensor(asset_keys=[AssetKey("a_source_asset")], job=the_job)
+@multi_asset_sensor(monitored_assets=[AssetKey("a_source_asset")], job=the_job)
 def monitor_source_asset_sensor(context):
     asset_events = context.latest_materialization_records_by_key()
     if all(asset_events.values()):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -39,7 +39,6 @@ from dagster import (
     run_status_sensor,
     sensor,
 )
-from dagster._check import CheckError
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.test_utils import instance_for_test
 
@@ -329,7 +328,7 @@ def test_multi_asset_sensor():
     def asset_b():
         return 1
 
-    @multi_asset_sensor(asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
+    @multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
     def a_and_b_sensor(context):
         asset_events = context.latest_materialization_records_by_key()
         if all(asset_events.values()):
@@ -343,7 +342,7 @@ def test_multi_asset_sensor():
     with instance_for_test() as instance:
         materialize([asset_a, asset_b], instance=instance)
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+            monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
             instance=instance,
             repository_def=my_repo,
         )
@@ -355,7 +354,7 @@ def test_multi_asset_sensor_selection():
     def two_assets():
         return 1, 2
 
-    @multi_asset_sensor(asset_keys=[AssetKey("asset_a")])
+    @multi_asset_sensor(monitored_assets=[AssetKey("asset_a")])
     def passing_sensor(context):  # pylint: disable=unused-argument
         pass
 
@@ -369,7 +368,7 @@ def test_multi_asset_sensor_has_assets():
     def two_assets():
         return 1, 2
 
-    @multi_asset_sensor(asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")])
+    @multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")])
     def passing_sensor(context):
         assert (
             context.assets_defs_by_key[  # pylint: disable=comparison-with-callable
@@ -389,10 +388,9 @@ def test_multi_asset_sensor_has_assets():
     def my_repo():
         return [two_assets, passing_sensor]
 
-    assert passing_sensor.monitored_asset_keys == [AssetKey("asset_a"), AssetKey("asset_b")]
     with instance_for_test() as instance:
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[AssetKey("asset_a"), AssetKey("asset_b")],
+            monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
             instance=instance,
             repository_def=my_repo,
         )
@@ -416,7 +414,9 @@ def test_multi_asset_sensor_invalid_partitions():
 
     with instance_for_test() as instance:
         with build_multi_asset_sensor_context(
-            asset_keys=[static_partitions_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[static_partitions_asset.key],
+            instance=instance,
+            repository_def=my_repo,
         ) as context:
             with pytest.raises(DagsterInvalidInvocationError):
                 context.get_downstream_partition_keys(
@@ -445,7 +445,7 @@ def test_partitions_multi_asset_sensor_context():
         "yay", selection="daily_partitions_asset", partitions_def=daily_partitions_def
     )
 
-    @multi_asset_sensor(asset_keys=[daily_partitions_asset.key, daily_partitions_asset_2.key])
+    @multi_asset_sensor(monitored_assets=[daily_partitions_asset.key, daily_partitions_asset_2.key])
     def two_asset_sensor(context):
         partition_1 = next(
             iter(
@@ -473,7 +473,7 @@ def test_partitions_multi_asset_sensor_context():
             instance=instance,
         )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[daily_partitions_asset.key, daily_partitions_asset_2.key],
+            monitored_assets=[daily_partitions_asset.key, daily_partitions_asset_2.key],
             instance=instance,
             repository_def=my_repo,
         )
@@ -502,7 +502,7 @@ def my_repo():
 
 
 def test_multi_asset_sensor_after_cursor_partition_flag():
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def after_cursor_partitions_asset_sensor(context):
         events = context.latest_materialization_records_by_key([july_asset.key])
 
@@ -538,7 +538,7 @@ def test_multi_asset_sensor_after_cursor_partition_flag():
             instance=instance,
         )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         after_cursor_partitions_asset_sensor(ctx)
         materialize([july_asset], partition_key="2022-07-05", instance=instance)
@@ -546,7 +546,7 @@ def test_multi_asset_sensor_after_cursor_partition_flag():
 
 
 def test_multi_asset_sensor_all_partitions_materialized():
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def asset_sensor(context):
         assert context.all_partitions_materialized(july_asset.key) is False
         assert (
@@ -566,7 +566,7 @@ def test_multi_asset_sensor_all_partitions_materialized():
             instance=instance,
         )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         asset_sensor(ctx)
 
@@ -614,7 +614,7 @@ def test_multi_asset_sensor_custom_partition_mapping():
     def my_repo():
         return [july_daily_partitions, downstream_daily_partitions]
 
-    @multi_asset_sensor(asset_keys=[july_daily_partitions.key])
+    @multi_asset_sensor(monitored_assets=[july_daily_partitions.key])
     def asset_sensor(context):
         for partition_key, _ in context.latest_materialization_records_by_partition(
             july_daily_partitions.key
@@ -633,7 +633,9 @@ def test_multi_asset_sensor_custom_partition_mapping():
             instance=instance,
         )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_daily_partitions.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_daily_partitions.key],
+            instance=instance,
+            repository_def=my_repo,
         )
         asset_sensor(ctx)
 
@@ -641,7 +643,7 @@ def test_multi_asset_sensor_custom_partition_mapping():
 def test_multi_asset_sensor_retains_ordering_and_fetches_latest_per_partition():
     partition_ordering = ["2022-07-15", "2022-07-14", "2022-07-13", "2022-07-12", "2022-07-15"]
 
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def asset_sensor(context):
         assert (
             list(context.latest_materialization_records_by_partition(july_asset.key).keys())
@@ -658,13 +660,13 @@ def test_multi_asset_sensor_retains_ordering_and_fetches_latest_per_partition():
                 instance=instance,
             )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         asset_sensor(ctx)
 
 
 def test_multi_asset_sensor_update_cursor_no_overwrite():
-    @multi_asset_sensor(asset_keys=[july_asset.key, august_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key, august_asset.key])
     def after_cursor_partitions_asset_sensor(context):
         events = context.latest_materialization_records_by_key()
 
@@ -692,7 +694,9 @@ def test_multi_asset_sensor_update_cursor_no_overwrite():
             instance=instance,
         )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key, august_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key, august_asset.key],
+            instance=instance,
+            repository_def=my_repo,
         )
         after_cursor_partitions_asset_sensor(ctx)
         materialize([august_asset], partition_key="2022-08-05", instance=instance)
@@ -700,7 +704,7 @@ def test_multi_asset_sensor_update_cursor_no_overwrite():
 
 
 def test_multi_asset_sensor_latest_materialization_records_by_partition_and_asset():
-    @multi_asset_sensor(asset_keys=[july_asset.key, july_asset_2.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key, july_asset_2.key])
     def my_sensor(context):
         events = context.latest_materialization_records_by_partition_and_asset()
         for partition_key, materialization_by_asset in events.items():
@@ -717,17 +721,11 @@ def test_multi_asset_sensor_latest_materialization_records_by_partition_and_asse
         )
         materialize([july_asset], partition_key="2022-08-04", instance=instance)
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key, july_asset_2.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key, july_asset_2.key],
+            instance=instance,
+            repository_def=my_repo,
         )
         my_sensor(ctx)
-
-
-def test_asset_keys_or_selection_mandatory():
-    with pytest.raises(CheckError, match="Must provide asset_keys or asset_selection"):
-
-        @multi_asset_sensor()
-        def asset_selection_sensor(context):  # pylint: disable=unused-argument
-            pass
 
 
 def test_build_multi_asset_sensor_context_asset_selection():
@@ -742,7 +740,7 @@ def test_build_multi_asset_sensor_context_asset_selection():
     )
 
     @multi_asset_sensor(
-        asset_selection=AssetSelection.groups("ladies").upstream(depth=1, include_self=False)
+        monitored_assets=AssetSelection.groups("ladies").upstream(depth=1, include_self=False)
     )
     def asset_selection_sensor(context):
         assert context.asset_keys == [danny.key]
@@ -753,30 +751,17 @@ def test_build_multi_asset_sensor_context_asset_selection():
 
     with instance_for_test() as instance:
         ctx = build_multi_asset_sensor_context(
-            asset_selection=AssetSelection.groups("ladies").upstream(depth=1, include_self=False),
+            monitored_assets=AssetSelection.groups("ladies").upstream(depth=1, include_self=False),
             instance=instance,
             repository_def=my_repo,
         )
         asset_selection_sensor(ctx)
 
 
-def test_asset_selection_or_asset_keys_mandatory_on_context():
-    @repository
-    def my_repo():
-        return []
-
-    with instance_for_test() as instance:
-        with pytest.raises(CheckError, match="Must provide asset_keys or asset_selection"):
-            build_multi_asset_sensor_context(
-                instance=instance,
-                repository_def=my_repo,
-            )
-
-
 def test_multi_asset_sensor_unconsumed_events():
     invocation_num = 0
 
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def test_unconsumed_events_sensor(context):
         if invocation_num == 0:
             events = context.latest_materialization_records_by_partition(july_asset.key)
@@ -814,7 +799,7 @@ def test_multi_asset_sensor_unconsumed_events():
         assert first_2022_07_10_mat < event_records[2].storage_id
 
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
@@ -842,7 +827,7 @@ def test_multi_asset_sensor_unconsumed_events():
 def test_advance_all_cursors_clears_unconsumed_events():
     invocation_num = 0
 
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def test_unconsumed_events_sensor(context):
         if invocation_num == 0:
             events = context.latest_materialization_records_by_partition(july_asset.key)
@@ -871,7 +856,7 @@ def test_advance_all_cursors_clears_unconsumed_events():
         materialize([july_asset], partition_key="2022-07-10", instance=instance)
 
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
@@ -897,7 +882,7 @@ def test_advance_all_cursors_clears_unconsumed_events():
 
 
 def test_error_when_max_num_unconsumed_events():
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def test_unconsumed_events_sensor(context):
         latest_record = context.materialization_records_for_key(july_asset.key, limit=25)
         context.advance_cursor({july_asset.key: latest_record[-1]})
@@ -914,7 +899,7 @@ def test_error_when_max_num_unconsumed_events():
                 instance=instance,
             )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         test_unconsumed_events_sensor(ctx)
         july_asset_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
@@ -938,7 +923,7 @@ def test_error_when_max_num_unconsumed_events():
 def test_latest_materialization_records_by_partition_fetches_unconsumed_events():
     invocation_num = 0
 
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def test_unconsumed_events_sensor(context):
         if invocation_num == 0:
             context.advance_cursor(
@@ -973,7 +958,7 @@ def test_latest_materialization_records_by_partition_fetches_unconsumed_events()
                 instance=instance,
             )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         test_unconsumed_events_sensor(ctx)
         first_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
@@ -1000,7 +985,7 @@ def test_latest_materialization_records_by_partition_fetches_unconsumed_events()
 
 
 def test_unfetched_partitioned_events_are_unconsumed():
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def test_unconsumed_events_sensor(context):
         context.advance_cursor(
             {
@@ -1023,7 +1008,7 @@ def test_unfetched_partitioned_events_are_unconsumed():
                 instance=instance,
             )
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         test_unconsumed_events_sensor(ctx)
         first_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
@@ -1055,7 +1040,7 @@ def test_unfetched_partitioned_events_are_unconsumed():
         )
 
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key], instance=instance, repository_def=my_repo
+            monitored_assets=[july_asset.key], instance=instance, repository_def=my_repo
         )
         test_unconsumed_events_sensor(ctx)
         second_july_cursor = ctx._get_cursor(july_asset.key)  # pylint: disable=protected-access
@@ -1074,7 +1059,7 @@ def test_build_multi_asset_sensor_context_asset_selection_set_to_latest_material
     def my_asset():
         pass
 
-    @multi_asset_sensor(asset_keys=[my_asset.key])
+    @multi_asset_sensor(monitored_assets=[my_asset.key])
     def my_sensor(context):
         my_asset_cursor = context._get_cursor(my_asset.key)  # pylint: disable=protected-access
         assert my_asset_cursor.latest_consumed_event_id is not None
@@ -1091,7 +1076,7 @@ def test_build_multi_asset_sensor_context_asset_selection_set_to_latest_material
         assert records.event_log_entry.run_id == result.run_id
 
         ctx = build_multi_asset_sensor_context(
-            asset_selection=AssetSelection.groups("default"),
+            monitored_assets=AssetSelection.groups("default"),
             instance=instance,
             cursor_from_latest_materializations=True,
             repository_def=my_repo,
@@ -1112,7 +1097,7 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
     def my_asset():
         return Output(1, metadata={"evaluated": evaluated})
 
-    @multi_asset_sensor(asset_keys=[my_asset.key])
+    @multi_asset_sensor(monitored_assets=[my_asset.key])
     def my_sensor(context):
         if not evaluated:
             assert context.latest_materialization_records_by_key()[my_asset.key] is None
@@ -1138,7 +1123,7 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
         assert records.event_log_entry.run_id == result.run_id
 
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[my_asset.key],
+            monitored_assets=[my_asset.key],
             instance=instance,
             cursor_from_latest_materializations=True,
             repository_def=my_repo,
@@ -1187,7 +1172,7 @@ def test_build_multi_asset_context_set_after_multiple_materializations():
         my_asset_2_cursor = records[1].storage_id
 
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[my_asset.key, my_asset_2.key],
+            monitored_assets=[my_asset.key, my_asset_2.key],
             instance=instance,
             cursor_from_latest_materializations=True,
             repository_def=my_repo,
@@ -1219,7 +1204,7 @@ def test_error_exec_in_process_to_build_multi_asset_sensor_context():
         with instance_for_test() as instance:
             materialize([my_asset], instance=instance)
             build_multi_asset_sensor_context(
-                asset_keys=[my_asset.key],
+                monitored_assets=[my_asset.key],
                 repository_def=my_repo,
                 cursor_from_latest_materializations=True,
             )
@@ -1231,7 +1216,7 @@ def test_error_exec_in_process_to_build_multi_asset_sensor_context():
         with instance_for_test() as instance:
             materialize([my_asset], instance=instance)
             build_multi_asset_sensor_context(
-                asset_keys=[my_asset.key],
+                monitored_assets=[my_asset.key],
                 repository_def=my_repo,
                 cursor_from_latest_materializations=True,
                 cursor="alskdjalsjk",
@@ -1239,13 +1224,13 @@ def test_error_exec_in_process_to_build_multi_asset_sensor_context():
 
 
 def test_error_not_thrown_for_skip_reason():
-    @multi_asset_sensor(asset_keys=[july_asset.key])
+    @multi_asset_sensor(monitored_assets=[july_asset.key])
     def test_unconsumed_events_sensor(_):
         return SkipReason("I am skipping")
 
     with instance_for_test() as instance:
         ctx = build_multi_asset_sensor_context(
-            asset_keys=[july_asset.key],
+            monitored_assets=[july_asset.key],
             repository_def=my_repo,
             instance=instance,
         )


### PR DESCRIPTION
### Summary & Motivation

This takes advantage of the fact that multi-asset sensor is a relatively recent experimental API to do a breaking change. It replaces the `asset_keys` and `asset_selection` arguments to `@multi_asset_sensor` with a single `monitored_assets` argument.

The advantages:
- We've received a number of user reports that, generally, asset selection parameters are finicky and difficult to get right. If we standardize everywhere on a single `asset_selection` parameter that accepts `Union[AssetSelection, Sequence[AssetKey]]`, it would make life easier.
- Avoids conflict with the `asset_selection` param on @sensor, which means something different.

Fixes https://github.com/dagster-io/dagster/issues/11558.

### How I Tested These Changes

bk