### PR TITLE
[dagit] Add backfill warnings and run tags options to the Materialize modal

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -1,16 +1,15 @@
 import {gql, useApolloClient, useQuery} from '@apollo/client';
 import {
-  Alert,
   Box,
   Button,
   ButtonLink,
   Colors,
   Dialog,
   DialogBody,
-  DialogBodySection,
   DialogFooter,
   DialogHeader,
   Tooltip,
+  Alert,
 } from '@dagster-io/ui';
 import reject from 'lodash/reject';
 import React from 'react';
@@ -38,10 +37,13 @@ import {
 } from '../launchpad/types/ConfigEditorConfigPicker.types';
 import {
   DaemonNotRunningAlert,
+  DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT,
   showBackfillErrorToast,
   showBackfillSuccessToast,
   UsingDefaultLauncherAlert,
+  USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT,
 } from '../partitions/BackfillMessaging';
+import {Section} from '../partitions/BackfillSelector';
 import {DimensionRangeWizard} from '../partitions/DimensionRangeWizard';
 import {PartitionStateCheckboxes} from '../partitions/PartitionStateCheckboxes';
 import {PartitionState} from '../partitions/PartitionStatus';
@@ -362,8 +364,8 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           setSelections={setSelections}
         />
 
-        <Box flex={{direction: 'column', gap: 32}} style={{marginTop: 32}}>
-          <DialogBodySection title="Tags">
+        <Box flex={{direction: 'column', gap: 16}} style={{marginTop: 24}}>
+          <Section title="Tags">
             <TagEditor
               tagsFromSession={tags}
               onChange={setTags}
@@ -381,7 +383,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                 </Button>
               </div>
             )}
-          </DialogBodySection>
+          </Section>
 
           {instance && keysFiltered.length > 1 && <DaemonNotRunningAlert instance={instance} />}
 
@@ -490,4 +492,7 @@ const LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY = gql`
       ...UsingDefaultLauncherAlertInstanceFragment
     }
   }
+
+  ${DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT}
+  ${USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -1,0 +1,19 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type LaunchAssetChoosePartitionsQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type LaunchAssetChoosePartitionsQuery = {
+  __typename: 'DagitQuery';
+  instance: {
+    __typename: 'Instance';
+    runQueuingSupported: boolean;
+    daemonHealth: {
+      __typename: 'DaemonHealth';
+      id: string;
+      daemonStatus: {__typename: 'DaemonStatus'; id: string; healthy: boolean | null};
+    };
+    runLauncher: {__typename: 'RunLauncher'; name: string} | null;
+  };
+};

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -1,6 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
 import {
-  Alert,
   Box,
   CursorPaginationControls,
   NonIdealState,
@@ -16,6 +15,7 @@ import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {OverviewTabs} from '../overview/OverviewTabs';
+import {DaemonNotRunningAlertBody} from '../partitions/BackfillMessaging';
 import {useCursorPaginatedQuery} from '../runs/useCursorPaginatedQuery';
 import {Loading} from '../ui/Loading';
 
@@ -86,23 +86,7 @@ export const InstanceBackfills = () => {
             <div>
               {isBackfillHealthy ? null : (
                 <Box padding={{horizontal: 24, vertical: 16}}>
-                  <Alert
-                    intent="warning"
-                    title="The backfill daemon is not running."
-                    description={
-                      <div>
-                        See the{' '}
-                        <a
-                          href="https://docs.dagster.io/deployment/dagster-daemon"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          dagster-daemon documentation
-                        </a>{' '}
-                        for more information on how to deploy the dagster-daemon process.
-                      </div>
-                    }
-                  />
+                  <DaemonNotRunningAlertBody />
                 </Box>
               )}
               <BackfillTable

--- a/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
@@ -1,0 +1,153 @@
+import {gql} from '@apollo/client';
+import {Alert, ButtonLink, Colors, Group, Mono} from '@dagster-io/ui';
+import {History} from 'history';
+import * as React from 'react';
+
+import {showCustomAlert} from '../app/CustomAlertProvider';
+import {SharedToaster} from '../app/DomUtils';
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {LaunchPartitionBackfillMutation} from '../instance/types/BackfillUtils.types';
+
+import {
+  DaemonNotRunningAlertInstanceFragment,
+  UsingDefaultLauncherAlertInstanceFragment,
+} from './types/BackfillMessaging.types';
+
+const DEFAULT_RUN_LAUNCHER_NAME = 'DefaultRunLauncher';
+
+function messageForLaunchBackfillError(data: LaunchPartitionBackfillMutation | null | undefined) {
+  const result = data?.launchPartitionBackfill;
+
+  let errors = <></>;
+  if (result?.__typename === 'PythonError' || result?.__typename === 'PartitionSetNotFoundError') {
+    errors = <PythonErrorInfo error={result} />;
+  } else if (result?.__typename === 'InvalidStepError') {
+    errors = <div>{`Invalid step: ${result.invalidStepKey}`}</div>;
+  } else if (result?.__typename === 'InvalidOutputError') {
+    errors = <div>{`Invalid output: ${result.invalidOutputName} for ${result.stepKey}`}</div>;
+  } else if (result && 'errors' in result) {
+    errors = (
+      <>
+        {result['errors'].map((error, idx) => (
+          <PythonErrorInfo error={error} key={idx} />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <Group direction="column" spacing={4}>
+      <div>An unexpected error occurred. This backfill was not launched.</div>
+      {errors ? (
+        <ButtonLink
+          color={Colors.White}
+          underline="always"
+          onClick={() => {
+            showCustomAlert({
+              body: errors,
+            });
+          }}
+        >
+          View error
+        </ButtonLink>
+      ) : null}
+    </Group>
+  );
+}
+
+export function showBackfillErrorToast(data: LaunchPartitionBackfillMutation | null | undefined) {
+  SharedToaster.show({
+    message: messageForLaunchBackfillError(data),
+    icon: 'error',
+    intent: 'danger',
+  });
+}
+
+export function showBackfillSuccessToast(history: History<unknown>, backfillId: string) {
+  SharedToaster.show({
+    intent: 'success',
+    message: (
+      <div>
+        Created backfill <Mono>{backfillId}</Mono>
+      </div>
+    ),
+    action: {
+      text: 'View',
+      onClick: () => history.push('/overview/backfills'),
+    },
+  });
+}
+
+export const DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT = gql`
+  fragment DaemonNotRunningAlertInstanceFragment on Instance {
+    daemonHealth {
+      id
+      daemonStatus(daemonType: "BACKFILL") {
+        id
+        healthy
+      }
+    }
+  }
+`;
+
+export const DaemonNotRunningAlert: React.FC<{
+  instance: DaemonNotRunningAlertInstanceFragment;
+}> = ({instance}) =>
+  !instance.daemonHealth.daemonStatus.healthy ? <DaemonNotRunningAlertBody /> : null;
+
+export const DaemonNotRunningAlertBody = () => (
+  <Alert
+    intent="warning"
+    title="The backfill daemon is not running."
+    description={
+      <div>
+        See the{' '}
+        <a
+          href="https://docs.dagster.io/deployment/dagster-daemon"
+          target="_blank"
+          rel="noreferrer"
+        >
+          dagster-daemon documentation
+        </a>{' '}
+        for more information on how to deploy the dagster-daemon process.
+      </div>
+    }
+  />
+);
+
+export const USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT = gql`
+  fragment UsingDefaultLauncherAlertInstanceFragment on Instance {
+    runQueuingSupported
+    runLauncher {
+      name
+    }
+  }
+`;
+
+export const UsingDefaultLauncherAlert: React.FC<{
+  instance: UsingDefaultLauncherAlertInstanceFragment;
+}> = ({instance}) =>
+  instance.runLauncher?.name === DEFAULT_RUN_LAUNCHER_NAME && !instance.runQueuingSupported ? (
+    <Alert
+      intent="warning"
+      title={
+        <div>
+          Using the default run launcher <code>{DEFAULT_RUN_LAUNCHER_NAME}</code> for launching
+          backfills without a queued run coordinator is not advised.
+        </div>
+      }
+      description={
+        <div>
+          Check your instance configuration in <code>dagster.yaml</code> to either configure the{' '}
+          <a
+            href="https://docs.dagster.io/deployment/run-coordinator"
+            target="_blank"
+            rel="noreferrer"
+          >
+            queued run coordinator
+          </a>{' '}
+          or to configure a run launcher more appropriate for launching a large number of jobs.
+        </div>
+      }
+    />
+  ) : null;

--- a/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
@@ -18,7 +18,7 @@ const DEFAULT_RUN_LAUNCHER_NAME = 'DefaultRunLauncher';
 function messageForLaunchBackfillError(data: LaunchPartitionBackfillMutation | null | undefined) {
   const result = data?.launchPartitionBackfill;
 
-  let errors = <></>;
+  let errors: React.ReactNode = undefined;
   if (result?.__typename === 'PythonError' || result?.__typename === 'PartitionSetNotFoundError') {
     errors = <PythonErrorInfo error={result} />;
   } else if (result?.__typename === 'InvalidStepError') {
@@ -132,13 +132,13 @@ export const UsingDefaultLauncherAlert: React.FC<{
       intent="warning"
       title={
         <div>
-          Using the default run launcher <code>{DEFAULT_RUN_LAUNCHER_NAME}</code> for launching
+          Using the default run launcher <code>{DEFAULT_RUN_LAUNCHER_NAME}</code> to launch
           backfills without a queued run coordinator is not advised.
         </div>
       }
       description={
         <div>
-          Check your instance configuration in <code>dagster.yaml</code> to either configure the{' '}
+          Check your instance configuration in <code>dagster.yaml</code> to configure the{' '}
           <a
             href="https://docs.dagster.io/deployment/run-coordinator"
             target="_blank"
@@ -146,7 +146,7 @@ export const UsingDefaultLauncherAlert: React.FC<{
           >
             queued run coordinator
           </a>{' '}
-          or to configure a run launcher more appropriate for launching a large number of jobs.
+          or a run launcher more appropriate for launching a large number of jobs.
         </div>
       }
     />

--- a/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
@@ -5,11 +5,11 @@ import {
   Checkbox,
   Colors,
   DialogBody,
-  DialogBodySection,
   DialogFooter,
   Icon,
   NonIdealState,
   Spinner,
+  Subheading,
   Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
@@ -34,9 +34,11 @@ import {RepoAddress} from '../workspace/types';
 
 import {
   DaemonNotRunningAlert,
+  DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT,
   showBackfillErrorToast,
   showBackfillSuccessToast,
   UsingDefaultLauncherAlert,
+  USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT,
 } from './BackfillMessaging';
 import {DimensionRangeWizard} from './DimensionRangeWizard';
 import {PartitionStateCheckboxes} from './PartitionStateCheckboxes';
@@ -167,8 +169,8 @@ export const BackfillPartitionSelector: React.FC<{
   return (
     <>
       <DialogBody>
-        <Box flex={{direction: 'column', gap: 32}}>
-          <DialogBodySection title="Partitions">
+        <Box flex={{direction: 'column', gap: 24}}>
+          <Section title="Partitions">
             <Box>
               Select partitions to materialize. Click and drag to select a range on the timeline.
             </Box>
@@ -199,10 +201,10 @@ export const BackfillPartitionSelector: React.FC<{
               }
               onChange={setStateFilters}
             />
-          </DialogBodySection>
+          </Section>
 
           {failedPartitions.length ? (
-            <DialogBodySection title="Reexecution">
+            <Section title="Reexecution">
               <Checkbox
                 checked={options.fromFailure}
                 disabled={!selected.every(isFailed)}
@@ -231,10 +233,10 @@ export const BackfillPartitionSelector: React.FC<{
                   </Box>
                 }
               />
-            </DialogBodySection>
+            </Section>
           ) : null}
 
-          <DialogBodySection
+          <Section
             title={
               <Box flex={{display: 'inline-flex', alignItems: 'center'}}>
                 <Box margin={{right: 4}}>Step subset</Box>
@@ -263,9 +265,9 @@ export const BackfillPartitionSelector: React.FC<{
                 </div>
               ) : null}
             </Box>
-          </DialogBodySection>
+          </Section>
 
-          <DialogBodySection title="Tags">
+          <Section title="Tags">
             <TagEditor
               tagsFromSession={tags}
               onChange={setTags}
@@ -281,11 +283,13 @@ export const BackfillPartitionSelector: React.FC<{
                 <Button onClick={() => setTagEditorOpen(true)}>Add tags to backfill runs</Button>
               </div>
             )}
-          </DialogBodySection>
+          </Section>
 
-          <DaemonNotRunningAlert instance={instance} />
+          <Box flex={{direction: 'column', gap: 16}}>
+            <DaemonNotRunningAlert instance={instance} />
 
-          <UsingDefaultLauncherAlert instance={instance} />
+            <UsingDefaultLauncherAlert instance={instance} />
+          </Box>
         </Box>
       </DialogBody>
       <DialogFooter>
@@ -450,4 +454,25 @@ const BACKFILL_SELECTOR_QUERY = gql`
   }
 
   ${GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT}
+  ${DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT}
+  ${USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT}
 `;
+
+export const Section = ({
+  title,
+  children,
+}: {
+  title: string | React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <Box flex={{direction: 'column', gap: 4}}>
+    <Subheading>{title}</Subheading>
+    <Box
+      flex={{direction: 'column', gap: 8}}
+      padding={{top: 16}}
+      border={{width: 1, color: Colors.KeylineGray, side: 'top'}}
+    >
+      {children}
+    </Box>
+  </Box>
+);

--- a/js_modules/dagit/packages/core/src/partitions/types/BackfillMessaging.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/BackfillMessaging.types.ts
@@ -1,0 +1,18 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type DaemonNotRunningAlertInstanceFragment = {
+  __typename: 'Instance';
+  daemonHealth: {
+    __typename: 'DaemonHealth';
+    id: string;
+    daemonStatus: {__typename: 'DaemonStatus'; id: string; healthy: boolean | null};
+  };
+};
+
+export type UsingDefaultLauncherAlertInstanceFragment = {
+  __typename: 'Instance';
+  runQueuingSupported: boolean;
+  runLauncher: {__typename: 'RunLauncher'; name: string} | null;
+};

--- a/js_modules/dagit/packages/ui/src/components/Dialog.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Dialog.tsx
@@ -61,26 +61,6 @@ export const DialogBody: React.FC = (props) => {
   );
 };
 
-// The subheadings used in the backfill modals
-export const DialogBodySection = ({
-  title,
-  children,
-}: {
-  title: string | React.ReactNode;
-  children: React.ReactNode;
-}) => (
-  <Box flex={{direction: 'column', gap: 8}}>
-    <strong style={{display: 'block'}}>{title}</strong>
-    <Box
-      flex={{direction: 'column', gap: 8}}
-      padding={{top: 16}}
-      border={{width: 1, color: Colors.KeylineGray, side: 'top'}}
-    >
-      {children}
-    </Box>
-  </Box>
-);
-
 interface DialogFooterProps {
   topBorder?: boolean;
   left?: React.ReactFragment;

--- a/js_modules/dagit/packages/ui/src/components/Dialog.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Dialog.tsx
@@ -61,6 +61,26 @@ export const DialogBody: React.FC = (props) => {
   );
 };
 
+// The subheadings used in the backfill modals
+export const DialogBodySection = ({
+  title,
+  children,
+}: {
+  title: string | React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <Box flex={{direction: 'column', gap: 8}}>
+    <strong style={{display: 'block'}}>{title}</strong>
+    <Box
+      flex={{direction: 'column', gap: 8}}
+      padding={{top: 16}}
+      border={{width: 1, color: Colors.KeylineGray, side: 'top'}}
+    >
+      {children}
+    </Box>
+  </Box>
+);
+
 interface DialogFooterProps {
   topBorder?: boolean;
   left?: React.ReactFragment;


### PR DESCRIPTION
### Summary & Motivation

Related: https://github.com/dagster-io/dagster/issues/11585
A user recently flagged that our "Materialize" button for assets doesn't offer the ability to add tags to your run or backfill. I think this was just an oversight - these concepts are supported by the underlying APIs.

This PR moves more components of the job backfill modal into a shared set and re-uses them in the asset modal. In addition to the tag UI, I also added the two warnings that can appear in the job backfill modal: "You are using the default run launcher"  and "Your backfill daemon is not running". To make these cleaner, I also put the display conditionals inside them and gave them proper GraphQL fragments.

Here's what both modals look like now (in a worst-case scenario where all the warning states are present). In the asset modal, if you select only one partition the warnings disappear, since they're not relevant in the single job case, but you can add tags either way.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/1037212/211971708-5a930f83-9f2d-4f6e-aa83-01f78df3a9c1.png">

<img width="908" alt="image" src="https://user-images.githubusercontent.com/1037212/211971735-d9c74f3f-fdb8-4c72-8a7d-b8a8ac2b8328.png">

### How I Tested These Changes

I verified that tags are applied for both single jobs and backfills of assets, and verified that the job backfill modal is not impacted. I also verified that turning on my dagster backfill daemon makes the warning disappear in both dialogs. Also verified that if you make the screen really small, the asset backfill modal scrolls, since it's getting a bit large.