### PR TITLE
[docs] [tutorial-overhaul] [1-2] Adding Setup and Troubleshooting Pages

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -11,7 +11,13 @@
       },
       {
         "title": "Installation",
-        "path": "/getting-started/install"
+        "path": "/getting-started/install",
+        "children": [
+          {
+            "title": "Troubleshooting",
+            "path": "/getting-started/installation/troubleshooting-installation"
+          }
+        ]
       },
       {
         "title": "Create a New Project",

--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -7,56 +7,15 @@ description: Contributions are welcome and are greatly appreciated. Here's the c
 
 We love to see our community members get involved! If you are planning to contribute to Dagster, you will first need to set up a local development environment.
 
-## Environment Setup
+## Dagster environment setup
 
-### Apple M1-specific setup
-
-If you have a Mac with an M1 chip, you will need to set up a separate environment to emulate an x86 architecture before following the remaining setup instructions. To find out if your Mac has an M1 chip, follow the instructions [here](https://www.howtogeek.com/706226/how-to-check-if-your-mac-is-using-an-intel-or-apple-silicon-processor/).
-
-If you don't have a Mac with an M1 chip, skip ahead to the next section - [Dagster development setup](#dagster-development-setup).
-
-1. Install rosetta. [About rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment).
-
-   ```bash
-   softwareupdate --install-rosetta --agree-to-license
-   ```
-
-2. Create a duplicate terminal that will default to running the rosetta x86 emulator. [Source stack overflow post](https://apple.stackexchange.com/questions/428768/on-apple-m1-with-rosetta-how-to-open-entire-terminal-iterm-in-x86-64-architec).
-
-   - Go to `Finder` > `Applications` and find your terminal app.
-   - Right click the app and duplicate it.
-   - Right click the new terminal > `Get Info` > `Enable Open using Rosetta`.
-   - Click to open the terminal, type `arch` to verify it says `i386` now.
-
-3. In your rosetta terminal, install `homebrew`.
-
-   ```bash
-   arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-   ```
-
-4. To ensure that the correct installation of `homebrew` is automatically used in your rosetta terminal, add the following snippet to your `~/.bashrc`, `~/.zshrc` or profile manager of choice.
-
-   ```bash
-   arch_name="$(uname -m)"
-
-   if [ "${arch_name}" = "x86_64" ]; then
-      echo "Running in x86 mode"
-      eval $(/usr/local/bin/brew shellenv)
-   elif [ "${arch_name}" = "arm64" ]; then
-      echo "Running in Arm mode"
-      eval $(/opt/homebrew/bin/brew shellenv)
-   else
-      echo "Unexpected uname -m result ${arch_name}"
-   fi
-
-   # brew libraries
-   export LDFLAGS="-L $(brew --prefix openssl)/lib"
-   export CFLAGS="-I $(brew --prefix openssl)/include"
-   ```
-
-After sourcing this file, you can ensure that the correct version of `homebrew` is being used by confirming the output of `which brew` is `/usr/local/bin/brew`.
-
-### Dagster development setup
+<Note>
+  If you're on a Mac with an M1 chip, then you'll need to use Rosetta to build
+  Dagster. You can find instructions on how to set up Rosetta in our
+  <a href="/getting-started/installation/troubleshooting-installation#for-people-using-apple-m1-computers">
+    Troubleshooting section
+  </a> .
+</Note>
 
 1. Install Python. Python 3.6 or above recommended, but our CI/CD pipeline currently tests against up-to-date patch versions of Python 3.6, 3.7 and 3.8.
 

--- a/docs/content/getting-started/install.mdx
+++ b/docs/content/getting-started/install.mdx
@@ -11,6 +11,9 @@ Dagster is a a data orchestrator. Learn what Dagster is all about on our [homepa
 
 ## Installing Dagster
 
+- `dagster` is the command line interface (CLI) tool to run Dagster. It also is the stateless, single-node, single-process and multi-process execution engines
+- `dagit` is the web-based UI for operating Dagster, including ways to visualize your DAGs, a type-aware config editor, and a live execution interface.
+
 To install Dagster and Dagit into an existing Python environment, run:
 
 ```bash
@@ -34,6 +37,13 @@ python --version
 pip --version
 ```
 
-We strongly recommend installing Dagster inside a Python virtualenv. If you are running Anaconda, you should install Dagster inside a Conda environment.
+We strongly recommend installing Dagster inside a Python virtual environment.
+
+- If you are unfamiliar with Python virtual environments, you can read more about them on [the official Python documentation](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/)
+- If you are running Anaconda, you should install Dagster inside a conda environment. The official conda [documentation for managing environments](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) can help you get set up.
+
+---
+
+## Contributing to Dagster
 
 If you would like to install Dagster from source, please see the section on [Contributing](/community/contributing).

--- a/docs/content/getting-started/installation/troubleshooting-installation.mdx
+++ b/docs/content/getting-started/installation/troubleshooting-installation.mdx
@@ -1,0 +1,83 @@
+---
+title: Troubleshooting Installation | Dagster
+description: Resources for getting help and troubleshooting common Dagster installation problems, ex. Python and its dependencies
+---
+
+# Troubleshooting Installation
+
+This page covers common troubleshooting issues when installing Dagster. You will also you find resources for getting more help.
+
+---
+
+## Resources
+
+If you have questions about Dagster that are not covered by the documentation, feel welcome to reach out to the team and community by:
+
+- joining the [Dagster Slack community](https://dagster.slack.com/join/shared_invite/zt-1mkwtli11-w4SJ9ucNAyAfl\~Q8qXWz8g#/shared-invite/email) and asking for help on the `#dagster-support` channel.
+- raising a [GitHub issue](https://github.com/dagster-io/dagster/issues)
+
+The team working on Dagster is committed to responding to your questions within a couple of hours during US business days.
+
+---
+
+## For people using Apple M1 computers
+
+If you get an error that reads similar to:
+
+    mach-o, but wrong architecture
+
+The likely issue is that a Python dependency of Dagster's (or another package you're trying to install) is incompatible with your Apple M1 computer. The incompatibility is because some of the package's dependencies run code specific to the computer's architecture, such as x86 or ARM. This issue is most common when working on Macs with an M1 chip.
+
+To find out if your Mac has an M1 chip, follow the instructions [here](https://www.howtogeek.com/706226/how-to-check-if-your-mac-is-using-an-intel-or-apple-silicon-processor/).
+
+To work around this, you'll need to use macOS [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment).
+
+1. Install Rosetta.
+
+   [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) is Apple's software to emulate an x86 architecture environment on their M1 chip's ARM architecture.
+
+   To install Rosetta, open your terminal and run:
+
+   ```bash
+   softwareupdate --install-rosetta --agree-to-license
+   ```
+
+2. Create another terminal that will default to running the Rosetta x86 emulator.
+
+   1. Go to `Finder` > `Applications` and find your terminal app.
+   2. Right-click the terminal app and make a new terminal app by clicking `Duplicate`.
+   3. Right-click the new terminal > `Get Info` > `Enable Open using Rosetta`.
+   4. Open the newly duplicated terminal app.
+   5. Type `arch` into the terminal prompt.
+   6. If the output says `i386`, then the installation and creation of the x86 emulator works.
+   7. From now on, use this terminal while working with your Dagster project.
+
+   For more details, you can you look at [this Stack Overflow post](https://apple.stackexchange.com/questions/428768/on-apple-m1-with-rosetta-how-to-open-entire-terminal-iterm-in-x86-64-architec)
+
+3. In your Rosetta terminal, install `homebrew`.
+
+   ```bash
+   arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+4. Confirm that the correct `homebrew` installation is used in your Rosetta terminal. Add the following snippet to your `~/.bashrc`, `~/.zshrc`, or profile manager of choice. If you are unfamiliar with profile managers, you likely should use `~/.bashrc`.
+
+   ```bash
+   arch_name="$(uname -m)"
+
+   if [ "${arch_name}" = "x86_64" ]; then
+      echo "Running in x86 mode"
+      eval $(/usr/local/bin/brew shellenv)
+   elif [ "${arch_name}" = "arm64" ]; then
+      echo "Running in Arm mode"
+      eval $(/opt/homebrew/bin/brew shellenv)
+   else
+      echo "Unexpected uname -m result ${arch_name}"
+   fi
+
+   # brew libraries
+   export LDFLAGS="-L $(brew --prefix openssl)/lib"
+   export CFLAGS="-I $(brew --prefix openssl)/include"
+   ```
+
+Save the file and restart your terminal. You can check that the correct version of `homebrew` is being used by confirming the output of `which brew` is `/usr/local/bin/brew`.

--- a/docs/content/new-tutorial/setup.mdx
+++ b/docs/content/new-tutorial/setup.mdx
@@ -26,7 +26,28 @@ To complete this tutorial, you'll need:
   - `dagit` is the web-based UI for developing and operating Dagster jobs, including a DAG browser, a type-aware config editor, and a live execution interface.
   - `requests` is not a part of Dagster, but you'll use it in the tutorial to download data from the internet.
 
-## Troubleshooting Installations
+## Making your first Dagster project
+
+To verify that your dagster installation was successful, let's create your first Dagster project! We'll use the Dagster scaffolding command to give you an empty Dagster project that you can run locally.
+
+To create the project, run:
+
+```bash
+dagster project scaffold --name tutorial-project
+```
+
+To verify that it worked and that you can run Dagster locally, run:
+
+```bash
+cd tutorial-project
+dagit
+```
+
+If you'd like an explanation on what files were made and why, you can look at the [Creating a new Dagster project page](/getting-started/create-new-project#using-the-default-project-skeleton).
+
+---
+
+## Troubleshooting Installation
 
 If you are having issues with installing Dagster, Dagit, or any of its dependencies, you can look at the [Installation Troubleshooting Page](/getting-started/installation/troubleshooting-installation) for help and resources.
 
@@ -34,4 +55,4 @@ If you are having issues with installing Dagster, Dagit, or any of its dependenc
 
 ## Ready to get started?
 
-When you've fulfilled all the prerequistes for the tutorial, you can get started [creating your first asset](/tutorial/assets/defining-an-asset).
+When you've created your first Dagster project, you start writing your own pipeline by [creating your first asset](/tutorial/assets/defining-an-asset).

--- a/docs/content/new-tutorial/setup.mdx
+++ b/docs/content/new-tutorial/setup.mdx
@@ -28,7 +28,7 @@ To complete this tutorial, you'll need:
 
 ## Troubleshooting Installations
 
-If you are having issues with installing Dagster, Dagit, or any of its dependencies, you can look at the [Installation Troubleshooting Page](www.inserthere.com) for help and resources.
+If you are having issues with installing Dagster, Dagit, or any of its dependencies, you can look at the [Installation Troubleshooting Page](/getting-started/installation/troubleshooting-installation) for help and resources.
 
 ---
 

--- a/docs/content/new-tutorial/setup.mdx
+++ b/docs/content/new-tutorial/setup.mdx
@@ -34,4 +34,4 @@ If you are having issues with installing Dagster, Dagit, or any of its dependenc
 
 ## Ready to get started?
 
-When you've fulfilled all the prerequistes for the tutorial, you can get started [creating your first asset](/update/link/in).
+When you've fulfilled all the prerequistes for the tutorial, you can get started [creating your first asset](/tutorial/assets/defining-an-asset).

--- a/docs/content/new-tutorial/setup.mdx
+++ b/docs/content/new-tutorial/setup.mdx
@@ -1,0 +1,37 @@
+---
+title: "Intro to the Dagster Tutorial: Getting set up | Dagster Docs"
+description: "Get set up for the intro to assets tutorial."
+noindex: True
+---
+
+# Intro to Dagster: Getting set up
+
+To complete this tutorial, you'll need:
+
+- **To install Python and pip.** This tutorial assumes that you have some familiarity with Python, but you should be able to follow along even if you’re coming from a different programming language. To check that Python and `pip` (Python's package manager) are already installed in your environment or install them, follow the instructions [here](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
+
+  <DagsterVersion />
+
+<!-- ^ Lives in: /next/components/mdx/includes/dagster/DagsterVersion.mdx -->
+
+- **To install Dagster, Dagit, and the `requests` library**:
+
+  ```shell
+  pip install dagster dagit requests
+  ```
+
+  This installs the following Python packages:
+
+  - `dagster` is the command line interface (CLI) tool to run Dagster. For more information, you can look at the [Dagster installation guide](/getting-started/install)
+  - `dagit` is the web-based UI for developing and operating Dagster jobs, including a DAG browser, a type-aware config editor, and a live execution interface.
+  - `requests` is not a part of Dagster, but you'll use it in the tutorial to download data from the internet.
+
+## Troubleshooting Installations
+
+If you are having issues with installing Dagster, Dagit, or any of its dependencies, you can look at the [Installation Troubleshooting Page](www.inserthere.com) for help and resources.
+
+---
+
+## Ready to get started?
+
+When you've fulfilled all the prerequistes for the tutorial, you can get started [creating your first asset](/update/link/in).


### PR DESCRIPTION
### Summary & Motivation

As part of the Tutorial Overhaul, this refreshes the `Setup` page a bit in the tutorial, moves some more generic guidance into the `Installation Page`, and also creates a new `Troubleshooting Installation` page. It currently just has links to the Slack community and the GitHub issues. It also stubs out our guidance when folks with M1 on installing Dagster. Hopefully as we encounter and have solutions for installation issues, this will serve as a centralized resource to put them.

**Note**: This draft PR currently points back to the existing `docs/tutorial/part-one` branch, with its currently open PR here #11614 .

Links to the pages with the biggest changes:
- [The new setup page](https://dagster-git-docs-tutorialpart-two-elementl.vercel.app/new-tutorial/setup)
- [The troubleshooting page](https://dagster-git-docs-tutorialpart-two-elementl.vercel.app/getting-started/installation/troubleshooting-installation)
- [The contributing page](https://dagster-git-docs-tutorialpart-two-elementl.vercel.app/community/contributing)

### How I Tested These Changes

Got snakebit a bit in my previous PR because I didn't know `black` ran on `doc_snippets`. Thankfully no snippets here, and I promise that I ran `make mdx-format` and spot-checked the URLs to make sure they pointed to the right places!