### PR TITLE
[OSS Nux] Add kill switch + persist Nux dismissal in temp folder

### DIFF
--- a/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
@@ -17,14 +17,15 @@ import React from 'react';
 import isEmail from 'validator/lib/isEmail';
 
 export const CommunityNux = () => {
-  const [didDismissCommunityNux, dismissCommunityNux] = useStateWithStorage(
+  const [didDismissCommunityNux, dissmissInBrowser] = useStateWithStorage(
     'communityNux',
     (data) => data,
   );
   const {data, loading} = useQuery(GET_SHOULD_SHOW_NUX_QUERY);
-  const [dismiss] = useMutation(SET_NUX_SEEN_MUTATION);
+  const [dismissOnServer] = useMutation(SET_NUX_SEEN_MUTATION);
 
   if (!isLocalhost()) {
+    // Yes, we only want to show this on localhost for now.
     return null;
   }
   if (didDismissCommunityNux || loading || (data && !data.shouldShowNux)) {
@@ -33,8 +34,8 @@ export const CommunityNux = () => {
   return (
     <CommunityNuxImpl
       dismiss={() => {
-        dismissCommunityNux('1');
-        dismiss();
+        dissmissInBrowser('1');
+        dismissOnServer();
       }}
     />
   );

--- a/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
@@ -24,7 +24,7 @@ export const CommunityNux = () => {
   const {data, loading} = useQuery(GET_SHOULD_SHOW_NUX_QUERY);
   const [dismiss] = useMutation(SET_NUX_SEEN_MUTATION);
 
-  if (!window.location.origin.startsWith('http://localhost')) {
+  if (!isLocalhost()) {
     return null;
   }
   if (didDismissCommunityNux || loading || (data && !data.shouldShowNux)) {
@@ -232,3 +232,8 @@ const GET_SHOULD_SHOW_NUX_QUERY = gql`
     shouldShowNux
   }
 `;
+
+function isLocalhost() {
+  const origin = window.location.origin;
+  return origin.startsWith('http://127.0.0.1') || origin.startsWith('http://localhost');
+}

--- a/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
@@ -1,3 +1,4 @@
+import {gql, useMutation, useQuery} from '@apollo/client';
 import {useStateWithStorage} from '@dagster-io/dagit-core/hooks/useStateWithStorage';
 import {
   Body,
@@ -20,13 +21,20 @@ export const CommunityNux = () => {
     'communityNux',
     (data) => data,
   );
-  if (didDismissCommunityNux) {
+  const {data, loading} = useQuery(GET_SHOULD_SHOW_NUX_QUERY);
+  const [dismiss] = useMutation(SET_NUX_SEEN_MUTATION);
+
+  if (!window.location.origin.startsWith('http://localhost')) {
+    return null;
+  }
+  if (didDismissCommunityNux || loading || (data && !data.shouldShowNux)) {
     return null;
   }
   return (
     <CommunityNuxImpl
       dismiss={() => {
         dismissCommunityNux('1');
+        dismiss();
       }}
     />
   );
@@ -212,3 +220,15 @@ const RecaptchaIFrame: React.FC<{
 };
 
 const IFRAME_SRC = '//dagster.io/dagit_iframes/community_nux';
+
+const SET_NUX_SEEN_MUTATION = gql`
+  mutation SetNuxSeen {
+    setNuxSeen
+  }
+`;
+
+const GET_SHOULD_SHOW_NUX_QUERY = gql`
+  query ShouldShowNux {
+    shouldShowNux
+  }
+`;

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2651,6 +2651,7 @@ type DagitQuery {
   logsForRun(runId: ID!, afterCursor: String, limit: Int): EventConnectionOrError!
   capturedLogsMetadata(logKey: [String!]!): CapturedLogsMetadata!
   capturedLogs(logKey: [String!]!, cursor: String, limit: Int): CapturedLogs!
+  shouldShowNux: Boolean!
 }
 
 union WorkspaceOrError = Workspace | PythonError
@@ -2772,6 +2773,7 @@ type DagitMutation {
     clientTime: String!
     metadata: String!
   ): LogTelemetryMutationResult!
+  setNuxSeen: Boolean!
 }
 
 input ReexecutionParams {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -424,6 +424,7 @@ export type DagitMutation = {
   reloadRepositoryLocation: ReloadRepositoryLocationMutationResult;
   reloadWorkspace: ReloadWorkspaceMutationResult;
   resumePartitionBackfill: ResumeBackfillResult;
+  setNuxSeen: Scalars['Boolean'];
   setSensorCursor: SensorOrError;
   shutdownRepositoryLocation: ShutdownRepositoryLocationMutationResult;
   startSchedule: ScheduleMutationResult;
@@ -564,6 +565,7 @@ export type DagitQuery = {
   schedulesOrError: SchedulesOrError;
   sensorOrError: SensorOrError;
   sensorsOrError: SensorsOrError;
+  shouldShowNux: Scalars['Boolean'];
   unloadableInstigationStatesOrError: InstigationStatesOrError;
   version: Scalars['String'];
   workspaceOrError: WorkspaceOrError;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -1,6 +1,7 @@
 import dagster._check as check
 import graphene
 from dagster._core.definitions.events import AssetKey
+from dagster._core.nux import get_has_seen_nux, set_nux_seen
 from dagster._core.workspace.permissions import Permissions
 
 from dagster_graphql.implementation.execution.backfill import (
@@ -619,6 +620,20 @@ class GrapheneLogTelemetryMutation(graphene.Mutation):
         return action
 
 
+class GrapheneSetNuxSeenMutation(graphene.Mutation):
+    """Store whether we've shown the nux to any user and they've dismissed or submitted it"""
+
+    Output = graphene.NonNull(graphene.Boolean)
+
+    class Meta:
+        name = "SetNuxSeenMutation"
+
+    @capture_error
+    def mutate(self, _graphene_info):
+        set_nux_seen()
+        return get_has_seen_nux()
+
+
 class GrapheneDagitMutation(graphene.ObjectType):
     """The root for all mutations to modify data in your Dagster instance."""
 
@@ -646,3 +661,4 @@ class GrapheneDagitMutation(graphene.ObjectType):
     resume_partition_backfill = GrapheneResumeBackfillMutation.Field()
     cancel_partition_backfill = GrapheneCancelBackfillMutation.Field()
     log_telemetry = GrapheneLogTelemetryMutation.Field()
+    set_nux_seen = GrapheneSetNuxSeenMutation.Field()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -10,6 +10,7 @@ from dagster._core.host_representation import (
     ScheduleSelector,
     SensorSelector,
 )
+from dagster._core.nux import get_has_seen_nux
 from dagster._core.scheduler.instigation import InstigatorType
 
 from dagster_graphql.implementation.fetch_logs import get_captured_log_metadata
@@ -409,6 +410,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
         description="Captured logs are the stdout/stderr logs for a given log key",
     )
 
+    shouldShowNux = graphene.Field(
+        graphene.NonNull(graphene.Boolean),
+        description="Whether or not the NUX should be shown to the user",
+    )
+
     def resolve_repositoriesOrError(self, graphene_info, **kwargs):
         if kwargs.get("repositorySelector"):
             return GrapheneRepositoryConnection(
@@ -723,3 +729,6 @@ class GrapheneDagitQuery(graphene.ObjectType):
             logKey, cursor=cursor, max_bytes=limit
         )
         return from_captured_log_data(log_data)
+
+    def resolve_shouldShowNux(self, graphene_info):
+        return graphene_info.context.instance.nux_enabled and not get_has_seen_nux()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
@@ -1,0 +1,30 @@
+from dagster_graphql.test.utils import (
+    execute_dagster_graphql,
+)
+
+SET_NUX_SEEN_MUTATION = """
+    mutation SetNuxSeen {
+       setNuxSeen
+    }
+"""
+
+GET_SHOULD_SHOW_NUX_QUERY = """
+  query ShouldShowNux {
+    shouldShowNux
+  }
+
+"""
+
+
+def test_stores_nux_seen_state(graphql_context):
+    result = execute_dagster_graphql(graphql_context, GET_SHOULD_SHOW_NUX_QUERY)
+    assert not result.errors
+    assert result.data
+    assert result.data["shouldShowNux"] is True
+
+    execute_dagster_graphql(graphql_context, SET_NUX_SEEN_MUTATION)
+
+    result = execute_dagster_graphql(graphql_context, GET_SHOULD_SHOW_NUX_QUERY)
+    assert not result.errors
+    assert result.data
+    assert result.data["shouldShowNux"] is False

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -705,7 +705,7 @@ class DagsterInstance:
         if "enabled" in nux_settings:
             return nux_settings["enabled"]
         else:
-            return nux_enabled_by_default 
+            return nux_enabled_by_default
 
     # run monitoring
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -691,6 +691,22 @@ class DagsterInstance:
         else:
             return dagster_telemetry_enabled_default
 
+    @property
+    def nux_enabled(self) -> bool:
+        if self.is_ephemeral:
+            return False
+
+        nux_enabled_by_default = True
+
+        nux_settings = self.get_settings("nux")
+        if not nux_settings:
+            return nux_enabled_by_default
+
+        if "enabled" in nux_settings:
+            return nux_settings["enabled"]
+        else:
+            return nux_enabled_by_default 
+
     # run monitoring
 
     @property

--- a/python_modules/dagster/dagster/_core/nux.py
+++ b/python_modules/dagster/dagster/_core/nux.py
@@ -1,0 +1,30 @@
+import os
+
+import yaml
+
+from dagster._core.telemetry import get_or_create_dir_from_dagster_home
+
+NUX_FILE_STR = "nux.yaml"
+
+
+# Filepath for where we store if we've seen the nux
+def nux_seen_filepath():
+    return os.path.join(get_or_create_dir_from_dagster_home(".nux"), "nux.yaml")
+
+
+# Sets whether we've shown the Nux to any user on this instance
+def set_nux_seen():
+    try:  # In case we encounter an error while writing to user's file system
+        with open(nux_seen_filepath(), "w", encoding="utf8") as nux_seen_file:
+            # the contents of the file dont matter, we just check that it exists, but lets write seen: True here anyways.
+            yaml.dump({"seen": 1}, nux_seen_file, default_flow_style=False)
+    except Exception:
+        return "<<unable_to_write_instance_id>>"
+
+
+# Gets whether we've shown the Nux to any user on this instance
+def get_has_seen_nux():
+    # We only care about the existence of the file
+    if not os.path.exists(nux_seen_filepath()):
+        return False
+    return True

--- a/python_modules/dagster/dagster/_core/nux.py
+++ b/python_modules/dagster/dagster/_core/nux.py
@@ -25,6 +25,4 @@ def set_nux_seen():
 # Gets whether we've shown the Nux to any user on this instance
 def get_has_seen_nux():
     # We only care about the existence of the file
-    if not os.path.exists(nux_seen_filepath()):
-        return False
-    return True
+    return os.path.exists(nux_seen_filepath())

--- a/python_modules/dagster/dagster/_core/nux.py
+++ b/python_modules/dagster/dagster/_core/nux.py
@@ -19,7 +19,7 @@ def set_nux_seen():
             # the contents of the file dont matter, we just check that it exists, but lets write seen: True here anyways.
             yaml.dump({"seen": 1}, nux_seen_file, default_flow_style=False)
     except Exception:
-        return "<<unable_to_write_instance_id>>"
+        return "<<unable_to_write_nux_seen>>"
 
 
 # Gets whether we've shown the Nux to any user on this instance


### PR DESCRIPTION
### Summary & Motivation

Couple of changes:

1. Only show the Nux if you're on localhost
2. Persist that we dismissed the nux in the directory we use for telemetry too
3. Add killswitch to completely disable this

For the kill switch in dagser.yaml we need to add
```
nux:
  enabled: False
```


### How I Tested These Changes

Unit tests for the graphql

Made sure the file was persisted and stayed past restarts but wasn't sure how to effectively test this in python.

<img width="770" alt="Screen Shot 2023-01-17 at 5 58 23 PM" src="https://user-images.githubusercontent.com/2286579/213030927-26d05434-eb6c-4015-8a84-6f0255340e53.png">

