### PR TITLE
[structured config] Allow structured config resources, IO managers to depend on other resources

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Type, cast
+from typing import Any, Generic, Optional, Set, Type, TypeVar, cast, get_args, get_origin
 
 from pydantic import BaseModel, Extra
 from pydantic.fields import SHAPE_SINGLETON, ModelField
@@ -94,6 +94,21 @@ def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSch
     return configured_resource_def.config_schema
 
 
+RequiredResources = TypeVar("RequiredResources")
+
+
+class RequiresResources(Generic[RequiredResources]):
+    _resources: Optional[RequiredResources] = None
+
+    @property
+    def required_resources(self) -> RequiredResources:
+        check.invariant(
+            self._resources is not None,
+            "Attempted to access required_resources before they were set.",
+        )
+        return self._resources
+
+
 class Resource(
     ResourceDefinition,
     Config,
@@ -119,14 +134,35 @@ class Resource(
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)
         Config.__init__(self, **data)
+
+        required_resource_keys = self.__class__.get_required_resource_keys()
+
         ResourceDefinition.__init__(
             self,
             resource_fn=self.create_object_to_pass_to_user_code,
             config_schema=_curry_config_schema(schema, data),
             description=self.__doc__,
+            required_resource_keys=required_resource_keys,
         )
 
-    def create_object_to_pass_to_user_code(self, context) -> Any:  # pylint: disable=unused-argument
+    @classmethod
+    def get_required_resource_keys(cls) -> Optional[Set[str]]:
+        rrcls = cls.get_required_resource_cls()
+        if rrcls:
+            return set(rrcls.__fields__.keys())
+        return None
+
+    @classmethod
+    def get_required_resource_cls(cls) -> Optional[Type[Config]]:
+        if issubclass(cls, RequiresResources):
+            for base in cls.__orig_bases__:
+                if get_origin(base) == RequiresResources:
+                    return get_args(base)[0]
+        return None
+
+    def create_object_to_pass_to_user_code(
+        self, context: InitResourceContext
+    ) -> Any:  # pylint: disable=unused-argument
         """
         Returns the object that this resource hands to user code, accessible by ops or assets
         through the context or resource parameters. This works like the function decorated
@@ -135,6 +171,14 @@ class Resource(
         Default behavior for new class-based resources is to return itself, passing
         the actual resource object to user code.
         """
+
+        if isinstance(self, RequiresResources):
+            resource_dict = {}
+            for resource_key in self.required_resource_keys:
+                resource_dict[resource_key] = getattr(context.resources, resource_key)
+
+            self._resources = self.__class__.get_required_resource_cls()(**resource_dict)
+
         return self
 
 
@@ -152,6 +196,7 @@ class UnconfiguredStructuredResource(ResourceDefinition):
         resource: Type[Resource],
     ):
         schema = infer_schema_from_config_class(resource)
+        required_resource_keys = resource.get_required_resource_keys()
 
         def resource_fn(context: InitResourceContext):
             instantiated = resource(**context.resource_config)
@@ -161,6 +206,7 @@ class UnconfiguredStructuredResource(ResourceDefinition):
             resource_fn=resource_fn,
             config_schema=schema,
             description=resource.__doc__,
+            required_resource_keys=required_resource_keys,
         )
 
 
@@ -219,18 +265,37 @@ class StructuredConfigIOManagerBase(IOManagerDefinition, Config, ABC):
 
     def __init__(self, **data: Any):
         schema = infer_schema_from_config_class(self.__class__)
+
+        required_resource_keys = self.__class__.get_required_resource_keys()
+
         Config.__init__(self, **data)
         IOManagerDefinition.__init__(
             self,
             resource_fn=self.create_io_manager_to_pass_to_user_code,
             config_schema=_curry_config_schema(schema, data),
             description=self.__doc__,
+            required_resource_keys=required_resource_keys,
         )
 
     @abstractmethod
     def create_io_manager_to_pass_to_user_code(self, context) -> IOManager:
         """Implement as one would implement a @io_manager decorator function"""
         raise NotImplementedError()
+
+    @classmethod
+    def get_required_resource_keys(cls) -> Optional[Set[str]]:
+        rrcls = cls.get_required_resource_cls()
+        if rrcls:
+            return set(rrcls.__fields__.keys())
+        return None
+
+    @classmethod
+    def get_required_resource_cls(cls) -> Optional[Type[Config]]:
+        if issubclass(cls, RequiresResources):
+            for base in cls.__orig_bases__:
+                if get_origin(base) == RequiresResources:
+                    return get_args(base)[0]
+        return None
 
 
 class StructuredConfigIOManager(StructuredConfigIOManagerBase, IOManager):
@@ -243,6 +308,13 @@ class StructuredConfigIOManager(StructuredConfigIOManagerBase, IOManager):
     """
 
     def create_io_manager_to_pass_to_user_code(self, context) -> IOManager:
+        if isinstance(self, RequiresResources):
+            resource_dict = {}
+            for resource_key in self.required_resource_keys:
+                resource_dict[resource_key] = getattr(context.resources, resource_key)
+
+            self._resources = self.__class__.get_required_resource_cls()(**resource_dict)
+
         return self
 
 
@@ -261,6 +333,8 @@ class UnconfiguredStructuredIOManager(IOManagerDefinition):
     ):
         schema = infer_schema_from_config_class(io_manager)
 
+        required_resource_keys = io_manager.get_required_resource_keys()
+
         def resource_fn(context: InitResourceContext):
             instantiated = io_manager(**context.resource_config)
             return instantiated.create_io_manager_to_pass_to_user_code(context)
@@ -269,6 +343,7 @@ class UnconfiguredStructuredIOManager(IOManagerDefinition):
             resource_fn=resource_fn,
             config_schema=schema,
             description=io_manager.__doc__,
+            required_resource_keys=required_resource_keys,
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -418,8 +418,6 @@ def test_nested_resources():
 
 
 def test_nested_resources_multiuse():
-    out_txt = []
-
     class AWSCredentialsResource(Resource):
         username: str
         password: str
@@ -460,8 +458,6 @@ def test_nested_resources_multiuse():
 
 
 def test_nested_resources_runtime_config():
-    out_txt = []
-
     class AWSCredentialsResource(Resource):
         username: str
         password: str

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -7,6 +7,10 @@ from dagster._config.structured_config import (
     Resource,
     StructuredConfigIOManager,
 )
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster._core.execution.context.input import InputContext
+from dagster._core.execution.context.output import OutputContext
+from dagster._core.storage.io_manager import IOManager
 
 
 def test_load_input_handle_output():
@@ -89,7 +93,7 @@ def test_structured_resource_runtime_config():
     assert out_txt == ["greeting: hello, world!"]
 
 
-def test_io_manager_resource_deps():
+def test_multiple_similar_resource_deps():
     out_txt = []
 
     class AWSCredentialsResource(Resource):
@@ -134,3 +138,69 @@ def test_io_manager_resource_deps():
         .success
     )
     assert out_txt == ["my_bucket: hello, world"]
+
+
+def test_io_manager_resource_deps():
+    prod_data_store = {}
+    staging_data_store = {}
+
+    class MyProdIOManager(StructuredConfigIOManager):
+        def handle_output(self, context: OutputContext, obj):
+            prod_data_store[context.name] = obj
+
+        def load_input(self, context: InputContext):
+            return prod_data_store.get(context.name)
+
+    class MyStagingIOManager(StructuredConfigIOManager):
+        def handle_output(self, context: OutputContext, obj):
+            staging_data_store[context.name] = obj
+
+        def load_input(self, context: InputContext):
+            return staging_data_store.get(context.name)
+
+    class BranchingIOManagerDeps(Config):
+        prod_io_manager: IOManager
+        staging_io_manager: IOManager
+
+    class BranchingIOManager(StructuredConfigIOManager, RequiresResources[BranchingIOManagerDeps]):
+        def handle_output(self, context: OutputContext, obj):
+            self.required_resources.staging_io_manager.handle_output(context, obj)
+
+        def load_input(self, context: InputContext):
+            staging_value = self.required_resources.staging_io_manager.load_input(context)
+            if staging_value is not None:
+                return staging_value
+
+            return self.required_resources.prod_io_manager.load_input(context)
+
+    @asset
+    def hello_world():
+        return "hello, world, in staging this time"
+
+    @asset
+    def hello_world_capitalized(hello_world: str):
+        return hello_world.capitalize()
+
+    hello_world_capitalized_job = define_asset_job(
+        name="hello_world_capitalized_job", selection="hello_world_capitalized"
+    )
+
+    prod_data_store["hello_world"] = "hello, world"
+
+    defs = Definitions(
+        assets=[hello_world, hello_world_capitalized],
+        jobs=[hello_world_capitalized_job],
+        resources={
+            "prod_io_manager": MyProdIOManager(),
+            "staging_io_manager": MyStagingIOManager(),
+            "io_manager": BranchingIOManager(),
+        },
+    )
+
+    assert defs.get_job_def("hello_world_capitalized_job").execute_in_process().success
+    assert staging_data_store["result"] == "Hello, world"
+
+    staging_data_store["hello_world"] = "hello, world, in staging this time"
+
+    assert defs.get_job_def("hello_world_capitalized_job").execute_in_process().success
+    assert staging_data_store["result"] == "Hello, world, in staging this time"


### PR DESCRIPTION
## Summary

Allows users of structured config resources/IO managers to specify resource-to-resource dependencies. These are introduced through ineriting the `RequiresResources` generic class:

```python
class AWSCredentials(Resource):
    username: str
    password: str

# Specifies a list of resource dependencies
class AWSDeps(Config):
    aws_creds: AWSCredentials

class S3Resource(Resource, RequiresResources[AWSDeps]):
    bucket: str

class EC2Resource(Resource, RequiresResources[AWSDeps]):
    pass

@asset
def my_asset(s3: S3Resource, ec2: EC2Resource):
    assert s3.required_resources.aws_creds.username == "foo"

defs = Definitions(
    assets=[my_asset],
    resources={
        "aws_creds": AWSCredentials(username=EnvVar("AWS_USER"), password=EnvVar("AWS_PASSWORD")),
        "s3": S3Resource(bucket="my_bucket"),
        "ec2": EC2Resource(),
    },
)
```

### Alternatives Considered

Another route, explored earlier in #11360, would specify resource-resource dependencies more simply as parameters, e.g.

```python
class AWSCredentials(Resource):
    username: str
		password: str

class S3Resource(Resource):
    creds: Credentials
    bucket: str

class EC2Resource(Resource):
    creds: Credentials

@asset
def my_asset(s3: S3Resource, ec2: EC2Resource):
    assert s3.creds.username == "foo"

aws_creds = AWSCredentials(
	username=EnvVar("AWS_USER"), 
	password=EnvVar("AWS_PASSWORD")
)

defs = Definitions(
	assets=[my_asset],
	resources={	
  	        "s3": S3Resource(creds=aws_creds, bucket="my_bucket"),
		"ec2": EC2Resource(creds=aws_creds),
	}
)
```

However, this approach runs into trouble when runtime config comes into play:
```python
# Unconfigured AWS credentials, should be provided in launchpad
aws_creds = AWSCredentials

defs = Definitions(
    assets=[my_asset],
    resources={
        "s3": S3Resource(creds=aws_creds, bucket="my_bucket"),
        "ec2": EC2Resource(creds=aws_creds),
    },
)

# What schema to display? Unclear where AWSCredentials config lives in hierarchy. 
# Can't be nested within one of the dependent resources because it affects both.
# In addition, resource is "anonymous"
# since it's not included in resource dict, it has no identifier associated with it.
```

I'm still open to this approach since the ergonomics seem better, but I'm not sure how to reconcile this issue. Since inner resources are by nature "anonymous", it's hard to keep track of all the places they are used.

One potential way to reconcile this would be to just require any resource which is not fully configured at definition-time to be specified at the top level.

## Test Plan

Unit tests.
