### PR TITLE
Fix for backoff logic incorrectly storing state

### DIFF
--- a/python_modules/dagster/dagster/_utils/backoff.py
+++ b/python_modules/dagster/dagster/_utils/backoff.py
@@ -22,7 +22,7 @@ def backoff(
     args: Optional[Sequence[object]] = None,
     kwargs: Optional[Mapping[str, object]] = None,
     max_retries: int = BACKOFF_MAX_RETRIES,
-    delay_generator: Generator[float, None, None] = backoff_delay_generator(),
+    delay_generator: Optional[Generator[float, None, None]] = None,
 ) -> T:
     """Straightforward backoff implementation.
 
@@ -44,7 +44,10 @@ def backoff(
     args = check.opt_sequence_param(args, "args")
     kwargs = check.opt_mapping_param(kwargs, "kwargs", key_type=str)
     check.int_param(max_retries, "max_retries")
-    check.generator_param(delay_generator, "delay_generator")
+    check.opt_generator_param(delay_generator, "delay_generator")
+
+    if not delay_generator:
+        delay_generator = backoff_delay_generator()
 
     retries = 0
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_backoff.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_backoff.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from dagster._utils.backoff import backoff, backoff_delay_generator
 
@@ -42,7 +44,18 @@ def test_backoff_delay_generator():
     assert vals == [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2]
 
 
-def test_backoff():
+@pytest.fixture
+def fake_sleep_times(monkeypatch):
+    sleeps = []
+
+    def fake_sleep(s):
+        sleeps.append(s)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    yield sleeps
+
+
+def test_backoff(fake_sleep_times):
     fn = Failer(fails=100)
     with pytest.raises(RetryableException):
         backoff(fn, retry_on=(RetryableException,), args=[3, 2, 1], kwargs={"foo": "bar"})
@@ -50,6 +63,7 @@ def test_backoff():
     assert fn.call_count == 5
     assert all([args == (3, 2, 1) for args in fn.args])
     assert all([kwargs == {"foo": "bar"} for kwargs in fn.kwargs])
+    assert fake_sleep_times == [0.1, 0.2, 0.4, 0.8]
 
     fn = Failer()
     assert backoff(fn, retry_on=(RetryableException,), args=[3, 2, 1], kwargs={"foo": "bar"})
@@ -58,6 +72,8 @@ def test_backoff():
     fn = Failer(fails=1)
     assert backoff(fn, retry_on=(RetryableException,), args=[3, 2, 1], kwargs={"foo": "bar"})
     assert fn.call_count == 2
+
+    assert fake_sleep_times == [0.1, 0.2, 0.4, 0.8, 0.1]
 
     fn = Failer(fails=1)
     with pytest.raises(RetryableException):


### PR DESCRIPTION
Summary:
User reported an error with our backoff logic hitting a maximum python int limit. This is likely because we were initializing the default backoff generator once and keeping it running forever. This fixes that.

One question is whether we need to do anything to clean up the old generator as well.

### Summary & Motivation

### How I Tested These Changes
