### PR TITLE
[typing/runtime] [gql] eliminate resolver **kwargs (1)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -414,11 +414,10 @@ class GrapheneInstigationState(graphene.ObjectType):
 
         return None
 
-    def resolve_runs(self, graphene_info: ResolveInfo, **kwargs):
+    def resolve_runs(self, graphene_info: ResolveInfo, limit: Optional[int] = None):
         from .pipelines.pipeline import GrapheneRun
 
-        if kwargs.get("limit") and self._batch_loader:
-            limit = kwargs["limit"]
+        if limit and self._batch_loader:
             records = (
                 self._batch_loader.get_run_records_for_sensor(self._instigator_state.name, limit)
                 if self._instigator_state.instigator_type == InstigatorType.SENSOR
@@ -447,7 +446,7 @@ class GrapheneInstigationState(graphene.ObjectType):
             GrapheneRun(record)
             for record in graphene_info.context.instance.get_run_records(
                 filters=filters,
-                limit=kwargs.get("limit"),
+                limit=limit,
             )
         ]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional
+
 import dagster._check as check
 import graphene
 from dagster._core.host_representation import RepresentedPipeline
@@ -32,7 +34,7 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
 
     isRunConfigValid = graphene.Field(
         graphene.NonNull(GraphenePipelineConfigValidationResult),
-        args={"runConfigData": graphene.Argument(GrapheneRunConfigData)},
+        runConfigData=graphene.Argument(GrapheneRunConfigData),
         description="""Parse a particular run config result. The return value
         either indicates that the validation succeeded by returning
         `PipelineConfigValidationValid` or that there are configuration errors
@@ -74,12 +76,16 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
             self._represented_pipeline.get_mode_def_snap(self._mode).root_config_key,
         )
 
-    def resolve_isRunConfigValid(self, graphene_info: ResolveInfo, **kwargs):
+    def resolve_isRunConfigValid(
+        self,
+        graphene_info: ResolveInfo,
+        runConfigData: Optional[Any] = None,  # custom scalar (GrapheneRunConfigData)
+    ):
         return resolve_is_run_config_valid(
             graphene_info,
             self._represented_pipeline,
             self._mode,
-            parse_run_config_input(kwargs.get("runConfigData", {}), raise_on_error=False),
+            parse_run_config_input(runConfigData or {}, raise_on_error=False),
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -696,9 +696,10 @@ class GrapheneCompositeSolidDefinition(graphene.ObjectType, ISolidDefinitionMixi
     def resolve_solid_handle(self, _graphene_info, handleID):
         return build_solid_handles(self._represented_pipeline).get(handleID)
 
-    def resolve_solid_handles(self, _graphene_info, **kwargs):
+    def resolve_solid_handles(
+        self, _graphene_info: ResolveInfo, parentHandleID: Optional[str] = None
+    ) -> Sequence[GrapheneSolidHandle]:
         handles = build_solid_handles(self._represented_pipeline)
-        parentHandleID = kwargs.get("parentHandleID")
 
         if parentHandleID == "":
             handles = {key: handle for key, handle in handles.items() if not handle.parent}


### PR DESCRIPTION
### Summary & Motivation

Many resolver methods currently use `**kwargs` for their arguments. This makes for less readable and poorly typed code. This PR updates all resolvers using `**kwargs` to instead explicitly list their arguments. This requires various changes to the corresponding function bodies (to access the params directly instead of `kwargs`), but the intent here is a pure refactor with no behavior change. This also removes extraneous `**_kwargs` in mutation signatures.

I determined how to change the signatures by looking at the corresponding field definition, which defines the arguments. Note that in a few cases the existing resolver body contained extraneous logic given the type of the arg, which I removed.

### How I Tested These Changes

BK

The correctness of the signatures is tested by the lack of `**kwargs`-- if the resolver is exercised in our runtime tests, then any arguments will be passed as keyword arguments, which will generate a runtime error if it a corresponding parameter is not present in the signature.