### PR TITLE
use Python type annotations in loading-from-config docs examples

### DIFF
--- a/docs/content/concepts/io-management/unconnected-inputs.mdx
+++ b/docs/content/concepts/io-management/unconnected-inputs.mdx
@@ -32,8 +32,8 @@ When you have an op at the beginning of a job that operates on a built-in dagste
 Here's a basic job with an unconnected string input:
 
 ```python file=/concepts/io_management/load_from_config.py startafter=def_start_marker endbefore=def_end_marker
-@op(ins={"input_string": In(String)})
-def my_op(context, input_string):
+@op
+def my_op(context, input_string: str):
     context.log.info(f"input string: {input_string}")
 
 
@@ -59,7 +59,6 @@ from typing import Dict, Union
 
 from dagster import (
     DagsterTypeLoaderContext,
-    In,
     dagster_type_loader,
     job,
     op,
@@ -88,8 +87,8 @@ class Apple:
         self.cultivar = cultivar
 
 
-@op(ins={"input_apple": In(Apple)})
-def my_op(context, input_apple):
+@op
+def my_op(context, input_apple: Apple):
     context.log.info(f"input apple diameter: {input_apple.diameter}")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_custom_type_from_config.py
@@ -3,7 +3,6 @@ from typing import Dict, Union
 
 from dagster import (
     DagsterTypeLoaderContext,
-    In,
     dagster_type_loader,
     job,
     op,
@@ -32,8 +31,8 @@ class Apple:
         self.cultivar = cultivar
 
 
-@op(ins={"input_apple": In(Apple)})
-def my_op(context, input_apple):
+@op
+def my_op(context, input_apple: Apple):
     context.log.info(f"input apple diameter: {input_apple.diameter}")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/load_from_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/load_from_config.py
@@ -1,9 +1,9 @@
-from dagster import In, String, job, op
+from dagster import job, op
 
 
 # def_start_marker
-@op(ins={"input_string": In(String)})
-def my_op(context, input_string):
+@op
+def my_op(context, input_string: str):
     context.log.info(f"input string: {input_string}")
 
 


### PR DESCRIPTION
### Summary & Motivation

Using Python types with `In`s is an old-fashioned way of doing things.

### How I Tested These Changes
