### PR TITLE
[pyright] examples/with-airflow

### DIFF
--- a/examples/with_airflow/setup.py
+++ b/examples/with_airflow/setup.py
@@ -8,7 +8,7 @@ setup(
         "dagster_airflow",
         "apache-airflow==2.3.0",
         # pin jinja2 to version compatible with dagit and airflow
-        "jinja2==3.0.3",
+        "jinja2",
         # for the kubernetes operator
         "apache-airflow-providers-cncf-kubernetes>=4.4.0",
         "apache-airflow-providers-docker>=3.1.0",

--- a/examples/with_airflow/with_airflow/airflow_complex_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_complex_dag.py
@@ -1,4 +1,4 @@
-# pylint: disable=pointless-statement
+# pyright: reportUnusedExpression=none
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -21,9 +21,11 @@
 Example Airflow DAG that shows the complex DAG structure.
 """
 
+# Type errors ignored because some of these imports target deprecated modules for compatibility with
+# airflow 1.x and 2.x.
 from airflow import models
-from airflow.operators.bash_operator import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.bash_operator import BashOperator  # type: ignore  # (airflow 1 compat)
+from airflow.operators.python_operator import PythonOperator  # type: ignore  # (airflow 1 compat)
 from airflow.utils.dates import days_ago
 from airflow.utils.helpers import chain
 

--- a/examples/with_airflow/with_airflow/airflow_kubernetes_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_kubernetes_dag.py
@@ -1,4 +1,4 @@
-# pylint: disable=pointless-statement
+# pyright: reportUnusedExpression=none
 
 from airflow import models
 from airflow.operators.dummy_operator import DummyOperator

--- a/examples/with_airflow/with_airflow/airflow_operator_to_op.py
+++ b/examples/with_airflow/with_airflow/airflow_operator_to_op.py
@@ -1,7 +1,9 @@
 import json
 
+# Type errors ignored because some of these imports target deprecated modules for compatibility with
+# airflow 1.x and 2.x.
 from airflow.models import Connection
-from airflow.operators.http_operator import SimpleHttpOperator
+from airflow.operators.http_operator import SimpleHttpOperator  # type: ignore
 from dagster import job
 from dagster_airflow import airflow_operator_to_op
 

--- a/examples/with_airflow/with_airflow/airflow_simple_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_simple_dag.py
@@ -1,7 +1,9 @@
-# pylint: disable=pointless-statement
+# pyright: reportUnusedExpression=none
 
+# Type errors ignored because some of these imports target deprecated modules for compatibility with
+# airflow 1.x and 2.x.
 from airflow import models
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash_operator import BashOperator  # type: ignore  # (airflow 1 compat)
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 


### PR DESCRIPTION
### Summary & Motivation

Remove strict jinja2 pin and fix some type errors in `examples/with-airflow`. Strict jinja 2 pin caused difficulty installing in same env with other packages.

### How I Tested These Changes

BK