### PR TITLE
[asset-reconciliation] pre-fetch the results of some queries

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -21,6 +21,7 @@ import toposort
 import dagster._check as check
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.selector.subset_selector import DependencyGraph, generate_asset_dep_graph
+from dagster._utils.cached_method import cached_method
 
 from .assets import AssetsDefinition
 from .events import AssetKey, AssetKeyPartitionKey
@@ -311,6 +312,7 @@ class AssetGraph:
             return self._required_multi_asset_sets_by_key[asset_key]
         return set()
 
+    @cached_method
     def toposort_asset_keys(self) -> Sequence[AbstractSet[AssetKey]]:
         return [
             {key for key in level} for level in toposort.toposort(self._asset_dep_graph["upstream"])

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 from abc import abstractmethod
 from collections import OrderedDict, defaultdict
@@ -132,6 +133,7 @@ class SqlEventLogStorage(EventLogStorage):
             partition=partition,
         )
 
+    @functools.lru_cache(maxsize=None)
     def has_asset_key_col(self, column_name: str):
         with self.index_connection() as conn:
             column_names = [x.get("name") for x in db.inspect(conn).get_columns(AssetKeyTable.name)]

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -199,6 +199,15 @@ class CachingInstanceQueryer:
         else:
             asset_partition = asset
 
+        # no materialization exists for this asset partition
+        if (
+            asset_partition.partition_key is not None
+            and asset_partition.asset_key in self._asset_partition_count_cache[None]
+            and asset_partition.partition_key
+            not in self._asset_partition_count_cache[None][asset_partition.asset_key]
+        ):
+            return None
+
         if before_cursor is not None:
             latest_record = self._latest_materialization_record_cache.get(asset_partition)
             if latest_record is not None and latest_record.storage_id < before_cursor:


### PR DESCRIPTION
### Summary & Motivation

The two biggest time sucks in terms of querying are:

a) getting the latest materialization record per-asset
b) getting the AssetRecords per asset (slightly different from the above, these are the things containing AssetEntries, which are used to determine if a previous run failed to materialize a given asset)

This does a best-effort approach to batching together as much of that work into a couple of database queries, with some pretty large performance improvements. In particular, for a test case I cooked up, this took the execution time down from 75 seconds to 8.5(!!) seconds.

### How I Tested These Changes
