### PR TITLE
fix(helm): fix unable to customize postgresql docker image registry

### DIFF
--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml $celeryK8sRunLauncherConfig.podSecurityContext | nindent 8 }}
       initContainers:
         - name: check-db-ready
-          image: "{{- $.Values.postgresql.image.repository -}}:{{- $.Values.postgresql.image.tag -}}"
+          image: "{{ include "common.images.image" ( dict "imageRoot" .Values.postgresql.image ) }}"
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" $ | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml .Values.dagsterDaemon.podSecurityContext | nindent 8 }}
       initContainers:
         - name: check-db-ready
-          image: {{ include "dagster.externalImage.name" $.Values.postgresql.image | quote }}
+          image: "{{ include "common.images.image" ( dict "imageRoot" .Values.postgresql.image ) }}"
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -36,7 +36,7 @@ spec:
       {{- toYaml .Values.flower.podSecurityContext | nindent 8 }}
       initContainers:
         - name: check-db-ready
-          image: "{{- $.Values.postgresql.image.repository -}}:{{- $.Values.postgresql.image.tag -}}"
+          image: "{{ include "common.images.image" ( dict "imageRoot" .Values.postgresql.image ) }}"
           imagePullPolicy: "{{- $.Values.postgresql.image.pullPolicy -}}"
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/helpers/_deployment-dagit.tpl
+++ b/helm/dagster/templates/helpers/_deployment-dagit.tpl
@@ -46,7 +46,7 @@ spec:
         {{- toYaml .Values.dagit.podSecurityContext | nindent 8 }}
       initContainers:
         - name: check-db-ready
-          image: {{ include "dagster.externalImage.name" .Values.postgresql.image | quote }}
+          image: "{{ include "common.images.image" ( dict "imageRoot" .Values.postgresql.image ) }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           command: ['sh', '-c', {{ include "dagster.postgresql.pgisready" . | squote }}]
           securityContext:

--- a/helm/dagster/templates/helpers/_image.tpl
+++ b/helm/dagster/templates/helpers/_image.tpl
@@ -1,0 +1,34 @@
+{{/*
+Return the proper image name
+
+```
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image) }}
+```
+
+Example:
+
+```
+# Define the following image in values.yaml
+image:
+  registry: docker.io
+  repository: bitnami/postgresql
+  tag: 11.6.0-debian-9-r0
+```
+
+```
+# Use in the template
+{{ include "common.images.image" ( dict "imageRoot" .Values.image ) }}
+```
+
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := ( default .imageRoot.registry "docker.io" ) -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if .imageRoot.digest -}}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+{{- end -}}
+{{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- end -}}


### PR DESCRIPTION
### Summary & Motivation

When I try to use the posgresql mirror of the private repository, I get the error

(1)

when using 

```yaml
registry: ''
repository: xxx.com/libarry/posgresql:xxx
```

something went wrong on postgresql subchart

(2)

when using 

```yaml
registry: 'xxx.com'
repository: libarry/posgresql:xxx
```

something went wrong on dagster chart

### How I Tested These Changes

using 

```bash
cd helm

helm template . --set postgresql.image.registry=xxx.com
```

postgres image will set to `xxx.com/library/postgres:9.6.21`
