### PR TITLE
[airbyte] Consider keys containing credentials a secret

### DIFF
--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
@@ -10,7 +10,7 @@ class ManagedElementError(enum.Enum):
     CANNOT_CONNECT = "cannot_connect"
 
 
-SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key"]
+SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials"]
 SANITIZE_KEY_EXACT_MATCHES = ["pat"]
 
 SECRET_MASK_VALUE = "**********"


### PR DESCRIPTION
### Summary & Motivation

There are lots of keys which should be secret, such as any of google api's `credentials_json` fields that are currently not masked. The Airbyte api also does not return these fields, so they are always considered a diff, even if the credential is correctly applied

### How I Tested These Changes

I made the requested change locally, and then tested the CLI `apply` and `check` commands. Fields with `credentials_json` were correctly masked and applied
