### PR TITLE
[dagster-airflow] pass airflow dag timezone to dagster schedule definition

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -19,8 +19,6 @@ from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.settings import LOG_FORMAT
 from airflow.utils import db
-from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
-
 from dagster import (
     Array,
     DagsterInvariantViolationError,
@@ -32,14 +30,18 @@ from dagster import (
     Nothing,
     Out,
     ScheduleDefinition,
+    _check as check,
+    op,
+    repository,
+    resource,
 )
-from dagster import _check as check
-from dagster import op, repository, resource
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
 from dagster._legacy import ModeDefinition, PipelineDefinition
 from dagster._utils.schedules import is_valid_cron_schedule
+
+from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
 # pylint: disable=no-name-in-module,import-error
 if str(airflow_version) >= "2.0.0":

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -19,29 +19,20 @@ from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.settings import LOG_FORMAT
 from airflow.utils import db
-from dagster import (
-    Array,
-    DagsterInvariantViolationError,
-    DependencyDefinition,
-    Field,
-    In,
-    JobDefinition,
-    MultiDependencyDefinition,
-    Nothing,
-    Out,
-    ScheduleDefinition,
-    _check as check,
-    op,
-    repository,
-    resource,
-)
+from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
+
+from dagster import (Array, DagsterInvariantViolationError,
+                     DependencyDefinition, Field, In, JobDefinition,
+                     MultiDependencyDefinition, Nothing, Out,
+                     ScheduleDefinition)
+from dagster import _check as check
+from dagster import op, repository, resource
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
-from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
+from dagster._core.instance import (AIRFLOW_EXECUTION_DATE_STR,
+                                    IS_AIRFLOW_INGEST_PIPELINE_STR)
 from dagster._legacy import ModeDefinition, PipelineDefinition
 from dagster._utils.schedules import is_valid_cron_schedule
-
-from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
 # pylint: disable=no-name-in-module,import-error
 if str(airflow_version) >= "2.0.0":
@@ -287,7 +278,10 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
 
     if isinstance(dag.normalized_schedule_interval, str) and is_valid_cron_schedule(cron_schedule):
         return ScheduleDefinition(
-            job=job_def, cron_schedule=cron_schedule, description=schedule_description
+            job=job_def,
+            cron_schedule=cron_schedule,
+            description=schedule_description,
+            execution_timezone=dag.timezone,
         )
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -21,16 +21,23 @@ from airflow.settings import LOG_FORMAT
 from airflow.utils import db
 from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
-from dagster import (Array, DagsterInvariantViolationError,
-                     DependencyDefinition, Field, In, JobDefinition,
-                     MultiDependencyDefinition, Nothing, Out,
-                     ScheduleDefinition)
+from dagster import (
+    Array,
+    DagsterInvariantViolationError,
+    DependencyDefinition,
+    Field,
+    In,
+    JobDefinition,
+    MultiDependencyDefinition,
+    Nothing,
+    Out,
+    ScheduleDefinition,
+)
 from dagster import _check as check
 from dagster import op, repository, resource
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
-from dagster._core.instance import (AIRFLOW_EXECUTION_DATE_STR,
-                                    IS_AIRFLOW_INGEST_PIPELINE_STR)
+from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
 from dagster._legacy import ModeDefinition, PipelineDefinition
 from dagster._utils.schedules import is_valid_cron_schedule
 
@@ -281,7 +288,7 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
             job=job_def,
             cron_schedule=cron_schedule,
             description=schedule_description,
-            execution_timezone=dag.timezone,
+            execution_timezone=str(dag.timezone),
         )
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -19,29 +19,20 @@ from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.settings import LOG_FORMAT
 from airflow.utils import db
-from dagster import (
-    Array,
-    DagsterInvariantViolationError,
-    DependencyDefinition,
-    Field,
-    In,
-    JobDefinition,
-    MultiDependencyDefinition,
-    Nothing,
-    Out,
-    ScheduleDefinition,
-    _check as check,
-    op,
-    repository,
-    resource,
-)
+from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
+
+from dagster import (Array, DagsterInvariantViolationError,
+                     DependencyDefinition, Field, In, JobDefinition,
+                     MultiDependencyDefinition, Nothing, Out,
+                     ScheduleDefinition)
+from dagster import _check as check
+from dagster import op, repository, resource
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
-from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
+from dagster._core.instance import (AIRFLOW_EXECUTION_DATE_STR,
+                                    IS_AIRFLOW_INGEST_PIPELINE_STR)
 from dagster._legacy import ModeDefinition, PipelineDefinition
 from dagster._utils.schedules import is_valid_cron_schedule
-
-from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
 # pylint: disable=no-name-in-module,import-error
 if str(airflow_version) >= "2.0.0":
@@ -290,7 +281,7 @@ def make_dagster_schedule_from_airflow_dag(dag, job_def):
             job=job_def,
             cron_schedule=cron_schedule,
             description=schedule_description,
-            execution_timezone=str(dag.timezone),
+            execution_timezone=dag.timezone.name,
         )
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_pipeline_factory.py
@@ -19,20 +19,29 @@ from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.settings import LOG_FORMAT
 from airflow.utils import db
-from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
-
-from dagster import (Array, DagsterInvariantViolationError,
-                     DependencyDefinition, Field, In, JobDefinition,
-                     MultiDependencyDefinition, Nothing, Out,
-                     ScheduleDefinition)
-from dagster import _check as check
-from dagster import op, repository, resource
+from dagster import (
+    Array,
+    DagsterInvariantViolationError,
+    DependencyDefinition,
+    Field,
+    In,
+    JobDefinition,
+    MultiDependencyDefinition,
+    Nothing,
+    Out,
+    ScheduleDefinition,
+    _check as check,
+    op,
+    repository,
+    resource,
+)
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX, validate_tags
-from dagster._core.instance import (AIRFLOW_EXECUTION_DATE_STR,
-                                    IS_AIRFLOW_INGEST_PIPELINE_STR)
+from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
 from dagster._legacy import ModeDefinition, PipelineDefinition
 from dagster._utils.schedules import is_valid_cron_schedule
+
+from dagster_airflow.patch_airflow_example_dag import patch_airflow_example_dag
 
 # pylint: disable=no-name-in-module,import-error
 if str(airflow_version) >= "2.0.0":

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_schedule_timezone.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_schedule_timezone.py
@@ -1,0 +1,29 @@
+import pendulum
+from airflow.models.dag import DAG
+from dagster_airflow.dagster_pipeline_factory import \
+    make_dagster_schedule_from_airflow_dag
+
+from dagster import job
+
+
+def test_schedule_timezone():
+    args = {
+        'owner': 'airflow',
+        'start_date': pendulum.today('Europe/London').add(days=-2),
+    }
+    dag = DAG(
+        dag_id='test_schedules',
+        default_args=args,
+        schedule='0 0 * * *',
+
+    )
+    @job
+    def job_def():
+        return
+
+    schedule = make_dagster_schedule_from_airflow_dag(
+        dag=dag,
+        job_def=job_def
+    )
+    assert schedule.cron_schedule == '0 0 * * *'
+    assert schedule.execution_timezone == 'Europe/London'

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_schedule_timezone.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_schedule_timezone.py
@@ -1,29 +1,28 @@
 import pendulum
+import pytest
+from airflow import __version__ as airflow_version
 from airflow.models.dag import DAG
-from dagster_airflow.dagster_pipeline_factory import \
-    make_dagster_schedule_from_airflow_dag
+from dagster_airflow.dagster_pipeline_factory import make_dagster_schedule_from_airflow_dag
 
 from dagster import job
 
 
+@pytest.mark.skipif(airflow_version < "2.0.0", reason="requires airflow 2")
 def test_schedule_timezone():
     args = {
-        'owner': 'airflow',
-        'start_date': pendulum.today('Europe/London').add(days=-2),
+        "owner": "airflow",
+        "start_date": pendulum.today("Europe/London").add(days=-2),
     }
     dag = DAG(
-        dag_id='test_schedules',
+        dag_id="test_schedules",
         default_args=args,
-        schedule='0 0 * * *',
-
+        schedule="0 0 * * *",
     )
+
     @job
     def job_def():
         return
 
-    schedule = make_dagster_schedule_from_airflow_dag(
-        dag=dag,
-        job_def=job_def
-    )
-    assert schedule.cron_schedule == '0 0 * * *'
-    assert schedule.execution_timezone == 'Europe/London'
+    schedule = make_dagster_schedule_from_airflow_dag(dag=dag, job_def=job_def)
+    assert schedule.cron_schedule == "0 0 * * *"
+    assert schedule.execution_timezone == "Europe/London"

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_schedule_timezone.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_schedule_timezone.py
@@ -2,9 +2,8 @@ import pendulum
 import pytest
 from airflow import __version__ as airflow_version
 from airflow.models.dag import DAG
-from dagster_airflow.dagster_pipeline_factory import make_dagster_schedule_from_airflow_dag
-
 from dagster import job
+from dagster_airflow.dagster_pipeline_factory import make_dagster_schedule_from_airflow_dag
 
 
 @pytest.mark.skipif(airflow_version < "2.0.0", reason="requires airflow 2")


### PR DESCRIPTION
### Summary & Motivation

This fixes whats currently converted airflow schedules that are always in UTC instead of whichever timezone was defined on the dag

### How I Tested These Changes
