### PR TITLE
fix code location status when a new location is added in a loading state

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -125,10 +125,11 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     const anyCurrentlyLoading = currentlyLoading.length > 0;
 
     // If this is a fresh pageload and any locations are loading, show the spinner but not the toaster.
-    if (!previousEntriesById) {
+    if (!previousEntries.length) {
       if (anyCurrentlyLoading) {
         setShowSpinner(true);
       }
+      reloadWorkspaceQuietly();
       return;
     }
 


### PR DESCRIPTION
### Summary & Motivation
Hitting a bug where a newly added code location in a loading state requires a page refresh to load the placeholder table.

### How I Tested These Changes
Removed all code locations locally, created a new one in a new tab, saw the locations table immediately