### PR TITLE
add after_cursor to get_materialization_counts_by_partition

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1649,9 +1649,9 @@ class DagsterInstance:
 
     @traced
     def get_materialization_count_by_partition(
-        self, asset_keys: Sequence[AssetKey]
+        self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
     ) -> Mapping[AssetKey, Mapping[str, int]]:
-        return self._event_storage.get_materialization_count_by_partition(asset_keys)
+        return self._event_storage.get_materialization_count_by_partition(asset_keys, after_cursor)
 
     # event subscriptions
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -357,7 +357,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref):
 
     @abstractmethod
     def get_materialization_count_by_partition(
-        self, asset_keys: Sequence[AssetKey]
+        self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
     ) -> Mapping[AssetKey, Mapping[str, int]]:
         pass
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1565,7 +1565,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
 
     def get_materialization_count_by_partition(
-        self, asset_keys: Sequence[AssetKey]
+        self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int] = None
     ) -> Mapping[AssetKey, Mapping[str, int]]:
         check.sequence_param(asset_keys, "asset_keys", AssetKey)
 
@@ -1597,6 +1597,9 @@ class SqlEventLogStorage(EventLogStorage):
 
         assets_details = self._get_assets_details(asset_keys)
         query = self._add_assets_wipe_filter_to_query(query, assets_details, asset_keys)
+
+        if after_cursor:
+            query = query.where(SqlEventLogStorageTable.c.id > after_cursor)
 
         with self.index_connection() as conn:
             results = conn.execute(query).fetchall()

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -463,9 +463,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         return self._storage.event_log_storage.wipe_asset(asset_key)
 
     def get_materialization_count_by_partition(
-        self, asset_keys: Sequence["AssetKey"]
+        self, asset_keys: Sequence["AssetKey"], after_cursor: Optional[int] = None
     ) -> Mapping["AssetKey", Mapping[str, int]]:
-        return self._storage.event_log_storage.get_materialization_count_by_partition(asset_keys)
+        return self._storage.event_log_storage.get_materialization_count_by_partition(
+            asset_keys, after_cursor
+        )
 
     def get_event_tags_for_asset(
         self,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1925,7 +1925,7 @@ class TestEventLogStorage:
                     storage.store_event(event)
 
                 cursor_run1 = storage.get_event_records(
-                    EventRecordsFilter(event_type=DagsterEventType.RUN_SUCCESS),
+                    EventRecordsFilter(event_type=DagsterEventType.ASSET_MATERIALIZATION),
                     limit=1,
                     ascending=False,
                 )[0].storage_id

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1906,8 +1906,8 @@ class TestEventLogStorage:
             yield AssetMaterialization(c, partition="b")
             yield Output(None)
 
-        def _fetch_counts(storage):
-            return storage.get_materialization_count_by_partition([c, d])
+        def _fetch_counts(storage, after_cursor=None):
+            return storage.get_materialization_count_by_partition([c, d], after_cursor=after_cursor)
 
         with instance_for_test() as created_instance:
             if not storage._instance:  # pylint: disable=protected-access
@@ -1923,6 +1923,12 @@ class TestEventLogStorage:
                 )
                 for event in events_one:
                     storage.store_event(event)
+
+                cursor_run1 = storage.get_event_records(
+                    EventRecordsFilter(event_type=DagsterEventType.RUN_SUCCESS),
+                    limit=1,
+                    ascending=False,
+                )[0].storage_id
 
                 materialization_count_by_key = storage.get_materialization_count_by_partition(
                     [a, b, c]
@@ -1947,6 +1953,25 @@ class TestEventLogStorage:
                 assert materialization_count_by_key.get(c)["a"] == 2
                 assert materialization_count_by_key.get(c)["b"] == 1
 
+                # after_cursor
+                materialization_count_by_key_after_run1 = (
+                    storage.get_materialization_count_by_partition(
+                        [a, b, c], after_cursor=cursor_run1
+                    )
+                )
+                assert materialization_count_by_key_after_run1.get(a) == {}
+                assert materialization_count_by_key_after_run1.get(b) == {}
+                assert materialization_count_by_key_after_run1.get(c)["a"] == 1
+                assert materialization_count_by_key_after_run1.get(c)["b"] == 1
+                assert len(materialization_count_by_key_after_run1.get(c)) == 2
+
+                materialization_count_by_key_after_everything = (
+                    storage.get_materialization_count_by_partition([a, b, c], after_cursor=9999999)
+                )
+                assert materialization_count_by_key_after_everything.get(a) == {}
+                assert materialization_count_by_key_after_everything.get(b) == {}
+                assert materialization_count_by_key_after_everything.get(c) == {}
+
                 # wipe asset, make sure we respect that
                 if self.can_wipe():
                     storage.wipe_asset(c)
@@ -1965,6 +1990,13 @@ class TestEventLogStorage:
                     materialization_count_by_partition = _fetch_counts(storage)
                     assert materialization_count_by_partition.get(c)["a"] == 1
                     assert materialization_count_by_partition.get(d)["x"] == 2
+
+                    # make sure adding an after_cursor doesn't mess with the wiped events
+                    assert (
+                        _fetch_counts(storage, after_cursor=cursor_run1)
+                        == materialization_count_by_partition
+                    )
+                    assert _fetch_counts(storage, after_cursor=9999999) == {c: {}, d: {}}
 
     def test_get_observation(self, storage, test_run_id):
         a = AssetKey(["key_a"])


### PR DESCRIPTION
### Summary & Motivation

This is very useful in the reconciliation world, where we often want to produce a record of all things that have changed since a given cursor. Currently, this requires querying for all events since that cursor, which requires deserializing a potentially very large number of events.

In addition, the fact that this function already supports querying for multiple asset keys at once means that we can batch up a lot of work into a single DB query, rather than having to do N separate `get_event_log_records` queries (one for each asset).

### How I Tested These Changes

unit