### PR TITLE
[2/4 partition status cache] Storing range length in Time Window Subset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -1053,11 +1053,12 @@ class PartitionsSubset(ABC):
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "PartitionsSubset":
         raise NotImplementedError()
 
-    @abstractmethod
     def with_partition_key_range(
         self, partition_key_range: PartitionKeyRange
     ) -> "PartitionsSubset":
-        raise NotImplementedError()
+        return self.with_partition_keys(
+            self.partitions_def.get_partition_keys_in_range(partition_key_range)
+        )
 
     @abstractmethod
     def serialize(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -200,11 +200,7 @@ class TimeWindowPartitionMapping(
 
         return TimeWindowPartitionsSubset(
             to_partitions_def,
-            time_windows,
-            num_partitions=sum(
-                len(to_partitions_def.get_partition_keys_in_time_window(time_window))
-                for time_window in time_windows
-            ),
+            to_partitions_def.build_merged_subset_time_windows(time_windows),
         )
 
 

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -65,6 +65,10 @@ class DagsterInvalidSubsetError(DagsterError):
     """
 
 
+class DagsterInvalidDeserializationVersionError(DagsterError):
+    """Indicates that a serialized value has an unsupported version and cannot be deserialized."""
+
+
 CONFIG_ERROR_VERBIAGE = """
 This value can be a:
     - Field


### PR DESCRIPTION
The key Dagit performance optimization we'd like to make is to be able to directly render the time window partition bar without recalculating the partitions in each range.

This PR enables this by:
- Adjusting `TimeWindowPartitionsSubset` to store a length for each range
- Creating a `get_inverse_subset` method that performantly builds a `TimeWindowPartitionsSubset` that contains all partitions not contained in the original subset. This enables fetching the unmaterialized partitions from a serialized representation of materialized partitions.
- Because the serialization representation has changed, this PR adds a serialization version to the serialization string. It also enables backcompat deserialization, allowing for deserializing serialized subsets created prior to this change.