### PR TITLE
Fix graphene enum not being instantiated

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -13,6 +13,7 @@ from dagster._core.host_representation import (
 )
 from dagster._core.host_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
+    LocationStateChangeEventType,
     LocationStateSubscriber,
 )
 from dagster._core.workspace.context import (
@@ -38,15 +39,7 @@ from .sensors import GrapheneSensor
 from .used_solid import GrapheneUsedSolid
 from .util import HasContext, non_null_list
 
-
-class GrapheneLocationStateChangeEventType(graphene.Enum):
-    LOCATION_UPDATED = "LOCATION_UPDATED"
-    LOCATION_DISCONNECTED = "LOCATION_DISCONNECTED"
-    LOCATION_RECONNECTED = "LOCATION_RECONNECTED"
-    LOCATION_ERROR = "LOCATION_ERROR"
-
-    class Meta:
-        name = "LocationStateChangeEventType"
+GrapheneLocationStateChangeEventType = graphene.Enum.from_enum(LocationStateChangeEventType)
 
 
 class GrapheneRepositoryLocationLoadStatus(graphene.Enum):


### PR DESCRIPTION
Summary:
I'm unsure when exactly this broke but I am suspicious of the graphql 3 migration? Unclear. At any rate, this resolves an error where eventType could not be instantiated b/c we were passing an instance of the Python enum into the identically typed Graphene class.

Test Plan:
Tried to write an automated graphql test and was unsuccessful at getting the subscription to actually return something, but:
- load a grpc server
- load dagit pointing at it
- shut down grpc server, no more error in dagit
- restart grpc server, code reloads in dagit

### Summary & Motivation

### How I Tested These Changes
