### PR TITLE
Move pyproject.toml => origin generation to a WorkspaceLoadTarget class so that it can be reloaded in dagit

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -1,5 +1,8 @@
+import os
 from abc import ABC, abstractmethod
 from typing import NamedTuple, Optional, Sequence
+
+import tomli
 
 from dagster._core.host_representation.origin import (
     GrpcServerRepositoryLocationOrigin,
@@ -35,6 +38,28 @@ class WorkspaceFileTarget(
 ):
     def create_origins(self):
         return location_origins_from_yaml_paths(self.paths)
+
+
+def get_origins_from_toml(path) -> Sequence[RepositoryLocationOrigin]:
+    with open(path, "rb") as f:
+        data = tomli.load(f)
+        if not isinstance(data, dict):
+            return []
+
+        dagster_block = data.get("tool", {}).get("dagster", {})
+        if "module_name" in dagster_block:
+            return ModuleTarget(
+                module_name=dagster_block["module_name"],
+                attribute=None,
+                working_directory=os.getcwd(),
+                location_name=None,
+            ).create_origins()
+        return []
+
+
+class PyProjectFileTarget(NamedTuple("PyProjectFileTarget", [("path", str)]), WorkspaceLoadTarget):
+    def create_origins(self):
+        return get_origins_from_toml(self.path)
 
 
 class PythonFileTarget(

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -9,8 +9,7 @@ from dagster._cli.project import (
     scaffold_command,
     scaffold_repository_command,
 )
-from dagster._cli.workspace.cli_target import get_target_from_toml
-from dagster._core.workspace.load_target import ModuleTarget
+from dagster._core.workspace.load_target import get_origins_from_toml
 from dagster._generate.download import AVAILABLE_EXAMPLES, EXAMPLES_TO_IGNORE
 from dagster._generate.generate import _should_skip_file
 
@@ -36,9 +35,9 @@ def test_project_scaffold_command_succeeds():
         assert os.path.exists("my_dagster_project/pyproject.toml")
 
         # test target loadable
-        target = get_target_from_toml("my_dagster_project/pyproject.toml")
-        assert isinstance(target, ModuleTarget)
-        assert target.module_name == "my_dagster_project"
+        origins = get_origins_from_toml("my_dagster_project/pyproject.toml")
+        assert len(origins) == 1
+        assert origins[0].loadable_target_origin.module_name == "my_dagster_project"
 
 
 def test_scaffold_code_location_scaffold_command_fails_when_dir_path_exists():
@@ -61,9 +60,9 @@ def test_scaffold_code_location_command_succeeds():
         assert os.path.exists("my_dagster_code/pyproject.toml")
 
         # test target loadable
-        target = get_target_from_toml("my_dagster_code/pyproject.toml")
-        assert isinstance(target, ModuleTarget)
-        assert target.module_name == "my_dagster_code"
+        origins = get_origins_from_toml("my_dagster_code/pyproject.toml")
+        assert len(origins) == 1
+        assert origins[0].loadable_target_origin.module_name == "my_dagster_code"
 
 
 def test_from_example_command_fails_when_example_not_available():

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -1,17 +1,16 @@
-from dagster._cli.workspace.cli_target import get_target_from_toml
-from dagster._core.workspace.load_target import ModuleTarget
+from dagster._core.workspace.load_target import get_origins_from_toml
 from dagster._utils import file_relative_path
 
 
 def test_load_python_module_from_toml():
-    target = get_target_from_toml(file_relative_path(__file__, "single_module.toml"))
-    assert isinstance(target, ModuleTarget)
-    assert target.module_name == "baaz"
+    origins = get_origins_from_toml(file_relative_path(__file__, "single_module.toml"))
+    assert len(origins) == 1
+    assert origins[0].loadable_target_origin.module_name == "baaz"
 
 
 def test_load_empty_toml():
-    assert get_target_from_toml(file_relative_path(__file__, "empty.toml")) is None
+    assert get_origins_from_toml(file_relative_path(__file__, "empty.toml")) == []
 
 
 def test_load_toml_with_other_stuff():
-    assert get_target_from_toml(file_relative_path(__file__, "other_stuff.toml")) is None
+    assert get_origins_from_toml(file_relative_path(__file__, "other_stuff.toml")) == []


### PR DESCRIPTION
Summary:
This gives us the nice property that you can change the contents of the pyproject.toml file and hit "Reload All" in dagit without needing to restart it to pick up the changes. Also clears the deck for returning multiple modules which I remember was requestsed.

Test Plan: BK, sanity check with a local dagit load

### Summary & Motivation

### How I Tested These Changes
