### PR TITLE
[pyright] [gql] add ResolveInfo everywhere

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         GraphenePipelineRunLogsSubscriptionFailure,
         GraphenePipelineRunLogsSubscriptionSuccess,
     )
-    from dagster_graphql.schema.util import HasContext
+    from dagster_graphql.schema.util import ResolveInfo
 
 
 def _force_mark_as_canceled(instance: DagsterInstance, run_id):
@@ -53,7 +53,7 @@ def _force_mark_as_canceled(instance: DagsterInstance, run_id):
     return GrapheneTerminateRunSuccess(GrapheneRun(reloaded_record))
 
 
-def terminate_pipeline_execution(graphene_info: "HasContext", run_id, terminate_policy):
+def terminate_pipeline_execution(graphene_info: "ResolveInfo", run_id, terminate_policy):
     from ...schema.errors import GrapheneRunNotFoundError
     from ...schema.pipelines.pipeline import GrapheneRun
     from ...schema.roots.mutation import (
@@ -129,7 +129,7 @@ def terminate_pipeline_execution(graphene_info: "HasContext", run_id, terminate_
 
 
 @capture_error
-def delete_pipeline_run(graphene_info: "HasContext", run_id: str):
+def delete_pipeline_run(graphene_info: "ResolveInfo", run_id: str):
     from ...schema.errors import GrapheneRunNotFoundError
     from ...schema.roots.mutation import GrapheneDeletePipelineRunSuccess
 
@@ -159,7 +159,7 @@ def get_chunk_size() -> int:
 
 
 async def gen_events_for_run(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     run_id: str,
     after_cursor: Optional[str] = None,
 ) -> AsyncIterator[
@@ -241,7 +241,7 @@ async def gen_events_for_run(
 
 
 async def gen_compute_logs(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     run_id: str,
     step_key: str,
     io_type: ComputeIOType,
@@ -275,7 +275,7 @@ async def gen_compute_logs(
 
 
 async def gen_captured_log_data(
-    graphene_info: "HasContext", log_key: Sequence[str], cursor: Optional[str] = None
+    graphene_info: "ResolveInfo", log_key: Sequence[str], cursor: Optional[str] = None
 ):
     from ...schema.logs.compute_logs import from_captured_log_data
 
@@ -305,7 +305,7 @@ async def gen_captured_log_data(
 
 
 @capture_error
-def wipe_assets(graphene_info: "HasContext", asset_keys):
+def wipe_assets(graphene_info: "ResolveInfo", asset_keys):
     from ...schema.roots.mutation import GrapheneAssetWipeSuccess
 
     instance = graphene_info.context.instance

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -6,7 +6,6 @@ from dagster._core.host_representation.selector import PipelineSelector
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRun, RunsFilter
 from dagster._core.workspace.permissions import Permissions
-from graphene import ResolveInfo
 
 from ..external import get_external_pipeline_or_raise
 from ..utils import (
@@ -19,27 +18,26 @@ from .run_lifecycle import create_valid_pipeline_run
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.runs import GrapheneLaunchRunSuccess
-    from dagster_graphql.schema.util import HasContext
+    from dagster_graphql.schema.util import ResolveInfo
 
 
 @capture_error
 def launch_pipeline_reexecution(
-    graphene_info: "HasContext", execution_params: ExecutionParams
+    graphene_info: "ResolveInfo", execution_params: ExecutionParams
 ) -> "GrapheneLaunchRunSuccess":
     return _launch_pipeline_execution(graphene_info, execution_params, is_reexecuted=True)
 
 
 @capture_error
 def launch_pipeline_execution(
-    graphene_info: "HasContext", execution_params: ExecutionParams
+    graphene_info: "ResolveInfo", execution_params: ExecutionParams
 ) -> "GrapheneLaunchRunSuccess":
     return _launch_pipeline_execution(graphene_info, execution_params)
 
 
 def do_launch(
-    graphene_info: "HasContext", execution_params: ExecutionParams, is_reexecuted: bool = False
+    graphene_info: "ResolveInfo", execution_params: ExecutionParams, is_reexecuted: bool = False
 ) -> DagsterRun:
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(execution_params, "execution_params", ExecutionParams)
     check.bool_param(is_reexecuted, "is_reexecuted")
 
@@ -65,7 +63,6 @@ def _launch_pipeline_execution(
     from ...schema.pipelines.pipeline import GrapheneRun
     from ...schema.runs import GrapheneLaunchRunSuccess
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(execution_params, "execution_params", ExecutionParams)
     check.bool_param(is_reexecuted, "is_reexecuted")
 
@@ -77,7 +74,7 @@ def _launch_pipeline_execution(
 
 @capture_error
 def launch_reexecution_from_parent_run(
-    graphene_info: "HasContext", parent_run_id: str, strategy: str
+    graphene_info: "ResolveInfo", parent_run_id: str, strategy: str
 ) -> "GrapheneLaunchRunSuccess":
     """
     Launch a re-execution by referencing the parent run id.
@@ -85,7 +82,6 @@ def launch_reexecution_from_parent_run(
     from ...schema.pipelines.pipeline import GrapheneRun
     from ...schema.runs import GrapheneLaunchRunSuccess
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.str_param(parent_run_id, "parent_run_id")
 
     instance: DagsterInstance = graphene_info.context.instance

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -9,13 +9,12 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.utils import make_new_run_id
 from dagster._utils.merger import merge_dicts
-from graphene import ResolveInfo
 
 from ..external import ensure_valid_config, get_external_execution_plan_or_raise
 from ..utils import ExecutionParams, UserFacingGraphQLError
 
 if TYPE_CHECKING:
-    from dagster_graphql.schema.util import HasContext
+    from dagster_graphql.schema.util import ResolveInfo
 
 
 def _get_run(instance: DagsterInstance, run_id: str) -> DagsterRun:
@@ -26,9 +25,8 @@ def _get_run(instance: DagsterInstance, run_id: str) -> DagsterRun:
 
 
 def compute_step_keys_to_execute(
-    graphene_info: "HasContext", execution_params: ExecutionParams
+    graphene_info: "ResolveInfo", execution_params: ExecutionParams
 ) -> Tuple[Optional[Sequence[str]], Optional[KnownExecutionState]]:
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(execution_params, "execution_params", ExecutionParams)
 
     instance = graphene_info.context.instance
@@ -59,7 +57,7 @@ def is_resume_retry(execution_params):
 
 
 def create_valid_pipeline_run(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     external_pipeline: ExternalPipeline,
     execution_params: ExecutionParams,
 ):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -10,7 +10,6 @@ from dagster._core.host_representation import ExternalPipeline, PipelineSelector
 from dagster._core.host_representation.external import ExternalExecutionPlan
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
-from graphene import ResolveInfo
 
 from .utils import UserFacingGraphQLError, capture_error
 
@@ -22,28 +21,26 @@ if TYPE_CHECKING:
         GrapheneWorkspace,
         GrapheneWorkspaceLocationStatusEntries,
     )
-    from dagster_graphql.schema.util import HasContext
+    from dagster_graphql.schema.util import ResolveInfo
 
 
 def get_full_external_pipeline_or_raise(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     selector: PipelineSelector,
 ) -> ExternalPipeline:
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
     return _get_external_pipeline_or_raise(graphene_info, selector, ignore_subset=True)
 
 
 def get_external_pipeline_or_raise(
-    graphene_info: "HasContext", selector: PipelineSelector
+    graphene_info: "ResolveInfo", selector: PipelineSelector
 ) -> ExternalPipeline:
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
     return _get_external_pipeline_or_raise(graphene_info, selector)
 
 
 def _get_external_pipeline_or_raise(
-    graphene_info: "HasContext", selector: PipelineSelector, ignore_subset: bool = False
+    graphene_info: "ResolveInfo", selector: PipelineSelector, ignore_subset: bool = False
 ) -> ExternalPipeline:
     from ..schema.errors import GrapheneInvalidSubsetError, GraphenePipelineNotFoundError
     from ..schema.pipelines.pipeline import GraphenePipeline
@@ -100,7 +97,7 @@ def ensure_valid_config(
 
 
 def get_external_execution_plan_or_raise(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     external_pipeline: ExternalPipeline,
     mode: Optional[str],
     run_config: Mapping[str, object],
@@ -117,10 +114,9 @@ def get_external_execution_plan_or_raise(
 
 
 @capture_error
-def fetch_repositories(graphene_info: "HasContext") -> GrapheneRepositoryConnection:
+def fetch_repositories(graphene_info: "ResolveInfo") -> GrapheneRepositoryConnection:
     from ..schema.external import GrapheneRepository, GrapheneRepositoryConnection
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     return GrapheneRepositoryConnection(
         nodes=[
             GrapheneRepository(
@@ -136,12 +132,11 @@ def fetch_repositories(graphene_info: "HasContext") -> GrapheneRepositoryConnect
 
 @capture_error
 def fetch_repository(
-    graphene_info: "HasContext", repository_selector: RepositorySelector
+    graphene_info: "ResolveInfo", repository_selector: RepositorySelector
 ) -> Union[GrapheneRepository, GrapheneRepositoryNotFoundError]:
     from ..schema.errors import GrapheneRepositoryNotFoundError
     from ..schema.external import GrapheneRepository
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(repository_selector, "repository_selector", RepositorySelector)
 
     if graphene_info.context.has_repository_location(repository_selector.location_name):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -37,15 +37,12 @@ from dagster_graphql.implementation.loader import (
     StaleStatusLoader,
 )
 
-if TYPE_CHECKING:
-    pass
-
 from .utils import capture_error
 
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode
     from ..schema.freshness_policy import GrapheneAssetFreshnessInfo
-    from ..schema.util import HasContext
+    from ..schema.util import ResolveInfo
 
 
 def _normalize_asset_cursor_str(cursor_string):
@@ -105,7 +102,7 @@ def asset_node_iter(
 
 
 def get_asset_node_definition_collisions(
-    graphene_info: "HasContext", asset_keys: AbstractSet[AssetKey]
+    graphene_info: "ResolveInfo", asset_keys: AbstractSet[AssetKey]
 ):
     from ..schema.asset_graph import GrapheneAssetNodeDefinitionCollision
     from ..schema.external import GrapheneRepository
@@ -142,7 +139,7 @@ def get_asset_node_definition_collisions(
 
 
 def get_asset_nodes_by_asset_key(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
 ) -> Mapping[AssetKey, "GrapheneAssetNode"]:
     """
     If multiple repositories have asset nodes for the same asset key, chooses the asset node that

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -11,11 +11,11 @@ from dagster._core.scheduler.instigation import InstigatorStatus
 from .utils import capture_error
 
 if TYPE_CHECKING:
-    from dagster_graphql.schema.util import HasContext
+    from dagster_graphql.schema.util import ResolveInfo
 
 
 @capture_error
-def get_unloadable_instigator_states_or_error(graphene_info: "HasContext", instigator_type=None):
+def get_unloadable_instigator_states_or_error(graphene_info: "ResolveInfo", instigator_type=None):
     from ..schema.instigation import GrapheneInstigationState, GrapheneInstigationStates
 
     check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_logs.py
@@ -1,7 +1,8 @@
 from typing import Sequence
 
 from dagster._core.storage.captured_log_manager import CapturedLogManager
-from graphene import ResolveInfo
+
+from dagster_graphql.schema.util import ResolveInfo
 
 
 def get_captured_log_metadata(graphene_info: ResolveInfo, log_key: Sequence[str]):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -18,7 +18,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._utils.yaml_utils import dump_run_config_yaml
 
-from dagster_graphql.schema.util import HasContext
+from dagster_graphql.schema.util import ResolveInfo
 
 from .utils import capture_error
 
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 @capture_error
 def get_partition_sets_or_error(
-    graphene_info: HasContext, repository_selector: RepositorySelector, pipeline_name: str
+    graphene_info: ResolveInfo, repository_selector: RepositorySelector, pipeline_name: str
 ) -> "GraphenePartitionSets":
     from ..schema.partition_sets import GraphenePartitionSet, GraphenePartitionSets
 
@@ -67,7 +67,7 @@ def get_partition_sets_or_error(
 
 @capture_error
 def get_partition_set(
-    graphene_info: HasContext, repository_selector: RepositorySelector, partition_set_name: str
+    graphene_info: ResolveInfo, repository_selector: RepositorySelector, partition_set_name: str
 ) -> Union["GraphenePartitionSet", "GraphenePartitionSetNotFoundError"]:
     from ..schema.partition_sets import GraphenePartitionSet, GraphenePartitionSetNotFoundError
 
@@ -141,7 +141,7 @@ def get_partition_tags(graphene_info, repository_handle, partition_set_name, par
 
 @capture_error
 def get_partitions(
-    graphene_info: HasContext,
+    graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
     partition_set: ExternalPartitionSet,
     cursor: Optional[str] = None,
@@ -269,7 +269,7 @@ def partition_status_counts_from_run_partition_data(run_partition_data, partitio
     return [GraphenePartitionStatusCounts(runStatus=k, count=v) for k, v in count_by_status.items()]
 
 
-def get_partition_set_partition_runs(graphene_info: HasContext, partition_set):
+def get_partition_set_partition_runs(graphene_info: ResolveInfo, partition_set):
     from ..schema.partition_sets import GraphenePartitionRun
     from ..schema.pipelines.pipeline import GrapheneRun
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
@@ -1,13 +1,16 @@
 import dagster._check as check
 from dagster._core.storage.pipeline_run import DagsterRun
-from graphene import ResolveInfo
+
+from dagster_graphql.schema.util import ResolveInfo
 
 from .external import get_external_pipeline_or_raise, get_full_external_pipeline_or_raise
 from .utils import PipelineSelector, UserFacingGraphQLError, capture_error
 
 
 @capture_error
-def get_pipeline_snapshot_or_error_from_pipeline_selector(graphene_info, pipeline_selector):
+def get_pipeline_snapshot_or_error_from_pipeline_selector(
+    graphene_info: ResolveInfo, pipeline_selector
+):
     from ..schema.pipelines.snapshot import GraphenePipelineSnapshot
 
     check.inst_param(pipeline_selector, "pipeline_selector", PipelineSelector)
@@ -17,7 +20,7 @@ def get_pipeline_snapshot_or_error_from_pipeline_selector(graphene_info, pipelin
 
 
 @capture_error
-def get_pipeline_snapshot_or_error_from_snapshot_id(graphene_info, snapshot_id):
+def get_pipeline_snapshot_or_error_from_snapshot_id(graphene_info: ResolveInfo, snapshot_id):
     check.str_param(snapshot_id, "snapshot_id")
     return _get_pipeline_snapshot_from_instance(graphene_info.context.instance, snapshot_id)
 
@@ -40,19 +43,19 @@ def _get_pipeline_snapshot_from_instance(instance, snapshot_id):
 
 
 @capture_error
-def get_pipeline_or_error(graphene_info, selector):
+def get_pipeline_or_error(graphene_info: ResolveInfo, selector):
     """Returns a PipelineOrError."""
     return get_pipeline_from_selector(graphene_info, selector)
 
 
-def get_pipeline_or_raise(graphene_info, selector):
+def get_pipeline_or_raise(graphene_info: ResolveInfo, selector):
     """Returns a Pipeline or raises a UserFacingGraphQLError if one cannot be retrieved
     from the selector, e.g., the pipeline is not present in the loaded repository.
     """
     return get_pipeline_from_selector(graphene_info, selector)
 
 
-def get_pipeline_reference_or_raise(graphene_info, pipeline_run):
+def get_pipeline_reference_or_raise(graphene_info: ResolveInfo, pipeline_run):
     """Returns a PipelineReference or raises a UserFacingGraphQLError if a pipeline
     reference cannot be retrieved based on the run, e.g, a UserFacingGraphQLError that wraps an
     InvalidSubsetError.
@@ -72,10 +75,9 @@ def get_pipeline_reference_or_raise(graphene_info, pipeline_run):
     )
 
 
-def get_pipeline_from_selector(graphene_info, selector):
+def get_pipeline_from_selector(graphene_info: ResolveInfo, selector):
     from ..schema.pipelines.pipeline import GraphenePipeline
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
 
     return GraphenePipeline(get_external_pipeline_or_raise(graphene_info, selector))

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -39,11 +39,11 @@ if TYPE_CHECKING:
     from ..schema.pipelines.pipeline import GrapheneEventConnection, GrapheneRun
     from ..schema.pipelines.pipeline_run_stats import GrapheneRunStatsSnapshot
     from ..schema.runs import GrapheneRunGroup
-    from ..schema.util import HasContext
+    from ..schema.util import ResolveInfo
 
 
 def get_run_by_id(
-    graphene_info: "HasContext", run_id: str
+    graphene_info: "ResolveInfo", run_id: str
 ) -> Union["GrapheneRun", "GrapheneRunNotFoundError"]:
     from ..schema.errors import GrapheneRunNotFoundError
     from ..schema.pipelines.pipeline import GrapheneRun
@@ -56,7 +56,7 @@ def get_run_by_id(
         return GrapheneRun(record)
 
 
-def get_run_tags(graphene_info: "HasContext") -> List["GraphenePipelineTagAndValues"]:
+def get_run_tags(graphene_info: "ResolveInfo") -> List["GraphenePipelineTagAndValues"]:
     from ..schema.tags import GraphenePipelineTagAndValues
 
     instance = graphene_info.context.instance
@@ -68,7 +68,7 @@ def get_run_tags(graphene_info: "HasContext") -> List["GraphenePipelineTagAndVal
 
 
 @capture_error
-def get_run_group(graphene_info: "HasContext", run_id: str) -> "GrapheneRunGroup":
+def get_run_group(graphene_info: "ResolveInfo", run_id: str) -> "GrapheneRunGroup":
     from ..schema.errors import GrapheneRunGroupNotFoundError
     from ..schema.pipelines.pipeline import GrapheneRun
     from ..schema.runs import GrapheneRunGroup
@@ -93,7 +93,7 @@ def get_run_group(graphene_info: "HasContext", run_id: str) -> "GrapheneRunGroup
 
 
 def get_runs(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     filters: Optional[RunsFilter],
     cursor: Optional[str] = None,
     limit: Optional[int] = None,
@@ -147,7 +147,7 @@ def add_all_upstream_keys(
 
 
 def get_assets_latest_info(
-    graphene_info: "HasContext", step_keys_by_asset: Mapping[AssetKey, Sequence[str]]
+    graphene_info: "ResolveInfo", step_keys_by_asset: Mapping[AssetKey, Sequence[str]]
 ) -> Sequence["GrapheneAssetLatestInfo"]:
     from dagster_graphql.implementation.fetch_assets import get_asset_nodes_by_asset_key
 
@@ -215,7 +215,7 @@ def get_assets_latest_info(
 
 
 def _get_in_progress_runs_for_assets(
-    graphene_info,
+    graphene_info: "ResolveInfo",
     in_progress_records: Sequence[RunRecord],
     step_keys_by_asset: Mapping[AssetKey, Sequence[str]],
 ) -> Tuple[Mapping[AssetKey, AbstractSet[str]], Mapping[AssetKey, AbstractSet[str]]]:
@@ -273,12 +273,12 @@ def _get_in_progress_runs_for_assets(
     return in_progress_run_ids_by_asset, unstarted_run_ids_by_asset
 
 
-def get_runs_count(graphene_info: "HasContext", filters: Optional[RunsFilter]) -> int:
+def get_runs_count(graphene_info: "ResolveInfo", filters: Optional[RunsFilter]) -> int:
     return graphene_info.context.instance.get_runs_count(filters)
 
 
 def get_run_groups(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     filters: Optional[RunsFilter] = None,
     cursor: Optional[str] = None,
     limit: Optional[int] = None,
@@ -311,7 +311,7 @@ def get_run_groups(
 
 @capture_error
 def validate_pipeline_config(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     selector: PipelineSelector,
     run_config: Union[str, Mapping[str, object]],
     mode: Optional[str],
@@ -328,7 +328,7 @@ def validate_pipeline_config(
 
 @capture_error
 def get_execution_plan(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     selector: PipelineSelector,
     run_config: Mapping[str, Any],
     mode: Optional[str],
@@ -352,7 +352,7 @@ def get_execution_plan(
 
 
 @capture_error
-def get_stats(graphene_info: "HasContext", run_id: str) -> "GrapheneRunStatsSnapshot":
+def get_stats(graphene_info: "ResolveInfo", run_id: str) -> "GrapheneRunStatsSnapshot":
     from ..schema.pipelines.pipeline_run_stats import GrapheneRunStatsSnapshot
 
     stats = graphene_info.context.instance.get_run_stats(run_id)
@@ -361,7 +361,7 @@ def get_stats(graphene_info: "HasContext", run_id: str) -> "GrapheneRunStatsSnap
 
 
 def get_step_stats(
-    graphene_info: "HasContext", run_id: str, step_keys: Optional[Sequence[str]] = None
+    graphene_info: "ResolveInfo", run_id: str, step_keys: Optional[Sequence[str]] = None
 ) -> Sequence["GrapheneRunStepStats"]:
     from ..schema.logs.events import GrapheneRunStepStats
 
@@ -371,7 +371,7 @@ def get_step_stats(
 
 @capture_error
 def get_logs_for_run(
-    graphene_info: "HasContext",
+    graphene_info: "ResolveInfo",
     run_id: str,
     cursor: Optional[str] = None,
     limit: Optional[int] = None,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -3,7 +3,8 @@ from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.host_representation import PipelineSelector, RepositorySelector, ScheduleSelector
 from dagster._core.workspace.permissions import Permissions
 from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
-from graphene import ResolveInfo
+
+from dagster_graphql.schema.util import ResolveInfo
 
 from .loader import RepositoryScopedBatchLoader
 from .utils import (
@@ -15,11 +16,10 @@ from .utils import (
 
 
 @capture_error
-def start_schedule(graphene_info, schedule_selector):
+def start_schedule(graphene_info: ResolveInfo, schedule_selector):
     from ..schema.instigation import GrapheneInstigationState
     from ..schema.schedules import GrapheneScheduleStateResult
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(schedule_selector, "schedule_selector", ScheduleSelector)
     location = graphene_info.context.get_repository_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
@@ -31,11 +31,10 @@ def start_schedule(graphene_info, schedule_selector):
 
 
 @capture_error
-def stop_schedule(graphene_info, schedule_origin_id, schedule_selector_id):
+def stop_schedule(graphene_info: ResolveInfo, schedule_origin_id, schedule_selector_id):
     from ..schema.instigation import GrapheneInstigationState
     from ..schema.schedules import GrapheneScheduleStateResult
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     instance = graphene_info.context.instance
 
     external_schedules = {
@@ -66,7 +65,7 @@ def stop_schedule(graphene_info, schedule_origin_id, schedule_selector_id):
 
 
 @capture_error
-def get_scheduler_or_error(graphene_info):
+def get_scheduler_or_error(graphene_info: ResolveInfo):
     from ..schema.errors import GrapheneSchedulerNotDefinedError
     from ..schema.schedules import GrapheneScheduler
 
@@ -79,10 +78,9 @@ def get_scheduler_or_error(graphene_info):
 
 
 @capture_error
-def get_schedules_or_error(graphene_info, repository_selector):
+def get_schedules_or_error(graphene_info: ResolveInfo, repository_selector):
     from ..schema.schedules import GrapheneSchedule, GrapheneSchedules
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(repository_selector, "repository_selector", RepositorySelector)
 
     location = graphene_info.context.get_repository_location(repository_selector.location_name)
@@ -108,10 +106,9 @@ def get_schedules_or_error(graphene_info, repository_selector):
     return GrapheneSchedules(results=results)
 
 
-def get_schedules_for_pipeline(graphene_info, pipeline_selector):
+def get_schedules_for_pipeline(graphene_info: ResolveInfo, pipeline_selector):
     from ..schema.schedules import GrapheneSchedule
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(pipeline_selector, "pipeline_selector", PipelineSelector)
 
     location = graphene_info.context.get_repository_location(pipeline_selector.location_name)
@@ -133,11 +130,10 @@ def get_schedules_for_pipeline(graphene_info, pipeline_selector):
 
 
 @capture_error
-def get_schedule_or_error(graphene_info, schedule_selector):
+def get_schedule_or_error(graphene_info: ResolveInfo, schedule_selector):
     from ..schema.errors import GrapheneScheduleNotFoundError
     from ..schema.schedules import GrapheneSchedule
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(schedule_selector, "schedule_selector", ScheduleSelector)
     location = graphene_info.context.get_repository_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
@@ -155,7 +151,7 @@ def get_schedule_or_error(graphene_info, schedule_selector):
     return GrapheneSchedule(external_schedule, schedule_state)
 
 
-def get_schedule_next_tick(graphene_info, schedule_state):
+def get_schedule_next_tick(graphene_info: ResolveInfo, schedule_state):
     from ..schema.instigation import GrapheneFutureInstigationTick
 
     if not schedule_state.is_running:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -4,7 +4,8 @@ from dagster._core.host_representation import PipelineSelector, RepositorySelect
 from dagster._core.scheduler.instigation import InstigatorState, SensorInstigatorData
 from dagster._core.workspace.permissions import Permissions
 from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
-from graphene import ResolveInfo
+
+from dagster_graphql.schema.util import ResolveInfo
 
 from .loader import RepositoryScopedBatchLoader
 from .utils import (
@@ -16,10 +17,9 @@ from .utils import (
 
 
 @capture_error
-def get_sensors_or_error(graphene_info, repository_selector):
+def get_sensors_or_error(graphene_info: ResolveInfo, repository_selector):
     from ..schema.sensors import GrapheneSensor, GrapheneSensors
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(repository_selector, "repository_selector", RepositorySelector)
 
     location = graphene_info.context.get_repository_location(repository_selector.location_name)
@@ -43,11 +43,10 @@ def get_sensors_or_error(graphene_info, repository_selector):
 
 
 @capture_error
-def get_sensor_or_error(graphene_info, selector):
+def get_sensor_or_error(graphene_info: ResolveInfo, selector):
     from ..schema.errors import GrapheneSensorNotFoundError
     from ..schema.sensors import GrapheneSensor
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", SensorSelector)
     location = graphene_info.context.get_repository_location(selector.location_name)
     repository = location.get_repository(selector.repository_name)
@@ -64,11 +63,10 @@ def get_sensor_or_error(graphene_info, selector):
 
 
 @capture_error
-def start_sensor(graphene_info, sensor_selector):
+def start_sensor(graphene_info: ResolveInfo, sensor_selector):
     from ..schema.errors import GrapheneSensorNotFoundError
     from ..schema.sensors import GrapheneSensor
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(sensor_selector, "sensor_selector", SensorSelector)
 
     location = graphene_info.context.get_repository_location(sensor_selector.location_name)
@@ -85,10 +83,9 @@ def start_sensor(graphene_info, sensor_selector):
 
 
 @capture_error
-def stop_sensor(graphene_info, instigator_origin_id, instigator_selector_id):
+def stop_sensor(graphene_info: ResolveInfo, instigator_origin_id, instigator_selector_id):
     from ..schema.sensors import GrapheneStopSensorMutationResult
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.str_param(instigator_origin_id, "instigator_origin_id")
     instance = graphene_info.context.instance
 
@@ -152,10 +149,9 @@ def get_unloadable_sensor_states_or_error(graphene_info):
     )
 
 
-def get_sensors_for_pipeline(graphene_info, pipeline_selector):
+def get_sensors_for_pipeline(graphene_info: ResolveInfo, pipeline_selector):
     from ..schema.sensors import GrapheneSensor
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(pipeline_selector, "pipeline_selector", PipelineSelector)
 
     location = graphene_info.context.get_repository_location(pipeline_selector.location_name)
@@ -178,10 +174,9 @@ def get_sensors_for_pipeline(graphene_info, pipeline_selector):
     return results
 
 
-def get_sensor_next_tick(graphene_info, sensor_state):
+def get_sensor_next_tick(graphene_info: ResolveInfo, sensor_state):
     from ..schema.instigation import GrapheneFutureInstigationTick
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(sensor_state, "sensor_state", InstigatorState)
 
     repository_origin = sensor_state.origin.external_repository_origin
@@ -220,8 +215,7 @@ def get_sensor_next_tick(graphene_info, sensor_state):
 
 
 @capture_error
-def set_sensor_cursor(graphene_info, selector, cursor):
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
+def set_sensor_cursor(graphene_info: ResolveInfo, selector, cursor):
     check.inst_param(selector, "selector", SensorSelector)
     check.opt_str_param(cursor, "cursor")
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
@@ -1,18 +1,18 @@
 import dagster._check as check
 from dagster._config import validate_config_from_snap
 from dagster._core.host_representation import RepresentedPipeline
-from graphene import ResolveInfo
+
+from dagster_graphql.schema.util import ResolveInfo
 
 from .external import get_external_pipeline_or_raise
 from .utils import PipelineSelector, UserFacingGraphQLError, capture_error
 
 
 @capture_error
-def resolve_run_config_schema_or_error(graphene_info, selector, mode):
+def resolve_run_config_schema_or_error(graphene_info: ResolveInfo, selector, mode):
     from ..schema.errors import GrapheneModeNotFoundError
     from ..schema.run_config import GrapheneRunConfigSchema
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(selector, "selector", PipelineSelector)
     check.opt_str_param(mode, "mode")
 
@@ -31,14 +31,13 @@ def resolve_run_config_schema_or_error(graphene_info, selector, mode):
 
 
 @capture_error
-def resolve_is_run_config_valid(graphene_info, represented_pipeline, mode, run_config):
+def resolve_is_run_config_valid(graphene_info: ResolveInfo, represented_pipeline, mode, run_config):
     from ..schema.pipelines.config import (
         GraphenePipelineConfigValidationError,
         GraphenePipelineConfigValidationValid,
         GrapheneRunConfigValidationInvalid,
     )
 
-    check.inst_param(graphene_info, "graphene_info", ResolveInfo)
     check.inst_param(represented_pipeline, "represented_pipeline", RepresentedPipeline)
     check.str_param(mode, "mode")
     check.dict_param(run_config, "run_config", key_type=str)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -28,11 +28,11 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.host_representation import GraphSelector, PipelineSelector
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
-from graphene import ResolveInfo
 from typing_extensions import ParamSpec, TypeAlias
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.errors import GrapheneError, GraphenePythonError
+    from dagster_graphql.schema.util import ResolveInfo
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -41,7 +41,9 @@ GrapheneResolverFn: TypeAlias = Callable[..., object]
 T_Callable = TypeVar("T_Callable", bound=Callable)
 
 
-def assert_permission_for_location(graphene_info: ResolveInfo, permission: str, location_name: str):
+def assert_permission_for_location(
+    graphene_info: "ResolveInfo", permission: str, location_name: str
+):
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
     context = cast(BaseWorkspaceRequestContext, graphene_info.context)
@@ -80,7 +82,7 @@ def check_permission(permission: str) -> Callable[[GrapheneResolverFn], Graphene
     return decorator
 
 
-def assert_permission(graphene_info: ResolveInfo, permission: str) -> None:
+def assert_permission(graphene_info: "ResolveInfo", permission: str) -> None:
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
     context = cast(BaseWorkspaceRequestContext, graphene_info.context)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -21,7 +21,7 @@ from .errors import (
     create_execution_params_error_types,
 )
 from .pipelines.config import GrapheneRunConfigValidationInvalid
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 pipeline_execution_error_types = (
     GrapheneInvalidStepError,
@@ -135,7 +135,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             assetSelection=backfill_job.asset_selection,
         )
 
-    def _get_partition_set(self, graphene_info):
+    def _get_partition_set(self, graphene_info: ResolveInfo):
         if self._backfill_job.partition_set_origin is None:
             return None
 
@@ -160,7 +160,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
         return external_partition_sets[0]
 
-    def _get_records(self, graphene_info):
+    def _get_records(self, graphene_info: ResolveInfo):
         if self._records is None:
             filters = RunsFilter.for_backfill(self._backfill_job.backfill_id)
             self._records = graphene_info.context.instance.get_run_records(
@@ -168,7 +168,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             )
         return self._records
 
-    def _get_partition_run_data(self, graphene_info):
+    def _get_partition_run_data(self, graphene_info: ResolveInfo):
         if self._partition_run_data is None:
             self._partition_run_data = (
                 graphene_info.context.instance.run_storage.get_run_partition_data(
@@ -181,28 +181,28 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             )
         return self._partition_run_data
 
-    def resolve_unfinishedRuns(self, graphene_info):
+    def resolve_unfinishedRuns(self, graphene_info: ResolveInfo):
         from .pipelines.pipeline import GrapheneRun
 
         records = self._get_records(graphene_info)
         return [GrapheneRun(record) for record in records if not record.pipeline_run.is_finished]
 
-    def resolve_runs(self, graphene_info):
+    def resolve_runs(self, graphene_info: ResolveInfo):
         from .pipelines.pipeline import GrapheneRun
 
         records = self._get_records(graphene_info)
         return [GrapheneRun(record) for record in records]
 
-    def resolve_partitionNames(self, _graphene_info):
+    def resolve_partitionNames(self, _graphene_info: ResolveInfo):
         return self._backfill_job.get_partition_names(_graphene_info.context)
 
-    def resolve_numPartitions(self, _graphene_info):
+    def resolve_numPartitions(self, _graphene_info: ResolveInfo):
         return self._backfill_job.get_num_partitions(_graphene_info.context)
 
-    def resolve_numCancelable(self, _graphene_info):
+    def resolve_numCancelable(self, _graphene_info: ResolveInfo):
         return self._backfill_job.get_num_cancelable()
 
-    def resolve_partitionSet(self, graphene_info):
+    def resolve_partitionSet(self, graphene_info: ResolveInfo):
         from ..schema.partition_sets import GraphenePartitionSet
 
         partition_set = self._get_partition_set(graphene_info)
@@ -215,7 +215,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             external_partition_set=partition_set,
         )
 
-    def resolve_partitionStatuses(self, graphene_info):
+    def resolve_partitionStatuses(self, graphene_info: ResolveInfo):
         partition_set_origin = self._backfill_job.partition_set_origin
         partition_set_name = (
             partition_set_origin.partition_set_name if partition_set_origin else None

--- a/python_modules/dagster-graphql/dagster_graphql/schema/config_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/config_types.py
@@ -5,7 +5,7 @@ import graphene
 from dagster._config import ConfigTypeKind, get_recursive_type_keys
 from dagster._core.snap import ConfigFieldSnap, ConfigSchemaSnapshot, ConfigTypeSnap
 
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 GrapheneConfigTypeUnion = Union[
     "GrapheneEnumConfigType",
@@ -110,7 +110,9 @@ class GrapheneRegularConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -142,7 +144,9 @@ class GrapheneMapConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -150,19 +154,19 @@ class GrapheneMapConfigType(graphene.ObjectType):
             )
         )
 
-    def resolve_key_type(self, _graphene_info) -> GrapheneConfigTypeUnion:
+    def resolve_key_type(self, _graphene_info: ResolveInfo) -> GrapheneConfigTypeUnion:
         return to_config_type(
             self._config_schema_snapshot,
             self._config_type_snap.key_type_key,
         )
 
-    def resolve_value_type(self, _graphene_info) -> GrapheneConfigTypeUnion:
+    def resolve_value_type(self, _graphene_info: ResolveInfo) -> GrapheneConfigTypeUnion:
         return to_config_type(
             self._config_schema_snapshot,
             self._config_type_snap.inner_type_key,
         )
 
-    def resolve_key_label_name(self, _graphene_info) -> Optional[str]:
+    def resolve_key_label_name(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._config_type_snap.given_name
 
 
@@ -189,7 +193,9 @@ class GrapheneArrayConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -197,7 +203,7 @@ class GrapheneArrayConfigType(graphene.ObjectType):
             )
         )
 
-    def resolve_of_type(self, _graphene_info) -> GrapheneConfigTypeUnion:
+    def resolve_of_type(self, _graphene_info: ResolveInfo) -> GrapheneConfigTypeUnion:
         return to_config_type(
             self._config_schema_snapshot,
             self._config_type_snap.inner_type_key,
@@ -225,7 +231,9 @@ class GrapheneScalarUnionConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -268,7 +276,9 @@ class GrapheneNullableConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -276,7 +286,7 @@ class GrapheneNullableConfigType(graphene.ObjectType):
             )
         )
 
-    def resolve_of_type(self, _graphene_info) -> GrapheneConfigTypeUnion:
+    def resolve_of_type(self, _graphene_info: ResolveInfo) -> GrapheneConfigTypeUnion:
         return to_config_type(self._config_schema_snapshot, self._config_type_snap.inner_type_key)
 
 
@@ -307,7 +317,9 @@ class GrapheneEnumConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -315,7 +327,7 @@ class GrapheneEnumConfigType(graphene.ObjectType):
             )
         )
 
-    def resolve_values(self, _graphene_info) -> List[GrapheneEnumConfigValue]:
+    def resolve_values(self, _graphene_info: ResolveInfo) -> List[GrapheneEnumConfigValue]:
         return [
             GrapheneEnumConfigValue(value=ev.value, description=ev.description)
             for ev in check.not_none(self._config_type_snap.enum_values)
@@ -352,10 +364,10 @@ class GrapheneConfigTypeField(graphene.ObjectType):
             is_required=field_snap.is_required,
         )
 
-    def resolve_config_type(self, _graphene_info) -> GrapheneConfigTypeUnion:
+    def resolve_config_type(self, _graphene_info: ResolveInfo) -> GrapheneConfigTypeUnion:
         return to_config_type(self._config_schema_snapshot, self._field_snap.type_key)
 
-    def resolve_default_value_as_json(self, _graphene_info) -> Optional[str]:
+    def resolve_default_value_as_json(self, _graphene_info: ResolveInfo) -> Optional[str]:
         return self._field_snap.default_value_as_json_str
 
 
@@ -377,7 +389,9 @@ class GrapheneCompositeConfigType(graphene.ObjectType):
         )
         super().__init__(**_ctor_kwargs_for_snap(config_type_snap))
 
-    def resolve_recursive_config_types(self, _graphene_info) -> List[GrapheneConfigTypeUnion]:
+    def resolve_recursive_config_types(
+        self, _graphene_info: ResolveInfo
+    ) -> List[GrapheneConfigTypeUnion]:
         return list(
             map(
                 lambda key: to_config_type(self._config_schema_snapshot, key),
@@ -385,7 +399,7 @@ class GrapheneCompositeConfigType(graphene.ObjectType):
             )
         )
 
-    def resolve_fields(self, _graphene_info) -> List[GrapheneConfigTypeField]:
+    def resolve_fields(self, _graphene_info: ResolveInfo) -> List[GrapheneConfigTypeField]:
         return sorted(
             [
                 GrapheneConfigTypeField(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/errors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/errors.py
@@ -5,7 +5,7 @@ import graphene
 from dagster._core.definitions.events import AssetKey
 from dagster._utils.error import SerializableErrorInfo
 
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneError(graphene.Interface):
@@ -114,7 +114,7 @@ class GraphenePythonError(graphene.ObjectType):
         )
         return self._className
 
-    def resolve_causes(self, _graphene_info):
+    def resolve_causes(self, _graphene_info: ResolveInfo):
         causes: List[GraphenePythonError] = []
         current_error = self._cause
         while current_error and len(causes) < 10:  # Sanity check the depth of the causes

--- a/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
@@ -4,7 +4,7 @@ from dagster._core.host_representation import ExternalExecutionPlan
 from dagster._core.snap import ExecutionStepInputSnap, ExecutionStepOutputSnap, ExecutionStepSnap
 
 from .metadata import GrapheneMetadataItemDefinition
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneExecutionStepOutput(graphene.ObjectType):
@@ -19,7 +19,7 @@ class GrapheneExecutionStepOutput(graphene.ObjectType):
             step_output_snap, "step_output_snap", ExecutionStepOutputSnap
         )
 
-    def resolve_name(self, _graphene_info):
+    def resolve_name(self, _graphene_info: ResolveInfo):
         return self._step_output_snap.name
 
 
@@ -39,10 +39,10 @@ class GrapheneExecutionStepInput(graphene.ObjectType):
             external_execution_plan, "external_execution_plan", ExternalExecutionPlan
         )
 
-    def resolve_name(self, _graphene_info):
+    def resolve_name(self, _graphene_info: ResolveInfo):
         return self._step_input_snap.name
 
-    def resolve_dependsOn(self, _graphene_info):
+    def resolve_dependsOn(self, _graphene_info: ResolveInfo):
         return [  # type: ignore  # fmt: skip
             GrapheneExecutionStep(
                 self._external_execution_plan,
@@ -98,28 +98,28 @@ class GrapheneExecutionStep(graphene.ObjectType):
             execution_step_snap, "execution_step_snap", ExecutionStepSnap
         )
 
-    def resolve_metadata(self, _graphene_info):
+    def resolve_metadata(self, _graphene_info: ResolveInfo):
         return [
             GrapheneMetadataItemDefinition(key=mdi.key, value=mdi.value)
             for mdi in self._step_snap.metadata_items
         ]
 
-    def resolve_inputs(self, _graphene_info):
+    def resolve_inputs(self, _graphene_info: ResolveInfo):
         return [
             GrapheneExecutionStepInput(inp, self._external_execution_plan)
             for inp in self._step_snap.inputs
         ]
 
-    def resolve_outputs(self, _graphene_info):
+    def resolve_outputs(self, _graphene_info: ResolveInfo):
         return [GrapheneExecutionStepOutput(out) for out in self._step_snap.outputs]
 
-    def resolve_key(self, _graphene_info):
+    def resolve_key(self, _graphene_info: ResolveInfo):
         return self._step_snap.key
 
-    def resolve_solidHandleID(self, _graphene_info):
+    def resolve_solidHandleID(self, _graphene_info: ResolveInfo):
         return self._step_snap.solid_handle_id
 
-    def resolve_kind(self, _graphene_info):
+    def resolve_kind(self, _graphene_info: ResolveInfo):
         return self._step_snap.kind.value
 
 
@@ -136,7 +136,7 @@ class GrapheneExecutionPlan(graphene.ObjectType):
             external_execution_plan, external_execution_plan, ExternalExecutionPlan
         )
 
-    def resolve_steps(self, _graphene_info):
+    def resolve_steps(self, _graphene_info: ResolveInfo):
         return [
             GrapheneExecutionStep(
                 self._external_execution_plan,
@@ -145,7 +145,7 @@ class GrapheneExecutionPlan(graphene.ObjectType):
             for step in self._external_execution_plan.get_steps_in_plan()
         ]
 
-    def resolve_artifactsPersisted(self, _graphene_info):
+    def resolve_artifactsPersisted(self, _graphene_info: ResolveInfo):
         return self._external_execution_plan.execution_plan_snapshot.artifacts_persisted
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -29,7 +29,7 @@ from .errors import GrapheneError, GraphenePythonError
 from .logs.log_level import GrapheneLogLevel
 from .repository_origin import GrapheneRepositoryOrigin
 from .tags import GraphenePipelineTag
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneInstigationType(graphene.Enum):
@@ -149,7 +149,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
     def resolve_id(self, _):
         return "%s:%s" % (self._tick.instigator_origin_id, self._tick.timestamp)
 
-    def resolve_runs(self, graphene_info):
+    def resolve_runs(self, graphene_info: ResolveInfo):
         from .pipelines.pipeline import GrapheneRun
 
         instance = graphene_info.context.instance
@@ -164,7 +164,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
 
         return [GrapheneRun(records_by_id[run_id]) for run_id in run_ids if run_id in records_by_id]
 
-    def resolve_logEvents(self, graphene_info):
+    def resolve_logEvents(self, graphene_info: ResolveInfo):
         return get_tick_log_events(graphene_info, self._tick)
 
 
@@ -182,7 +182,7 @@ class GrapheneFutureInstigationTick(graphene.ObjectType):
             timestamp=check.float_param(timestamp, "timestamp"),
         )
 
-    def resolve_evaluationResult(self, graphene_info):
+    def resolve_evaluationResult(self, graphene_info: ResolveInfo):
         if not self._state.is_running or self._state.instigator_type != InstigatorType.SCHEDULE:
             return None
 
@@ -251,7 +251,7 @@ class GrapheneTickEvaluation(graphene.ObjectType):
         )
         super().__init__(skipReason=skip_reason, error=error)
 
-    def resolve_runRequests(self, _graphene_info):
+    def resolve_runRequests(self, _graphene_info: ResolveInfo):
         if not self._run_requests:
             return self._run_requests
 
@@ -270,14 +270,14 @@ class GrapheneRunRequest(graphene.ObjectType):
         super().__init__(runKey=run_request.run_key)
         self._run_request = check.inst_param(run_request, "run_request", RunRequest)
 
-    def resolve_tags(self, _graphene_info):
+    def resolve_tags(self, _graphene_info: ResolveInfo):
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in self._run_request.tags.items()
             if get_tag_type(key) != TagType.HIDDEN
         ]
 
-    def resolve_runConfigYaml(self, _graphene_info):
+    def resolve_runConfigYaml(self, _graphene_info: ResolveInfo):
         return dump_run_config_yaml(self._run_request.run_config)
 
 
@@ -345,17 +345,17 @@ class GrapheneInstigationState(graphene.ObjectType):
             ),
         )
 
-    def resolve_repositoryOrigin(self, _graphene_info):
+    def resolve_repositoryOrigin(self, _graphene_info: ResolveInfo):
         origin = self._instigator_state.origin.external_repository_origin
         return GrapheneRepositoryOrigin(origin)
 
-    def resolve_repositoryName(self, _graphene_info):
+    def resolve_repositoryName(self, _graphene_info: ResolveInfo):
         return self._instigator_state.repository_selector.repository_name
 
-    def resolve_repositoryLocationName(self, _graphene_info):
+    def resolve_repositoryLocationName(self, _graphene_info: ResolveInfo):
         return self._instigator_state.repository_selector.location_name
 
-    def resolve_typeSpecificData(self, _graphene_info):
+    def resolve_typeSpecificData(self, _graphene_info: ResolveInfo):
         if not self._instigator_state.instigator_data:
             return None
 
@@ -367,7 +367,7 @@ class GrapheneInstigationState(graphene.ObjectType):
 
         return None
 
-    def resolve_runs(self, graphene_info, **kwargs):
+    def resolve_runs(self, graphene_info: ResolveInfo, **kwargs):
         from .pipelines.pipeline import GrapheneRun
 
         if kwargs.get("limit") and self._batch_loader:
@@ -404,14 +404,14 @@ class GrapheneInstigationState(graphene.ObjectType):
             )
         ]
 
-    def resolve_runsCount(self, graphene_info):
+    def resolve_runsCount(self, graphene_info: ResolveInfo):
         if self._instigator_state.instigator_type == InstigatorType.SENSOR:
             filters = RunsFilter.for_sensor(self._instigator_state)
         else:
             filters = RunsFilter.for_schedule(self._instigator_state)
         return graphene_info.context.instance.get_runs_count(filters=filters)
 
-    def resolve_tick(self, graphene_info, timestamp):
+    def resolve_tick(self, graphene_info: ResolveInfo, timestamp):
         matches = graphene_info.context.instance.get_ticks(
             self._instigator_state.instigator_origin_id,
             self._instigator_state.selector_id,
@@ -471,14 +471,14 @@ class GrapheneInstigationState(graphene.ObjectType):
             )
         ]
 
-    def resolve_nextTick(self, graphene_info):
+    def resolve_nextTick(self, graphene_info: ResolveInfo):
         # sensor
         if self._instigator_state.instigator_type == InstigatorType.SENSOR:
             return get_sensor_next_tick(graphene_info, self._instigator_state)
         else:
             return get_schedule_next_tick(graphene_info, self._instigator_state)
 
-    def resolve_runningCount(self, _graphene_info):
+    def resolve_runningCount(self, _graphene_info: ResolveInfo):
         return 1 if self._instigator_state.is_running else 0
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/compute_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/compute_logs.py
@@ -3,7 +3,7 @@ import graphene
 from dagster._core.storage.captured_log_manager import CapturedLogData
 from dagster._core.storage.compute_log_manager import ComputeIOType, ComputeLogFileData
 
-from dagster_graphql.schema.util import non_null_list
+from dagster_graphql.schema.util import ResolveInfo, non_null_list
 
 
 class GrapheneComputeIOType(graphene.Enum):
@@ -49,15 +49,15 @@ class GrapheneComputeLogs(graphene.ObjectType):
     class Meta:
         name = "ComputeLogs"
 
-    def _resolve_compute_log(self, graphene_info, io_type):
+    def _resolve_compute_log(self, graphene_info: ResolveInfo, io_type):
         return graphene_info.context.instance.compute_log_manager.read_logs_file(
             self.runId, self.stepKey, io_type, 0
         )
 
-    def resolve_stdout(self, graphene_info):
+    def resolve_stdout(self, graphene_info: ResolveInfo):
         return self._resolve_compute_log(graphene_info, ComputeIOType.STDOUT)
 
-    def resolve_stderr(self, graphene_info):
+    def resolve_stderr(self, graphene_info: ResolveInfo):
         return self._resolve_compute_log(graphene_info, ComputeIOType.STDERR)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -14,7 +14,7 @@ from ..asset_key import GrapheneAssetKey, GrapheneAssetLineageInfo
 from ..errors import GraphenePythonError, GrapheneRunNotFoundError
 from ..metadata import GrapheneMetadataEntry
 from ..runs import GrapheneStepEventStatus
-from ..util import non_null_list
+from ..util import ResolveInfo, non_null_list
 from .log_level import GrapheneLogLevel
 
 if TYPE_CHECKING:
@@ -195,7 +195,7 @@ class GrapheneObjectStoreOperationResult(graphene.ObjectType):
         interfaces = (GrapheneDisplayableEvent,)
         name = "ObjectStoreOperationResult"
 
-    def resolve_metadataEntries(self, _graphene_info):
+    def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
         return _to_metadata_entries(self.metadata_entries)
@@ -208,7 +208,7 @@ class GrapheneExpectationResult(graphene.ObjectType):
         interfaces = (GrapheneDisplayableEvent,)
         name = "ExpectationResult"
 
-    def resolve_metadataEntries(self, _graphene_info):
+    def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
         return _to_metadata_entries(self.metadata_entries)
@@ -221,7 +221,7 @@ class GrapheneTypeCheck(graphene.ObjectType):
         interfaces = (GrapheneDisplayableEvent,)
         name = "TypeCheck"
 
-    def resolve_metadataEntries(self, _graphene_info):
+    def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
         return _to_metadata_entries(self.metadata_entries)
@@ -232,7 +232,7 @@ class GrapheneFailureMetadata(graphene.ObjectType):
         interfaces = (GrapheneDisplayableEvent,)
         name = "FailureMetadata"
 
-    def resolve_metadataEntries(self, _graphene_info):
+    def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
         return _to_metadata_entries(self.metadata_entries)
@@ -339,12 +339,12 @@ class AssetEventMixin:
         stats = get_step_stats(graphene_info, run_id, step_keys=[step_key])
         return stats[0]
 
-    def resolve_metadataEntries(self, _graphene_info):
+    def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
         return _to_metadata_entries(self._metadata.metadata_entries)
 
-    def resolve_partition(self, _graphene_info):
+    def resolve_partition(self, _graphene_info: ResolveInfo):
         return self._metadata.partition
 
 
@@ -367,7 +367,7 @@ class GrapheneMaterializationEvent(graphene.ObjectType, AssetEventMixin):
             metadata=materialization,
         )
 
-    def resolve_runOrError(self, graphene_info):
+    def resolve_runOrError(self, graphene_info: ResolveInfo):
         from ..pipelines.pipeline import GrapheneRun
 
         if self._batch_run_loader:
@@ -379,7 +379,7 @@ class GrapheneMaterializationEvent(graphene.ObjectType, AssetEventMixin):
 
         return super().resolve_runOrError(graphene_info)
 
-    def resolve_assetLineage(self, _graphene_info):
+    def resolve_assetLineage(self, _graphene_info: ResolveInfo):
         return [
             GrapheneAssetLineageInfo(
                 assetKey=lineage_info.asset_key,
@@ -416,10 +416,10 @@ class GrapheneAssetMaterializationPlannedEvent(graphene.ObjectType):
         self._event = event
         super().__init__(**construct_basic_params(event))
 
-    def resolve_assetKey(self, _graphene_info):
+    def resolve_assetKey(self, _graphene_info: ResolveInfo):
         return self._event.dagster_event.asset_materialization_planned_data.asset_key
 
-    def resolve_runOrError(self, graphene_info):
+    def resolve_runOrError(self, graphene_info: ResolveInfo):
         return get_run_by_id(graphene_info, self._event.run_id)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -32,7 +32,7 @@ from .pipelines.pipeline import GrapheneRun
 from .pipelines.status import GrapheneRunStatus
 from .repository_origin import GrapheneRepositoryOrigin
 from .tags import GraphenePipelineTag
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GraphenePartitionTags(graphene.ObjectType):
@@ -136,7 +136,7 @@ class GraphenePartition(graphene.ObjectType):
             mode=external_partition_set.mode,
         )
 
-    def resolve_runConfigOrError(self, graphene_info):
+    def resolve_runConfigOrError(self, graphene_info: ResolveInfo):
         return get_partition_config(
             graphene_info,
             self._external_repository_handle,
@@ -144,7 +144,7 @@ class GraphenePartition(graphene.ObjectType):
             self._partition_name,
         )
 
-    def resolve_tagsOrError(self, graphene_info):
+    def resolve_tagsOrError(self, graphene_info: ResolveInfo):
         return get_partition_tags(
             graphene_info,
             self._external_repository_handle,
@@ -152,7 +152,7 @@ class GraphenePartition(graphene.ObjectType):
             self._partition_name,
         )
 
-    def resolve_runs(self, graphene_info, **kwargs):
+    def resolve_runs(self, graphene_info: ResolveInfo, **kwargs):
         filters = kwargs.get("filter")
         partition_tags = {
             PARTITION_SET_TAG: self._external_partition_set.name,
@@ -227,10 +227,10 @@ class GraphenePartitionSet(graphene.ObjectType):
             mode=external_partition_set.mode,
         )
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         return self._external_partition_set.get_external_origin_id()
 
-    def resolve_partitionsOrError(self, graphene_info, **kwargs):
+    def resolve_partitionsOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_partitions(
             graphene_info,
             self._external_repository_handle,
@@ -240,7 +240,7 @@ class GraphenePartitionSet(graphene.ObjectType):
             reverse=kwargs.get("reverse") or False,
         )
 
-    def resolve_partition(self, graphene_info, partition_name):
+    def resolve_partition(self, graphene_info: ResolveInfo, partition_name):
         return get_partition_by_name(
             graphene_info,
             self._external_repository_handle,
@@ -248,10 +248,10 @@ class GraphenePartitionSet(graphene.ObjectType):
             partition_name,
         )
 
-    def resolve_partitionRuns(self, graphene_info):
+    def resolve_partitionRuns(self, graphene_info: ResolveInfo):
         return get_partition_set_partition_runs(graphene_info, self._external_partition_set)
 
-    def resolve_partitionStatusesOrError(self, graphene_info):
+    def resolve_partitionStatusesOrError(self, graphene_info: ResolveInfo):
         return get_partition_set_partition_statuses(
             graphene_info,
             self._external_partition_set,
@@ -261,7 +261,7 @@ class GraphenePartitionSet(graphene.ObjectType):
         origin = self._external_partition_set.get_external_origin().external_repository_origin
         return GrapheneRepositoryOrigin(origin)
 
-    def resolve_backfills(self, graphene_info, **kwargs):
+    def resolve_backfills(self, graphene_info: ResolveInfo, **kwargs):
         matching = [
             backfill
             for backfill in graphene_info.context.instance.get_backfills(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/mode.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/mode.py
@@ -2,7 +2,7 @@ import dagster._check as check
 import graphene
 from dagster._core.snap import ConfigSchemaSnapshot, ModeDefSnap
 
-from ..util import non_null_list
+from ..util import ResolveInfo, non_null_list
 from .logger import GrapheneLogger
 from .resource import GrapheneResource
 
@@ -25,24 +25,24 @@ class GrapheneMode(graphene.ObjectType):
         )
         self._pipeline_snapshot_id = pipeline_snapshot_id
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         return "{pipeline}-{mode}".format(
             pipeline=self._pipeline_snapshot_id, mode=self._mode_def_snap.name
         )
 
-    def resolve_name(self, _graphene_info):
+    def resolve_name(self, _graphene_info: ResolveInfo):
         return self._mode_def_snap.name
 
-    def resolve_description(self, _graphene_info):
+    def resolve_description(self, _graphene_info: ResolveInfo):
         return self._mode_def_snap.description
 
-    def resolve_resources(self, _graphene_info):
+    def resolve_resources(self, _graphene_info: ResolveInfo):
         return [
             GrapheneResource(self._config_schema_snapshot, resource_def_snap)
             for resource_def_snap in sorted(self._mode_def_snap.resource_def_snaps)
         ]
 
-    def resolve_loggers(self, _graphene_info):
+    def resolve_loggers(self, _graphene_info: ResolveInfo):
         return [
             GrapheneLogger(self._config_schema_snapshot, logger_def_snap)
             for logger_def_snap in sorted(self._mode_def_snap.logger_def_snaps)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -50,7 +50,7 @@ from ..solids import (
     build_solids,
 )
 from ..tags import GraphenePipelineTag
-from ..util import get_compute_log_manager, non_null_list
+from ..util import ResolveInfo, get_compute_log_manager, non_null_list
 from .mode import GrapheneMode
 from .pipeline_ref import GraphenePipelineReference
 from .pipeline_run_stats import GrapheneRunStatsSnapshotOrError
@@ -155,7 +155,7 @@ class GrapheneAsset(graphene.ObjectType):
             )
         return get_unique_asset_id(self.key)
 
-    def resolve_assetMaterializations(self, graphene_info, **kwargs):
+    def resolve_assetMaterializations(self, graphene_info: ResolveInfo, **kwargs):
         from ...implementation.fetch_assets import get_asset_materializations
 
         before_timestamp, after_timestamp = parse_time_range_args(kwargs)
@@ -179,7 +179,7 @@ class GrapheneAsset(graphene.ObjectType):
         loader = BatchRunLoader(graphene_info.context.instance, run_ids) if run_ids else None
         return [GrapheneMaterializationEvent(event=event, loader=loader) for event in events]
 
-    def resolve_assetObservations(self, graphene_info, **kwargs):
+    def resolve_assetObservations(self, graphene_info: ResolveInfo, **kwargs):
         from ...implementation.fetch_assets import get_asset_observations
 
         before_timestamp, after_timestamp = parse_time_range_args(kwargs)
@@ -321,10 +321,10 @@ class GrapheneRun(graphene.ObjectType):
         self._run_record = record
         self._run_stats: Optional[PipelineRunStatsSnapshot] = None
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.run_id
 
-    def resolve_repositoryOrigin(self, _graphene_info):
+    def resolve_repositoryOrigin(self, _graphene_info: ResolveInfo):
         return (
             GrapheneRepositoryOrigin(
                 self._pipeline_run.external_pipeline_origin.external_repository_origin
@@ -333,28 +333,28 @@ class GrapheneRun(graphene.ObjectType):
             else None
         )
 
-    def resolve_pipeline(self, graphene_info):
+    def resolve_pipeline(self, graphene_info: ResolveInfo):
         return get_pipeline_reference_or_raise(graphene_info, self._pipeline_run)
 
-    def resolve_pipelineName(self, _graphene_info):
+    def resolve_pipelineName(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.pipeline_name
 
-    def resolve_jobName(self, _graphene_info):
+    def resolve_jobName(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.pipeline_name
 
-    def resolve_solidSelection(self, _graphene_info):
+    def resolve_solidSelection(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.solid_selection
 
-    def resolve_assetSelection(self, _graphene_info):
+    def resolve_assetSelection(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.asset_selection
 
-    def resolve_resolvedOpSelection(self, _graphene_info):
+    def resolve_resolvedOpSelection(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.solids_to_execute
 
-    def resolve_pipelineSnapshotId(self, _graphene_info):
+    def resolve_pipelineSnapshotId(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.pipeline_snapshot_id
 
-    def resolve_parentPipelineSnapshotId(self, graphene_info):
+    def resolve_parentPipelineSnapshotId(self, graphene_info: ResolveInfo):
         pipeline_snapshot_id = self._pipeline_run.pipeline_snapshot_id
         if (
             pipeline_snapshot_id is not None
@@ -365,24 +365,22 @@ class GrapheneRun(graphene.ObjectType):
                 return snapshot.lineage_snapshot.parent_snapshot_id
         return None
 
-    def resolve_stats(self, graphene_info):
+    def resolve_stats(self, graphene_info: ResolveInfo):
         return get_stats(graphene_info, self.run_id)
 
-    def resolve_stepStats(self, graphene_info):
+    def resolve_stepStats(self, graphene_info: ResolveInfo):
         return get_step_stats(graphene_info, self.run_id)
 
-    def resolve_computeLogs(self, _graphene_info, stepKey):
+    def resolve_computeLogs(self, _graphene_info: ResolveInfo, stepKey):
         return GrapheneComputeLogs(runId=self.run_id, stepKey=stepKey)
 
-    def resolve_capturedLogs(self, graphene_info, fileKey):
+    def resolve_capturedLogs(self, graphene_info: ResolveInfo, fileKey):
         compute_log_manager = get_compute_log_manager(graphene_info)
-        log_key = compute_log_manager.build_log_key_for_run(
-            self.run_id, fileKey  # type: ignore  # (value obj access)
-        )
+        log_key = compute_log_manager.build_log_key_for_run(self.run_id, fileKey)
         log_data = compute_log_manager.get_log_data(log_key)
         return from_captured_log_data(log_data)
 
-    def resolve_executionPlan(self, graphene_info):
+    def resolve_executionPlan(self, graphene_info: ResolveInfo):
         if not (
             self._pipeline_run.execution_plan_snapshot_id
             and self._pipeline_run.pipeline_snapshot_id
@@ -402,33 +400,33 @@ class GrapheneRun(graphene.ObjectType):
             else None
         )
 
-    def resolve_stepKeysToExecute(self, _graphene_info):
+    def resolve_stepKeysToExecute(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.step_keys_to_execute
 
-    def resolve_runConfigYaml(self, _graphene_info):
+    def resolve_runConfigYaml(self, _graphene_info: ResolveInfo):
         return dump_run_config_yaml(self._pipeline_run.run_config)
 
-    def resolve_runConfig(self, _graphene_info):
+    def resolve_runConfig(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.run_config
 
-    def resolve_tags(self, _graphene_info):
+    def resolve_tags(self, _graphene_info: ResolveInfo):
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in self._pipeline_run.tags.items()
             if get_tag_type(key) != TagType.HIDDEN
         ]
 
-    def resolve_rootRunId(self, _graphene_info):
+    def resolve_rootRunId(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.root_run_id
 
-    def resolve_parentRunId(self, _graphene_info):
+    def resolve_parentRunId(self, _graphene_info: ResolveInfo):
         return self._pipeline_run.parent_run_id
 
     @property
     def run_id(self):
         return self.runId
 
-    def resolve_canTerminate(self, _graphene_info):
+    def resolve_canTerminate(self, _graphene_info: ResolveInfo):
         # short circuit if the pipeline run is in a terminal state
         if self._pipeline_run.is_finished:
             return False
@@ -437,10 +435,10 @@ class GrapheneRun(graphene.ObjectType):
             or self._pipeline_run.status == DagsterRunStatus.STARTED
         )
 
-    def resolve_assets(self, graphene_info):
+    def resolve_assets(self, graphene_info: ResolveInfo):
         return get_assets_for_run_id(graphene_info, self.run_id)
 
-    def resolve_assetMaterializations(self, graphene_info):
+    def resolve_assetMaterializations(self, graphene_info: ResolveInfo):
         # convenience field added for users querying directly via GraphQL
         return [
             GrapheneMaterializationEvent(event=event)
@@ -449,7 +447,7 @@ class GrapheneRun(graphene.ObjectType):
             )
         ]
 
-    def resolve_eventConnection(self, graphene_info, afterCursor=None):
+    def resolve_eventConnection(self, graphene_info: ResolveInfo, afterCursor=None):
         conn = graphene_info.context.instance.get_records_for_run(self.run_id, cursor=afterCursor)
         return GrapheneEventConnection(
             events=[
@@ -465,7 +463,7 @@ class GrapheneRun(graphene.ObjectType):
             self._run_record = instance.get_run_records(RunsFilter(run_ids=[self.run_id]))[0]
         return self._run_record
 
-    def resolve_startTime(self, graphene_info):
+    def resolve_startTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
         # If a user has not migrated in 0.13.15, then run_record will not have start_time and end_time. So it will be necessary to fill this data using the run_stats. Since we potentially make this call multiple times, we cache the result.
         if run_record.start_time is None and self._pipeline_run.status in STARTED_STATUSES:
@@ -482,7 +480,7 @@ class GrapheneRun(graphene.ObjectType):
             return self._run_stats.start_time
         return run_record.start_time
 
-    def resolve_endTime(self, graphene_info):
+    def resolve_endTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
         if run_record.end_time is None and self._pipeline_run.status in COMPLETED_STATUSES:
             if self._run_stats is None or self._run_stats.end_time is None:
@@ -490,7 +488,7 @@ class GrapheneRun(graphene.ObjectType):
             return self._run_stats.end_time
         return run_record.end_time
 
-    def resolve_updateTime(self, graphene_info):
+    def resolve_updateTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
         return datetime_as_float(run_record.update_timestamp)
 
@@ -539,19 +537,19 @@ class GrapheneIPipelineSnapshotMixin:
     def get_represented_pipeline(self):
         raise NotImplementedError()
 
-    def resolve_pipeline_snapshot_id(self, _graphene_info):
+    def resolve_pipeline_snapshot_id(self, _graphene_info: ResolveInfo):
         return self.get_represented_pipeline().identifying_pipeline_snapshot_id
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         return self.get_represented_pipeline().identifying_pipeline_snapshot_id
 
-    def resolve_name(self, _graphene_info):
+    def resolve_name(self, _graphene_info: ResolveInfo):
         return self.get_represented_pipeline().name
 
-    def resolve_description(self, _graphene_info):
+    def resolve_description(self, _graphene_info: ResolveInfo):
         return self.get_represented_pipeline().description
 
-    def resolve_dagster_types(self, _graphene_info):
+    def resolve_dagster_types(self, _graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_pipeline()
         return sorted(
             list(
@@ -564,7 +562,7 @@ class GrapheneIPipelineSnapshotMixin:
         )
 
     @capture_error
-    def resolve_dagster_type_or_error(self, _graphene_info, **kwargs):
+    def resolve_dagster_type_or_error(self, _graphene_info: ResolveInfo, **kwargs):
         type_name = kwargs["dagsterTypeName"]
 
         represented_pipeline = self.get_represented_pipeline()
@@ -579,14 +577,14 @@ class GrapheneIPipelineSnapshotMixin:
             represented_pipeline.get_dagster_type_by_name(type_name).key,
         )
 
-    def resolve_solids(self, _graphene_info):
+    def resolve_solids(self, _graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_pipeline()
         return build_solids(
             represented_pipeline,
             represented_pipeline.dep_structure_index,
         )
 
-    def resolve_modes(self, _graphene_info):
+    def resolve_modes(self, _graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_pipeline()
         return [
             GrapheneMode(
@@ -599,10 +597,10 @@ class GrapheneIPipelineSnapshotMixin:
             )
         ]
 
-    def resolve_solid_handle(self, _graphene_info, handleID):
+    def resolve_solid_handle(self, _graphene_info: ResolveInfo, handleID):
         return build_solid_handles(self.get_represented_pipeline()).get(handleID)
 
-    def resolve_solid_handles(self, _graphene_info, **kwargs):
+    def resolve_solid_handles(self, _graphene_info: ResolveInfo, **kwargs):
         handles = build_solid_handles(self.get_represented_pipeline())
         parentHandleID = kwargs.get("parentHandleID")
 
@@ -617,21 +615,21 @@ class GrapheneIPipelineSnapshotMixin:
 
         return [handles[key] for key in sorted(handles)]
 
-    def resolve_tags(self, _graphene_info):
+    def resolve_tags(self, _graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_pipeline()
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in represented_pipeline.pipeline_snapshot.tags.items()
         ]
 
-    def resolve_metadata_entries(self, _graphene_info) -> List[GrapheneMetadataEntry]:
+    def resolve_metadata_entries(self, _graphene_info: ResolveInfo) -> List[GrapheneMetadataEntry]:
         represented_pipeline = self.get_represented_pipeline()
         return list(iterate_metadata_entries(represented_pipeline.pipeline_snapshot.metadata))
 
-    def resolve_solidSelection(self, _graphene_info):
+    def resolve_solidSelection(self, _graphene_info: ResolveInfo):
         return self.get_represented_pipeline().solid_selection
 
-    def resolve_runs(self, graphene_info, **kwargs):
+    def resolve_runs(self, graphene_info: ResolveInfo, **kwargs):
         pipeline = self.get_represented_pipeline()
         if isinstance(pipeline, ExternalPipeline):
             runs_filter = RunsFilter(
@@ -644,7 +642,7 @@ class GrapheneIPipelineSnapshotMixin:
             runs_filter = RunsFilter(pipeline_name=pipeline.name)
         return get_runs(graphene_info, runs_filter, kwargs.get("cursor"), kwargs.get("limit"))
 
-    def resolve_schedules(self, graphene_info):
+    def resolve_schedules(self, graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_pipeline()
         if not isinstance(represented_pipeline, ExternalPipeline):
             # this is an historical pipeline snapshot, so there are not any associated running
@@ -655,7 +653,7 @@ class GrapheneIPipelineSnapshotMixin:
         schedules = get_schedules_for_pipeline(graphene_info, pipeline_selector)
         return schedules
 
-    def resolve_sensors(self, graphene_info):
+    def resolve_sensors(self, graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_pipeline()
         if not isinstance(represented_pipeline, ExternalPipeline):
             # this is an historical pipeline snapshot, so there are not any associated running
@@ -666,14 +664,14 @@ class GrapheneIPipelineSnapshotMixin:
         sensors = get_sensors_for_pipeline(graphene_info, pipeline_selector)
         return sensors
 
-    def resolve_parent_snapshot_id(self, _graphene_info):
+    def resolve_parent_snapshot_id(self, _graphene_info: ResolveInfo):
         lineage_snapshot = self.get_represented_pipeline().pipeline_snapshot.lineage_snapshot
         if lineage_snapshot:
             return lineage_snapshot.parent_snapshot_id
         else:
             return None
 
-    def resolve_graph_name(self, _graphene_info):
+    def resolve_graph_name(self, _graphene_info: ResolveInfo):
         return self.get_represented_pipeline().get_graph_name()
 
 
@@ -728,19 +726,19 @@ class GraphenePipelinePreset(graphene.ObjectType):
         )
         self._pipeline_name = check.str_param(pipeline_name, "pipeline_name")
 
-    def resolve_name(self, _graphene_info):
+    def resolve_name(self, _graphene_info: ResolveInfo):
         return self._active_preset_data.name
 
-    def resolve_solidSelection(self, _graphene_info):
+    def resolve_solidSelection(self, _graphene_info: ResolveInfo):
         return self._active_preset_data.solid_selection
 
-    def resolve_runConfigYaml(self, _graphene_info):
+    def resolve_runConfigYaml(self, _graphene_info: ResolveInfo):
         return dump_run_config_yaml(self._active_preset_data.run_config) or ""
 
-    def resolve_mode(self, _graphene_info):
+    def resolve_mode(self, _graphene_info: ResolveInfo):
         return self._active_preset_data.mode
 
-    def resolve_tags(self, _graphene_info):
+    def resolve_tags(self, _graphene_info: ResolveInfo):
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in self._active_preset_data.tags.items()
@@ -770,28 +768,28 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
             batch_loader, "batch_loader", RepositoryScopedBatchLoader
         )
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         return self._external_pipeline.get_external_origin_id()
 
     def get_represented_pipeline(self):
         return self._external_pipeline
 
-    def resolve_presets(self, _graphene_info):
+    def resolve_presets(self, _graphene_info: ResolveInfo):
         return [
             GraphenePipelinePreset(preset, self._external_pipeline.name)
             for preset in sorted(self._external_pipeline.active_presets, key=lambda item: item.name)
         ]
 
-    def resolve_isJob(self, _graphene_info):
+    def resolve_isJob(self, _graphene_info: ResolveInfo):
         return self._external_pipeline.is_job
 
-    def resolve_isAssetJob(self, graphene_info):
+    def resolve_isAssetJob(self, graphene_info: ResolveInfo):
         handle = self._external_pipeline.repository_handle
         location = graphene_info.context.get_repository_location(handle.location_name)
         repository = location.get_repository(handle.repository_name)
         return bool(repository.get_external_asset_nodes(self._external_pipeline.name))
 
-    def resolve_repository(self, graphene_info):
+    def resolve_repository(self, graphene_info: ResolveInfo):
         from ..external import GrapheneRepository
 
         handle = self._external_pipeline.repository_handle
@@ -802,7 +800,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
             location,
         )
 
-    def resolve_runs(self, graphene_info, **kwargs):
+    def resolve_runs(self, graphene_info: ResolveInfo, **kwargs):
         # override the implementation to use the batch run loader
         if not kwargs.get("cursor") and kwargs.get("limit") and self._batch_loader:
             records = self._batch_loader.get_run_records_for_job(
@@ -856,23 +854,23 @@ class GrapheneGraph(graphene.ObjectType):
         self._solid_handle_id = check.opt_str_param(solid_handle_id, "solid_handle_id")
         super().__init__()
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         if self._solid_handle_id:
             return (
                 f"{self._external_pipeline.get_external_origin_id()}:solid:{self._solid_handle_id}"
             )
         return f"graph:{self._external_pipeline.get_external_origin_id()}"
 
-    def resolve_name(self, _graphene_info):
+    def resolve_name(self, _graphene_info: ResolveInfo):
         return self._external_pipeline.get_graph_name()
 
-    def resolve_description(self, _graphene_info):
+    def resolve_description(self, _graphene_info: ResolveInfo):
         return self._external_pipeline.description
 
-    def resolve_solid_handle(self, _graphene_info, handleID):
+    def resolve_solid_handle(self, _graphene_info: ResolveInfo, handleID):
         return build_solid_handles(self._external_pipeline).get(handleID)
 
-    def resolve_solid_handles(self, _graphene_info, **kwargs):
+    def resolve_solid_handles(self, _graphene_info: ResolveInfo, **kwargs):
         handles = build_solid_handles(self._external_pipeline)
         parentHandleID = kwargs.get("parentHandleID")
 
@@ -887,7 +885,7 @@ class GrapheneGraph(graphene.ObjectType):
 
         return [handles[key] for key in sorted(handles)]
 
-    def resolve_modes(self, _graphene_info):
+    def resolve_modes(self, _graphene_info: ResolveInfo):
         # returns empty list... graphs don't have modes, this is a vestige of the old
         # pipeline explorer, which expected all solid containers to be pipelines
         return []

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -2,6 +2,8 @@ import dagster._check as check
 import graphene
 from dagster._core.snap import ConfigSchemaSnapshot, ResourceDefSnap
 
+from dagster_graphql.schema.util import ResolveInfo
+
 from ..config_types import GrapheneConfigTypeField
 
 
@@ -24,7 +26,7 @@ class GrapheneResource(graphene.ObjectType):
         self.name = resource_def_snap.name
         self.description = resource_def_snap.description
 
-    def resolve_configField(self, _graphene_info):
+    def resolve_configField(self, _graphene_info: ResolveInfo):
         if (
             self._resource_def_snap.config_field_snap
             # config type may not be present if mode config mapped

--- a/python_modules/dagster-graphql/dagster_graphql/schema/repository_origin.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/repository_origin.py
@@ -2,7 +2,7 @@ import dagster._check as check
 import graphene
 from dagster._core.host_representation import ExternalRepositoryOrigin
 
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneRepositoryMetadata(graphene.ObjectType):
@@ -26,16 +26,16 @@ class GrapheneRepositoryOrigin(graphene.ObjectType):
         super().__init__()
         self._origin = check.inst_param(origin, "origin", ExternalRepositoryOrigin)
 
-    def resolve_id(self, _graphene_info):
+    def resolve_id(self, _graphene_info: ResolveInfo):
         return self._origin.get_id()
 
-    def resolve_repository_location_name(self, _graphene_info):
+    def resolve_repository_location_name(self, _graphene_info: ResolveInfo):
         return self._origin.repository_location_origin.location_name
 
-    def resolve_repository_name(self, _graphene_info):
+    def resolve_repository_name(self, _graphene_info: ResolveInfo):
         return self._origin.repository_name
 
-    def resolve_repository_location_metadata(self, _graphene_info):
+    def resolve_repository_location_metadata(self, _graphene_info: ResolveInfo):
         metadata = self._origin.repository_location_origin.get_display_metadata()
         return [
             GrapheneRepositoryMetadata(key=key, value=value)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -67,7 +67,7 @@ from ..sensors import (
     GrapheneStartSensorMutation,
     GrapheneStopSensorMutation,
 )
-from ..util import non_null_list
+from ..util import ResolveInfo, non_null_list
 
 
 def create_execution_params(graphene_info, graphql_execution_params):
@@ -178,7 +178,7 @@ class GrapheneDeleteRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.DELETE_PIPELINE_RUN)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         run_id = kwargs["runId"]
         return delete_pipeline_run(graphene_info, run_id)
 
@@ -265,7 +265,7 @@ class GrapheneLaunchRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PIPELINE_EXECUTION)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         return create_execution_params_and_launch_pipeline_exec(
             graphene_info, kwargs["executionParams"]
         )
@@ -284,7 +284,7 @@ class GrapheneLaunchBackfillMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         return create_and_launch_partition_backfill(graphene_info, kwargs["backfillParams"])
 
 
@@ -301,7 +301,7 @@ class GrapheneCancelBackfillMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.CANCEL_PARTITION_BACKFILL)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         return cancel_partition_backfill(graphene_info, kwargs["backfillId"])
 
 
@@ -318,7 +318,7 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         return resume_partition_backfill(graphene_info, kwargs["backfillId"])
 
 
@@ -349,7 +349,7 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PIPELINE_REEXECUTION)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         execution_params = kwargs.get("executionParams")
         reexecution_params = kwargs.get("reexecutionParams")
         check.invariant(
@@ -401,7 +401,7 @@ class GrapheneTerminateRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.TERMINATE_PIPELINE_EXECUTION)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         return terminate_pipeline_execution(
             graphene_info,
             kwargs["runId"],
@@ -458,7 +458,7 @@ class GrapheneReloadRepositoryLocationMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.RELOAD_REPOSITORY_LOCATION)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         location_name = kwargs["repositoryLocationName"]
         assert_permission_for_location(
             graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, location_name
@@ -494,7 +494,7 @@ class GrapheneShutdownRepositoryLocationMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.RELOAD_REPOSITORY_LOCATION)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         location_name = kwargs["repositoryLocationName"]
         assert_permission_for_location(
             graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, location_name
@@ -531,7 +531,7 @@ class GrapheneReloadWorkspaceMutation(graphene.Mutation):
 
     @capture_error
     @check_permission(Permissions.RELOAD_WORKSPACE)
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         new_context = graphene_info.context.reload_workspace()
         return fetch_workspace(new_context)
 
@@ -571,7 +571,7 @@ class GrapheneAssetWipeMutation(graphene.Mutation):
 
     @capture_error
     @check_permission(Permissions.WIPE_ASSETS)
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         return wipe_assets(
             graphene_info,
             [AssetKey.from_graphql_input(asset_key) for asset_key in kwargs["assetKeys"]],
@@ -613,7 +613,7 @@ class GrapheneLogTelemetryMutation(graphene.Mutation):
         name = "LogTelemetryMutation"
 
     @capture_error
-    def mutate(self, graphene_info, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **kwargs):
         action = log_dagit_telemetry_event(
             graphene_info,
             action=kwargs["action"],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -121,7 +121,7 @@ from ..runs import (
 from ..schedules import GrapheneScheduleOrError, GrapheneSchedulerOrError, GrapheneSchedulesOrError
 from ..sensors import GrapheneSensorOrError, GrapheneSensorsOrError
 from ..tags import GraphenePipelineTagAndValues
-from ..util import HasContext, non_null_list
+from ..util import ResolveInfo, get_compute_log_manager, non_null_list
 from .assets import GrapheneAssetOrError, GrapheneAssetsOrError
 from .execution_plan import GrapheneExecutionPlanOrError
 from .pipeline import GrapheneGraphOrError, GraphenePipelineOrError
@@ -415,7 +415,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         description="Whether or not the NUX should be shown to the user",
     )
 
-    def resolve_repositoriesOrError(self, graphene_info, **kwargs):
+    def resolve_repositoriesOrError(self, graphene_info: ResolveInfo, **kwargs):
         if kwargs.get("repositorySelector"):
             return GrapheneRepositoryConnection(
                 nodes=[
@@ -427,19 +427,19 @@ class GrapheneDagitQuery(graphene.ObjectType):
             )
         return fetch_repositories(graphene_info)
 
-    def resolve_repositoryOrError(self, graphene_info, **kwargs):
+    def resolve_repositoryOrError(self, graphene_info: ResolveInfo, **kwargs):
         return fetch_repository(
             graphene_info,
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
         )
 
-    def resolve_workspaceOrError(self, graphene_info):
+    def resolve_workspaceOrError(self, graphene_info: ResolveInfo):
         return fetch_workspace(graphene_info.context)
 
-    def resolve_locationStatusesOrError(self, graphene_info):
+    def resolve_locationStatusesOrError(self, graphene_info: ResolveInfo):
         return fetch_location_statuses(graphene_info.context)
 
-    def resolve_pipelineSnapshotOrError(self, graphene_info, **kwargs):
+    def resolve_pipelineSnapshotOrError(self, graphene_info: ResolveInfo, **kwargs):
         snapshot_id_arg = kwargs.get("snapshotId")
         pipeline_selector_arg = kwargs.get("activePipelineSelector")
         check.invariant(
@@ -459,28 +459,28 @@ class GrapheneDagitQuery(graphene.ObjectType):
         else:
             return get_pipeline_snapshot_or_error_from_snapshot_id(graphene_info, snapshot_id_arg)
 
-    def resolve_graphOrError(self, graphene_info, **kwargs):
+    def resolve_graphOrError(self, graphene_info: ResolveInfo, **kwargs):
         graph_selector = graph_selector_from_graphql(kwargs["selector"])
         return get_graph_or_error(graphene_info, graph_selector)
 
-    def resolve_version(self, graphene_info):
+    def resolve_version(self, graphene_info: ResolveInfo):
         return graphene_info.context.version
 
-    def resolve_scheduler(self, graphene_info):
+    def resolve_scheduler(self, graphene_info: ResolveInfo):
         return get_scheduler_or_error(graphene_info)
 
-    def resolve_scheduleOrError(self, graphene_info, schedule_selector):
+    def resolve_scheduleOrError(self, graphene_info: ResolveInfo, schedule_selector):
         return get_schedule_or_error(
             graphene_info, ScheduleSelector.from_graphql_input(schedule_selector)
         )
 
-    def resolve_schedulesOrError(self, graphene_info, **kwargs):
+    def resolve_schedulesOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_schedules_or_error(
             graphene_info,
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
         )
 
-    def resolve_sensorOrError(self, graphene_info, sensorSelector):
+    def resolve_sensorOrError(self, graphene_info: ResolveInfo, sensorSelector):
         return get_sensor_or_error(graphene_info, SensorSelector.from_graphql_input(sensorSelector))
 
     def resolve_sensorsOrError(self, graphene_info, **kwargs):
@@ -489,24 +489,24 @@ class GrapheneDagitQuery(graphene.ObjectType):
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
         )
 
-    def resolve_instigationStateOrError(self, graphene_info, instigationSelector):
+    def resolve_instigationStateOrError(self, graphene_info: ResolveInfo, instigationSelector):
         return get_instigator_state_or_error(
             graphene_info, InstigatorSelector.from_graphql_input(instigationSelector)
         )
 
-    def resolve_unloadableInstigationStatesOrError(self, graphene_info, **kwargs):
+    def resolve_unloadableInstigationStatesOrError(self, graphene_info: ResolveInfo, **kwargs):
         instigation_type = (
             InstigatorType(kwargs["instigationType"]) if "instigationType" in kwargs else None
         )
         return get_unloadable_instigator_states_or_error(graphene_info, instigation_type)
 
-    def resolve_pipelineOrError(self, graphene_info, **kwargs):
+    def resolve_pipelineOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_pipeline_or_error(
             graphene_info,
             pipeline_selector_from_graphql(kwargs["params"]),
         )
 
-    def resolve_pipelineRunsOrError(self, _graphene_info, **kwargs):
+    def resolve_pipelineRunsOrError(self, _graphene_info: ResolveInfo, **kwargs):
         filters = kwargs.get("filter")
         if filters is not None:
             filters = filters.to_selector()
@@ -517,10 +517,10 @@ class GrapheneDagitQuery(graphene.ObjectType):
             limit=kwargs.get("limit"),
         )
 
-    def resolve_pipelineRunOrError(self, graphene_info, runId):
+    def resolve_pipelineRunOrError(self, graphene_info: ResolveInfo, runId):
         return get_run_by_id(graphene_info, runId)
 
-    def resolve_runsOrError(self, _graphene_info, **kwargs):
+    def resolve_runsOrError(self, _graphene_info: ResolveInfo, **kwargs):
         filters = kwargs.get("filter")
         if filters is not None:
             filters = filters.to_selector()
@@ -531,10 +531,10 @@ class GrapheneDagitQuery(graphene.ObjectType):
             limit=kwargs.get("limit"),
         )
 
-    def resolve_runOrError(self, graphene_info, runId):
+    def resolve_runOrError(self, graphene_info: ResolveInfo, runId):
         return get_run_by_id(graphene_info, runId)
 
-    def resolve_runGroupsOrError(self, graphene_info, **kwargs):
+    def resolve_runGroupsOrError(self, graphene_info: ResolveInfo, **kwargs):
         filters = kwargs.get("filter")
         if filters is not None:
             filters = filters.to_selector()
@@ -545,27 +545,27 @@ class GrapheneDagitQuery(graphene.ObjectType):
             )
         )
 
-    def resolve_partitionSetsOrError(self, graphene_info, **kwargs):
+    def resolve_partitionSetsOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_partition_sets_or_error(
             graphene_info,
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
             kwargs["pipelineName"],
         )
 
-    def resolve_partitionSetOrError(self, graphene_info, **kwargs):
+    def resolve_partitionSetOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_partition_set(
             graphene_info,
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
             kwargs.get("partitionSetName"),  # type: ignore  # (partitionSetName should prob be required)
         )
 
-    def resolve_pipelineRunTags(self, graphene_info):
+    def resolve_pipelineRunTags(self, graphene_info: ResolveInfo):
         return get_run_tags(graphene_info)
 
-    def resolve_runGroupOrError(self, graphene_info, runId):
+    def resolve_runGroupOrError(self, graphene_info: ResolveInfo, runId):
         return get_run_group(graphene_info, runId)
 
-    def resolve_isPipelineConfigValid(self, graphene_info, pipeline, **kwargs):
+    def resolve_isPipelineConfigValid(self, graphene_info: ResolveInfo, pipeline, **kwargs):
         return validate_pipeline_config(
             graphene_info,
             pipeline_selector_from_graphql(pipeline),
@@ -573,7 +573,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             kwargs.get("mode"),
         )
 
-    def resolve_executionPlanOrError(self, graphene_info, pipeline, **kwargs):
+    def resolve_executionPlanOrError(self, graphene_info: ResolveInfo, pipeline, **kwargs):
         return get_execution_plan(
             graphene_info,
             pipeline_selector_from_graphql(pipeline),
@@ -581,17 +581,17 @@ class GrapheneDagitQuery(graphene.ObjectType):
             kwargs.get("mode"),
         )
 
-    def resolve_runConfigSchemaOrError(self, graphene_info, **kwargs):
+    def resolve_runConfigSchemaOrError(self, graphene_info: ResolveInfo, **kwargs):
         return resolve_run_config_schema_or_error(
             graphene_info,
             pipeline_selector_from_graphql(kwargs["selector"]),
             kwargs.get("mode"),
         )
 
-    def resolve_instance(self, graphene_info):
+    def resolve_instance(self, graphene_info: ResolveInfo):
         return GrapheneInstance(graphene_info.context.instance)
 
-    def resolve_assetNodes(self, graphene_info, **kwargs):
+    def resolve_assetNodes(self, graphene_info: ResolveInfo, **kwargs):
         asset_keys = set(
             AssetKey.from_graphql_input(asset_key) for asset_key in kwargs.get("assetKeys", [])
         )
@@ -663,11 +663,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
             for node in results
         ]
 
-    def resolve_assetNodeOrError(self, graphene_info, **kwargs):
+    def resolve_assetNodeOrError(self, graphene_info: ResolveInfo, **kwargs):
         asset_key_input = cast(Mapping[str, Sequence[str]], kwargs.get("assetKey"))
         return get_asset_node(graphene_info, AssetKey.from_graphql_input(asset_key_input))
 
-    def resolve_assetsOrError(self, graphene_info, **kwargs):
+    def resolve_assetsOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_assets(
             graphene_info,
             prefix=kwargs.get("prefix"),
@@ -675,18 +675,18 @@ class GrapheneDagitQuery(graphene.ObjectType):
             limit=kwargs.get("limit"),
         )
 
-    def resolve_assetOrError(self, graphene_info, **kwargs):
+    def resolve_assetOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_asset(graphene_info, AssetKey.from_graphql_input(kwargs["assetKey"]))
 
-    def resolve_assetNodeDefinitionCollisions(self, graphene_info, **kwargs):
+    def resolve_assetNodeDefinitionCollisions(self, graphene_info: ResolveInfo, **kwargs):
         raw_asset_keys = cast(Sequence[Mapping[str, Sequence[str]]], kwargs.get("assetKeys"))
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in raw_asset_keys)
         return get_asset_node_definition_collisions(graphene_info, asset_keys)
 
-    def resolve_partitionBackfillOrError(self, graphene_info, backfillId):
+    def resolve_partitionBackfillOrError(self, graphene_info: ResolveInfo, backfillId):
         return get_backfill(graphene_info, backfillId)
 
-    def resolve_partitionBackfillsOrError(self, graphene_info, **kwargs):
+    def resolve_partitionBackfillsOrError(self, graphene_info: ResolveInfo, **kwargs):
         status = kwargs.get("status")
         return get_backfills(
             graphene_info,
@@ -695,11 +695,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
             limit=kwargs.get("limit"),
         )
 
-    def resolve_permissions(self, graphene_info):
+    def resolve_permissions(self, graphene_info: ResolveInfo):
         permissions = graphene_info.context.permissions
         return [GraphenePermission(permission, value) for permission, value in permissions.items()]
 
-    def resolve_assetsLatestInfo(self, graphene_info: HasContext, **kwargs: Any):
+    def resolve_assetsLatestInfo(self, graphene_info: ResolveInfo, **kwargs: Any):
         raw_asset_keys = cast(Sequence[Mapping[str, Sequence[str]]], kwargs["assetKeys"])
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in raw_asset_keys)
 
@@ -715,18 +715,17 @@ class GrapheneDagitQuery(graphene.ObjectType):
 
         return get_assets_latest_info(graphene_info, step_keys_by_asset)
 
-    def resolve_logsForRun(self, graphene_info, runId, afterCursor=None, limit=None):
+    def resolve_logsForRun(self, graphene_info: ResolveInfo, runId, afterCursor=None, limit=None):
         return get_logs_for_run(graphene_info, runId, afterCursor, limit)
 
     def resolve_capturedLogsMetadata(
-        self, graphene_info, logKey: Sequence[str]
+        self, graphene_info: ResolveInfo, logKey: Sequence[str]
     ) -> GrapheneCapturedLogsMetadata:
         return get_captured_log_metadata(graphene_info, logKey)
 
-    def resolve_capturedLogs(self, graphene_info, logKey, cursor=None, limit=None):
-        log_data = graphene_info.context.instance.compute_log_manager.get_log_data(
-            logKey, cursor=cursor, max_bytes=limit
-        )
+    def resolve_capturedLogs(self, graphene_info: ResolveInfo, logKey, cursor=None, limit=None):
+        compute_log_manager = get_compute_log_manager(graphene_info)
+        log_data = compute_log_manager.get_log_data(logKey, cursor=cursor, max_bytes=limit)
         return from_captured_log_data(log_data)
 
     def resolve_shouldShowNux(self, graphene_info):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/subscription.py
@@ -5,7 +5,7 @@ from ...implementation.execution import gen_captured_log_data, gen_compute_logs,
 from ..external import GrapheneLocationStateChangeSubscription, gen_location_state_changes
 from ..logs.compute_logs import GrapheneCapturedLogs, GrapheneComputeIOType, GrapheneComputeLogFile
 from ..pipelines.subscription import GraphenePipelineRunLogsSubscriptionPayload
-from ..util import non_null_list
+from ..util import ResolveInfo, non_null_list
 
 
 class GrapheneDagitSubscription(graphene.ObjectType):
@@ -53,14 +53,16 @@ class GrapheneDagitSubscription(graphene.ObjectType):
         ),
     )
 
-    def subscribe_pipelineRunLogs(self, graphene_info, runId, cursor=None):
+    def subscribe_pipelineRunLogs(self, graphene_info: ResolveInfo, runId, cursor=None):
         return gen_events_for_run(graphene_info, runId, cursor)
 
-    def subscribe_computeLogs(self, graphene_info, runId, stepKey, ioType, cursor=None):
+    def subscribe_computeLogs(
+        self, graphene_info: ResolveInfo, runId, stepKey, ioType, cursor=None
+    ):
         return gen_compute_logs(graphene_info, runId, stepKey, ComputeIOType(ioType.value), cursor)
 
-    def subscribe_capturedLogs(self, graphene_info, logKey, cursor=None):
+    def subscribe_capturedLogs(self, graphene_info: ResolveInfo, logKey, cursor=None):
         return gen_captured_log_data(graphene_info, logKey, cursor)
 
-    def subscribe_locationStateChangeEvents(self, graphene_info):
+    def subscribe_locationStateChangeEvents(self, graphene_info: ResolveInfo):
         return gen_location_state_changes(graphene_info)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -12,7 +12,7 @@ from .errors import (
 )
 from .pipelines.config_result import GraphenePipelineConfigValidationResult
 from .runs import GrapheneRunConfigData, parse_run_config_input
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneRunConfigSchema(graphene.ObjectType):
@@ -55,7 +55,7 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
         )
         self._mode = check.str_param(mode, "mode")
 
-    def resolve_allConfigTypes(self, _graphene_info):
+    def resolve_allConfigTypes(self, _graphene_info: ResolveInfo):
         return sorted(
             list(
                 map(
@@ -68,13 +68,13 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
             key=lambda ct: ct.key,
         )
 
-    def resolve_rootConfigType(self, _graphene_info):
+    def resolve_rootConfigType(self, _graphene_info: ResolveInfo):
         return to_config_type(
             self._represented_pipeline.config_schema_snapshot,
             self._represented_pipeline.get_mode_def_snap(self._mode).root_config_key,
         )
 
-    def resolve_isRunConfigValid(self, graphene_info, **kwargs):
+    def resolve_isRunConfigValid(self, graphene_info: ResolveInfo, **kwargs):
         return resolve_is_run_config_valid(
             graphene_info,
             self._represented_pipeline,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -15,7 +15,7 @@ from .errors import (
     GraphenePythonError,
     GrapheneRunGroupNotFoundError,
 )
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneStepEventStatus(graphene.Enum):
@@ -110,10 +110,10 @@ class GrapheneRuns(graphene.ObjectType):
         self._cursor = cursor
         self._limit = limit
 
-    def resolve_results(self, graphene_info):
+    def resolve_results(self, graphene_info: ResolveInfo):
         return get_runs(graphene_info, self._filters, self._cursor, self._limit)
 
-    def resolve_count(self, graphene_info):
+    def resolve_count(self, graphene_info: ResolveInfo):
         return get_runs_count(graphene_info, self._filters)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -2,6 +2,8 @@ import graphene
 from dagster._core.host_representation import ScheduleSelector
 from dagster._core.workspace.permissions import Permissions
 
+from dagster_graphql.schema.util import ResolveInfo
+
 from ...implementation.fetch_schedules import start_schedule, stop_schedule
 from ...implementation.utils import (
     assert_permission_for_location,
@@ -72,7 +74,7 @@ class GrapheneStartScheduleMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.START_SCHEDULE)
-    def mutate(self, graphene_info, schedule_selector):
+    def mutate(self, graphene_info: ResolveInfo, schedule_selector):
         selector = ScheduleSelector.from_graphql_input(schedule_selector)
         assert_permission_for_location(
             graphene_info, Permissions.START_SCHEDULE, selector.location_name
@@ -94,7 +96,7 @@ class GrapheneStopRunningScheduleMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.STOP_RUNNING_SCHEDULE)
-    def mutate(self, graphene_info, schedule_origin_id, schedule_selector_id):
+    def mutate(self, graphene_info: ResolveInfo, schedule_origin_id, schedule_selector_id):
         return stop_schedule(graphene_info, schedule_origin_id, schedule_selector_id)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -15,7 +15,7 @@ from ..instigation import (
     GrapheneFutureInstigationTicks,
     GrapheneInstigationState,
 )
-from ..util import non_null_list
+from ..util import ResolveInfo, non_null_list
 
 
 class GrapheneSchedule(graphene.ObjectType):
@@ -74,11 +74,11 @@ class GrapheneSchedule(graphene.ObjectType):
     def resolve_id(self, _graphene_info):
         return self._external_schedule.get_external_origin_id()
 
-    def resolve_scheduleState(self, _graphene_info):
+    def resolve_scheduleState(self, _graphene_info: ResolveInfo):
         # forward the batch run loader to the instigation state, which provides the schedule runs
         return GrapheneInstigationState(self._schedule_state, self._batch_loader)
 
-    def resolve_partition_set(self, graphene_info):
+    def resolve_partition_set(self, graphene_info: ResolveInfo):
         from ..partition_sets import GraphenePartitionSet
 
         if self._external_schedule.partition_set_name is None:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -26,7 +26,7 @@ from .errors import (
 )
 from .inputs import GrapheneSensorSelector
 from .instigation import GrapheneFutureInstigationTick, GrapheneInstigationState
-from .util import non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class GrapheneTarget(graphene.ObjectType):
@@ -93,11 +93,11 @@ class GrapheneSensor(graphene.ObjectType):
     def resolve_id(self, _):
         return self._external_sensor.get_external_origin_id()
 
-    def resolve_sensorState(self, _graphene_info):
+    def resolve_sensorState(self, _graphene_info: ResolveInfo):
         # forward the batch run loader to the instigation state, which provides the sensor runs
         return GrapheneInstigationState(self._sensor_state, self._batch_loader)
 
-    def resolve_nextTick(self, graphene_info):
+    def resolve_nextTick(self, graphene_info: ResolveInfo):
         return get_sensor_next_tick(graphene_info, self._sensor_state)
 
 
@@ -138,7 +138,7 @@ class GrapheneStartSensorMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.EDIT_SENSOR)
-    def mutate(self, graphene_info, sensor_selector):
+    def mutate(self, graphene_info: ResolveInfo, sensor_selector):
         selector = SensorSelector.from_graphql_input(sensor_selector)
         assert_permission_for_location(
             graphene_info, Permissions.EDIT_SENSOR, selector.location_name
@@ -158,7 +158,7 @@ class GrapheneStopSensorMutationResult(graphene.ObjectType):
             instigator_state, "instigator_state", InstigatorState
         )
 
-    def resolve_instigationState(self, _graphene_info):
+    def resolve_instigationState(self, _graphene_info: ResolveInfo):
         return GrapheneInstigationState(instigator_state=self._instigator_state)
 
 
@@ -182,7 +182,7 @@ class GrapheneStopSensorMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.EDIT_SENSOR)
-    def mutate(self, graphene_info, job_origin_id, job_selector_id):
+    def mutate(self, graphene_info: ResolveInfo, job_origin_id, job_selector_id):
         return stop_sensor(graphene_info, job_origin_id, job_selector_id)
 
 
@@ -199,7 +199,7 @@ class GrapheneSetSensorCursorMutation(graphene.Mutation):
         name = "SetSensorCursorMutation"
 
     @capture_error
-    def mutate(self, graphene_info, sensor_selector, cursor=None):
+    def mutate(self, graphene_info: ResolveInfo, sensor_selector, cursor=None):
         selector = SensorSelector.from_graphql_input(sensor_selector)
         assert_permission_for_location(
             graphene_info, Permissions.EDIT_SENSOR, selector.location_name

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -18,7 +18,7 @@ from .config_types import GrapheneConfigTypeField
 from .dagster_types import GrapheneDagsterType, to_dagster_type
 from .errors import GrapheneError
 from .metadata import GrapheneMetadataItemDefinition
-from .util import HasContext, non_null_list
+from .util import ResolveInfo, non_null_list
 
 
 class _ArgNotPresentSentinel:
@@ -56,7 +56,7 @@ class GrapheneInputDefinition(graphene.ObjectType):
         )
 
     def resolve_solid_definition(
-        self, _graphene_info: HasContext
+        self, _graphene_info: ResolveInfo
     ) -> Union["GrapheneSolidDefinition", "GrapheneCompositeSolidDefinition"]:
         return build_solid_definition(
             self._represented_pipeline, self._solid_def_snap.name  # pylint: disable=no-member
@@ -144,19 +144,19 @@ class GrapheneInput(graphene.ObjectType):
 
         super().__init__()
 
-    def resolve_solid(self, _graphene_info: HasContext) -> "GrapheneSolid":
+    def resolve_solid(self, _graphene_info: ResolveInfo) -> "GrapheneSolid":
         return GrapheneSolid(
             self._represented_pipeline, self._solid_name, self._current_dep_structure
         )
 
-    def resolve_definition(self, _graphene_info: HasContext) -> GrapheneInputDefinition:
+    def resolve_definition(self, _graphene_info: ResolveInfo) -> GrapheneInputDefinition:
         return GrapheneInputDefinition(
             self._represented_pipeline,
             self._solid_def_snap.name,
             self._input_def_snap.name,
         )
 
-    def resolve_depends_on(self, _graphene_info: HasContext) -> Sequence["GrapheneOutput"]:
+    def resolve_depends_on(self, _graphene_info: ResolveInfo) -> Sequence["GrapheneOutput"]:
         return [
             GrapheneOutput(
                 self._represented_pipeline,
@@ -202,7 +202,7 @@ class GrapheneOutput(graphene.ObjectType):
             self._represented_pipeline, self._solid_name, self._current_dep_structure
         )
 
-    def resolve_definition(self, _graphene_info: HasContext) -> GrapheneOutputDefinition:
+    def resolve_definition(self, _graphene_info: ResolveInfo) -> GrapheneOutputDefinition:
         return GrapheneOutputDefinition(
             self._represented_pipeline,
             self._solid_def_snap.name,
@@ -210,7 +210,7 @@ class GrapheneOutput(graphene.ObjectType):
             self._output_def_snap.is_dynamic,
         )
 
-    def resolve_depended_by(self, _graphene_info: HasContext) -> Sequence[GrapheneInput]:
+    def resolve_depended_by(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneInput]:
         return [
             GrapheneInput(
                 self._represented_pipeline,
@@ -544,11 +544,11 @@ class GrapheneSolid(graphene.ObjectType):
         return self._represented_pipeline.name
 
     def resolve_definition(
-        self, _graphene_info: HasContext
+        self, _graphene_info: ResolveInfo
     ) -> Union[GrapheneSolidDefinition, "GrapheneCompositeSolidDefinition"]:
         return self.get_solid_definition()
 
-    def resolve_inputs(self, _graphene_info: HasContext) -> Sequence[GrapheneInput]:
+    def resolve_inputs(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneInput]:
         return [
             GrapheneInput(
                 self._represented_pipeline,
@@ -559,7 +559,7 @@ class GrapheneSolid(graphene.ObjectType):
             for input_def_snap in self._solid_def_snap.input_def_snaps
         ]
 
-    def resolve_outputs(self, _graphene_info: HasContext) -> Sequence[GrapheneOutput]:
+    def resolve_outputs(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneOutput]:
         return [
             GrapheneOutput(
                 self._represented_pipeline,
@@ -570,7 +570,7 @@ class GrapheneSolid(graphene.ObjectType):
             for output_def_snap in self._solid_def_snap.output_def_snaps
         ]
 
-    def resolve_is_dynamic_mapped(self, _graphene_info: HasContext) -> bool:
+    def resolve_is_dynamic_mapped(self, _graphene_info: ResolveInfo) -> bool:
         return self._solid_invocation_snap.is_dynamic_mapped
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/util.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/util.py
@@ -3,14 +3,12 @@ from typing import cast
 import graphene
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.workspace.context import WorkspaceRequestContext
-from typing_extensions import Protocol
 
 
-# Assign this type to `graphene_info` in a resolver to apply typing to `graphene_info.context`.
-class HasContext(Protocol):
+class ResolveInfo(graphene.ResolveInfo):
     @property
     def context(self) -> WorkspaceRequestContext:
-        ...
+        return cast(WorkspaceRequestContext, super().context)
 
 
 def non_null_list(of_type):
@@ -21,5 +19,5 @@ def non_null_list(of_type):
 # always also an instance of `CapturedLogManager`, which defines the APIs that we access in
 # dagster-graphql. Probably `ComputeLogManager` should subclass `CapturedLogManager`-- this is a
 # temporary workaround to satisfy type-checking.
-def get_compute_log_manager(graphene_info: HasContext) -> CapturedLogManager:
+def get_compute_log_manager(graphene_info: ResolveInfo) -> CapturedLogManager:
     return cast(CapturedLogManager, graphene_info.context.instance.compute_log_manager)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_permissions.py
@@ -15,6 +15,7 @@ from dagster_graphql.implementation.utils import (
     check_permission,
     require_permission_check,
 )
+from dagster_graphql.schema.util import ResolveInfo
 from dagster_graphql.test.utils import execute_dagster_graphql
 
 from .graphql_context_test_suite import NonLaunchableGraphQLContextTestMatrix
@@ -48,37 +49,37 @@ WORKSPACE_PERMISSIONS_QUERY = """
 
 class FakeMutation:
     @check_permission("fake_permission")
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         pass
 
 
 class FakeOtherPermissionMutation:
     @check_permission("fake_other_permission")
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         pass
 
 
 class FakeMissingPermissionMutation:
     @check_permission("fake_missing_permission")
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         pass
 
 
 class FakeEnumPermissionMutation:
     @check_permission(Permissions.LAUNCH_PIPELINE_EXECUTION)
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         pass
 
 
 class FakeOtherEnumPermissionMutation:
     @check_permission(Permissions.LAUNCH_PIPELINE_REEXECUTION)
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         pass
 
 
 class FakeMissingEnumPermissionMutation:
     @check_permission(Permissions.LAUNCH_PARTITION_BACKFILL)
-    def mutate(self, graphene_info, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
         pass
 
 


### PR DESCRIPTION
### Summary & Motivation

The first argument to GQL resolvers is of class `graphene.ResolveInfo`, which exposes a method `context` which can return a custom context object. However, using `graphene.ResolveInfo` as a type annotation is mostly useless since it doesn't actually provide any information about your custom context. This has been a source of errors in GQL resolvers, since methods on e.g. `context.instance` have had no typing info available.

Previously, there was a `HasContext` protocol which could be used to type the first argument instead of `graphene.ResolveInfo`-- this provided access to a typed `graphene_info.context` in resolvers, but removed any reference to the true class `graphene.ResolveInfo`. This PR improves the situation by:

- Replacing `schema.util::HasContext` with `schema.util::ResolveInfo`, a drop-in replacement for `graphene.ResolveInfo`.
- Types the first arguments of all resolvers with the new `ResolveInfo` type (vast majority of changes).

### How I Tested These Changes

BK