### PR TITLE
[structured config] Allow specifying unconfigured struct config resources

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -165,9 +165,9 @@ class UnconfiguredStructuredResource(ResourceDefinition):
             instantiated = resource(**context.resource_config)
 
             if is_context_provided(instantiated):
-                return resource_fn(context)
+                return instantiated.resource_fn(context)
             else:
-                return resource_fn()
+                return instantiated.resource_fn()
 
         super().__init__(
             resource_fn=resource_fn,
@@ -277,9 +277,9 @@ class UnconfiguredStructuredIOManager(IOManagerDefinition):
             instantiated = io_manager(**context.resource_config)
 
             if is_io_manager_context_provided(instantiated):
-                return resource_fn(context)
+                return instantiated.resource_fn(context)
             else:
-                return resource_fn()
+                return instantiated.resource_fn()
 
         super().__init__(
             resource_fn=resource_fn,

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -27,16 +27,8 @@ from dagster._config.field_utils import (
     config_dictionary_from_values,
     convert_potential_field,
 )
-from dagster._core.definitions.resource_definition import (
-    ResourceDefinition,
-    ResourceFunction,
-    is_context_provided,
-)
-from dagster._core.storage.io_manager import (
-    IOManager,
-    IOManagerDefinition,
-    is_io_manager_context_provided,
-)
+from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
+from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
 
 class MakeConfigCacheable(BaseModel):
@@ -163,11 +155,7 @@ class UnconfiguredStructuredResource(ResourceDefinition):
 
         def resource_fn(context: InitResourceContext):
             instantiated = resource(**context.resource_config)
-
-            if is_context_provided(instantiated):
-                return instantiated.resource_fn(context)
-            else:
-                return instantiated.resource_fn()
+            return instantiated.create_object_to_pass_to_user_code(context)
 
         super().__init__(
             resource_fn=resource_fn,
@@ -275,11 +263,7 @@ class UnconfiguredStructuredIOManager(IOManagerDefinition):
 
         def resource_fn(context: InitResourceContext):
             instantiated = io_manager(**context.resource_config)
-
-            if is_io_manager_context_provided(instantiated):
-                return instantiated.resource_fn(context)
-            else:
-                return instantiated.resource_fn()
+            return instantiated.create_io_manager_to_pass_to_user_code(context)
 
         super().__init__(
             resource_fn=resource_fn,

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -3,6 +3,12 @@ from typing import Any, Dict, Generator, Mapping, Optional, cast
 
 import dagster._check as check
 from dagster._config import process_config
+from dagster._config.structured_config import (
+    UnconfiguredStructuredIOManager,
+    UnconfiguredStructuredResource,
+    is_structured_io_manager_cls,
+    is_structured_resource_cls,
+)
 from dagster._core.definitions.resource_definition import (
     ResourceDefinition,
     Resources,
@@ -124,6 +130,10 @@ def wrap_resources_for_execution(
     for resource_key, resource in resources.items():
         if isinstance(resource, ResourceDefinition):
             resource_defs[resource_key] = resource
+        elif is_structured_resource_cls(resource):
+            resource_defs[resource_key] = UnconfiguredStructuredResource(resource)
+        elif is_structured_io_manager_cls(resource):
+            resource_defs[resource_key] = UnconfiguredStructuredIOManager(resource)
         elif isinstance(resource, IOManager):
             resource_defs[resource_key] = IOManagerDefinition.hardcoded_io_manager(resource)
         else:

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -1,6 +1,17 @@
 from abc import abstractmethod
 from functools import update_wrapper
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Set, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Callable,
+    Optional,
+    Set,
+    TypeGuard,
+    Union,
+    cast,
+    overload,
+)
 
 from typing_extensions import TypeAlias
 
@@ -18,15 +29,24 @@ from dagster._core.storage.input_manager import InputManager
 from dagster._core.storage.output_manager import IOutputManagerDefinition, OutputManager
 from dagster._core.storage.root_input_manager import IInputManagerDefinition
 
+from ..decorator_utils import get_function_params
+
 if TYPE_CHECKING:
     from dagster._core.execution.context.init import InitResourceContext
     from dagster._core.execution.context.input import InputContext
     from dagster._core.execution.context.output import OutputContext
 
+IOManagerFunctionWithContext = (Callable[["InitResourceContext"], "IOManager"],)
 IOManagerFunction: TypeAlias = Union[
-    Callable[["InitResourceContext"], "IOManager"],
+    IOManagerFunctionWithContext,
     Callable[[], "IOManager"],
 ]
+
+
+def is_io_manager_context_provided(
+    fn: IOManagerFunction,
+) -> TypeGuard[IOManagerFunctionWithContext]:
+    return len(get_function_params(fn)) >= 1
 
 
 class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputManagerDefinition):

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -1,19 +1,8 @@
 from abc import abstractmethod
 from functools import update_wrapper
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    Callable,
-    Optional,
-    Set,
-    TypeGuard,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Set, Union, cast, overload
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
 from dagster._annotations import public
@@ -36,7 +25,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.context.input import InputContext
     from dagster._core.execution.context.output import OutputContext
 
-IOManagerFunctionWithContext = (Callable[["InitResourceContext"], "IOManager"],)
+IOManagerFunctionWithContext = Callable[["InitResourceContext"], "IOManager"]
 IOManagerFunction: TypeAlias = Union[
     IOManagerFunctionWithContext,
     Callable[[], "IOManager"],

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from functools import update_wrapper
 from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Set, Union, cast, overload
 
-from typing_extensions import TypeAlias, TypeGuard
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
@@ -18,24 +18,15 @@ from dagster._core.storage.input_manager import InputManager
 from dagster._core.storage.output_manager import IOutputManagerDefinition, OutputManager
 from dagster._core.storage.root_input_manager import IInputManagerDefinition
 
-from ..decorator_utils import get_function_params
-
 if TYPE_CHECKING:
     from dagster._core.execution.context.init import InitResourceContext
     from dagster._core.execution.context.input import InputContext
     from dagster._core.execution.context.output import OutputContext
 
-IOManagerFunctionWithContext = Callable[["InitResourceContext"], "IOManager"]
 IOManagerFunction: TypeAlias = Union[
-    IOManagerFunctionWithContext,
+    Callable[["InitResourceContext"], "IOManager"],
     Callable[[], "IOManager"],
 ]
-
-
-def is_io_manager_context_provided(
-    fn: IOManagerFunction,
-) -> TypeGuard[IOManagerFunctionWithContext]:
-    return len(get_function_params(fn)) >= 1
 
 
 class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputManagerDefinition):


### PR DESCRIPTION
## Summary

Allows using structured-config based resources and IO managers without binding config at defintiions-time, e.g.:


```python

class MyResource(Resource):
    a_string: str

@asset
def my_asset(res: MyResource):
    print(res.a_string)


defs = Definitions(
    assets=[my_asset],
    resources={"res": MyResource}
)
```
<img width="1395" alt="Screen Shot 2023-01-09 at 12 40 57 PM" src="https://user-images.githubusercontent.com/10215173/211403937-e1c2c0b6-794d-4cda-a081-6c4fe6a2da47.png">

## Test Plan

Add unit tests for resources, IO managers.
