### PR TITLE
telemetry: add step start/success/failure event + client timestamp

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -35,7 +35,7 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.selector import parse_step_selection
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.system_config.objects import ResolvedRunConfig
-from dagster._core.telemetry import log_repo_stats, telemetry_wrapper
+from dagster._core.telemetry import log_repo_stats, log_step_event, telemetry_wrapper
 from dagster._core.utils import str_format_set
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.interrupts import capture_interrupts
@@ -1095,6 +1095,9 @@ def pipeline_execution_iterator(
                 failed_steps.append(event.step_key)
             elif event.is_resource_init_failure and event.step_key:
                 failed_steps.append(event.step_key)
+
+            # Telemetry
+            log_step_event(event, pipeline_context)
 
             yield event
     except GeneratorExit:

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -35,7 +35,7 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.selector import parse_step_selection
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.system_config.objects import ResolvedRunConfig
-from dagster._core.telemetry import log_repo_stats, log_step_event, telemetry_wrapper
+from dagster._core.telemetry import log_dagster_event, log_repo_stats, telemetry_wrapper
 from dagster._core.utils import str_format_set
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.interrupts import capture_interrupts
@@ -1097,7 +1097,7 @@ def pipeline_execution_iterator(
                 failed_steps.append(event.step_key)
 
             # Telemetry
-            log_step_event(event, pipeline_context)
+            log_dagster_event(event, pipeline_context)
 
             yield event
     except GeneratorExit:

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -33,6 +33,8 @@ from dagster._core.definitions.reconstruct import (
     get_ephemeral_repository_name,
 )
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.events import DagsterEvent
+from dagster._core.execution.context.system import PlanOrchestrationContext
 from dagster._core.instance import DagsterInstance
 from dagster._utils.merger import merge_dicts
 from dagster.version import __version__ as dagster_module_version
@@ -48,6 +50,9 @@ DAEMON_ALIVE = "daemon_alive"
 SCHEDULED_RUN_CREATED = "scheduled_run_created"
 SENSOR_RUN_CREATED = "sensor_run_created"
 BACKFILL_RUN_CREATED = "backfill_run_created"
+STEP_START_EVENT = "step_start_event"
+STEP_SUCCESS_EVENT = "step_success_event"
+STEP_FAILURE_EVENT = "step_failure_event"
 OS_DESC = platform.platform()
 OS_PLATFORM = platform.system()
 
@@ -520,6 +525,40 @@ def log_action(
                 metadata=metadata,
                 run_storage_id=run_storage_id,
             )._asdict()
+        )
+
+
+def log_step_event(event: DagsterEvent, pipeline_context: PlanOrchestrationContext):
+    if event.is_step_start:
+        log_action(
+            instance=pipeline_context.instance,
+            action=STEP_START_EVENT,
+            client_time=datetime.datetime.now(),
+            metadata={
+                "run_id_hash": hash_name(pipeline_context.run_id),
+                "step_key_hash": hash_name(event.step_key),
+            },
+        )
+    elif event.is_step_success:
+        log_action(
+            instance=pipeline_context.instance,
+            action=STEP_SUCCESS_EVENT,
+            client_time=datetime.datetime.now(),
+            metadata={
+                "run_id_hash": hash_name(pipeline_context.run_id),
+                "step_key_hash": hash_name(event.step_key),
+                "duration_ms": event.event_specific_data.duration_ms,
+            },
+        )
+    elif event.is_step_failure:
+        log_action(
+            instance=pipeline_context.instance,
+            action=STEP_FAILURE_EVENT,
+            client_time=datetime.datetime.now(),
+            metadata={
+                "run_id_hash": hash_name(pipeline_context.run_id),
+                "step_key_hash": hash_name(event.step_key),
+            },
         )
 
 

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -529,7 +529,7 @@ def log_action(
         )
 
 
-def log_step_event(event: DagsterEvent, pipeline_context: PlanOrchestrationContext):
+def log_dagster_event(event: DagsterEvent, pipeline_context: PlanOrchestrationContext):
     if not any((event.is_step_start, event.is_step_success, event.is_step_failure)):
         return
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -67,7 +67,7 @@ def test_dagster_telemetry_enabled(caplog):
                         get_ephemeral_repository_name(job_name)
                     )
                 assert set(message.keys()) == EXPECTED_KEYS
-            assert len(caplog.records) == 5
+            assert len(caplog.records) == 9
             assert result.exit_code == 0
 
         # Needed to avoid file contention issues on windows with the telemetry log file
@@ -119,7 +119,7 @@ def test_dagster_telemetry_unset(caplog):
                         )
                     assert set(message.keys()) == EXPECTED_KEYS
 
-                assert len(caplog.records) == 5
+                assert len(caplog.records) == 9
                 assert result.exit_code == 0
 
             # Needed to avoid file contention issues on windows with the telemetry log file
@@ -160,7 +160,7 @@ def test_repo_stats(caplog):
                         assert metadata.get("repo_hash") == hash_name("dagster_test_repository")
                     assert set(message.keys()) == EXPECTED_KEYS
 
-                assert len(caplog.records) == 5
+                assert len(caplog.records) == 7
                 assert result.exit_code == 0
 
             # Needed to avoid file contention issues on windows with the telemetry log file

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -55,6 +55,7 @@ def test_compute_log_manager(mock_s3_bucket):
                 run_coordinator=DefaultRunCoordinator(),
                 run_launcher=DefaultRunLauncher(),
                 ref=InstanceRef.from_dir(temp_dir),
+                settings={"telemetry": {"enabled": False}},
             )
             result = simple.execute_in_process(instance=instance)
             capture_events = [
@@ -151,6 +152,7 @@ def test_compute_log_manager_skip_empty_upload(mock_s3_bucket):
                 run_coordinator=DefaultRunCoordinator(),
                 run_launcher=DefaultRunLauncher(),
                 ref=InstanceRef.from_dir(temp_dir),
+                settings={"telemetry": {"enabled": False}},
             )
             result = simple.execute_in_process(instance=instance)
             capture_events = [

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -64,6 +64,7 @@ def test_compute_log_manager(
                 run_coordinator=DefaultRunCoordinator(),
                 run_launcher=SyncInMemoryRunLauncher(),
                 ref=InstanceRef.from_dir(temp_dir),
+                settings={"telemetry": {"enabled": False}},
             )
             result = simple.execute_in_process(instance=instance)
             capture_events = [

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -53,6 +53,7 @@ def test_compute_log_manager(gcs_bucket):
                 run_coordinator=DefaultRunCoordinator(),
                 run_launcher=DefaultRunLauncher(),
                 ref=InstanceRef.from_dir(temp_dir),
+                settings={"telemetry": {"enabled": False}},
             )
             result = simple.execute_in_process(instance=instance)
             capture_events = [
@@ -146,6 +147,7 @@ def test_compute_log_manager_with_envvar(gcs_bucket):
                     run_coordinator=DefaultRunCoordinator(),
                     run_launcher=DefaultRunLauncher(),
                     ref=InstanceRef.from_dir(temp_dir),
+                    settings={"telemetry": {"enabled": False}},
                 )
                 result = simple.execute_in_process(instance=instance)
                 capture_events = [


### PR DESCRIPTION
### Summary & Motivation
add 3 additional data collection points:
- step_start_event
- step_success_event, which comes with duration_ms
- step_failure_event
with the `client_time` so we can reconstruct the duration in post-processing (based on the same `run_id_hash` and `step_key_hash` within the same `instance_id`)

### How I Tested These Changes
code for testing:
```python
from dagster import op, job, DagsterInstance
import time


@op
def step_1():
    time.sleep(1)


@op
def step_2():
    time.sleep(2)


@op
def step_3():
    time.sleep(3)


@op
def step_4():
    time.sleep(4)
    raise Exception("fail at 4s")


@job
def my_job():
    step_1()
    step_2()
    step_3()
    step_4()

if __name__ == "__main__":
    my_job.execute_in_process(instance=DagsterInstance.get())
```

results:
- logs from running via api: https://gist.github.com/yuhan/cd9fa453683a6b7463f5651289b71ae0
- logs from running via dagit: https://gist.github.com/yuhan/d160d01cf12a67ceaa4c6234fa13a21a

