### PR TITLE
[1/n][structured config] Add ability to runtime-configure struct-config resources

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -199,7 +199,7 @@ class Resource(
         return cast(T, self)
 
     @classmethod
-    def partial(cls, **kwargs) -> "PartialResource[Self]":
+    def configure_at_launch(cls, **kwargs) -> "PartialResource[Self]":
         """
         Returns a partially initialized copy of the resource, with remaining config fields
         set at runtime.
@@ -223,8 +223,6 @@ class PartialResource(Generic[T], ResourceDefinition, MakeConfigCacheable):
 
     def __init__(self, resource_cls: Type[Resource[T]], data: Dict[str, Any]):
         check.invariant(data == {}, "PartialResource currently does not support config fields")
-
-        Config.__init__(self, data=data, resource_cls=resource_cls)
 
         MakeConfigCacheable.__init__(self, data=data, resource_cls=resource_cls)
 
@@ -317,7 +315,7 @@ class StructuredConfigIOManagerBase(Resource[IOManager], IOManagerDefinition):
         raise NotImplementedError()
 
     @classmethod
-    def partial(cls, **kwargs) -> "PartialIOManager":
+    def configure_at_launch(cls, **kwargs) -> "PartialIOManager":
         """
         Returns a partially initialized copy of the resource, with remaining config fields
         set at runtime.

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -152,11 +152,11 @@ def _curry_config_schema(schema_field: Field, data: Any) -> IDefinitionConfigSch
     return DefinitionConfigSchema(_apply_defaults_to_schema_field(schema_field, data))
 
 
-T = TypeVar("T")
+ResValue = TypeVar("ResValue")
 
 
 class Resource(
-    Generic[T],
+    Generic[ResValue],
     ResourceDefinition,
     Config,
 ):
@@ -196,10 +196,10 @@ class Resource(
         Default behavior for new class-based resources is to return itself, passing
         the actual resource object to user code.
         """
-        return cast(T, self)
+        return cast(ResValue, self)
 
     @classmethod
-    def configure_at_launch(cls, **kwargs) -> "PartialResource[Self]":
+    def configure_at_launch(cls, **kwargs) -> "PartialResource[ResValue]":
         """
         Returns a partially initialized copy of the resource, with remaining config fields
         set at runtime.
@@ -207,7 +207,7 @@ class Resource(
         return PartialResource(cls, data=kwargs)
 
     # The following methods are used to implement the descriptor protocol
-    # https://docs.python.org/3/howto/descriptor.html
+    # https://docs.python.org/3/howto/de scriptor.html
     #
     # Used to adjust the types of resource inputs and outputs, e.g. resource dependencies can be passed in
     # as PartialResources or Resources, but will always be returned as Resources
@@ -225,11 +225,11 @@ class Resource(
         setattr(obj, self._assigned_name, value)
 
 
-class PartialResource(Generic[T], ResourceDefinition, MakeConfigCacheable):
+class PartialResource(Generic[ResValue], ResourceDefinition, MakeConfigCacheable):
     data: Dict[str, Any]
-    resource_cls: Type[Resource[T]]
+    resource_cls: Type[Resource[ResValue]]
 
-    def __init__(self, resource_cls: Type[Resource[T]], data: Dict[str, Any]):
+    def __init__(self, resource_cls: Type[Resource[ResValue]], data: Dict[str, Any]):
         check.invariant(data == {}, "PartialResource currently does not support config fields")
 
         MakeConfigCacheable.__init__(self, data=data, resource_cls=resource_cls)
@@ -250,7 +250,7 @@ class PartialResource(Generic[T], ResourceDefinition, MakeConfigCacheable):
         )
 
 
-ResourceOrPartial: TypeAlias = Union[Resource[T], PartialResource[T]]
+ResourceOrPartial: TypeAlias = Union[Resource[ResValue], PartialResource[ResValue]]
 
 
 class StructuredResourceAdapter(Resource, ABC):

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -206,6 +206,10 @@ class Resource(
         """
         return PartialResource(cls, data=kwargs)
 
+    # Python descriptor
+    # https://docs.python.org/3/howto/descriptor.html
+    # Used to adjust the types of resource inputs and outputs, e.g. resource dependencies can be passed in
+    # as PartialResources or Resources, but will always be returned as Resources
     def __get__(self, obj: "Resource", __owner: Any) -> Self:
         ...
 

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -43,8 +43,6 @@ from dagster._config.field_utils import (
 from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 
-Self = TypeVar("Self", bound="Resource")
-
 
 def _safe_is_subclass(cls: Any, possible_parent_cls: Type) -> bool:
     """Version of issubclass that returns False if cls is not a Type."""

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -12,6 +12,7 @@ from dagster._core.definitions.definition_config_schema import (
     IDefinitionConfigSchema,
 )
 from dagster._core.errors import DagsterInvalidConfigError
+from dagster._config.structured_config.typing_utils import AllowPartialResourceInitParams
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster._core.execution.context.init import InitResourceContext
 
@@ -159,6 +160,7 @@ class Resource(
     Generic[ResValue],
     ResourceDefinition,
     Config,
+    AllowPartialResourceInitParams,
 ):
     """
     Base class for Dagster resources that utilize structured config.
@@ -205,24 +207,6 @@ class Resource(
         set at runtime.
         """
         return PartialResource(cls, data=kwargs)
-
-    # The following methods are used to implement the descriptor protocol
-    # https://docs.python.org/3/howto/de scriptor.html
-    #
-    # Used to adjust the types of resource inputs and outputs, e.g. resource dependencies can be passed in
-    # as PartialResources or Resources, but will always be returned as Resources
-    # Very similar to https://github.com/pydantic/pydantic/discussions/4262
-
-    def __set_name__(self, _owner, name):
-        self._assigned_name = name
-
-    def __get__(self: Self, obj: Any, __owner: Any) -> Self:
-        return cast(Self, getattr(obj, self._assigned_name))
-
-    def __set__(
-        self: Self, obj: Optional[object], value: Union[Self, "PartialResource[Self]"]
-    ) -> None:
-        setattr(obj, self._assigned_name, value)
 
 
 class PartialResource(Generic[ResValue], ResourceDefinition, MakeConfigCacheable):

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -211,7 +211,7 @@ class PartialResource(Generic[ResValue], ResourceDefinition, MakeConfigCacheable
     def __init__(self, resource_cls: Type[Resource[ResValue]], data: Dict[str, Any]):
         check.invariant(data == {}, "PartialResource currently does not support config fields")
 
-        MakeConfigCacheable.__init__(self, data=data, resource_cls=resource_cls)  # type: ignore (extends BaseModel, takes kwargs)
+        MakeConfigCacheable.__init__(self, data=data, resource_cls=resource_cls)  # type: ignore  # extends BaseModel, takes kwargs
 
         schema = infer_schema_from_config_class(
             resource_cls,

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -6,14 +6,13 @@ from typing_extensions import TypeAlias
 from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType
 from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
+from dagster._config.structured_config.typing_utils import TypecheckAllowPartialResourceInitParams
 from dagster._config.validate import validate_config
 from dagster._core.definitions.definition_config_schema import (
     DefinitionConfigSchema,
     IDefinitionConfigSchema,
 )
 from dagster._core.errors import DagsterInvalidConfigError
-from dagster._config.structured_config.typing_utils import TypecheckAllowPartialResourceInitParams
-from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster._core.execution.context.init import InitResourceContext
 
 try:
@@ -25,12 +24,10 @@ except ImportError:
 
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Type
 from typing import Any, Dict, Optional, Type, cast
 
 from pydantic import BaseModel, Extra
 from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_MAPPING, SHAPE_SINGLETON, ModelField
-from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster import Field, Shape
@@ -214,7 +211,7 @@ class PartialResource(Generic[ResValue], ResourceDefinition, MakeConfigCacheable
     def __init__(self, resource_cls: Type[Resource[ResValue]], data: Dict[str, Any]):
         check.invariant(data == {}, "PartialResource currently does not support config fields")
 
-        MakeConfigCacheable.__init__(self, data=data, resource_cls=resource_cls)
+        MakeConfigCacheable.__init__(self, data=data, resource_cls=resource_cls)  # type: ignore (extends BaseModel, takes kwargs)
 
         schema = infer_schema_from_config_class(
             resource_cls,

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.definition_config_schema import (
     IDefinitionConfigSchema,
 )
 from dagster._core.errors import DagsterInvalidConfigError
-from dagster._config.structured_config.typing_utils import AllowPartialResourceInitParams
+from dagster._config.structured_config.typing_utils import TypecheckAllowPartialResourceInitParams
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster._core.execution.context.init import InitResourceContext
 
@@ -158,7 +158,7 @@ class Resource(
     Generic[ResValue],
     ResourceDefinition,
     Config,
-    AllowPartialResourceInitParams,
+    TypecheckAllowPartialResourceInitParams,
 ):
     """
     Base class for Dagster resources that utilize structured config.

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -1,0 +1,49 @@
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
+
+if TYPE_CHECKING:
+    from dagster._config.structured_config import PartialResource, Self
+
+
+class AllowPartialResourceInitParams:
+    """
+    Implementation of the Python descriptor protocol (https://docs.python.org/3/howto/descriptor.html)
+    to adjust the types of resource inputs and outputs, e.g. resource dependencies can be passed in
+    as PartialResources or Resources, but will always be returned as Resources.
+
+    For example, given a resource with the following signature:
+
+    .. code-block:: python
+
+        class FooResource(Resource):
+            bar: BarResource
+
+    The following code will work:
+
+    .. code-block:: python
+
+        # Types as PartialResource[BarResource]
+        partial_bar = BarResource.configure_at_runtime()
+
+        # bar parameter takes BarResource | PartialResource[BarResource]
+        foo = FooResource(bar=partial_bar)
+
+        # bar attribute is BarResource
+        print(foo.bar)
+
+    Very similar to https://github.com/pydantic/pydantic/discussions/4262.
+    """
+
+    def __set_name__(self, _owner, name):
+        self._assigned_name = name
+
+    def __get__(self: "Self", obj: Any, __owner: Any) -> "Self":
+        # no-op implementation (only used to affect type signature)
+        from dagster._config.structured_config import Self
+
+        return cast(Self, getattr(obj, self._assigned_name))
+
+    def __set__(
+        self: "Self", obj: Optional[object], value: Union["Self", "PartialResource[Self]"]
+    ) -> None:
+        # no-op implementation (only used to affect type signature)
+        setattr(obj, self._assigned_name, value)

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -1,6 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
-
-from typing_extensions import TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
 
 if TYPE_CHECKING:
     from dagster._config.structured_config import PartialResource
@@ -42,8 +40,6 @@ class AllowPartialResourceInitParams:
 
     def __get__(self: "Self", obj: Any, __owner: Any) -> "Self":
         # no-op implementation (only used to affect type signature)
-        from dagster._config.structured_config import Self
-
         return cast(Self, getattr(obj, self._assigned_name))
 
     def __set__(

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -1,7 +1,11 @@
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
+from typing_extensions import TypeVar
+
 if TYPE_CHECKING:
-    from dagster._config.structured_config import PartialResource, Self
+    from dagster._config.structured_config import PartialResource
+
+Self = TypeVar("Self", bound="AllowPartialResourceInitParams")
 
 
 class AllowPartialResourceInitParams:

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
 if TYPE_CHECKING:
     from dagster._config.structured_config import PartialResource
 
-Self = TypeVar("Self", bound="AllowPartialResourceInitParams")
+Self = TypeVar("Self", bound="TypecheckAllowPartialResourceInitParams")
 
 
-class AllowPartialResourceInitParams:
+class TypecheckAllowPartialResourceInitParams:
     """
     Implementation of the Python descriptor protocol (https://docs.python.org/3/howto/descriptor.html)
     to adjust the types of resource inputs and outputs, e.g. resource dependencies can be passed in
@@ -29,7 +29,11 @@ class AllowPartialResourceInitParams:
         # bar parameter takes BarResource | PartialResource[BarResource]
         foo = FooResource(bar=partial_bar)
 
-        # bar attribute is BarResource
+        # initialization of FooResource succeeds,
+        # populating the bar attribute with a full BarResource
+
+        # bar attribute is typed as BarResource, since
+        # it is fully initialized when a user accesses it
         print(foo.bar)
 
     Very similar to https://github.com/pydantic/pydantic/discussions/4262.

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from functools import update_wrapper
 from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Set, Union, cast, overload
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
 from dagster._annotations import public
@@ -18,15 +18,24 @@ from dagster._core.storage.input_manager import InputManager
 from dagster._core.storage.output_manager import IOutputManagerDefinition, OutputManager
 from dagster._core.storage.root_input_manager import IInputManagerDefinition
 
+from ..decorator_utils import get_function_params
+
 if TYPE_CHECKING:
     from dagster._core.execution.context.init import InitResourceContext
     from dagster._core.execution.context.input import InputContext
     from dagster._core.execution.context.output import OutputContext
 
+IOManagerFunctionWithContext = Callable[["InitResourceContext"], "IOManager"]
 IOManagerFunction: TypeAlias = Union[
-    Callable[["InitResourceContext"], "IOManager"],
+    IOManagerFunctionWithContext,
     Callable[[], "IOManager"],
 ]
+
+
+def is_io_manager_context_provided(
+    fn: IOManagerFunction,
+) -> TypeGuard[IOManagerFunctionWithContext]:
+    return len(get_function_params(fn)) >= 1
 
 
 class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputManagerDefinition):

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -331,7 +331,7 @@ def test_structured_resource_runtime_config():
 
     defs = Definitions(
         assets=[hello_world_asset],
-        resources={"writer": WriterResource.partial()},
+        resources={"writer": WriterResource.configure_at_launch()},
     )
 
     assert (

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -314,3 +314,38 @@ def test_io_manager_factory_class():
     defs.get_implicit_global_asset_job_def().execute_in_process()
 
     assert executed["yes"]
+
+
+def test_structured_resource_runtime_config():
+    out_txt = []
+
+    class WriterResource(Resource):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    @asset
+    def hello_world_asset(writer: WriterResource):
+        writer.output("hello, world!")
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={"writer": WriterResource.partial()},
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process({"resources": {"writer": {"config": {"prefix": ""}}}})
+        .success
+    )
+    assert out_txt == ["hello, world!"]
+
+    out_txt.clear()
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process({"resources": {"writer": {"config": {"prefix": "greeting: "}}}})
+        .success
+    )
+    assert out_txt == ["greeting: hello, world!"]

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -64,7 +64,7 @@ def test_runtime_config():
 
     defs = Definitions(
         assets=[hello_world_asset],
-        resources={"io_manager": MyIOManager.partial()},
+        resources={"io_manager": MyIOManager.configure_at_launch()},
     )
 
     assert (

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -1,7 +1,7 @@
 # pylint: disable=unused-argument
 
 from dagster import Definitions, In, asset, job, op
-from dagster._config.structured_config import Resource, StructuredConfigIOManager
+from dagster._config.structured_config import StructuredConfigIOManager
 
 
 def test_load_input_handle_output():
@@ -81,34 +81,4 @@ def test_runtime_config():
         .execute_in_process({"resources": {"io_manager": {"config": {"prefix": "greeting: "}}}})
         .success
     )
-    assert out_txt == ["greeting: hello, world!"]
-
-
-def test_nested_resources():
-    out_txt = []
-
-    class IOConfigResource(Resource):
-        prefix: str
-
-    class MyIOManager(StructuredConfigIOManager):
-        config: IOConfigResource
-
-        def handle_output(self, context, obj):
-            out_txt.append(f"{self.config.prefix}{obj}")
-
-        def load_input(self, context):
-            assert False, "should not be called"
-
-    @asset
-    def hello_world_asset():
-        return "hello, world!"
-
-    defs = Definitions(
-        assets=[hello_world_asset],
-        resources={
-            "io_manager": MyIOManager(config=IOConfigResource(prefix="greeting: ")),
-        },
-    )
-
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
     assert out_txt == ["greeting: hello, world!"]


### PR DESCRIPTION
## Summary

Allows using structured-config based resources and IO managers without binding config at defintiions-time, e.g.:


```python

class MyResource(Resource):
    a_string: str

@asset
def my_asset(res: MyResource):
    print(res.a_string)


defs = Definitions(
    assets=[my_asset],
    resources={"res": MyResource.partial()}
)
```
<img width="1395" alt="Screen Shot 2023-01-09 at 12 40 57 PM" src="https://user-images.githubusercontent.com/10215173/211403937-e1c2c0b6-794d-4cda-a081-6c4fe6a2da47.png">

## Test Plan

Add unit tests for resources, IO managers.
