### PR TITLE
[2/n][structured config] Enable struct config resources, IO managers to depend on other resources

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -339,6 +339,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "scheduler_tests_old_pendulum",
             "execution_tests",
             "storage_tests",
+            "type_signature_tests",
             "definitions_tests",
             "asset_defs_tests",
             "launcher_tests",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
@@ -18,8 +18,8 @@ def my_asset():
 class MyResource(Resource):
     """my description"""
 
-    a_string: str = "baz"
     a_bool: bool
+    a_string: str = "baz"
     an_unset_string: str = "defaulted"
 
 

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -333,7 +333,7 @@ class IOManagerWithKeyMapping(ResourceWithKeyMapping, IOManagerDefinition):
 def attach_resource_id_to_key_mapping(
     resource_def: Any, resource_id_to_key_mapping: Dict[ResourceId, str]
 ) -> Any:
-    if isinstance(resource_def, ResourceDefinition):
+    if isinstance(resource_def, (Resource, PartialResource)):
         return (
             IOManagerWithKeyMapping(resource_def, resource_id_to_key_mapping)
             if isinstance(resource_def, IOManagerDefinition)

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -61,8 +61,7 @@ from dagster._core.definitions.resource_definition import (
 )
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
-from . import typing_utils
-from .typing_utils import BaseResourceMeta
+from .typing_utils import BaseResourceMeta, LateBoundTypesForResourceTypeChecking
 from .utils import safe_is_subclass
 
 Self = TypeVar("Self", bound="Resource")
@@ -823,6 +822,9 @@ def _call_resource_fn_with_default(obj: ResourceDefinition, context: InitResourc
         return cast(ResourceFunctionWithoutContext, obj.resource_fn)()
 
 
-typing_utils._Resource = Resource
-typing_utils._PartialResource = PartialResource
-typing_utils._ResourceDep = ResourceDependency
+
+LateBoundTypesForResourceTypeChecking.set_actual_types_for_type_checking(
+    resource_dep_type=ResourceDependency,
+    resource_type=Resource,
+    partial_resource_type=PartialResource,
+)

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -414,7 +414,11 @@ class Resource(
                 check.inst(
                     context,
                     InitResourceContextWithKeyMapping,
-                    "ConfiguredResource should only be used with InitResourceContextWithKeyMapping",
+                    (
+                        "This ConfiguredResource contains unresolved partially-specified nested"
+                        " resources, and so can only be initialized using a"
+                        " InitResourceContextWithKeyMapping"
+                    ),
                 ),
             )
             partial_resources_to_update = {

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -780,7 +780,7 @@ def _call_resource_fn_with_default(obj: ResourceDefinition, context: InitResourc
         context = context.replace_config(value["config"])
     elif obj.config_schema.default_provided:
         context = context.replace_config(obj.config_schema.default_value)
-    if has_at_least_one_parameter(obj.resource_fn):  # type: ignore  # fmt: skip
+    if has_at_least_one_parameter(obj.resource_fn):
         return cast(ResourceFunctionWithContext, obj.resource_fn)(context)
     else:
         return cast(ResourceFunctionWithoutContext, obj.resource_fn)()

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -1,7 +1,78 @@
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, Union, cast
+
+import pydantic
+from typing_extensions import dataclass_transform, get_origin
+
+from .utils import safe_is_subclass
 
 if TYPE_CHECKING:
     from dagster._config.structured_config import PartialResource
+
+
+# Since a metaclass is invoked by Resource before Resource or PartialResource is defined, we need to
+# define a temporary class to use as a placeholder for use in the initial metaclass invocation.
+# When the metaclass is invoked for a Resource subclass, it will use the non-placeholder values.
+
+_ResValue = TypeVar("_ResValue")
+
+
+class _Temp(Generic[_ResValue]):
+    pass
+
+
+_ResourceDep: Type = _Temp
+_Resource: Type = _Temp
+_PartialResource: Type = _Temp
+
+
+@dataclass_transform()
+class BaseResourceMeta(pydantic.main.ModelMetaclass):
+    """
+    Custom metaclass for Resource and PartialResource. This metaclass is responsible for
+    transforming the type annotations on the class so that Pydantic constructor-time validation
+    does not error when users provide partially configured resources to resource params.
+
+    For example, the following code would ordinarily fail Pydantic validation:
+
+    .. code-block:: python
+
+        class FooResource(Resource):
+            bar: BarResource
+
+        # Types as PartialResource[BarResource]
+        partial_bar = BarResource.configure_at_runtime()
+
+        # Pydantic validation fails because bar is not a BarResource
+        foo = FooResource(bar=partial_bar)
+
+    This metaclass transforms the type annotations on the class so that Pydantic validation
+    accepts either a PartialResource or a Resource as a value for the resource dependency.
+    """
+
+    def __new__(self, name, bases, namespaces, **kwargs):
+        # Gather all type annotations from the class and its base classes
+        annotations = namespaces.get("__annotations__", {})
+        for base in bases:
+            if hasattr(base, "__annotations__"):
+                annotations.update(base.__annotations__)
+        for field in annotations:
+            if not field.startswith("__"):
+                # Check if the annotation is a ResourceDependency
+                if get_origin(annotations[field]) == _ResourceDep:
+                    # arg = get_args(annotations[field])[0]
+                    # If so, we treat it as a Union of a PartialResource and a Resource
+                    # for Pydantic's sake.
+                    annotations[field] = Any
+                elif safe_is_subclass(annotations[field], _Resource):
+                    # If the annotation is a Resource, we treat it as a Union of a PartialResource
+                    # and a Resource for Pydantic's sake, so that a user can pass in a partially
+                    # configured resource.
+                    base = annotations[field]
+                    annotations[field] = Union[_PartialResource[base], base]
+
+        namespaces["__annotations__"] = annotations
+        return super().__new__(self, name, bases, namespaces, **kwargs)
+
 
 Self = TypeVar("Self", bound="TypecheckAllowPartialResourceInitParams")
 

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
 # actually change the type annotations is when it's invoked for a user-created subclass of Resource,
 # at which point the placeholder values will be replaced with the actual types.
 class LateBoundTypesForResourceTypeChecking:
-    _ResValue = TypeVar("_ResValue")
+    _TResValue = TypeVar("_TResValue")
 
-    class _Temp(Generic[_ResValue]):
+    class _Temp(Generic[_TResValue]):
         pass
 
     _ResourceDep: Type = _Temp

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -49,7 +49,7 @@ class BaseResourceMeta(pydantic.main.ModelMetaclass):
     accepts either a PartialResource or a Resource as a value for the resource dependency.
     """
 
-    def __new__(self, name, bases, namespaces, **kwargs):
+    def __new__(cls, name, bases, namespaces, **kwargs):
         # Gather all type annotations from the class and its base classes
         annotations = namespaces.get("__annotations__", {})
         for base in bases:
@@ -71,7 +71,7 @@ class BaseResourceMeta(pydantic.main.ModelMetaclass):
                     annotations[field] = Union[_PartialResource[base], base]
 
         namespaces["__annotations__"] = annotations
-        return super().__new__(self, name, bases, namespaces, **kwargs)
+        return super().__new__(cls, name, bases, namespaces, **kwargs)
 
 
 Self = TypeVar("Self", bound="TypecheckAllowPartialResourceInitParams")

--- a/python_modules/dagster/dagster/_config/structured_config/utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/utils.py
@@ -1,0 +1,15 @@
+from typing import Any, Type
+
+
+def safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:
+    """Version of issubclass that returns False if cls is not a Type."""
+    if not isinstance(cls, type):
+        return False
+
+    try:
+        return issubclass(cls, possible_parent_cls)
+    except TypeError:
+        # Using builtin Python types in python 3.9+ will raise a TypeError when using issubclass
+        # even though the isinstance check will succeed (as will inspect.isclass), for example
+        # list[dict[str, str]] will raise a TypeError
+        return False

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -85,7 +85,7 @@ def format_docstring_for_description(fn: Callable) -> Optional[str]:
 # Type-ignores are used throughout the codebase when this function returns False to ignore the type
 # error arising from assuming
 # When/if `StrictTypeGuard` is supported, we can drop `is_context_not_provided` since a False from
-# `is_context_provided` will be sufficient.
+# `has_at_least_one_parameter` will be sufficient.
 def has_at_least_one_parameter(
     fn: Union[Callable[Concatenate[T, P], R], Callable[P, R]],
 ) -> TypeGuard[Callable[Concatenate[T, P], R]]:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/conftest.py
@@ -1,0 +1,11 @@
+# turn off type signature tests by default
+# they are slow when run locally
+# you can specify the -m "typesignature" flag to run them (& tox will run them in CI)
+def pytest_configure(config):
+    markexpr = getattr(config.option, "markexpr", None)
+    if not markexpr or "typesignature" not in markexpr:
+        setattr(
+            config.option,
+            "markexpr",
+            markexpr + " and not typesignature" if markexpr else "not typesignature",
+        )

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1,13 +1,20 @@
+import json
 import os
+import re
+import subprocess
 import sys
+import tempfile
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import Any, Callable, List
 
 import pytest
 from dagster import IOManager, asset, job, op, resource
+from dagster._check import CheckError
+from dagster._config.field import Field
 from dagster._config.field_utils import EnvVar
 from dagster._config.structured_config import (
     Resource,
+    ResourceDependency,
     StructuredConfigIOManagerBase,
     StructuredIOManagerAdapter,
     StructuredResourceAdapter,
@@ -140,30 +147,30 @@ def test_caching_within_resource():
 def test_abc_resource():
     out_txt = []
 
-    class WriterResource(Resource, ABC):
+    class Writer(Resource, ABC):
         @abstractmethod
         def output(self, text: str) -> None:
             pass
 
-    class PrefixedWriterResource(WriterResource):
+    class PrefixedWriterResource(Writer):
         prefix: str
 
         def output(self, text: str) -> None:
             out_txt.append(f"{self.prefix}{text}")
 
-    class RepetitiveWriterResource(WriterResource):
+    class RepetitiveWriterResource(Writer):
         repetitions: int
 
         def output(self, text: str) -> None:
             out_txt.append(f"{text} " * self.repetitions)
 
     @op
-    def hello_world_op(writer: WriterResource):
+    def hello_world_op(writer: Writer):
         writer.output("hello, world!")
 
     # Can't instantiate abstract class
     with pytest.raises(TypeError):
-        WriterResource()  # pylint: disable=abstract-class-instantiated
+        Writer()  # pylint: disable=abstract-class-instantiated
 
     @job(resource_defs={"writer": PrefixedWriterResource(prefix="greeting: ")})
     def prefixed_job():
@@ -430,3 +437,583 @@ def test_runtime_config_env_var():
         assert out_txt == ["greeting: hello, world!"]
     finally:
         del os.environ["MY_PREFIX_FOR_TEST"]
+
+
+def test_nested_resources():
+    out_txt = []
+
+    class Writer(Resource, ABC):
+        @abstractmethod
+        def output(self, text: str) -> None:
+            pass
+
+    class WriterResource(Writer):
+        def output(self, text: str) -> None:
+            out_txt.append(text)
+
+    class PrefixedWriterResource(Writer):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    class JsonWriterResource(
+        Writer,
+    ):
+        base_writer: Writer
+        indent: int
+
+        def output(self, obj: Any) -> None:
+            self.base_writer.output(json.dumps(obj, indent=self.indent))
+
+    @asset
+    def hello_world_asset(writer: JsonWriterResource):
+        writer.output({"hello": "world"})
+
+    # Construct a resource that is needed by another resource
+    writer_resource = WriterResource()
+    json_writer_resource = JsonWriterResource(indent=2, base_writer=writer_resource)
+
+    assert (
+        Definitions(
+            assets=[hello_world_asset],
+            resources={
+                "writer": json_writer_resource,
+            },
+        )
+        .get_implicit_global_asset_job_def()
+        .execute_in_process()
+        .success
+    )
+
+    assert out_txt == ['{\n  "hello": "world"\n}']
+
+    # Do it again, with a different nested resource
+    out_txt.clear()
+    prefixed_writer_resource = PrefixedWriterResource(prefix="greeting: ")
+    prefixed_json_writer_resource = JsonWriterResource(
+        indent=2, base_writer=prefixed_writer_resource
+    )
+
+    assert (
+        Definitions(
+            assets=[hello_world_asset],
+            resources={
+                "writer": prefixed_json_writer_resource,
+            },
+        )
+        .get_implicit_global_asset_job_def()
+        .execute_in_process()
+        .success
+    )
+
+    assert out_txt == ['greeting: {\n  "hello": "world"\n}']
+
+
+def test_nested_resources_multiuse():
+    class AWSCredentialsResource(Resource):
+        username: str
+        password: str
+
+    class S3Resource(Resource):
+        aws_credentials: AWSCredentialsResource
+        bucket_name: str
+
+    class EC2Resource(Resource):
+        aws_credentials: AWSCredentialsResource
+
+    completed = {}
+
+    @asset
+    def my_asset(s3: S3Resource, ec2: EC2Resource):
+        assert s3.aws_credentials.username == "foo"
+        assert s3.aws_credentials.password == "bar"
+        assert s3.bucket_name == "my_bucket"
+
+        assert ec2.aws_credentials.username == "foo"
+        assert ec2.aws_credentials.password == "bar"
+
+        completed["yes"] = True
+
+    aws_credentials = AWSCredentialsResource(username="foo", password="bar")
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "s3": S3Resource(bucket_name="my_bucket", aws_credentials=aws_credentials),
+            "ec2": EC2Resource(aws_credentials=aws_credentials),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert completed["yes"]
+
+
+def test_nested_resources_runtime_config():
+    class AWSCredentialsResource(Resource):
+        username: str
+        password: str
+
+    class S3Resource(Resource):
+        aws_credentials: AWSCredentialsResource
+        bucket_name: str
+
+    class EC2Resource(Resource):
+        aws_credentials: AWSCredentialsResource
+
+    completed = {}
+
+    @asset
+    def my_asset(s3: S3Resource, ec2: EC2Resource):
+        assert s3.aws_credentials.username == "foo"
+        assert s3.aws_credentials.password == "bar"
+        assert s3.bucket_name == "my_bucket"
+
+        assert ec2.aws_credentials.username == "foo"
+        assert ec2.aws_credentials.password == "bar"
+
+        completed["yes"] = True
+
+    aws_credentials = AWSCredentialsResource.configure_at_launch()
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "aws_credentials": aws_credentials,
+            "s3": S3Resource(bucket_name="my_bucket", aws_credentials=aws_credentials),
+            "ec2": EC2Resource(aws_credentials=aws_credentials),
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "aws_credentials": {
+                        "config": {
+                            "username": "foo",
+                            "password": "bar",
+                        }
+                    }
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+
+def test_nested_resources_runtime_config_complex():
+    class CredentialsResource(Resource):
+        username: str
+        password: str
+
+    class DBConfigResource(Resource):
+        creds: CredentialsResource
+        host: str
+        database: str
+
+    class DBResource(Resource):
+        config: DBConfigResource
+
+    completed = {}
+
+    @asset
+    def my_asset(db: DBResource):
+        assert db.config.creds.username == "foo"
+        assert db.config.creds.password == "bar"
+        assert db.config.host == "localhost"
+        assert db.config.database == "my_db"
+        completed["yes"] = True
+
+    credentials = CredentialsResource.configure_at_launch()
+    db_config = DBConfigResource.configure_at_launch(creds=credentials)
+    db = DBResource(config=db_config)
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "credentials": credentials,
+            "db_config": db_config,
+            "db": db,
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "credentials": {
+                        "config": {
+                            "username": "foo",
+                            "password": "bar",
+                        }
+                    },
+                    "db_config": {
+                        "config": {
+                            "host": "localhost",
+                            "database": "my_db",
+                        }
+                    },
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+    credentials = CredentialsResource.configure_at_launch()
+    db_config = DBConfigResource(creds=credentials, host="localhost", database="my_db")
+    db = DBResource(config=db_config)
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "credentials": credentials,
+            "db": db,
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "credentials": {
+                        "config": {
+                            "username": "foo",
+                            "password": "bar",
+                        }
+                    },
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+
+def test_resources_which_return():
+    class StringResource(Resource[str]):
+        a_string: str
+
+        def create_object_to_pass_to_user_code(self, context) -> str:
+            return self.a_string
+
+    class MyResource(Resource):
+        string_from_resource: ResourceDependency[str]
+
+    completed = {}
+
+    @asset
+    def my_asset(my_resource: MyResource):
+        assert my_resource.string_from_resource == "foo"
+        completed["yes"] = True
+
+    str_resource = StringResource(a_string="foo")
+    my_resource = MyResource(string_from_resource=str_resource)
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "my_resource": my_resource,
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert completed["yes"]
+
+    str_resource_partial = StringResource.configure_at_launch()
+    my_resource = MyResource(string_from_resource=str_resource_partial)
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "str_resource_partial": str_resource_partial,
+            "my_resource": my_resource,
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "str_resource_partial": {
+                        "config": {
+                            "a_string": "foo",
+                        },
+                    }
+                }
+            }
+        )
+        .success
+    )
+    assert completed["yes"]
+
+
+def test_nested_function_resource():
+    out_txt = []
+
+    @resource
+    def writer_resource(context):
+        def output(text: str) -> None:
+            out_txt.append(text)
+
+        return output
+
+    class PostfixWriterResource(Resource[Callable[[str], None]]):
+        writer: ResourceDependency[Callable[[str], None]]
+        postfix: str
+
+        def create_object_to_pass_to_user_code(self, context) -> Callable[[str], None]:
+            def output(text: str):
+                self.writer(f"{text}{self.postfix}")
+
+            return output
+
+    @asset
+    def my_asset(writer: PostfixWriterResource):
+        writer("foo")
+        writer("bar")
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["foo!", "bar!"]
+
+
+def test_nested_function_resource_configured():
+    out_txt = []
+
+    @resource(config_schema={"prefix": Field(str, default_value="")})
+    def writer_resource(context):
+        prefix = context.resource_config["prefix"]
+
+        def output(text: str) -> None:
+            out_txt.append(f"{prefix}{text}")
+
+        return output
+
+    class PostfixWriterResource(Resource[Callable[[str], None]]):
+        writer: ResourceDependency[Callable[[str], None]]
+        postfix: str
+
+        def create_object_to_pass_to_user_code(self, context) -> Callable[[str], None]:
+            def output(text: str):
+                self.writer(f"{text}{self.postfix}")
+
+            return output
+
+    @asset
+    def my_asset(writer: PostfixWriterResource):
+        writer("foo")
+        writer("bar")
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["foo!", "bar!"]
+
+    out_txt.clear()
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "writer": PostfixWriterResource(
+                writer=writer_resource.configured({"prefix": "msg: "}), postfix="!"
+            ),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["msg: foo!", "msg: bar!"]
+
+
+def test_nested_function_resource_runtime_config():
+    out_txt = []
+
+    @resource(config_schema={"prefix": str})
+    def writer_resource(context):
+        prefix = context.resource_config["prefix"]
+
+        def output(text: str) -> None:
+            out_txt.append(f"{prefix}{text}")
+
+        return output
+
+    class PostfixWriterResource(Resource[Callable[[str], None]]):
+        writer: ResourceDependency[Callable[[str], None]]
+        postfix: str
+
+        def create_object_to_pass_to_user_code(self, context) -> Callable[[str], None]:
+            def output(text: str):
+                self.writer(f"{text}{self.postfix}")
+
+            return output
+
+    @asset
+    def my_asset(writer: PostfixWriterResource):
+        writer("foo")
+        writer("bar")
+
+    with pytest.raises(
+        CheckError,
+        match="Any partially configured, nested resources must be specified to Definitions",
+    ):
+        # errors b/c writer_resource is not configured
+        # and not provided as a top-level resource to Definitions
+        defs = Definitions(
+            assets=[my_asset],
+            resources={
+                "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+            },
+        )
+
+    defs = Definitions(
+        assets=[my_asset],
+        resources={
+            "base_writer": writer_resource,
+            "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            {
+                "resources": {
+                    "base_writer": {
+                        "config": {
+                            "prefix": "msg: ",
+                        },
+                    },
+                },
+            }
+        )
+        .success
+    )
+    assert out_txt == ["msg: foo!", "msg: bar!"]
+
+
+def get_pyright_reveal_type_output(filename) -> List[str]:
+    stdout = subprocess.check_output(["pyright", filename]).decode("utf-8")
+    match = re.findall(r'Type of "(?:[^"]+)" is "([^"]+)"', stdout)
+    assert match
+    return match
+
+
+def get_mypy_type_output(filename) -> List[str]:
+    stdout = subprocess.check_output(["mypy", filename]).decode("utf-8")
+    match = re.findall(r'note: Revealed type is "([^"]+)"', stdout)
+    assert match
+    return match
+
+
+def test_type_signatures_constructor_nested_resource():
+    with tempfile.TemporaryDirectory() as tempdir:
+        filename = os.path.join(tempdir, "test.py")
+
+        with open(filename, "w") as f:
+            f.write(
+                """
+from dagster._config.structured_config import Resource
+
+class InnerResource(Resource):
+    a_string: str
+
+class OuterResource(Resource):
+    inner: InnerResource
+    a_bool: bool
+
+reveal_type(InnerResource.__init__)
+reveal_type(OuterResource.__init__)
+
+my_outer = OuterResource(inner=InnerResource(a_string="foo"), a_bool=True)
+reveal_type(my_outer.inner)
+"""
+            )
+
+        pyright_out = get_pyright_reveal_type_output(filename)
+        mypy_out = get_mypy_type_output(filename)
+
+        # Ensure constructor signature is correct (mypy doesn't yet support Pydantic model constructor type hints)
+        assert pyright_out[0] == "(self: InnerResource, a_string: str) -> None"
+        assert (
+            pyright_out[1]
+            == "(self: OuterResource, inner: InnerResource | PartialResource[InnerResource],"
+            " a_bool: bool) -> None"
+        )
+
+        # Ensure that the retrieved type is the same as the type of the resource (no partial)
+        assert pyright_out[2] == "InnerResource"
+        assert mypy_out[2] == "test.InnerResource"
+
+
+def test_type_signatures_config_at_launch():
+    with tempfile.TemporaryDirectory() as tempdir:
+        filename = os.path.join(tempdir, "test.py")
+
+        with open(filename, "w") as f:
+            f.write(
+                """
+from dagster._config.structured_config import Resource
+
+class MyResource(Resource):
+    a_string: str
+
+reveal_type(MyResource.configure_at_launch())
+"""
+            )
+
+        pyright_out = get_pyright_reveal_type_output(filename)
+        mypy_out = get_mypy_type_output(filename)
+
+        # Ensure partial resource is correctly parameterized
+        assert pyright_out[0] == "PartialResource[MyResource]"
+        assert mypy_out[0].endswith("PartialResource[test.MyResource]")
+
+
+def test_type_signatures_constructor_resource_dependency():
+    with tempfile.TemporaryDirectory() as tempdir:
+        filename = os.path.join(tempdir, "test.py")
+
+        with open(filename, "w") as f:
+            f.write(
+                """
+from dagster._config.structured_config import Resource, ResourceDependency
+
+class StringDependentResource(Resource):
+    a_string: ResourceDependency[str]
+
+reveal_type(StringDependentResource.__init__)
+
+my_str_resource = StringDependentResource(a_string="foo")
+reveal_type(my_str_resource.a_string)
+"""
+            )
+
+        pyright_out = get_pyright_reveal_type_output(filename)
+        mypy_out = get_mypy_type_output(filename)
+
+        # Ensure constructor signature supports str Resource, PartialResource, raw str, or a
+        # resource function that returns a str
+        assert (
+            pyright_out[0]
+            == "(self: StringDependentResource, a_string: Resource[str] | PartialResource[str] |"
+            " ResourceDefinition | str) -> None"
+        )
+
+        # Ensure that the retrieved type is str
+        assert pyright_out[1] == "str"
+        assert mypy_out[1] == "builtins.str"

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -920,6 +920,9 @@ def get_mypy_type_output(filename) -> List[str]:
     return match
 
 
+# you can specify the -m "typesignature" flag to run these tests, they're
+# slow so we don't want to run them by default
+@pytest.mark.typesignature
 def test_type_signatures_constructor_nested_resource():
     with tempfile.TemporaryDirectory() as tempdir:
         filename = os.path.join(tempdir, "test.py")
@@ -960,6 +963,7 @@ reveal_type(my_outer.inner)
         assert mypy_out[2] == "test.InnerResource"
 
 
+@pytest.mark.typesignature
 def test_type_signatures_config_at_launch():
     with tempfile.TemporaryDirectory() as tempdir:
         filename = os.path.join(tempdir, "test.py")
@@ -984,6 +988,7 @@ reveal_type(MyResource.configure_at_launch())
         assert mypy_out[0].endswith("PartialResource[test.MyResource]")
 
 
+@pytest.mark.typesignature
 def test_type_signatures_constructor_resource_dependency():
     with tempfile.TemporaryDirectory() as tempdir:
         filename = os.path.join(tempdir, "test.py")

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -869,7 +869,7 @@ def test_nested_function_resource_runtime_config():
 
     with pytest.raises(
         CheckError,
-        match="Any partially configured, nested resources must be specified to Definitions",
+        match="Any partially configured, nested resources must be provided to Definitions",
     ):
         # errors b/c writer_resource is not configured
         # and not provided as a top-level resource to Definitions

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -1,7 +1,7 @@
 # pylint: disable=unused-argument
 
 from dagster import Definitions, In, asset, job, op
-from dagster._config.structured_config import StructuredConfigIOManager
+from dagster._config.structured_config import Resource, StructuredConfigIOManager
 
 
 def test_load_input_handle_output():
@@ -79,6 +79,82 @@ def test_runtime_config():
     assert (
         defs.get_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"io_manager": {"config": {"prefix": "greeting: "}}}})
+        .success
+    )
+    assert out_txt == ["greeting: hello, world!"]
+
+
+def test_nested_resources():
+    out_txt = []
+
+    class IOConfigResource(Resource):
+        prefix: str
+
+    class MyIOManager(StructuredConfigIOManager):
+        config: IOConfigResource
+
+        def handle_output(self, context, obj):
+            out_txt.append(f"{self.config.prefix}{obj}")
+
+        def load_input(self, context):
+            assert False, "should not be called"
+
+    @asset
+    def hello_world_asset():
+        return "hello, world!"
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={
+            "io_manager": MyIOManager(config=IOConfigResource(prefix="greeting: ")),
+        },
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert out_txt == ["greeting: hello, world!"]
+
+
+def test_nested_resources_runtime_config():
+    out_txt = []
+
+    class IOConfigResource(Resource):
+        prefix: str
+
+    class MyIOManager(StructuredConfigIOManager):
+        config: IOConfigResource
+
+        def handle_output(self, context, obj):
+            out_txt.append(f"{self.config.prefix}{obj}")
+
+        def load_input(self, context):
+            assert False, "should not be called"
+
+    @asset
+    def hello_world_asset():
+        return "hello, world!"
+
+    io_config = IOConfigResource.configure_at_launch()
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={
+            "io_config": io_config,
+            "io_manager": MyIOManager(config=io_config),
+        },
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process({"resources": {"io_config": {"config": {"prefix": ""}}}})
+        .success
+    )
+    assert out_txt == ["hello, world!"]
+
+    out_txt.clear()
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process({"resources": {"io_config": {"config": {"prefix": "greeting: "}}}})
         .success
     )
     assert out_txt == ["greeting: hello, world!"]

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -122,6 +122,9 @@ setup(
         "black": [
             "black[jupyter]==22.12.0",
         ],
+        "mypy": [
+            "mypy==0.991",
+        ],
         "pyright": [
             "pyright==1.1.293",
             ### Stub packages

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -22,6 +22,7 @@ commands =
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  type_signature_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs} -m 'typesignature'
   storage_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/storage_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests_old_pendulum: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -13,7 +13,7 @@ deps =
   definitions_tests_old_pendulum: pendulum==1.4.4
   storage_tests_old_sqlalchemy: sqlalchemy==1.3.24
   -e ../dagster-test
-  -e .[test]
+  -e .[mypy,test,pyright]
 allowlist_externals =
   /bin/bash
 commands =


### PR DESCRIPTION
## Summary

Allows resources to depend on other resources:

```python
class AWSCredentials(Resource):
    username: str
    password: str

class S3Resource(Resource):
    credentials: AWSCredentials
    region: str
    bucket: str

class EC2Resource(Resource):
    credentials: AWSCredentials

credentials = AWSCredentials(
    username=EnvVar("AWS_USERNAME"),
    password=EnvVar("AWS_PASSWORD"),
)

s3 = S3Resource(credentials=credentials)
ec2 = EC2Resource(credentials=credentials)

defs = Definitions(
    assets=[...],
    resources={
        "aws_credentials": credentials,
        "s3": s3,
        "ec2": snowflake,
    }
)
```

When using raw-Python outputs, these must be categorized as resources using the `ResourceDependency` annotation:


```python
@resource(config_schema={"username": str, "password": str})
def postgres_engine(context):
    return sqlalchemy.create_engine(...)

class DBResource:
    engine: ResourceOutput[sqlalchemy.engine.Engine]

engine = postgres_engine.configured({"username": "foo", "password": "bar"})

# engine input is typed to take any of
# sqlalchemy.engine.Engine, Resource[sqlalchemy.engine.Engine],
# PartialResource[sqlalchemy.engine.Engine],
# or ResourceDefintion (for old, function-based resources)
db = DBResource(engine=engine)
```

## Implementation

The goal of this PR is to allow for the following pattern:

```python
foo = FooResource.configure_at_runtime()
bar = BarResource(inner=foo)

defs = Definitions(
    ...
    resources={
        "my_foo": foo,
        "my_bar": bar,
    }
)
```

Here, `bar` has a pointer to a `ResourceDefinition` for `foo`, but has no knowledge that `foo` is tied to the resource key `"my_foo"` (this is only specified at `Definitions` time). However, any pipeline which depends on `"my_bar"` as a required resource key must also depend on `"my_foo"`, so `bar.required_resource_keys` must return `{"my_foo"}`.

Getting this information (that `foo` has `"my_foo"` as a resource key) to `required_resource_keys` is tricky. 

This PR adds a new wrapper `ResourceDefinition` called `ResourceWithKeyMapping` which pairs the wrapped resource with mapping that takes `ResourceDefinition` IDs to resource keys (e.g. allowing us to map `foo`->`"my_foo"`). It catches any calls to `required_resource_keys` and instead forwards them to `_resolve_required_resource_keys`, which takes the mapping.

See #12232 for more context.

## Test Plan

Added unit tests for I/O managers, resources.
## Test Plan