### PR TITLE
perf improvement for TimeWindowPartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1168,7 +1168,7 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
                 for time_window in self.included_time_windows
                 for pk in self._partitions_def.get_partition_keys_in_time_window(time_window)
             ]
-        return self._included_partition_keys
+        return list(self._included_partition_keys)
 
     def get_partition_key_ranges(
         self, current_time: Optional[datetime] = None

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1169,10 +1169,7 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
                 for time_window in self.included_time_windows
                 for pk in self._partitions_def.get_partition_keys_in_time_window(time_window)
             ]
-        return sorted(
-            list(self._included_partition_keys),
-            key=lambda pkey: self._partitions_def.start_time_for_partition_key(pkey),
-        )
+        return list(self._included_partition_keys) if self._included_partition_keys else []
 
     def get_partition_key_ranges(
         self, current_time: Optional[datetime] = None


### PR DESCRIPTION
### Summary & Motivation

In a lot of cases (i.e. when the number of individual partition keys is small), it's way more efficient for TimeWindowPartitionsSubset to just be a list of partition keys.

This PR makes that possible, only requiring the included_time_windows to be calculated when needed. These subsets will still always be serialized/deserialized with TimeWindows, this is mostly just for making stuff like `TimeWindowPartitionsDefinition(...).empty_subset().with_partition_keys([small, set, of, keys])` performant.

This results in a surprisingly dramatic performance improvement for the build_asset_reconciliation_sensor. For a toy example with 50 assets (all hourly partitioned):

**Before**: 70s
**After**: 2.5s


### How I Tested These Changes
