### PR TITLE
Performance improvements for large multi assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -454,7 +454,7 @@ def multi_asset(
                 (
                     f"Invalid out key '{out_name}' supplied to `internal_asset_deps` argument for"
                     f" multi-asset {op_name}. Must be one of the outs for this multi-asset"
-                    f" {list(outs.keys())}."
+                    f" {list(outs.keys())[:20]}."
                 ),
             )
             invalid_asset_deps = asset_keys.difference(valid_asset_deps)
@@ -464,7 +464,8 @@ def multi_asset(
                     f"Invalid asset dependencies: {invalid_asset_deps} specified in"
                     f" `internal_asset_deps` argument for multi-asset '{op_name}' on key"
                     f" '{out_name}'. Each specified asset key must be associated with an input to"
-                    f" the asset or produced by this asset. Valid keys: {valid_asset_deps}"
+                    " the asset or produced by this asset. Valid keys:"
+                    f" {list(valid_asset_deps)[:20]}"
                 ),
             )
         with warnings.catch_warnings():

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -1477,7 +1477,7 @@ class RepositoryDefinition:
     @property
     def asset_graph(self) -> AssetGraph:
         return AssetGraph.from_assets(
-            [*self._assets_defs_by_key.values(), *self.source_assets_by_key.values()]
+            [*set(self._assets_defs_by_key.values()), *self.source_assets_by_key.values()]
         )
 
     # If definition comes from the @repository decorator, then the __call__ method will be


### PR DESCRIPTION
### Summary & Motivation

generate_asset_dep_graph for a multi asset with 5000 nodes took 30 *minutes* (!!)

This is because we were passing in 5000 copies of the same multi-asset when constructing our asset dependency graph. I also noticed that generating those error messages (regardless of if the error is relevant or not) took a significant amount of time for a graph of that size (around 20 seconds). It seems very unhelpful to list more than 20 or so keys, so I put that limit there, which brings the time back down to a couple of seconds.

### How I Tested These Changes
