### PR TITLE
[pyright] [dagster-databricks] misc

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -349,7 +349,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
             # allow for retry if we get malformed data
             return backoff(
                 fn=_get_step_records,
-                retry_on=(pickle.UnpicklingError, gzip.BadGzipFile, zlib.error, EOFError),
+                retry_on=(pickle.UnpicklingError, OSError, zlib.error, EOFError),
                 max_retries=4,
             )
         # if you poll before the Databricks process has had a chance to create the file,


### PR DESCRIPTION
### Summary & Motivation

Fix type error. `gzip.BadGzipFile` is not defined in Python 3.7, it throws the base class `OSError` instead.

### How I Tested These Changes

BK