### PR TITLE
[instance] get_run_record_by_id

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -9,7 +9,7 @@ from dagster._core.events import EngineEventData
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType, ComputeLogFileData
-from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.workspace.permissions import Permissions
 from dagster._utils.error import serializable_error_info_from_exc_info
 from starlette.concurrency import (
@@ -40,7 +40,7 @@ def _force_mark_as_canceled(instance: DagsterInstance, run_id):
     from ...schema.pipelines.pipeline import GrapheneRun
     from ...schema.roots.mutation import GrapheneTerminateRunSuccess
 
-    reloaded_record = instance.get_run_records(RunsFilter(run_ids=[run_id]))[0]
+    reloaded_record = check.not_none(instance.get_run_record_by_id(run_id))
 
     if not reloaded_record.pipeline_run.is_finished:
         message = (
@@ -48,12 +48,12 @@ def _force_mark_as_canceled(instance: DagsterInstance, run_id):
             "computational resources created by the run may not have been fully cleaned up."
         )
         instance.report_run_canceled(reloaded_record.pipeline_run, message=message)
-        reloaded_record = instance.get_run_records(RunsFilter(run_ids=[run_id]))[0]
+        reloaded_record = check.not_none(instance.get_run_record_by_id(run_id))
 
     return GrapheneTerminateRunSuccess(GrapheneRun(reloaded_record))
 
 
-def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
+def terminate_pipeline_execution(graphene_info: "HasContext", run_id, terminate_policy):
     from ...schema.errors import GrapheneRunNotFoundError
     from ...schema.pipelines.pipeline import GrapheneRun
     from ...schema.roots.mutation import (
@@ -66,17 +66,16 @@ def terminate_pipeline_execution(graphene_info, run_id, terminate_policy):
 
     instance = graphene_info.context.instance
 
-    records = instance.get_run_records(RunsFilter(run_ids=[run_id]))
+    record = instance.get_run_record_by_id(run_id)
 
     force_mark_as_canceled = (
         terminate_policy == GrapheneTerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY
     )
 
-    if not records:
+    if not record:
         assert_permission(graphene_info, Permissions.TERMINATE_PIPELINE_EXECUTION)
         return GrapheneRunNotFoundError(run_id)
 
-    record = records[0]
     run = record.pipeline_run
     graphene_run = GrapheneRun(record)
 
@@ -179,17 +178,16 @@ async def gen_events_for_run(
     check.str_param(run_id, "run_id")
     after_cursor = check.opt_str_param(after_cursor, "after_cursor")
     instance = graphene_info.context.instance
-    records = instance.get_run_records(RunsFilter(run_ids=[run_id]))
+    record = instance.get_run_record_by_id(run_id)
 
-    if not records:
+    if not record:
         yield GraphenePipelineRunLogsSubscriptionFailure(
             missingRunId=run_id,
             message="Could not load run with id {}".format(run_id),
         )
         return
 
-    record = records[0]
-    run = record.pipeline_run
+    run = record.dagster_run
 
     dont_send_past_records = False
     # special sigil cursor that signals to start watching for updates only after the current point in time

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -20,6 +20,7 @@ from .utils import UserFacingGraphQLError, capture_error
 
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode
+    from ..schema.util import HasContext
 
 
 def is_config_valid(pipeline_def, run_config, mode):
@@ -51,16 +52,16 @@ def get_validated_config(pipeline_def, run_config, mode):
     return validated_config
 
 
-def get_run_by_id(graphene_info, run_id):
+def get_run_by_id(graphene_info: "HasContext", run_id):
     from ..schema.errors import GrapheneRunNotFoundError
     from ..schema.pipelines.pipeline import GrapheneRun
 
     instance = graphene_info.context.instance
-    records = instance.get_run_records(RunsFilter(run_ids=[run_id]))
-    if not records:
+    record = instance.get_run_record_by_id(run_id)
+    if not record:
         return GrapheneRunNotFoundError(run_id)
     else:
-        return GrapheneRun(records[0])
+        return GrapheneRun(record)
 
 
 def get_run_tags(graphene_info):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -819,9 +819,19 @@ class DagsterInstance:
 
     # run storage
     @public
-    @traced
     def get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
-        return cast(DagsterRun, self._run_storage.get_run_by_id(run_id))
+        record = self.get_run_record_by_id(run_id)
+        if record is None:
+            return None
+        return record.dagster_run
+
+    @public
+    @traced
+    def get_run_record_by_id(self, run_id: str) -> Optional[RunRecord]:
+        records = self._run_storage.get_run_records(RunsFilter(run_ids=[run_id]))
+        if not records:
+            return None
+        return records[0]
 
     @traced
     def get_pipeline_snapshot(self, snapshot_id: str) -> "PipelineSnapshot":

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -190,9 +190,6 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     ) -> Mapping[str, Mapping[str, Union[Iterable["DagsterRun"], int]]]:
         return self._storage.run_storage.get_run_groups(filters, cursor, limit)
 
-    def get_run_by_id(self, run_id: str) -> Optional["DagsterRun"]:
-        return self._storage.run_storage.get_run_by_id(run_id)
-
     def get_run_records(
         self,
         filters: Optional["RunsFilter"] = None,

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -727,6 +727,10 @@ class RunRecord(
             end_time=check.opt_float_param(end_time, "end_time"),
         )
 
+    @property
+    def dagster_run(self) -> DagsterRun:
+        return self.pipeline_run
+
 
 @whitelist_for_serdes
 class RunPartitionData(

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -138,17 +138,6 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         # more than 2x total instances of PipelineRun.
 
     @abstractmethod
-    def get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
-        """Get a run by its id.
-
-        Args:
-            run_id (str): The id of the run
-
-        Returns:
-            Optional[PipelineRun]
-        """
-
-    @abstractmethod
     def get_run_records(
         self,
         filters: Optional[RunsFilter] = None,

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -163,7 +163,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         if event.event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
             return
 
-        run = self.get_run_by_id(run_id)
+        run = self._get_run_by_id(run_id)
         if not run:
             # TODO log?
             return
@@ -464,15 +464,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         count = rows[0][0]
         return count
 
-    def get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
-        """Get a run by its id.
-
-        Args:
-            run_id (str): The id of the run
-
-        Returns:
-            Optional[PipelineRun]
-        """
+    def _get_run_by_id(self, run_id: str) -> Optional[DagsterRun]:
         check.str_param(run_id, "run_id")
 
         query = db.select([RunsTable.c.run_body, RunsTable.c.status]).where(
@@ -537,7 +529,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
         check.str_param(run_id, "run_id")
         check.mapping_param(new_tags, "new_tags", key_type=str, value_type=str)
 
-        run = self.get_run_by_id(run_id)
+        run = self._get_run_by_id(run_id)
         if not run:
             raise DagsterRunNotFoundError(
                 f"Run {run_id} was not found in instance.", invalid_run_id=run_id
@@ -583,7 +575,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     def get_run_group(self, run_id: str) -> Optional[Tuple[str, Iterable[DagsterRun]]]:
         check.str_param(run_id, "run_id")
-        pipeline_run = self.get_run_by_id(run_id)
+        pipeline_run = self._get_run_by_id(run_id)
         if not pipeline_run:
             raise DagsterRunNotFoundError(
                 f"Run {run_id} was not found in instance.", invalid_run_id=run_id
@@ -591,7 +583,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         # find root_run
         root_run_id = pipeline_run.root_run_id if pipeline_run.root_run_id else pipeline_run.run_id
-        root_run = self.get_run_by_id(root_run_id)
+        root_run = self._get_run_by_id(root_run_id)
         if not root_run:
             raise DagsterRunNotFoundError(
                 (
@@ -776,7 +768,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
     def has_run(self, run_id: str) -> bool:
         check.str_param(run_id, "run_id")
-        return bool(self.get_run_by_id(run_id))
+        return bool(self._get_run_by_id(run_id))
 
     def delete_run(self, run_id: str):
         check.str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -83,10 +83,7 @@ class CachingInstanceQueryer:
 
     @cached_method
     def _get_run_record_by_id(self, run_id: str) -> Optional[RunRecord]:
-        return next(
-            iter(self._instance.get_run_records(filters=RunsFilter(run_ids=[run_id]), limit=1)),
-            None,
-        )
+        return self._instance.get_run_record_by_id(run_id)
 
     @cached_method
     def _get_planned_materializations_for_run_from_events(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -60,7 +60,7 @@ def test_fs_stores():
             result = simple.execute_in_process(instance=instance)
 
             assert run_store.has_run(result.run_id)
-            assert run_store.get_run_by_id(result.run_id).status == DagsterRunStatus.SUCCESS
+            assert instance.get_run_by_id(result.run_id).status == DagsterRunStatus.SUCCESS
             assert DagsterEventType.PIPELINE_SUCCESS in [
                 event.dagster_event.event_type
                 for event in event_store.get_logs_for_run(result.run_id)


### PR DESCRIPTION
this is useful for people who need record properties like `start_time` `end_time`

### How I Tested These Changes

update some callsites in tests to use the new API, existing coverage
