### PR TITLE
Fix typo in Dagster instance documentation

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Dagster instnace | Dagster Docs"
+title: "Dagster instance | Dagster Docs"
 description: "Define configuration options for your Dagster instance."
 ---
 


### PR DESCRIPTION
### Summary & Motivation
Noticed that the https://docs.dagster.io/deployment/dagster-instance has a wrong tab title:

dagster insTNace instead of dagster insTAnce

### How I Tested These Changes
