### PR TITLE
Fix k8s_job_op with multiple containers

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -573,7 +573,9 @@ class DagsterKubernetesClient:
             else:
                 raise DagsterK8sError("Should not get here, unknown pod state")
 
-    def retrieve_pod_logs(self, pod_name: str, namespace: str) -> str:
+    def retrieve_pod_logs(
+        self, pod_name: str, namespace: str, container_name: Optional[str] = None
+    ) -> str:
         """Retrieves the raw pod logs for the pod named `pod_name` from Kubernetes.
 
         Args:
@@ -592,5 +594,5 @@ class DagsterKubernetesClient:
         #
         # https://github.com/kubernetes-client/python/issues/811
         return self.core_api.read_namespaced_pod_log(
-            name=pod_name, namespace=namespace, _preload_content=False
+            name=pod_name, namespace=namespace, container=container_name, _preload_content=False
         ).data.decode("utf-8")

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -715,6 +715,8 @@ def construct_dagster_k8s_job(
 
     user_defined_resources = container_config.pop("resources", {})
 
+    container_name = container_config.pop("name", "dagster")
+
     volume_mounts = job_config.volume_mounts + user_defined_k8s_volume_mounts
 
     resources = user_defined_resources if user_defined_resources else job_config.resources
@@ -724,7 +726,7 @@ def construct_dagster_k8s_job(
     container_config = merge_dicts(
         container_config,
         {
-            "name": "dagster",
+            "name": container_name,
             "image": job_image,
             "image_pull_policy": job_config.image_pull_policy,
             "env": [*env, *job_config.env, *user_defined_env_vars],

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -207,6 +207,8 @@ def execute_k8s_job(
     if command:
         container_config["command"] = command
 
+    container_name = container_config.get("name", "dagster")
+
     op_container_context = K8sContainerContext(
         image_pull_policy=image_pull_policy,
         image_pull_secrets=image_pull_secrets,
@@ -315,7 +317,10 @@ def execute_k8s_job(
     api_client.wait_for_pod(pod_to_watch, namespace, wait_timeout=timeout, start_time=start_time)
 
     log_stream = watch.stream(
-        api_client.core_api.read_namespaced_pod_log, name=pod_to_watch, namespace=namespace
+        api_client.core_api.read_namespaced_pod_log,
+        name=pod_to_watch,
+        namespace=namespace,
+        container=container_name,
     )
 
     while True:


### PR DESCRIPTION
Summary:
Some of these APIs require a container name if there are more than one. Explicitly pass in the container_name (and allow it to be overridden instead of always overriding it as "dagster").

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
