### PR TITLE
Prefer ECS secrets to environment variables of the same name when both are set

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -212,6 +212,11 @@ def get_task_definition_dict_from_current_task(
             *environment,
         ]
 
+    secret_names = set(secret.get("name") for secret in new_container_definition["secrets"])
+    for env in new_container_definition["environment"]:
+        if env.get("name") in secret_names:
+            new_container_definition["environment"].remove(env)
+
     if include_sidecars:
         container_definitions = current_task_definition_dict.get("containerDefinitions")
         container_definitions.remove(container_definition)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -301,7 +301,7 @@ class StubbedEcs:
                 ),
                 expected_params={**kwargs},
             )
-            client_error=True
+            client_error = True
         else:
             # Sleep for long enough that we hit the lock
             time.sleep(0.2)
@@ -332,19 +332,24 @@ class StubbedEcs:
 
             # Secrets and environment variables can't overlap
             for container_definition in new_container_definitions:
-                secret_names = set(secret.get("name") for secret in container_definition.get("secrets", []))
-                env_names = set(env.get("name") for env in container_definition.get("environment", []))
+                secret_names = set(
+                    secret.get("name") for secret in container_definition.get("secrets", [])
+                )
+                env_names = set(
+                    env.get("name") for env in container_definition.get("environment", [])
+                )
 
                 for overlap in secret_names.intersection(env_names):
                     self.stubber.add_client_error(
                         method="register_task_definition",
                         service_message=(
-                            f"The secret name must be unique and not shared with any new or existing environment variables set on the container, such as '{overlap}'."
+                            "The secret name must be unique and not shared with any new or"
+                            " existing environment variables set on the container, such as"
+                            f" '{overlap}'."
                         ),
                         expected_params={**kwargs},
                     )
                     client_error = True
-
 
             if self._valid_cpu_and_memory(cpu=cpu, memory=memory):
                 task_definition = {


### PR DESCRIPTION
https://github.com/dagster-io/dagster/issues/11622 describes a situation where we try to register a task definition with a secret and an environment variable with identical names.

This can happen because of something you do explicitly: you set both a secret and an env var in your container context.

It can also happen for more subtle and unexpected reasons: you set an environment variable but don't realize that you have a "tagged" secret with the same name, you set a secret but don't realize that an environment variable has been inherited from a "parent" task definition, etc.

I'm not entirely sure what the right fix is here. For now, I've opted to always prefer the secret to the env var if the two overlap. Of course, that raises the question of "what if I want to prefer the env var." Perhaps the best answer there for now is "rename one of the two."