### PR TITLE
Fix airflow_op_to_dagster_op test

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -50,6 +50,7 @@ setup(
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",
             "apache-airflow-providers-apache-spark>=3.0.0,<4",
+            "apache-airflow-providers-http!=4.1.1",
         ],
         "test_airflow_1": [
             "apache-airflow>=1.0.0,<2.0.0",

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -50,7 +50,8 @@ setup(
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",
             "apache-airflow-providers-apache-spark>=3.0.0,<4",
-            "apache-airflow-providers-http!=4.1.1",
+            # Logging messages are set to debug starting 4.1.1
+            "apache-airflow-providers-http<4.1.1",
         ],
         "test_airflow_1": [
             "apache-airflow>=1.0.0,<2.0.0",


### PR DESCRIPTION
As of `apache-airflow-providers-http>=4.1.1`, [logging messages in hooks are now changed to debug level](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/index.html#id1).

This results in the test failures we see in dagster-airflow: https://buildkite.com/dagster/dagster/builds/45890#0185c207-caf4-4a39-82bb-1d17f63e4113/6-331

This PR amends tests to test versions < 4.1.1 until we can capture logs within hooks at the debug level.