### PR TITLE
RFC: Native multi-environment execution

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1269,6 +1269,18 @@ def iterable_param(
     return _check_iterable_items(obj, of_type, "iterable")
 
 
+def opt_iterable_param(
+    obj: Optional[Iterable[T]],
+    param_name: str,
+    of_type: Optional[TypeOrTupleOfTypes] = None,
+    additional_message: Optional[str] = None,
+) -> Optional[Iterable[T]]:
+    if obj is None:
+        return None
+
+    return iterable_param(obj, param_name, of_type, additional_message)
+
+
 # ########################
 # ##### SET
 # ########################

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -96,6 +96,7 @@ def _create_repository_using_definitions_args(
 
     resource_defs = wrap_resources_for_execution(resources or {})
 
+    check.opt_inst_param(executor, "executor", (Executor, ExecutorDefinition))
     executor_def = (
         executor
         if isinstance(executor, ExecutorDefinition) or executor is None

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -85,23 +85,20 @@ def _create_repository_using_definitions_args(
     if jobs:
         check.iterable_param(jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition))
 
-    if resources:
-        check.mapping_param(resources, "resources", key_type=str)
-
-    if executor:
-        check.inst_param(executor, "executor", (ExecutorDefinition, Executor))
-
-    if loggers:
-        check.mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
+    check.opt_mapping_param(resources, "resources", key_type=str)
 
     resource_defs = wrap_resources_for_execution(resources or {})
 
-    check.opt_inst_param(executor, "executor", (Executor, ExecutorDefinition))
+    check.opt_inst_param(executor, "executor", (ExecutorDefinition, Executor))
+
     executor_def = (
         executor
         if isinstance(executor, ExecutorDefinition) or executor is None
         else ExecutorDefinition.hardcoded_executor(executor)
     )
+
+    check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
+
 
     @repository(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
+from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
 from dagster._utils.cached_method import cached_method
 
@@ -67,7 +68,7 @@ def _create_repository_using_definitions_args(
     sensors: Optional[Iterable[SensorDefinition]] = None,
     jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]] = None,
     resources: Optional[Mapping[str, Any]] = None,
-    executor: Optional[ExecutorDefinition] = None,
+    executor: Optional[Union[ExecutorDefinition, Executor]] = None,
     loggers: Optional[Mapping[str, LoggerDefinition]] = None,
 ):
     if assets:
@@ -88,16 +89,22 @@ def _create_repository_using_definitions_args(
         check.mapping_param(resources, "resources", key_type=str)
 
     if executor:
-        check.inst_param(executor, "executor", ExecutorDefinition)
+        check.inst_param(executor, "executor", (ExecutorDefinition, Executor))
 
     if loggers:
         check.mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
 
     resource_defs = wrap_resources_for_execution(resources or {})
 
+    executor_def = (
+        executor
+        if isinstance(executor, ExecutorDefinition) or executor is None
+        else ExecutorDefinition.hardcoded_executor(executor)
+    )
+
     @repository(
         name=name,
-        default_executor_def=executor,
+        default_executor_def=executor_def,
         default_logger_defs=loggers,
     )
     def created_repo():
@@ -146,12 +153,14 @@ class Definitions:
             resources already bound using :py:func:`with_resources <with_resources>` will
             override this dictionary.
 
-        executor (Optional[ExecutorDefinition]):
+        executor (Optional[Union[ExecutorDefinition, Executor]]):
             Default executor for jobs. Individual jobs
             can override this and define their own executors by setting the executor
             on :py:func:`@job <job>` or :py:func:`define_asset_job <define_asset_job>`
             explicitly. This executor will also be used for materializing assets directly
             outside of the context of jobs.
+
+            If an Executor is passed, it is coerced into a ExecutorDefinition.
 
 
         loggers (Optional[Mapping[str, LoggerDefinition]):
@@ -207,7 +216,7 @@ class Definitions:
         sensors: Optional[Iterable[SensorDefinition]] = None,
         jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]] = None,
         resources: Optional[Mapping[str, Any]] = None,
-        executor: Optional[ExecutorDefinition] = None,
+        executor: Optional[Union[ExecutorDefinition, Executor]] = None,
         loggers: Optional[Mapping[str, LoggerDefinition]] = None,
     ):
         self._created_pending_or_normal_repo = _create_repository_using_definitions_args(

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -71,20 +71,12 @@ def _create_repository_using_definitions_args(
     executor: Optional[Union[ExecutorDefinition, Executor]] = None,
     loggers: Optional[Mapping[str, LoggerDefinition]] = None,
 ):
-    if assets:
-        check.iterable_param(
-            assets, "assets", (AssetsDefinition, SourceAsset, CacheableAssetsDefinition)
-        )
-
-    if schedules:
-        check.iterable_param(schedules, "schedules", ScheduleDefinition)
-
-    if sensors:
-        check.iterable_param(sensors, "sensors", SensorDefinition)
-
-    if jobs:
-        check.iterable_param(jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition))
-
+    check.opt_iterable_param(
+        assets, "assets", (AssetsDefinition, SourceAsset, CacheableAssetsDefinition)
+    )
+    check.opt_iterable_param(schedules, "schedules", ScheduleDefinition)
+    check.opt_iterable_param(sensors, "sensors", SensorDefinition)
+    check.opt_iterable_param(jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition))
     check.opt_mapping_param(resources, "resources", key_type=str)
 
     resource_defs = wrap_resources_for_execution(resources or {})

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -99,7 +99,6 @@ def _create_repository_using_definitions_args(
 
     check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
 
-
     @repository(
         name=name,
         default_executor_def=executor_def,

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -139,6 +139,15 @@ class ExecutorDefinition(NamedConfigurableDefinition):
             requirements=self._requirements_fn,
         )
 
+    @staticmethod
+    def hardcoded_executor(executor: "Executor"):
+        return ExecutorDefinition(
+            # Executor name was only relevant in the pipeline/solid/mode world, so we
+            # can put a dummy value
+            name="__executor__",
+            executor_creation_fn=lambda _init_context: executor,
+        )
+
     # Backcompat: Overrides configured method to provide name as a keyword argument.
     # If no name is provided, the name is pulled off of this ExecutorDefinition.
     @public

--- a/python_modules/dagster/dagster/_core/executor/multi_environment/execute_out_of_process.py
+++ b/python_modules/dagster/dagster/_core/executor/multi_environment/execute_out_of_process.py
@@ -1,0 +1,117 @@
+from dagster import _check as check
+from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster._core.executor.multi_environment.remote_step_information import (
+    get_remote_step_info,
+)
+from dagster._core.instance import DagsterInstance
+from dagster._core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
+from dagster._core.storage.pipeline_run import DagsterRun
+from dagster._grpc.types import ExecuteStepArgs
+
+
+# So that we can use PipelinePythonOrigin to wrap an ephemeral, in-process job
+class InMemoryCodePointer(CodePointer):
+    def __init__(self, target):
+        self.target = target
+
+    def load_target(self) -> object:
+        return self.target
+
+    def describe(self) -> str:
+        return "inmem"
+
+
+def pipeline_origin_for_op(job_def: JobDefinition):
+    return pipeline_origin_for_job_in_defs(Definitions(jobs=[job_def]), job_def.name)
+
+
+def pipeline_origin_for_job_in_defs(
+    definitions: Definitions, job_name: str
+) -> PipelinePythonOrigin:
+    repo = definitions.get_inner_repository_for_loading_process()
+    return PipelinePythonOrigin(
+        pipeline_name=job_name,
+        repository_origin=RepositoryPythonOrigin(
+            executable_path="invalid", code_pointer=InMemoryCodePointer(repo)
+        ),
+    )
+
+
+def execute_op_within_inprogress_run(
+    instance: DagsterInstance,
+    job_def: JobDefinition,
+    run_id: str,
+    step_key: str,
+):
+    fake_pipeline_origin = pipeline_origin_for_op(job_def)
+    dagster_run = check.not_none(instance.get_run_by_id(run_id))
+    dagster_run = dagster_run._replace(pipeline_code_origin=fake_pipeline_origin)
+    execute_step_in_out_of_proc_step(instance, dagster_run, step_key)
+
+
+def execute_step_in_out_of_proc_step(
+    instance: DagsterInstance,
+    dagster_run: DagsterRun,
+    step_key: str,
+):
+    run_id = dagster_run.run_id
+    remote_step_info = get_remote_step_info(instance=instance, run_id=run_id, step_key=step_key)
+
+    step_args = ExecuteStepArgs(
+        pipeline_origin=check.not_none(dagster_run.pipeline_code_origin),
+        pipeline_run_id=run_id,
+        step_keys_to_execute=[step_key],
+        instance_ref=None,
+        retry_mode=remote_step_info.retry_mode,
+        known_state=remote_step_info.known_state,
+        should_verify_step=False,
+    )
+
+    from dagster._cli.api import _execute_step_command_body
+
+    for event in _execute_step_command_body(step_args, instance, dagster_run):
+        print(f"processing event in worker {event}")
+
+
+def defs_for_single_assets_def(assets_def: AssetsDefinition, job_name: str):
+    source_assets = []
+    for _input_name, asset_keys_for_input in assets_def.keys_by_input_name.items():
+        for asset_key in asset_keys_for_input:
+            source_assets.append(SourceAsset(asset_key))
+
+    return Definitions(
+        jobs=[define_asset_job(job_name)],
+        assets=[assets_def, *source_assets],
+    )
+
+
+def execute_asset_within_inprogress_run(
+    instance: DagsterInstance,
+    assets_def: AssetsDefinition,
+    run_id: str,
+    step_key: str,
+):
+    dagster_run = check.not_none(instance.get_run_by_id(run_id), "Run must exist in instance")
+    job_name = dagster_run.pipeline_name
+
+    in_worker_process_origin = pipeline_origin_for_job_in_defs(
+        defs_for_single_assets_def(assets_def, job_name),
+        job_name,
+    )
+
+    dagster_run = dagster_run._replace(
+        pipeline_code_origin=in_worker_process_origin,
+        # right now if you do materialize all in dagit it actually fully
+        # expands the asset selection to be all the assets. when this
+        # gets passed through it fails a subsetting check because the
+        # source asset is not executable. So here we only execute the single
+        # asset key
+        asset_selection=frozenset([assets_def.key]),
+    )
+
+    execute_step_in_out_of_proc_step(instance, dagster_run, step_key)

--- a/python_modules/dagster/dagster/_core/executor/multi_environment/multi_environment_step_handler.py
+++ b/python_modules/dagster/dagster/_core/executor/multi_environment/multi_environment_step_handler.py
@@ -51,9 +51,7 @@ class MultiEnvironmentStepHandler(StepHandler):
         )
 
         remote_handler = self.handler_for_key(step_context)
-        # .launch_single_step(
-        #     step_context, step_handler_context
-        # )
+
         yield DagsterEvent.step_worker_starting(
             step_context,
             message=f'Executing step "{step_context.step.key}" in external process',

--- a/python_modules/dagster/dagster/_core/executor/multi_environment/multi_environment_step_handler.py
+++ b/python_modules/dagster/dagster/_core/executor/multi_environment/multi_environment_step_handler.py
@@ -1,0 +1,115 @@
+from typing import Callable, Iterator, Optional
+
+from dagster import _check as check
+from dagster._core.events import DagsterEvent
+from dagster._core.execution.context.system import IStepContext, PlanOrchestrationContext
+from dagster._core.execution.plan.plan import ExecutionPlan
+from dagster._core.execution.retries import RetryMode
+from dagster._core.executor.base import Executor
+from dagster._core.executor.multi_environment.remote_step_information import (
+    RemoteStepInformation,
+    set_remote_step_info,
+)
+from dagster._core.executor.step_delegating.step_delegating_executor import StepDelegatingExecutor
+from dagster._core.executor.step_delegating.step_handler.base import (
+    CheckStepHealthResult,
+    StepHandler,
+    StepHandlerContext,
+)
+
+
+class MultiEnvironmentStepHandler(StepHandler):
+    def __init__(
+        self,
+        single_step_handler_factory: Callable[[IStepContext], "RemoteEnvironmentSingleStepHandler"],
+    ):
+        self._single_step_handler_factory = single_step_handler_factory
+
+    @property
+    def name(self) -> str:
+        return "MultiEnvironmentStepHandler"
+
+    def handler_for_key(self, step_context: IStepContext) -> "RemoteEnvironmentSingleStepHandler":
+        return self._single_step_handler_factory(step_context)
+
+    def _get_step_context(self, step_handler_context: StepHandlerContext) -> IStepContext:
+        step_keys = step_handler_context.step_keys
+        check.invariant(len(step_keys) == 1)
+        return step_handler_context.get_step_context(step_keys[0])
+
+    def launch_step(self, step_handler_context: StepHandlerContext) -> Iterator[DagsterEvent]:
+        step_context = self._get_step_context(step_handler_context)
+
+        set_remote_step_info(
+            instance=step_handler_context.instance,
+            run_id=step_context.run_id,
+            step_key=step_context.step.key,
+            remote_step_info=RemoteStepInformation(
+                retry_mode=step_handler_context.execute_step_args.retry_mode,
+                known_state=step_handler_context.execute_step_args.known_state,
+            ),
+        )
+
+        remote_handler = self.handler_for_key(step_context)
+        # .launch_single_step(
+        #     step_context, step_handler_context
+        # )
+        yield DagsterEvent.step_worker_starting(
+            step_context,
+            message=f'Executing step "{step_context.step.key}" in external process',
+            metadata_entries=[],
+        )
+
+        iterator = remote_handler.launch_single_step(step_context, step_handler_context)
+        if iterator:
+            yield from iterator
+
+    def check_step_health(self, step_handler_context: StepHandlerContext) -> CheckStepHealthResult:
+        step_context = self._get_step_context(step_handler_context)
+        return self.handler_for_key(step_context).check_step_health(
+            step_context, step_handler_context
+        )
+
+    def terminate_step(self, step_handler_context: StepHandlerContext) -> Iterator[DagsterEvent]:
+        step_context = self._get_step_context(step_handler_context)
+        iterator = self.handler_for_key(step_context).terminate_single_step(
+            step_context, step_handler_context
+        )
+        if iterator:
+            yield from iterator
+
+
+class RemoteEnvironmentSingleStepHandler:
+    def launch_single_step(
+        self, step_context: IStepContext, step_handler_context: StepHandlerContext
+    ) -> Optional[Iterator[DagsterEvent]]:
+        raise NotImplementedError()
+
+    def terminate_single_step(
+        self, step_context: IStepContext, step_handler_context: StepHandlerContext
+    ) -> Optional[Iterator[DagsterEvent]]:
+        raise NotImplementedError()
+
+    def check_step_health(
+        self, step_context: IStepContext, step_handler_context: StepHandlerContext
+    ):
+        raise NotImplementedError()
+
+
+class MultiEnvironmentExecutor(Executor):
+    def __init__(
+        self,
+        single_step_handler_factory: Callable[[IStepContext], "RemoteEnvironmentSingleStepHandler"],
+        **kwargs,  # pass along all remaining executor args
+    ):
+        self._inner_executor = StepDelegatingExecutor(
+            MultiEnvironmentStepHandler(single_step_handler_factory),
+            **kwargs,
+        )
+
+    def execute(self, plan_context: PlanOrchestrationContext, execution_plan: ExecutionPlan):
+        return self._inner_executor.execute(plan_context, execution_plan)
+
+    @property
+    def retries(self) -> RetryMode:
+        return self._inner_executor.retries

--- a/python_modules/dagster/dagster/_core/executor/multi_environment/remote_step_information.py
+++ b/python_modules/dagster/dagster/_core/executor/multi_environment/remote_step_information.py
@@ -1,0 +1,39 @@
+from typing import NamedTuple, Optional
+
+from dagster._core.execution.plan.state import KnownExecutionState
+from dagster._core.execution.retries import RetryMode
+from dagster._core.instance import DagsterInstance
+from dagster._serdes.serdes import (
+    deserialize_as,
+    serialize_dagster_namedtuple,
+    whitelist_for_serdes,
+)
+
+
+@whitelist_for_serdes
+class RemoteStepInformation(NamedTuple):
+    retry_mode: Optional[RetryMode]
+    known_state: Optional[KnownExecutionState]
+
+
+def get_kv_key_for_step_args(run_id: str, step_key: str) -> str:
+    return f"STEPARGS:{run_id}:{step_key}"
+
+
+def set_remote_step_info(
+    instance: DagsterInstance, run_id: str, step_key: str, remote_step_info: RemoteStepInformation
+):
+    step_args_kv_key = get_kv_key_for_step_args(run_id, step_key)
+    return instance.kvs_set(
+        {
+            step_args_kv_key: serialize_dagster_namedtuple(remote_step_info),
+        }
+    )
+
+
+def get_remote_step_info(
+    instance: DagsterInstance, run_id: str, step_key: str
+) -> RemoteStepInformation:
+    kv_key = get_kv_key_for_step_args(run_id, step_key)
+    remote_step_info_json = instance.kvs_get({kv_key})[kv_key]
+    return deserialize_as(remote_step_info_json, RemoteStepInformation)

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_handler/base.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_handler/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterator, Mapping, NamedTuple, Optional, Sequence
+from typing import Iterator, List, Mapping, NamedTuple, Optional, Sequence
 
 from dagster import (
     DagsterInstance,
@@ -7,6 +7,7 @@ from dagster import (
 )
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.context.system import IStepContext, PlanOrchestrationContext
+from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.plan.step import ExecutionStep
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._grpc.types import ExecuteStepArgs
@@ -32,6 +33,10 @@ class StepHandlerContext:
         return self._execute_step_args
 
     @property
+    def step_keys(self) -> List[str]:
+        return [*self._steps_by_key.keys()]
+
+    @property
     def pipeline_run(self) -> DagsterRun:
         # lazy load
         if not self._pipeline_run:
@@ -50,6 +55,10 @@ class StepHandlerContext:
     @property
     def instance(self) -> DagsterInstance:
         return self._instance
+
+    @property
+    def known_state(self) -> Optional[KnownExecutionState]:
+        return self._execute_step_args.known_state
 
     def get_step_context(self, step_key: str) -> IStepContext:
         return self._plan_context.for_step(self._steps_by_key[step_key])

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -195,7 +195,7 @@ class InProcessRepositoryLocationOrigin(
             InProcessRepositoryLocation,
         )
 
-        return InProcessRepositoryLocation(self)
+        return InProcessRepositoryLocation.from_in_process_origin(self)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -195,7 +195,7 @@ class InProcessRepositoryLocationOrigin(
             InProcessRepositoryLocation,
         )
 
-        return InProcessRepositoryLocation.from_in_process_origin(self)
+        return InProcessRepositoryLocation(self)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -73,7 +73,6 @@ if TYPE_CHECKING:
         ExternalPartitionSetExecutionParamData,
         ExternalPartitionTagsData,
     )
-    from dagster._grpc.server import LoadedRepositories
 
 
 class RepositoryLocation(AbstractContextManager):
@@ -278,19 +277,18 @@ class RepositoryLocation(AbstractContextManager):
 
 
 class InProcessRepositoryLocation(RepositoryLocation):
-    def __init__(
-        self,
-        loaded_repositories: "LoadedRepositories",
-        original_origin: Optional[InProcessRepositoryLocationOrigin] = None,
-    ):
+    def __init__(self, origin: InProcessRepositoryLocationOrigin):
+        from dagster._grpc.server import LoadedRepositories
         from dagster._utils.hosted_user_process import external_repo_from_def
 
-        # other option is to introduce other subclass
-        self._original_origin = check.opt_inst_param(
-            original_origin, "origin", InProcessRepositoryLocationOrigin
-        )
+        self._origin = check.inst_param(origin, "origin", InProcessRepositoryLocationOrigin)
 
-        self._loaded_repositories = loaded_repositories
+        loadable_target_origin = self._origin.loadable_target_origin
+        self._loaded_repositories = LoadedRepositories(
+            loadable_target_origin,
+            self._origin.entry_point,
+            self._origin.container_image,
+        )
 
         self._repository_code_pointer_dict = self._loaded_repositories.code_pointers_by_repo_name
 
@@ -301,49 +299,29 @@ class InProcessRepositoryLocation(RepositoryLocation):
                 RepositoryHandle(repository_name=repo_name, repository_location=self),
             )
 
-    @staticmethod
-    def from_in_process_origin(origin: InProcessRepositoryLocationOrigin):
-        from dagster._grpc.server import LoadedRepositories
-
-        loadable_target_origin = origin.loadable_target_origin
-        loaded_repositories = LoadedRepositories.from_target_origin(
-            loadable_target_origin,
-            origin.entry_point,
-            origin.container_image,
-        )
-        return InProcessRepositoryLocation(
-            loaded_repositories=loaded_repositories, original_origin=origin
-        )
-
     @property
     def is_reload_supported(self) -> bool:
         return False
 
     @property
     def origin(self) -> InProcessRepositoryLocationOrigin:
-        return check.not_none(
-            self._original_origin,
-            (
-                "Must provide origin via InProcessRepositoryLocation.from_in_process_origin at"
-                " construction time."
-            ),
-        )
+        return self._origin
 
     @property
     def executable_path(self) -> Optional[str]:
-        return self.origin.loadable_target_origin.executable_path
+        return self._origin.loadable_target_origin.executable_path
 
     @property
     def container_image(self) -> Optional[str]:
-        return self.origin.container_image
+        return self._origin.container_image
 
     @property
     def container_context(self) -> Optional[Mapping[str, Any]]:
-        return self.origin.container_context
+        return self._origin.container_context
 
     @property
     def entry_point(self) -> Optional[Sequence[str]]:
-        return self.origin.entry_point
+        return self._origin.entry_point
 
     @property
     def repository_code_pointer_dict(self) -> Mapping[str, CodePointer]:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2357,3 +2357,9 @@ class DagsterInstance:
             materialization = next(iter(materializations), None)
 
         return materialization or observation
+
+    def kvs_get(self, keys: Set[str]) -> Mapping[str, str]:
+        return self._run_storage.kvs_get(keys=keys)
+
+    def kvs_set(self, pairs: Mapping[str, str]) -> None:
+        return self._run_storage.kvs_set(pairs=pairs)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -96,51 +96,67 @@ class CouldNotBindGrpcServerToAddress(Exception):
 class LoadedRepositories:
     def __init__(
         self,
+        code_pointers_by_repo_name: Dict[str, CodePointer],
+        recon_repos_by_name: Dict[str, ReconstructableRepository],
+        repo_defs_by_name: Dict[str, RepositoryDefinition],
+        loadable_repository_symbols: List[LoadableRepositorySymbol],
+    ):
+        self._code_pointers_by_repo_name: Dict[str, CodePointer] = code_pointers_by_repo_name
+        self._recon_repos_by_name: Dict[str, ReconstructableRepository] = recon_repos_by_name
+        self._repo_defs_by_name: Dict[str, RepositoryDefinition] = repo_defs_by_name
+        self._loadable_repository_symbols: List[
+            LoadableRepositorySymbol
+        ] = loadable_repository_symbols
+
+    @staticmethod
+    def from_target_origin(
         loadable_target_origin: Optional[LoadableTargetOrigin],
         entry_point: Sequence[str],
         container_image: Optional[str] = None,
     ):
-        self._loadable_target_origin = loadable_target_origin
+        code_pointers_by_repo_name: Dict[str, CodePointer] = {}
+        recon_repos_by_name: Dict[str, ReconstructableRepository] = {}
+        repo_defs_by_name: Dict[str, RepositoryDefinition] = {}
+        loadable_repository_symbols: List[LoadableRepositorySymbol] = []
 
-        self._code_pointers_by_repo_name: Dict[str, CodePointer] = {}
-        self._recon_repos_by_name: Dict[str, ReconstructableRepository] = {}
-        self._repo_defs_by_name: Dict[str, RepositoryDefinition] = {}
-        self._loadable_repository_symbols: List[LoadableRepositorySymbol] = []
-
-        if not loadable_target_origin:
-            # empty workspace
-            return
-
-        loadable_targets = get_loadable_targets(
-            loadable_target_origin.python_file,
-            loadable_target_origin.module_name,
-            loadable_target_origin.package_name,
-            loadable_target_origin.working_directory,
-            loadable_target_origin.attribute,
-        )
-        for loadable_target in loadable_targets:
-            pointer = _get_code_pointer(loadable_target_origin, loadable_target)
-            recon_repo = ReconstructableRepository(
-                pointer,
-                container_image,
-                sys.executable,
-                entry_point=entry_point,
+        if loadable_target_origin:
+            loadable_targets = get_loadable_targets(
+                loadable_target_origin.python_file,
+                loadable_target_origin.module_name,
+                loadable_target_origin.package_name,
+                loadable_target_origin.working_directory,
+                loadable_target_origin.attribute,
             )
-            repo_def = recon_repo.get_definition()
-            # force load of all lazy constructed code artifacts to prevent
-            # any thread-safety issues loading them later on when serving
-            # definitions from multiple threads
-            repo_def.load_all_definitions()
-
-            self._code_pointers_by_repo_name[repo_def.name] = pointer
-            self._recon_repos_by_name[repo_def.name] = recon_repo
-            self._repo_defs_by_name[repo_def.name] = repo_def
-            self._loadable_repository_symbols.append(
-                LoadableRepositorySymbol(
-                    attribute=loadable_target.attribute,
-                    repository_name=repo_def.name,
+            for loadable_target in loadable_targets:
+                pointer = _get_code_pointer(loadable_target_origin, loadable_target)
+                recon_repo = ReconstructableRepository(
+                    pointer,
+                    container_image,
+                    sys.executable,
+                    entry_point=entry_point,
                 )
-            )
+                repo_def = recon_repo.get_definition()
+                # force load of all lazy constructed code artifacts to prevent
+                # any thread-safety issues loading them later on when serving
+                # definitions from multiple threads
+                repo_def.load_all_definitions()
+
+                code_pointers_by_repo_name[repo_def.name] = pointer
+                recon_repos_by_name[repo_def.name] = recon_repo
+                repo_defs_by_name[repo_def.name] = repo_def
+                loadable_repository_symbols.append(
+                    LoadableRepositorySymbol(
+                        attribute=loadable_target.attribute,
+                        repository_name=repo_def.name,
+                    )
+                )
+
+        return LoadedRepositories(
+            code_pointers_by_repo_name=code_pointers_by_repo_name,
+            recon_repos_by_name=recon_repos_by_name,
+            repo_defs_by_name=repo_defs_by_name,
+            loadable_repository_symbols=loadable_repository_symbols,
+        )
 
     @property
     def loadable_repository_symbols(self) -> Sequence[LoadableRepositorySymbol]:
@@ -253,7 +269,9 @@ class DagsterApiServer(DagsterApiServicer):
                 ) if instance_ref else DagsterInstance.get() as instance:
                     instance.inject_env_vars(location_name)
 
-            self._loaded_repositories: Optional[LoadedRepositories] = LoadedRepositories(
+            self._loaded_repositories: Optional[
+                LoadedRepositories
+            ] = LoadedRepositories.from_target_origin(
                 loadable_target_origin,
                 self._entry_point,
                 self._container_image,

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/add_one_to_one_asset.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/add_one_to_one_asset.py
@@ -1,0 +1,25 @@
+import sys
+
+from dagster import asset
+from dagster._core.executor.multi_environment.execute_out_of_process import (
+    execute_asset_within_inprogress_run,
+)
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
+from dagster._serdes.serdes import deserialize_as
+
+
+@asset
+def add_one_to_one_asset(one_asset: int) -> int:
+    return one_asset + 1
+
+
+if __name__ == "__main__":
+    run_id = sys.argv[1]
+    step_key = sys.argv[2]
+    ref_json = sys.argv[3]
+    ref = deserialize_as(ref_json, InstanceRef)
+    instance = DagsterInstance.from_ref(ref)
+    execute_asset_within_inprogress_run(
+        instance=instance, assets_def=add_one_to_one_asset, run_id=run_id, step_key=step_key
+    )

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/one_asset.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/one_asset.py
@@ -1,0 +1,25 @@
+import sys
+
+from dagster import asset
+from dagster._core.executor.multi_environment.execute_out_of_process import (
+    execute_asset_within_inprogress_run,
+)
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
+from dagster._serdes.serdes import deserialize_as
+
+
+@asset
+def one_asset() -> int:
+    return 1
+
+
+if __name__ == "__main__":
+    run_id = sys.argv[1]
+    step_key = sys.argv[2]
+    ref_json = sys.argv[3]
+    ref = deserialize_as(ref_json, InstanceRef)
+    instance = DagsterInstance.from_ref(ref)
+    execute_asset_within_inprogress_run(
+        instance=instance, assets_def=one_asset, run_id=run_id, step_key=step_key
+    )

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/test_multi_environment_asset_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/test_multi_environment_asset_execution.py
@@ -1,0 +1,143 @@
+import tempfile
+from typing import NamedTuple, Sequence
+
+from dagster import Definitions
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
+from dagster._core.definitions.input import In
+from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.reconstruct import reconstructable
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster._core.execution.api import execute_job
+from dagster._core.execution.retries import RetryMode
+from dagster._core.executor.multi_environment.multi_environment_step_handler import (
+    MultiEnvironmentExecutor,
+    RemoteEnvironmentSingleStepHandler,
+)
+from dagster._core.test_utils import instance_for_test
+from dagster._utils import file_relative_path
+
+from dagster_tests.execution_tests.engine_tests.multienvironment_tests.python_script_single_step_handler import (
+    PythonScriptSingleStepHandler,
+)
+
+
+class RemoteAsset(NamedTuple):
+    asset_key: CoercibleToAssetKey
+    upstream_asset_keys: Sequence[CoercibleToAssetKey]
+    single_step_handler: RemoteEnvironmentSingleStepHandler
+
+
+def remote_asset_in_script(asset_key: str, upstream_asset_keys: Sequence[str]):
+    return RemoteAsset(
+        asset_key=asset_key,
+        upstream_asset_keys=upstream_asset_keys,
+        # you can customize step handling per step
+        single_step_handler=PythonScriptSingleStepHandler(
+            file_relative_path(__file__, f"{asset_key}.py")
+        ),
+    )
+
+
+def build_definitions_for_remote_assets(
+    asset_job_name: str, remote_assets: Sequence[RemoteAsset]
+) -> Definitions:
+    def _never_called(*args, **kwargs):
+        raise Exception("This assets exists only for metadata. Do not call")
+
+    assets_defs = []
+
+    for remote_asset in remote_assets:
+        asset_key = AssetKey.from_coerceable(remote_asset.asset_key)
+        upstream_asset_keys = [
+            AssetKey.from_coerceable(uak) for uak in remote_asset.upstream_asset_keys
+        ]
+        keys_by_input_name = {
+            upstream_asset_key.to_python_identifier(): upstream_asset_key
+            for upstream_asset_key in upstream_asset_keys
+        }
+        keys_by_output_name = {"result": asset_key}
+        op_def = OpDefinition(
+            compute_fn=_never_called,
+            name=asset_key.to_user_string(),
+            ins={
+                upstream_asset_key.to_python_identifier(): In()
+                for upstream_asset_key in upstream_asset_keys
+            },
+        )
+        assets_defs.append(
+            AssetsDefinition(
+                keys_by_input_name=keys_by_input_name,
+                keys_by_output_name=keys_by_output_name,
+                node_def=op_def,
+            )
+        )
+
+    assets_to_handlers = {
+        remote_asset.asset_key: remote_asset.single_step_handler for remote_asset in remote_assets
+    }
+
+    return Definitions(
+        assets=assets_defs,
+        jobs=[define_asset_job(asset_job_name, "*")],
+        executor=MultiEnvironmentExecutor(
+            lambda step_context: assets_to_handlers[step_context.step.key],
+            retries=RetryMode.DISABLED,
+            check_step_health_interval_seconds=1,
+        ),
+    )
+
+
+def get_defs_for_one_asset():
+    return build_definitions_for_remote_assets(
+        "one_asset_job", [remote_asset_in_script("one_asset", [])]
+    )
+
+
+def get_one_asset_job():
+    return get_defs_for_one_asset().get_job_def("one_asset_job")
+
+
+def test_one_asset_on_its_own():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        with instance_for_test(temp_dir=tmpdir_path) as instance:
+            with execute_job(
+                job=reconstructable(get_one_asset_job),
+                instance=instance,
+            ) as result:
+                assert result.success
+                defs = get_defs_for_one_asset()
+                assert defs.load_asset_value("one_asset") == 1
+
+
+def get_defs_for_two_assets():
+    # Imagine parsing a yaml file or other arbitrary metadata format and creating
+    # RemoteAsset instances
+    return build_definitions_for_remote_assets(
+        "two_assets_job",
+        [
+            remote_asset_in_script("one_asset", []),
+            remote_asset_in_script("add_one_to_one_asset", ["one_asset"]),
+        ],
+    )
+
+
+def get_two_assets_job():
+    return get_defs_for_two_assets().get_job_def("two_assets_job")
+
+
+def test_two_assets():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        with instance_for_test(temp_dir=tmpdir_path) as instance:
+            with execute_job(
+                job=reconstructable(get_two_assets_job),
+                instance=instance,
+            ) as result:
+                assert result.success
+                defs = get_defs_for_two_assets()
+                assert defs.load_asset_value("one_asset") == 1
+                assert defs.load_asset_value("add_one_to_one_asset") == 2
+
+
+# so this file can be loaded by dagit directly
+defs = get_defs_for_two_assets()

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/test_multi_environment_asset_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/asset_variant/test_multi_environment_asset_execution.py
@@ -43,7 +43,7 @@ def build_definitions_for_remote_assets(
     asset_job_name: str, remote_assets: Sequence[RemoteAsset]
 ) -> Definitions:
     def _never_called(*args, **kwargs):
-        raise Exception("This assets exists only for metadata. Do not call")
+        raise Exception("This assets exists only for metadata. Should not be called.")
 
     assets_defs = []
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/add.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/add.py
@@ -1,0 +1,44 @@
+import sys
+
+from dagster import op
+from dagster._core.definitions.decorators.job_decorator import job
+from dagster._core.executor.multi_environment.execute_out_of_process import (
+    execute_op_within_inprogress_run,
+)
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
+from dagster._serdes.serdes import deserialize_as
+
+
+@op
+def returns_one() -> int:
+    raise Exception("never executed, stub")
+
+
+@op
+def returns_two() -> int:
+    raise Exception("never executed, stub")
+
+
+@op
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+@job
+def job_for_add():
+    add(returns_one(), returns_two())
+
+
+if __name__ == "__main__":
+    run_id = sys.argv[1]
+    step_key = sys.argv[2]
+    ref_json = sys.argv[3]
+    ref = deserialize_as(ref_json, InstanceRef)
+    instance = DagsterInstance.from_ref(ref)
+    execute_op_within_inprogress_run(
+        instance=instance,
+        job_def=job_for_add,
+        run_id=run_id,
+        step_key=step_key,
+    )

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/returns_one.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/returns_one.py
@@ -1,0 +1,31 @@
+import sys
+
+from dagster import op
+from dagster._core.definitions.decorators.job_decorator import job
+from dagster._core.executor.multi_environment.execute_out_of_process import (
+    execute_op_within_inprogress_run,
+)
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
+from dagster._serdes.serdes import deserialize_as
+
+
+@op
+def returns_one() -> int:
+    return 1
+
+
+@job
+def job_for_return_one():
+    returns_one()
+
+
+if __name__ == "__main__":
+    run_id = sys.argv[1]
+    step_key = sys.argv[2]
+    ref_json = sys.argv[3]
+    ref = deserialize_as(ref_json, InstanceRef)
+    instance = DagsterInstance.from_ref(ref)
+    execute_op_within_inprogress_run(
+        instance=instance, job_def=job_for_return_one, run_id=run_id, step_key=step_key
+    )

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/returns_two.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/returns_two.py
@@ -1,0 +1,30 @@
+import sys
+
+from dagster import job, op
+from dagster._core.executor.multi_environment.execute_out_of_process import (
+    execute_op_within_inprogress_run,
+)
+from dagster._core.instance import DagsterInstance
+from dagster._core.instance.ref import InstanceRef
+from dagster._serdes.serdes import deserialize_as
+
+
+@op
+def returns_two() -> int:
+    return 2
+
+
+@job
+def job_for_returns_two():
+    returns_two()
+
+
+if __name__ == "__main__":
+    run_id = sys.argv[1]
+    step_key = sys.argv[2]
+    ref_json = sys.argv[3]
+    ref = deserialize_as(ref_json, InstanceRef)
+    instance = DagsterInstance.from_ref(ref)
+    execute_op_within_inprogress_run(
+        instance=instance, job_def=job_for_returns_two, run_id=run_id, step_key=step_key
+    )

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/test_multi_environment_op_execution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/op_variant/test_multi_environment_op_execution.py
@@ -1,0 +1,66 @@
+import tempfile
+
+from dagster import job, op
+from dagster._core.definitions.executor_definition import ExecutorDefinition
+from dagster._core.definitions.reconstruct import reconstructable
+from dagster._core.execution.api import execute_job
+from dagster._core.execution.context.system import IStepContext
+from dagster._core.execution.retries import RetryMode
+from dagster._core.executor.multi_environment.multi_environment_step_handler import (
+    MultiEnvironmentStepHandler,
+    RemoteEnvironmentSingleStepHandler,
+)
+from dagster._core.executor.step_delegating.step_delegating_executor import StepDelegatingExecutor
+from dagster._core.test_utils import instance_for_test
+from dagster._utils import file_relative_path
+
+from dagster_tests.execution_tests.engine_tests.multienvironment_tests.python_script_single_step_handler import (
+    PythonScriptSingleStepHandler,
+)
+
+
+@op
+def returns_one() -> int:
+    raise NotImplementedError("not executed, metadata only")
+
+
+@op
+def returns_two() -> int:
+    raise NotImplementedError("not executed, metadata only")
+
+
+@op
+def add(x: int, y: int) -> int:
+    raise NotImplementedError("not executed, metadata only")
+
+
+def _get_remote_step_handler(step_context: IStepContext) -> RemoteEnvironmentSingleStepHandler:
+    scripts = {
+        "returns_one": file_relative_path(__file__, "returns_one.py"),
+        "returns_two": file_relative_path(__file__, "returns_two.py"),
+        "add": file_relative_path(__file__, "add.py"),
+    }
+    return PythonScriptSingleStepHandler(scripts[step_context.step.key])
+
+
+@job(
+    executor_def=ExecutorDefinition.hardcoded_executor(
+        StepDelegatingExecutor(
+            step_handler=MultiEnvironmentStepHandler(_get_remote_step_handler),
+            retries=RetryMode.DISABLED,
+            check_step_health_interval_seconds=1,
+        )
+    )
+)
+def a_job():
+    add(returns_one(), returns_two())
+
+
+def test_multi_environment_with_intermediates():
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        with instance_for_test(temp_dir=tmpdir_path) as instance:
+            with execute_job(job=reconstructable(a_job), instance=instance) as result:
+                assert result.success
+                assert result.output_for_node("returns_one") == 1
+                assert result.output_for_node("returns_two") == 2
+                assert result.output_for_node("add") == 3

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/python_script_single_step_handler.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/python_script_single_step_handler.py
@@ -43,6 +43,8 @@ class PythonScriptSingleStepHandler(RemoteEnvironmentSingleStepHandler):
             text=True,
         )
 
+        return None
+
     def terminate_single_step(
         self, _step_context: IStepContext, step_handler_context: StepHandlerContext
     ) -> Optional[Iterator[DagsterEvent]]:

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/python_script_single_step_handler.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/multienvironment_tests/python_script_single_step_handler.py
@@ -1,0 +1,55 @@
+import subprocess
+import sys
+from subprocess import CompletedProcess
+from typing import Iterator, Optional
+
+from dagster._core.events import DagsterEvent
+from dagster._core.execution.context.system import IStepContext
+from dagster._core.executor.multi_environment.multi_environment_step_handler import (
+    RemoteEnvironmentSingleStepHandler,
+)
+from dagster._core.executor.step_delegating.step_handler.base import (
+    CheckStepHealthResult,
+    StepHandlerContext,
+)
+from dagster._serdes.serdes import serialize_dagster_namedtuple
+
+
+# This is an example of what an integrator would have to write
+# to instigate a step on a remote environment
+class PythonScriptSingleStepHandler(RemoteEnvironmentSingleStepHandler):
+    def __init__(self, python_script: str, executable: Optional[str] = None):
+        self._python_script = python_script
+        self._executable: str = executable if executable else sys.executable
+        self._result: Optional[CompletedProcess[str]] = None
+
+    def launch_single_step(
+        self, step_context: IStepContext, step_handler_context: StepHandlerContext
+    ) -> Optional[Iterator[DagsterEvent]]:
+        step_key = step_context.step.key
+        run_id = step_context.run_id
+        ref = step_handler_context.instance.get_ref()
+        ref_json = serialize_dagster_namedtuple(ref)
+
+        # For example this could launch a spark job on a remote environment instead
+        # Serialization the InstanceRef not necessarily required. For example
+        # the other process could new up a DagsterInstance the communicates with
+        # Dagster Cloud over HTTP. Run_id and step_key are always required as they
+        # are necessary to fetch additional per-step information that we stash
+        # in the key value store
+        self._result = subprocess.run(
+            [sys.executable, self._python_script, run_id, step_key, ref_json],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+
+    def terminate_single_step(
+        self, _step_context: IStepContext, step_handler_context: StepHandlerContext
+    ) -> Optional[Iterator[DagsterEvent]]:
+        raise NotImplementedError()
+
+    def check_step_health(
+        self, _step_context: IStepContext, _step_handler_context: StepHandlerContext
+    ):
+        assert self._result
+        return CheckStepHealthResult(is_healthy=self._result.returncode == 0)

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1423,3 +1423,58 @@ def test_not_implemented():
 
     with pytest.raises(CheckError, match="desc argument must be a string"):
         check.not_implemented(None)  # type: ignore
+
+
+def test_iterable():
+    assert check.iterable_param([], "thisisfine") == []
+    assert check.iterable_param([1], "thisisfine") == [1]
+    assert check.iterable_param([1], "thisisfine", of_type=int) == [1]
+    assert check.iterable_param((i for i in [1, 2]), "thisisfine")
+    # assert that it does not coerce generator to list
+    assert check.iterable_param((i for i in [1, 2]), "thisisfine") != [1, 2]
+    assert list(check.iterable_param((i for i in [1, 2]), "thisisfine")) == [1, 2]
+
+    check.iterable_param("lkjsdkf", "stringisiterable")
+
+    with pytest.raises(CheckError, match="Iterable.*None"):
+        check.iterable_param(None, "nonenotallowed")  # type: ignore
+
+    with pytest.raises(CheckError, match="Iterable.*int"):
+        check.iterable_param(1, "intnotallowed")  # type: ignore
+
+    with pytest.raises(CheckError, match="Member of iterable mismatches type"):
+        check.iterable_param([1], "typemismatch", of_type=str)
+
+    with pytest.raises(CheckError, match="Member of iterable mismatches type"):
+        check.iterable_param(["atr", 2], "typemismatchmixed", of_type=str)
+
+    with pytest.raises(CheckError, match="Member of iterable mismatches type"):
+        check.iterable_param(["atr", None], "nonedoesntcount", of_type=str)
+
+
+def test_opt_iterable():
+    assert check.opt_iterable_param([], "thisisfine") == []
+    assert check.opt_iterable_param([1], "thisisfine") == [1]
+    assert check.opt_iterable_param((i for i in [1, 2]), "thisisfine")
+    # assert that it does not coerce generator to list
+    assert check.opt_iterable_param((i for i in [1, 2]), "thisisfine") != [1, 2]
+    # not_none coerces to Iterable[T] so
+    assert list(check.not_none(check.opt_iterable_param((i for i in [1, 2]), "thisisfine"))) == [
+        1,
+        2,
+    ]
+
+    check.opt_iterable_param("lkjsdkf", "stringisiterable")
+    check.opt_iterable_param(None, "noneisallowed")
+
+    with pytest.raises(CheckError, match="Iterable.*int"):
+        check.opt_iterable_param(1, "intnotallowed")  # type: ignore
+
+    with pytest.raises(CheckError, match="Member of iterable mismatches type"):
+        check.opt_iterable_param([1], "typemismatch", of_type=str)
+
+    with pytest.raises(CheckError, match="Member of iterable mismatches type"):
+        check.opt_iterable_param(["atr", 2], "typemismatchmixed", of_type=str)
+
+    with pytest.raises(CheckError, match="Member of iterable mismatches type"):
+        check.opt_iterable_param(["atr", None], "nonedoesntcount", of_type=str)


### PR DESCRIPTION
### Summary & Motivation

We have some community members clamoring for more flexible execution models that (1) separate the orchestration environment from the compute/business logic environment (2) run steps in distinct python environments in Dagster-native way (meaning using `@asset` and `@op` in the remote process, not just the execution of raw code) and (3) provide a more lightweight of launching remote steps than the step launcher that integrates with existing deployment processes and existing code.

For example w/r/t to orchestration environment and compute environment separation, we have users who want to orchestrate on Dagster Cloud but have their steps execute in isolated environments withn AWS Lambda.

We have another user that wants to use the Dagster programming model within Databricks, but they want to use their existing mechanisms for deploying code, have their orchestration and transformation logic in separate github repos, and do not want to the launching environment to have a pyspark/jvm dependency. These requirements preclude the usage of existing pyspark step launchers.

This RFC contains a few changes that allow for these scenarios.

* `MultiEnvironmentExecutor`: This is an executor that allows each step of execution to delegate to a distinct environment. It leverages the existing `StepDelegatingExecutor`, but provides a `StepHandler` that in turn composes a new concept a `RemoteEnvironmentSingleStepHandler` that allows for remote execution on a per step basis. One can return different instances of `RemoteEnvironmentSingleStepHandler` for each step. One variant might launch a k8s pod; another might launch a spark job. This, in effect, enables native multi-container/environment execution  within the run worker.
* `execute_asset_within_inprogress_run` and `execute_op_within_inprogress_run`: These are new public APIs provided to users for usage in the worker processes. This allows users to control code deployment and the "main" function in the external process. Note how this constrasts with step launchers, that control the entry point in the target runtime. Instead here, we assume that the user will take responsibility for deploying code to the target runtime and has their own entry point, and they call back _into_ our library to participate in a Dagster run. 

These take an asset/op definitions respectively, a run_id, a step_key, and a Dagster Instance. Any further information needed for executed is stashed in the Instance's KV store and fetched in the worker process.

![image](https://user-images.githubusercontent.com/28738937/213694830-23bf7dce-b48e-4096-897c-8e894217f04b.png)

In terms of metadata, we need to represent ops and assets in both processes. The asset-based tests are how I imagine this working, where we generate stub `AssetsDefinitions` that do not implement an execution function. However they do have metadata for display, and it will be the responsibility of the `MultiEnvironmentStepHandler` to stash all the data needed for execution so that the worker process can retrieve it.

A big next step here is further fleshing out this metadata interchange. Partitions are a critical thing. Partitions will have to be represented in both the launching and the worker process, and information like the current partition key will have be passed to the worker process.

Before proceeding further I wanted to get feedback on the approach.
 
### How I Tested These Changes

Included unit tests. Also used Dagit to run unit tests.
