### PR TITLE
Fixes dead link to Slack community

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -30,7 +30,7 @@ Dagster is built to be used at every stage of the data development lifecycle - l
 
 <ArticleList>
   <ArticleListItem
-    href="https://dagster-slackin.herokuapp.com/"
+    href="https://dagster.io/slack"
     title="Dagster Slack"
   ></ArticleListItem>
   <ArticleListItem


### PR DESCRIPTION
### Summary & Motivation

Fixes dead link to Slack community in Getting Started docs.

### How I Tested These Changes

Clicked the link.