### PR TITLE
Cap some dagster dependencies to at most their current major version

### DIFF
--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -35,8 +35,8 @@ setup(
     include_package_data=True,
     install_requires=[
         f"dagster{pin}",
-        "graphene>=3",
-        "gql[requests]>=3.0.0",
+        "graphene>=3,<4",
+        "gql[requests]>=3,<4",
         "requests",
         "starlette",  # used for run_in_threadpool utility fn
     ],

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -76,7 +76,7 @@ setup(
     install_requires=[
         # cli
         "click>=5.0",
-        "coloredlogs>=6.1, <=14.0",
+        "coloredlogs>=6.1,<=14.0",
         "Jinja2",
         "PyYAML>=5.1",
         # core (not explicitly expressed atm)
@@ -87,26 +87,26 @@ setup(
         f"grpcio-health-checking>={GRPC_VERSION_FLOOR}",
         "packaging>=20.9",
         "pendulum>=0.7.0,<3",
-        "protobuf>=3.20.0",  # min protobuf version to be compatible with both protobuf 3 and 4
+        "protobuf>=3.20.0,<5",  # min protobuf version to be compatible with both protobuf 3 and 4
         "python-dateutil",
         "python-dotenv",
         "pytz",
         "requests",
         "setuptools",
         "tabulate",
-        "tomli",
-        "tqdm",
-        "typing_extensions>=4.4.0",
-        "sqlalchemy>=1.0",
+        "tomli<3",
+        "tqdm<5",
+        "typing_extensions>=4.4.0,<5",
+        "sqlalchemy>=1.0,<3",
         "toposort>=1.0",
         "watchdog>=0.8.3",
-        'psutil >= 1.0; platform_system=="Windows"',
+        'psutil>=1.0; platform_system=="Windows"',
         # https://github.com/mhammond/pywin32/issues/1439
-        'pywin32 != 226; platform_system=="Windows"',
+        'pywin32!=226; platform_system=="Windows"',
         "docstring-parser",
         "universal_pathlib",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic >1.10.0,!= 1.10.7",
+        "pydantic>1.10.0,!= 1.10.7,<3",
         f"dagster-pipes{pin}",
     ],
     extras_require={


### PR DESCRIPTION
Summary:
The goal of this change would be to avoid automatically upgrade to new major versions, which often include breaking changes (e.g. sqlalchemy 2 which broke all dagster users yesterday who made a fresh install)
The downside of this change would be that on older versions, users could be potentially pinned to older versions of their dependencies.
Not strongly held as a good idea but wanted to put it out for discussion.

Resolves https://github.com/dagster-io/dagster/issues/11882

### Summary & Motivation

### How I Tested These Changes
