### PR TITLE
[dagit] Fix Definitions filter dialog

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -2,14 +2,12 @@ import {
   Box,
   Checkbox,
   Colors,
-  Group,
   Icon,
   IconWrapper,
   Spinner,
   Table,
   Caption,
   Tooltip,
-  FontFamily,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -66,7 +64,7 @@ export const RepoSelector: React.FC<Props> = (props) => {
         />
         {`${selected.length} of ${options.length} selected`}
       </Box>
-      <Table>
+      <Table $monospaceFont={false}>
         <tbody>
           {options.map((option) => {
             const checked = selected.includes(option);
@@ -90,20 +88,17 @@ export const RepoSelector: React.FC<Props> = (props) => {
                 </td>
                 <td>
                   <RepoLabel htmlFor={`switch-${addressString}`}>
-                    <Group direction="column" spacing={4}>
-                      <Box flex={{direction: 'row'}} title={addressString}>
-                        <RepoLocation>{repoAddress.location}</RepoLocation>
-                        <RepoName>{repoAddress.name}</RepoName>
-                      </Box>
-                      <Group direction="column" spacing={2}>
+                    <Box flex={{direction: 'column', gap: 4}}>
+                      <RepoLocation>{addressString}</RepoLocation>
+                      <Box flex={{direction: 'column', gap: 2}}>
                         {option.repository.displayMetadata.map(({key, value}) => (
                           <Caption
-                            style={{color: Colors.Gray400, fontFamily: FontFamily.monospace}}
+                            style={{color: Colors.Gray400}}
                             key={key}
                           >{`${key}: ${value}`}</Caption>
                         ))}
-                      </Group>
-                    </Group>
+                      </Box>
+                    </Box>
                   </RepoLabel>
                 </td>
                 <td>
@@ -129,7 +124,6 @@ const RepoLabel = styled.label`
   cursor: pointer;
   display: block;
   font-weight: 500;
-  line-height: 1;
   overflow: hidden;
   position: relative;
   top: 1px;
@@ -147,13 +141,8 @@ const RepoLabel = styled.label`
   }
 `;
 
-const RepoName = styled.div`
-  color: ${Colors.Gray800};
-`;
-
 const RepoLocation = styled.div`
   color: ${Colors.Gray700};
-  font-family: ${FontFamily.monospace};
 `;
 
 const ReloadButton: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {


### PR DESCRIPTION
### Summary & Motivation

Code location names are broken in the Definitions filter dialog. We should just use the "human" string.

Also remove the monospace font and fix spacing.

<img width="1391" alt="Screenshot 2023-01-13 at 2 40 21 PM" src="https://user-images.githubusercontent.com/2823852/212415392-33d9ec22-ac9b-4a15-b32e-4314c1790926.png">


### How I Tested These Changes

Load Dagit, open dialog via "Filter" button in left nav. Verify correct rendering.
