### PR TITLE
Enable use of arguments when using the `asset` function directly instead of as a decorator

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -10,7 +10,6 @@ from typing import (
     Tuple,
     Union,
     cast,
-    overload,
 )
 
 import dagster._check as check
@@ -42,42 +41,7 @@ from ..resource_definition import ResourceDefinition
 from ..utils import DEFAULT_IO_MANAGER_KEY, NoValueSentinel
 
 
-@overload
 def asset(
-    compute_fn: Callable,
-) -> AssetsDefinition:
-    ...
-
-
-@overload
-def asset(
-    *,
-    name: Optional[str] = ...,
-    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-    ins: Optional[Mapping[str, AssetIn]] = ...,
-    non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = ...,
-    metadata: Optional[Mapping[str, Any]] = ...,
-    description: Optional[str] = ...,
-    config_schema: Optional[UserConfigSchema] = None,
-    required_resource_keys: Optional[Set[str]] = ...,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
-    io_manager_def: Optional[IOManagerDefinition] = ...,
-    io_manager_key: Optional[str] = ...,
-    compute_kind: Optional[str] = ...,
-    dagster_type: Optional[DagsterType] = ...,
-    partitions_def: Optional[PartitionsDefinition[Any]] = ...,
-    op_tags: Optional[Mapping[str, Any]] = ...,
-    group_name: Optional[str] = ...,
-    output_required: bool = ...,
-    freshness_policy: Optional[FreshnessPolicy] = ...,
-    retry_policy: Optional[RetryPolicy] = ...,
-    code_version: Optional[str] = ...,
-) -> Callable[[Callable[..., Any]], AssetsDefinition]:
-    ...
-
-
-def asset(
-    compute_fn: Optional[Callable] = None,
     *,
     name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
@@ -170,7 +134,20 @@ def asset(
             def my_asset(my_upstream_asset: int) -> int:
                 return my_upstream_asset + 1
     """
-    def create_asset():
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
+        check.invariant(
+            not (io_manager_key and io_manager_def),
+            (
+                "Both io_manager_key and io_manager_def were provided to `@asset` decorator. Please"
+                " provide one or the other. "
+            ),
+        )
+        if resource_defs is not None:
+            experimental_arg_warning("resource_defs", "asset")
+
+        if io_manager_def is not None:
+            experimental_arg_warning("io_manager_def", "asset")
+
         return _Asset(
             name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
             key_prefix=key_prefix,
@@ -191,26 +168,7 @@ def asset(
             freshness_policy=freshness_policy,
             retry_policy=retry_policy,
             code_version=code_version,
-        )
-
-    if compute_fn is not None:
-        return create_asset()(compute_fn)
-
-    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
-        check.invariant(
-            not (io_manager_key and io_manager_def),
-            (
-                "Both io_manager_key and io_manager_def were provided to `@asset` decorator. Please"
-                " provide one or the other. "
-            ),
-        )
-        if resource_defs is not None:
-            experimental_arg_warning("resource_defs", "asset")
-
-        if io_manager_def is not None:
-            experimental_arg_warning("io_manager_def", "asset")
-
-        return create_asset()(fn)
+        )(fn)
 
     return inner
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -67,6 +67,29 @@ def test_asset_with_inputs():
     assert AssetKey("arg1") in my_asset.keys_by_input_name.values()
 
 
+def test_asset_no_decorator_args_direct_call():
+    def func():
+        return 1
+
+    my_asset = asset(func)
+
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 0
+
+
+def test_asset_with_inputs_direct_call():
+    def func(arg1):
+        return arg1
+
+    my_asset = asset(func)
+
+    assert isinstance(my_asset, AssetsDefinition)
+    assert len(my_asset.op.output_defs) == 1
+    assert len(my_asset.op.input_defs) == 1
+    assert AssetKey("arg1") in my_asset.keys_by_input_name.values()
+
+
 def test_asset_with_config_schema():
     @asset(config_schema={"foo": int})
     def my_asset(context):
@@ -277,6 +300,16 @@ def test_asset_with_code_version():
     @asset(code_version="foo")
     def my_asset(arg1):
         return arg1
+
+    assert my_asset.op.version == "foo"
+    assert my_asset.op.output_def_named("result").code_version == "foo"
+
+
+def test_asset_with_code_version_direct_call():
+    def func(arg1):
+        return arg1
+
+    my_asset = asset(func, code_version="foo")
 
     assert my_asset.op.version == "foo"
     assert my_asset.op.output_def_named("result").code_version == "foo"


### PR DESCRIPTION
### Summary & Motivation

I would like to be able to create assets by calling the `dagster.asset` function directly and passing in a callable, rather than using it is a decorator on a function.

I noticed that though this functionality is enabled, all the named arguments to the `dagster.asset` function get dropped.

### How I Tested These Changes

I tested these changes locally by creating assets by calling the `dagster.asset` function directly. Before the changes, the assets were created, but named arguments to the `dagster.asset` function had no effect. In particular, dependencies specified through the `non_argument_dependencies` argument to the `dagster.asset` function were not registered. After the changes, the assets were created with the appropriate dependencies.
