### PR TITLE
Load OSS Nux iframe via https

### DIFF
--- a/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
@@ -93,7 +93,7 @@ const CommunityNuxImpl: React.FC<{dismiss: () => void}> = ({dismiss}) => {
   );
 };
 
-const IFRAME_SRC = 'http://dagster.io/dagit_iframes/community_nux';
+const IFRAME_SRC = 'https://dagster.io/dagit_iframes/community_nux';
 
 type Props = {
   width: string;

--- a/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
@@ -20,7 +20,8 @@ export const CommunityNux = () => {
   );
 };
 
-const TIMEOUT = 5000;
+// Wait 1 second before trying to show Nux
+const TIMEOUT = 1000;
 
 const CommunityNuxImpl: React.FC<{dismiss: () => void}> = ({dismiss}) => {
   const [shouldShowNux, setShouldShowNux] = React.useState(false);
@@ -157,6 +158,7 @@ const useCommuniyNuxIframe = ({width, height}: Props) => {
                 top: parentRect.top,
                 zIndex: 21,
                 overflow: 'hidden',
+                border: 'none',
               }
             : {width, height, left: '-999999px', position: 'absolute', zIndex: 0}
         }


### PR DESCRIPTION
### Summary & Motivation
1. Load over https
2. Remove ugly iframe border
3. 1 second timeout.

### How I Tested These Changes

OSS Dagit:
<img width="879" alt="Screen Shot 2023-01-11 at 2 43 05 AM" src="https://user-images.githubusercontent.com/2286579/211889039-6361aafa-1fb5-494b-a273-c688c814fc94.png">
