### PR TITLE
[graphql] launch backfills over assets with different partitionings, if all roots have same partitioning

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -10,6 +10,7 @@ from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import submit_backfill_runs
 from dagster._core.utils import make_new_backfill_id
 from dagster._core.workspace.permissions import Permissions
+from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from ..utils import assert_permission, assert_permission_for_location, capture_error
 
@@ -151,6 +152,7 @@ def create_and_launch_partition_backfill(
             backfill_timestamp=backfill_timestamp,
             asset_selection=asset_selection,
             partition_names=backfill_params["partitionNames"],
+            dynamic_partitions_store=CachingInstanceQueryer(graphene_info.context.instance),
         )
     else:
         raise DagsterError(

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -25,19 +25,19 @@ class AssetGraphSubset:
         self._non_partitioned_asset_keys = non_partitioned_asset_keys or set()
 
     @property
-    def asset_graph(self):
+    def asset_graph(self) -> AssetGraph:
         return self._asset_graph
 
     @property
-    def partitions_subsets_by_asset_key(self):
+    def partitions_subsets_by_asset_key(self) -> Mapping[AssetKey, PartitionsSubset]:
         return self._partitions_subsets_by_asset_key
 
     @property
-    def non_partitioned_asset_keys(self):
+    def non_partitioned_asset_keys(self) -> AbstractSet[AssetKey]:
         return self._non_partitioned_asset_keys
 
     @property
-    def asset_keys(self) -> Iterable[AssetKey]:
+    def asset_keys(self) -> AbstractSet[AssetKey]:
         return self.partitions_subsets_by_asset_key.keys() | self._non_partitioned_asset_keys
 
     @property
@@ -105,9 +105,9 @@ class AssetGraphSubset:
             else:
                 subset = self.get_partitions_subset(asset_key)
                 check.invariant(asset_key not in self.non_partitioned_asset_keys)
-                result_partition_subsets_by_asset_key[asset_key] = subset.with_partition_keys(
-                    other.get_partitions_subset(asset_key).get_partition_keys()
-                )
+                result_partition_subsets_by_asset_key[
+                    asset_key
+                ] = subset | other.get_partitions_subset(asset_key)
 
         return AssetGraphSubset(
             self.asset_graph,
@@ -131,6 +131,7 @@ class AssetGraphSubset:
             isinstance(other, AssetGraphSubset)
             and self.asset_graph == other.asset_graph
             and self.partitions_subsets_by_asset_key == other.partitions_subsets_by_asset_key
+            and self.non_partitioned_asset_keys == other.non_partitioned_asset_keys
         )
 
     def __repr__(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -306,6 +306,17 @@ class PartitionsDefinition(ABC, Generic[T]):
     def empty_subset(self) -> "PartitionsSubset":
         return self.partitions_subset_class.empty_subset(self)
 
+    def subset_with_partition_keys(self, partition_keys: Iterable[str]) -> "PartitionsSubset":
+        return self.empty_subset().with_partition_keys(partition_keys)
+
+    def subset_with_all_partitions(
+        self,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> "PartitionsSubset":
+        return self.subset_with_partition_keys(
+            self.get_partition_keys(dynamic_partitions_store=dynamic_partitions_store)
+        )
+
     def deserialize_subset(self, serialized: str) -> "PartitionsSubset":
         return self.partitions_subset_class.from_serialized(self, serialized)
 
@@ -1325,6 +1336,11 @@ class PartitionsSubset(ABC):
                 partition_key_range, dynamic_partitions_store=dynamic_partitions_store
             )
         )
+
+    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self is other:
+            return self
+        return self.with_partition_keys(other.get_partition_keys())
 
     @abstractmethod
     def serialize(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1491,3 +1491,6 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
             and time_window.start < included_time_window.end
             for included_time_window in self.included_time_windows
         )
+
+    def __repr__(self) -> str:
+        return f"TimeWindowPartitionsSubset({self.get_partition_key_ranges()})"

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -686,6 +686,7 @@ def test_pure_asset_backfill(instance, workspace_context, external_repo):
             backfill_timestamp=pendulum.now().timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_name_list,
+            dynamic_partitions_store=instance,
         )
     )
     assert instance.get_runs_count() == 0


### PR DESCRIPTION
### Summary & Motivation

Recent changes enabled the backfill engine to include assets with different PartitionsDefinitions. However, there's still no way to launch such a backfill.  Based on some user discussions, we believe that the main scenario for launching this kind of value involves a single root asset and a set of assets downstream of it. I.e. "backfill X partitions of asset A and all the partitions of downstream assets B and C that are downstream of X".

This changes the launch backfill mutation to support asset selections that include assets with different partitionings, as long all of the assets are downstream of a set of root assets that are of the backfill and have the same PartitionsDefinition.  In that case, the `partition_names` will apply to the root assets, and partitions will be targeted for downstream assets if they descend from any of the partitions targeted by the root assets.

### How I Tested These Changes
