### PR TITLE
[dagit] fix clientTime arg

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Telemetry.tsx
+++ b/js_modules/dagit/packages/core/src/app/Telemetry.tsx
@@ -51,7 +51,7 @@ export async function logTelemetry(
       variables: {
         action,
         metadata: JSON.stringify(metadata),
-        clientTime: Date.now(),
+        clientTime: String(Date.now()),
         clientId: clientID(),
       },
     }),


### PR DESCRIPTION
currently failing with
```
{"data":null,"errors":[{"message":"Variable '$clientTime' got invalid value 1673542779858; String cannot represent a non string value: 1673542779858","locations":[{"line":1,"column":69}]}]}
```

### How I Tested These Changes

rebuild_dagit with change - see mutation success
