### PR TITLE
fix GQL snapshot tests on py310

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -37,7 +37,6 @@ def get_partition_sets_or_error(
 ) -> "GraphenePartitionSets":
     from ..schema.partition_sets import GraphenePartitionSet, GraphenePartitionSets
 
-    check.inst_param(graphene_info, "graphene_info", HasContext)
     check.inst_param(repository_selector, "repository_selector", RepositorySelector)
     check.str_param(pipeline_name, "pipeline_name")
     location = graphene_info.context.get_repository_location(repository_selector.location_name)
@@ -72,7 +71,6 @@ def get_partition_set(
 ) -> Union["GraphenePartitionSet", "GraphenePartitionSetNotFoundError"]:
     from ..schema.partition_sets import GraphenePartitionSet, GraphenePartitionSetNotFoundError
 
-    check.inst_param(graphene_info, "graphene_info", HasContext)
     check.inst_param(repository_selector, "repository_selector", RepositorySelector)
     check.str_param(partition_set_name, "partition_set_name")
     location = graphene_info.context.get_repository_location(repository_selector.location_name)
@@ -92,7 +90,6 @@ def get_partition_set(
 def get_partition_by_name(graphene_info, repository_handle, partition_set, partition_name):
     from ..schema.partition_sets import GraphenePartition
 
-    check.inst_param(graphene_info, "graphene_info", HasContext)
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.inst_param(partition_set, "partition_set", ExternalPartitionSet)
     check.str_param(partition_name, "partition_name")


### PR DESCRIPTION
### Summary & Motivation

A previous PR I merged had some `check` calls that failed only on 3.10 (related to checking a `Protocol`). This is causing BK master to fail. This PR removes the check calls and fixes the error.

### How I Tested These Changes

BK with `test-py310`, ensuring tests failing on master are run in this PR's feature branch.
