### PR TITLE
misc docs fixes in tutorial / getting started / assets

### DIFF
--- a/docs/content/concepts/assets/asset-observations.mdx
+++ b/docs/content/concepts/assets/asset-observations.mdx
@@ -16,7 +16,7 @@ An asset observation is an event that records metadata about a given asset. Unli
 
 ## Overview
 
-<PyObject object="AssetObservation" /> events are used record metadata in Dagster
+<PyObject object="AssetObservation" /> events are used to record metadata in Dagster
 about a given asset. Asset observation events can be logged at runtime within ops
 and assets. An asset must be defined using the <PyObject
 object="asset"
@@ -108,13 +108,13 @@ def partitioned_dataset_op(context):
 
 ### Observable source assets
 
-<PyObject object="SourceAsset" /> objects may have a user-defined _observation function_
+<PyObject object="SourceAsset" /> objects may have a user-defined observation function
 that returns a <PyObject object="LogicalVersion" />. Whenever the observation
-function is run, an `AssetObservation` will be generated for the source asset
-and tagged with the returned logical version. The logical version is used in
-staleness calculations for downstream assets.
+function is run, an <PyObject object="AssetObservation" /> will be generated for
+the source asset and tagged with the returned logical version. The logical
+version is used in staleness calculations for downstream assets.
 
-The <PyObject object="observable_source_asset" /> decorator provides a convenient way to define source assets with observation functions. The below observable source asset takes a file hash and returns it as the logical version. Every time you run the observation function, a new observation will be generated with this hash set as logical version.
+The <PyObject object="observable_source_asset" /> decorator provides a convenient way to define source assets with observation functions. The below observable source asset takes a file hash and returns it as the logical version. Every time you run the observation function, a new observation will be generated with this hash set as its logical version.
 
 ```python file=/concepts/assets/observable_source_assets.py startafter=start_marker endbefore=end_marker
 from hashlib import sha256
@@ -129,7 +129,7 @@ def foo_source_asset(_context):
     return LogicalVersion(hash_sig.hexdigest())
 ```
 
-When the file content changes, the hash and therefore the logical version will change-- this will notify Dagster that downstream assets derived from an older value (i.e. a different logical version) of this source asset are stale.
+When the file content changes, the hash and therefore the logical version will change - this will notify Dagster that downstream assets derived from an older value (i.e. a different logical version) of this source asset are stale.
 
 Source asset observations can be triggered via the "Observe sources" button in the Dagit graph explorer view. Note that this button will only be visible if at least one source asset in the current graph defines an observation function.
 

--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -635,7 +635,7 @@ Interested in learning more about software-defined assets and working through a 
 
 For more examples of software-defined assets, check out these examples:
 
-- In the [SDA Hacker News example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
+- In the [Fully Featured Project example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
 
   - [Defining an asset](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/assets/activity_analytics/activity_forecast.py)
   - [Loading assets from dbt](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/assets/\__init\_\_.py)

--- a/docs/content/getting-started/create-new-project.mdx
+++ b/docs/content/getting-started/create-new-project.mdx
@@ -231,7 +231,7 @@ pytest my_dagster_project_tests
 
 If you want to enable Dagster [schedules](/concepts/partitions-schedules-sensors/schedules) or [sensors](/concepts/partitions-schedules-sensors/sensors), you will need to start a [Dagster Daemon](/deployment/dagster-daemon).
 
-Start a daemon process in the same folder as your `workspace.yaml` file, but in a different shell or terminal:
+Start a daemon process in the same folder as your `pyproject.toml` file, but in a different shell or terminal:
 
 ```bash
 dagster-daemon run
@@ -253,4 +253,4 @@ Once your project is ready to move to production, check out our recommendation f
 Check out the following resources to learn more about deployment options:
 
 - [Dagster Cloud](/dagster-cloud) - Deploy using Dagster-managed infrastructure
-- [Your own infrastrucutre](/deployment) - Deploy to your own infrastructure, such as Docker, Kubernetes, Amazon Web Services, etc.
+- [Your own infrastructure](/deployment) - Deploy to your own infrastructure, such as Docker, Kubernetes, Amazon Web Services, etc.

--- a/docs/content/getting-started/hello-dagster.mdx
+++ b/docs/content/getting-started/hello-dagster.mdx
@@ -21,7 +21,7 @@ Create a file named `hello-dagster.py` that contains the following code:
 import pandas as pd
 import requests
 
-from dagster import MetadataValue, Output, asset, repository
+from dagster import MetadataValue, Output, asset
 
 
 @asset

--- a/docs/content/tutorial/assets/next-steps.mdx
+++ b/docs/content/tutorial/assets/next-steps.mdx
@@ -9,7 +9,7 @@ description: What if you want to do more after completing the asset tutorial?
 
 What if you want to do more?
 
-- **Automating asset materialization** - This tutorial covered how to manually materialize assets. Dagster can also kick off materializations automatically: on fixed [schedules](/concepts/partitions-schedules-sensors/schedules) or when your [sensor](/concepts/partitions-schedules-sensors/sensors) says to.
+- **Automating asset materialization** - This tutorial covered how to manually materialize assets. Dagster can also kick off materializations automatically: on fixed [schedules](/concepts/partitions-schedules-sensors/schedules) or when a [sensor](/concepts/partitions-schedules-sensors/sensors) says to.
 - **Partitioning assets** - This tutorial covered assets whose entire contents get re-computed and overwritten with every materialization. When assets are large, it’s common to [partition](/concepts/partitions-schedules-sensors/partitions) them, so that each run only materializes a single partition.
 - **Customizing asset storage** - The assets in this tutorial were materialized as pickle files on the local filesystem. [IO managers](/concepts/io-management/io-managers) let you customize how and where assets are stored - e.g. as tables in Snowflake or Parquet files in S3.
 - **Non-asset jobs** - This tutorial showed you how to work with Dagster's primary building block, assets. However, sometimes you'll have tasks that don't produce assets. To learn how to execute tasks, check out the [Intro to ops and jobs guide](/guides/dagster/intro-to-ops-jobs).

--- a/examples/docs_snippets/docs_snippets/getting-started/hello-dagster/hello-dagster.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/hello-dagster/hello-dagster.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import requests
 
-from dagster import MetadataValue, Output, asset, repository
+from dagster import MetadataValue, Output, asset
 
 
 @asset


### PR DESCRIPTION
Summary:
- Stray reference to workspace.yaml snuck through in the create new project page
- Unneeded repository import in the hello world code
- Some weird formatting in the asset observations page, seems to require html not markdown, maybe b/c the paragraph starts with a bracket?
- Misc typos

### Summary & Motivation

### How I Tested These Changes
