### PR TITLE
[dagit] Display source data used in specific asset materializations

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
@@ -4,6 +4,7 @@ import {Link} from 'react-router-dom';
 
 import {Timestamp} from '../app/time/Timestamp';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {AssetKeyInput} from '../graphql/types';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {titleForRun, linkToRunEvent} from '../runs/RunUtils';
@@ -12,14 +13,16 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {AssetLineageElements} from './AssetLineageElements';
+import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {
   AssetMaterializationFragment,
   AssetObservationFragment,
 } from './types/useRecentAssetEvents.types';
 
 export const AssetEventDetail: React.FC<{
+  assetKey: AssetKeyInput;
   event: AssetMaterializationFragment | AssetObservationFragment;
-}> = ({event}) => {
+}> = ({event, assetKey}) => {
   const run = event.runOrError?.__typename === 'Run' ? event.runOrError : null;
   const repositoryOrigin = run?.repositoryOrigin;
   const repoAddress = repositoryOrigin
@@ -112,6 +115,13 @@ export const AssetEventDetail: React.FC<{
         <Subheading>Metadata</Subheading>
         <AssetEventMetadataEntriesTable event={event} />
       </Box>
+
+      {event.__typename === 'MaterializationEvent' && (
+        <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
+          <Subheading>Source Data</Subheading>
+          <AssetMaterializationUpstreamData timestamp={event.timestamp} assetKey={assetKey} />
+        </Box>
+      )}
 
       {assetLineage.length > 0 && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -164,12 +164,16 @@ export const AssetEvents: React.FC<Props> = ({
         >
           {xAxis === 'partition' ? (
             focused ? (
-              <AssetPartitionDetail group={focused} hasLineage={assetHasLineage} />
+              <AssetPartitionDetail
+                group={focused}
+                hasLineage={assetHasLineage}
+                assetKey={assetKey}
+              />
             ) : (
               <AssetPartitionDetailEmpty />
             )
           ) : focused?.latest ? (
-            <AssetEventDetail event={focused.latest} />
+            <AssetEventDetail assetKey={assetKey} event={focused.latest} />
           ) : (
             <AssetEventDetailEmpty />
           )}

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -1,0 +1,151 @@
+import {gql, useQuery} from '@apollo/client';
+import {Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {Timestamp} from '../app/time/Timestamp';
+import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {AssetKeyInput} from '../graphql/types';
+
+import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {
+  AssetMaterializationUpstreamQuery,
+  AssetMaterializationUpstreamQueryVariables,
+  MaterializationUpstreamDataVersionFragment,
+} from './types/AssetMaterializationUpstreamData.types';
+
+dayjs.extend(relativeTime);
+
+export const AssetMaterializationUpstreamData: React.FC<{
+  assetKey: AssetKeyInput;
+  timestamp?: string;
+}> = ({assetKey, timestamp}) => {
+  const result = useQuery<
+    AssetMaterializationUpstreamQuery,
+    AssetMaterializationUpstreamQueryVariables
+  >(ASSET_MATERIALIZATION_UPSTREAM_QUERY, {
+    skip: !timestamp,
+    variables: {assetKey, timestamp: timestamp || ''},
+  });
+
+  const displayName = displayNameForAssetKey(assetKey);
+  const entries =
+    result.data?.assetNodeOrError.__typename === 'AssetNode'
+      ? result.data.assetNodeOrError.assetMaterializationUsedData
+      : [];
+
+  const renderEntryAndParents = (
+    entry: MaterializationUpstreamDataVersionFragment,
+    depth: number,
+    isFirstAtDepth: boolean,
+  ): React.ReactNode[] => {
+    const entryDisplayName = displayNameForAssetKey(entry.assetKey);
+    const entryLink = assetDetailsPathForKey(entry.assetKey, {
+      view: 'events',
+      time: entry.timestamp,
+    });
+
+    return [
+      <tr key={entryDisplayName}>
+        <td>
+          <Box flex={{gap: 4}} style={{paddingLeft: Math.max(0, depth) * 20}}>
+            {isFirstAtDepth && <Icon name="arrow_indent" style={{marginLeft: -20}} />}
+            <Link to={entryLink}>
+              <Box flex={{gap: 4}}>
+                <Icon name="asset" />
+                <MiddleTruncate text={entryDisplayName} />
+              </Box>
+            </Link>
+          </Box>
+        </td>
+        <td>
+          <Box flex={{gap: 8}} style={{whiteSpace: 'nowrap'}}>
+            <Link to={entryLink}>
+              <Timestamp
+                timestamp={{ms: Number(entry.timestamp)}}
+                timeFormat={{showSeconds: true, showTimezone: false}}
+              />
+            </Link>
+            <span>({dayjs(Number(entry.timestamp)).from(Number(timestamp), true)} earlier)</span>
+          </Box>
+        </td>
+      </tr>,
+      ...entries
+        .filter((e) => displayNameForAssetKey(e.downstreamAssetKey) === entryDisplayName)
+        .map((e, idx) => renderEntryAndParents(e, depth + 1, idx === 0)),
+    ];
+  };
+
+  if (result.loading) {
+    return (
+      <AssetUpstreamDataTable>
+        <tbody>
+          <tr>
+            <td>Loading…</td>
+          </tr>
+        </tbody>
+      </AssetUpstreamDataTable>
+    );
+  }
+  if (!entries.length) {
+    return (
+      <AssetUpstreamDataTable>
+        <tbody>
+          <tr>
+            <td>No materializations to display.</td>
+          </tr>
+        </tbody>
+      </AssetUpstreamDataTable>
+    );
+  }
+  return (
+    <AssetUpstreamDataTable>
+      <tbody>
+        {entries
+          .filter((e) => displayNameForAssetKey(e.downstreamAssetKey) === displayName)
+          .map((e) => renderEntryAndParents(e, 0, false))}
+      </tbody>
+    </AssetUpstreamDataTable>
+  );
+};
+
+const ASSET_MATERIALIZATION_UPSTREAM_QUERY = gql`
+  query AssetMaterializationUpstreamQuery($assetKey: AssetKeyInput!, $timestamp: String!) {
+    assetNodeOrError(assetKey: $assetKey) {
+      __typename
+      ... on AssetNode {
+        id
+        assetMaterializationUsedData(timestampMillis: $timestamp) {
+          ...MaterializationUpstreamDataVersionFragment
+        }
+      }
+    }
+  }
+
+  fragment MaterializationUpstreamDataVersionFragment on MaterializationUpstreamDataVersion {
+    __typename
+    timestamp
+    assetKey {
+      path
+    }
+    downstreamAssetKey {
+      path
+    }
+  }
+`;
+
+const AssetUpstreamDataTable = styled.table`
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+
+  tr td {
+    border: 1px solid ${Colors.KeylineGray};
+    padding: 8px 12px;
+    font-size: 14px;
+    vertical-align: top;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -13,6 +13,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AllIndividualEventsLink} from './AllIndividualEventsLink';
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
+import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {AssetEventGroup} from './groupByPartition';
 import {AssetKey} from './types';
 import {
@@ -57,6 +58,7 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
 
   return (
     <AssetPartitionDetail
+      assetKey={props.assetKey}
       hasLineage={hasLineage}
       group={{
         latest: materializations[0],
@@ -97,10 +99,11 @@ const ASSET_PARTITION_DETAIL_QUERY = gql`
 `;
 
 export const AssetPartitionDetail: React.FC<{
+  assetKey: AssetKey;
   group: AssetEventGroup;
   hasLineage: boolean;
   hasLoadingState?: boolean;
-}> = ({group, hasLineage, hasLoadingState}) => {
+}> = ({assetKey, group, hasLineage, hasLoadingState}) => {
   const {latest, partition, all} = group;
   const run = latest?.runOrError?.__typename === 'Run' ? latest.runOrError : null;
   const repositoryOrigin = run?.repositoryOrigin;
@@ -211,12 +214,17 @@ export const AssetPartitionDetail: React.FC<{
         <Subheading>Metadata</Subheading>
         <AssetEventMetadataEntriesTable event={latest} observations={observationsAboutLatest} />
       </Box>
+      <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
+        <Subheading>Source Data</Subheading>
+        <AssetMaterializationUpstreamData timestamp={latest?.timestamp} assetKey={assetKey} />
+      </Box>
     </Box>
   );
 };
 
 export const AssetPartitionDetailEmpty = ({partitionKey}: {partitionKey?: string}) => (
   <AssetPartitionDetail
+    assetKey={{path: ['']}}
     group={{all: [], latest: null, timestamp: '0', partition: partitionKey}}
     hasLineage={false}
     hasLoadingState

--- a/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationUpstreamData.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetMaterializationUpstreamData.types.ts
@@ -1,0 +1,31 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type AssetMaterializationUpstreamQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+  timestamp: Types.Scalars['String'];
+}>;
+
+export type AssetMaterializationUpstreamQuery = {
+  __typename: 'DagitQuery';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        assetMaterializationUsedData: Array<{
+          __typename: 'MaterializationUpstreamDataVersion';
+          timestamp: string;
+          assetKey: {__typename: 'AssetKey'; path: Array<string>};
+          downstreamAssetKey: {__typename: 'AssetKey'; path: Array<string>};
+        }>;
+      }
+    | {__typename: 'AssetNotFoundError'};
+};
+
+export type MaterializationUpstreamDataVersionFragment = {
+  __typename: 'MaterializationUpstreamDataVersion';
+  timestamp: string;
+  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  downstreamAssetKey: {__typename: 'AssetKey'; path: Array<string>};
+};

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -637,6 +637,7 @@ type AssetNode {
     beforeTimestampMillis: String
     limit: Int
   ): [MaterializationEvent!]!
+  assetMaterializationUsedData(timestampMillis: String!): [MaterializationUpstreamDataVersion!]!
   assetObservations(
     partitions: [String]
     beforeTimestampMillis: String
@@ -674,6 +675,12 @@ type AssetNode {
   repository: Repository!
   requiredResources: [ResourceRequirement!]!
   type: DagsterType
+}
+
+type MaterializationUpstreamDataVersion {
+  assetKey: AssetKey!
+  downstreamAssetKey: AssetKey!
+  timestamp: String!
 }
 
 type AssetDependency {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -171,6 +171,7 @@ export type AssetMetadataEntry = MetadataEntry & {
 export type AssetNode = {
   __typename: 'AssetNode';
   assetKey: AssetKey;
+  assetMaterializationUsedData: Array<MaterializationUpstreamDataVersion>;
   assetMaterializations: Array<MaterializationEvent>;
   assetObservations: Array<ObservationEvent>;
   computeKind: Maybe<Scalars['String']>;
@@ -205,6 +206,10 @@ export type AssetNode = {
   repository: Repository;
   requiredResources: Array<ResourceRequirement>;
   type: Maybe<DagsterType>;
+};
+
+export type AssetNodeAssetMaterializationUsedDataArgs = {
+  timestampMillis: Scalars['String'];
 };
 
 export type AssetNodeAssetMaterializationsArgs = {
@@ -1855,6 +1860,13 @@ export type MaterializationEvent = DisplayableEvent &
     stepStats: RunStepStats;
     timestamp: Scalars['String'];
   };
+
+export type MaterializationUpstreamDataVersion = {
+  __typename: 'MaterializationUpstreamDataVersion';
+  assetKey: AssetKey;
+  downstreamAssetKey: AssetKey;
+  timestamp: Scalars['String'];
+};
 
 export type MessageEvent = {
   eventType: Maybe<DagsterEventType>;

--- a/js_modules/dagit/packages/ui/src/components/Icon.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Icon.tsx
@@ -10,6 +10,7 @@ import arrow_back from '../icon-svgs/arrow_back.svg';
 import arrow_downward from '../icon-svgs/arrow_downward.svg';
 import arrow_drop_down from '../icon-svgs/arrow_drop_down.svg';
 import arrow_forward from '../icon-svgs/arrow_forward.svg';
+import arrow_indent from '../icon-svgs/arrow_indent.svg';
 import arrow_upward from '../icon-svgs/arrow_upward.svg';
 import asset from '../icon-svgs/asset.svg';
 import asset_group from '../icon-svgs/asset_group.svg';
@@ -179,6 +180,7 @@ export const Icons = {
   github_pr_merged,
   gitlab,
   youtube,
+  arrow_indent,
 
   graph_downstream,
   graph_upstream,

--- a/js_modules/dagit/packages/ui/src/icon-svgs/arrow_indent.svg
+++ b/js_modules/dagit/packages/ui/src/icon-svgs/arrow_indent.svg
@@ -1,0 +1,10 @@
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g stroke="#000000" stroke-width="1.8">
+            <line x1="8.29411765" y1="0.907311396" x2="8.29411765" y2="10.1" id="Line" stroke-linecap="square"></line>
+            <line x1="17.7058824" y1="10.1" x2="8.29411765" y2="10.1" id="Line" stroke-linecap="round"></line>
+            <line x1="17.7058824" y1="10.1" x2="14.1764706" y2="6.5" id="Line" stroke-linecap="square"></line>
+            <line x1="17.7058824" y1="10.1" x2="14.1764706" y2="13.7" id="Line" stroke-linecap="square"></line>
+        </g>
+    </g>
+</svg>

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
+from collections import deque
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union, cast
 
 import graphene
 from dagster import (
@@ -10,6 +11,8 @@ from dagster._core.definitions.logical_version import (
     DEFAULT_LOGICAL_VERSION,
     extract_logical_version_from_entry,
 )
+from dagster._core.event_api import EventRecordsFilter
+from dagster._core.events import DagsterEventType
 from dagster._core.host_representation import ExternalRepository, RepositoryLocation
 from dagster._core.host_representation.external import ExternalPipeline
 from dagster._core.host_representation.external_data import (
@@ -53,7 +56,10 @@ from .asset_key import GrapheneAssetKey
 from .dagster_types import GrapheneDagsterType, to_dagster_type
 from .errors import GrapheneAssetNotFoundError
 from .freshness_policy import GrapheneAssetFreshnessInfo, GrapheneFreshnessPolicy
-from .logs.events import GrapheneMaterializationEvent, GrapheneObservationEvent
+from .logs.events import (
+    GrapheneMaterializationEvent,
+    GrapheneObservationEvent,
+)
 from .pipelines.pipeline import (  # GraphenePartitionMaterializationS,
     GrapheneMaterializationCountGroupedByDimension,
     GrapheneMaterializationCountSingleDimension,
@@ -131,6 +137,15 @@ class GrapheneAssetNodeDefinitionCollision(graphene.ObjectType):
         name = "AssetNodeDefinitionCollision"
 
 
+class GrapheneMaterializationUpstreamDataVersion(graphene.ObjectType):
+    assetKey = graphene.NonNull(GrapheneAssetKey)
+    downstreamAssetKey = graphene.NonNull(GrapheneAssetKey)
+    timestamp = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "MaterializationUpstreamDataVersion"
+
+
 class GrapheneAssetNode(graphene.ObjectType):
     _depended_by_loader: Optional[CrossRepoAssetDependedByLoader]
     _external_asset_node: ExternalAssetNode
@@ -147,6 +162,10 @@ class GrapheneAssetNode(graphene.ObjectType):
         partitions=graphene.List(graphene.String),
         beforeTimestampMillis=graphene.String(),
         limit=graphene.Int(),
+    )
+    assetMaterializationUsedData = graphene.Field(
+        non_null_list(GrapheneMaterializationUpstreamDataVersion),
+        timestampMillis=graphene.NonNull(graphene.String),
     )
     assetObservations = graphene.Field(
         non_null_list(GrapheneObservationEvent),
@@ -330,6 +349,63 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def is_source_asset(self) -> bool:
         return self._external_asset_node.is_source
+
+    def resolve_assetMaterializationUsedData(
+        self, graphene_info, **kwargs
+    ) -> Sequence[GrapheneMaterializationUpstreamDataVersion]:
+        timestamp_millis: Optional[str] = kwargs.get("timestampMillis")
+        if not timestamp_millis:
+            return []
+
+        instance = graphene_info.context.instance
+        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
+        asset_key = self._external_asset_node.asset_key
+
+        # in the future, we can share this same CachingInstanceQueryer across all
+        # GrapheneMaterializationEvent which share an external repository for improved performance
+        data_time_queryer = CachingInstanceQueryer(instance=graphene_info.context.instance)
+        event_records = instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                before_timestamp=int(timestamp_millis) / 1000.0 + 1,
+                after_timestamp=int(timestamp_millis) / 1000.0 - 1,
+                asset_key=asset_key,
+            ),
+            limit=1,
+        )
+
+        if not event_records:
+            return []
+
+        parents_to_children: Dict[AssetKey, AssetKey] = dict()
+        queue = deque([[asset_key, None]])
+        while queue:
+            [current_key, child_key] = queue.popleft()
+            if not current_key or asset_graph.is_source(current_key):
+                continue
+            # just return the nearest 20 assets or all the immediate parents
+            if len(parents_to_children) > 20 and child_key != asset_key:
+                break
+            for parent_key in asset_graph.get_parents(current_key):
+                if parent_key not in parents_to_children:
+                    parents_to_children[parent_key] = current_key
+                    queue.append([parent_key, current_key])
+
+        used_data_times = data_time_queryer.get_used_data_times_for_record(
+            asset_graph=asset_graph,
+            record=event_records[0],
+            upstream_keys=parents_to_children.keys(),
+        )
+
+        return [
+            GrapheneMaterializationUpstreamDataVersion(
+                assetKey=asset_key,
+                downstreamAssetKey=parents_to_children[asset_key],
+                timestamp=int(materialization_time.timestamp() * 1000),
+            )
+            for asset_key, materialization_time in used_data_times.items()
+            if materialization_time
+        ]
 
     def resolve_assetMaterializations(
         self, graphene_info, **kwargs

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1528,8 +1528,8 @@ def asset_one():
 
 
 @asset
-def asset_two(asset_one):  # pylint: disable=redefined-outer-name,unused-argument
-    return first_asset + 1
+def asset_two(asset_one):  # pylint: disable=redefined-outer-name
+    return asset_one + 1
 
 
 two_assets_job = build_assets_job(name="two_assets_job", assets=[asset_one, asset_two])

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -185,6 +185,26 @@ GET_LATEST_MATERIALIZATION_PER_PARTITION = """
     }
 """
 
+GET_MATERIALIZATION_USED_DATA = """
+    query AssetNodeQuery($assetKey: AssetKeyInput!, $timestamp: String!) {
+        assetNodeOrError(assetKey: $assetKey) {
+            ...on AssetNode {
+                id
+                assetMaterializationUsedData(timestampMillis: $timestamp) {
+                    __typename
+                    timestamp
+                    assetKey {
+                        path
+                    }
+                    downstreamAssetKey {
+                        path
+                    }
+                }
+            }
+        }
+    }
+"""
+
 GET_FRESHNESS_INFO = """
     query AssetNodeQuery {
         assetNodes {
@@ -773,6 +793,36 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert new_start_time > start_time
 
         assert asset_node["latestMaterializationByPartition"][1] is None
+
+    def test_materialization_used_data(self, graphql_context):
+        def get_response_by_asset(response):
+            return {stat["assetKey"]["path"][0]: stat for stat in response}
+
+        _create_run(graphql_context, "two_assets_job")
+
+        # Obtain the timestamp of the asset_one, asset_two materializations
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_LATEST_RUN_STATS,
+            variables={"assetKeys": [{"path": ["asset_one"]}, {"path": ["asset_two"]}]},
+        )
+
+        assert result.data["assetsLatestInfo"]
+        info = get_response_by_asset(result.data["assetsLatestInfo"])
+        timestamp_a1 = info["asset_one"]["latestMaterialization"]["timestamp"]
+        timestamp_a2 = info["asset_two"]["latestMaterialization"]["timestamp"]
+
+        # Verify that the "used data" for asset_two matches the asset_one timestamp
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_MATERIALIZATION_USED_DATA,
+            variables={"assetKey": {"path": ["asset_two"]}, "timestamp": timestamp_a2},
+        )
+
+        used_data = result.data["assetNodeOrError"]["assetMaterializationUsedData"]
+        assert len(used_data) == 1
+        assert used_data[0]["assetKey"]["path"] == ["asset_one"]
+        assert used_data[0]["timestamp"] == timestamp_a1
 
     def test_materialization_count_by_partition(self, graphql_context):
         # test for unpartitioned asset


### PR DESCRIPTION
### Summary & Motivation

This PR addresses #11174 - a new section of Dagit's materialization event / partition detail view shows the upstream materializations that were "source data" for the displayed event.

This uses a new GraphQL resolver built on the underlying storage + fetching for asset versioning.

![image](https://user-images.githubusercontent.com/1037212/212723976-644bacfc-23a3-4a38-8aa8-cc5d667e1747.png)


### How I Tested These Changes

There's a new unit test, but I also tested this on a large set of existing materializations, verified it does not appear for observations, and checked that navigating the referenced assets produces internally consistent views. (eg: clicking B in A->B->C->D still shows the same C->D)