### PR TITLE
CachingProjectedLogicalVersionResolver -> CachingStaleStatusResolver

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -10,7 +10,9 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.logical_version import CachingStaleStatusResolver
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.host_representation.external_data import (
@@ -23,7 +25,6 @@ from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from dagster_graphql.implementation.loader import (
     CrossRepoAssetDependedByLoader,
-    ProjectedLogicalVersionLoader,
 )
 
 if TYPE_CHECKING:
@@ -130,7 +131,9 @@ def get_asset_node_definition_collisions(
     return results
 
 
-def get_asset_nodes_by_asset_key(graphene_info) -> Mapping[AssetKey, "GrapheneAssetNode"]:
+def get_asset_nodes_by_asset_key(
+    graphene_info: "HasContext",
+) -> Mapping[AssetKey, "GrapheneAssetNode"]:
     """
     If multiple repositories have asset nodes for the same asset key, chooses the asset node that
     has an op.
@@ -139,10 +142,9 @@ def get_asset_nodes_by_asset_key(graphene_info) -> Mapping[AssetKey, "GrapheneAs
 
     depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
 
-    projected_logical_version_loader = ProjectedLogicalVersionLoader(
+    stale_status_loader = CachingStaleStatusResolver(
         instance=graphene_info.context.instance,
-        key_to_node_map={node.asset_key: node for _, _, node in asset_node_iter(graphene_info)},
-        repositories=unique_repos(repo for _, repo, _ in asset_node_iter(graphene_info)),
+        asset_graph=ExternalAssetGraph.from_workspace(graphene_info.context),
     )
 
     asset_nodes_by_asset_key: Dict[AssetKey, GrapheneAssetNode] = {}
@@ -154,7 +156,7 @@ def get_asset_nodes_by_asset_key(graphene_info) -> Mapping[AssetKey, "GrapheneAs
                 repo,
                 external_asset_node,
                 depended_by_loader=depended_by_loader,
-                projected_logical_version_loader=projected_logical_version_loader,
+                stale_status_loader=stale_status_loader,
             )
 
     return asset_nodes_by_asset_key

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -12,7 +12,6 @@ from dagster import (
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.logical_version import CachingStaleStatusResolver
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.host_representation.external import ExternalRepository
 from dagster._core.host_representation.external_data import (
@@ -25,6 +24,7 @@ from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from dagster_graphql.implementation.loader import (
     CrossRepoAssetDependedByLoader,
+    StaleStatusLoader,
 )
 
 if TYPE_CHECKING:
@@ -142,7 +142,7 @@ def get_asset_nodes_by_asset_key(
 
     depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
 
-    stale_status_loader = CachingStaleStatusResolver(
+    stale_status_loader = StaleStatusLoader(
         instance=graphene_info.context.instance,
         asset_graph=ExternalAssetGraph.from_workspace(graphene_info.context),
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -8,6 +8,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.logical_version import CachingStaleStatusResolver
 from dagster._core.events.log import EventLogEntry
 from dagster._core.host_representation import ExternalRepository
 from dagster._core.host_representation.external_data import (
@@ -437,3 +438,7 @@ class CrossRepoAssetDependedByLoader:
         return external_asset_deps.get((repository_location_name, repository_name), {}).get(
             asset_key, []
         )
+
+
+# CachingStaleStatusResolver from core can be used directly as a GQL batch loader.
+StaleStatusLoader = CachingStaleStatusResolver

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -8,9 +8,6 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.logical_version import (
-    CachingProjectedLogicalVersionResolver,
-)
 from dagster._core.events.log import EventLogEntry
 from dagster._core.host_representation import ExternalRepository
 from dagster._core.host_representation.external_data import (
@@ -440,26 +437,3 @@ class CrossRepoAssetDependedByLoader:
         return external_asset_deps.get((repository_location_name, repository_name), {}).get(
             asset_key, []
         )
-
-
-class ProjectedLogicalVersionLoader:
-    """
-    A batch loader that computes the projected logical version for a set of asset keys. This is
-    necessary to avoid recomputation, since each asset's logical version is a function of its
-    dependency logical versions. We use similar functionality in core, so this loader simply proxies
-    to `CachingProjectedLogicalVersionResolver` and extracts the string value of the returned
-    `LogicalVersion` objects.
-    """
-
-    def __init__(
-        self,
-        instance: DagsterInstance,
-        repositories: Sequence[ExternalRepository],
-        key_to_node_map: Optional[Mapping[AssetKey, ExternalAssetNode]],
-    ):
-        self._caching_resolver = CachingProjectedLogicalVersionResolver(
-            instance, repositories, key_to_node_map
-        )
-
-    def get(self, asset_key: AssetKey) -> str:
-        return self._caching_resolver.get(asset_key).value

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -6,7 +6,6 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.logical_version import CachingStaleStatusResolver
 from dagster._core.host_representation import (
     ExternalRepository,
     GrpcServerRepositoryLocation,
@@ -27,6 +26,7 @@ from dagster._core.workspace.context import (
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
 from dagster_graphql.implementation.loader import (
     RepositoryScopedBatchLoader,
+    StaleStatusLoader,
 )
 
 from .asset_graph import GrapheneAssetGroup, GrapheneAssetNode
@@ -225,7 +225,7 @@ class GrapheneRepository(graphene.ObjectType):
         )
         check.inst_param(instance, "instance", DagsterInstance)
         self._batch_loader = RepositoryScopedBatchLoader(instance, repository)
-        self._stale_status_loader = CachingStaleStatusResolver(
+        self._stale_status_loader = StaleStatusLoader(
             instance=instance,
             asset_graph=ExternalAssetGraph.from_external_repository(repository),
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -4,7 +4,6 @@ import dagster._check as check
 import graphene
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
-from dagster._core.definitions.logical_version import CachingStaleStatusResolver
 from dagster._core.execution.backfill import BulkActionStatus
 from dagster._core.host_representation import (
     InstigatorSelector,
@@ -61,6 +60,7 @@ from ...implementation.fetch_solids import get_graph_or_error
 from ...implementation.loader import (
     BatchMaterializationLoader,
     CrossRepoAssetDependedByLoader,
+    StaleStatusLoader,
 )
 from ...implementation.run_config_schema import resolve_run_config_schema_or_error
 from ...implementation.utils import graph_selector_from_graphql, pipeline_selector_from_graphql
@@ -646,7 +646,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         else:
             asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
 
-        stale_status_loader = CachingStaleStatusResolver(
+        stale_status_loader = StaleStatusLoader(
             instance=graphene_info.context.instance,
             asset_graph=asset_graph,
         )

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -180,3 +180,6 @@ class ExternalAssetGraph(AssetGraph):
 
     def get_job_names(self, asset_key: AssetKey) -> Iterable[str]:
         return self._job_names_by_key[asset_key]
+
+    def get_asset_keys_for_job(self, job_name: str) -> Sequence[AssetKey]:
+        return [k for k in self.all_asset_keys if job_name in self.get_job_names(k)]

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -34,7 +34,7 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, Run
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._scheduler.stale import resolve_stale_assets
+from dagster._scheduler.stale import resolve_stale_or_unknown_assets
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
 
@@ -629,7 +629,7 @@ def _evaluate_sensor(
 
     for run_request in sensor_runtime_data.run_requests:
         if run_request.stale_assets_only:
-            stale_assets = resolve_stale_assets(workspace_process_context, run_request, external_sensor)  # type: ignore
+            stale_assets = resolve_stale_or_unknown_assets(workspace_process_context, run_request, external_sensor)  # type: ignore
             # asset selection is empty set after filtering for stale
             if len(stale_assets) == 0:
                 continue

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -34,7 +34,7 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, Run
 from dagster._core.storage.tags import RUN_KEY_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.telemetry import SCHEDULED_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._scheduler.stale import resolve_stale_assets
+from dagster._scheduler.stale import resolve_stale_or_unknown_assets
 from dagster._seven.compat.pendulum import to_timezone
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.log import default_date_format_string
@@ -609,7 +609,7 @@ def _schedule_runs_at_time(
 
     for run_request in schedule_execution_data.run_requests:
         if run_request.stale_assets_only:
-            stale_assets = resolve_stale_assets(workspace_process_context, run_request, external_schedule)  # type: ignore
+            stale_assets = resolve_stale_or_unknown_assets(workspace_process_context, run_request, external_schedule)  # type: ignore
             # asset selection is empty set after filtering for stale
             if len(stale_assets) == 0:
                 continue

--- a/python_modules/dagster/dagster/_scheduler/stale.py
+++ b/python_modules/dagster/dagster/_scheduler/stale.py
@@ -1,90 +1,34 @@
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import List, Sequence, Union
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.logical_version import (
-    DEFAULT_LOGICAL_VERSION,
-    CachingProjectedLogicalVersionResolver,
-    LogicalVersion,
-    extract_logical_version_from_entry,
+    CachingStaleStatusResolver,
+    StaleStatus,
 )
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.host_representation.external import (
-    ExternalRepository,
     ExternalSchedule,
     ExternalSensor,
 )
-from dagster._core.host_representation.external_data import ExternalAssetNode
-from dagster._core.instance import DagsterInstance
-from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
+from dagster._core.workspace.context import WorkspaceProcessContext
 
 
-def resolve_stale_assets(
+def resolve_stale_or_unknown_assets(
     context: WorkspaceProcessContext,
     run_request: RunRequest,
     instigator: Union[ExternalSensor, ExternalSchedule],
 ) -> Sequence[AssetKey]:
-    request_context = context.create_request_context()
-    repositories = _get_repositories(request_context)
-    key_to_node_map = _get_asset_nodes_by_asset_key(repositories)
+    asset_graph = ExternalAssetGraph.from_workspace(context.create_request_context())
     asset_selection = (
         run_request.asset_selection
         if run_request.asset_selection is not None
-        else _get_assets_for_job(check.not_none(instigator.pipeline_name), key_to_node_map.values())
+        else asset_graph.get_asset_keys_for_job(check.not_none(instigator.pipeline_name))
     )
-    resolver = CachingProjectedLogicalVersionResolver(
-        context.instance, repositories, key_to_node_map
-    )
-    stale_keys: List[AssetKey] = []
+    resolver = CachingStaleStatusResolver(context.instance, asset_graph)
+    stale_or_unknown_keys: List[AssetKey] = []
     for asset_key in asset_selection:
-        projected_logical_version = resolver.get(asset_key)
-        current_logical_version = _get_current_logical_version(
-            key_to_node_map[asset_key], context.instance
-        )
-        if projected_logical_version != current_logical_version:
-            stale_keys.append(asset_key)
-    return stale_keys
-
-
-def _get_repositories(context: WorkspaceRequestContext) -> Sequence[ExternalRepository]:
-    return [
-        repo for loc in context.repository_locations for repo in loc.get_repositories().values()
-    ]
-
-
-def _get_asset_nodes_by_asset_key(
-    repositories: Sequence[ExternalRepository],
-) -> Mapping[AssetKey, ExternalAssetNode]:
-    """
-    If multiple repositories have asset nodes for the same asset key, chooses the asset node that
-    has an op.
-    """
-    asset_nodes_by_asset_key: Dict[AssetKey, ExternalAssetNode] = {}
-    for repository in repositories:
-        for external_asset_node in repository.get_external_asset_nodes():
-            preexisting_node = asset_nodes_by_asset_key.get(external_asset_node.asset_key)
-            if preexisting_node is None or preexisting_node.is_source:
-                asset_nodes_by_asset_key[external_asset_node.asset_key] = external_asset_node
-    return asset_nodes_by_asset_key
-
-
-def _get_current_logical_version(
-    node: ExternalAssetNode, instance: DagsterInstance
-) -> Optional[LogicalVersion]:
-    event = instance.get_latest_logical_version_record(
-        node.asset_key,
-        node.is_source,
-    )
-    if event is None and node.is_source:
-        return DEFAULT_LOGICAL_VERSION
-    elif event is None:
-        return None
-    else:
-        logical_version = extract_logical_version_from_entry(event.event_log_entry)
-        return logical_version or DEFAULT_LOGICAL_VERSION
-
-
-def _get_assets_for_job(
-    job_name: str, all_nodes: Iterable[ExternalAssetNode]
-) -> Sequence[AssetKey]:
-    return [node.asset_key for node in all_nodes if job_name in node.job_names]
+        if resolver.get_status(asset_key) in [StaleStatus.STALE, StaleStatus.UNKNOWN]:
+            stale_or_unknown_keys.append(asset_key)
+    return stale_or_unknown_keys


### PR DESCRIPTION
### Summary & Motivation

Significant refactor of `CachingProjectedLogicalVersionResolver` and its GQL proxy `ProjectedLogicalVersionLoader`:

- New `StaleStatus` enum to indicate stale status for an asset. Three values:
    - FRESH (currentLogicalVersion == projectedLogicalVersion)
    - STALE (currentLogicalVersion != projectedLogicalVersion)
    - UNKNOWN (projectedLogicalVersion is unknown)
- `CachingProjectedLogicalVersionResolver` is now `CachingStaleStatusResolver`. It allows retrieval of current logical version, projected logical version, or stale status for a key.
- `CachingStaleStatusResolver` uses `ExternalAssetGraph` instead of the previous `Mapping[AssetKey, ExternalAssetNode]`
- `ProjectedLogicalVersionLoader` is gone-- GQL resolvers now directly use `CachingStaleStatusResolver`

Anytime we want stale status without other, you can now construct a `CachingStaleStatusResolver` and just call `get_status` (cc @owenkephart). In this PR I updated the stale schedule/sensor logic to use this.

### How I Tested These Changes

This doesn't hit any public APIs, so existing BK tests.
