### PR TITLE
Adds group_label to build_fivetran_assets

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -41,6 +41,7 @@ def _build_fivetran_assets(
     metadata_by_table_name: Optional[Mapping[str, MetadataUserInput]] = None,
     table_to_asset_key_map: Optional[Mapping[str, AssetKey]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+    group_name: Optional[str] = None,
 ) -> Sequence[AssetsDefinition]:
     asset_key_prefix = check.opt_sequence_param(asset_key_prefix, "asset_key_prefix", of_type=str)
 
@@ -66,6 +67,7 @@ def _build_fivetran_assets(
         required_resource_keys={"fivetran"},
         compute_kind="fivetran",
         resource_defs=resource_defs,
+        group_name=group_name,
     )
     def _assets(context):
         fivetran_output = context.resources.fivetran.sync_and_poll(
@@ -101,6 +103,7 @@ def build_fivetran_assets(
     io_manager_key: Optional[str] = None,
     asset_key_prefix: Optional[Sequence[str]] = None,
     metadata_by_table_name: Optional[Mapping[str, MetadataUserInput]] = None,
+    group_name: Optional[str] = None,
 ) -> Sequence[AssetsDefinition]:
     """
     Build a set of assets for a given Fivetran connector.
@@ -168,6 +171,7 @@ def build_fivetran_assets(
         io_manager_key=io_manager_key,
         asset_key_prefix=asset_key_prefix,
         metadata_by_table_name=metadata_by_table_name,
+        group_name=group_name,
     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -127,6 +127,8 @@ def build_fivetran_assets(
             If left blank, assets will have a key of `AssetKey([schema_name, table_name])`.
         metadata_by_table_name (Optional[Mapping[str, MetadataUserInput]]): A mapping from destination
             table name to user-supplied metadata that should be associated with the asset for that table.
+        group_name (Optional[str]): A string name used to organize multiple assets into groups. This
+            group name will be applied to all assets produced by this multi_asset.
 
     **Examples:**
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -25,6 +25,21 @@ def test_fivetran_asset_keys():
     )
     assert ft_assets[0].keys == {AssetKey(["x", "foo"]), AssetKey(["y", "bar"])}
 
+@pytest.mark.parametrize(
+    "group_name,expected_group_name",
+    [
+        (None, "default"),
+        ("my_group_name", "my_group_name"),
+    ],
+)
+def test_fivetran_group_label(group_name, expected_group_name):
+    ft_assets = build_fivetran_assets(
+        connector_id=DEFAULT_CONNECTOR_ID, destination_tables=["x.foo", "y.bar"]
+    )
+    group_name = list(ft_assets[0].group_names_by_key.values())
+    assert len(groups) == 1
+    assert group_name == expected_group_name
+
 
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -25,6 +25,7 @@ def test_fivetran_asset_keys():
     )
     assert ft_assets[0].keys == {AssetKey(["x", "foo"]), AssetKey(["y", "bar"])}
 
+
 @pytest.mark.parametrize(
     "group_name,expected_group_name",
     [
@@ -34,11 +35,13 @@ def test_fivetran_asset_keys():
 )
 def test_fivetran_group_label(group_name, expected_group_name):
     ft_assets = build_fivetran_assets(
-        connector_id=DEFAULT_CONNECTOR_ID, destination_tables=["x.foo", "y.bar"]
+        connector_id=DEFAULT_CONNECTOR_ID,
+        destination_tables=["x.foo", "y.bar"],
+        group_name=group_name,
     )
-    group_names = list(ft_assets[0].group_names_by_key.values())
+    group_names = set(ft_assets[0].group_names_by_key.values())
     assert len(group_names) == 1
-    assert group_names[0] == expected_group_name
+    assert list(group_names)[0] == expected_group_name
 
 
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -36,9 +36,9 @@ def test_fivetran_group_label(group_name, expected_group_name):
     ft_assets = build_fivetran_assets(
         connector_id=DEFAULT_CONNECTOR_ID, destination_tables=["x.foo", "y.bar"]
     )
-    group_name = list(ft_assets[0].group_names_by_key.values())
-    assert len(groups) == 1
-    assert group_name == expected_group_name
+    group_names = list(ft_assets[0].group_names_by_key.values())
+    assert len(group_names) == 1
+    assert group_names[0] == expected_group_name
 
 
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])


### PR DESCRIPTION
### Summary & Motivation

- `build_fivetran_assets` does not currently support `group_name`
- Therefore, all assets loaded are assigned to the `default` group

### How I Tested These Changes

- Unable to run unit tests locally due to issue with setting up a dev env on M1 Mac. So zero idea if they actually run or are correct. See [this thread](https://dagster.slack.com/archives/C01U5LFUZJS/p1673710355471919)
- Have run locally and confirmed that 1) assets are correctly assigned to `default` if no `group_name` is set and 2) assets are correctly assigned to the group, if the `group_name` is set
