### PR TITLE
telemetry: add is_known_ci_env

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -323,6 +323,7 @@ def test_dagit_logs(_, caplog):
                         "dagster_version",
                         "os_desc",
                         "os_platform",
+                        "is_known_ci_env",
                     ]
                 )
 

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -217,8 +217,6 @@ class TelemetryEntry(
         metadata = check.opt_mapping_param(metadata, "metadata")
         run_storage_id = check.opt_str_param(run_storage_id, "run_storage_id", default="")
 
-        print("!!!!!!!!!", get_is_known_ci_env())
-
         return super(TelemetryEntry, cls).__new__(
             cls,
             action=action,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -33,6 +33,7 @@ EXPECTED_KEYS = set(
         "os_desc",
         "os_platform",
         "dagster_version",
+        "is_known_ci_env",
     ]
 )
 


### PR DESCRIPTION
### Summary & Motivation
explicitly track whether it's a CI env

### How I Tested These Changes

https://buildkite.com/dagster/dagster/builds/45285#0185a23c-4664-49bd-bbeb-f9e59fa2735a/6-958