### PR TITLE
[dagit] Support range-based partition health data

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -91,8 +91,8 @@ export const AssetPartitions: React.FC<Props> = ({
         // you have not clicked dimension 1, dimension 2 shows the merged state of all the keys
         // in that dimension (for all values of dimension 1)
         const state =
-          idx > 0 && focusedDimensionKeys.length >= idx
-            ? assetHealth.stateForPartialKey([...focusedDimensionKeys.slice(0, idx), dimensionKey])
+          idx === 1 && focusedDimensionKeys.length >= 1
+            ? assetHealth.stateForKey([focusedDimensionKeys[0], dimensionKey])
             : assetHealth.stateForSingleDimension(
                 idx,
                 dimensionKey,

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -18,7 +18,6 @@ export function mergedAssetHealth(
 ): {
   dimensions: PartitionHealthDimension[];
   stateForKey: (dimensionKeys: string[]) => PartitionState;
-  stateForPartialKey: (dimensionKeys: string[]) => PartitionState;
   stateForSingleDimension: (
     dimensionIdx: number,
     dimensionKey: string,
@@ -29,7 +28,6 @@ export function mergedAssetHealth(
     return {
       dimensions: [],
       stateForKey: () => PartitionState.MISSING,
-      stateForPartialKey: () => PartitionState.MISSING,
       stateForSingleDimension: () => PartitionState.MISSING,
     };
   }
@@ -59,8 +57,6 @@ export function mergedAssetHealth(
     })),
     stateForKey: (dimensionKeys: string[]) =>
       mergedStates(assetHealth.map((health) => health.stateForKey(dimensionKeys))),
-    stateForPartialKey: (dimensionKeys: string[]) =>
-      mergedStates(assetHealth.map((health) => health.stateForPartialKey(dimensionKeys))),
     stateForSingleDimension: (
       dimensionIdx: number,
       dimensionKey: string,

--- a/js_modules/dagit/packages/core/src/assets/types/usePartitionHealthData.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/usePartitionHealthData.types.ts
@@ -18,13 +18,10 @@ export type PartitionHealthQuery = {
           partitionKeys: Array<string>;
         }>;
         materializedPartitions:
-          | {
-              __typename: 'DefaultPartitions';
-              materializedPartitions: Array<string>;
-              unmaterializedPartitions: Array<string>;
-            }
+          | {__typename: 'DefaultPartitions'; materializedPartitions: Array<string>}
           | {
               __typename: 'MultiPartitions';
+              primaryDimensionName: string;
               ranges: Array<{
                 __typename: 'MaterializedPartitionRange2D';
                 primaryDimStartKey: string;
@@ -32,11 +29,7 @@ export type PartitionHealthQuery = {
                 primaryDimStartTime: number | null;
                 primaryDimEndTime: number | null;
                 secondaryDim:
-                  | {
-                      __typename: 'DefaultPartitions';
-                      materializedPartitions: Array<string>;
-                      unmaterializedPartitions: Array<string>;
-                    }
+                  | {__typename: 'DefaultPartitions'; materializedPartitions: Array<string>}
                   | {
                       __typename: 'TimePartitions';
                       ranges: Array<{
@@ -62,3 +55,68 @@ export type PartitionHealthQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export type PartitionHealthMaterialized1DPartitionsFragment_DefaultPartitions_ = {
+  __typename: 'DefaultPartitions';
+  materializedPartitions: Array<string>;
+};
+
+export type PartitionHealthMaterialized1DPartitionsFragment_TimePartitions_ = {
+  __typename: 'TimePartitions';
+  ranges: Array<{
+    __typename: 'TimePartitionRange';
+    startTime: number;
+    endTime: number;
+    startKey: string;
+    endKey: string;
+  }>;
+};
+
+export type PartitionHealthMaterialized1DPartitionsFragment =
+  | PartitionHealthMaterialized1DPartitionsFragment_DefaultPartitions_
+  | PartitionHealthMaterialized1DPartitionsFragment_TimePartitions_;
+
+export type PartitionHealthMaterializedPartitionsFragment_DefaultPartitions_ = {
+  __typename: 'DefaultPartitions';
+  materializedPartitions: Array<string>;
+};
+
+export type PartitionHealthMaterializedPartitionsFragment_MultiPartitions_ = {
+  __typename: 'MultiPartitions';
+  primaryDimensionName: string;
+  ranges: Array<{
+    __typename: 'MaterializedPartitionRange2D';
+    primaryDimStartKey: string;
+    primaryDimEndKey: string;
+    primaryDimStartTime: number | null;
+    primaryDimEndTime: number | null;
+    secondaryDim:
+      | {__typename: 'DefaultPartitions'; materializedPartitions: Array<string>}
+      | {
+          __typename: 'TimePartitions';
+          ranges: Array<{
+            __typename: 'TimePartitionRange';
+            startTime: number;
+            endTime: number;
+            startKey: string;
+            endKey: string;
+          }>;
+        };
+  }>;
+};
+
+export type PartitionHealthMaterializedPartitionsFragment_TimePartitions_ = {
+  __typename: 'TimePartitions';
+  ranges: Array<{
+    __typename: 'TimePartitionRange';
+    startTime: number;
+    endTime: number;
+    startKey: string;
+    endKey: string;
+  }>;
+};
+
+export type PartitionHealthMaterializedPartitionsFragment =
+  | PartitionHealthMaterializedPartitionsFragment_DefaultPartitions_
+  | PartitionHealthMaterializedPartitionsFragment_MultiPartitions_
+  | PartitionHealthMaterializedPartitionsFragment_TimePartitions_;

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -2,11 +2,13 @@ import {gql, useApolloClient} from '@apollo/client';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 
+import {assertUnreachable} from '../app/Util';
 import {PartitionState} from '../partitions/PartitionStatus';
 
 import {mergedStates} from './MultipartitioningSupport';
 import {AssetKey} from './types';
 import {
+  PartitionHealthMaterializedPartitionsFragment,
   PartitionHealthQuery,
   PartitionHealthQueryVariables,
 } from './types/usePartitionHealthData.types';
@@ -24,7 +26,6 @@ export interface PartitionHealthData {
   assetKey: AssetKey;
   dimensions: PartitionHealthDimension[];
   stateForKey: (dimensionKeys: string[]) => PartitionState;
-  stateForPartialKey: (dimensionKeys: string[]) => PartitionState;
   stateForSingleDimension: (
     dimensionIdx: number,
     dimensionKey: string,
@@ -49,82 +50,182 @@ export type PartitionDimensionSelection = {
 };
 
 export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: AssetKey) {
-  const dimensions =
+  const __dims =
     data.assetNodeOrError.__typename === 'AssetNode'
       ? data.assetNodeOrError.partitionKeysByDimension
       : [];
 
-  const materializationStatus = (data.assetNodeOrError.__typename === 'AssetNode' &&
-    data.assetNodeOrError.partitionMaterializationStatus) || {
-    __typename: 'MaterializationStatusSingleDimension',
-    materializationStatus: [],
+  const materializedPartitions = (data.assetNodeOrError.__typename === 'AssetNode' &&
+    data.assetNodeOrError.materializedPartitions) || {
+    __typename: 'DefaultPartitions',
+    unmaterializedPartitions: [],
+    materializedPartitions: [],
   };
 
-  const stateByKey = Object.fromEntries(
-    materializationStatus.__typename === 'MaterializationStatusSingleDimension'
-      ? materializationStatus.materializationStatus.map((materialized, idx) => [
-          dimensions[0].partitionKeys[idx],
-          materialized ? PartitionState.SUCCESS : PartitionState.MISSING,
-        ])
-      : materializationStatus.materializationStatusGrouped.map((dim0, idx0) => [
-          dimensions[0].partitionKeys[idx0],
-          Object.fromEntries(
-            dim0.map((materialized, idx1) => [
-              dimensions[1].partitionKeys[idx1],
-              materialized ? PartitionState.SUCCESS : PartitionState.MISSING,
-            ]),
-          ),
-        ]),
-  );
+  // The backend re-orders the dimensions only for the materializedPartitions ranges so that
+  // the time partition is the "primary" one, even if it's dimension[1] elsewhere.
+  // This matches the way we display them in the UI and makes some common data retrieval faster,
+  // but Dagit's internals always use the REAL ordering of the partition keys, we need to flip
+  // everything in this function to match the range data.
+  const isRangeDataInverted =
+    __dims.length === 2 &&
+    materializedPartitions.__typename === 'MultiPartitions' &&
+    materializedPartitions.primaryDimensionName !== __dims[0].name;
 
-  const stateForKey = (dimensionKeys: string[]): PartitionState =>
-    dimensionKeys.reduce((counts, dimensionKey) => counts[dimensionKey], stateByKey);
+  const dimensions = isRangeDataInverted ? [__dims[1], __dims[0]] : __dims;
+  const ranges = addKeyIndexesToMaterializedRanges(dimensions, materializedPartitions);
+  const stateForKey = (dimensionKeys: string[]): PartitionState => {
+    return stateForKeyWithRangeOrdering(
+      isRangeDataInverted ? dimensionKeys.reverse() : dimensionKeys,
+    );
+  };
+
+  const stateForKeyWithRangeOrdering = (dimensionKeys: string[]): PartitionState => {
+    if (dimensionKeys.length !== dimensions.length) {
+      console.warn('[stateForKey] called with incorrect number of dimensions');
+      return PartitionState.MISSING;
+    }
+
+    const dIndexes = dimensionKeys.map((key, idx) => dimensions[idx].partitionKeys.indexOf(key));
+    const d0Range = ranges.find((r) => r.start.idx <= dIndexes[0] && r.end.idx >= dIndexes[0]);
+
+    if (!d0Range) {
+      return PartitionState.MISSING;
+    }
+    if (!d0Range.subranges) {
+      return PartitionState.SUCCESS; // 1D case
+    }
+    const d1Range = d0Range.subranges.find(
+      (r) => r.start.idx <= dIndexes[1] && r.end.idx >= dIndexes[1],
+    );
+    return d1Range ? PartitionState.SUCCESS : PartitionState.MISSING;
+  };
 
   const stateForSingleDimension = (
     dimensionIdx: number,
     dimensionKey: string,
-    otherDimensionSelectedKeys?: string[],
+    otherDimensionSelectedKeys?: string[], // using this feature is slow
   ) => {
     if (dimensionIdx === 0 && dimensions.length === 1) {
-      return stateForKey([dimensionKey]);
+      return stateForKeyWithRangeOrdering([dimensionKey]);
     }
-    if (dimensionIdx === 0) {
-      return mergedStates(
-        Object.entries<PartitionState>(stateByKey[dimensionKey])
-          .filter(
-            ([key]) => !otherDimensionSelectedKeys || otherDimensionSelectedKeys.includes(key),
-          )
-          .map(([_, val]) => val),
-      );
-    } else if (dimensionIdx === 1) {
-      return mergedStates(
-        Object.entries<{[subdimensionKey: string]: PartitionState}>(stateByKey)
-          .filter(
-            ([key]) => !otherDimensionSelectedKeys || otherDimensionSelectedKeys.includes(key),
-          )
-          .map(([_, val]) => val[dimensionKey]),
-      );
-    } else {
-      throw new Error('stateForSingleDimension asked for third dimension');
-    }
-  };
 
-  const stateForPartialKey = (dimensionKeys: string[]) => {
-    return dimensionKeys.length === dimensions.length
-      ? stateForKey(dimensionKeys)
-      : mergedStates(Object.values(stateByKey[dimensionKeys[0]]));
+    const [d0, d1] = dimensions;
+    if (isRangeDataInverted) {
+      dimensionIdx = 1 - dimensionIdx;
+    }
+
+    if (dimensionIdx === 0) {
+      if (otherDimensionSelectedKeys) {
+        return mergedStates(
+          otherDimensionSelectedKeys.map((k) => stateForKeyWithRangeOrdering([dimensionKey, k])),
+        );
+      }
+      const d0Idx = d0.partitionKeys.indexOf(dimensionKey);
+      const d0Range = ranges.find((r) => r.start.idx <= d0Idx && r.end.idx >= d0Idx);
+      return d0Range?.value || PartitionState.MISSING;
+    }
+    if (dimensionIdx === 1) {
+      if (otherDimensionSelectedKeys) {
+        return mergedStates(
+          otherDimensionSelectedKeys.map((k) => stateForKeyWithRangeOrdering([k, dimensionKey])),
+        );
+      }
+
+      const d1Idx = d1.partitionKeys.indexOf(dimensionKey);
+      const d0RangesContainingSubrangeWithD1Idx = ranges.filter((r) =>
+        r.subranges?.some((sr) => sr.start.idx <= d1Idx && sr.end.idx >= d1Idx),
+      );
+      return ranges.length && d0RangesContainingSubrangeWithD1Idx.length === ranges.length
+        ? PartitionState.SUCCESS
+        : d0RangesContainingSubrangeWithD1Idx.length > 0
+        ? PartitionState.SUCCESS_MISSING
+        : PartitionState.MISSING;
+    }
+
+    throw new Error('stateForSingleDimension asked for third dimension');
   };
 
   const result: PartitionHealthData = {
     assetKey: loadKey,
+    dimensions: __dims.map((d) => ({name: d.name, partitionKeys: d.partitionKeys})),
     stateForKey,
-    stateForPartialKey,
     stateForSingleDimension,
-    dimensions: dimensions.map((d) => ({
-      name: d.name,
-      partitionKeys: d.partitionKeys,
-    })),
   };
+
+  return result;
+}
+
+// Add indexes to the materializedPartitions data so that we can find specific keys in
+// the range structures without having to indexOf the start and end key of every range.
+//
+type Range = {
+  start: {key: string; idx: number};
+  end: {key: string; idx: number};
+  value: PartitionState.SUCCESS | PartitionState.SUCCESS_MISSING;
+  subranges?: Range[];
+};
+
+function addKeyIndexesToMaterializedRanges(
+  dimensions: {name: string; partitionKeys: string[]}[],
+  materializedPartitions: PartitionHealthMaterializedPartitionsFragment,
+) {
+  const result: Range[] = [];
+
+  if (materializedPartitions.__typename === 'DefaultPartitions') {
+    const dim = dimensions[0];
+    const count = dim.partitionKeys.length;
+    if (materializedPartitions.materializedPartitions.length === count) {
+      return [
+        {
+          start: {key: dim.partitionKeys[0], idx: 0},
+          end: {key: dim.partitionKeys[count - 1], idx: count - 1},
+          value: PartitionState.SUCCESS as const,
+        },
+      ];
+    } else {
+      return materializedPartitions.materializedPartitions.map<Range>((key) => {
+        const idx = dim.partitionKeys.indexOf(key);
+        return {start: {key, idx}, end: {key, idx}, value: PartitionState.SUCCESS};
+      });
+    }
+  }
+
+  for (const range of materializedPartitions.ranges) {
+    if (range.__typename === 'TimePartitionRange') {
+      result.push({
+        value: PartitionState.SUCCESS,
+        start: {key: range.startKey, idx: dimensions[0].partitionKeys.indexOf(range.startKey)},
+        end: {key: range.endKey, idx: dimensions[0].partitionKeys.indexOf(range.endKey)},
+      });
+    } else if (range.__typename === 'MaterializedPartitionRange2D') {
+      if (dimensions.length !== 2) {
+        console.warn('[addKeyIndexesToMaterializedRanges] Found 2D health data for 1D asset');
+        return result;
+      }
+      const [dim0, dim1] = dimensions;
+      const subranges: Range[] = addKeyIndexesToMaterializedRanges([dim1], range.secondaryDim);
+      const subrangeIsAll =
+        subranges.length === 1 &&
+        subranges[0].start.idx === 0 &&
+        subranges[0].end.idx === dim1.partitionKeys.length - 1;
+
+      result.push({
+        value: subrangeIsAll ? PartitionState.SUCCESS : PartitionState.SUCCESS_MISSING,
+        subranges,
+        start: {
+          key: range.primaryDimStartKey,
+          idx: dim0.partitionKeys.indexOf(range.primaryDimStartKey),
+        },
+        end: {
+          key: range.primaryDimEndKey,
+          idx: dim0.partitionKeys.indexOf(range.primaryDimEndKey),
+        },
+      });
+    } else {
+      assertUnreachable(range);
+    }
+  }
 
   return result;
 }
@@ -184,40 +285,37 @@ const PARTITION_HEALTH_QUERY = gql`
           partitionKeys
         }
         materializedPartitions {
-          ... on TimePartitions {
-            ranges {
-              startTime
-              endTime
-              startKey
-              endKey
-            }
-          }
-          ... on DefaultPartitions {
-            materializedPartitions
-            unmaterializedPartitions
-          }
-          ... on MultiPartitions {
-            ranges {
-              primaryDimStartKey
-              primaryDimEndKey
-              primaryDimStartTime
-              primaryDimEndTime
-              secondaryDim {
-                ... on TimePartitions {
-                  ranges {
-                    startTime
-                    endTime
-                    startKey
-                    endKey
-                  }
-                }
-                ... on DefaultPartitions {
-                  materializedPartitions
-                  unmaterializedPartitions
-                }
-              }
-            }
-          }
+          ...PartitionHealthMaterializedPartitionsFragment
+        }
+      }
+    }
+  }
+
+  fragment PartitionHealthMaterialized1DPartitionsFragment on PartitionStatus1D {
+    ... on TimePartitions {
+      ranges {
+        startTime
+        endTime
+        startKey
+        endKey
+      }
+    }
+    ... on DefaultPartitions {
+      materializedPartitions
+    }
+  }
+
+  fragment PartitionHealthMaterializedPartitionsFragment on MaterializedPartitions {
+    ...PartitionHealthMaterialized1DPartitionsFragment
+    ... on MultiPartitions {
+      primaryDimensionName
+      ranges {
+        primaryDimStartKey
+        primaryDimEndKey
+        primaryDimStartTime
+        primaryDimEndTime
+        secondaryDim {
+          ...PartitionHealthMaterialized1DPartitionsFragment
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -708,6 +708,7 @@ type DefaultPartitions {
 
 type MultiPartitions {
   ranges: [MaterializedPartitionRange2D!]!
+  primaryDimensionName: String!
 }
 
 type MaterializedPartitionRange2D {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1945,6 +1945,7 @@ export type ModeNotFoundError = Error & {
 
 export type MultiPartitions = {
   __typename: 'MultiPartitions';
+  primaryDimensionName: Scalars['String'];
   ranges: Array<MaterializedPartitionRange2D>;
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -474,7 +474,9 @@ def get_2d_run_length_encoded_materialized_partitions(
             range_start_idx = unevaluated_idx
         unevaluated_idx += 1
 
-    return GrapheneMultiPartitions(ranges=materialized_2d_ranges)
+    return GrapheneMultiPartitions(
+        ranges=materialized_2d_ranges, primaryDimensionName=primary_dim.name
+    )
 
 
 def get_freshness_info(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -137,6 +137,7 @@ class GrapheneMultiPartitionRange(graphene.ObjectType):
 
 class GrapheneMultiPartitions(graphene.ObjectType):
     ranges = non_null_list(GrapheneMultiPartitionRange)
+    primaryDimensionName = graphene.NonNull(graphene.String)
 
     class Meta:
         name = "MultiPartitions"


### PR DESCRIPTION
### Summary & Motivation

This PR makes Dagit compile again with the updates in #10822

This is phase 1 of two phases of work to use range-based partition health data. This PR updates our existing client-side health structures to read the new GraphQL endpoints which return the state of partition ranges rather than the state of each individual partition in a "matrix" of booleans.

Mapping the new APIs to our client-side requirements does require some transforms, and it increases code complexity in `usePartitionHealthData`. Namely, we need to add the start/end partition indexes of each range so we can efficiently look up the status of a particular partition within the range data. (eg: `given these ranges of [A->C], [E->F], is D materialized?`)

The second phase of work is to 1) make the "partition health bar" rely more directly on this data and not load the partition key space along with it, and 2) make Dagit query for the health of individual partitions individually via a new endpoint (so it doesn't have to answer the question above). This is our eventual goal, but will require a bit more work:

- In the static partitions case, `materializedPartitions` alone cannot tell us the correct display order for `materializedPartitions` / `unmaterializedParttions`. We still need to load all the keys in order in order to display the health bar.

- In the multi-dimensional health case, the returned structure contains subranges. We don't actually care at all about the subranges, but we need to know whether the second dimension is `"complete", "partial" or "missing"`. I think a backend resolver might need to be added for this that just returns these three states, or missingCount / completeCount.

We're planning to postpone the second chunk of work here, because the current implementation (which loads the partition keys) isn't actually that slow now that we've made other changes, and it's unclear if all the work will be worthwhile.