### PR TITLE
Revamp GrapheneFutureInstigationTick behavior

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1362,8 +1362,8 @@ type Schedule {
   description: String
   scheduleState: InstigationState!
   partitionSet: PartitionSet
-  futureTicks(cursor: Float, limit: Int, until: Float): FutureInstigationTicks!
-  futureTick(tickTimestamp: Int!): FutureInstigationTick!
+  futureTicks(cursor: Float, limit: Int, until: Float): DryRunInstigationTicks!
+  futureTick(tickTimestamp: Int!): DryRunInstigationTick!
 }
 
 union ScheduleMutationResult = PythonError | UnauthorizedError | ScheduleStateResult
@@ -2016,7 +2016,7 @@ type RunLauncher {
   name: String!
 }
 
-type FutureInstigationTick {
+type DryRunInstigationTick {
   timestamp: Float!
   evaluationResult: TickEvaluation
 }
@@ -2033,8 +2033,8 @@ type RunRequest {
   runConfigYaml: String!
 }
 
-type FutureInstigationTicks {
-  results: [FutureInstigationTick!]!
+type DryRunInstigationTicks {
+  results: [DryRunInstigationTick!]!
   cursor: Float!
 }
 
@@ -2060,7 +2060,7 @@ type InstigationState {
     cursor: String
     statuses: [InstigationTickStatus!]
   ): [InstigationTick!]!
-  nextTick: FutureInstigationTick
+  nextTick: DryRunInstigationTick
   runningCount: Int!
 }
 
@@ -2428,7 +2428,7 @@ type Sensor {
   sensorState: InstigationState!
   minIntervalSeconds: Int!
   description: String
-  nextTick: FutureInstigationTick
+  nextTick: DryRunInstigationTick
   metadata: SensorMetadata!
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -915,6 +915,18 @@ export type DisplayableEvent = {
   metadataEntries: Array<MetadataEntry>;
 };
 
+export type DryRunInstigationTick = {
+  __typename: 'DryRunInstigationTick';
+  evaluationResult: Maybe<TickEvaluation>;
+  timestamp: Scalars['Float'];
+};
+
+export type DryRunInstigationTicks = {
+  __typename: 'DryRunInstigationTicks';
+  cursor: Scalars['Float'];
+  results: Array<DryRunInstigationTick>;
+};
+
 export type EngineEvent = DisplayableEvent &
   ErrorEvent &
   MarkerEvent &
@@ -1236,18 +1248,6 @@ export type FreshnessPolicy = {
   maximumLagMinutes: Scalars['Float'];
 };
 
-export type FutureInstigationTick = {
-  __typename: 'FutureInstigationTick';
-  evaluationResult: Maybe<TickEvaluation>;
-  timestamp: Scalars['Float'];
-};
-
-export type FutureInstigationTicks = {
-  __typename: 'FutureInstigationTicks';
-  cursor: Scalars['Float'];
-  results: Array<FutureInstigationTick>;
-};
-
 export type Graph = SolidContainer & {
   __typename: 'Graph';
   description: Maybe<Scalars['String']>;
@@ -1448,7 +1448,7 @@ export type InstigationState = {
   id: Scalars['ID'];
   instigationType: InstigationType;
   name: Scalars['String'];
-  nextTick: Maybe<FutureInstigationTick>;
+  nextTick: Maybe<DryRunInstigationTick>;
   repositoryLocationName: Scalars['String'];
   repositoryName: Scalars['String'];
   repositoryOrigin: RepositoryOrigin;
@@ -3096,8 +3096,8 @@ export type Schedule = {
   cronSchedule: Scalars['String'];
   description: Maybe<Scalars['String']>;
   executionTimezone: Maybe<Scalars['String']>;
-  futureTick: FutureInstigationTick;
-  futureTicks: FutureInstigationTicks;
+  futureTick: DryRunInstigationTick;
+  futureTicks: DryRunInstigationTicks;
   id: Scalars['ID'];
   mode: Scalars['String'];
   name: Scalars['String'];
@@ -3206,7 +3206,7 @@ export type Sensor = {
   metadata: SensorMetadata;
   minIntervalSeconds: Scalars['Int'];
   name: Scalars['String'];
-  nextTick: Maybe<FutureInstigationTick>;
+  nextTick: Maybe<DryRunInstigationTick>;
   sensorState: InstigationState;
   targets: Maybe<Array<Target>>;
 };

--- a/js_modules/dagit/packages/core/src/instance/types/NextTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/NextTick.types.ts
@@ -8,7 +8,7 @@ export type ScheduleFutureTicksFragment = {
   executionTimezone: string | null;
   scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
   futureTicks: {
-    __typename: 'FutureInstigationTicks';
-    results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+    __typename: 'DryRunInstigationTicks';
+    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
   };
 };

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -385,7 +385,7 @@ const JOB_TICK_HISTORY_QUERY = gql`
     }
   }
 
-  fragment NextTickForHistoy on FutureInstigationTick {
+  fragment NextTickForHistoy on DryRunInstigationTick {
     timestamp
   }
 

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
@@ -17,7 +17,7 @@ export type TickHistoryQuery = {
         __typename: 'InstigationState';
         id: string;
         instigationType: Types.InstigationType;
-        nextTick: {__typename: 'FutureInstigationTick'; timestamp: number} | null;
+        nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
         ticks: Array<{
           __typename: 'InstigationTick';
           id: string;
@@ -55,7 +55,7 @@ export type TickHistoryQuery = {
       };
 };
 
-export type NextTickForHistoyFragment = {__typename: 'FutureInstigationTick'; timestamp: number};
+export type NextTickForHistoyFragment = {__typename: 'DryRunInstigationTick'; timestamp: number};
 
 export type HistoryTickFragment = {
   __typename: 'InstigationTick';

--- a/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
@@ -64,8 +64,8 @@ export type ScheduledRunsListQuery = {
               status: Types.InstigationStatus;
             };
             futureTicks: {
-              __typename: 'FutureInstigationTicks';
-              results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+              __typename: 'DryRunInstigationTicks';
+              results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
             };
           }>;
         }>;

--- a/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
@@ -93,8 +93,8 @@ export type RunTimelineQuery = {
                       status: Types.InstigationStatus;
                     };
                     futureTicks: {
-                      __typename: 'FutureInstigationTicks';
-                      results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+                      __typename: 'DryRunInstigationTicks';
+                      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
                     };
                   }>;
                 }>;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -75,8 +75,8 @@ export type ScheduleRootQuery = {
           }>;
         };
         futureTicks: {
-          __typename: 'FutureInstigationTicks';
-          results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+          __typename: 'DryRunInstigationTicks';
+          results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
         };
       }
     | {__typename: 'ScheduleNotFoundError'; message: string};

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
@@ -58,8 +58,8 @@ export type ScheduleFragment = {
     }>;
   };
   futureTicks: {
-    __typename: 'FutureInstigationTicks';
-    results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+    __typename: 'DryRunInstigationTicks';
+    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
   };
 };
 
@@ -124,8 +124,8 @@ export type RepositorySchedulesFragment = {
       }>;
     };
     futureTicks: {
-      __typename: 'FutureInstigationTicks';
-      results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+      __typename: 'DryRunInstigationTicks';
+      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
     };
   }>;
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
@@ -210,8 +210,8 @@ export type SchedulesRootQuery = {
             }>;
           };
           futureTicks: {
-            __typename: 'FutureInstigationTicks';
-            results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+            __typename: 'DryRunInstigationTicks';
+            results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
           };
         }>;
         displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
@@ -12,8 +12,8 @@ export type ScheduleNextFiveTicksFragment = {
   pipelineName: string;
   scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
   futureTicks: {
-    __typename: 'FutureInstigationTicks';
-    results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+    __typename: 'DryRunInstigationTicks';
+    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
   };
 };
 
@@ -32,8 +32,8 @@ export type RepositoryForNextTicksFragment = {
     pipelineName: string;
     scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
     futureTicks: {
-      __typename: 'FutureInstigationTicks';
-      results: Array<{__typename: 'FutureInstigationTick'; timestamp: number}>;
+      __typename: 'DryRunInstigationTicks';
+      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
     };
   }>;
 };
@@ -51,7 +51,7 @@ export type ScheduleTickConfigQuery = {
         __typename: 'Schedule';
         id: string;
         futureTick: {
-          __typename: 'FutureInstigationTick';
+          __typename: 'DryRunInstigationTick';
           evaluationResult: {
             __typename: 'TickEvaluation';
             skipReason: string | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
@@ -9,7 +9,7 @@ export type SensorFragment = {
   name: string;
   description: string | null;
   minIntervalSeconds: number;
-  nextTick: {__typename: 'FutureInstigationTick'; timestamp: number} | null;
+  nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
   sensorState: {
     __typename: 'InstigationState';
     id: string;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
@@ -26,7 +26,7 @@ export type SensorRootQuery = {
         name: string;
         description: string | null;
         minIntervalSeconds: number;
-        nextTick: {__typename: 'FutureInstigationTick'; timestamp: number} | null;
+        nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
         sensorState: {
           __typename: 'InstigationState';
           id: string;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRoot.types.ts
@@ -30,7 +30,7 @@ export type SensorsRootQuery = {
           name: string;
           description: string | null;
           minIntervalSeconds: number;
-          nextTick: {__typename: 'FutureInstigationTick'; timestamp: number} | null;
+          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
           sensorState: {
             __typename: 'InstigationState';
             id: string;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -52,7 +52,7 @@ export type SingleScheduleQuery = {
             endTime: number | null;
             updateTime: number | null;
           }>;
-          nextTick: {__typename: 'FutureInstigationTick'; timestamp: number} | null;
+          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
         };
         partitionSet: {__typename: 'PartitionSet'; id: string; name: string} | null;
       }

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -56,7 +56,7 @@ export type SingleSensorQuery = {
             endTime: number | null;
             updateTime: number | null;
           }>;
-          nextTick: {__typename: 'FutureInstigationTick'; timestamp: number} | null;
+          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
         };
       }
     | {__typename: 'SensorNotFoundError'}

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -156,7 +156,7 @@ def get_schedule_or_error(graphene_info: ResolveInfo, schedule_selector):
 
 
 def get_schedule_next_tick(graphene_info: ResolveInfo, schedule_state):
-    from ..schema.instigation import GrapheneFutureInstigationTick
+    from ..schema.instigation import GrapheneDryRunInstigationTick
 
     if not schedule_state.is_running:
         return None
@@ -183,4 +183,4 @@ def get_schedule_next_tick(graphene_info: ResolveInfo, schedule_state):
     )
 
     next_timestamp = next(time_iter).timestamp()
-    return GrapheneFutureInstigationTick(schedule_state, next_timestamp)
+    return GrapheneDryRunInstigationTick(schedule_state, next_timestamp)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -183,4 +183,9 @@ def get_schedule_next_tick(graphene_info: ResolveInfo, schedule_state):
     )
 
     next_timestamp = next(time_iter).timestamp()
-    return GrapheneDryRunInstigationTick(schedule_state, next_timestamp)
+    selector = ScheduleSelector(
+        location_name=repository_origin.repository_location_origin.location_name,
+        repository_name=repository_origin.repository_name,
+        schedule_name=external_schedule.name,
+    )
+    return GrapheneDryRunInstigationTick(selector, next_timestamp)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -175,7 +175,7 @@ def get_sensors_for_pipeline(graphene_info: ResolveInfo, pipeline_selector):
 
 
 def get_sensor_next_tick(graphene_info: ResolveInfo, sensor_state):
-    from ..schema.instigation import GrapheneFutureInstigationTick
+    from ..schema.instigation import GrapheneDryRunInstigationTick
 
     check.inst_param(sensor_state, "sensor_state", InstigatorState)
 
@@ -211,7 +211,7 @@ def get_sensor_next_tick(graphene_info: ResolveInfo, sensor_state):
     next_timestamp = latest_tick.timestamp + external_sensor.min_interval_seconds
     if next_timestamp < get_timestamp_from_utc_datetime(get_current_datetime_in_utc()):
         return None
-    return GrapheneFutureInstigationTick(sensor_state, next_timestamp)
+    return GrapheneDryRunInstigationTick(sensor_state, next_timestamp)
 
 
 @capture_error

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -211,7 +211,13 @@ def get_sensor_next_tick(graphene_info: ResolveInfo, sensor_state):
     next_timestamp = latest_tick.timestamp + external_sensor.min_interval_seconds
     if next_timestamp < get_timestamp_from_utc_datetime(get_current_datetime_in_utc()):
         return None
-    return GrapheneDryRunInstigationTick(sensor_state, next_timestamp)
+
+    selector = SensorSelector(
+        location_name=repository_origin.repository_location_origin.location_name,
+        repository_name=repository_origin.repository_name,
+        sensor_name=external_sensor.name,
+    )
+    return GrapheneDryRunInstigationTick(selector, next_timestamp)
 
 
 @capture_error

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -168,12 +168,12 @@ class GrapheneInstigationTick(graphene.ObjectType):
         return get_tick_log_events(graphene_info, self._tick)
 
 
-class GrapheneFutureInstigationTick(graphene.ObjectType):
+class GrapheneDryRunInstigationTick(graphene.ObjectType):
     timestamp = graphene.NonNull(graphene.Float)
     evaluationResult = graphene.Field(lambda: GrapheneTickEvaluation)
 
     class Meta:
-        name = "FutureInstigationTick"
+        name = "DryRunInstigationTick"
 
     def __init__(self, state, timestamp):
         self._state = check.inst_param(state, "state", InstigatorState)
@@ -281,12 +281,12 @@ class GrapheneRunRequest(graphene.ObjectType):
         return dump_run_config_yaml(self._run_request.run_config)
 
 
-class GrapheneFutureInstigationTicks(graphene.ObjectType):
-    results = non_null_list(GrapheneFutureInstigationTick)
+class GrapheneDryRunInstigationTicks(graphene.ObjectType):
+    results = non_null_list(GrapheneDryRunInstigationTick)
     cursor = graphene.NonNull(graphene.Float)
 
     class Meta:
-        name = "FutureInstigationTicks"
+        name = "DryRunInstigationTicks"
 
 
 class GrapheneInstigationState(graphene.ObjectType):
@@ -313,7 +313,7 @@ class GrapheneInstigationState(graphene.ObjectType):
         cursor=graphene.String(),
         statuses=graphene.List(graphene.NonNull(GrapheneInstigationTickStatus)),
     )
-    nextTick = graphene.Field(GrapheneFutureInstigationTick)
+    nextTick = graphene.Field(GrapheneDryRunInstigationTick)
     runningCount = graphene.NonNull(graphene.Int)  # remove with cron scheduler
 
     class Meta:
@@ -519,8 +519,8 @@ class GrapheneInstigationStatesOrError(graphene.Union):
 
 
 types = [
-    GrapheneFutureInstigationTick,
-    GrapheneFutureInstigationTicks,
+    GrapheneDryRunInstigationTick,
+    GrapheneDryRunInstigationTicks,
     GrapheneInstigationTypeSpecificData,
     GrapheneInstigationState,
     GrapheneInstigationStateNotFoundError,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -11,8 +11,8 @@ from ..errors import (
     GrapheneScheduleNotFoundError,
 )
 from ..instigation import (
-    GrapheneFutureInstigationTick,
-    GrapheneFutureInstigationTicks,
+    GrapheneDryRunInstigationTick,
+    GrapheneDryRunInstigationTicks,
     GrapheneInstigationState,
 )
 from ..util import ResolveInfo, non_null_list
@@ -30,13 +30,13 @@ class GrapheneSchedule(graphene.ObjectType):
     scheduleState = graphene.NonNull(GrapheneInstigationState)
     partition_set = graphene.Field("dagster_graphql.schema.partition_sets.GraphenePartitionSet")
     futureTicks = graphene.NonNull(
-        GrapheneFutureInstigationTicks,
+        GrapheneDryRunInstigationTicks,
         cursor=graphene.Float(),
         limit=graphene.Int(),
         until=graphene.Float(),
     )
     futureTick = graphene.NonNull(
-        GrapheneFutureInstigationTick, tick_timestamp=graphene.NonNull(graphene.Int)
+        GrapheneDryRunInstigationTick, tick_timestamp=graphene.NonNull(graphene.Int)
     )
 
     class Meta:
@@ -123,15 +123,15 @@ class GrapheneSchedule(graphene.ObjectType):
                 tick_times.append(next(time_iter).timestamp())
 
         future_ticks = [
-            GrapheneFutureInstigationTick(self._schedule_state, tick_time)
+            GrapheneDryRunInstigationTick(self._schedule_state, tick_time)
             for tick_time in tick_times
         ]
 
         new_cursor = tick_times[-1] + 1 if tick_times else cursor
-        return GrapheneFutureInstigationTicks(results=future_ticks, cursor=new_cursor)
+        return GrapheneDryRunInstigationTicks(results=future_ticks, cursor=new_cursor)
 
     def resolve_futureTick(self, _graphene_info, tick_timestamp: int):
-        return GrapheneFutureInstigationTick(self._schedule_state, float(tick_timestamp))
+        return GrapheneDryRunInstigationTick(self._schedule_state, float(tick_timestamp))
 
 
 class GrapheneScheduleOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -26,7 +26,7 @@ from .errors import (
     GrapheneUnauthorizedError,
 )
 from .inputs import GrapheneSensorSelector
-from .instigation import GrapheneFutureInstigationTick, GrapheneInstigationState
+from .instigation import GrapheneDryRunInstigationTick, GrapheneInstigationState
 from .util import ResolveInfo, non_null_list
 
 
@@ -64,7 +64,7 @@ class GrapheneSensor(graphene.ObjectType):
     sensorState = graphene.NonNull(GrapheneInstigationState)
     minIntervalSeconds = graphene.NonNull(graphene.Int)
     description = graphene.String()
-    nextTick = graphene.Field(GrapheneFutureInstigationTick)
+    nextTick = graphene.Field(GrapheneDryRunInstigationTick)
     metadata = graphene.NonNull(GrapheneSensorMetadata)
 
     class Meta:


### PR DESCRIPTION
Makes some changes to the API formerly known as GrapheneFutureInstigationTick
- Renames to GrapheneDryRunInstigationTick
- Remove restriction of instigator being on in order to use
- Switch to using instigator selector instead of instigator state
- Be able to use either schedules or sensors for instigation behavior