### PR TITLE
Specify credentials masking.

### DIFF
--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
@@ -10,7 +10,7 @@ class ManagedElementError(enum.Enum):
     CANNOT_CONNECT = "cannot_connect"
 
 
-SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials"]
+SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials_json"]
 SANITIZE_KEY_EXACT_MATCHES = ["pat"]
 
 SECRET_MASK_VALUE = "**********"


### PR DESCRIPTION
### Summary & Motivation
`credentials` is too broad a sanitization keyword, as some sources, such as Hubspot, have a nested `credentials_title` plaintext key.  If this key gets masked the reconciler can never resolve the diff from the remote instance. I specified the keyword to `credentials_json` as that is a key I am certain that was previously going unmasked. 

Looking into the future; I foresee the case where there might be naming collisions with keys across different sources, where one is an Airbyte secret, and one is not. The sanitization functionality might have to be specified in a different way. It looks like Airbyte determines secrets on a per field basis with a flag in the spec.yaml. Example included below.

```
            client_secret:
              title: Client Secret
              description: >-
                The client secret for your HubSpot developer application. See the <a
                href="https://legacydocs.hubspot.com/docs/methods/oauth2/oauth2-quickstart">Hubspot docs</a>
                if you need help finding this secret.
              type: string
              examples:
                - secret
              airbyte_secret: true
```
### How I Tested These Changes
