### PR TITLE
When can't deserialize asset backfill because asset is no longer partitioned, return it as empty

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from dagster import Definitions, StaticPartitionsDefinition, asset
+from dagster import AssetKey, Definitions, StaticPartitionsDefinition, asset
 from dagster._core.execution.asset_backfill import AssetBackfillData
 from dagster._core.test_utils import instance_for_test
 from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
@@ -61,6 +61,20 @@ def get_repo():
 
     @asset(partitions_def=partitions_def)
     def asset2():
+        ...
+
+    return Definitions(assets=[asset1, asset2]).get_repository_def()
+
+
+def get_repo_with_non_partitioned_asset():
+    partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        ...
+
+    @asset
+    def asset2(asset1):
         ...
 
     return Definitions(assets=[asset1, asset2]).get_repository_def()
@@ -140,9 +154,33 @@ def test_launch_asset_backfill():
                 partition_status_result["partitionName"]
                 for partition_status_result in partition_status_results
             } == {"a", "b"}
+
+
+def test_remove_partitions_defs_after_backfill():
+    repo = get_repo()
+    all_asset_keys = repo.asset_graph.all_asset_keys
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo", instance) as context:
+            # launchPartitionBackfill
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            backfill_id, asset_backfill_data = _get_backfill_data(
+                launch_backfill_result, instance, repo
             )
             assert asset_backfill_data.target_subset.asset_keys == all_asset_keys
 
+        with define_out_of_process_context(
+            __file__, "get_repo_with_non_partitioned_asset", instance
+        ) as context:
             # on PartitionBackfills
             get_backfills_result = execute_dagster_graphql(
                 context, GET_PARTITION_BACKFILLS_QUERY, variables={}
@@ -151,11 +189,11 @@ def test_launch_asset_backfill():
             assert get_backfills_result.data
             backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
             assert len(backfill_results) == 1
-            assert backfill_results[0]["numPartitions"] == 2
+            assert backfill_results[0]["numPartitions"] == 0
             assert backfill_results[0]["backfillId"] == backfill_id
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
-            assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
+            assert set(backfill_results[0]["partitionNames"]) == set()
 
             # on PartitionBackfill
             single_backfill_result = execute_dagster_graphql(
@@ -166,11 +204,44 @@ def test_launch_asset_backfill():
             partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
                 "partitionStatuses"
             ]["results"]
-            assert len(partition_status_results) == 2
+            assert len(partition_status_results) == 0
             assert {
                 partition_status_result["partitionName"]
                 for partition_status_result in partition_status_results
-            } == {"a", "b"}
+            } == set()
+
+
+def test_launch_asset_backfill_with_non_partitioned_asset():
+    repo = get_repo_with_non_partitioned_asset()
+    all_asset_keys = repo.asset_graph.all_asset_keys
+
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_non_partitioned_asset", instance
+        ) as context:
+            # launchPartitionBackfill
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                    }
+                },
+            )
+            backfill_id, asset_backfill_data = _get_backfill_data(
+                launch_backfill_result, instance, repo
+            )
+            target_subset = asset_backfill_data.target_subset
+            assert target_subset.asset_keys == all_asset_keys
+            assert target_subset.get_partitions_subset(AssetKey("asset1")).get_partition_keys() == {
+                "a",
+                "b",
+            }
+            assert AssetKey("asset2") in target_subset.non_partitioned_asset_keys
+            assert AssetKey("asset2") not in target_subset.partitions_subsets_by_asset_key
+
 
 def _get_backfill_data(launch_backfill_result, instance, repo):
     assert launch_backfill_result

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -594,3 +594,10 @@ class DagsterUndefinedLogicalVersionError(DagsterError):
     """
     The user attempted to retrieve the most recent logical version for an asset, but no logical version is defined.
     """
+
+
+class DagsterDefinitionChangedDeserializationError(DagsterError):
+    """
+    Indicates that a stored value can't be deserialized because the definition needed to interpret
+    it has changed.
+    """

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
+from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
 from dagster._core.workspace.workspace import IWorkspace
@@ -118,9 +119,14 @@ class PartitionBackfill(
 
     def get_num_partitions(self, workspace: IWorkspace) -> int:
         if self.serialized_asset_backfill_data is not None:
-            asset_backfill_data = AssetBackfillData.from_serialized(
-                self.serialized_asset_backfill_data, ExternalAssetGraph.from_workspace(workspace)
-            )
+            try:
+                asset_backfill_data = AssetBackfillData.from_serialized(
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
+                )
+            except DagsterDefinitionChangedDeserializationError:
+                return 0
+
             return asset_backfill_data.get_num_partitions()
         else:
             if self.partition_names is None:
@@ -130,9 +136,14 @@ class PartitionBackfill(
 
     def get_partition_names(self, workspace: IWorkspace) -> Sequence[str]:
         if self.serialized_asset_backfill_data is not None:
-            asset_backfill_data = AssetBackfillData.from_serialized(
-                self.serialized_asset_backfill_data, ExternalAssetGraph.from_workspace(workspace)
-            )
+            try:
+                asset_backfill_data = AssetBackfillData.from_serialized(
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
+                )
+            except DagsterDefinitionChangedDeserializationError:
+                return []
+
             return asset_backfill_data.get_partition_names()
         else:
             if self.partition_names is None:


### PR DESCRIPTION
### Summary & Motivation

Addresses https://github.com/dagster-io/dagster/issues/11787

Prior to this change, the backfill UI would fail to load if any of the asset backfills had assets that were partitioned at the time of the backfill and are no longer partitioned.

A more principled solution would be to store some sort of snapshot of the backfill that's loadable even if the asset definitions change, but the approach in this PR assumes that, in most cases, users won't care about the partitions of a backfill that targeted an asset that's no longer partitioned.

### How I Tested These Changes
