### PR TITLE
Use ExecutableDefinition instead of Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition] in internal apis

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -146,12 +146,14 @@ class Definitions:
             resources already bound using :py:func:`with_resources <with_resources>` will
             override this dictionary.
 
-        executor (Optional[ExecutorDefinition]):
+        executor (Optional[Union[ExecutorDefinition, Executor]]):
             Default executor for jobs. Individual jobs
             can override this and define their own executors by setting the executor
             on :py:func:`@job <job>` or :py:func:`define_asset_job <define_asset_job>`
             explicitly. This executor will also be used for materializing assets directly
             outside of the context of jobs.
+
+            If an Executor is passed, it is coerced into a ExecutorDefinition.
 
 
         loggers (Optional[Mapping[str, LoggerDefinition]):

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -11,6 +11,7 @@ from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
 
 def build_schedule_from_partitioned_job(
+    # TODO: support executable?
     job: Union[JobDefinition, UnresolvedAssetJobDefinition],
     description: Optional[str] = None,
     name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -11,7 +11,6 @@ from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
 
 def build_schedule_from_partitioned_job(
-    # TODO: support executable?
     job: Union[JobDefinition, UnresolvedAssetJobDefinition],
     description: Optional[str] = None,
     name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -49,6 +49,7 @@ from .utils import check_valid_name
 if TYPE_CHECKING:
     from dagster._core.definitions import AssetGroup, AssetsDefinition
     from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+    from dagster._core.definitions.target import ExecutableDefinition
     from dagster._core.storage.asset_value_loader import AssetValueLoader
 
 
@@ -1581,7 +1582,7 @@ def _process_and_validate_target(
     coerced_graphs: Dict[str, JobDefinition],
     unresolved_jobs: Dict[str, UnresolvedAssetJobDefinition],
     pipelines_or_jobs: Dict[str, PipelineDefinition],
-    target: Union[GraphDefinition, PipelineDefinition, UnresolvedAssetJobDefinition],
+    target: "ExecutableDefinition",
 ):
     # This function modifies the state of coerced_graphs and unresolved_jobs
     targeter = (

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -39,9 +39,7 @@ from ..errors import (
 from ..instance import DagsterInstance
 from ..instance.ref import InstanceRef
 from ..storage.pipeline_run import DagsterRun
-from .graph_definition import GraphDefinition
 from .mode import DEFAULT_MODE_NAME
-from .pipeline_definition import PipelineDefinition
 from .run_request import RunRequest, SkipReason
 from .target import DirectTarget, ExecutableDefinition, RepoRelativeTarget
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
@@ -560,7 +558,7 @@ class ScheduleDefinition:
 
     @public  # type: ignore
     @property
-    def job(self) -> Union[GraphDefinition, PipelineDefinition, UnresolvedAssetJobDefinition]:
+    def job(self) -> ExecutableDefinition:
         if isinstance(self._target, DirectTarget):
             return self._target.target
         raise DagsterInvalidDefinitionError("No job was provided to ScheduleDefinition.")
@@ -638,9 +636,7 @@ class ScheduleDefinition:
             self.load_target(), UnresolvedAssetJobDefinition
         )
 
-    def load_target(
-        self,
-    ) -> Union[GraphDefinition, PipelineDefinition, UnresolvedAssetJobDefinition]:
+    def load_target(self) -> ExecutableDefinition:
         if isinstance(self._target, DirectTarget):
             return self._target.load()
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -32,12 +32,9 @@ from dagster._serdes import whitelist_for_serdes
 
 from ..decorator_utils import get_function_params
 from .asset_selection import AssetSelection
-from .graph_definition import GraphDefinition
 from .mode import DEFAULT_MODE_NAME
-from .pipeline_definition import PipelineDefinition
 from .run_request import PipelineRunReaction, RunRequest, SkipReason
 from .target import DirectTarget, ExecutableDefinition, RepoRelativeTarget
-from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from .utils import check_valid_name
 
 if TYPE_CHECKING:
@@ -396,7 +393,7 @@ class SensorDefinition:
 
     @public  # type: ignore
     @property
-    def job(self) -> Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]:
+    def job(self) -> ExecutableDefinition:
         if self._targets:
             if len(self._targets) == 1 and isinstance(self._targets[0], DirectTarget):
                 return self._targets[0].target
@@ -479,9 +476,7 @@ class SensorDefinition:
                 return True
         return False
 
-    def load_targets(
-        self,
-    ) -> Sequence[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]:
+    def load_targets(self) -> Sequence[ExecutableDefinition]:
         targets = []
         for target in self._targets:
             if isinstance(target, DirectTarget):


### PR DESCRIPTION
### Summary & Motivation

I am exploring adding a new pending job type for late-bound non-asset jobs. I'm doing some refactoring along the way. In this case we have an `ExecutableDefinition` Union to capture all the differential varietals of job, pipeline, asset job, and graph. Use that instead of the full union 

### How I Tested These Changes

BK