### PR TITLE
docs: fix typo Telementry -> Telemetry

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -173,7 +173,7 @@ To do this, provide a `$DAGSTER_HOME/dagster.yaml` file, which Dagit and all Dag
     </tr>
     <tr>
       <td>
-        <a href="#telemetry">Telementry</a>
+        <a href="#telemetry">Telemetry</a>
       </td>
       <td>
         <code>telemetry</code>


### PR DESCRIPTION
### Summary & Motivation

This PR fixes a typo in the docs where telemetry is referred to as "Telementry" in one usage.
