### PR TITLE
[asset-graph] keep track of source asset partitions defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -88,6 +88,8 @@ class AssetGraph:
         for asset in all_assets:
             if isinstance(asset, SourceAsset):
                 source_assets.append(asset)
+                partitions_defs_by_key[asset.key] = asset.partitions_def
+                group_names_by_key[asset.key] = asset.group_name
             elif isinstance(asset, AssetsDefinition):
                 assets_defs.append(asset)
                 partition_mappings_by_key.update(

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -121,8 +121,6 @@ class ExternalAssetGraph(AssetGraph):
 
                 source_asset_keys.add(node.asset_key)
 
-            print("-------------------")
-            print(node)
             upstream[node.asset_key] = {dep.upstream_asset_key for dep in node.dependencies}
             for dep in node.dependencies:
                 if dep.partition_mapping is not None:

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -121,6 +121,8 @@ class ExternalAssetGraph(AssetGraph):
 
                 source_asset_keys.add(node.asset_key)
 
+            print("-------------------")
+            print(node)
             upstream[node.asset_key] = {dep.upstream_asset_key for dep in node.dependencies}
             for dep in node.dependencies:
                 if dep.partition_mapping is not None:

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1084,6 +1084,11 @@ def external_asset_graph_from_defs(
                     group_name=source_asset.group_name,
                     is_source=True,
                     is_observable=source_asset.is_observable,
+                    partitions_def_data=external_partitions_definition_from_def(
+                        source_asset.partitions_def
+                    )
+                    if source_asset.partitions_def
+                    else None,
                 )
             )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -322,3 +322,21 @@ def test_get_non_source_roots_missing_source():
 
     asset_graph = AssetGraph.from_assets([foo, bar, source_asset])
     assert asset_graph.get_non_source_roots(AssetKey("bar")) == {AssetKey("foo")}
+
+
+def test_partitioned_source_asset():
+    partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
+
+    partitioned_source = SourceAsset(
+        "partitioned_source",
+        partitions_def=partitions_def,
+    )
+
+    @asset(partitions_def=partitions_def, non_argument_deps={"partitioned_source"})
+    def downstream_of_partitioned_source():
+        pass
+
+    asset_graph = AssetGraph.from_assets([partitioned_source, downstream_of_partitioned_source])
+
+    assert asset_graph.is_partitioned(AssetKey("partitioned_source"))
+    assert asset_graph.is_partitioned(AssetKey("downstream_of_partitioned_source"))


### PR DESCRIPTION
### Summary & Motivation

The regular AssetGraph issue was the root cause of: https://dagster.slack.com/archives/C01U954MEER/p1674242395576239

The ExternalAssetGraph issue is actually unrelated but was discovered when writing unit tests.

### How I Tested These Changes
