### PR TITLE
RFC - db io manager partition support 2/n

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import (
+    Any,
+    Callable,
     Dict,
     Generic,
     Mapping,
@@ -27,6 +30,7 @@ T = TypeVar("T")
 class TablePartition(NamedTuple):
     time_window: TimeWindow
     partition_column: str
+    partition_conversion: Optional[Callable[[datetime], Any]]
 
 
 class TableSlice(NamedTuple):
@@ -203,9 +207,13 @@ class DbIOManager(IOManager):
                     f"Asset '{context.asset_key}' has partitions, but no 'partition_column'"
                     " metadata value, so we don't know what column to filter it on."
                 )
+            conversion = cast(
+                Callable[[datetime], Any], output_context_metadata.get("partition_key_conversion")
+            )
             partition = TablePartition(
                 time_window=time_window,
                 partition_column=partition_column,
+                partition_conversion=conversion,
             )
         else:
             partition = None

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -148,6 +148,10 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
 
 def _time_window_where_clause(table_partition: TablePartition) -> str:
     start_dt, end_dt = table_partition.time_window
-    start_dt_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
-    end_dt_str = end_dt.strftime(DUCKDB_DATETIME_FORMAT)
-    return f"""WHERE {table_partition.partition_column} >= '{start_dt_str}' AND {table_partition.partition_column} < '{end_dt_str}'"""
+    if table_partition.partition_conversion is not None:
+        start_str = table_partition.partition_conversion(start_dt)
+        end_str = table_partition.partition_conversion(end_dt)
+    else:
+        start_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
+        end_str = end_dt.strftime(DUCKDB_DATETIME_FORMAT)
+    return f"""WHERE {table_partition.partition_column} >= '{start_str}' AND {table_partition.partition_column} < '{end_str}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -180,8 +180,12 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
 
 def _time_window_where_clause(table_partition: TablePartition) -> str:
     start_dt, end_dt = table_partition.time_window
-    start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
-    end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+    if table_partition.partition_conversion is not None:
+        start_str = table_partition.partition_conversion(start_dt)
+        end_str = table_partition.partition_conversion(end_dt)
+    else:
+        start_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+        end_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
     # Snowflake BETWEEN is inclusive; start <= partition expr <= end. We don't want to remove the next partition so we instead
     # write this as start <= partition expr < end.
-    return f"""WHERE {table_partition.partition_column} >= '{start_dt_str}' AND {table_partition.partition_column} < '{end_dt_str}'"""
+    return f"""WHERE {table_partition.partition_column} >= '{start_str}' AND {table_partition.partition_column} < '{end_str}'"""


### PR DESCRIPTION
### Summary & Motivation
The goal of this RFC is to prototype/demonstrate the method for supporting partitions for database io managers that requires the least invasive changes to dagster code. There are other, more invasive changes that could be made instead, see this [RFC](https://github.com/dagster-io/dagster/pull/10976) and this [notion page](https://www.notion.so/dagster/Proposed-Snowflake-integration-improvements-63fec38f93964dbaa179cf0b1796f0a2) for an overview of what those changes would look like. I'm interested to hear your thoughts on this minimal change version vs one of the more involved changes. 

---
Part 2 of the set of changes I think we need to make to support partitions for the DB IO managers

Problem: The DB IO managers expect the time data in the partition column to be a string of the form `2023-01-13 12:45:30`. But some users may not want to store data that way. For example, in our full feature example, the time data is a posix time. 

Solution: Allow users to specify a conversion function that tells us how to convert a partition key to the format the data is stored as. This will allow the SELECT statement to work correctly.

### How I Tested These Changes
