### PR TITLE
[structured config] Enable nesting of non-structured resources in structured resources

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -37,6 +37,7 @@ from dagster._config.field_utils import (
 from dagster._core.definitions.resource_definition import (
     ResourceDefinition,
     ResourceFunction,
+    ResourceFunctionWithoutContext,
     is_context_provided,
 )
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
@@ -327,6 +328,7 @@ def _is_fully_configured(resource: ResourceDefinition) -> bool:
         )
         .resolve_config({})
         .success
+        is True
     )
 
 
@@ -605,14 +607,14 @@ def _separate_resource_params(
 
 def _call_resource_fn_with_default(obj: ResourceDefinition, context: InitResourceContext) -> Any:
     if isinstance(obj.config_schema, ConfiguredDefinitionConfigSchema):
-        value = obj.config_schema.resolve_config({}).value
+        value = cast(Dict[str, Any], obj.config_schema.resolve_config({}).value)
         context = context.replace_config(value["config"])
     elif obj.config_schema.default_provided:
         context = context.replace_config(obj.config_schema.default_value)
     if is_context_provided(obj.resource_fn):
         return obj.resource_fn(context)
     else:
-        return obj.resource_fn()
+        return cast(ResourceFunctionWithoutContext, obj.resource_fn)()
 
 
 _Resource = Resource

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -5,6 +5,7 @@ from dagster._annotations import experimental, public
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
+from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.instance import DagsterInstance
@@ -92,11 +93,10 @@ def _create_repository_using_definitions_args(
 
     if loggers:
         check.mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
-    from dagster._config.structured_config import AllowDelayedDependencies
 
     if resources:
         for rkey, resource in resources.items():
-            if isinstance(resource, AllowDelayedDependencies):
+            if isinstance(resource, ResourceDefinition):
                 resource.set_top_level_key(rkey)
 
     resource_defs = wrap_resources_for_execution(resources or {})

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -106,7 +106,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
             required_resource_keys, "required_resource_keys"
         )
         self._version = check.opt_str_param(version, "version")
-        self._top_level_key = None
+        self._top_level_key: Optional[str] = None
         if version:
             experimental_arg_warning("version", "ResourceDefinition.__init__")
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -106,8 +106,24 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
             required_resource_keys, "required_resource_keys"
         )
         self._version = check.opt_str_param(version, "version")
+        self._top_level_key = None
         if version:
             experimental_arg_warning("version", "ResourceDefinition.__init__")
+
+    def set_top_level_key(self, key: str):
+        """
+        Sets the top-level resource key for this resource, when passed
+        into the Definitions object.
+        """
+        self._top_level_key = key
+
+    @property
+    def top_level_key(self) -> Optional[str]:
+        """
+        Gets the top-level resource key for this resource which was associated with it
+        in the Definitions object.
+        """
+        return self._top_level_key
 
     @property
     def resource_fn(self) -> ResourceFunction:


### PR DESCRIPTION
## Summary

Makes much of the nested-structured-resource code generic so that non-structured resources can be nested within structured resources.

This works with partially or non-partially configured resources.

For example:

```python

@resource(config_schema={"a_string": str})
def my_str_resource() -> str:
    ...

class MyOuterResource(Resource):
    my_str_resource: ResourceDependency[str]
    an_int: int


@asset
def my_asset(outer: MyOuterResource):
    assert outer.an_int == 5
    assert outer.my_str_resource == "foo"

defs = Definitions(
    assets=[my_asset],
    resources={
        "outer": MyOuterResource(
	    my_str_resource=my_str_resource.configured({"a_string": "foo"}),
	    an_int=5
	)
    }
)
```



## Test Plan

New unit tests.
