### PR TITLE
Add tip when the multiprocess executor hits a likely OOM error

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -27,7 +27,7 @@ from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
-from dagster._utils import start_termination_thread
+from dagster._utils import get_run_crash_explanation, start_termination_thread
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.timing import format_duration, time_execution_scope
 
@@ -253,10 +253,10 @@ class MultiprocessExecutor(Executor):
                             )
                             yield DagsterEvent.engine_event(
                                 step_context,
-                                (
-                                    "Multiprocess executor: child process for step {step_key} "
-                                    "unexpectedly exited with code {exit_code}"
-                                ).format(step_key=key, exit_code=crash.exit_code),
+                                get_run_crash_explanation(
+                                    prefix=f"Multiprocess executor: child process for step {key}",
+                                    exit_code=crash.exit_code,
+                                ),
                                 EngineEventData.engine_error(serializable_error),
                             )
                             step_failure_event = DagsterEvent.step_failure_event(

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_signals.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_signals.py
@@ -1,0 +1,16 @@
+from signal import Signals
+
+from dagster._utils import get_run_crash_explanation
+
+
+def test_get_run_crash_explanation():
+    assert get_run_crash_explanation("foo", 1) == "foo unexpectedly exited with code 1."
+    assert (
+        get_run_crash_explanation("foo", -Signals.SIGTERM)
+        == "foo was terminated by signal 15 (SIGTERM)."
+    )
+    assert (
+        "foo was terminated by signal 9 (SIGKILL). This usually indicates that the process was"
+        " killed by the operating system due to running out of memory."
+        in get_run_crash_explanation("foo", -Signals.SIGKILL)
+    )


### PR DESCRIPTION
- Handle POSIX errors differently in error message instead of mysterious "exit code -9"
- Include OOM-specific tips on SIGKILL since 99/100 times this is an OOM

