### PR TITLE
Upgrade base image on Dagster Dockerfiles to latest python version

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
@@ -7,10 +7,10 @@ from dagster_buildkite.utils import is_release_branch, safe_getenv
 
 class AvailablePythonVersion(str, Enum):
     # Ordering is important here, because some steps will take the highest/lowest available version.
-    V3_7 = "3.7.13"
-    V3_8 = "3.8.13"
-    V3_9 = "3.9.13"
-    V3_10 = "3.10.5"
+    V3_7 = "3.7"
+    V3_8 = "3.8"
+    V3_9 = "3.9"
+    V3_10 = "3.10"
 
     @classmethod
     def get_all(cls) -> List["AvailablePythonVersion"]:

--- a/python_modules/automation/automation/docker/images/buildkite-build-test-project-image/versions.yaml
+++ b/python_modules/automation/automation/docker/images/buildkite-build-test-project-image/versions.yaml
@@ -1,3 +1,3 @@
-3.8.13:
+3.8:
   docker_args:
-    BASE_IMAGE: python:3.8.13-slim
+    BASE_IMAGE: python:3.8-slim

--- a/python_modules/automation/automation/docker/images/buildkite-integration-windows/versions.yaml
+++ b/python_modules/automation/automation/docker/images/buildkite-integration-windows/versions.yaml
@@ -1,3 +1,3 @@
-3.8.7:
+3.8:
   docker_args:
-    BASE_IMAGE: python:3.8.7-windowsservercore-1809
+    BASE_IMAGE: python:3.8-windowsservercore-1809

--- a/python_modules/automation/automation/docker/images/buildkite-test/versions.yaml
+++ b/python_modules/automation/automation/docker/images/buildkite-test/versions.yaml
@@ -1,15 +1,12 @@
-3.6.15:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.6.15-slim
-3.7.13:
+    BASE_IMAGE: python:3.7-slim
+3.8:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
-3.8.13:
+    BASE_IMAGE: python:3.8-slim
+3.9:
   docker_args:
-    BASE_IMAGE: python:3.8.13-slim
-3.9.13:
+    BASE_IMAGE: python:3.9-slim
+3.10:
   docker_args:
-    BASE_IMAGE: python:3.9.13-slim
-3.10.5:
-  docker_args:
-    BASE_IMAGE: python:3.10.5-slim
+    BASE_IMAGE: python:3.10-slim

--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s-editable/versions.yaml
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s-editable/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/dagster-celery-k8s/versions.yaml
+++ b/python_modules/automation/automation/docker/images/dagster-celery-k8s/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/dagster-k8s-editable/versions.yaml
+++ b/python_modules/automation/automation/docker/images/dagster-k8s-editable/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/dagster-k8s/versions.yaml
+++ b/python_modules/automation/automation/docker/images/dagster-k8s/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-celery-worker-editable/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-celery-worker-editable/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-celery-worker/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-celery-worker/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-dagit-editable/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-dagit-editable/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-dagit-example/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-dagit-example/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-dagit/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-dagit/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-example-editable/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-example-editable/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/k8s-example/versions.yaml
+++ b/python_modules/automation/automation/docker/images/k8s-example/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/test-project-base/versions.yaml
+++ b/python_modules/automation/automation/docker/images/test-project-base/versions.yaml
@@ -1,15 +1,12 @@
-3.6.15:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.6.15-slim
-3.7.13:
+    BASE_IMAGE: python:3.7-slim
+3.8:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
-3.8.13:
+    BASE_IMAGE: python:3.8-slim
+3.9:
   docker_args:
-    BASE_IMAGE: python:3.8.13-slim
-3.9.13:
+    BASE_IMAGE: python:3.9-slim
+3.10:
   docker_args:
-    BASE_IMAGE: python:3.9.13-slim
-3.10.5:
-  docker_args:
-    BASE_IMAGE: python:3.10.5-slim
+    BASE_IMAGE: python:3.10-slim

--- a/python_modules/automation/automation/docker/images/user-code-example-editable/versions.yaml
+++ b/python_modules/automation/automation/docker/images/user-code-example-editable/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim

--- a/python_modules/automation/automation/docker/images/user-code-example/versions.yaml
+++ b/python_modules/automation/automation/docker/images/user-code-example/versions.yaml
@@ -1,3 +1,3 @@
-3.7.13:
+3.7:
   docker_args:
-    BASE_IMAGE: python:3.7.13-slim
+    BASE_IMAGE: python:3.7-slim


### PR DESCRIPTION
Summary:
Use python:3.x-slim instead of pinning to a specific patch release, so that we automatically move to the latest version on each push

### Summary & Motivation

### How I Tested These Changes
