### PR TITLE
[pyright] [core] _core/storage/event_log/sql_event_log

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -969,6 +969,7 @@ class SqlEventLogStorage(EventLogStorage):
             results = conn.execute(query).fetchall()
 
         events = {}
+        record_id = None
         try:
             for (
                 record_id,


### PR DESCRIPTION
### Summary & Motivation

Very simple change to ensure `record_id` is defined inside the `except` block.

### How I Tested These Changes

BK