### PR TITLE
Kill stray tqdms when starting up dagster

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/schedules/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/migration.py
@@ -39,7 +39,9 @@ def add_selector_id_to_jobs_table(storage, print_fn=None):
             ).order_by(JobTable.c.id.asc())
         ).fetchall()
 
-        for row_id, state_str, create_timestamp, update_timestamp in tqdm(rows):
+        rows_progress = tqdm(rows) if print_fn else rows
+
+        for row_id, state_str, create_timestamp, update_timestamp in rows_progress:
             state = deserialize_as(state_str, InstigatorState)
             selector_id = state.selector_id
 
@@ -90,7 +92,10 @@ def add_selector_id_to_ticks_table(storage, print_fn=None):
         print_fn("Querying storage.")
 
     instigator_states = storage.all_instigator_state()
-    for state in tqdm(instigator_states):
+
+    states = tqdm(instigator_states) if print_fn else instigator_states
+
+    for state in states:
         with storage.connect() as conn:
             conn.execute(
                 JobTickTable.update()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Summary:
These produce an unsightly "0it [00:00, ?it/s]" in the console output every time you start up dagit with no dagster home set.

Test Plan: Run dagit without DAGSTER_HOME set

### Summary & Motivation

### How I Tested These Changes
