### PR TITLE
Fix multidimensional partition backfills

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -253,7 +253,9 @@ const BackfillRunStatus = ({
   return statuses ? (
     <PartitionStatus
       partitionNames={backfill.partitionNames}
-      partitionStateForKey={(key) => runStatusToPartitionState(statuses[key])}
+      partitionStateForKey={(key, _) =>
+        runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0].runStatus)
+      }
       splitPartitions={true}
       onClick={(partitionName) => {
         const entry = statuses.find((r) => r.partitionName === partitionName);

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -28,9 +28,8 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 from dagster._core.storage.pipeline_run import get_partition_tags_from_partition_def
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_selection import AssetGraph, AssetSelection
 from .decorators.sensor_decorator import sensor

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -761,7 +761,7 @@ def build_run_requests(
         if partition_key is not None:
             if partitions_def is None:
                 check.failed("Partition key provided for unpartitioned asset")
-            tags.update({**partitions_def.get_tags_from_partition_key(partition_key)})
+            tags.update({**partitions_def.get_tags_for_partition_key(partition_key)})
 
         run_requests.append(
             RunRequest(

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -28,7 +28,6 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.storage.pipeline_run import get_partition_tags_from_partition_def
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from .asset_selection import AssetGraph, AssetSelection
@@ -762,7 +761,7 @@ def build_run_requests(
         if partition_key is not None:
             if partitions_def is None:
                 check.failed("Partition key provided for unpartitioned asset")
-            tags.update({**get_partition_tags_from_partition_def(partitions_def, partition_key)})
+            tags.update({**partitions_def.get_tags_from_partition_key(partition_key)})
 
         run_requests.append(
             RunRequest(

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -293,9 +293,9 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def secondary_dimension(self) -> PartitionDimensionDefinition:
         return self._get_primary_and_secondary_dimension()[1]
 
-    def get_tags_from_partition_key(self, partition_key: str) -> Mapping[str, str]:
+    def get_tags_for_partition_key(self, partition_key: str) -> Mapping[str, str]:
         partition_key = cast(MultiPartitionKey, self.get_partition_key_from_str(partition_key))
-        tags = {**super().get_tags_from_partition_key(partition_key)}
+        tags = {**super().get_tags_for_partition_key(partition_key)}
         tags.update(get_tags_from_multi_partition_key(partition_key))
         return tags
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -293,6 +293,12 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def secondary_dimension(self) -> PartitionDimensionDefinition:
         return self._get_primary_and_secondary_dimension()[1]
 
+    def get_tags_from_partition_key(self, partition_key: str) -> Mapping[str, str]:
+        partition_key = cast(MultiPartitionKey, self.get_partition_key_from_str(partition_key))
+        tags = {**super().get_tags_from_partition_key(partition_key)}
+        tags.update(get_tags_from_multi_partition_key(partition_key))
+        return tags
+
 
 class MultiPartitionsSubset(DefaultPartitionsSubset):
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -278,7 +278,7 @@ class PartitionsDefinition(ABC, Generic[T]):
     def serializable_unique_identifier(self) -> str:
         return hashlib.sha1(json.dumps(self.get_partition_keys()).encode("utf-8")).hexdigest()
 
-    def get_tags_from_partition_key(self, partition_key: str) -> Mapping[str, str]:
+    def get_tags_for_partition_key(self, partition_key: str) -> Mapping[str, str]:
         tags = {PARTITION_NAME_TAG: partition_key}
         return tags
 

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -29,6 +29,7 @@ import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.target import ExecutableDefinition
+from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._serdes import whitelist_for_serdes
 from dagster._seven.compat.pendulum import PendulumDateTime, to_timezone
 from dagster._utils import frozenlist
@@ -276,6 +277,10 @@ class PartitionsDefinition(ABC, Generic[T]):
     @property
     def serializable_unique_identifier(self) -> str:
         return hashlib.sha1(json.dumps(self.get_partition_keys()).encode("utf-8")).hexdigest()
+
+    def get_tags_from_partition_key(self, partition_key: str) -> Mapping[str, str]:
+        tags = {PARTITION_NAME_TAG: partition_key}
+        return tags
 
 
 class StaticPartitionsDefinition(
@@ -617,6 +622,10 @@ class PartitionSetDefinition(Generic[T]):
     @property
     def mode(self) -> Optional[str]:
         return self._mode
+
+    @property
+    def partitions_def(self) -> PartitionsDefinition:
+        return self._partitions_def
 
     def run_config_for_partition(self, partition: Partition[T]) -> Mapping[str, Any]:
         return copy.deepcopy(self._user_defined_run_config_fn_for_partition(partition))  # type: ignore

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -101,7 +101,7 @@ def _step_output_error_checked_user_event_sequence(
         if not step.has_step_output(cast(str, output.output_name)):
             raise DagsterInvariantViolationError(
                 f'Core compute for {op_label} returned an output "{output.output_name}" that does '
-                f"not exist. The available outputs are {output_names}"
+                f'not exist. The available outputs are {output_names}'
             )
 
         step_output = step.step_output_named(cast(str, output.output_name))
@@ -113,13 +113,13 @@ def _step_output_error_checked_user_event_sequence(
             if step_context.has_seen_output(output.output_name):
                 raise DagsterInvariantViolationError(
                     f'Compute for {op_label} returned an output "{output.output_name}" multiple '
-                    "times"
+                    'times'
                 )
 
             if output_def.is_dynamic:
                 raise DagsterInvariantViolationError(
                     f'Compute for {op_label} for output "{output.output_name}" defined as dynamic '
-                    "must yield DynamicOutput, got Output."
+                    'must yield DynamicOutput, got Output.'
                 )
 
             step_context.observe_output(output.output_name)
@@ -145,7 +145,7 @@ def _step_output_error_checked_user_event_sequence(
             if step_context.has_seen_output(output.output_name, output.mapping_key):
                 raise DagsterInvariantViolationError(
                     f"Compute for {op_label} yielded a DynamicOutput with mapping_key "
-                    f'"{output.mapping_key}" multiple times.'
+                    f"\"{output.mapping_key}\" multiple times."
                 )
             step_context.observe_output(output.output_name, output.mapping_key)
             metadata = step_context.get_output_metadata(
@@ -175,7 +175,7 @@ def _step_output_error_checked_user_event_sequence(
                 raise DagsterStepOutputNotFoundError(
                     (
                         f"Core compute for {op_label} did not return an output for non-optional "
-                        f'output "{step_output_def.name}"'
+                        f"output \"{step_output_def.name}\""
                     ),
                     step_key=step.key,
                     output_name=step_output_def.name,
@@ -253,7 +253,7 @@ def _type_checked_event_sequence_for_input(
             description=(
                 f'Type check failed for step input "{input_name}" - '
                 f'expected type "{dagster_type.display_name}". '
-                f"Description: {type_check.description}"
+                f'Description: {type_check.description}'
             ),
             metadata_entries=type_check.metadata_entries,
             dagster_type=dagster_type,
@@ -306,7 +306,7 @@ def _type_check_output(
             description=(
                 f'Type check failed for step output "{output.output_name}" - '
                 f'expected type "{dagster_type.display_name}". '
-                f"Description: {type_check.description}"
+                f'Description: {type_check.description}'
             ),
             metadata_entries=type_check.metadata_entries,
             dagster_type=dagster_type,
@@ -544,6 +544,8 @@ def _get_output_asset_materializations(
                     if isinstance(partition, MultiPartitionKey)
                     else {}
                 )
+                print(isinstance(partition, MultiPartitionKey), "is multipartitionkey")
+                print("Tags on materialization", tags)
 
                 yield AssetMaterialization(
                     asset_key=asset_key,

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -101,7 +101,7 @@ def _step_output_error_checked_user_event_sequence(
         if not step.has_step_output(cast(str, output.output_name)):
             raise DagsterInvariantViolationError(
                 f'Core compute for {op_label} returned an output "{output.output_name}" that does '
-                f'not exist. The available outputs are {output_names}'
+                f"not exist. The available outputs are {output_names}"
             )
 
         step_output = step.step_output_named(cast(str, output.output_name))
@@ -113,13 +113,13 @@ def _step_output_error_checked_user_event_sequence(
             if step_context.has_seen_output(output.output_name):
                 raise DagsterInvariantViolationError(
                     f'Compute for {op_label} returned an output "{output.output_name}" multiple '
-                    'times'
+                    "times"
                 )
 
             if output_def.is_dynamic:
                 raise DagsterInvariantViolationError(
                     f'Compute for {op_label} for output "{output.output_name}" defined as dynamic '
-                    'must yield DynamicOutput, got Output.'
+                    "must yield DynamicOutput, got Output."
                 )
 
             step_context.observe_output(output.output_name)
@@ -145,7 +145,7 @@ def _step_output_error_checked_user_event_sequence(
             if step_context.has_seen_output(output.output_name, output.mapping_key):
                 raise DagsterInvariantViolationError(
                     f"Compute for {op_label} yielded a DynamicOutput with mapping_key "
-                    f"\"{output.mapping_key}\" multiple times."
+                    f'"{output.mapping_key}" multiple times.'
                 )
             step_context.observe_output(output.output_name, output.mapping_key)
             metadata = step_context.get_output_metadata(
@@ -175,7 +175,7 @@ def _step_output_error_checked_user_event_sequence(
                 raise DagsterStepOutputNotFoundError(
                     (
                         f"Core compute for {op_label} did not return an output for non-optional "
-                        f"output \"{step_output_def.name}\""
+                        f'output "{step_output_def.name}"'
                     ),
                     step_key=step.key,
                     output_name=step_output_def.name,
@@ -253,7 +253,7 @@ def _type_checked_event_sequence_for_input(
             description=(
                 f'Type check failed for step input "{input_name}" - '
                 f'expected type "{dagster_type.display_name}". '
-                f'Description: {type_check.description}'
+                f"Description: {type_check.description}"
             ),
             metadata_entries=type_check.metadata_entries,
             dagster_type=dagster_type,
@@ -306,7 +306,7 @@ def _type_check_output(
             description=(
                 f'Type check failed for step output "{output.output_name}" - '
                 f'expected type "{dagster_type.display_name}". '
-                f'Description: {type_check.description}'
+                f"Description: {type_check.description}"
             ),
             metadata_entries=type_check.metadata_entries,
             dagster_type=dagster_type,
@@ -544,8 +544,6 @@ def _get_output_asset_materializations(
                     if isinstance(partition, MultiPartitionKey)
                     else {}
                 )
-                print(isinstance(partition, MultiPartitionKey), "is multipartitionkey")
-                print("Tags on materialization", tags)
 
                 yield AssetMaterialization(
                     asset_key=asset_key,

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -527,7 +527,7 @@ class DagsterRun(
         partition_set: "PartitionSetDefinition", partition: "Partition"
     ) -> Mapping[str, str]:
         tags = {PARTITION_SET_TAG: partition_set.name}
-        tags.update(partition_set.partitions_def.get_tags_from_partition_key(partition.name))
+        tags.update(partition_set.partitions_def.get_tags_for_partition_key(partition.name))
         return tags
 
 

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from enum import Enum
 from inspect import Parameter
 from typing import (
-    cast,
     TYPE_CHECKING,
     Any,
     Dict,
@@ -15,6 +14,7 @@ from typing import (
     Sequence,
     Type,
     Union,
+    cast,
 )
 
 from typing_extensions import Self
@@ -49,8 +49,8 @@ from .tags import (
 if TYPE_CHECKING:
     from dagster._core.definitions.partition import (
         Partition,
-        PartitionSetDefinition,
         PartitionsDefinition,
+        PartitionSetDefinition,
     )
     from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
@@ -536,8 +536,8 @@ class DagsterRun(
 
 def get_tags_from_partition_key(partition_key: str) -> Mapping[str, str]:
     from dagster._core.definitions.multi_dimensional_partitions import (
-        get_tags_from_multi_partition_key,
         MultiPartitionKey,
+        get_tags_from_multi_partition_key,
     )
 
     tags = {PARTITION_NAME_TAG: partition_key}
@@ -551,8 +551,8 @@ def get_partition_tags_from_partition_def(
     partitions_def: "PartitionsDefinition", partition_key: str
 ) -> Mapping[str, str]:
     from dagster._core.definitions.multi_dimensional_partitions import (
-        MultiPartitionsDefinition,
         MultiPartitionKey,
+        MultiPartitionsDefinition,
     )
 
     if isinstance(partitions_def, MultiPartitionsDefinition):

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -14,7 +14,6 @@ from typing import (
     Sequence,
     Type,
     Union,
-    cast,
 )
 
 from typing_extensions import Self
@@ -38,7 +37,6 @@ from dagster._serdes.serdes import (
 
 from .tags import (
     BACKFILL_ID_TAG,
-    PARTITION_NAME_TAG,
     PARTITION_SET_TAG,
     REPOSITORY_LABEL_TAG,
     RESUME_RETRY_TAG,
@@ -49,7 +47,6 @@ from .tags import (
 if TYPE_CHECKING:
     from dagster._core.definitions.partition import (
         Partition,
-        PartitionsDefinition,
         PartitionSetDefinition,
     )
     from dagster._core.host_representation.origin import ExternalPipelineOrigin
@@ -530,37 +527,8 @@ class DagsterRun(
         partition_set: "PartitionSetDefinition", partition: "Partition"
     ) -> Mapping[str, str]:
         tags = {PARTITION_SET_TAG: partition_set.name}
-        tags.update(get_tags_from_partition_key(partition.name))
+        tags.update(partition_set.partitions_def.get_tags_from_partition_key(partition.name))
         return tags
-
-
-def get_tags_from_partition_key(partition_key: str) -> Mapping[str, str]:
-    from dagster._core.definitions.multi_dimensional_partitions import (
-        MultiPartitionKey,
-        get_tags_from_multi_partition_key,
-    )
-
-    tags = {PARTITION_NAME_TAG: partition_key}
-    if isinstance(partition_key, MultiPartitionKey):
-        tags.update(get_tags_from_multi_partition_key(partition_key))
-
-    return tags
-
-
-def get_partition_tags_from_partition_def(
-    partitions_def: "PartitionsDefinition", partition_key: str
-) -> Mapping[str, str]:
-    from dagster._core.definitions.multi_dimensional_partitions import (
-        MultiPartitionKey,
-        MultiPartitionsDefinition,
-    )
-
-    if isinstance(partitions_def, MultiPartitionsDefinition):
-        partition_key = cast(
-            MultiPartitionKey, partitions_def.get_partition_key_from_str(partition_key)
-        )
-
-    return get_tags_from_partition_key(partition_key)
 
 
 # DagsterRun is serialized as PipelineRun so that it can be read by older (pre 0.13.x) version of


### PR DESCRIPTION
This PR rolls up a couple of fixes into one.

- Currently, multidimensional asset backfills do not update partition status in Dagit. This is because recent changes to backfill logic did not add the corresponding per-dimension tags to the requested runs. This PR fixes this.
- The run status column of the backfill page displays as empty. This is because:
  - Multidimensional asset runs do not write a partition to the runs table
  - Minor JS bug (fix enclosed in PR)

This PR amends multidimensionally partitioned runs to also have the `partition` tag, which is the multidimensional partition key e.g. `a|2022-01-01`, subsequently writing this tag to the partition column of the runs table. Also updates the asset backfill logic to also add the multipartitions tags to asset backfill runs so multidimensional runs also contain per-dimension tags.
