### PR TITLE
Make StaticPartitionMapping serializable. Add autodoc.

### DIFF
--- a/docs/sphinx/sections/api/apidocs/partitions.rst
+++ b/docs/sphinx/sections/api/apidocs/partitions.rst
@@ -76,3 +76,6 @@ Partition Mapping (Experimental)
 
 .. autoclass:: LastPartitionMapping
     :members:
+
+.. autoclass:: StaticPartitionMapping
+    :members:

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -332,7 +332,12 @@ class StaticPartitionMapping(
     PartitionMapping,
     NamedTuple(
         "_StaticPartitionMapping",
-        [("downstream_partition_keys_by_upstream_partition_key", PublicAttr[Mapping])],
+        [
+            (
+                "downstream_partition_keys_by_upstream_partition_key",
+                PublicAttr[Mapping[str, Union[str, Collection[str]]]],
+            )
+        ],
     ),
 ):
     """

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Collection, Mapping, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import PublicAttr, experimental, public
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
@@ -327,7 +327,14 @@ class SingleDimensionDependencyMapping(PartitionMapping):
         return downstream_partitions_def.empty_subset().with_partition_keys(set(matching_keys))
 
 
-class StaticPartitionMapping(PartitionMapping):
+@whitelist_for_serdes
+class StaticPartitionMapping(
+    PartitionMapping,
+    NamedTuple(
+        "_StaticPartitionMapping",
+        [("downstream_partition_keys_by_upstream_partition_key", PublicAttr[Mapping])],
+    ),
+):
     """
     Define an explicit correspondence between two StaticPartitionsDefinitions.
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -1,6 +1,10 @@
 import pytest
 from dagster import StaticPartitionMapping, StaticPartitionsDefinition
 from dagster._core.definitions.partition import DefaultPartitionsSubset
+from dagster._serdes.serdes import (
+    deserialize_json_to_dagster_namedtuple,
+    serialize_dagster_namedtuple,
+)
 
 
 def test_single_valued_static_mapping():
@@ -69,3 +73,12 @@ def test_error_on_extra_keys_in_mapping():
             downstream_partitions_subset=downstream_parts.empty_subset(),
             upstream_partitions_def=upstream_parts,
         )
+
+
+def test_static_partition_mapping_serdes():
+    mapping = StaticPartitionMapping(
+        {"p1": "p", "p2": "p", "p3": "p", "q": ["q1", "q2"], "r1": "r"}
+    )
+    ser = serialize_dagster_namedtuple(mapping)
+    deser = deserialize_json_to_dagster_namedtuple(ser)
+    assert mapping == deser


### PR DESCRIPTION
### Summary & Motivation

Changes made by https://github.com/dagster-io/dagster/pull/11521 do not work in tandem with dagit due to lack of serialization.

This PR adds serde whitelisting similar to TimeWindowPartitionMapping.

Also adds basic class autodoc.

### How I Tested These Changes
`dagit -f partitioned.py`

with the following as partitioned.py:
```python
from dagster import (
    AssetIn,
    Definitions,
    StaticPartitionMapping,
    StaticPartitionsDefinition,
    asset,
)

upstream_parts = StaticPartitionsDefinition(["p1", "p2", "p3", "q1", "q2", "r1"])
downstream_parts = StaticPartitionsDefinition(["p", "q", "r"])
mapping = StaticPartitionMapping({"p1": "p", "p2": "p", "p3": "p", "r1": "r"})


@asset(partitions_def=upstream_parts)
def a(context):
    return "key-" + context.asset_partition_key_for_output()


@asset(
    partitions_def=downstream_parts,
    ins={"up": AssetIn("a", partition_mapping=mapping)},
)
def b(up) -> dict:
    return up


defs = Definitions(
    assets=[a, b],
)
```