### PR TITLE
Allow bare executor in Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -164,7 +164,7 @@ class Definitions:
             explicitly. This executor will also be used for materializing assets directly
             outside of the context of jobs.
 
-            If an Executor is passed, it is coerced into a ExecutorDefinition.
+            If an Executor is passed, it is coerced into an ExecutorDefinition.
 
 
         loggers (Optional[Mapping[str, LoggerDefinition]):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
+from dagster._core.executor.base import Executor
 from dagster._core.instance import DagsterInstance
 from dagster._utils.cached_method import cached_method
 
@@ -70,7 +71,7 @@ def _create_repository_using_definitions_args(
     sensors: Optional[Iterable[SensorDefinition]] = None,
     jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]] = None,
     resources: Optional[Mapping[str, Any]] = None,
-    executor: Optional[ExecutorDefinition] = None,
+    executor: Optional[Union[ExecutorDefinition, Executor]] = None,
     loggers: Optional[Mapping[str, LoggerDefinition]] = None,
 ):
     if assets:
@@ -91,20 +92,23 @@ def _create_repository_using_definitions_args(
     if jobs:
         check.iterable_param(jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition))
 
-    if resources:
-        check.mapping_param(resources, "resources", key_type=str)
-
-    if executor:
-        check.inst_param(executor, "executor", ExecutorDefinition)
-
-    if loggers:
-        check.mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
+    check.opt_mapping_param(resources, "resources", key_type=str)
 
     resource_defs = wrap_resources_for_execution(resources or {})
 
+    check.opt_inst_param(executor, "executor", (ExecutorDefinition, Executor))
+
+    executor_def = (
+        executor
+        if isinstance(executor, ExecutorDefinition) or executor is None
+        else ExecutorDefinition.hardcoded_executor(executor)
+    )
+
+    check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
+
     @repository(
         name=name,
-        default_executor_def=executor,
+        default_executor_def=executor_def,
         default_logger_defs=loggers,
     )
     def created_repo():
@@ -153,12 +157,14 @@ class Definitions:
             resources already bound using :py:func:`with_resources <with_resources>` will
             override this dictionary.
 
-        executor (Optional[ExecutorDefinition]):
+        executor (Optional[Union[ExecutorDefinition, Executor]]):
             Default executor for jobs. Individual jobs
             can override this and define their own executors by setting the executor
             on :py:func:`@job <job>` or :py:func:`define_asset_job <define_asset_job>`
             explicitly. This executor will also be used for materializing assets directly
             outside of the context of jobs.
+
+            If an Executor is passed, it is coerced into a ExecutorDefinition.
 
 
         loggers (Optional[Mapping[str, LoggerDefinition]):
@@ -216,7 +222,7 @@ class Definitions:
         sensors: Optional[Iterable[SensorDefinition]] = None,
         jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]] = None,
         resources: Optional[Mapping[str, Any]] = None,
-        executor: Optional[ExecutorDefinition] = None,
+        executor: Optional[Union[ExecutorDefinition, Executor]] = None,
         loggers: Optional[Mapping[str, LoggerDefinition]] = None,
     ):
         self._created_pending_or_normal_repo = _create_repository_using_definitions_args(

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -139,6 +139,15 @@ class ExecutorDefinition(NamedConfigurableDefinition):
             requirements=self._requirements_fn,
         )
 
+    @staticmethod
+    def hardcoded_executor(executor: "Executor"):
+        return ExecutorDefinition(
+            # Executor name was only relevant in the pipeline/solid/mode world, so we
+            # can put a dummy value
+            name="__executor__",
+            executor_creation_fn=lambda _init_context: executor,
+        )
+
     # Backcompat: Overrides configured method to provide name as a keyword argument.
     # If no name is provided, the name is pulled off of this ExecutorDefinition.
     @public


### PR DESCRIPTION
### Summary & Motivation

I found this very useful in a separate branch I was working on, and this is much more ergonomic in cases where all executor config is bound at definition time.

I also did a minor refactor to use opt* variants of check calls and do coercions closer to those calls because I think co-locating that makes it clearer.

### How I Tested These Changes

BK.
