### PR TITLE
[dagit] Fix Backfills page locking up when displaying large backfills, improve "target" column

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppCache.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppCache.tsx
@@ -7,6 +7,11 @@ export const createAppCache = () =>
   new InMemoryCache({
     addTypename: true,
     possibleTypes,
+    typePolicies: {
+      PartitionStatus: {
+        keyFields: false,
+      },
+    },
     dataIdFromObject: (object: any) => {
       if (
         object.name &&
@@ -17,6 +22,8 @@ export const createAppCache = () =>
         return 'Instance';
       } else if (object.__typename === 'Workspace') {
         return 'Workspace';
+      } else if (object.__typename === 'PartitionBackfill') {
+        return object.backfillId;
       } else {
         return defaultDataIdFromObject(object);
       }

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2249,6 +2249,7 @@ type PartitionBackfill {
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
   partitionStatuses: PartitionStatuses!
+  partitionStatusCounts: [PartitionStatusCounts!]!
 }
 
 enum BulkActionStatus {
@@ -2274,6 +2275,11 @@ type PartitionStatus {
   runId: String
   runStatus: RunStatus
   runDuration: Float
+}
+
+type PartitionStatusCounts {
+  runStatus: RunStatus!
+  count: Int!
 }
 
 type PartitionStatuses {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2081,6 +2081,7 @@ export type PartitionBackfill = {
   partitionNames: Array<Scalars['String']>;
   partitionSet: Maybe<PartitionSet>;
   partitionSetName: Maybe<Scalars['String']>;
+  partitionStatusCounts: Array<PartitionStatusCounts>;
   partitionStatuses: PartitionStatuses;
   reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
@@ -2194,6 +2195,12 @@ export type PartitionStatus = {
   runDuration: Maybe<Scalars['Float']>;
   runId: Maybe<Scalars['String']>;
   runStatus: Maybe<RunStatus>;
+};
+
+export type PartitionStatusCounts = {
+  __typename: 'PartitionStatusCounts';
+  count: Scalars['Int'];
+  runStatus: RunStatus;
 };
 
 export type PartitionStatuses = {

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -85,11 +85,11 @@ export const BackfillTable = ({
       <Table $monospaceFont={false}>
         <thead>
           <tr>
-            <th style={{width: 120}}>Backfill ID</th>
-            <th style={{width: 200}}>Created</th>
+            <th>Backfill ID</th>
+            <th>Created</th>
             {showBackfillTarget ? <th>Backfill target</th> : null}
-            {allPartitions ? <th>Requested</th> : null}
-            <th style={{width: 140}}>Backfill status</th>
+            <th>Requested</th>
+            <th>Backfill status</th>
             <th>Run status</th>
             <th style={{width: 80}} />
           </tr>

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -7,7 +7,7 @@ import {BulkActionStatus} from '../graphql/types';
 import {cancelableStatuses} from '../runs/RunStatuses';
 import {TerminationDialog} from '../runs/TerminationDialog';
 
-import {SINGLE_BACKFILL_QUERY} from './BackfillRow';
+import {SINGLE_BACKFILL_STATUS_DETAILS_QUERY} from './BackfillRow';
 import {SingleBackfillQuery, SingleBackfillQueryVariables} from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
 import {
@@ -25,7 +25,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     CANCEL_BACKFILL_MUTATION,
   );
   const {data} = useQuery<SingleBackfillQuery, SingleBackfillQueryVariables>(
-    SINGLE_BACKFILL_QUERY,
+    SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
     {
       variables: {
         backfillId: backfill?.backfillId || '',

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
@@ -2,6 +2,25 @@
 
 import * as Types from '../../graphql/types';
 
+export type SingleBackfillCountsQueryVariables = Types.Exact<{
+  backfillId: Types.Scalars['String'];
+}>;
+
+export type SingleBackfillCountsQuery = {
+  __typename: 'DagitQuery';
+  partitionBackfillOrError:
+    | {
+        __typename: 'PartitionBackfill';
+        backfillId: string;
+        partitionStatusCounts: Array<{
+          __typename: 'PartitionStatusCounts';
+          runStatus: Types.RunStatus;
+          count: number;
+        }>;
+      }
+    | {__typename: 'PythonError'};
+};
+
 export type SingleBackfillQueryVariables = Types.Exact<{
   backfillId: Types.Scalars['String'];
 }>;
@@ -11,6 +30,7 @@ export type SingleBackfillQuery = {
   partitionBackfillOrError:
     | {
         __typename: 'PartitionBackfill';
+        backfillId: string;
         partitionStatuses: {
           __typename: 'PartitionStatuses';
           results: Array<{

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -1,5 +1,4 @@
 import {Box, Tooltip, Colors} from '@dagster-io/ui';
-import countBy from 'lodash/countBy';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -334,33 +333,6 @@ export const PartitionStatus: React.FC<{
         </Box>
       ) : null}
     </div>
-  );
-};
-
-export const PartitionStatusCountsOnly: React.FC<{
-  small?: boolean;
-  partitionNames: string[];
-  partitionStateForKey: (key: string) => PartitionState;
-}> = ({small, partitionNames, partitionStateForKey}) => {
-  const byState = countBy(partitionNames, partitionStateForKey);
-
-  const counts = Object.entries(byState)
-    .filter(([, count]) => count > 0)
-    .map(([state, count]) => `${count.toLocaleString()} ${state}`)
-    .join(', ');
-
-  return (
-    <PartitionSpansContainer
-      style={{
-        height: small ? 12 : 24,
-        textAlign: 'center',
-        lineHeight: small ? '12px' : '24px',
-        cursor: 'default',
-        fontSize: 12,
-      }}
-    >
-      {counts}
-    </PartitionSpansContainer>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -1,4 +1,5 @@
 import {Box, Tooltip, Colors} from '@dagster-io/ui';
+import countBy from 'lodash/countBy';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -333,6 +334,33 @@ export const PartitionStatus: React.FC<{
         </Box>
       ) : null}
     </div>
+  );
+};
+
+export const PartitionStatusCountsOnly: React.FC<{
+  small?: boolean;
+  partitionNames: string[];
+  partitionStateForKey: (key: string) => PartitionState;
+}> = ({small, partitionNames, partitionStateForKey}) => {
+  const byState = countBy(partitionNames, partitionStateForKey);
+
+  const counts = Object.entries(byState)
+    .filter(([, count]) => count > 0)
+    .map(([state, count]) => `${count.toLocaleString()} ${state}`)
+    .join(', ');
+
+  return (
+    <PartitionSpansContainer
+      style={{
+        height: small ? 12 : 24,
+        textAlign: 'center',
+        lineHeight: small ? '12px' : '24px',
+        cursor: 'default',
+        fontSize: 12,
+      }}
+    >
+      {counts}
+    </PartitionSpansContainer>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -229,7 +229,7 @@ const TimelineSection = (props: TimelineSectionProps) => {
 };
 
 const RunStatusTags = React.memo(({jobs}: {jobs: TimelineJob[]}) => {
-  const {inProgressCount, failedCount, succeededCount} = React.useMemo(() => {
+  const counts = React.useMemo(() => {
     let inProgressCount = 0;
     let failedCount = 0;
     let succeededCount = 0;
@@ -251,6 +251,18 @@ const RunStatusTags = React.memo(({jobs}: {jobs: TimelineJob[]}) => {
     return {inProgressCount, failedCount, succeededCount};
   }, [jobs]);
 
+  return <RunStatusTagsWithCounts {...counts} />;
+});
+
+export const RunStatusTagsWithCounts = ({
+  inProgressCount,
+  succeededCount,
+  failedCount,
+}: {
+  inProgressCount: number;
+  succeededCount: number;
+  failedCount: number;
+}) => {
   const inProgressText =
     inProgressCount === 1 ? '1 run in progress' : `${inProgressCount} runs in progress`;
   const succeededText =
@@ -276,7 +288,7 @@ const RunStatusTags = React.memo(({jobs}: {jobs: TimelineJob[]}) => {
       ) : null}
     </Box>
   );
-});
+};
 
 const StatusSpan = styled.span`
   white-space: nowrap;

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -76,7 +76,7 @@ const CaptionTextContainer = styled.div`
 
 const JOB_QUERY_DELAY = 100;
 
-export const useDelayedRowQuery = <Q, V>(lazyQueryFn: LazyQueryExecFunction<Q, V>) => {
+export const useDelayedRowQuery = (lazyQueryFn: LazyQueryExecFunction<any, any>) => {
   React.useEffect(() => {
     const timer = setTimeout(() => {
       lazyQueryFn();

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Optional
 
 import dagster._check as check
@@ -231,6 +232,24 @@ def partition_statuses_from_run_partition_data(
         )
 
     return GraphenePartitionStatuses(results=results)
+
+
+def partition_status_counts_from_run_partition_data(run_partition_data, partition_names):
+    from ..schema.partition_sets import GraphenePartitionStatusCounts
+
+    partition_data_by_name = {
+        partition_data.partition: partition_data for partition_data in run_partition_data
+    }
+
+    count_by_status = defaultdict(int)
+    for name in partition_names:
+        if not partition_data_by_name.get(name):
+            count_by_status["NOT_STARTED"] += 1
+            continue
+        partition_data = partition_data_by_name[name]
+        count_by_status[partition_data.status.value] += 1
+
+    return [GraphenePartitionStatusCounts(runStatus=k, count=v) for k, v in count_by_status.items()]
 
 
 def get_partition_set_partition_runs(graphene_info, partition_set):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -75,6 +75,14 @@ class GraphenePartitionRun(graphene.ObjectType):
         name = "PartitionRun"
 
 
+class GraphenePartitionStatusCounts(graphene.ObjectType):
+    runStatus = graphene.NonNull(GrapheneRunStatus)
+    count = graphene.NonNull(graphene.Int)
+
+    class Meta:
+        name = "PartitionStatusCounts"
+
+
 class GraphenePartitionStatuses(graphene.ObjectType):
     results = non_null_list(GraphenePartitionStatus)
 
@@ -373,6 +381,7 @@ types = [
     GraphenePartitionSetsOrError,
     GraphenePartitionsOrError,
     GraphenePartitionStatus,
+    GraphenePartitionStatusCounts,
     GraphenePartitionStatuses,
     GraphenePartitionStatusesOrError,
     GraphenePartitionTags,


### PR DESCRIPTION
### Summary & Motivation

I created a backfill of 180,000 partition keys and found that Dagit is unable to render the Overview > Backfills page. It seems this is due to several things:

- The API is returning a `PartitionStatuses` object for each backfill containing an object for each partition. It'd be great to move this to the ranges format that @clairelin135 is putting together which will pass straight through to the rendering!

- Apollo cache is trying to normalize all of these 160k objects into some sort of fancy cache, which it "deep partial updates" with the new data. We can disable this behavior for just `PartitionStatus` with an entry in AppCache.tsx, but I have mixed feelings about making global changes. Maybe we do it for now and remove it when we move this status data to a smaller / faster range format. It reduces the "page lock time" after data is received from 7s to about 2s on my machine.

- The Backfill page is using the `<PartitionStatus />` component in "separated bars" mode, which actually tries to render 180k divs for the 180k partitions.

This PR addresses the last two - if there are more than 1k partition keys in the backfill, we now just render a box that is the same shape of the PartitionStatus component but contains just the counts:

![image](https://user-images.githubusercontent.com/1037212/213035809-0e2638a6-c31c-4418-8879-f68e3fb71d56.png)


I also observed a lot of funkiness in the Backfill Target column because I have both asset and job backfills for both loaded and unloaded repositories in my test set. I changed the code so that it omits partition set names that are part of hidden asset jobs, and made it show asset keys even when the partition set isn't part of a loaded repo. 

### How I Tested These Changes

Page loads!

For the target backfill changes, I attached before and after screenshots and I think my setup tests all five cases (assets / non-assets + jobs / asset graph / asset partition set).

![image](https://user-images.githubusercontent.com/1037212/212241840-0421a01d-d151-4843-89cf-f32a5a2350ed.png)
