### PR TITLE
chore(dagster-dbt): pin dbt-core<1.4.0

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=["dagster_dbt_tests*"]),
     install_requires=[
         f"dagster{pin}",
-        "dbt-core",
+        "dbt-core<1.4.0",
         "requests",
         "typer[all]",
     ],


### PR DESCRIPTION
### Summary & Motivation
The latest version of dbt, published on 2022-01-25, has broken some usage of our internal APIs within the dbt integration. Pin the library until these are resolved.

https://github.com/dbt-labs/dbt-core/releases/tag/v1.4.0

### How I Tested These Changes
bk
