### PR TITLE
Heartbeat once at the beginning of every interval daemon

### DIFF
--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -212,6 +212,7 @@ class IntervalDaemon(DagsterDaemon[TContext], ABC):
         while True:
             start_time = time.time()
             try:
+                yield None  # Heartbeat once at the beginning to kick things off
                 yield from self.run_iteration(workspace_process_context)
             except Exception:
                 error_info = serializable_error_info_from_exc_info(sys.exc_info())


### PR DESCRIPTION
Summary:
We're seeing a report from a user about the backfill daemon giving up due to a lack of heartbeats - but curiously it is happening well before our default tolerance limit of 5 minutes. I suspect that what is happening is that the backfill daemon does something expensive right at the beginning before it yields anything - so the only heartbeat we have is super old and the tolerance doesn't really matter.

To resolve this, do an initial yield / potential heartbeat at the beginning of every daemon. So now we will have a baseline and will still catch it if the daemon hangs.

### Summary & Motivation

### How I Tested These Changes
