### PR TITLE
Fix black precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: refs/tags/22.12.0:refs/tags/22.12.0
   hooks:
     - id: black-jupyter
 - repo: https://github.com/charliermarsh/ruff-pre-commit


### PR DESCRIPTION
### Summary & Motivation

Previously landed version of this did not work due to a weird conflict
with black's `target-version` setting, this fixes it.

### How I Tested These Changes

Ran the pre-commit hook.
