### PR TITLE
[dagster-airbyte] Fix issue using freshness policy w/ Airbyte + multiprocessing executor

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -114,7 +114,9 @@ def _build_airbyte_asset_defn_metadata(
         }
         if schema_by_table_name
         else None,
-        freshness_policies_by_output_name={output: freshness_policy for output in outputs},
+        freshness_policies_by_output_name={output: freshness_policy for output in outputs}
+        if freshness_policy
+        else None,
         extra_metadata={
             "connection_id": connection_id,
             "group_name": group_name,
@@ -149,7 +151,9 @@ def _build_airbyte_assets_from_metadata(
                 if assets_defn_meta.metadata_by_output_name
                 else None,
                 io_manager_key=io_manager_key,
-                freshness_policy=assets_defn_meta.freshness_policies_by_output_name.get(k),
+                freshness_policy=assets_defn_meta.freshness_policies_by_output_name.get(k)
+                if assets_defn_meta.freshness_policies_by_output_name
+                else None,
             )
             for k, v in (assets_defn_meta.keys_by_output_name or {}).items()
         },

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -114,13 +114,13 @@ def _build_airbyte_asset_defn_metadata(
         }
         if schema_by_table_name
         else None,
+        freshness_policies_by_output_name={output: freshness_policy for output in outputs},
         extra_metadata={
             "connection_id": connection_id,
             "group_name": group_name,
             "destination_tables": destination_tables,
             "normalization_tables": normalization_tables,
             "io_manager_key": io_manager_key,
-            "freshness_policy": freshness_policy,
         },
     )
 
@@ -135,7 +135,6 @@ def _build_airbyte_assets_from_metadata(
     destination_tables = cast(List[str], metadata["destination_tables"])
     normalization_tables = cast(Mapping[str, List[str]], metadata["normalization_tables"])
     io_manager_key = cast(Optional[str], metadata["io_manager_key"])
-    freshness_policy = cast(Optional[FreshnessPolicy], metadata["freshness_policy"])
 
     @multi_asset(
         name=f"airbyte_sync_{connection_id[:5]}",
@@ -150,7 +149,7 @@ def _build_airbyte_assets_from_metadata(
                 if assets_defn_meta.metadata_by_output_name
                 else None,
                 io_manager_key=io_manager_key,
-                freshness_policy=freshness_policy,
+                freshness_policy=assets_defn_meta.freshness_policies_by_output_name.get(k),
             )
             for k, v in (assets_defn_meta.keys_by_output_name or {}).items()
         },


### PR DESCRIPTION
## Summary

Addresses #11822 - when attaching a freshness policy to cached Airbyte assets, a serialization error would occur if using the multiprocessing executor. Fixes the serialization process.

## Test Plan

Unit tests, verified works locally w/ multiprocessing executor.
