### PR TITLE
[3/4 partition status cache] Update multipartition and default  

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -1,22 +1,29 @@
 import itertools
 import json
+from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Mapping, NamedTuple, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Tuple
 
 import dagster._check as check
 from dagster._annotations import experimental
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+    DagsterInvalidDeserializationVersionError,
+    DagsterInvalidInvocationError,
+)
 from dagster._core.storage.tags import (
     MULTIDIMENSIONAL_PARTITION_PREFIX,
     get_multidimensional_partition_tag,
 )
 
 from .partition import (
-    DefaultPartitionsSubset,
     Partition,
+    PartitionKeyRange,
     PartitionsDefinition,
+    PartitionsSubset,
     StaticPartitionsDefinition,
 )
+from .time_window_partitions import TimeWindowPartitionsDefinition
 
 INVALID_STATIC_PARTITIONS_KEY_CHARACTERS = set(["|", ",", "[", "]"])
 
@@ -232,6 +239,27 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def __repr__(self) -> str:
         return f"{type(self).__name__}(dimensions={[str(dim) for dim in self.partitions_defs]}"
 
+    def split_partition_key_str(self, partition_key_str: str) -> Mapping[str, str]:
+        """
+        Given a string representation of a partition key, returns a list of per-dimension
+        partition keys in the supplied order.
+
+        Does not validate, relying on downstream checks to ensure that the partition key is valid
+        for performance reasons.
+        """
+        check.str_param(partition_key_str, "partition_key_str")
+
+        partition_key_strs = partition_key_str.split("|")
+        check.invariant(
+            len(partition_key_strs) == len(self.partitions_defs),
+            (
+                f"Expected {len(self.partitions_defs)} partition keys in partition key string"
+                f" {partition_key_str}, but got {len(partition_key_strs)}"
+            ),
+        )
+
+        return {dim.name: partition_key_strs[i] for i, dim in enumerate(self._partitions_defs)}
+
     def get_multi_partition_key_from_str(self, partition_key_str: str) -> MultiPartitionKey:
         """
         Given a string representation of a partition key, returns a MultiPartitionKey object.
@@ -262,28 +290,264 @@ class MultiPartitionsDefinition(PartitionsDefinition):
         )
         return multi_partition_key
 
+    def empty_subset(self) -> "MultiPartitionsSubset":
+        return MultiPartitionsSubset(self)
+
     def deserialize_subset(self, serialized: str) -> "MultiPartitionsSubset":
         return MultiPartitionsSubset.from_serialized(self, serialized)
 
+    def can_deserialize_subset(self, serialized: str) -> bool:
+        return MultiPartitionsSubset.can_deserialize(serialized)
 
-class MultiPartitionsSubset(DefaultPartitionsSubset):
-    @staticmethod
+    def _get_primary_and_secondary_dimension(
+        self,
+    ) -> Tuple[PartitionDimensionDefinition, PartitionDimensionDefinition]:
+        # Multipartitions subsets are serialized by primary dimension. If changing
+        # the selection of primary/secondary dimension, will need to also update the
+        # serialization of MultiPartitionsSubsets
+        partition_defs = self.partitions_defs
+        time_partition_defs = [
+            dimension_def
+            for dimension_def in partition_defs
+            if isinstance(dimension_def.partitions_def, TimeWindowPartitionsDefinition)
+        ]
+        secondary_serialization_dimension = (
+            next(iter(time_partition_defs)) if len(time_partition_defs) == 1 else partition_defs[1]
+        )
+        primary_serialization_dimension = next(
+            iter([dim for dim in partition_defs if dim != secondary_serialization_dimension])
+        )
+        return primary_serialization_dimension, secondary_serialization_dimension
+
+    @property
+    def primary_dimension(self) -> PartitionDimensionDefinition:
+        return self._get_primary_and_secondary_dimension()[0]
+
+    @property
+    def secondary_dimension(self) -> PartitionDimensionDefinition:
+        return self._get_primary_and_secondary_dimension()[1]
+
+
+class MultiPartitionsSubset(PartitionsSubset):
+    # Every time we change the serialization format, we should increment the version number.
+    # This will ensure that we can deserialize old data.
+    SERIALIZATION_VERSION = 1
+
+    def __init__(
+        self,
+        partitions_def: MultiPartitionsDefinition,
+        subsets_by_primary_dimension_partition_key: Optional[Mapping[str, PartitionsSubset]] = None,
+    ):
+        self._partitions_def = check.inst_param(
+            partitions_def, "partitions_def", MultiPartitionsDefinition
+        )
+
+        check.opt_mapping_param(
+            subsets_by_primary_dimension_partition_key,
+            "subsets_by_primary_dimension_partition_key",
+            key_type=str,
+            value_type=PartitionsSubset,
+        )
+        if not subsets_by_primary_dimension_partition_key:
+            self._subsets_by_primary_dimension_partition_key = {
+                primary_key: partitions_def.secondary_dimension.partitions_def.empty_subset()
+                for primary_key in partitions_def.primary_dimension.partitions_def.get_partition_keys()
+            }
+        else:
+            check.invariant(
+                set(partitions_def.primary_dimension.partitions_def.get_partition_keys())
+                == set(subsets_by_primary_dimension_partition_key.keys()),
+                (
+                    "The provided primary dimension partition keys must equal the set of partition"
+                    f" keys of dimension {partitions_def.primary_dimension.name}"
+                ),
+            )
+            for secondary_dim_subset in subsets_by_primary_dimension_partition_key.values():
+                check.invariant(
+                    secondary_dim_subset.partitions_def
+                    == partitions_def.secondary_dimension.partitions_def,
+                    (
+                        "Secondary dimension subset partitions definition"
+                        f" {secondary_dim_subset.partitions_def} does not match partitions"
+                        f" definition for dimension {partitions_def.secondary_dimension.name}"
+                    ),
+                )
+            self._subsets_by_primary_dimension_partition_key = dict(
+                subsets_by_primary_dimension_partition_key
+            )
+
+    @property
+    def partitions_def(self) -> MultiPartitionsDefinition:
+        return self._partitions_def
+
+    def get_partition_keys_not_in_subset(
+        self, current_time: Optional[datetime] = None
+    ) -> Iterable[str]:
+        keys_not_in_subset = set()
+        for (
+            primary_key,
+            secondary_subset,
+        ) in self._subsets_by_primary_dimension_partition_key.items():
+            for secondary_key in secondary_subset.get_partition_keys_not_in_subset(current_time):
+                keys_not_in_subset.add(
+                    MultiPartitionKey(
+                        {
+                            self.partitions_def.primary_dimension.name: primary_key,
+                            self.partitions_def.secondary_dimension.name: secondary_key,
+                        }
+                    )
+                )
+        return keys_not_in_subset
+
+    def get_partition_keys(self, current_time: Optional[datetime] = None) -> Iterable[str]:
+        keys_in_subset = set()
+        for (
+            primary_key,
+            secondary_subset,
+        ) in self._subsets_by_primary_dimension_partition_key.items():
+            for secondary_key in secondary_subset.get_partition_keys(current_time):
+                keys_in_subset.add(
+                    MultiPartitionKey(
+                        {
+                            self.partitions_def.primary_dimension.name: primary_key,
+                            self.partitions_def.secondary_dimension.name: secondary_key,
+                        }
+                    )
+                )
+        return keys_in_subset
+
+    def get_partition_key_ranges(
+        self, current_time: Optional[datetime] = None
+    ) -> Sequence[PartitionKeyRange]:
+        partition_keys = self._partitions_def.get_partition_keys(current_time)
+        cur_range_start = None
+        cur_range_end = None
+        result = []
+        for partition_key in partition_keys:
+            if partition_key in self:
+                if cur_range_start is None:
+                    cur_range_start = partition_key
+                cur_range_end = partition_key
+            else:
+                if cur_range_start is not None and cur_range_end is not None:
+                    result.append(PartitionKeyRange(cur_range_start, cur_range_end))
+                cur_range_start = cur_range_end = None
+
+        if cur_range_start is not None and cur_range_end is not None:
+            result.append(PartitionKeyRange(cur_range_start, cur_range_end))
+
+        return result
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, MultiPartitionsSubset)
+            and self.partitions_def == other.partitions_def
+            and self._subsets_by_primary_dimension_partition_key
+            == other._subsets_by_primary_dimension_partition_key
+        )
+
+    def __len__(self) -> int:
+        return sum(
+            len(subset) for subset in self._subsets_by_primary_dimension_partition_key.values()
+        )
+
+    def __contains__(self, partition_key: str) -> bool:
+        if not isinstance(partition_key, MultiPartitionKey):
+            check.failed("partition_key must be a MultiPartitionKey")
+
+        primary_key = partition_key.keys_by_dimension.get(
+            self.partitions_def.primary_dimension.name
+        )
+        secondary_key = partition_key.keys_by_dimension.get(
+            self.partitions_def.secondary_dimension.name
+        )
+        return (
+            primary_key is not None
+            and primary_key in self._subsets_by_primary_dimension_partition_key
+            and secondary_key is not None
+            and secondary_key in self._subsets_by_primary_dimension_partition_key[primary_key]
+        )
+
+    def with_partition_keys(self, partition_keys: Iterable[str]) -> "MultiPartitionsSubset":
+        new_keys_by_primary_dim_key = defaultdict(set)
+        keys_split_into_dimensions = [
+            self._partitions_def.split_partition_key_str(key) for key in partition_keys
+        ]
+
+        for dim_key_mapping in keys_split_into_dimensions:
+            new_keys_by_primary_dim_key[
+                dim_key_mapping[self.partitions_def.primary_dimension.name]
+            ].add(dim_key_mapping[self.partitions_def.secondary_dimension.name])
+
+        return MultiPartitionsSubset(
+            self._partitions_def,
+            {
+                primary_key: secondary_dim_subset.with_partition_keys(
+                    new_keys_by_primary_dim_key[primary_key],
+                )
+                for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+            },
+        )
+
+    def serialize(self) -> str:
+        # Serialize version number, so attempting to deserialize old versions can be handled gracefully.
+        # Any time the serialization format changes, we should increment the version number.
+        return json.dumps(
+            {
+                "version": self.SERIALIZATION_VERSION,
+                "serialized_subsets_by_primary_key": {
+                    primary_key: secondary_dim_subset.serialize()
+                    for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+                },
+            }
+        )
+
+    @classmethod
+    def can_deserialize(cls, serialized: str) -> bool:
+        # Check the version number to determine if the serialization format is supported
+        data = json.loads(serialized)
+        return data.get("version") == cls.SERIALIZATION_VERSION
+
+    @classmethod
     def from_serialized(
-        partitions_def: PartitionsDefinition, serialized: str
+        cls, partitions_def: PartitionsDefinition, serialized: str
     ) -> "MultiPartitionsSubset":
         if not isinstance(partitions_def, MultiPartitionsDefinition):
             check.failed(
                 "Must pass a MultiPartitionsDefinition object to deserialize MultiPartitionsSubset."
             )
+
+        data = json.loads(serialized)
+        if data.get("version") != cls.SERIALIZATION_VERSION:
+            raise DagsterInvalidDeserializationVersionError(
+                f"Attempted to deserialize partition subset with version {data.get('version')}, but"
+                f" only version {cls.SERIALIZATION_VERSION} is supported."
+            )
+
         return MultiPartitionsSubset(
-            subset=set(
-                [
-                    partitions_def.get_multi_partition_key_from_str(key)
-                    for key in json.loads(serialized)
-                ]
-            ),
             partitions_def=partitions_def,
+            subsets_by_primary_dimension_partition_key={
+                primary_key: partitions_def.secondary_dimension.partitions_def.deserialize_subset(
+                    subset
+                )
+                for primary_key, subset in data["serialized_subsets_by_primary_key"].items()
+            },
         )
+
+    def get_inverse_subset(
+        self, current_time: Optional[datetime] = None
+    ) -> "MultiPartitionsSubset":
+        return MultiPartitionsSubset(
+            partitions_def=self._partitions_def,
+            subsets_by_primary_dimension_partition_key={
+                primary_key: secondary_dim_subset.get_inverse_subset(current_time)
+                for primary_key, secondary_dim_subset in self._subsets_by_primary_dimension_partition_key.items()
+            },
+        )
+
+    @property
+    def subsets_by_primary_dimension_partition_key(self) -> Mapping[str, PartitionsSubset]:
+        return self._subsets_by_primary_dimension_partition_key
 
 
 def get_tags_from_multi_partition_key(multi_partition_key: MultiPartitionKey) -> Mapping[str, str]:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -11,9 +11,9 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Tuple,
     Union,
     cast,
-    Tuple
 )
 
 import pendulum

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -683,6 +683,19 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
     def serialize(self) -> str:
         raise NotImplementedError()
 
+    @classmethod
+    def from_serialized(
+        cls, partitions_def: "PartitionsDefinition", serialized: str
+    ) -> "PartitionsSubset":
+        raise NotImplementedError()
+
+    def get_inverse_subset(self, current_time: Optional[datetime] = None) -> "PartitionsSubset":
+        raise NotImplementedError()
+
+    @classmethod
+    def can_deserialize(cls, serialized: str) -> bool:
+        raise NotImplementedError()
+
     @property
     def partitions_def(self) -> "PartitionsDefinition":
         raise NotImplementedError()

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -18,14 +18,11 @@ def test_get_downstream_partitions_single_key_in_range():
         ),
         downstream_partitions_def=downstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
-        {
-            MultiPartitionKey({"abc": "a", "123": "1"}),
-            MultiPartitionKey({"abc": "a", "123": "2"}),
-            MultiPartitionKey({"abc": "a", "123": "3"}),
-        },
-    )
+    assert result.get_partition_keys() == {
+        MultiPartitionKey({"abc": "a", "123": "1"}),
+        MultiPartitionKey({"abc": "a", "123": "2"}),
+        MultiPartitionKey({"abc": "a", "123": "3"}),
+    }
 
     downstream_partitions_def = MultiPartitionsDefinition(
         {"abc": upstream_partitions_def, "xyz": StaticPartitionsDefinition(["x", "y", "z"])}
@@ -39,14 +36,11 @@ def test_get_downstream_partitions_single_key_in_range():
         ),
         downstream_partitions_def=downstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
-        {
-            MultiPartitionKey({"abc": "b", "xyz": "x"}),
-            MultiPartitionKey({"abc": "b", "xyz": "y"}),
-            MultiPartitionKey({"abc": "b", "xyz": "z"}),
-        },
-    )
+    assert result.get_partition_keys() == {
+        MultiPartitionKey({"abc": "b", "xyz": "x"}),
+        MultiPartitionKey({"abc": "b", "xyz": "y"}),
+        MultiPartitionKey({"abc": "b", "xyz": "z"}),
+    }
 
 
 def test_get_downstream_partitions_multiple_keys_in_range():
@@ -63,17 +57,14 @@ def test_get_downstream_partitions_multiple_keys_in_range():
         ),
         downstream_partitions_def=downstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
-        {
-            MultiPartitionKey({"abc": "a", "123": "1"}),
-            MultiPartitionKey({"abc": "a", "123": "2"}),
-            MultiPartitionKey({"abc": "a", "123": "3"}),
-            MultiPartitionKey({"abc": "b", "123": "1"}),
-            MultiPartitionKey({"abc": "b", "123": "2"}),
-            MultiPartitionKey({"abc": "b", "123": "3"}),
-        },
-    )
+    assert result.get_partition_keys() == {
+        MultiPartitionKey({"abc": "a", "123": "1"}),
+        MultiPartitionKey({"abc": "a", "123": "2"}),
+        MultiPartitionKey({"abc": "a", "123": "3"}),
+        MultiPartitionKey({"abc": "b", "123": "1"}),
+        MultiPartitionKey({"abc": "b", "123": "2"}),
+        MultiPartitionKey({"abc": "b", "123": "3"}),
+    }
 
 
 def test_get_upstream_single_dimension_to_multi_partition_mapping():
@@ -107,4 +98,4 @@ def test_get_upstream_single_dimension_to_multi_partition_mapping():
         ),
         upstream_partitions_def,
     )
-    assert result == DefaultPartitionsSubset(upstream_partitions_def, {"a", "b"})
+    assert result.get_partition_keys() == {"a", "b"}

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -1,0 +1,45 @@
+import pytest
+from dagster import DailyPartitionsDefinition, StaticPartitionsDefinition
+from dagster._core.definitions.partition import DefaultPartitionsSubset
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+from dagster._core.errors import DagsterInvalidDeserializationVersionError
+
+
+def test_default_subset_cannot_deserialize_invalid_version():
+    static_partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
+    serialized_subset = (
+        static_partitions_def.empty_subset().with_partition_keys(["a", "c", "d"]).serialize()
+    )
+
+    assert static_partitions_def.deserialize_subset(serialized_subset).get_partition_keys() == {
+        "a",
+        "c",
+        "d",
+    }
+
+    class NewSerializationVersionSubset(DefaultPartitionsSubset):
+        SERIALIZATION_VERSION = -1
+
+    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) is False
+
+    with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -1"):
+        NewSerializationVersionSubset.from_serialized(static_partitions_def, serialized_subset)
+
+
+def test_time_window_subset_cannot_deserialize_invalid_version():
+    daily_partitions_def = DailyPartitionsDefinition(start_date="2023-01-01")
+    serialized_subset = (
+        daily_partitions_def.empty_subset().with_partition_keys(["2023-01-02"]).serialize()
+    )
+
+    assert set(daily_partitions_def.deserialize_subset(serialized_subset).get_partition_keys()) == {
+        "2023-01-02"
+    }
+
+    class NewSerializationVersionSubset(TimeWindowPartitionsSubset):
+        SERIALIZATION_VERSION = -2
+
+    assert NewSerializationVersionSubset.can_deserialize(serialized_subset) is False
+
+    with pytest.raises(DagsterInvalidDeserializationVersionError, match="version -2"):
+        NewSerializationVersionSubset.from_serialized(daily_partitions_def, serialized_subset)

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -822,3 +822,22 @@ def test_static_partitions_subset():
     assert len(with_some_partitions) == 2
     assert len(deserialized) == 2
     assert "bar" in with_some_partitions
+
+
+def test_static_partitions_subset_backwards_compat():
+    partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
+    serialization = '["baz", "foo"]'
+
+    deserialized = partitions.deserialize_subset(serialization)
+    assert deserialized.get_partition_keys() == {"baz", "foo"}
+
+
+def test_static_partitions_subset_current_version_serialization():
+    partitions = StaticPartitionsDefinition(["foo", "bar", "baz", "qux"])
+    serialization = partitions.empty_subset().with_partition_keys(["foo", "baz"]).serialize()
+    deserialized = partitions.deserialize_subset(serialization)
+    assert deserialized.get_partition_keys() == {"baz", "foo"}
+
+    serialization = '{"version": 1, "subset": ["foo", "baz"]}'
+    deserialized = partitions.deserialize_subset(serialization)
+    assert deserialized.get_partition_keys() == {"baz", "foo"}


### PR DESCRIPTION
In Dagit, we will represent materialized partitions in multi-dimensional assets in terms of the static dimension. E.g. for each static partition key, we will calculate the corresponding time window partition bar. This is because many users think of each static partition key of a multipartitioned asset as a sub-asset.

Subsequently, for multipartitioned assets:
- Changes the multipartitioned subset to use a custom representation that maps the static partition keys to their corresponding time partition subsets.
- Adds "primary dimension" and "secondary dimension" as properties to the multipartitions definition to enable fetching this for Dagit

For default and multipartitions subsets:
- Serializes the serialization version. Also adds backcompat support for existing serialized subsets.
- Adds `get_inverse_subset` method
