### PR TITLE
[dagit] Bump react-scripts to remove codegen plugin

### DIFF
--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@dagster-io/eslint-config": "workspace:*",
-    "@dagster-io/react-scripts": "^5.0.5",
+    "@dagster-io/react-scripts": "^5.0.6",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.20",
     "@types/react": "17.0.4",

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -82,6 +82,7 @@
     "@graphql-codegen/add": "^3.2.3",
     "@graphql-codegen/cli": "^2.16.3",
     "@graphql-codegen/near-operation-file-preset": "^2.5.0",
+    "@graphql-codegen/typescript-operations": "^2.5.12",
     "@graphql-tools/mock": "^8.5.0",
     "@graphql-tools/schema": "^8.3.1",
     "@mdx-js/react": "^1.6.22",

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -6186,7 +6186,7 @@ __metadata:
     "@blueprintjs/select": ^3.16.4
     "@dagster-io/dagit-core": "workspace:*"
     "@dagster-io/eslint-config": "workspace:*"
-    "@dagster-io/react-scripts": ^5.0.5
+    "@dagster-io/react-scripts": ^5.0.6
     "@dagster-io/ui": "workspace:*"
     "@rive-app/react-canvas": ^3.0.34
     "@types/jest": ^27.4.0
@@ -6239,6 +6239,7 @@ __metadata:
     "@graphql-codegen/add": ^3.2.3
     "@graphql-codegen/cli": ^2.16.3
     "@graphql-codegen/near-operation-file-preset": ^2.5.0
+    "@graphql-codegen/typescript-operations": ^2.5.12
     "@graphql-tools/mock": ^8.5.0
     "@graphql-tools/schema": ^8.3.1
     "@mdx-js/react": ^1.6.22
@@ -6376,13 +6377,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dagster-io/react-scripts@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "@dagster-io/react-scripts@npm:5.0.5"
+"@dagster-io/react-scripts@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "@dagster-io/react-scripts@npm:5.0.6"
   dependencies:
     "@babel/core": ^7.16.0
     "@dagster-io/eslint-config": ^1.0.1
-    "@graphql-codegen/client-preset": ^1.2.5
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.3
     "@svgr/webpack": ^6.2.1
     babel-jest: ^27.4.2
@@ -6443,7 +6443,7 @@ __metadata:
       optional: true
   bin:
     react-scripts: bin/react-scripts.js
-  checksum: b0f095fb1c9dfa27cf708dcb42c12026a9cd0af67c3760c563dac9bea1e7f68cb12c384c4ff2dd0154b8c95c75425e2ef9d0f3915d059db44d64d3beb0b573af
+  checksum: 3cde1f670ec6b3a3b05473c75451cec7e893b29ffb611cce69520843723473174976ac1dfd40a47e475246ec2cbedaf72e0d3b77a8819eef95dfe89f415781f9
   languageName: node
   linkType: hard
 
@@ -6770,28 +6770,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/client-preset@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "@graphql-codegen/client-preset@npm:1.2.5"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.14.5
-    "@babel/template": ^7.15.4
-    "@graphql-codegen/add": ^3.2.3
-    "@graphql-codegen/gql-tag-operations": 1.6.0
-    "@graphql-codegen/plugin-helpers": ^3.1.2
-    "@graphql-codegen/typed-document-node": ^2.3.12
-    "@graphql-codegen/typescript": ^2.8.7
-    "@graphql-codegen/typescript-operations": ^2.5.12
-    "@graphql-codegen/visitor-plugin-common": ^2.13.7
-    "@graphql-tools/utils": ^9.0.0
-    "@graphql-typed-document-node/core": 3.1.1
-    tslib: ~2.4.0
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 2f45cbedc835c665aec28b388411ea82ab812054ea6a1406be40ab3f05614d079a88c6a433c4b0ae3429286fca2e616526620641bfb5601199f54fae8e4c98ff
-  languageName: node
-  linkType: hard
-
 "@graphql-codegen/core@npm:2.6.8":
   version: 2.6.8
   resolution: "@graphql-codegen/core@npm:2.6.8"
@@ -6803,21 +6781,6 @@ __metadata:
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
   checksum: 33a222798fd99adcaf5d6d48fcd6949798a62d7a25e9b2af5b13e4def3de4338e5a743e5ea87661d2b32ae3279e3ad8b555d0e212efe86018088cb85a7d59d6a
-  languageName: node
-  linkType: hard
-
-"@graphql-codegen/gql-tag-operations@npm:1.6.0":
-  version: 1.6.0
-  resolution: "@graphql-codegen/gql-tag-operations@npm:1.6.0"
-  dependencies:
-    "@graphql-codegen/plugin-helpers": ^3.1.2
-    "@graphql-codegen/visitor-plugin-common": 2.13.7
-    "@graphql-tools/utils": ^9.0.0
-    auto-bind: ~4.0.0
-    tslib: ~2.4.0
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: cec1d275ffd36b5a7267801112b4b387f3651b7f51c69fecd004ff2437a07684b0a979c0a525a1e58146240fd908750ad5c047acf5c05bcd5574f871d420788d
   languageName: node
   linkType: hard
 
@@ -6882,21 +6845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/typed-document-node@npm:^2.3.12":
-  version: 2.3.12
-  resolution: "@graphql-codegen/typed-document-node@npm:2.3.12"
-  dependencies:
-    "@graphql-codegen/plugin-helpers": ^3.1.2
-    "@graphql-codegen/visitor-plugin-common": 2.13.7
-    auto-bind: ~4.0.0
-    change-case-all: 1.0.15
-    tslib: ~2.4.0
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 2a280f436d906d24353ee830d39dc2c5d32683a8d09332e1234bd66f5501e3a6415939e1b1ec191db4f0b6535bcc46fca9dece5ede5d7d183b77ff130db16c06
-  languageName: node
-  linkType: hard
-
 "@graphql-codegen/typescript-operations@npm:^2.5.12":
   version: 2.5.12
   resolution: "@graphql-codegen/typescript-operations@npm:2.5.12"
@@ -6947,7 +6895,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/visitor-plugin-common@npm:2.13.7, @graphql-codegen/visitor-plugin-common@npm:^2.13.7":
+"@graphql-codegen/visitor-plugin-common@npm:2.13.7":
   version: 2.13.7
   resolution: "@graphql-codegen/visitor-plugin-common@npm:2.13.7"
   dependencies:


### PR DESCRIPTION
### Summary & Motivation

Cleaning up after myself. Bump react-script to 5.0.6 now that the codegen babel plugin is removed.

### How I Tested These Changes

Buildkite
