### PR TITLE
[pyright] [core] _core/definitions/scoped_resources_builder

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -95,6 +95,8 @@ def _execute_run_command_body(
         cancellation_thread, cancellation_thread_shutdown_event = start_run_cancellation_thread(
             instance, pipeline_run_id
         )
+    else:
+        cancellation_thread, cancellation_thread_shutdown_event = None, None
 
     pipeline_run: DagsterRun = check.not_none(
         instance.get_run_by_id(pipeline_run_id),
@@ -135,6 +137,8 @@ def _execute_run_command_body(
         run_worker_failed = True
     finally:
         if instance.should_start_background_run_thread:
+            cancellation_thread_shutdown_event = check.not_none(cancellation_thread_shutdown_event)
+            cancellation_thread = check.not_none(cancellation_thread)
             cancellation_thread_shutdown_event.set()
             if cancellation_thread.is_alive():
                 cancellation_thread.join(timeout=15)
@@ -198,6 +202,8 @@ def _resume_run_command_body(
         cancellation_thread, cancellation_thread_shutdown_event = start_run_cancellation_thread(
             instance, pipeline_run_id
         )
+    else:
+        cancellation_thread, cancellation_thread_shutdown_event = None, None
     pipeline_run = check.not_none(
         instance.get_run_by_id(pipeline_run_id),  # type: ignore
         "Pipeline run with id '{}' not found for run execution.".format(pipeline_run_id),
@@ -238,6 +244,8 @@ def _resume_run_command_body(
         run_worker_failed = True
     finally:
         if instance.should_start_background_run_thread:
+            cancellation_thread_shutdown_event = check.not_none(cancellation_thread_shutdown_event)
+            cancellation_thread = check.not_none(cancellation_thread)
             cancellation_thread_shutdown_event.set()
             if cancellation_thread.is_alive():
                 cancellation_thread.join(timeout=15)

--- a/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
@@ -6,7 +6,7 @@
 # See: https://github.com/python/mypy/issues/7281
 
 from collections import namedtuple
-from typing import AbstractSet, Mapping, NamedTuple, Optional
+from typing import AbstractSet, Any, Mapping, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._core.errors import DagsterUnknownResourceError
@@ -24,6 +24,9 @@ class Resources:
     incompatible with type annotations on its own due to its dynamic attributes, so this tag class
     provides a workaround.
     """
+
+    def __getattr__(self, name: str) -> Any:
+        raise DagsterUnknownResourceError(name)
 
 
 class ScopedResourcesBuilder(
@@ -85,8 +88,7 @@ class ScopedResourcesBuilder(
                 Resources,
                 IContainsGenerator,
             ):
-                def __getattr__(self, attr):
-                    raise DagsterUnknownResourceError(attr)
+                ...
 
             return _ScopedResourcesContainsGenerator(**resource_instance_dict)  # type: ignore[call-arg]
 
@@ -96,7 +98,6 @@ class ScopedResourcesBuilder(
                 namedtuple("_ScopedResources", list(resource_instance_dict.keys())),  # type: ignore[misc]
                 Resources,
             ):
-                def __getattr__(self, attr):
-                    raise DagsterUnknownResourceError(attr)
+                ...
 
             return _ScopedResources(**resource_instance_dict)  # type: ignore[call-arg]

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -969,6 +969,7 @@ class SqlEventLogStorage(EventLogStorage):
             results = conn.execute(query).fetchall()
 
         events = {}
+        record_id = None
         try:
             for (
                 record_id,


### PR DESCRIPTION
### Summary & Motivation

Eliminates some type errors on access to the `Resource` class. AFAICT, the `Resource` class is not constructed anywhere other than in `ScopedResourceBuilder`, where there are dynamically generated subclasses of it. All of these subclasses have an identical `__getattr__` method-- so moving this into `Resource` provides equivalent functionality, while also solving type errors from accessing attributes on `Resource` objects.

### How I Tested These Changes

BK