### PR TITLE
[pyright] [examples/docs-snippets] misc

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -296,7 +296,7 @@ def op_1():
     return [1, 2, 3]
 
 
-@op(ins=In(input_manager_key="pandas_series"))
+@op(ins={"a": In(input_manager_key="pandas_series")})
 def op_2(a):
     return pd.concat([a, pd.Series([4, 5, 6])])
 

--- a/docs/content/concepts/ops-jobs-graphs/graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/graphs.mdx
@@ -336,6 +336,7 @@ def subtract(left: int, right: int) -> int:
 
 def construct_graph_with_yaml(yaml_file, op_defs) -> GraphDefinition:
     yaml_data = load_yaml_from_path(yaml_file)
+    assert isinstance(yaml_data, dict)
 
     deps = {}
 

--- a/docs/content/concepts/partitions-schedules-sensors/asset-sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/asset-sensors.mdx
@@ -67,14 +67,14 @@ from dagster import FreshnessPolicySensorContext, freshness_policy_sensor
 
 @freshness_policy_sensor(asset_selection=AssetSelection.all())
 def my_freshness_alerting_sensor(context: FreshnessPolicySensorContext):
-    if context.current_minutes_late is None or context.previous_minutes_late is None:
+    if context.minutes_late is None or context.previous_minutes_late is None:
         return
 
-    if context.current_minutes_late >= 10 and context.previous_minutes_late < 10:
+    if context.minutes_late >= 10 and context.previous_minutes_late < 10:
         send_alert(
             f"Asset with key {context.asset_key} is now more than 10 minutes late."
         )
-    elif context.current_minutes_late == 0 and context.previous_minutes_late >= 10:
+    elif context.minutes_late == 0 and context.previous_minutes_late >= 10:
         send_alert(f"Asset with key {context.asset_key} is now on time.")
 ```
 

--- a/docs/content/guides/dagster/branch_deployments.mdx
+++ b/docs/content/guides/dagster/branch_deployments.mdx
@@ -130,7 +130,7 @@ Because we want to configure our assets to write to Snowflake using a different 
 # __init__.py
 from dagster import Definitions
 
-from .assets import comments, items, stories
+from ..assets import comments, items, stories
 
 snowflake_config = {
     "account": "abc1234.us-east-1",

--- a/docs/content/guides/dagster/run-attribution.mdx
+++ b/docs/content/guides/dagster/run-attribution.mdx
@@ -27,6 +27,7 @@ from dagster._core.storage.pipeline_run import DagsterRun
 class CustomRunCoordinator(QueuedRunCoordinator):
     def submit_run(self, context: SubmitRunContext) -> DagsterRun:
         desired_header = context.get_request_header(CUSTOM_HEADER_NAME)
+        ...
 ```
 
 Then we can parse the relevant header (in this case, called the `jwt_claims_header`) with any custom hook. In the following example, we're decoding a JWT header which contains the user's email.

--- a/docs/content/integrations/airflow/from-airflow-to-dagster.mdx
+++ b/docs/content/integrations/airflow/from-airflow-to-dagster.mdx
@@ -26,7 +26,7 @@ with DAG(
         "retries": 1,
     },
     description="A simple tutorial DAG",
-    schedule=timedelta(days=1),
+    schedule_interval=timedelta(days=1),
     start_date=datetime(2021, 1, 1),
     catchup=False,
     tags=["example"],

--- a/docs/content/integrations/airflow/migrating-to-dagster.mdx
+++ b/docs/content/integrations/airflow/migrating-to-dagster.mdx
@@ -39,7 +39,7 @@ import os
 from dagster_airflow import make_dagster_repo_from_airflow_dags_path
 
 migrated_airflow_repo = make_dagster_repo_from_airflow_dags_path(
-    os.path.join(os.getenv("AIRFLOW_HOME"), "dags"),
+    os.path.join(os.environ["AIRFLOW_HOME"], "dags"),
     "migrated_airflow_repo",
 )
 ```
@@ -59,7 +59,7 @@ from airflow.models import Connection
 from dagster_airflow import make_dagster_repo_from_airflow_dags_path
 
 migrated_airflow_repo = make_dagster_repo_from_airflow_dags_path(
-    os.path.join(os.getenv("AIRFLOW_HOME"), "dags"),
+    os.path.join(os.environ["AIRFLOW_HOME"], "dags"),
     "migrated_airflow_repo",
     connections=[
         Connection(conn_id="http_default", conn_type="uri", host="https://google.com")

--- a/docs/content/integrations/airflow/reference.mdx
+++ b/docs/content/integrations/airflow/reference.mdx
@@ -19,7 +19,7 @@ import os
 from dagster_airflow import make_dagster_repo_from_airflow_dags_path
 
 migrated_airflow_repo = make_dagster_repo_from_airflow_dags_path(
-    os.path.join(os.getenv("AIRFLOW_HOME"), "dags"),
+    os.path.join(os.environ["AIRFLOW_HOME"], "dags"),
     "migrated_airflow_repo",
 )
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_group_module.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_group_module.py
@@ -1,5 +1,5 @@
-# isort: skip_file
-# pylint: disable=import-error
+# pyright: reportMissingImports=false
+# isort: off
 
 from dagster import (
     load_assets_from_package_module,

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -76,7 +76,7 @@ def middle_asset(upstream_asset):
     return add_one(upstream_asset)
 
 
-middle_asset = AssetsDefinition.from_graph(middle_asset)
+middle_asset = AssetsDefinition.from_graph(middle_asset)  # type: ignore
 
 
 @asset
@@ -88,7 +88,7 @@ def downstream_asset(middle_asset):
 
 basic_deps_job = define_asset_job(
     "basic_deps_job",
-    AssetSelection.assets(upstream_asset, middle_asset, downstream_asset),
+    AssetSelection.assets(upstream_asset, middle_asset, downstream_asset),  # type: ignore
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -40,7 +41,7 @@ def write_dataframe_to_table(*_args, **_kwargs):
     pass
 
 
-pd_series_io_manager = None
+pd_series_io_manager: Any = None
 
 # start_different_input_managers
 
@@ -50,7 +51,7 @@ def op_1():
     return [1, 2, 3]
 
 
-@op(ins=In(input_manager_key="pandas_series"))
+@op(ins={"a": In(input_manager_key="pandas_series")})
 def op_2(a):
     return pd.concat([a, pd.Series([4, 5, 6])])
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dep_dsl.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/dep_dsl.py
@@ -25,6 +25,7 @@ def subtract(left: int, right: int) -> int:
 
 def construct_graph_with_yaml(yaml_file, op_defs) -> GraphDefinition:
     yaml_data = load_yaml_from_path(yaml_file)
+    assert isinstance(yaml_data, dict)
 
     deps = {}
 

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
@@ -52,6 +52,7 @@ def my_input_op(abc, xyz):
 
 # start_typed_input_op_marker
 
+
 MyDagsterType = DagsterType(
     type_check_fn=lambda _, value: value % 2 == 0, name="MyDagsterType"
 )

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -48,7 +48,7 @@ def configurable_job():
 
 @schedule(job=configurable_job, cron_schedule="0 0 * * *")
 def configurable_job_schedule(context: ScheduleEvaluationContext):
-    scheduled_date = context.scheduled_execution_time.strftime("%Y-%m-%d")
+    scheduled_date = context.scheduled_execution_time.strftime("%Y-%m-%d")  # type: ignore  # (didactic)
     return RunRequest(
         run_key=None,
         run_config={

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
@@ -28,7 +28,7 @@ def my_asset_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry
             "ops": {
                 "read_materialization": {
                     "config": {
-                        "asset_key": asset_event.dagster_event.asset_key.path,
+                        "asset_key": asset_event.dagster_event.asset_key.path,  # type: ignore
                     }
                 }
             }
@@ -50,14 +50,14 @@ from dagster import FreshnessPolicySensorContext, freshness_policy_sensor
 
 @freshness_policy_sensor(asset_selection=AssetSelection.all())
 def my_freshness_alerting_sensor(context: FreshnessPolicySensorContext):
-    if context.current_minutes_late is None or context.previous_minutes_late is None:
+    if context.minutes_late is None or context.previous_minutes_late is None:
         return
 
-    if context.current_minutes_late >= 10 and context.previous_minutes_late < 10:
+    if context.minutes_late >= 10 and context.previous_minutes_late < 10:
         send_alert(
             f"Asset with key {context.asset_key} is now more than 10 minutes late."
         )
-    elif context.current_minutes_late == 0 and context.previous_minutes_late >= 10:
+    elif context.minutes_late == 0 and context.previous_minutes_late >= 10:
         send_alert(f"Asset with key {context.asset_key} is now on time.")
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -223,7 +223,7 @@ def the_db_connection(init_context):
     get_the_db_connection(init_context.resources.credentials)
 
 
-@sensor(job=the_job)
+@sensor(job=the_job)  # type: ignore  # (didactic)
 def uses_db_connection():
     with build_resources(
         {"db_connection": the_db_connection, "credentials": the_credentials}

--- a/examples/docs_snippets/docs_snippets/concepts/types/object_type.py
+++ b/examples/docs_snippets/docs_snippets/concepts/types/object_type.py
@@ -14,7 +14,7 @@ EvenDagsterType = PythonObjectDagsterType(EvenType, name="EvenDagsterType")
 
 # start_use_object_type
 @op
-def double_even(even_num: EvenDagsterType) -> EvenDagsterType:
+def double_even(even_num: EvenDagsterType) -> EvenDagsterType:  # type: ignore
     return EvenType(even_num.num * 2)
 
 

--- a/examples/docs_snippets/docs_snippets/deploying/airflow/mounted.py
+++ b/examples/docs_snippets/docs_snippets/deploying/airflow/mounted.py
@@ -1,6 +1,6 @@
 from dagster_airflow.factory import make_airflow_dag
 
-dag, steps = make_airflow_dag(
+dag, steps = make_airflow_dag(  # type: ignore  # (unused code?)
     module_name="docs_snippets.intro_tutorial.airflow",
     pipeline_name="hello_cereal_pipeline",
     run_config={"storage": {"filesystem": {"config": {"base_dir": "/container_tmp"}}}},

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/cereal.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/cereal.py
@@ -12,7 +12,7 @@ from dagster import asset
 
 
 @asset
-def cereals():
+def cereals():  # type: ignore  # (didactic)
     response = requests.get("https://docs.dagster.io/assets/cereal.csv")
     lines = response.text.split("\n")
     cereal_rows = [row for row in csv.DictReader(lines)]

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v1.py
@@ -6,7 +6,7 @@ from dagster_snowflake_pandas import snowflake_pandas_io_manager
 # __init__.py
 from dagster import Definitions
 
-from .assets import comments, items, stories
+from ..assets import comments, items, stories
 
 snowflake_config = {
     "account": "abc1234.us-east-1",

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v2.py
@@ -5,7 +5,7 @@ from dagster_snowflake_pandas import snowflake_pandas_io_manager
 
 from dagster import Definitions
 
-from .assets import comments, items, stories
+from ..assets import comments, items, stories
 from .clone_and_drop_db import clone_prod
 
 snowflake_config = {

--- a/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py
@@ -8,8 +8,9 @@ from dagster._core.storage.pipeline_run import DagsterRun
 
 
 class CustomRunCoordinator(QueuedRunCoordinator):
-    def submit_run(self, context: SubmitRunContext) -> DagsterRun:
+    def submit_run(self, context: SubmitRunContext) -> DagsterRun:  # type: ignore  # (didactic)
         desired_header = context.get_request_header(CUSTOM_HEADER_NAME)
+        ...
 
 
 # end_custom_run_coordinator_marker

--- a/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository.py
@@ -1,3 +1,5 @@
+# pyright: reportMissingImports=none
+
 # start
 # __init__.py
 

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/dags/tutorial.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/dags/tutorial.py
@@ -10,7 +10,7 @@ with DAG(
         "retries": 1,
     },
     description="A simple tutorial DAG",
-    schedule=timedelta(days=1),
+    schedule_interval=timedelta(days=1),
     start_date=datetime(2021, 1, 1),
     catchup=False,
     tags=["example"],
@@ -40,4 +40,4 @@ with DAG(
         bash_command=templated_command,
     )
 
-    t1 >> [t2, t3]
+    t1 >> [t2, t3]  # type: ignore

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/migrate_repo.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/migrate_repo.py
@@ -3,6 +3,6 @@ import os
 from dagster_airflow import make_dagster_repo_from_airflow_dags_path
 
 migrated_airflow_repo = make_dagster_repo_from_airflow_dags_path(
-    os.path.join(os.getenv("AIRFLOW_HOME"), "dags"),
+    os.path.join(os.environ["AIRFLOW_HOME"], "dags"),
     "migrated_airflow_repo",
 )

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/migrate_repo_connections.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/migrate_repo_connections.py
@@ -4,7 +4,7 @@ from airflow.models import Connection
 from dagster_airflow import make_dagster_repo_from_airflow_dags_path
 
 migrated_airflow_repo = make_dagster_repo_from_airflow_dags_path(
-    os.path.join(os.getenv("AIRFLOW_HOME"), "dags"),
+    os.path.join(os.environ["AIRFLOW_HOME"], "dags"),
     "migrated_airflow_repo",
     connections=[
         Connection(conn_id="http_default", conn_type="uri", host="https://google.com")

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/configuration.py
@@ -1,4 +1,10 @@
-iris_dataset = None
+from dagster import asset
+
+
+@asset
+def iris_dataset():
+    return None
+
 
 # start_example
 

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_type_factories_tests/test_pandas_dagster_types_examples.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_type_factories_tests/test_pandas_dagster_types_examples.py
@@ -17,7 +17,8 @@ from docs_snippets.guides.dagster.dagster_type_factories.simple_example import (
     set_has_element_type_factory,
 )
 
-EBIKE_TRIPS_PATH = os.path.join(example_root.__path__[0], "ebike_trips.csv")
+example_root_path = next(iter(example_root.__path__))
+EBIKE_TRIPS_PATH = os.path.join(example_root_path, "ebike_trips.csv")
 
 
 def test_simple_example_one_off():

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_type_guide.py
@@ -1,3 +1,7 @@
+# pyright: reportGeneralTypeIssues=none
+
+# Disable reportGeneralTypeIssues here due to use of Dagster types in annotations
+
 import typing
 
 import pytest


### PR DESCRIPTION
### Summary & Motivation

Fix some type errors (and a few straight-up runtime errors) in docs snippets. Note that `# type: ignore` comments added to snippets are stripped from their rendered form in the docs (I added this functionality in a PR a few weeks ago). Notes:

- I fixed one error by adding an `assert isinstance` on some data loaded from yaml, this seems to me to be the most universally understandable approach for user-facing content.
- The `@schedule` correction in the airflow tutorial was approved by @Ramshackle-Jamathon over slack

### How I Tested These Changes

BK