### PR TITLE
feat(dbt-cloud): cache compile run id as env var for job

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/cli.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/cli.py
@@ -1,0 +1,85 @@
+from typing import List
+
+import typer
+
+from dagster_dbt.cloud.asset_defs import DbtCloudCacheableAssetsDefinition
+from dagster_dbt.cloud.resources import DbtCloudResource
+
+app = typer.Typer()
+
+DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR = "DBT_DAGSTER_COMPILE_RUN_ID"
+
+
+@app.command()
+def cache_compile_references(
+    auth_token: str = typer.Argument(..., envvar="DBT_CLOUD_API_KEY"),
+    account_id: int = typer.Argument(..., envvar="DBT_CLOUD_ACCOUNT_ID"),
+    project_id: int = typer.Argument(..., envvar="DBT_CLOUD_PROJECT_ID"),
+) -> None:
+    """
+    Cache the latest dbt cloud compile run id for a given project.
+    """
+    dbt_cloud_resource = DbtCloudResource(
+        auth_token=auth_token, account_id=account_id, disable_schedule_on_trigger=False
+    )
+
+    # List the jobs from the project
+    dbt_cloud_jobs = dbt_cloud_resource.list_jobs(project_id=project_id)
+
+    # Compile each job with an override
+    for dbt_cloud_job in dbt_cloud_jobs:
+        job_id: int = dbt_cloud_job["id"]
+        job_commands: List[str] = dbt_cloud_job["execute_steps"]
+
+        # Retrieve the filters for the compile override step
+        job_materialization_command_step = (
+            DbtCloudCacheableAssetsDefinition.get_job_materialization_command_step(
+                execute_steps=job_commands
+            )
+        )
+        dbt_materialization_command = job_commands[job_materialization_command_step]
+        parsed_args = DbtCloudCacheableAssetsDefinition.parse_dbt_command(
+            dbt_materialization_command
+        )
+        dbt_compile_options: List[str] = DbtCloudCacheableAssetsDefinition.get_compile_filters(
+            parsed_args=parsed_args
+        )
+        dbt_compile_command = f"dbt compile {' '.join(dbt_compile_options)}"
+
+        # Run the compile command
+        dbt_cloud_compile_run = dbt_cloud_resource.run_job(
+            job_id=job_id,
+            cause="Generating software-defined assets for Dagster.",
+            steps_override=[dbt_compile_command],
+        )
+
+        # Cache the compile run as a reference in the dbt Cloud job's env var
+        dbt_cloud_compile_run_id = str(dbt_cloud_compile_run["id"])
+        dbt_cloud_job_env_vars = dbt_cloud_resource.get_job_environment_variables(
+            project_id=project_id, job_id=job_id
+        )
+        compile_run_environment_variable_id = dbt_cloud_job_env_vars[
+            DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR
+        ]["job"]["id"]
+
+        typer.echo(
+            f"Updating the value of environment variable `{DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR}`"
+            f" with id `{compile_run_environment_variable_id}` for job id `{job_id}`. Setting new"
+            f" value to `{dbt_cloud_compile_run_id}`."
+        )
+
+        dbt_cloud_resource.set_job_environment_variable(
+            project_id=project_id,
+            job_id=job_id,
+            environment_variable_id=compile_run_environment_variable_id,
+            name=DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR,
+            value=dbt_cloud_compile_run_id,
+        )
+
+        typer.echo("Update complete.")
+
+
+# https://typer.tiangolo.com/tutorial/commands/one-or-multiple/#one-command-and-one-callback
+@app.callback()
+def callback() -> None:
+    pass

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_cli.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_cli.py
@@ -1,0 +1,47 @@
+import responses
+from dagster_dbt.cloud.cli import DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR, app
+from typer.testing import CliRunner
+
+from .utils import (
+    SAMPLE_ACCOUNT_ID,
+    SAMPLE_API_PREFIX,
+    SAMPLE_API_V3_PREFIX,
+    SAMPLE_JOB_ID,
+    SAMPLE_PROJECT_ID,
+    sample_get_environment_variables,
+    sample_list_job_details,
+    sample_run_details,
+    sample_set_environment_variable,
+)
+
+runner = CliRunner()
+
+
+@responses.activate
+def test_cache_compile_references(monkeypatch):
+    monkeypatch.setenv("DBT_CLOUD_API_KEY", "test")
+    monkeypatch.setenv("DBT_CLOUD_ACCOUNT_ID", SAMPLE_ACCOUNT_ID)
+    monkeypatch.setenv("DBT_CLOUD_PROJECT_ID", SAMPLE_PROJECT_ID)
+    compile_run_environment_variable_id = 3
+
+    responses.get(f"{SAMPLE_API_PREFIX}/jobs", json=sample_list_job_details())
+    responses.post(f"{SAMPLE_API_PREFIX}/jobs/{SAMPLE_JOB_ID}/run/", json=sample_run_details())
+    responses.get(
+        f"{SAMPLE_API_V3_PREFIX}/projects/{SAMPLE_PROJECT_ID}/environment-variables/job",
+        json=sample_get_environment_variables(
+            environment_variable_id=compile_run_environment_variable_id,
+            name=DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR,
+        ),
+    )
+    responses.post(
+        f"{SAMPLE_API_V3_PREFIX}/projects/{SAMPLE_PROJECT_ID}/environment-variables/{compile_run_environment_variable_id}",
+        json=sample_set_environment_variable(
+            environment_variable_id=compile_run_environment_variable_id,
+            name=DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR,
+            value="500000",
+        ),
+    )
+
+    result = runner.invoke(app, ["cache-compile-references"])
+
+    assert result.exit_code == 0

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_resources.py
@@ -9,15 +9,18 @@ from dagster_dbt import dbt_cloud_resource
 from .utils import (
     SAMPLE_ACCOUNT_ID,
     SAMPLE_API_PREFIX,
+    SAMPLE_API_V3_PREFIX,
     SAMPLE_JOB_ID,
     SAMPLE_PROJECT_ID,
     SAMPLE_RUN_ID,
+    sample_get_environment_variables,
     sample_job_details,
     sample_list_artifacts,
     sample_list_job_details,
     sample_run_details,
     sample_run_results,
     sample_runs_details,
+    sample_set_environment_variable,
 )
 
 
@@ -303,69 +306,39 @@ def test_no_run_results_job():
 @responses.activate
 def test_get_environment_variables():
     dc_resource = get_dbt_cloud_resource()
-    project_id = 1000
 
     responses.add(
         responses.GET,
-        f"{dc_resource.api_v3_base_url}{SAMPLE_ACCOUNT_ID}/projects/{project_id}/environment-variables/job",
-        json={
-            "status": {
-                "code": 200,
-                "is_success": True,
-                "user_message": "Success!",
-                "developer_message": "",
-            },
-            "data": {
-                "DBT_DAGSTER_ENV_VAR": {
-                    "project": {"id": 1, "value": "-1"},
-                    "environment": {"id": 2, "value": "-1"},
-                    "job": {"id": 3, "value": "100"},
-                },
-            },
-        },
+        f"{SAMPLE_API_V3_PREFIX}/projects/{SAMPLE_PROJECT_ID}/environment-variables/job",
+        json=sample_get_environment_variables(
+            environment_variable_id=3, name="DBT_DAGSTER_ENV_VAR"
+        ),
     )
 
-    dc_resource.get_job_environment_variables(project_id=project_id, job_id=SAMPLE_JOB_ID)
+    assert dc_resource.get_job_environment_variables(
+        project_id=SAMPLE_PROJECT_ID, job_id=SAMPLE_JOB_ID
+    )
 
 
 @responses.activate
 def test_set_environment_variable():
     dc_resource = get_dbt_cloud_resource()
-    project_id = 1000
     environment_variable_id = 1
+    name = "DBT_DAGSTER_ENV_VAR"
+    value = "2000"
 
     responses.add(
         responses.POST,
-        f"{dc_resource.api_v3_base_url}{SAMPLE_ACCOUNT_ID}/projects/{project_id}/environment-variables/{environment_variable_id}",
-        json={
-            "status": {
-                "code": 200,
-                "is_success": True,
-                "user_message": "Success!",
-                "developer_message": "",
-            },
-            "data": {
-                "account_id": SAMPLE_ACCOUNT_ID,
-                "project_id": project_id,
-                "name": "DBT_DAGSTER_ENV_VAR",
-                "type": "job",
-                "state": 1,
-                "user_id": None,
-                "environment_id": None,
-                "job_definition_id": SAMPLE_JOB_ID,
-                "environment": None,
-                "display_value": "2000",
-                "id": 1,
-                "created_at": "2023-01-01 10:00:00.000000+00:00",
-                "updated_at": "2023-01-02 10:00:00.000000+00:00",
-            },
-        },
+        f"{SAMPLE_API_V3_PREFIX}/projects/{SAMPLE_PROJECT_ID}/environment-variables/{environment_variable_id}",
+        json=sample_set_environment_variable(
+            environment_variable_id=environment_variable_id, name=name, value=value
+        ),
     )
 
-    dc_resource.set_job_environment_variable(
-        project_id=project_id,
+    assert dc_resource.set_job_environment_variable(
+        project_id=SAMPLE_PROJECT_ID,
         job_id=SAMPLE_JOB_ID,
         environment_variable_id=environment_variable_id,
-        name="DBT_DAGSTER_ENV_VAR",
-        value=2000,
+        name=name,
+        value=value,
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/utils.py
@@ -3,10 +3,10 @@ from dagster._utils.merger import deep_merge_dicts
 SAMPLE_ACCOUNT_ID = 30000
 SAMPLE_PROJECT_ID = 35000
 SAMPLE_JOB_ID = 40000
-SAMPLE_JOB_ID_TWO = 40001
 SAMPLE_RUN_ID = 5000000
 
 SAMPLE_API_PREFIX = f"https://cloud.getdbt.com/api/v2/accounts/{SAMPLE_ACCOUNT_ID}"
+SAMPLE_API_V3_PREFIX = f"https://cloud.getdbt.com/api/v3/accounts/{SAMPLE_ACCOUNT_ID}"
 
 
 def job_details_data(job_id: int):
@@ -55,10 +55,7 @@ def sample_list_job_details():
             "user_message": "Success!",
             "developer_message": "",
         },
-        "data": [
-            job_details_data(job_id=SAMPLE_JOB_ID),
-            job_details_data(job_id=SAMPLE_JOB_ID_TWO),
-        ],
+        "data": [job_details_data(job_id=SAMPLE_JOB_ID)],
     }
 
 
@@ -314,5 +311,49 @@ def sample_run_results():
             "version_check": True,
             "which": "run",
             "rpc_method": "run",
+        },
+    }
+
+
+def sample_get_environment_variables(environment_variable_id: int, name: str):
+    return {
+        "status": {
+            "code": 200,
+            "is_success": True,
+            "user_message": "Success!",
+            "developer_message": "",
+        },
+        "data": {
+            name: {
+                "project": {"id": 1, "value": "-1"},
+                "environment": {"id": 2, "value": "-1"},
+                "job": {"id": environment_variable_id, "value": "100"},
+            },
+        },
+    }
+
+
+def sample_set_environment_variable(environment_variable_id: int, name: str, value: str):
+    return {
+        "status": {
+            "code": 200,
+            "is_success": True,
+            "user_message": "Success!",
+            "developer_message": "",
+        },
+        "data": {
+            "account_id": SAMPLE_ACCOUNT_ID,
+            "project_id": SAMPLE_PROJECT_ID,
+            "name": name,
+            "type": "job",
+            "state": 1,
+            "user_id": None,
+            "environment_id": None,
+            "job_definition_id": SAMPLE_JOB_ID,
+            "environment": None,
+            "display_value": value,
+            "id": environment_variable_id,
+            "created_at": "2023-01-01 10:00:00.000000+00:00",
+            "updated_at": "2023-01-02 10:00:00.000000+00:00",
         },
     }

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -36,12 +36,18 @@ setup(
         f"dagster{pin}",
         "dbt-core",
         "requests",
+        "typer[all]",
     ],
     extras_require={
         "test": [
             "Jinja2",
             "dbt-rpc<0.3.0",
             "dbt-postgres",
+        ]
+    },
+    entry_points={
+        "console_scripts": [
+            "dagster-dbt-cloud = dagster_dbt.cloud.cli:app",
         ]
     },
     zip_safe=False,


### PR DESCRIPTION
### Summary & Motivation
When generating software-defined assets from a dbt Cloud project, most of the latency comes from compiling the project. Rather than compiling the dbt project in an ad-hoc manner, only compile it when either:

- the project changes (via git commit), or when
- the dbt Cloud job commands change

If one of those conditions are met, then compile the project. And save the reference/overwrite the reference to the compilation. 

### How I Tested These Changes
pytest, local