### PR TITLE
Bring back dagit socket reuse

### DIFF
--- a/python_modules/dagit/dagit_tests/test_app.py
+++ b/python_modules/dagit/dagit_tests/test_app.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 from click.testing import CliRunner
 from dagit.app import create_app_from_workspace_process_context
-from dagit.cli import dagit, host_dagit_ui_with_workspace_process_context
+from dagit.cli import DEFAULT_DAGIT_PORT, dagit, host_dagit_ui_with_workspace_process_context
 from dagster import _seven
 from dagster._core.instance import DagsterInstance
 from dagster._core.telemetry import START_DAGIT_WEBSERVER, UPDATE_REPO_STATS, hash_name
@@ -127,7 +127,7 @@ def test_graphql_view_at_path_prefix():
 
 
 def test_successful_host_dagit_ui_from_workspace():
-    with mock.patch("uvicorn.run"), tempfile.TemporaryDirectory() as temp_dir:
+    with mock.patch("uvicorn.run") as server_call, tempfile.TemporaryDirectory() as temp_dir:
         instance = DagsterInstance.local_temp(temp_dir)
 
         with load_workspace_process_context_from_yaml_paths(
@@ -140,6 +140,57 @@ def test_successful_host_dagit_ui_from_workspace():
                 path_prefix="",
                 log_level="warning",
             )
+
+        assert server_call.called_with(mock.ANY, host="127.0.0.1", port=2343, log_level="warning")
+
+
+@pytest.fixture
+def mock_is_port_in_use():
+    with mock.patch("dagit.cli.is_port_in_use") as mock_is_port_in_use:
+        yield mock_is_port_in_use
+
+
+@pytest.fixture
+def mock_find_free_port():
+    with mock.patch("dagit.cli.find_free_port") as mock_find_free_port:
+        mock_find_free_port.return_value = 1234
+        yield mock_find_free_port
+
+
+def test_host_dagit_ui_choose_port(mock_is_port_in_use, mock_find_free_port):
+    with mock.patch("uvicorn.run") as server_call, tempfile.TemporaryDirectory() as temp_dir:
+        instance = DagsterInstance.local_temp(temp_dir)
+
+        mock_is_port_in_use.return_value = False
+
+        with load_workspace_process_context_from_yaml_paths(
+            instance, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            host_dagit_ui_with_workspace_process_context(
+                workspace_process_context=workspace_process_context,
+                host=None,
+                port=None,
+                path_prefix="",
+                log_level="warning",
+            )
+
+        assert server_call.called_with(
+            mock.ANY, host="127.0.0.1", port=DEFAULT_DAGIT_PORT, log_level="warning"
+        )
+
+        mock_is_port_in_use.return_value = True
+        with load_workspace_process_context_from_yaml_paths(
+            instance, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            host_dagit_ui_with_workspace_process_context(
+                workspace_process_context=workspace_process_context,
+                host=None,
+                port=None,
+                path_prefix="",
+                log_level="warning",
+            )
+
+        assert server_call.called_with(mock.ANY, host="127.0.0.1", port=1234, log_level="warning")
 
 
 def test_successful_host_dagit_ui_from_multiple_workspace_files():

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -576,6 +576,20 @@ def find_free_port() -> int:
         return s.getsockname()[1]
 
 
+def is_port_in_use(host, port) -> bool:
+    # Similar to the socket options that uvicorn uses to bind ports:
+    # https://github.com/encode/uvicorn/blob/62f19c1c39929c84968712c371c9b7b96a041dec/uvicorn/config.py#L565-L566
+    sock = socket.socket(family=socket.AF_INET)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+        return False
+    except socket.error as e:
+        return e.errno == errno.EADDRINUSE
+    finally:
+        sock.close()
+
+
 @contextlib.contextmanager
 def alter_sys_path(to_add: Sequence[str], to_remove: Sequence[str]) -> Iterator[None]:
     to_restore = [path for path in sys.path]


### PR DESCRIPTION
Summary:
With one additional line in is_port_in_use that makes our socket check more closely mimic the socket check that uvicorn does:
sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

Test Plan: Launch dagit, open browser
Close dagit process
Re-open dagit process
Repeat
Now reliably stays on 3000

### Summary & Motivation

### How I Tested These Changes
