### PR TITLE
Remove toposort dep for py>=3.9

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -16,11 +16,10 @@ from typing import (
     cast,
 )
 
-import toposort
-
 import dagster._check as check
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.selector.subset_selector import DependencyGraph, generate_asset_dep_graph
+from dagster._core.utils import toposort
 
 from .assets import AssetsDefinition
 from .events import AssetKey, AssetKeyPartitionKey
@@ -305,7 +304,7 @@ class AssetGraph:
 
     def toposort_asset_keys(self) -> Sequence[AbstractSet[AssetKey]]:
         return [
-            {key for key in level} for level in toposort.toposort(self._asset_dep_graph["upstream"])
+            {key for key in level} for level in toposort(self._asset_dep_graph["upstream"])
         ]
 
     def has_self_dependency(self, asset_key: AssetKey) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -303,9 +303,7 @@ class AssetGraph:
         return set()
 
     def toposort_asset_keys(self) -> Sequence[AbstractSet[AssetKey]]:
-        return [
-            {key for key in level} for level in toposort(self._asset_dep_graph["upstream"])
-        ]
+        return [{key for key in level} for level in toposort(self._asset_dep_graph["upstream"])]
 
     def has_self_dependency(self, asset_key: AssetKey) -> bool:
         return asset_key in self.get_parents(asset_key)

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -17,6 +17,7 @@ if sys.version_info >= (3, 9):
         ts: "TopologicalSorter[T]" = TopologicalSorter()
         for node, predecessors in dag.items():
             ts.add(node, *predecessors)
+        ts.prepare()
         res: List[Set[T]] = []
         while ts.is_active():
             ready = ts.get_ready()
@@ -68,9 +69,13 @@ def coerce_valid_log_level(log_level: Union[str, int]) -> int:
 
 
 def toposort(data: Mapping[T, Iterable[T]]) -> List[List[T]]:
-    # Workaround a bug in older versions of toposort that choke on frozenset
-    data = {k: set(v) if isinstance(v, frozenset) else v for k, v in data.items()}
-    return [sorted(list(level)) for level in _toposort(data)]  # type: ignore  # T should implement comparison
+    try:
+        # Workaround a bug in older versions of toposort that choke on frozenset
+        data = {k: set(v) if isinstance(v, frozenset) else v for k, v in data.items()}
+        return [sorted(list(level)) for level in _toposort(data)]  # type: ignore  # T should implement comparison
+    except Exception as e:
+        print(e)
+        raise e
 
 
 def toposort_flatten(data: Mapping[T, Iterable[T]]) -> List[T]:

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -23,6 +23,7 @@ if sys.version_info >= (3, 9):
             res.append(set(ready))
             ts.done(*ready)
         return res
+
 else:
     from toposort import toposort as _toposort
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -90,7 +90,7 @@ setup(
         "tqdm",
         "typing_extensions>=4.0.1",
         "sqlalchemy>=1.0",
-        "toposort>=1.0",
+        "toposort>=1.0; python_version < '3.9'",
         "watchdog>=0.8.3",
         'psutil >= 1.0; platform_system=="Windows"',
         # https://github.com/mhammond/pywin32/issues/1439


### PR DESCRIPTION
### Summary & Motivation

This removes the `toposort` dependency for Python >=3.9 with no new dependencies. See https://github.com/dagster-io/dagster/discussions/11598 for reasoning.

### How I Tested These Changes

Ran `python -m pytest python_modules/dagster/dagster_tests` with no errors.

I'm also curious about two things:
1. Could `TopologicalSorter`'s API be useful in places? Instead of grouping dependencies into "levels" it lets you dynamically mark dependencies as completed and get all newly unblocked dependencies. This seems like a great match for crunching through a DAG of computation given, but I didn't dig too deep into how Dagster is currently resolving the DAG or even if it is using the `toposort` module for that.
2. `toposort` could be removed altogether by using a graphlib backport (https://pypi.org/project/graphlib-backport/ or https://pypi.org/project/graphlib2/) which would also simplify things implementation wise.
