### PR TITLE
[docs] [dagster-snowflake] update docs with private key auth info

### DIFF
--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -7,10 +7,58 @@ description: Store your Dagster assets in Snowflake
 
 This reference page provides information for working with [`dagster-snowflake`](/\_apidocs/libraries/dagster-snowflake) features that are not covered as part of the [Using Dagster with Snowflake tutorial](/integrations/snowflake/using-snowflake-with-dagster).
 
+- [Authenticating using a private key](#authenticating-using-a-private-key)
 - [Selecting specific columns in a downstream asset](#selecting-specific-columns-in-a-downstream-asset)
 - [Storing tables in multiple schemas](#storing-tables-in-multiple-schemas)
 - [Using the Snowflake I/O manager with other I/O managers](#using-the-snowflake-io-manager-with-other-io-managers)
 - [Executing custom SQL commands with the Snowflake resource](#executing-custom-sql-commands-with-the-snowflake-resource)
+
+---
+
+## Authenticating using a private key
+
+In addition to password-based authentication, you can authenticate with Snowflake using a key pair. To set up private key authentication for your Snowflake account, see the instructions in the [Snowflake docs](https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication).
+
+You can provide the private key directly to the Snowflake I/O manager using the `private_key` configuration value. If your key is encrypted, you can provide the password using the `private_key_password`.
+
+```python file=/integrations/snowflake/private_key_auth.py startafter=start_direct_key endbefore=end_direct_key
+from dagster_snowflake_pandas import snowflake_pandas_io_manager
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "io_manager": snowflake_pandas_io_manager.configured(
+            {
+                "account": "abc1234.us-east-1",
+                "user": {"env": "SNOWFLAKE_USER"},
+                "private_key": {"env": "SNOWFLAKE_PK"},
+                "private_key_password": {"env": "SNOWFLAKE_PK_PASSWORD"},
+                "database": "FLOWERS",
+            }
+        )
+    },
+)
+```
+
+You can also provide a path to a file containing the private key with the `private_key_path` configuration value.
+
+```python file=/integrations/snowflake/private_key_auth.py startafter=start_key_file endbefore=end_key_file
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "io_manager": snowflake_pandas_io_manager.configured(
+            {
+                "account": "abc1234.us-east-1",
+                "user": {"env": "SNOWFLAKE_USER"},
+                "private_key_path": "/path/to/private/key/file.p8",
+                "database": "FLOWERS",
+            }
+        )
+    },
+)
+```
 
 ---
 

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -53,7 +53,6 @@ from dagster_snowflake_pandas import snowflake_pandas_io_manager
 
 from dagster import Definitions
 
-
 defs = Definitions(
     assets=[iris_dataset],
     resources={

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -17,9 +17,12 @@ This reference page provides information for working with [`dagster-snowflake`](
 
 ## Authenticating using a private key
 
-In addition to password-based authentication, you can authenticate with Snowflake using a key pair. To set up private key authentication for your Snowflake account, see the instructions in the [Snowflake docs](https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication).
+In addition to password-based authentication, you can authenticate with Snowflake using a key pair. To set up private key authentication for your Snowflake account, see the instructions in the [Snowflake docs](https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication). Currently, the Snowflake I/O manager only supports encrypted private keys.
 
-You can provide the private key directly to the Snowflake I/O manager using the `private_key` configuration value. If your key is encrypted, you can provide the password using the `private_key_password`.
+You can provide the private key directly to the Snowflake I/O manager, or via a file containing the private key.
+
+<TabGroup>
+<TabItem name="Directly to the I/O manager">
 
 ```python file=/integrations/snowflake/private_key_auth.py startafter=start_direct_key endbefore=end_direct_key
 from dagster_snowflake_pandas import snowflake_pandas_io_manager
@@ -42,9 +45,15 @@ defs = Definitions(
 )
 ```
 
-You can also provide a path to a file containing the private key with the `private_key_path` configuration value.
+</TabItem>
+<TabItem name="Via a file">
 
-```python file=/integrations/snowflake/private_key_auth.py startafter=start_key_file endbefore=end_key_file
+```python file=/integrations/snowflake/private_key_auth_file.py startafter=start_key_file endbefore=end_key_file
+from dagster_snowflake_pandas import snowflake_pandas_io_manager
+
+from dagster import Definitions
+
+
 defs = Definitions(
     assets=[iris_dataset],
     resources={
@@ -53,12 +62,16 @@ defs = Definitions(
                 "account": "abc1234.us-east-1",
                 "user": {"env": "SNOWFLAKE_USER"},
                 "private_key_path": "/path/to/private/key/file.p8",
+                "private_key_password": {"env": "SNOWFLAKE_PK_PASSWORD"},
                 "database": "FLOWERS",
             }
         )
     },
 )
 ```
+
+</TabItem>
+</TabGroup>
 
 ---
 

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
@@ -49,7 +49,6 @@ To complete this tutorial, you'll need:
 
     For more information on authenticating with a private key, see [Authenticating with a private key](/integrations/snowflake/reference#authenticating-using-a-private-key) in the Snowflake reference guide.
 
-
 ---
 
 ## Step 1: Configure the Snowflake I/O manager
@@ -70,7 +69,9 @@ defs = Definitions(
             {
                 "account": "abc1234.us-east-1",  # required
                 "user": {"env": "SNOWFLAKE_USER"},  # required
-                "password": {"env": "SNOWFLAKE_PASSWORD"},  # password or private key required
+                "password": {
+                    "env": "SNOWFLAKE_PASSWORD"
+                },  # password or private key required
                 "database": "FLOWERS",  # required
                 "role": "writer",  # optional, defaults to the default role for the account
                 "warehouse": "PLANTS",  # optional, defaults to default warehouse for the account

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
@@ -36,7 +36,9 @@ To complete this tutorial, you'll need:
     height={72}
     />
 
-  - **Snowflake credentials**: This includes a username and a password. The Snowflake I/O manager can read these values from environment variables. In this guide, we store the username and password as `SNOWFLAKE_USER` and `SNOWFLAKE_PASSWORD`, respectively.
+  - **Snowflake credentials**: You can authenticate with Snowflake two ways: with a username and password, or with a username and private key.
+
+    The Snowflake I/O manager can read all of these authentication values values from environment variables. In this guide, we use password authentication and store the username and password as `SNOWFLAKE_USER` and `SNOWFLAKE_PASSWORD`, respectively.
 
     ```shell
     export SNOWFLAKE_USER=<your username>
@@ -49,7 +51,7 @@ To complete this tutorial, you'll need:
 
 ## Step 1: Configure the Snowflake I/O manager
 
-The Snowflake I/O manager requires some configuration to connect to your Snowflake instance. The `account`, `user` and `password` are required to connect with Snowflake. Additionally, you need to specify a `database` to where all the tables should be stored.
+The Snowflake I/O manager requires some configuration to connect to your Snowflake instance. The `account`, `user` are required to connect with Snowflake. One method of authentication is required. You can use a password or a private key. Additionally, you need to specify a `database` to where all the tables should be stored.
 
 You can also provide some optional configuration to further customize the Snowflake I/O manager. You can specify a `warehouse` and `schema` where data should be stored, and a `role` for the I/O manager.
 
@@ -65,7 +67,7 @@ defs = Definitions(
             {
                 "account": "abc1234.us-east-1",  # required
                 "user": {"env": "SNOWFLAKE_USER"},  # required
-                "password": {"env": "SNOWFLAKE_PASSWORD"},  # required
+                "password": {"env": "SNOWFLAKE_PASSWORD"},  # password or private key required
                 "database": "FLOWERS",  # required
                 "role": "writer",  # optional, defaults to the default role for the account
                 "warehouse": "PLANTS",  # optional, defaults to default warehouse for the account
@@ -81,6 +83,8 @@ With this configuration, if you materialized an asset called `iris_dataset`, the
 Finally, in the <PyObject object="Definitions" /> object, we assign the `snowflake_pandas_io_manager` to the `io_manager` key. `io_manager` is a reserved key to set the default I/O manager for your assets.
 
 For more info about each of the configuration values, refer to the <PyObject module="dagster_snowflake" object="build_snowflake_io_manager" /> API documentation.
+
+For more information on authenticating with a private key, see [Authenticating with a private key](/integrations/snowflake/reference#authenticating-using-a-private-key) in the Snowflake reference guide.
 
 ---
 

--- a/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
+++ b/docs/content/integrations/snowflake/using-snowflake-with-dagster.mdx
@@ -38,7 +38,7 @@ To complete this tutorial, you'll need:
 
   - **Snowflake credentials**: You can authenticate with Snowflake two ways: with a username and password, or with a username and private key.
 
-    The Snowflake I/O manager can read all of these authentication values values from environment variables. In this guide, we use password authentication and store the username and password as `SNOWFLAKE_USER` and `SNOWFLAKE_PASSWORD`, respectively.
+    The Snowflake I/O manager can read all of these authentication values from environment variables. In this guide, we use password authentication and store the username and password as `SNOWFLAKE_USER` and `SNOWFLAKE_PASSWORD`, respectively.
 
     ```shell
     export SNOWFLAKE_USER=<your username>
@@ -46,6 +46,9 @@ To complete this tutorial, you'll need:
     ```
 
     Refer to the [Using environment variables and secrets guide](/guides/dagster/using-environment-variables-and-secrets) for more info.
+
+    For more information on authenticating with a private key, see [Authenticating with a private key](/integrations/snowflake/reference#authenticating-using-a-private-key) in the Snowflake reference guide.
+
 
 ---
 
@@ -83,8 +86,6 @@ With this configuration, if you materialized an asset called `iris_dataset`, the
 Finally, in the <PyObject object="Definitions" /> object, we assign the `snowflake_pandas_io_manager` to the `io_manager` key. `io_manager` is a reserved key to set the default I/O manager for your assets.
 
 For more info about each of the configuration values, refer to the <PyObject module="dagster_snowflake" object="build_snowflake_io_manager" /> API documentation.
-
-For more information on authenticating with a private key, see [Authenticating with a private key](/integrations/snowflake/reference#authenticating-using-a-private-key) in the Snowflake reference guide.
 
 ---
 

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/configuration.py
@@ -19,7 +19,9 @@ defs = Definitions(
             {
                 "account": "abc1234.us-east-1",  # required
                 "user": {"env": "SNOWFLAKE_USER"},  # required
-                "password": {"env": "SNOWFLAKE_PASSWORD"},  # required
+                "password": {
+                    "env": "SNOWFLAKE_PASSWORD"
+                },  # password or private key required
                 "database": "FLOWERS",  # required
                 "role": "writer",  # optional, defaults to the default role for the account
                 "warehouse": "PLANTS",  # optional, defaults to default warehouse for the account

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/private_key_auth.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/private_key_auth.py
@@ -1,0 +1,43 @@
+iris_dataset = None
+
+# start_direct_key
+
+from dagster_snowflake_pandas import snowflake_pandas_io_manager
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "io_manager": snowflake_pandas_io_manager.configured(
+            {
+                "account": "abc1234.us-east-1",
+                "user": {"env": "SNOWFLAKE_USER"},
+                "private_key": {"env": "SNOWFLAKE_PK"},
+                "private_key_password": {"env": "SNOWFLAKE_PK_PASSWORD"},
+                "database": "FLOWERS",
+            }
+        )
+    },
+)
+
+# end_direct_key
+
+
+# start_key_file
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "io_manager": snowflake_pandas_io_manager.configured(
+            {
+                "account": "abc1234.us-east-1",
+                "user": {"env": "SNOWFLAKE_USER"},
+                "private_key_path": "/path/to/private/key/file.p8",
+                "database": "FLOWERS",
+            }
+        )
+    },
+)
+
+# end_key_file

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/private_key_auth_file.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/private_key_auth_file.py
@@ -1,0 +1,24 @@
+iris_dataset = None
+
+# start_key_file
+
+from dagster_snowflake_pandas import snowflake_pandas_io_manager
+
+from dagster import Definitions
+
+defs = Definitions(
+    assets=[iris_dataset],
+    resources={
+        "io_manager": snowflake_pandas_io_manager.configured(
+            {
+                "account": "abc1234.us-east-1",
+                "user": {"env": "SNOWFLAKE_USER"},
+                "private_key_path": "/path/to/private/key/file.p8",
+                "private_key_password": {"env": "SNOWFLAKE_PK_PASSWORD"},
+                "database": "FLOWERS",
+            }
+        )
+    },
+)
+
+# end_key_file


### PR DESCRIPTION
### Summary & Motivation
The snowflake io manager supports private key authentication now, so add it to the docs

vercel previews:
https://dagster-git-jamie-snowflake-pk-docs-elementl.vercel.app/integrations/snowflake/using-snowflake-with-dagster
https://dagster-git-jamie-snowflake-pk-docs-elementl.vercel.app/integrations/snowflake/reference

### How I Tested These Changes
