### PR TITLE
[asset-reconciliation] Fix case where the partitions definition does not have partitions for some subset of the past 24 hours

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -301,10 +301,10 @@ def allowable_time_window_for_partitions_def(
         return None
 
     start = max(
-        # we use a greater than check later on, so we want to make sure we allow the earliest
-        # partition to be materialized
-        earliest_partition_window.start - datetime.timedelta.resolution,
-        latest_partition_window.start - datetime.timedelta(days=1),
+        earliest_partition_window.start,
+        # we add datetime.timedelta.resolution because if the latest partition starts at 2023-01-02,
+        # then we don't want 2023-01-01 to be within the allowable time window
+        latest_partition_window.start - datetime.timedelta(days=1) + datetime.timedelta.resolution,
     )
 
     return TimeWindow(
@@ -336,7 +336,7 @@ def candidates_unit_within_allowable_time_window(
 
     candidate_partition_window = partitions_def.time_window_for_partition_key(partition_key)
     return (
-        candidate_partition_window.start > allowable_time_window.start
+        candidate_partition_window.start >= allowable_time_window.start
         and candidate_partition_window.end <= allowable_time_window.end
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -295,8 +295,20 @@ def allowable_time_window_for_partitions_def(
     latest_partition_window = partitions_def.get_last_partition_window()
     if latest_partition_window is None:
         return None
+
+    earliest_partition_window = partitions_def.get_first_partition_window()
+    if earliest_partition_window is None:
+        return None
+
+    start = max(
+        # we use a greater than check later on, so we want to make sure we allow the earliest
+        # partition to be materialized
+        earliest_partition_window.start - datetime.timedelta.resolution,
+        latest_partition_window.start - datetime.timedelta(days=1),
+    )
+
     return TimeWindow(
-        start=latest_partition_window.start - datetime.timedelta(days=1),
+        start=start,
         end=latest_partition_window.end,
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -895,7 +895,9 @@ scenarios = {
     "self_dependency_never_materialized_recent": AssetReconciliationScenario(
         assets=one_asset_self_dependency_hourly,
         unevaluated_runs=[],
-        expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2020-01-01-00:00")],
+        expected_run_requests=[
+            run_request(asset_keys=["asset1"], partition_key="2020-01-01-00:00")
+        ],
         current_time=create_pendulum_time(year=2020, month=1, day=1, hour=4),
     ),
     "self_dependency_prior_partition_requested": AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -511,6 +511,14 @@ one_asset_self_dependency = [
     )
 ]
 
+one_asset_self_dependency_hourly = [
+    asset_def(
+        "asset1",
+        partitions_def=HourlyPartitionsDefinition(start_date="2020-01-01-00:00"),
+        deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
+    )
+]
+
 scenarios = {
     ################################################################################################
     # Basics
@@ -883,6 +891,12 @@ scenarios = {
         unevaluated_runs=[],
         expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2020-01-01")],
         current_time=create_pendulum_time(year=2020, month=1, day=2, hour=4),
+    ),
+    "self_dependency_never_materialized_recent": AssetReconciliationScenario(
+        assets=one_asset_self_dependency_hourly,
+        unevaluated_runs=[],
+        expected_run_requests=[run_request(asset_keys=["asset1"], partition_key="2020-01-01-00:00")],
+        current_time=create_pendulum_time(year=2020, month=1, day=1, hour=4),
     ),
     "self_dependency_prior_partition_requested": AssetReconciliationScenario(
         assets=one_asset_self_dependency,


### PR DESCRIPTION
### Summary & Motivation

Fixes issue discussed in: https://github.com/dagster-io/dagster/discussions/11829#discussioncomment-4756197

Added test failed before this change, now passes. The allowable time window for a partitions def now takes into account the start date of that partitions definition, preventing this issue.

### How I Tested These Changes
