### PR TITLE
[easy] List dagster_world.mp4 in static files

### DIFF
--- a/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
+++ b/js_modules/dagit/packages/app/src/NUX/CommunityNux.tsx
@@ -108,7 +108,7 @@ const Form: React.FC<{
           </ExternalAnchorButton>
         </Box>
         <video autoPlay muted loop playsInline width={120} height={120}>
-          <source src="/Dagster_world.mp4" type="video/mp4" />
+          <source src={`${process.env.PUBLIC_URL}/Dagster_world.mp4`} type="video/mp4" />
         </video>
       </Box>
       <Box flex={{direction: 'column', justifyContent: 'stretch', gap: 12}}>

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -44,6 +44,7 @@ ROOT_ADDRESS_STATIC_RESOURCES = [
     "/favicon-run-success.svg",
     "/asset-manifest.json",
     "/robots.txt",
+    "/Dagster_world.mp4",
 ]
 
 T_IWorkspaceProcessContext = TypeVar("T_IWorkspaceProcessContext", bound=IWorkspaceProcessContext)


### PR DESCRIPTION
### Summary & Motivation

We need to list /Dagster_world.mp4 as a static route... Really we should just iterate all of the files in the folder and expose them though imo.

### How I Tested These Changes

The video loaded locally on port 3333

<img width="997" alt="Screen Shot 2023-01-30 at 11 16 24 AM" src="https://user-images.githubusercontent.com/2286579/215532166-cfb275ab-ad50-4e43-a45b-b11a259359d9.png">

