### PR TITLE
 Change exclude to extra-include in pyproject.toml settings for ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,10 @@ filterwarnings = [
 
 [tool.ruff]
 
-exclude = [
+extend-exclude = [
   "*/__generated__/*",
   "*/dagster_airflow/vendor/*",
   "*/snapshots/*",
-  ".git/*"
 ]
 
 ignore = [


### PR DESCRIPTION
### Summary & Motivation

Per https://github.com/dagster-io/dagster/pull/11534#discussion_r1064031414 we can use extend-exclude instead of just exclude and keep exclusions of things like .git

### How I Tested These Changes

make ruff
BK
