### PR TITLE
Add black hook to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+    - id: black-jupyter
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.212
   hooks:


### PR DESCRIPTION
### Summary & Motivation

Since we now have an official team precommit configuration, it makes sense to add `black` to it.