### PR TITLE
[dagster-dbt] allow for non-model nodes to be part of the DbtManifestAssetSelection

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -698,7 +698,12 @@ def load_assets_from_dbt_manifest(
     display_raw_sql = check.opt_bool_param(display_raw_sql, "display_raw_sql", default=True)
     dbt_resource_key = check.str_param(dbt_resource_key, "dbt_resource_key")
 
-    dbt_nodes = {**manifest_json["nodes"], **manifest_json["sources"], **manifest_json["metrics"]}
+    dbt_nodes = {
+        **manifest_json["nodes"],
+        **manifest_json["sources"],
+        **manifest_json["metrics"],
+        **manifest_json["exposures"],
+    }
 
     if selected_unique_ids:
         select = (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
@@ -63,11 +63,17 @@ class DbtManifestAssetSelection(AssetSelection):
         )
 
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        dbt_nodes = {
+            **self.manifest_json["nodes"],
+            **self.manifest_json["sources"],
+            **self.manifest_json["metrics"],
+            **self.manifest_json["exposures"],
+        }
         keys = set()
         for unique_id in _select_unique_ids_from_manifest_json(
             manifest_json=self.manifest_json, select=self.select, exclude=self.exclude
         ):
-            node_info = self.manifest_json["nodes"][unique_id]
+            node_info = dbt_nodes[unique_id]
             if node_info["resource_type"] in self.resource_types and not _is_non_asset_node(
                 node_info
             ):


### PR DESCRIPTION
### Summary & Motivation

In the regular asset creation code, we mush together all of the dictionaries to make a single dictionary addressed by unique_id to select from. This does the same thing in the DbtManifestAssetSelection codepath.

If we don't do this, you can hit errors if you pass in a selection like `+foo`, where `foo` is downstream of a source, because that source's unique_id will not be a key of the `self.manifest_json["nodes"]` dictionary.

### How I Tested These Changes
