### PR TITLE
[dagit] Add ErrorBoundary to Dagit to reduce severity of React errors

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
@@ -1,4 +1,4 @@
-import {MainContent} from '@dagster-io/ui';
+import {MainContent, ErrorBoundary} from '@dagster-io/ui';
 import * as React from 'react';
 import {Route, Switch, useLocation} from 'react-router-dom';
 
@@ -27,68 +27,70 @@ export const ContentRoot = React.memo(() => {
 
   return (
     <MainContent ref={main}>
-      <Switch>
-        <Route path="/asset-groups(/?.*)">
-          <React.Suspense fallback={<div />}>
-            <AssetsGroupsGlobalGraphRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/assets(/?.*)">
-          <React.Suspense fallback={<div />}>
-            <AssetsCatalogRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/runs" exact>
-          <React.Suspense fallback={<div />}>
-            <RunsRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/runs/scheduled" exact>
-          <React.Suspense fallback={<div />}>
-            <ScheduledRunListRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/runs/:runId" exact>
-          <React.Suspense fallback={<div />}>
-            <RunRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/snapshots/:pipelinePath/:tab?">
-          <React.Suspense fallback={<div />}>
-            <SnapshotRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/health">
-          <React.Suspense fallback={<div />}>
-            <InstanceHealthPage />
-          </React.Suspense>
-        </Route>
-        <Route path="/config">
-          <React.Suspense fallback={<div />}>
-            <InstanceConfig />
-          </React.Suspense>
-        </Route>
-        <Route path="/locations" exact>
-          <React.Suspense fallback={<div />}>
-            <CodeLocationsPage />
-          </React.Suspense>
-        </Route>
-        <Route path="/locations">
-          <React.Suspense fallback={<div />}>
-            <WorkspaceRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="/overview">
-          <React.Suspense fallback={<div />}>
-            <OverviewRoot />
-          </React.Suspense>
-        </Route>
-        <Route path="*">
-          <React.Suspense fallback={<div />}>
-            <FallthroughRoot />
-          </React.Suspense>
-        </Route>
-      </Switch>
+      <ErrorBoundary region="page" resetErrorOnChange={[pathname]}>
+        <Switch>
+          <Route path="/asset-groups(/?.*)">
+            <React.Suspense fallback={<div />}>
+              <AssetsGroupsGlobalGraphRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/assets(/?.*)">
+            <React.Suspense fallback={<div />}>
+              <AssetsCatalogRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/runs" exact>
+            <React.Suspense fallback={<div />}>
+              <RunsRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/runs/scheduled" exact>
+            <React.Suspense fallback={<div />}>
+              <ScheduledRunListRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/runs/:runId" exact>
+            <React.Suspense fallback={<div />}>
+              <RunRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/snapshots/:pipelinePath/:tab?">
+            <React.Suspense fallback={<div />}>
+              <SnapshotRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/health">
+            <React.Suspense fallback={<div />}>
+              <InstanceHealthPage />
+            </React.Suspense>
+          </Route>
+          <Route path="/config">
+            <React.Suspense fallback={<div />}>
+              <InstanceConfig />
+            </React.Suspense>
+          </Route>
+          <Route path="/locations" exact>
+            <React.Suspense fallback={<div />}>
+              <CodeLocationsPage />
+            </React.Suspense>
+          </Route>
+          <Route path="/locations">
+            <React.Suspense fallback={<div />}>
+              <WorkspaceRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/overview">
+            <React.Suspense fallback={<div />}>
+              <OverviewRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="*">
+            <React.Suspense fallback={<div />}>
+              <FallthroughRoot />
+            </React.Suspense>
+          </Route>
+        </Switch>
+      </ErrorBoundary>
     </MainContent>
   );
 });

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -1,4 +1,11 @@
-import {Box, Checkbox, Colors, NonIdealState, SplitPanelContainer} from '@dagster-io/ui';
+import {
+  Box,
+  Checkbox,
+  Colors,
+  NonIdealState,
+  SplitPanelContainer,
+  ErrorBoundary,
+} from '@dagster-io/ui';
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
@@ -268,7 +275,7 @@ export const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
       firstInitialPercent={70}
       firstMinSize={400}
       first={
-        <>
+        <ErrorBoundary region="graph">
           {graphQueryItems.length === 0 ? (
             <EmptyDAGNotice nodeType="asset" isGraph />
           ) : applyingEmptyDefault ? (
@@ -430,22 +437,26 @@ export const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
               popoverPosition="bottom-left"
             />
           </QueryOverlay>
-        </>
+        </ErrorBoundary>
       }
       second={
         selectedGraphNodes.length === 1 && selectedGraphNodes[0] ? (
           <RightInfoPanel>
             <RightInfoPanelContent>
-              <SidebarAssetInfo
-                assetNode={selectedGraphNodes[0]}
-                liveData={liveDataByNode[selectedGraphNodes[0].id]}
-              />
+              <ErrorBoundary region="asset sidebar" resetErrorOnChange={[selectedGraphNodes[0].id]}>
+                <SidebarAssetInfo
+                  assetNode={selectedGraphNodes[0]}
+                  liveData={liveDataByNode[selectedGraphNodes[0].id]}
+                />
+              </ErrorBoundary>
             </RightInfoPanelContent>
           </RightInfoPanel>
         ) : fetchOptions.pipelineSelector ? (
           <RightInfoPanel>
             <RightInfoPanelContent>
-              <AssetGraphJobSidebar pipelineSelector={fetchOptions.pipelineSelector} />
+              <ErrorBoundary region="asset job sidebar">
+                <AssetGraphJobSidebar pipelineSelector={fetchOptions.pipelineSelector} />
+              </ErrorBoundary>
             </RightInfoPanelContent>
           </RightInfoPanel>
         ) : null

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -1,4 +1,4 @@
-import {Box, ButtonGroup, Colors, Spinner, Subheading} from '@dagster-io/ui';
+import {Box, ButtonGroup, Colors, Spinner, Subheading, ErrorBoundary} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {LiveDataForNode} from '../asset-graph/Utils';
@@ -162,21 +162,23 @@ export const AssetEvents: React.FC<Props> = ({
           flex={{direction: 'column'}}
           border={{side: 'left', color: Colors.KeylineGray, width: 1}}
         >
-          {xAxis === 'partition' ? (
-            focused ? (
-              <AssetPartitionDetail
-                group={focused}
-                hasLineage={assetHasLineage}
-                assetKey={assetKey}
-              />
+          <ErrorBoundary region="event" resetErrorOnChange={[focused]}>
+            {xAxis === 'partition' ? (
+              focused ? (
+                <AssetPartitionDetail
+                  group={focused}
+                  hasLineage={assetHasLineage}
+                  assetKey={assetKey}
+                />
+              ) : (
+                <AssetPartitionDetailEmpty />
+              )
+            ) : focused?.latest ? (
+              <AssetEventDetail assetKey={assetKey} event={focused.latest} />
             ) : (
-              <AssetPartitionDetailEmpty />
-            )
-          ) : focused?.latest ? (
-            <AssetEventDetail assetKey={assetKey} event={focused.latest} />
-          ) : (
-            <AssetEventDetailEmpty />
-          )}
+              <AssetEventDetailEmpty />
+            )}
+          </ErrorBoundary>
         </Box>
       </Box>
     </>

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -9,6 +9,7 @@ import {
   Tab,
   Tabs,
   Tag,
+  ErrorBoundary,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -222,7 +223,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
           <Spinner purpose="page" />
         </Box>
       ) : (
-        <>
+        <ErrorBoundary region="page" resetErrorOnChange={[assetKey, params]}>
           {selectedTab === 'definition' ? (
             renderDefinitionTab()
           ) : selectedTab === 'lineage' ? (
@@ -257,7 +258,7 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
           ) : (
             <span />
           )}
-        </>
+        </ErrorBoundary>
       )}
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewTimelineRoot.tsx
@@ -1,4 +1,13 @@
-import {Page, PageHeader, Heading, Box, TextInput, Button, ButtonGroup} from '@dagster-io/ui';
+import {
+  Page,
+  PageHeader,
+  Heading,
+  Box,
+  TextInput,
+  Button,
+  ButtonGroup,
+  ErrorBoundary,
+} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
@@ -129,7 +138,9 @@ export const OverviewTimelineRoot = () => {
           </Box>
         </Box>
       </Box>
-      <RunTimeline loading={initialLoading} range={range} jobs={visibleJobs} />
+      <ErrorBoundary region="timeline">
+        <RunTimeline loading={initialLoading} range={range} jobs={visibleJobs} />
+      </ErrorBoundary>
     </Page>
   );
 };

--- a/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/GraphExplorer.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 // eslint-disable-next-line no-restricted-imports
 import {Breadcrumbs} from '@blueprintjs/core';
-import {Checkbox, Colors, SplitPanelContainer, TextInput} from '@dagster-io/ui';
+import {Checkbox, Colors, SplitPanelContainer, TextInput, ErrorBoundary} from '@dagster-io/ui';
 import Color from 'color';
 import qs from 'qs';
 import * as React from 'react';
@@ -194,7 +194,7 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
       identifier="explorer"
       firstInitialPercent={70}
       first={
-        <>
+        <ErrorBoundary region="op graph">
           {solidsQueryEnabled ? (
             <QueryOverlay>
               <GraphQueryInput
@@ -281,7 +281,7 @@ export const GraphExplorer: React.FC<GraphExplorerProps> = (props) => {
               layout={layout}
             />
           )}
-        </>
+        </ErrorBoundary>
       }
       second={
         <RightInfoPanel>

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarRoot.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Tabs} from '@dagster-io/ui';
+import {Box, Colors, Tabs, ErrorBoundary} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {OpNameOrPath} from '../ops/OpNameOrPath';
@@ -111,7 +111,9 @@ export const SidebarRoot: React.FC<SidebarRootProps> = (props) => {
         </Tabs>
       </Box>
       <RightInfoPanelContent>
-        {TabDefinitions.find((t) => t.key === activeTab)?.content()}
+        <ErrorBoundary region="tab" resetErrorOnChange={[activeTab, explorerPath]}>
+          {TabDefinitions.find((t) => t.key === activeTab)?.content()}
+        </ErrorBoundary>
       </RightInfoPanelContent>
     </>
   );

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -1,4 +1,10 @@
-import {Box, NonIdealState, FirstOrSecondPanelToggle, SplitPanelContainer} from '@dagster-io/ui';
+import {
+  Box,
+  NonIdealState,
+  FirstOrSecondPanelToggle,
+  SplitPanelContainer,
+  ErrorBoundary,
+} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -283,30 +289,32 @@ const RunWithData: React.FC<RunWithDataProps> = ({
 
     if (run.executionPlan && runtimeGraph) {
       return (
-        <GanttChart
-          options={{
-            mode: GanttChartMode.WATERFALL_TIMED,
-          }}
-          toolbarActions={
-            <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
-              <FirstOrSecondPanelToggle axis="vertical" container={splitPanelContainer} />
-              <RunActionButtons
-                run={run}
-                onLaunch={onLaunch}
-                graph={runtimeGraph}
-                metadata={metadata}
-                selection={{query: selectionQuery, keys: selectionStepKeys}}
-              />
-            </Box>
-          }
-          runId={runId}
-          graph={runtimeGraph}
-          metadata={metadata}
-          selection={{query: selectionQuery, keys: selectionStepKeys}}
-          onClickStep={onClickStep}
-          onSetSelection={onSetSelectionQuery}
-          focusedTime={logsFilter.focusedTime}
-        />
+        <ErrorBoundary region="gantt chart">
+          <GanttChart
+            options={{
+              mode: GanttChartMode.WATERFALL_TIMED,
+            }}
+            toolbarActions={
+              <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
+                <FirstOrSecondPanelToggle axis="vertical" container={splitPanelContainer} />
+                <RunActionButtons
+                  run={run}
+                  onLaunch={onLaunch}
+                  graph={runtimeGraph}
+                  metadata={metadata}
+                  selection={{query: selectionQuery, keys: selectionStepKeys}}
+                />
+              </Box>
+            }
+            runId={runId}
+            graph={runtimeGraph}
+            metadata={metadata}
+            selection={{query: selectionQuery, keys: selectionStepKeys}}
+            onClickStep={onClickStep}
+            onSetSelection={onSetSelectionQuery}
+            focusedTime={logsFilter.focusedTime}
+          />
+        </ErrorBoundary>
       );
     }
 
@@ -328,46 +336,48 @@ const RunWithData: React.FC<RunWithDataProps> = ({
         firstMinSize={56}
         first={gantt(metadata)}
         second={
-          <LogsContainer>
-            <LogsToolbar
-              logType={logType}
-              onSetLogType={setLogType}
-              filter={logsFilter}
-              onSetFilter={onSetLogsFilter}
-              steps={stepKeys}
-              metadata={metadata}
-              computeLogFileKey={computeLogFileKey}
-              onSetComputeLogKey={onSetComputeLogKey}
-              computeLogUrl={computeLogUrl}
-              counts={logs.counts}
-            />
-            {logType !== LogType.structured ? (
-              supportsCapturedLogs ? (
-                <CapturedOrExternalLogPanel
-                  logKey={computeLogFileKey ? [runId, 'compute_logs', computeLogFileKey] : []}
-                  externalUrl={logCaptureInfo?.externalUrl}
-                  visibleIOType={LogType[logType]}
-                  onSetDownloadUrl={setComputeLogUrl}
-                />
-              ) : (
-                <ComputeLogPanel
-                  runId={runId}
-                  stepKeys={stepKeys}
-                  computeLogFileKey={computeLogFileKey}
-                  ioType={LogType[logType]}
-                  setComputeLogUrl={setComputeLogUrl}
-                />
-              )
-            ) : (
-              <LogsScrollingTable
-                logs={logs}
+          <ErrorBoundary region="logs">
+            <LogsContainer>
+              <LogsToolbar
+                logType={logType}
+                onSetLogType={setLogType}
                 filter={logsFilter}
-                filterStepKeys={logsFilterStepKeys}
-                filterKey={`${JSON.stringify(logsFilter)}`}
+                onSetFilter={onSetLogsFilter}
+                steps={stepKeys}
                 metadata={metadata}
+                computeLogFileKey={computeLogFileKey}
+                onSetComputeLogKey={onSetComputeLogKey}
+                computeLogUrl={computeLogUrl}
+                counts={logs.counts}
               />
-            )}
-          </LogsContainer>
+              {logType !== LogType.structured ? (
+                supportsCapturedLogs ? (
+                  <CapturedOrExternalLogPanel
+                    logKey={computeLogFileKey ? [runId, 'compute_logs', computeLogFileKey] : []}
+                    externalUrl={logCaptureInfo?.externalUrl}
+                    visibleIOType={LogType[logType]}
+                    onSetDownloadUrl={setComputeLogUrl}
+                  />
+                ) : (
+                  <ComputeLogPanel
+                    runId={runId}
+                    stepKeys={stepKeys}
+                    computeLogFileKey={computeLogFileKey}
+                    ioType={LogType[logType]}
+                    setComputeLogUrl={setComputeLogUrl}
+                  />
+                )
+              ) : (
+                <LogsScrollingTable
+                  logs={logs}
+                  filter={logsFilter}
+                  filterStepKeys={logsFilterStepKeys}
+                  filterKey={`${JSON.stringify(logsFilter)}`}
+                  metadata={metadata}
+                />
+              )}
+            </LogsContainer>
+          </ErrorBoundary>
         }
       />
     </>

--- a/js_modules/dagit/packages/ui/src/components/Dialog.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Dialog.tsx
@@ -5,6 +5,7 @@ import styled, {createGlobalStyle} from 'styled-components/macro';
 
 import {Box} from './Box';
 import {Colors} from './Colors';
+import {ErrorBoundary} from './ErrorBoundary';
 import {Group} from './Group';
 import {IconName, Icon} from './Icon';
 
@@ -27,7 +28,7 @@ export const Dialog: React.FC<Props> = (props) => {
       className="dagit-dialog"
     >
       {title ? <DialogHeader icon={icon} label={title} /> : null}
-      {children}
+      <ErrorBoundary region="dialog">{children}</ErrorBoundary>
     </BlueprintDialog>
   );
 };

--- a/js_modules/dagit/packages/ui/src/components/ErrorBoundary.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import {Box} from './Box';
+import {Colors} from './Colors';
+import {Body, Subheading} from './Text';
+import {FontFamily} from './styles';
+
+export type ErrorCollectionContextValue = {
+  errorStackIncluded: boolean;
+  errorCollectionMessage: string;
+  onReportError: (error: Error, context: Record<string, any>) => void;
+};
+
+export const ErrorCollectionContext = React.createContext<ErrorCollectionContextValue>({
+  errorStackIncluded: true,
+  errorCollectionMessage:
+    `Please report this error to the Dagster team via GitHub or Slack. ` +
+    `Refresh the page to try again.`,
+  onReportError: (error, context) => {
+    console.error(error, context);
+  },
+});
+
+interface ErrorBoundaryProps {
+  region: string;
+  resetErrorOnChange?: any[];
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  errorResetPropsValue: string | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {error: null, errorResetPropsValue: null};
+
+  static contextType = ErrorCollectionContext;
+
+  componentDidUpdate() {
+    if (
+      this.state.error &&
+      this.state.errorResetPropsValue !== JSON.stringify(this.props.resetErrorOnChange)
+    ) {
+      this.setState({error: null, errorResetPropsValue: null});
+    }
+  }
+
+  componentDidCatch(error: Error, info: any) {
+    this.context.onReportError(error, {info, region: this.props.region});
+    this.setState({error, errorResetPropsValue: JSON.stringify(this.props.resetErrorOnChange)});
+  }
+
+  render() {
+    const {error} = this.state;
+    const {errorCollectionMessage, errorStackIncluded} = this
+      .context as ErrorCollectionContextValue;
+
+    if (error) {
+      return (
+        <Box
+          style={{width: '100%', height: '100%', flex: 1, overflow: 'hidden'}}
+          border={{width: 1, side: 'all', color: Colors.HighlightRed}}
+          flex={{direction: 'column', gap: 8}}
+          padding={16}
+        >
+          <Subheading>Sorry, {this.props.region} can&apos;t be displayed.</Subheading>
+          <Body color={Colors.Gray700}>{errorCollectionMessage}</Body>
+          {errorStackIncluded && <Trace>{`${error.message}\n\n${error.stack}`}</Trace>}
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const Trace = styled.div`
+  color: ${Colors.Gray700};
+  font-family: ${FontFamily.monospace};
+  font-size: 1em;
+  white-space: pre;
+  padding-bottom: 1em;
+`;

--- a/js_modules/dagit/packages/ui/src/index.ts
+++ b/js_modules/dagit/packages/ui/src/index.ts
@@ -47,6 +47,7 @@ export * from './components/Trace';
 export * from './components/Warning';
 export * from './components/styles';
 export * from './components/useSuggestionsForString';
+export * from './components/ErrorBoundary';
 
 // Global font styles, exported as styled-component components to render in
 // your app tree root. E.g. <GlobalInconsolata />


### PR DESCRIPTION
### Summary & Motivation

Corresponding Internal PR: https://github.com/dagster-io/internal/pull/4659

Hey folks, this PR wraps key components of Dagit in React "error boundaries", which give us the opportunity to present errors more gracefully and let users recover / continue to use other parts of the app. So far I've added them to:

- The top component that renders page content (everything below the toolbar)
- The details section of the asset partitions and events pages (which was a production issue yesterday)
- The asset graph and asset graph sidebar
- The op graph and op graph sidebar
- The run logs container and the run gannt chart
- The instance run timeline
- The `<Dialog />` component (errors in a dialog should never take down the rest of the page)

Anywhere else we should add these?

### Resetting after errors

The component I added takes a `resetErrorOnChange` prop which acts a bit like a useMemo dependency list -- if any of the values change and it's in an error state, it resets the error and tries to render it's subtree again. We need this for cases where the error boundary is not unmounted / remounted but it's content could meaningfully change. (eg: you click another asset or tab). I think this is better than putting a `key={}` on the Error Boundary because that would force a re-render on the whole subtree in the happy case.

### Cloud

In cloud dagit, we need to implement a top level context exposed by the new Error Boundary class in order to send errors (which are now caught) to DataDog. I think we also want to change the text to let users know that their errors are automatically submitted to us, so I made that text configurable. We can also disable the display of the error stack trace in cloud if we want to.

### How I Tested These Changes

I tested these changes by adding `throw new Error()` to various React render methods and verifying that Dagit fails more gracefully. I also verified that this can catch the infinite recursion bug, which is a bit of an interesting one, by reverting to last night's code and running without the GraphQL patch.

![image](https://user-images.githubusercontent.com/1037212/213761842-9c01de3e-aa19-40e8-8ea5-2db143684ea6.png)

![image](https://user-images.githubusercontent.com/1037212/213762126-e94f2f8e-1a82-4d71-b624-525533c34d28.png)

Edit: Updated styling

<img width="727" alt="image" src="https://user-images.githubusercontent.com/1037212/213804637-46343cb0-34de-4154-bd5e-1f61d0a30e92.png">
