### PR TITLE
[dagit] Fix support for long descriptions in the asset catalog table

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeList.tsx
@@ -53,6 +53,6 @@ const Container = styled(Box)`
 
 const AssetNodeWrapper = styled.div`
   cursor: pointer;
-  width: 240px;
+  width: 260px;
   flex-shrink: 0;
 `;

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -107,8 +107,8 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
           </RowCell>
         ) : null}
         <RowCell>
-          <Box flex={{justifyContent: 'space-between'}} style={{position: 'relative'}}>
-            <div style={{maxWidth: '100%', minWidth: 0}}>
+          <Box flex={{alignItems: 'center'}}>
+            <div style={{flex: 1, minWidth: 0}}>
               <AssetLink
                 path={type === 'folder' || view === 'directory' ? path.slice(-1) : path}
                 url={linkUrl}
@@ -116,17 +116,6 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 icon={type}
                 textStyle="middle-truncate"
               />
-            </div>
-            <div
-              style={{
-                maxWidth: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              <Caption style={{color: Colors.Gray500, whiteSpace: 'nowrap'}}>
-                {asset?.definition?.description}
-              </Caption>
             </div>
             {asset?.definition && (
               <AssetComputeKindTag
@@ -137,6 +126,17 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
               />
             )}
           </Box>
+          <div
+            style={{
+              maxWidth: '100%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            <Caption style={{color: Colors.Gray500, whiteSpace: 'nowrap'}}>
+              {asset?.definition?.description}
+            </Caption>
+          </div>
         </RowCell>
         {showRepoColumn ? (
           <RowCell>

--- a/python_modules/dagster-test/dagster_test/toys/software_defined_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/software_defined_assets.py
@@ -31,7 +31,18 @@ def daily_temperature_highs(sfo_q2_weather_sample: DataFrame) -> DataFrame:
 
 @asset
 def hottest_dates(daily_temperature_highs: DataFrame) -> DataFrame:
-    """Computes the 10 hottest dates."""
+    """Computes the 10 hottest dates. In a more advanced demo, this might perform a complex
+    SQL query to aggregate the data. For now, just imagine that this implements something like:
+
+    ```sql
+    SELECT temp, date_part('day', date) FROM daily_temperature_highs ORDER BY date DESC;
+    ```
+
+    This could make use of [DATE_PART](https://www.postgresql.org/docs/8.1/functions-datetime.html),
+    and we can even link to that because this supports Markdown.
+
+    This concludes the demo of a long asset description.
+    """
     assert daily_temperature_highs
     time.sleep(3)
     return DataFrame()


### PR DESCRIPTION
### Summary & Motivation

This PR addresses an issue in the latest release related to my previous work in #10453.

Asset descriptions should appear on a line beneath the asset name and the kind tag, and should wrap accordingly. Here's the behavior after this fix:

<img width="507" alt="image" src="https://user-images.githubusercontent.com/1037212/213586567-69785bc2-2b52-4a23-9ac3-6192ffd9493e.png">

<img width="365" alt="image" src="https://user-images.githubusercontent.com/1037212/213586608-1c23d056-eea3-4063-8672-ae09edd6c2f4.png">


To make this easier for us to catch in the future, I've also added a long description (containing markdown, another largely untested-in-toys feature) to one of the weather assets in our toys repo:

<img width="587" alt="image" src="https://user-images.githubusercontent.com/1037212/213586702-52ff36f1-f1f1-47f5-baee-96ff6fa12a7d.png">
<img width="476" alt="image" src="https://user-images.githubusercontent.com/1037212/213586709-02e303e3-f45f-48c0-be8f-8c9cc6355df8.png">

This PR also tweaks a Firefox constant we have in our middle truncation code, because I noticed one scenario where the DOM and Canvas reported widths of a string were off by 0.12, which caused the text to middle truncate unnecessarily.

### How I Tested These Changes

Tested the asset catalog changes in Firefox and Chrome