### PR TITLE
Log to daemon output when running the schedule code fails or times out

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -496,10 +496,7 @@ def _process_tick_generator(
 
     except Exception:
         error_info = serializable_error_info_from_exc_info(sys.exc_info())
-        logger.error(
-            f"Sensor daemon caught an error for sensor {external_sensor.name} :"
-            f" {error_info.to_string()}"
-        )
+        logger.exception(f"Sensor daemon caught an error for sensor {external_sensor.name}")
 
     yield error_info
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -357,10 +357,7 @@ def launch_scheduled_runs(
                 )
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            logger.error(
-                f"Scheduler caught an error for schedule {external_schedule.name} :"
-                f" {error_info.to_string()}"
-            )
+            logger.exception(f"Scheduler caught an error for schedule {external_schedule.name}")
         yield error_info
 
 
@@ -529,6 +526,11 @@ def launch_scheduled_runs_for_schedule_iterator(
                     except:
                         error_data = serializable_error_info_from_exc_info(sys.exc_info())
 
+                        logger.exception(
+                            "Scheduler daemon caught an error for schedule "
+                            f"{external_schedule.name}"
+                        )
+
                         tick_context.update_state(
                             TickStatus.FAILURE,
                             error=error_data,
@@ -662,10 +664,7 @@ def _schedule_runs_at_time(
                 logger.info(f"Completed scheduled launch of run {run.run_id} for {schedule_name}")
             except Exception:
                 error_info = serializable_error_info_from_exc_info(sys.exc_info())
-                logger.error(
-                    f"Run {run.run_id} created successfully but failed to launch:"
-                    f" {str(serializable_error_info_from_exc_info(sys.exc_info()))}"
-                )
+                logger.exception(f"Run {run.run_id} created successfully but failed to launch")
                 yield error_info
 
         _check_for_debug_crash(debug_crash_flags, "RUN_LAUNCHED")


### PR DESCRIPTION
Summary:
We write the tick as a failure but we don't log to the daemon output - making it hard to understand what's going on when schedules are timing out or otherwise failing. add a lot in the same place as the sensor daemon.

While we're in here, change some .errors to .exceptions since that's the more appropriate level here

### Summary & Motivation

### How I Tested These Changes
