### PR TITLE
[perf] Allow TimeWindowPartitionMapping to accept a DefaultPartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -21,6 +21,7 @@ import toposort
 import dagster._check as check
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.selector.subset_selector import DependencyGraph, generate_asset_dep_graph
+from dagster._utils.cached_method import cached_method
 
 from .assets import AssetsDefinition
 from .events import AssetKey, AssetKeyPartitionKey
@@ -311,6 +312,7 @@ class AssetGraph:
             return self._required_multi_asset_sets_by_key[asset_key]
         return set()
 
+    @cached_method
     def toposort_asset_keys(self) -> Sequence[AbstractSet[AssetKey]]:
         return [
             {key for key in level} for level in toposort.toposort(self._asset_dep_graph["upstream"])

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 from abc import abstractmethod
 from collections import OrderedDict, defaultdict
@@ -132,6 +133,7 @@ class SqlEventLogStorage(EventLogStorage):
             partition=partition,
         )
 
+    @functools.lru_cache(maxsize=None)
     def has_asset_key_col(self, column_name: str):
         with self.index_connection() as conn:
             column_names = [x.get("name") for x in db.inspect(conn).get_columns(AssetKeyTable.name)]

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -326,9 +326,11 @@ class CachingInstanceQueryer:
         if latest_materialization_record is None:
             return False
 
+        print("AP", asset_partition)
         for parent in asset_graph.get_parents_partitions(
             asset_partition.asset_key, asset_partition.partition_key
         ):
+            print("PAP", parent)
             if (
                 self.get_latest_materialization_record(
                     parent, after_cursor=latest_materialization_record.storage_id

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -199,6 +199,15 @@ class CachingInstanceQueryer:
         else:
             asset_partition = asset
 
+        # no materialization exists for this asset partition
+        if (
+            asset_partition.partition_key is not None
+            and asset_partition.asset_key in self._asset_partition_count_cache[None]
+            and asset_partition.partition_key
+            not in self._asset_partition_count_cache[None][asset_partition.asset_key]
+        ):
+            return None
+
         if before_cursor is not None:
             latest_record = self._latest_materialization_record_cache.get(asset_partition)
             if latest_record is not None and latest_record.storage_id < before_cursor:

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -326,11 +326,9 @@ class CachingInstanceQueryer:
         if latest_materialization_record is None:
             return False
 
-        print("AP", asset_partition)
         for parent in asset_graph.get_parents_partitions(
             asset_partition.asset_key, asset_partition.partition_key
         ):
-            print("PAP", parent)
             if (
                 self.get_latest_materialization_record(
                     parent, after_cursor=latest_materialization_record.storage_id


### PR DESCRIPTION
### Summary & Motivation

It's expensive to create a TimeWindowPartitionSubset, as this requires creating a cron string iterator. We create a lot of single-element TimeWindowPartitionSubsets inside the reconciliation sensor, purely for the purpose of figuring out what partitions are upstream/downstream of another partition. In most common cases, this is a 1-1 mapping (i.e. the partitions upstream of [2023-01-01] are [2023-01-01]). 

This PR enables passing in a DefaultPartitionsSubset to a TimeWindowPartitionMapping, only converting this into a TimeWindowPartitionsSubset if we need to (i.e. the mapping is non-trivial) 

### How I Tested These Changes
