### PR TITLE
fix tz in time_windows_for_partition_keys

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -392,7 +392,8 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
             expected_keys_not_in_subset.append(full_set_keys[i])
 
     subset = partitions_def.empty_subset().with_partition_keys(subset_keys)
-    assert all(partition_key in subset for partition_key in subset_keys)
+    for partition_key in subset_keys:
+        assert partition_key in subset
     assert (
         subset.get_partition_keys_not_in_subset(
             current_time=partitions_def.end_time_for_partition_key(full_set_keys[-1])
@@ -520,8 +521,18 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
     assert len(updated_subset) == updated_subset_str.count("+")
 
 
-def test_time_window_partitions_subset():
+def test_weekly_time_window_partitions_subset():
     weekly_partitions_def = WeeklyPartitionsDefinition(start_date="2022-01-01")
+
+    with_keys = ["2022-01-02", "2022-01-09", "2022-01-23", "2022-02-06"]
+    subset = weekly_partitions_def.empty_subset().with_partition_keys(with_keys)
+    assert set(subset.get_partition_keys()) == set(with_keys)
+
+
+def test_time_window_partitions_subset_non_utc_timezone():
+    weekly_partitions_def = DailyPartitionsDefinition(
+        start_date="2022-01-01", timezone="America/Los_Angeles"
+    )
 
     with_keys = ["2022-01-02", "2022-01-09", "2022-01-23", "2022-02-06"]
     subset = weekly_partitions_def.empty_subset().with_partition_keys(with_keys)


### PR DESCRIPTION
### Summary & Motivation

This was causing test failures on my laptop that didn't replicate in buildkite, because of the different timezones.

### How I Tested These Changes
