### PR TITLE
[pyright] examples/tutorial-notebook-assets

### DIFF
--- a/examples/tutorial_notebook_assets/setup.py
+++ b/examples/tutorial_notebook_assets/setup.py
@@ -4,8 +4,8 @@ setup(
     name="tutorial_notebook_assets",
     packages=find_packages(exclude=["tutorial_notebook_assets"]),
     install_requires=[
-        "dagster>=1.0.16",
-        "dagstermill>=0.16.16",
+        "dagster",
+        "dagstermill",
         "papermill-origami>=0.0.8",
         "pandas",
         "matplotlib",


### PR DESCRIPTION
### Summary & Motivation

Remove dagster version lower bounds in `examples/tutorial-notebook-assets` (it is inconsistent with the rest of our examples)

### How I Tested These Changes

BK