### PR TITLE
unbreak backcompat tests after sqlalchemy upgrade

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -11,3 +11,6 @@ protobuf>=3.13.0,<4
 
 # Deadlock / hang issue in new version of grpc
 grpcio<1.48.1; python_version < '3.10'
+
+# Added sqlalchemy pins in later versions
+sqlalchemy<2.0.0


### PR DESCRIPTION
Summary:
Needed to stop older versions from failing

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
