### PR TITLE
Add apache-airflow test pin to <2.5.1

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "kubernetes": ["kubernetes>=3.0.0", "cryptography>=2.0.0"],
         "test_airflow_2": [
-            "apache-airflow>=2.0.0,<3.0.0",
+            "apache-airflow>=2.0.0,<2.5.1",
             "boto3>=1.26.7",
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",


### PR DESCRIPTION
Summary:
I imagine that we will want to fix the underlying issue causing these tests to fail on 2.5.1 - I can file a tracking issue so we don't forget that. But this change should make our test suite green again in the short term.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
