### PR TITLE
Add pin for jupyter-client<8

### DIFF
--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -48,6 +48,7 @@ setup(
         "papermill>=1.0.0",
         "scrapbook>=0.5.0",
         "nbconvert",
+        "jupyter-client<8",  # jupyter-client 8 causing test hangs
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Summary:
The jupyter-client 8 release is causing several tests to hang (pretty much any test that runs a job in dagstermill): https://buildkite.com/dagster/dagster/builds/46411#0185f429-208a-4222-ba2f-27fbec0da3e0

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
