### PR TITLE
Don't spew "Aborted!" to the command-line when the Daemon is cleanly interrupted

### DIFF
--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -48,11 +48,14 @@ def _get_heartbeat_tolerance():
 )
 @workspace_target_argument
 def run_command(code_server_log_level, instance_ref, **kwargs):
-    with capture_interrupts():
-        with DagsterInstance.from_ref(
-            deserialize_as(instance_ref, InstanceRef)
-        ) if instance_ref else DagsterInstance.get() as instance:
-            _daemon_run_command(instance, code_server_log_level, kwargs)
+    try:
+        with capture_interrupts():
+            with DagsterInstance.from_ref(
+                deserialize_as(instance_ref, InstanceRef)
+            ) if instance_ref else DagsterInstance.get() as instance:
+                _daemon_run_command(instance, code_server_log_level, kwargs)
+    except KeyboardInterrupt:
+        return  # Exit cleanly on interrupt
 
 
 @telemetry_wrapper(metadata={"DAEMON_SESSION_ID": get_telemetry_daemon_session_id()})

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -274,7 +274,14 @@ class DagsterDaemonController(AbstractContextManager):
                 last_heartbeat_check_time = time.time()
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self._logger.info("Shutting down daemon threads...")
+        if isinstance(exception_value, KeyboardInterrupt):
+            self._logger.info("Received interrupt, shutting down daemon threads...")
+        elif exception_type:
+            self._logger.warning(
+                f"Shutting down daemon threads due to {exception_type.__name__}..."
+            )
+        else:
+            self._logger.info("Shutting down daemon threads...")
         self._daemon_shutdown_event.set()
         for daemon_type, thread in self._daemon_threads.items():
             if thread.is_alive():


### PR DESCRIPTION
Right now whenever you CTRL-C the daemon (or `dagster dev` terminates the daemon) we hit some generic click logic that prints out a scary "Aborted!" message, even though its the expected way to end the process. Instead of
bubbling the interrupt up to click, catch it in the CLI command and exit cleanly.

uvicorn in dagit has similar logic that causes dagit to exit with return code 0 when an interrupt happens.

Test Plan:
Run daemon locally, CTRL-C, no more scary "Aborted!" message, same with dagster dev
