### PR TITLE
[pyright] [core] _utils/backcompat

### DIFF
--- a/python_modules/dagster/dagster/_utils/backcompat.py
+++ b/python_modules/dagster/dagster/_utils/backcompat.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, Optional, TypeVar, cast
+from typing import Callable, Optional, TypeVar
 
 import dagster._check as check
 
@@ -14,7 +14,15 @@ EXPERIMENTAL_WARNING_HELP = (
 
 
 def canonicalize_backcompat_args(
-    new_val: T, new_arg: str, old_val: T, old_arg: str, breaking_version: str, **kwargs: object
+    new_val: T,
+    new_arg: str,
+    old_val: T,
+    old_arg: str,
+    breaking_version: str,
+    coerce_old_to_new: Optional[Callable[[T], T]] = None,
+    additional_warn_txt: Optional[str] = None,
+    # stacklevel=3 punches up to the caller of canonicalize_backcompat_args
+    stacklevel: int = 3,
 ) -> T:
     """
     Utility for managing backwards compatibility of two related arguments.
@@ -49,16 +57,11 @@ def canonicalize_backcompat_args(
 
     canonicalize_backcompat_args returns the value as if *only* new_val were specified
     """
-    coerce_old_to_new = cast(Optional[Callable], kwargs.get("coerce_old_to_new"))
-    additional_warn_txt = kwargs.get("additional_warn_txt")
-    # stacklevel=3 punches up to the caller of canonicalize_backcompat_args
-    stacklevel = kwargs.get("stacklevel", 3)
-
     check.str_param(new_arg, "new_arg")
     check.str_param(old_arg, "old_arg")
     check.opt_callable_param(coerce_old_to_new, "coerce_old_to_new")
     check.opt_str_param(additional_warn_txt, "additional_warn_txt")
-    check.opt_int_param(stacklevel, "stacklevel")
+    check.int_param(stacklevel, "stacklevel")
     if new_val is not None:
         if old_val is not None:
             check.failed(


### PR DESCRIPTION
### Summary & Motivation

Fix type error and remove `**kwargs` in favor of explicit keyword args in `canonicalize_backcompat_args`.

### How I Tested These Changes

BK