### PR TITLE
[dagit] Strip down query for Scheduled Runs

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -8,19 +8,21 @@ import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
-import {REPOSITORY_SCHEDULES_FRAGMENT} from '../schedules/ScheduleUtils';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
-import {SchedulesNextTicks} from '../schedules/SchedulesNextTicks';
+import {
+  REPOSITORY_FOR_NEXT_TICKS_FRAGMENT,
+  SchedulesNextTicks,
+} from '../schedules/SchedulesNextTicks';
 import {Loading} from '../ui/Loading';
 
 import {RunsPageHeader} from './RunsPageHeader';
-import {SchedulerInfoQuery} from './types/ScheduledRunListRoot.types';
+import {ScheduledRunsListQuery} from './types/ScheduledRunListRoot.types';
 
 export const ScheduledRunListRoot = () => {
   useTrackPageView();
   useDocumentTitle('Runs | Scheduled');
 
-  const queryResult = useQuery<SchedulerInfoQuery>(SCHEDULER_INFO_QUERY, {
+  const queryResult = useQuery<ScheduledRunsListQuery>(SCHEDULED_RUNS_LIST_QUERY, {
     partialRefetch: true,
     notifyOnNetworkStatusChange: true,
   });
@@ -77,8 +79,8 @@ export const ScheduledRunListRoot = () => {
 // eslint-disable-next-line import/no-default-export
 export default ScheduledRunListRoot;
 
-const SCHEDULER_INFO_QUERY = gql`
-  query SchedulerInfoQuery {
+const SCHEDULED_RUNS_LIST_QUERY = gql`
+  query ScheduledRunsListQuery {
     instance {
       ...InstanceHealthFragment
     }
@@ -88,7 +90,8 @@ const SCHEDULER_INFO_QUERY = gql`
           __typename
           id
           ... on Repository {
-            ...RepositorySchedulesFragment
+            id
+            ...RepositoryForNextTicksFragment
           }
         }
       }
@@ -97,6 +100,6 @@ const SCHEDULER_INFO_QUERY = gql`
   }
 
   ${INSTANCE_HEALTH_FRAGMENT}
-  ${REPOSITORY_SCHEDULES_FRAGMENT}
+  ${REPOSITORY_FOR_NEXT_TICKS_FRAGMENT}
   ${PYTHON_ERROR_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
@@ -2,9 +2,9 @@
 
 import * as Types from '../../graphql/types';
 
-export type SchedulerInfoQueryVariables = Types.Exact<{[key: string]: never}>;
+export type ScheduledRunsListQueryVariables = Types.Exact<{[key: string]: never}>;
 
-export type SchedulerInfoQuery = {
+export type ScheduledRunsListQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
@@ -54,63 +54,20 @@ export type SchedulerInfoQuery = {
             __typename: 'Schedule';
             id: string;
             name: string;
-            cronSchedule: string;
             executionTimezone: string | null;
-            pipelineName: string;
-            solidSelection: Array<string | null> | null;
             mode: string;
-            description: string | null;
-            partitionSet: {__typename: 'PartitionSet'; id: string; name: string} | null;
+            solidSelection: Array<string | null> | null;
+            pipelineName: string;
             scheduleState: {
               __typename: 'InstigationState';
               id: string;
-              selectorId: string;
-              name: string;
-              instigationType: Types.InstigationType;
               status: Types.InstigationStatus;
-              repositoryName: string;
-              repositoryLocationName: string;
-              runningCount: number;
-              typeSpecificData:
-                | {__typename: 'ScheduleData'; cronSchedule: string}
-                | {__typename: 'SensorData'; lastRunKey: string | null; lastCursor: string | null}
-                | null;
-              runs: Array<{
-                __typename: 'Run';
-                id: string;
-                runId: string;
-                status: Types.RunStatus;
-                startTime: number | null;
-                endTime: number | null;
-                updateTime: number | null;
-              }>;
-              ticks: Array<{
-                __typename: 'InstigationTick';
-                id: string;
-                cursor: string | null;
-                status: Types.InstigationTickStatus;
-                timestamp: number;
-                skipReason: string | null;
-                runIds: Array<string>;
-                runKeys: Array<string>;
-                error: {
-                  __typename: 'PythonError';
-                  message: string;
-                  stack: Array<string>;
-                  errorChain: Array<{
-                    __typename: 'ErrorChainLink';
-                    isExplicitLink: boolean;
-                    error: {__typename: 'PythonError'; message: string; stack: Array<string>};
-                  }>;
-                } | null;
-              }>;
             };
             futureTicks: {
               __typename: 'FutureInstigationTicks';
               results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
             };
           }>;
-          displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
         }>;
       };
 };

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -43,22 +43,23 @@ import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {TimestampDisplay} from './TimestampDisplay';
-import {ScheduleFragment, RepositorySchedulesFragment} from './types/ScheduleUtils.types';
 import {
+  RepositoryForNextTicksFragment,
   ScheduleFutureTickEvaluationResultFragment,
   ScheduleFutureTickRunRequestFragment,
+  ScheduleNextFiveTicksFragment,
   ScheduleTickConfigQuery,
   ScheduleTickConfigQueryVariables,
 } from './types/SchedulesNextTicks.types';
 
 interface ScheduleTick {
-  schedule: ScheduleFragment;
+  schedule: ScheduleNextFiveTicksFragment;
   timestamp: number;
   repoAddress: RepoAddress;
 }
 
 export const SchedulesNextTicks: React.FC<{
-  repos: RepositorySchedulesFragment[];
+  repos: RepositoryForNextTicksFragment[];
 }> = React.memo(({repos}) => {
   const nextTicks: ScheduleTick[] = [];
   let anyPipelines = false;
@@ -138,7 +139,7 @@ export const SchedulesNextTicks: React.FC<{
   }
 
   return (
-    <Table>
+    <Table $monospaceFont={false}>
       <thead>
         <tr>
           <th style={{width: '260px'}}>Timestamp</th>
@@ -188,7 +189,7 @@ export const SchedulesNextTicks: React.FC<{
 
 const NextTickMenu: React.FC<{
   repoAddress: RepoAddress;
-  schedule: ScheduleFragment;
+  schedule: ScheduleNextFiveTicksFragment;
   tickTimestamp: number;
 }> = React.memo(({repoAddress, schedule, tickTimestamp}) => {
   const scheduleSelector = {
@@ -251,7 +252,7 @@ const NextTickMenu: React.FC<{
 const NextTickMenuItems: React.FC<{
   repoAddress: RepoAddress;
   evaluationResult: ScheduleFutureTickEvaluationResultFragment | null;
-  schedule: ScheduleFragment;
+  schedule: ScheduleNextFiveTicksFragment;
   loading: boolean;
   onItemOpen: (value: boolean) => void;
 }> = ({repoAddress, schedule, evaluationResult, loading, onItemOpen}) => {
@@ -313,7 +314,7 @@ const NextTickDialog: React.FC<{
   isOpen: boolean;
   setOpen: (value: boolean) => void;
   evaluationResult: ScheduleFutureTickEvaluationResultFragment | null;
-  schedule: ScheduleFragment;
+  schedule: ScheduleNextFiveTicksFragment;
   tickTimestamp: number;
 }> = ({repoAddress, evaluationResult, schedule, tickTimestamp, setOpen, isOpen}) => {
   const [
@@ -486,6 +487,43 @@ const NextTickDialog: React.FC<{
     </Dialog>
   );
 };
+
+export const SCHEDULE_NEXT_FIVE_TICKS_FRAGMENT = gql`
+  fragment ScheduleNextFiveTicksFragment on Schedule {
+    id
+    name
+    executionTimezone
+    mode
+    solidSelection
+    pipelineName
+    scheduleState {
+      id
+      status
+    }
+    futureTicks(limit: 5) {
+      results {
+        timestamp
+      }
+    }
+  }
+`;
+
+export const REPOSITORY_FOR_NEXT_TICKS_FRAGMENT = gql`
+  fragment RepositoryForNextTicksFragment on Repository {
+    name
+    id
+    location {
+      id
+      name
+    }
+    schedules {
+      id
+      ...ScheduleNextFiveTicksFragment
+    }
+  }
+
+  ${SCHEDULE_NEXT_FIVE_TICKS_FRAGMENT}
+`;
 
 const SCHEDULE_TICK_CONFIG_QUERY = gql`
   query ScheduleTickConfigQuery($scheduleSelector: ScheduleSelector!, $tickTimestamp: Int!) {

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
@@ -2,6 +2,42 @@
 
 import * as Types from '../../graphql/types';
 
+export type ScheduleNextFiveTicksFragment = {
+  __typename: 'Schedule';
+  id: string;
+  name: string;
+  executionTimezone: string | null;
+  mode: string;
+  solidSelection: Array<string | null> | null;
+  pipelineName: string;
+  scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
+  futureTicks: {
+    __typename: 'FutureInstigationTicks';
+    results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+  };
+};
+
+export type RepositoryForNextTicksFragment = {
+  __typename: 'Repository';
+  name: string;
+  id: string;
+  location: {__typename: 'RepositoryLocation'; id: string; name: string};
+  schedules: Array<{
+    __typename: 'Schedule';
+    id: string;
+    name: string;
+    executionTimezone: string | null;
+    mode: string;
+    solidSelection: Array<string | null> | null;
+    pipelineName: string;
+    scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
+    futureTicks: {
+      __typename: 'FutureInstigationTicks';
+      results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+    };
+  }>;
+};
+
 export type ScheduleTickConfigQueryVariables = Types.Exact<{
   scheduleSelector: Types.ScheduleSelector;
   tickTimestamp: Types.Scalars['Int'];


### PR DESCRIPTION
### Summary & Motivation

The "Scheduled runs" page currently overfetches, pulling in run information that we don't actually need for this page.

Use a couple of stripped-down fragments to get only the information we need.

### How I Tested These Changes

View "Scheduled runs" as Cloud user with lots of schedules, verify that the page loads and the ticks render properly.
