### PR TITLE
[pyright] [gql] InputObject alias

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/util.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/util.py
@@ -1,8 +1,13 @@
-from typing import cast
+from typing import Any, cast
 
 import graphene
 from dagster._core.workspace.context import WorkspaceRequestContext
-from typing_extensions import Protocol
+from typing_extensions import Protocol, TypeAlias
+
+# Unfortunately Graphene input objects do not play nicely with typing-- we can't type arguments to
+# resolvers with `GrapheneMyInputObjectType` and have it work. We use this `InputObject` type as a
+# stand-in until a better solution is found.
+InputObject: TypeAlias = Any
 
 class ResolveInfo(graphene.ResolveInfo):
     @property


### PR DESCRIPTION
### Summary & Motivation

Adds an `InputObject` alias for use in type annotations in resolvers that take an input object. Currently, it's just an alias to `Any`, and should be thought of as a placeholder for a better solution-- right now it is not possible to the actual defined `Graphene*` input objects do not work as type annotations.

This is used upstack.

### How I Tested These Changes

BK