### PR TITLE
Move string construction out of non-error path in check

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1066,8 +1066,8 @@ def two_dim_mapping_param(
 def not_none_param(
     obj: Optional[T], param_name: str, additional_message: Optional[str] = None
 ) -> T:
-    additional_message = " " + additional_message if additional_message else ""
     if obj is None:
+        additional_message = " " + additional_message if additional_message else ""
         raise _param_invariant_exception(
             param_name, f"Param {param_name} cannot be none.{additional_message}"
         )


### PR DESCRIPTION
### Summary & Motivation

This string construction happens on every call to check, not just on failure. Lots of unnecessary string construction. Blames to https://github.com/dagster-io/dagster/pull/7605

### How I Tested These Changes

BK
