### PR TITLE
[@dagster-io/ui] Output cjs

### DIFF
--- a/js_modules/dagit/packages/ui/CHANGES.md
+++ b/js_modules/dagit/packages/ui/CHANGES.md
@@ -1,6 +1,9 @@
-## 1.0.8 (TBD)
+## 1.0.8 (January 9, 2023)
 
 - Added ProductTour component
+- Build CJS output instead of ESM, with individual built components in subdirectories
+- Bump dependencies
+- Repair `MiddleTruncate` for Firefox
 
 ## 1.0.7 (October 31, 2022)
 

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/ui",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Dagster UI Component Library",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/js_modules/dagit/packages/ui/rollup.config.js
+++ b/js_modules/dagit/packages/ui/rollup.config.js
@@ -17,20 +17,20 @@ export default {
     index: './src/index.ts',
 
     // Our core fonts, usable as global style components, e.g. `<GlobalInconsolata />`.
-    GlobalInconsolata: './src/fonts/GlobalInconsolata.tsx',
-    GlobalInter: './src/fonts/GlobalInter.tsx',
+    'fonts/GlobalInconsolata': './src/fonts/GlobalInconsolata.tsx',
+    'fonts/GlobalInter': './src/fonts/GlobalInter.tsx',
 
     // Components are listed here individually so that they may be imported
     // without pulling in the entire library.
-    Box: './src/components/Box.tsx',
-    Button: './src/components/Button.tsx',
-    Colors: './src/components/Colors.tsx',
-    Icon: './src/components/Icon.tsx',
+    'components/Box': './src/components/Box.tsx',
+    'components/Button': './src/components/Button.tsx',
+    'components/Colors': './src/components/Colors.tsx',
+    'components/Icon': './src/components/Icon.tsx',
   },
   output: {
     dir: 'lib',
     exports: 'named',
-    format: 'esm',
+    format: 'cjs',
     sourcemap: true,
   },
   plugins: [


### PR DESCRIPTION
### Summary & Motivation

Our ESM output of `@dagster-io/ui` doesn't appear to work with Nextjs apps, though it does work with CRA apps.

Just build to cjs instead, which should work for both.

Also produce split built files at `components` so that imports can do:

```
import {Box} from '@dagster-io/ui/lib/components/Box';`
```

and correctly get both the implementation import and the generated `Box.d.ts` file that is adjacent to it.

### How I Tested These Changes

With a personal Next.js project, import `Box` as above and verify that the build works correctly (including types) and that the Box renders properly.

Repeat with one of our internal CRA apps, verify same. Verify that existing `@dagster-io/ui` imports work correclty.
