### PR TITLE
Restrict the grpcio pin to only py3.7/3.8/3.9

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -10,4 +10,4 @@ nbformat<=5.1.3
 protobuf>=3.13.0,<4
 
 # Deadlock / hang issue in new version of grpc
-grpcio<1.48.1
+grpcio<1.48.1; python_version < '3.10'

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -73,9 +73,10 @@ setup(
         # pin around issues in specific versions of alembic that broke our migrations
         "alembic>=1.2.1,!=1.6.3,!=1.7.0",
         "croniter>=0.3.34",
-        # grpcio 1.48.1 has hanging/crashing issues: https://github.com/grpc/grpc/issues/30843
+        # grpcio>=1.48.1 has hanging/crashing issues for python 3.9 and earlier: https://github.com/grpc/grpc/issues/30843
         # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
-        "grpcio>=1.32.0,<1.48.1",
+        "grpcio>=1.32.0,<1.48.1; python_version < '3.10'",
+        "grpcio>=1.32.0; python_version >= '3.10'",
         "grpcio-health-checking>=1.32.0,<1.44.0",
         "packaging>=20.9",
         "pendulum",


### PR DESCRIPTION
Hangs and segfaults are still happening reliably on 3.7 through 3.9, but are not happening on 3.10 - so relax the pin there for now.
