### PR TITLE
feat(dbt-cloud): disable schedule only if it exists

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -160,6 +160,30 @@ def test_no_disable_schedule():
         # endpoint for disabling the schedule has not been set up, so will fail if attempted
         dc_resource.run_job_and_poll(SAMPLE_JOB_ID)
 
+    # If the schedule was already disabled, no need to re-disable it.
+    dc_resource = get_dbt_cloud_resource()
+    with responses.RequestsMock() as rsps:
+        # endpoint for launching run
+        rsps.add(
+            rsps.POST,
+            f"{SAMPLE_API_PREFIX}/jobs/{SAMPLE_JOB_ID}/run/",
+            json=sample_run_details(job={"triggers": {"schedule": False}}),
+        )
+        # run will immediately succeed
+        rsps.add(
+            rsps.GET,
+            f"{SAMPLE_API_PREFIX}/runs/{SAMPLE_RUN_ID}/",
+            json=sample_run_details(status_humanized="Success"),
+        )
+        # endpoint for run_results.json
+        rsps.add(
+            rsps.GET,
+            f"{SAMPLE_API_PREFIX}/runs/{SAMPLE_RUN_ID}/artifacts/run_results.json",
+            json=sample_run_results(),
+        )
+        # endpoint for disabling the schedule has not been set up, so will fail if attempted
+        dc_resource.run_job_and_poll(SAMPLE_JOB_ID)
+
 
 @pytest.mark.parametrize(
     "final_status,expected_behavior",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
@@ -117,7 +117,7 @@ def sample_run_details(include_related=None, **kwargs):
         "last_heartbeat_at": None,
         "should_start_at": "2021-11-01 22:47:48.501943+00:00",
         "trigger": None,
-        "job": None,
+        "job": {"triggers": {"schedule": True}},
         "environment": None,
         "run_steps": [],
         "status_humanized": "Success",


### PR DESCRIPTION
### Summary & Motivation
We don't need to always disable the schedule. Disable it only if it exists.

This optimization is required in the future when we check the dbt Cloud job's update time to determine whether or not to invalidate its reference to run artifacts from a compile run.

### How I Tested These Changes
local, bk
