### PR TITLE
refactor(dbt-cloud): remove v2 suffix

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -12,6 +12,7 @@ from .cli import (
 )
 from .cloud import (
     DbtCloudOutput as DbtCloudOutput,
+    DbtCloudResource as DbtCloudResource,
     DbtCloudResourceV2 as DbtCloudResourceV2,
     dbt_cloud_resource as dbt_cloud_resource,
     dbt_cloud_run_op as dbt_cloud_run_op,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/__init__.py
@@ -1,6 +1,7 @@
 from .asset_defs import load_assets_from_dbt_cloud_job as load_assets_from_dbt_cloud_job
 from .ops import dbt_cloud_run_op as dbt_cloud_run_op
 from .resources import (
+    DbtCloudResource as DbtCloudResource,
     DbtCloudResourceV2 as DbtCloudResourceV2,
     dbt_cloud_resource as dbt_cloud_resource,
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -46,7 +46,7 @@ from ..asset_defs import (
 )
 from ..errors import DagsterDbtCloudJobInvariantViolationError
 from ..utils import ASSET_RESOURCE_TYPES, result_to_events
-from .resources import DbtCloudResourceV2
+from .resources import DbtCloudResource
 
 
 class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
@@ -61,7 +61,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         partition_key_to_vars_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
     ):
         self._dbt_cloud_resource_def = dbt_cloud_resource_def
-        self._dbt_cloud: DbtCloudResourceV2 = dbt_cloud_resource_def(build_init_resource_context())
+        self._dbt_cloud: DbtCloudResource = dbt_cloud_resource_def(build_init_resource_context())
         self._job_id = job_id
         self._project_id: int
         self._has_generate_docs: bool
@@ -361,7 +361,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             compute_kind="dbt",
         )
         def _assets(context: OpExecutionContext):
-            dbt_cloud = cast(DbtCloudResourceV2, context.resources.dbt_cloud)
+            dbt_cloud = cast(DbtCloudResource, context.resources.dbt_cloud)
 
             # Add the partition variable as a variable to the dbt Cloud job command.
             dbt_options: List[str] = []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -151,7 +151,7 @@ def test_load_assets_from_dbt_cloud_job(
         + after_dbt_materialization_command
     )
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=dbt_commands,
     )
 
@@ -160,7 +160,7 @@ def test_load_assets_from_dbt_cloud_job(
     )
 
     mock_run_job_and_poll = mocker.patch(
-        "dagster_dbt.cloud.resources.DbtCloudResourceV2.run_job_and_poll",
+        "dagster_dbt.cloud.resources.DbtCloudResource.run_job_and_poll",
         wraps=dbt_cloud_cacheable_assets._dbt_cloud.run_job_and_poll,  # pylint: disable=protected-access
     )
 
@@ -227,7 +227,7 @@ def test_invalid_dbt_cloud_job_commands(dbt_cloud, dbt_cloud_service, invalid_db
     )
 
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=invalid_dbt_commands,
     )
 
@@ -244,7 +244,7 @@ def test_empty_assets_dbt_cloud_job(dbt_cloud, dbt_cloud_service):
     )
 
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=["dbt build"],
         run_results_json=empty_run_results_json,
     )
@@ -256,7 +256,7 @@ def test_empty_assets_dbt_cloud_job(dbt_cloud, dbt_cloud_service):
 @responses.activate
 def test_custom_groups(dbt_cloud, dbt_cloud_service):
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=["dbt build"],
     )
 
@@ -281,7 +281,7 @@ def test_custom_groups(dbt_cloud, dbt_cloud_service):
 @responses.activate
 def test_node_info_to_asset_key(dbt_cloud, dbt_cloud_service):
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=["dbt build"],
     )
 
@@ -306,7 +306,7 @@ def test_node_info_to_asset_key(dbt_cloud, dbt_cloud_service):
 @responses.activate
 def test_custom_freshness_policy(dbt_cloud, dbt_cloud_service):
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=["dbt build"],
     )
 
@@ -331,7 +331,7 @@ def test_custom_freshness_policy(dbt_cloud, dbt_cloud_service):
 @responses.activate
 def test_partitions(mocker, dbt_cloud, dbt_cloud_service):
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=["dbt build"],
     )
 
@@ -346,7 +346,7 @@ def test_partitions(mocker, dbt_cloud, dbt_cloud_service):
     )
 
     mock_run_job_and_poll = mocker.patch(
-        "dagster_dbt.cloud.resources.DbtCloudResourceV2.run_job_and_poll",
+        "dagster_dbt.cloud.resources.DbtCloudResource.run_job_and_poll",
         wraps=dbt_cloud_cacheable_assets._dbt_cloud.run_job_and_poll,  # pylint: disable=protected-access
     )
 
@@ -415,7 +415,7 @@ def test_subsetting(
     mocker, dbt_cloud, dbt_cloud_service, asset_selection, expected_dbt_asset_names
 ):
     _add_dbt_cloud_job_responses(
-        dbt_cloud_api_base_url=dbt_cloud_service.api_base_url,
+        dbt_cloud_api_base_url=dbt_cloud_service.api_v2_base_url,
         dbt_commands=["dbt build"],
     )
 
@@ -425,7 +425,7 @@ def test_subsetting(
     )
 
     mock_run_job_and_poll = mocker.patch(
-        "dagster_dbt.cloud.resources.DbtCloudResourceV2.run_job_and_poll",
+        "dagster_dbt.cloud.resources.DbtCloudResource.run_job_and_poll",
         wraps=dbt_cloud_cacheable_assets._dbt_cloud.run_job_and_poll,  # pylint: disable=protected-access
     )
 


### PR DESCRIPTION
### Summary & Motivation
The version of the dbt Cloud API should not be leaked in the class name, especially since we don't expose an actual client object over all the v2 endpoints. In the future, this will be migrated to the v3 api, or even live in a state between v2 and v3, so remove the version from the name to avoid confusion.

### How I Tested These Changes
bk
