### PR TITLE
[dagit] Show partition status on the asset graph, catalog pages, add tests

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -476,3 +476,183 @@ export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
     numPartitions: 1500,
   },
 };
+
+export const AssetNodeScenariosBase = [
+  {
+    title: 'No Live Data',
+    liveData: undefined,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Loading'],
+  },
+
+  {
+    title: 'Run Started - Not Materializing Yet',
+    liveData: LiveDataForNodeRunStartedNotMaterializing,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materializing...', 'ABCDEF'],
+  },
+  {
+    title: 'Run Started - Materializing',
+    liveData: LiveDataForNodeRunStartedMaterializing,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materializing...', 'ABCDEF'],
+  },
+
+  {
+    title: 'Run Failed to Materialize',
+    liveData: LiveDataForNodeRunFailed,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Failed', 'Jan'],
+  },
+
+  {
+    title: 'Never Materialized',
+    liveData: LiveDataForNodeNeverMaterialized,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Never materialized'],
+  },
+
+  {
+    title: 'Materialized',
+    liveData: LiveDataForNodeMaterialized,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materialized', 'Feb'],
+  },
+
+  {
+    title: 'Materialized and Stale',
+    liveData: LiveDataForNodeMaterializedAndStale,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Stale', 'Feb'],
+  },
+
+  {
+    title: 'Materialized and Stale and Late',
+    liveData: LiveDataForNodeMaterializedAndStaleAndLate,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['12 minutes late', 'Feb'],
+  },
+
+  {
+    title: 'Materialized and Stale and Fresh',
+    liveData: LiveDataForNodeMaterializedAndStaleAndFresh,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materialized'],
+  },
+
+  {
+    title: 'Materialized and Fresh',
+    liveData: LiveDataForNodeMaterializedAndFresh,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Materialized'],
+  },
+
+  {
+    title: 'Materialized and Late',
+    liveData: LiveDataForNodeMaterializedAndLate,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['12 minutes late'],
+  },
+];
+
+export const AssetNodeScenariosSource = [
+  {
+    title: 'Source Asset - No Live Data',
+    liveData: undefined,
+    definition: AssetNodeFragmentSource,
+    expectedText: ['Observed', '–'],
+  },
+
+  {
+    title: 'Source Asset - Not Observable',
+    liveData: undefined,
+    definition: {...AssetNodeFragmentSource, isObservable: false},
+    expectedText: [],
+  },
+
+  {
+    title: 'Source Asset - Not Observable, No Description',
+    liveData: undefined,
+    definition: {...AssetNodeFragmentSource, isObservable: false, description: null},
+    expectedText: [],
+  },
+
+  {
+    title: 'Source Asset - Never Observed',
+    liveData: LiveDataForNodeSourceNeverObserved,
+    definition: AssetNodeFragmentSource,
+    expectedText: ['Observed', '–'],
+  },
+
+  {
+    title: 'Source Asset - Observation Running',
+    liveData: LiveDataForNodeSourceObservationRunning,
+    definition: AssetNodeFragmentSource,
+    expectedText: ['Observed', '–'],
+  },
+
+  {
+    title: 'Source Asset - Observed, Stale',
+    liveData: LiveDataForNodeSourceObservedStale,
+    definition: AssetNodeFragmentSource,
+    expectedText: ['Observed', 'Feb'],
+  },
+
+  {
+    title: 'Source Asset - Observed, Up To Date',
+    liveData: LiveDataForNodeSourceObservedUpToDate,
+    definition: AssetNodeFragmentSource,
+    expectedText: ['Observed', 'Feb'],
+  },
+];
+
+export const AssetNodeScenariosPartitioned = [
+  {
+    title: 'Partitioned Asset - Some Missing',
+    liveData: LiveDataForNodePartitionedSomeMissing,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '1,495 missing'],
+  },
+
+  {
+    title: 'Partitioned Asset - None Missing',
+    liveData: LiveDataForNodePartitionedNoneMissing,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '0 missing'],
+  },
+
+  {
+    title: 'Never Materialized',
+    liveData: LiveDataForNodePartitionedNeverMaterialized,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '1,500 missing'],
+  },
+
+  {
+    title: 'Partitioned Asset - Stale',
+    liveData: LiveDataForNodePartitionedStale,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '0 missing'],
+  },
+
+  {
+    title: 'Partitioned Asset - Stale and Late',
+    liveData: LiveDataForNodePartitionedStaleAndLate,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '12 minutes late'],
+  },
+
+  {
+    title: 'Partitioned Asset - Stale and Fresh',
+    liveData: LiveDataForNodePartitionedStaleAndFresh,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '0 missing'],
+  },
+
+  {
+    title: 'Partitioned Asset - Last Run Failed',
+    liveData: LiveDataForNodePartitionedLatestRunFailed,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '0 missing'],
+  },
+];

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -1,0 +1,478 @@
+import {RunStatus} from '../graphql/types';
+
+import {LiveDataForNode} from './Utils';
+import {AssetNodeFragment} from './types/AssetNode.types';
+
+export const AssetNodeFragmentBasic: AssetNodeFragment = {
+  __typename: 'AssetNode',
+  assetKey: {__typename: 'AssetKey', path: ['asset1']},
+  computeKind: null,
+  description: 'This is a test asset description',
+  graphName: null,
+  id: '["asset1"]',
+  isObservable: false,
+  isPartitioned: false,
+  isSource: false,
+  jobNames: ['job1'],
+  opNames: ['asset1'],
+  opVersion: '1',
+};
+
+export const AssetNodeFragmentSource: AssetNodeFragment = {
+  ...AssetNodeFragmentBasic,
+  assetKey: {__typename: 'AssetKey', path: ['source_asset']},
+  description: 'This is a test source asset',
+  id: '["source_asset"]',
+  isObservable: true,
+  isSource: true,
+  jobNames: [],
+  opNames: [],
+};
+
+export const AssetNodeFragmentPartitioned: AssetNodeFragment = {
+  ...AssetNodeFragmentBasic,
+  assetKey: {__typename: 'AssetKey', path: ['asset1']},
+  description: 'This is a partitioned asset description',
+  id: '["asset1"]',
+  isPartitioned: true,
+};
+
+export const LiveDataForNodeRunStartedNotMaterializing: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: ['ABCDEF'],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: null,
+  projectedLogicalVersion: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeRunStartedMaterializing: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: ['ABCDEF'],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: null,
+  projectedLogicalVersion: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeRunFailed: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: {
+    __typename: 'Run',
+    id: 'ABCDEF',
+    status: RunStatus.FAILURE,
+    endTime: 1673301346,
+  },
+  currentLogicalVersion: null,
+  projectedLogicalVersion: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeNeverMaterialized: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'INITIAL',
+  projectedLogicalVersion: 'V_A',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterialized: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'INITIAL',
+  projectedLogicalVersion: 'V_A',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedAndStale: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedAndStaleAndLate: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 12,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+  },
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedAndStaleAndFresh: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 0,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+  },
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedAndFresh: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_B',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 0,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+  },
+  partitionStats: null,
+};
+
+export const LiveDataForNodeMaterializedAndLate: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_A',
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 12,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+  },
+  partitionStats: null,
+};
+
+export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
+  stepKey: 'source_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'INITIAL',
+  projectedLogicalVersion: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
+  stepKey: 'source_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: ['12345'],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'INITIAL',
+  projectedLogicalVersion: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeSourceObservedStale: LiveDataForNode = {
+  stepKey: 'source_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: ['12345'],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: {
+    __typename: 'ObservationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'INITIAL',
+  projectedLogicalVersion: 'DIFFERENT',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodeSourceObservedUpToDate: LiveDataForNode = {
+  stepKey: 'source_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: {
+    __typename: 'ObservationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'DIFFERENT',
+  projectedLogicalVersion: 'DIFFERENT',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: null,
+};
+
+export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
+  stepKey: 'partitioned_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'DIFFERENT',
+  projectedLogicalVersion: 'DIFFERENT',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 5,
+    numPartitions: 1500,
+  },
+};
+
+export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
+  stepKey: 'partitioned_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'DIFFERENT',
+  projectedLogicalVersion: 'DIFFERENT',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 1500,
+    numPartitions: 1500,
+  },
+};
+
+export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'INITIAL',
+  projectedLogicalVersion: 'V_A',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 0,
+    numPartitions: 1500,
+  },
+};
+
+export const LiveDataForNodePartitionedStale: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 1500,
+    numPartitions: 1500,
+  },
+};
+
+export const LiveDataForNodePartitionedStaleAndLate: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 12,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+  },
+  partitionStats: {
+    numMaterialized: 1500,
+    numPartitions: 1500,
+  },
+};
+
+export const LiveDataForNodePartitionedStaleAndFresh: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: `${Date.now()}`,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  currentLogicalVersion: 'V_A',
+  projectedLogicalVersion: 'V_B',
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 0,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+  },
+  partitionStats: {
+    numMaterialized: 1500,
+    numPartitions: 1500,
+  },
+};
+
+export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: {
+    __typename: 'Run',
+    id: 'ABCDEF',
+    status: RunStatus.FAILURE,
+    endTime: 1673301346,
+  },
+  currentLogicalVersion: null,
+  projectedLogicalVersion: null,
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 1500,
+    numPartitions: 1500,
+  },
+};

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
@@ -5,35 +5,37 @@ import {KNOWN_TAGS} from '../graph/OpTags';
 
 import {AssetNode, AssetNodeMinimal} from './AssetNode';
 import * as Mocks from './AssetNode.mocks';
-import {LiveDataForNode} from './Utils';
 import {getAssetNodeDimensions} from './layout';
-import {AssetNodeFragment} from './types/AssetNode.types';
 
 // eslint-disable-next-line import/no-default-export
 export default {component: AssetNode};
 
 export const LiveStates = () => {
-  const caseWithLiveData = (
-    name: string,
-    liveData: LiveDataForNode | undefined = undefined,
-    def: AssetNodeFragment = Mocks.AssetNodeFragmentBasic,
-  ) => {
-    const dimensions = getAssetNodeDimensions(def);
+  const caseWithLiveData = (scenario: typeof Mocks.AssetNodeScenariosBase[0]) => {
+    const dimensions = getAssetNodeDimensions(scenario.definition);
     return (
       <Box flex={{direction: 'column', gap: 0, alignItems: 'flex-start'}}>
         <div
           style={{position: 'relative', width: 280, height: dimensions.height, overflowY: 'hidden'}}
         >
-          <AssetNode definition={def} selected={false} liveData={liveData} />
+          <AssetNode
+            definition={scenario.definition}
+            liveData={scenario.liveData}
+            selected={false}
+          />
         </div>
         <div style={{position: 'relative', width: 280, height: 82}}>
           <div style={{position: 'absolute', width: 280, height: 82}}>
-            <AssetNodeMinimal definition={def} selected={false} liveData={liveData} />
+            <AssetNodeMinimal
+              definition={scenario.definition}
+              liveData={scenario.liveData}
+              selected={false}
+            />
           </div>
         </div>
         <code>
-          <strong>{name}</strong>
-          <pre>{JSON.stringify(liveData, null, 2)}</pre>
+          <strong>{scenario.title}</strong>
+          <pre>{JSON.stringify(scenario.liveData, null, 2)}</pre>
         </code>
       </Box>
     );
@@ -42,120 +44,14 @@ export const LiveStates = () => {
   return (
     <>
       <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
-        {caseWithLiveData('No Live Data', undefined)}
-
-        {caseWithLiveData(
-          'Run Started - Not Materializing Yet',
-          Mocks.LiveDataForNodeRunStartedNotMaterializing,
-        )}
-        {caseWithLiveData(
-          'Run Started - Materializing',
-          Mocks.LiveDataForNodeRunStartedMaterializing,
-        )}
-
-        {caseWithLiveData('Run Failed to Materialize', Mocks.LiveDataForNodeRunFailed)}
-
-        {caseWithLiveData('Never Materialized', Mocks.LiveDataForNodeNeverMaterialized)}
-
-        {caseWithLiveData('Materialized', Mocks.LiveDataForNodeMaterialized)}
-
-        {caseWithLiveData('Materialized and Stale', Mocks.LiveDataForNodeMaterializedAndStale)}
-
-        {caseWithLiveData(
-          'Materialized and Stale and Late',
-          Mocks.LiveDataForNodeMaterializedAndStaleAndLate,
-        )}
-
-        {caseWithLiveData(
-          'Materialized and Stale and Fresh',
-          Mocks.LiveDataForNodeMaterializedAndStaleAndFresh,
-        )}
-
-        {caseWithLiveData('Materialized and Fresh', Mocks.LiveDataForNodeMaterializedAndFresh)}
-
-        {caseWithLiveData('Materialized and Late', Mocks.LiveDataForNodeMaterializedAndLate)}
+        {Mocks.AssetNodeScenariosBase.map(caseWithLiveData)}
       </Box>
 
       <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
-        {caseWithLiveData('Source Asset - No Live Data', undefined, Mocks.AssetNodeFragmentSource)}
-
-        {caseWithLiveData('Source Asset - Not Observable', undefined, {
-          ...Mocks.AssetNodeFragmentSource,
-          isObservable: false,
-        })}
-
-        {caseWithLiveData('Source Asset - Not Observable, No Description', undefined, {
-          ...Mocks.AssetNodeFragmentSource,
-          isObservable: false,
-          description: null,
-        })}
-
-        {caseWithLiveData(
-          'Source Asset - Never Observed',
-          Mocks.LiveDataForNodeSourceNeverObserved,
-          Mocks.AssetNodeFragmentSource,
-        )}
-
-        {caseWithLiveData(
-          'Source Asset - Observation Running',
-          Mocks.LiveDataForNodeSourceObservationRunning,
-          Mocks.AssetNodeFragmentSource,
-        )}
-
-        {caseWithLiveData(
-          'Source Asset - Observed, Stale',
-          Mocks.LiveDataForNodeSourceObservedStale,
-          Mocks.AssetNodeFragmentSource,
-        )}
-
-        {caseWithLiveData(
-          'Source Asset - Observed, Up To Date',
-          Mocks.LiveDataForNodeSourceObservedUpToDate,
-          Mocks.AssetNodeFragmentSource,
-        )}
+        {Mocks.AssetNodeScenariosSource.map(caseWithLiveData)}
       </Box>
       <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
-        {caseWithLiveData(
-          'Partitioned Asset - Some Missing',
-          Mocks.LiveDataForNodePartitionedSomeMissing,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
-
-        {caseWithLiveData(
-          'Partitioned Asset - None Missing',
-          Mocks.LiveDataForNodePartitionedNoneMissing,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
-
-        {caseWithLiveData(
-          'Never Materialized',
-          Mocks.LiveDataForNodePartitionedNeverMaterialized,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
-
-        {caseWithLiveData(
-          'Partitioned Asset - Stale',
-          Mocks.LiveDataForNodePartitionedStale,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
-
-        {caseWithLiveData(
-          'Partitioned Asset - Stale and Late',
-          Mocks.LiveDataForNodePartitionedStaleAndLate,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
-
-        {caseWithLiveData(
-          'Partitioned Asset - Stale and Fresh',
-          Mocks.LiveDataForNodePartitionedStaleAndFresh,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
-
-        {caseWithLiveData(
-          'Partitioned Asset - Last Run Failed',
-          Mocks.LiveDataForNodePartitionedLatestRunFailed,
-          Mocks.AssetNodeFragmentPartitioned,
-        )}
+        {Mocks.AssetNodeScenariosPartitioned.map(caseWithLiveData)}
       </Box>
     </>
   );

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.stories.tsx
@@ -1,41 +1,13 @@
 import {Box} from '@dagster-io/ui';
 import React from 'react';
 
-import {RunStatus} from '../graphql/types';
+import {KNOWN_TAGS} from '../graph/OpTags';
 
 import {AssetNode, AssetNodeMinimal} from './AssetNode';
+import * as Mocks from './AssetNode.mocks';
 import {LiveDataForNode} from './Utils';
+import {getAssetNodeDimensions} from './layout';
 import {AssetNodeFragment} from './types/AssetNode.types';
-
-const ASSET_NODE_DEFINITION: AssetNodeFragment = {
-  __typename: 'AssetNode',
-  assetKey: {__typename: 'AssetKey', path: ['asset1']},
-  computeKind: null,
-  description: 'This is a test asset description',
-  graphName: null,
-  id: '["asset1"]',
-  isObservable: false,
-  isPartitioned: false,
-  isSource: false,
-  jobNames: ['job1'],
-  opNames: ['asset1'],
-  opVersion: '1',
-};
-
-const SOURCE_ASSET_NODE_DEFINITION: AssetNodeFragment = {
-  __typename: 'AssetNode',
-  assetKey: {__typename: 'AssetKey', path: ['source_asset']},
-  computeKind: null,
-  description: 'This is a test source asset',
-  graphName: null,
-  id: '["source_asset"]',
-  isObservable: true,
-  isPartitioned: false,
-  isSource: true,
-  jobNames: [],
-  opNames: [],
-  opVersion: '1',
-};
 
 // eslint-disable-next-line import/no-default-export
 export default {component: AssetNode};
@@ -44,11 +16,14 @@ export const LiveStates = () => {
   const caseWithLiveData = (
     name: string,
     liveData: LiveDataForNode | undefined = undefined,
-    def: AssetNodeFragment = ASSET_NODE_DEFINITION,
+    def: AssetNodeFragment = Mocks.AssetNodeFragmentBasic,
   ) => {
+    const dimensions = getAssetNodeDimensions(def);
     return (
       <Box flex={{direction: 'column', gap: 0, alignItems: 'flex-start'}}>
-        <div style={{position: 'relative', width: 280}}>
+        <div
+          style={{position: 'relative', width: 280, height: dimensions.height, overflowY: 'hidden'}}
+        >
           <AssetNode definition={def} selected={false} liveData={liveData} />
         </div>
         <div style={{position: 'relative', width: 280, height: 82}}>
@@ -63,287 +38,153 @@ export const LiveStates = () => {
       </Box>
     );
   };
+
   return (
-    <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
-      {caseWithLiveData('No Live Data', undefined)}
-      {caseWithLiveData('Run Started - Not Materializing Yet', {
-        stepKey: 'asset1',
-        unstartedRunIds: ['ABCDEF'],
-        inProgressRunIds: [],
-        lastMaterialization: null,
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: null,
-        projectedLogicalVersion: null,
-        freshnessInfo: null,
-        freshnessPolicy: null,
-      })}
-      {caseWithLiveData('Run Started - Materializing', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: ['ABCDEF'],
-        lastMaterialization: null,
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: null,
-        projectedLogicalVersion: null,
-        freshnessInfo: null,
-        freshnessPolicy: null,
-      })}
+    <>
+      <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
+        {caseWithLiveData('No Live Data', undefined)}
 
-      {caseWithLiveData('Run Failed to Materialize', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: null,
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: {
-          __typename: 'Run',
-          id: 'ABCDEF',
-          status: RunStatus.FAILURE,
-          endTime: 1673301346,
-        },
-        currentLogicalVersion: null,
-        projectedLogicalVersion: null,
-        freshnessInfo: null,
-        freshnessPolicy: null,
-      })}
+        {caseWithLiveData(
+          'Run Started - Not Materializing Yet',
+          Mocks.LiveDataForNodeRunStartedNotMaterializing,
+        )}
+        {caseWithLiveData(
+          'Run Started - Materializing',
+          Mocks.LiveDataForNodeRunStartedMaterializing,
+        )}
 
-      {caseWithLiveData('Never Materialized', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: null,
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'INITIAL',
-        projectedLogicalVersion: 'V_A',
-        freshnessInfo: null,
-        freshnessPolicy: null,
-      })}
+        {caseWithLiveData('Run Failed to Materialize', Mocks.LiveDataForNodeRunFailed)}
 
-      {caseWithLiveData('Materialized', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: {
-          __typename: 'MaterializationEvent',
-          runId: 'ABCDEF',
-          timestamp: `${Date.now()}`,
-        },
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'INITIAL',
-        projectedLogicalVersion: 'V_A',
-        freshnessInfo: null,
-        freshnessPolicy: null,
-      })}
+        {caseWithLiveData('Never Materialized', Mocks.LiveDataForNodeNeverMaterialized)}
 
-      {caseWithLiveData('Materialized and Stale', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: {
-          __typename: 'MaterializationEvent',
-          runId: 'ABCDEF',
-          timestamp: `${Date.now()}`,
-        },
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'V_A',
-        projectedLogicalVersion: 'V_B',
-        freshnessInfo: null,
-        freshnessPolicy: null,
-      })}
-      {caseWithLiveData('Materialized and Stale and Late', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: {
-          __typename: 'MaterializationEvent',
-          runId: 'ABCDEF',
-          timestamp: `${Date.now()}`,
-        },
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'V_A',
-        projectedLogicalVersion: 'V_B',
-        freshnessInfo: {
-          __typename: 'AssetFreshnessInfo',
-          currentMinutesLate: 12,
-        },
-        freshnessPolicy: {
-          __typename: 'FreshnessPolicy',
-          maximumLagMinutes: 10,
-          cronSchedule: null,
-        },
-      })}
-      {caseWithLiveData('Materialized and Stale and Fresh', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: {
-          __typename: 'MaterializationEvent',
-          runId: 'ABCDEF',
-          timestamp: `${Date.now()}`,
-        },
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'V_A',
-        projectedLogicalVersion: 'V_B',
-        freshnessInfo: {
-          __typename: 'AssetFreshnessInfo',
-          currentMinutesLate: 0,
-        },
-        freshnessPolicy: {
-          __typename: 'FreshnessPolicy',
-          maximumLagMinutes: 10,
-          cronSchedule: null,
-        },
-      })}
-      {caseWithLiveData('Materialized and Fresh', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: {
-          __typename: 'MaterializationEvent',
-          runId: 'ABCDEF',
-          timestamp: `${Date.now()}`,
-        },
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'V_B',
-        projectedLogicalVersion: 'V_B',
-        freshnessInfo: {
-          __typename: 'AssetFreshnessInfo',
-          currentMinutesLate: 0,
-        },
-        freshnessPolicy: {
-          __typename: 'FreshnessPolicy',
-          maximumLagMinutes: 10,
-          cronSchedule: null,
-        },
-      })}
-      {caseWithLiveData('Materialized and Late', {
-        stepKey: 'asset1',
-        unstartedRunIds: [],
-        inProgressRunIds: [],
-        lastMaterialization: {
-          __typename: 'MaterializationEvent',
-          runId: 'ABCDEF',
-          timestamp: `${Date.now()}`,
-        },
-        lastMaterializationRunStatus: null,
-        lastObservation: null,
-        runWhichFailedToMaterialize: null,
-        currentLogicalVersion: 'V_A',
-        projectedLogicalVersion: 'V_A',
-        freshnessInfo: {
-          __typename: 'AssetFreshnessInfo',
-          currentMinutesLate: 12,
-        },
-        freshnessPolicy: {
-          __typename: 'FreshnessPolicy',
-          maximumLagMinutes: 10,
-          cronSchedule: null,
-        },
-      })}
-      {caseWithLiveData('Source Asset - No Live Data', undefined, SOURCE_ASSET_NODE_DEFINITION)}
+        {caseWithLiveData('Materialized', Mocks.LiveDataForNodeMaterialized)}
 
-      {caseWithLiveData('Source Asset - Not Observable', undefined, {
-        ...SOURCE_ASSET_NODE_DEFINITION,
-        isObservable: false,
-      })}
+        {caseWithLiveData('Materialized and Stale', Mocks.LiveDataForNodeMaterializedAndStale)}
 
-      {caseWithLiveData(
-        'Source Asset - Never Observed',
-        {
-          stepKey: 'source_asset',
-          unstartedRunIds: [],
-          inProgressRunIds: [],
-          lastMaterialization: null,
-          lastMaterializationRunStatus: null,
-          lastObservation: null,
-          runWhichFailedToMaterialize: null,
-          currentLogicalVersion: 'INITIAL',
-          projectedLogicalVersion: null,
-          freshnessInfo: null,
-          freshnessPolicy: null,
-        },
-        SOURCE_ASSET_NODE_DEFINITION,
-      )}
+        {caseWithLiveData(
+          'Materialized and Stale and Late',
+          Mocks.LiveDataForNodeMaterializedAndStaleAndLate,
+        )}
 
-      {caseWithLiveData(
-        'Source Asset - Observation Running',
-        {
-          stepKey: 'source_asset',
-          unstartedRunIds: [],
-          inProgressRunIds: ['12345'],
-          lastMaterialization: null,
-          lastMaterializationRunStatus: null,
-          lastObservation: null,
-          runWhichFailedToMaterialize: null,
-          currentLogicalVersion: 'INITIAL',
-          projectedLogicalVersion: null,
-          freshnessInfo: null,
-          freshnessPolicy: null,
-        },
-        SOURCE_ASSET_NODE_DEFINITION,
-      )}
+        {caseWithLiveData(
+          'Materialized and Stale and Fresh',
+          Mocks.LiveDataForNodeMaterializedAndStaleAndFresh,
+        )}
 
-      {caseWithLiveData(
-        'Source Asset - Observed, Stale',
-        {
-          stepKey: 'source_asset',
-          unstartedRunIds: [],
-          inProgressRunIds: ['12345'],
-          lastMaterialization: null,
-          lastMaterializationRunStatus: null,
-          lastObservation: {
-            __typename: 'ObservationEvent',
-            runId: 'ABCDEF',
-            timestamp: `${Date.now()}`,
-          },
-          runWhichFailedToMaterialize: null,
-          currentLogicalVersion: 'INITIAL',
-          projectedLogicalVersion: 'DIFFERENT',
-          freshnessInfo: null,
-          freshnessPolicy: null,
-        },
-        SOURCE_ASSET_NODE_DEFINITION,
-      )}
+        {caseWithLiveData('Materialized and Fresh', Mocks.LiveDataForNodeMaterializedAndFresh)}
 
-      {caseWithLiveData(
-        'Source Asset - Observed, Up To Date',
-        {
-          stepKey: 'source_asset',
-          unstartedRunIds: [],
-          inProgressRunIds: [],
-          lastMaterialization: null,
-          lastMaterializationRunStatus: null,
-          lastObservation: {
-            __typename: 'ObservationEvent',
-            runId: 'ABCDEF',
-            timestamp: `${Date.now()}`,
-          },
-          runWhichFailedToMaterialize: null,
-          currentLogicalVersion: 'DIFFERENT',
-          projectedLogicalVersion: 'DIFFERENT',
-          freshnessInfo: null,
-          freshnessPolicy: null,
-        },
-        SOURCE_ASSET_NODE_DEFINITION,
-      )}
-    </Box>
+        {caseWithLiveData('Materialized and Late', Mocks.LiveDataForNodeMaterializedAndLate)}
+      </Box>
+
+      <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
+        {caseWithLiveData('Source Asset - No Live Data', undefined, Mocks.AssetNodeFragmentSource)}
+
+        {caseWithLiveData('Source Asset - Not Observable', undefined, {
+          ...Mocks.AssetNodeFragmentSource,
+          isObservable: false,
+        })}
+
+        {caseWithLiveData('Source Asset - Not Observable, No Description', undefined, {
+          ...Mocks.AssetNodeFragmentSource,
+          isObservable: false,
+          description: null,
+        })}
+
+        {caseWithLiveData(
+          'Source Asset - Never Observed',
+          Mocks.LiveDataForNodeSourceNeverObserved,
+          Mocks.AssetNodeFragmentSource,
+        )}
+
+        {caseWithLiveData(
+          'Source Asset - Observation Running',
+          Mocks.LiveDataForNodeSourceObservationRunning,
+          Mocks.AssetNodeFragmentSource,
+        )}
+
+        {caseWithLiveData(
+          'Source Asset - Observed, Stale',
+          Mocks.LiveDataForNodeSourceObservedStale,
+          Mocks.AssetNodeFragmentSource,
+        )}
+
+        {caseWithLiveData(
+          'Source Asset - Observed, Up To Date',
+          Mocks.LiveDataForNodeSourceObservedUpToDate,
+          Mocks.AssetNodeFragmentSource,
+        )}
+      </Box>
+      <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
+        {caseWithLiveData(
+          'Partitioned Asset - Some Missing',
+          Mocks.LiveDataForNodePartitionedSomeMissing,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+
+        {caseWithLiveData(
+          'Partitioned Asset - None Missing',
+          Mocks.LiveDataForNodePartitionedNoneMissing,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+
+        {caseWithLiveData(
+          'Never Materialized',
+          Mocks.LiveDataForNodePartitionedNeverMaterialized,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+
+        {caseWithLiveData(
+          'Partitioned Asset - Stale',
+          Mocks.LiveDataForNodePartitionedStale,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+
+        {caseWithLiveData(
+          'Partitioned Asset - Stale and Late',
+          Mocks.LiveDataForNodePartitionedStaleAndLate,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+
+        {caseWithLiveData(
+          'Partitioned Asset - Stale and Fresh',
+          Mocks.LiveDataForNodePartitionedStaleAndFresh,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+
+        {caseWithLiveData(
+          'Partitioned Asset - Last Run Failed',
+          Mocks.LiveDataForNodePartitionedLatestRunFailed,
+          Mocks.AssetNodeFragmentPartitioned,
+        )}
+      </Box>
+    </>
   );
   return;
+};
+
+export const PartnerTags = () => {
+  const caseWithComputeKind = (computeKind: string) => {
+    const def = {...Mocks.AssetNodeFragmentBasic, computeKind};
+    const liveData = Mocks.LiveDataForNodeMaterialized;
+    const dimensions = getAssetNodeDimensions(def);
+
+    return (
+      <Box flex={{direction: 'column', gap: 0, alignItems: 'flex-start'}}>
+        <strong>{computeKind}</strong>
+        <div
+          style={{position: 'relative', width: 280, height: dimensions.height, overflowY: 'hidden'}}
+        >
+          <AssetNode definition={def} selected={false} liveData={liveData} />
+        </div>
+      </Box>
+    );
+  };
+
+  return (
+    <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
+      {Object.keys(KNOWN_TAGS).map(caseWithComputeKind)}
+      {caseWithComputeKind('Unknown-Kind-Long')}
+      {caseWithComputeKind('another')}
+    </Box>
+  );
 };

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.test.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.test.tsx
@@ -1,0 +1,42 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {TestProvider} from '../testing/TestProvider';
+
+import {AssetNode} from './AssetNode';
+import {
+  AssetNodeScenariosBase,
+  AssetNodeScenariosPartitioned,
+  AssetNodeScenariosSource,
+} from './AssetNode.mocks';
+import {displayNameForAssetKey} from './Utils';
+
+const Scenarios = [
+  ...AssetNodeScenariosBase,
+  ...AssetNodeScenariosPartitioned,
+  ...AssetNodeScenariosSource,
+];
+
+describe('AssetNode', () => {
+  Scenarios.forEach((scenario) =>
+    it(`renders ${scenario.expectedText.join(',')} when ${scenario.title}`, async () => {
+      render(
+        <TestProvider>
+          <AssetNode
+            definition={scenario.definition}
+            liveData={scenario.liveData}
+            selected={false}
+          />
+        </TestProvider>,
+      );
+
+      await waitFor(() => {
+        const displayName = displayNameForAssetKey(scenario.definition.assetKey);
+        expect(screen.getByText(displayName)).toBeVisible();
+        for (const text of scenario.expectedText) {
+          expect(screen.getByText(new RegExp(text))).toBeVisible();
+        }
+      });
+    }),
+  );
+});

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -181,7 +181,7 @@ export function buildAssetNodeStatusRow({
       content: (
         <>
           <Caption color={late ? Colors.Red700 : numMissing ? Colors.Yellow700 : Colors.Green700}>
-            {`${numPartitions.toLocaleString()} Partitions`}
+            {`${numPartitions.toLocaleString()} partitions`}
           </Caption>
           <Caption>
             <Link

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -136,6 +136,7 @@ export interface LiveDataForNode {
   lastObservation: AssetNodeLiveObservationFragment | null;
   currentLogicalVersion: string | null;
   projectedLogicalVersion: string | null;
+  partitionStats: {numMaterialized: number; numPartitions: number} | null;
 }
 
 export const MISSING_LIVE_DATA: LiveDataForNode = {
@@ -149,6 +150,7 @@ export const MISSING_LIVE_DATA: LiveDataForNode = {
   lastObservation: null,
   currentLogicalVersion: null,
   projectedLogicalVersion: null,
+  partitionStats: null,
   stepKey: '',
 };
 
@@ -211,6 +213,7 @@ export const buildLiveDataForNode = (
     freshnessPolicy: assetNode.freshnessPolicy,
     inProgressRunIds: assetLatestInfo?.inProgressRunIds || [],
     unstartedRunIds: assetLatestInfo?.unstartedRunIds || [],
+    partitionStats: assetNode.partitionStats || null,
     runWhichFailedToMaterialize,
   };
 };

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -229,6 +229,7 @@ export const getAssetNodeDimensions = (def: {
   opNames: string[];
   isSource: boolean;
   isObservable: boolean;
+  isPartitioned: boolean;
   graphName: string | null;
   description?: string | null;
   computeKind: string | null;
@@ -236,14 +237,14 @@ export const getAssetNodeDimensions = (def: {
   const width = 255;
 
   if (def.isSource && !def.isObservable) {
-    return {width, height: 40};
+    return {width, height: 72};
   } else {
-    let height = 60; // name + description
+    let height = 70; // name + description
 
     if (def.isSource) {
-      height += 36; // observed
+      height += 30; // observed
     } else {
-      height += 36; // status row
+      height += 26; // status row
     }
     if (def.computeKind) {
       height += 30; // tag

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNode.types.ts
@@ -22,6 +22,11 @@ export type AssetNodeLiveFragment = {
   } | null;
   freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
   assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+  partitionStats: {
+    __typename: 'PartitionStats';
+    numMaterialized: number;
+    numPartitions: number;
+  } | null;
 };
 
 export type AssetNodeLiveFreshnessPolicyFragment = {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -48,6 +48,11 @@ export type AssetGraphLiveQuery = {
     } | null;
     freshnessInfo: {__typename: 'AssetFreshnessInfo'; currentMinutesLate: number | null} | null;
     assetObservations: Array<{__typename: 'ObservationEvent'; timestamp: string; runId: string}>;
+    partitionStats: {
+      __typename: 'PartitionStats';
+      numMaterialized: number;
+      numPartitions: number;
+    } | null;
   }>;
   assetsLatestInfo: Array<{
     __typename: 'AssetLatestInfo';

--- a/js_modules/dagit/packages/core/src/graph/OpTags.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpTags.tsx
@@ -30,7 +30,7 @@ interface OpTagsProps {
   reduceText?: boolean;
 }
 
-const KNOWN_TAGS = {
+export const KNOWN_TAGS = {
   jupyter: {
     color: '#4E4E4E',
     icon: jupyter,

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -167,22 +167,27 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
         ) : null}
         <RowCell>
           {liveData?.lastMaterialization ? (
-            <Box flex={{gap: 4, alignItems: 'flex-start', justifyContent: 'space-between'}}>
-              <AssetRunLink
-                runId={liveData.lastMaterialization.runId}
-                event={{
-                  stepKey: liveData.stepKey,
-                  timestamp: liveData.lastMaterialization.timestamp,
-                }}
-              >
-                <TimestampDisplay
-                  timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
-                  timeFormat={{showSeconds: false, showTimezone: false}}
-                />
-              </AssetRunLink>
-              <div style={{marginTop: '-2px'}}>
-                <StaleTag liveData={liveData} />
-              </div>
+            <Box flex={{direction: 'column'}}>
+              <Box flex={{gap: 4, alignItems: 'flex-start', justifyContent: 'space-between'}}>
+                <AssetRunLink
+                  runId={liveData.lastMaterialization.runId}
+                  event={{
+                    stepKey: liveData.stepKey,
+                    timestamp: liveData.lastMaterialization.timestamp,
+                  }}
+                >
+                  <TimestampDisplay
+                    timestamp={Number(liveData.lastMaterialization.timestamp) / 1000}
+                    timeFormat={{showSeconds: false, showTimezone: false}}
+                  />
+                </AssetRunLink>
+                <div style={{marginTop: '-2px'}}>
+                  <StaleTag liveData={liveData} />
+                </div>
+              </Box>
+              {liveData.partitionStats && (
+                <AssetPartitionStatsText stats={liveData.partitionStats} />
+              )}
             </Box>
           ) : (
             <LoadingOrNone queryResult={queryResult} noneString={'\u2013'} />
@@ -202,6 +207,20 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
         </RowCell>
       </RowGrid>
     </Row>
+  );
+};
+
+const AssetPartitionStatsText: React.FC<{
+  stats: {numMaterialized: number; numPartitions: number};
+}> = ({stats}) => {
+  const {numMaterialized, numPartitions} = stats;
+  const numMissing = numPartitions - numMaterialized;
+  return (
+    <span>
+      {numMissing > 0
+        ? `${numPartitions.toLocaleString()} Partitions (${numMissing.toLocaleString()} missing)`
+        : `${numPartitions.toLocaleString()} Partitions`}
+    </span>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
@@ -53,6 +53,11 @@ export type SingleAssetQuery = {
             timestamp: string;
             runId: string;
           }>;
+          partitionStats: {
+            __typename: 'PartitionStats';
+            numMaterialized: number;
+            numPartitions: number;
+          } | null;
           partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
         } | null;
         key: {__typename: 'AssetKey'; path: Array<string>};


### PR DESCRIPTION
### Summary & Motivation

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/1037212/215374800-f406a981-03dd-496c-9062-8068aeac8053.png">

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/1037212/215374827-3222409f-967b-40dc-885e-7e986bf1cf71.png">

### How I Tested These Changes

Looked at a wide range of assets in the asset graph, updated storybook

<img width="683" alt="image" src="https://user-images.githubusercontent.com/1037212/215374755-33d77efb-be1a-40dd-8617-6b27df3bee60.png">

Also added storybooks for all of the partner tags 

<img width="1477" alt="image" src="https://user-images.githubusercontent.com/1037212/216724597-1b3217d4-aedf-470f-a8d2-ad9032fbbb11.png">
