### PR TITLE
[pythonic config] Add structured RunConfig object for specifying runtime, job config

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from typing import (
-    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -37,9 +36,6 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 
 # Prefix for auto created jobs that are used to materialize assets
 ASSET_BASE_JOB_PREFIX = "__ASSET_JOB"
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.run_config import ConfigInput
 
 
 def is_base_asset_job_name(name) -> bool:
@@ -98,9 +94,7 @@ def build_assets_job(
     source_assets: Optional[Sequence[Union[SourceAsset, AssetsDefinition]]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
-    config: Optional[
-        Union[ConfigMapping, Mapping[str, object], PartitionedConfig[object], "ConfigInput"]
-    ] = None,
+    config: Optional[Union[ConfigMapping, Mapping[str, object], PartitionedConfig[object]]] = None,
     tags: Optional[Mapping[str, str]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition[object]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -39,7 +39,7 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 ASSET_BASE_JOB_PREFIX = "__ASSET_JOB"
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.run_config import RunConfig
+    from dagster._core.definitions.run_config import ConfigInput
 
 
 def is_base_asset_job_name(name) -> bool:
@@ -99,7 +99,7 @@ def build_assets_job(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
     config: Optional[
-        Union[ConfigMapping, Mapping[str, object], PartitionedConfig[object], "RunConfig"]
+        Union[ConfigMapping, Mapping[str, object], PartitionedConfig[object], "ConfigInput"]
     ] = None,
     tags: Optional[Mapping[str, str]] = None,
     executor_def: Optional[ExecutorDefinition] = None,

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -1,5 +1,17 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from toposort import CircularDependencyError, toposort
 
@@ -25,6 +37,9 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 
 # Prefix for auto created jobs that are used to materialize assets
 ASSET_BASE_JOB_PREFIX = "__ASSET_JOB"
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.run_config import RunConfig
 
 
 def is_base_asset_job_name(name) -> bool:
@@ -83,7 +98,9 @@ def build_assets_job(
     source_assets: Optional[Sequence[Union[SourceAsset, AssetsDefinition]]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     description: Optional[str] = None,
-    config: Optional[Union[ConfigMapping, Mapping[str, object], PartitionedConfig[object]]] = None,
+    config: Optional[
+        Union[ConfigMapping, Mapping[str, object], PartitionedConfig[object], "RunConfig"]
+    ] = None,
     tags: Optional[Mapping[str, str]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition[object]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     from .job_definition import JobDefinition
     from .op_definition import OpDefinition
     from .partition import PartitionedConfig, PartitionsDefinition
+    from .run_config import RunConfig
     from .source_asset import SourceAsset
 
 T = TypeVar("T")
@@ -533,7 +534,9 @@ class GraphDefinition(NodeDefinition):
         name: Optional[str] = None,
         description: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-        config: Optional[Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]"]] = None,
+        config: Optional[
+            Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]", "RunConfig"]
+        ] = None,
         tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -63,7 +63,6 @@ if TYPE_CHECKING:
     from .job_definition import JobDefinition
     from .op_definition import OpDefinition
     from .partition import PartitionedConfig, PartitionsDefinition
-    from .run_config import ConfigInput
     from .source_asset import SourceAsset
 
 T = TypeVar("T")
@@ -534,9 +533,7 @@ class GraphDefinition(NodeDefinition):
         name: Optional[str] = None,
         description: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-        config: Optional[
-            Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]", "ConfigInput"]
-        ] = None,
+        config: Optional[Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]"]] = None,
         tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from .job_definition import JobDefinition
     from .op_definition import OpDefinition
     from .partition import PartitionedConfig, PartitionsDefinition
-    from .run_config import RunConfig
+    from .run_config import ConfigInput
     from .source_asset import SourceAsset
 
 T = TypeVar("T")
@@ -535,7 +535,7 @@ class GraphDefinition(NodeDefinition):
         description: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         config: Optional[
-            Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]", "RunConfig"]
+            Union[ConfigMapping, Mapping[str, object], "PartitionedConfig[T]", "ConfigInput"]
         ] = None,
         tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -75,7 +75,6 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.run_config import ConfigInput
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.execution.resources_init import InitResourceContext
     from dagster._core.instance import DagsterInstance
@@ -95,9 +94,7 @@ class JobDefinition(PipelineDefinition):
         executor_def: Optional[ExecutorDefinition] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         name: Optional[str] = None,
-        config: Optional[
-            Union[ConfigMapping, Mapping[str, object], PartitionedConfig, "ConfigInput"]
-        ] = None,
+        config: Optional[Union[ConfigMapping, Mapping[str, object], PartitionedConfig]] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         tags: Optional[Mapping[str, Any]] = None,
@@ -295,7 +292,7 @@ class JobDefinition(PipelineDefinition):
     @public
     def execute_in_process(
         self,
-        run_config: Optional[Union[Mapping[str, Any], "ConfigInput"]] = None,
+        run_config: Optional[Mapping[str, Any]] = None,
         instance: Optional["DagsterInstance"] = None,
         partition_key: Optional[str] = None,
         raise_on_error: bool = True,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -110,7 +110,7 @@ class JobDefinition(PipelineDefinition):
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
     ):
-        from dagster._core.definitions.run_config import ConfigInput, convert_config_input
+        from dagster._core.definitions.run_config import RunConfig, convert_config_input
         from dagster._loggers import default_loggers
 
         check.inst_param(graph_def, "graph_def", GraphDefinition)
@@ -146,7 +146,7 @@ class JobDefinition(PipelineDefinition):
         name = check_valid_name(check.opt_str_param(name, "name", default=graph_def.name))
 
         config = check.opt_inst_param(
-            config, "config", (Mapping, ConfigMapping, PartitionedConfig, ConfigInput)
+            config, "config", (Mapping, ConfigMapping, PartitionedConfig, RunConfig)
         )
         config = convert_config_input(config)
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -75,7 +75,7 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 from .version_strategy import VersionStrategy
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.run_config import RunConfig
+    from dagster._core.definitions.run_config import ConfigInput
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.execution.resources_init import InitResourceContext
     from dagster._core.instance import DagsterInstance
@@ -96,7 +96,7 @@ class JobDefinition(PipelineDefinition):
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         name: Optional[str] = None,
         config: Optional[
-            Union[ConfigMapping, Mapping[str, object], PartitionedConfig, "RunConfig"]
+            Union[ConfigMapping, Mapping[str, object], PartitionedConfig, "ConfigInput"]
         ] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
@@ -113,7 +113,7 @@ class JobDefinition(PipelineDefinition):
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
     ):
-        from dagster._core.definitions.run_config import RunConfig, convert_run_config
+        from dagster._core.definitions.run_config import ConfigInput, convert_config_input
         from dagster._loggers import default_loggers
 
         check.inst_param(graph_def, "graph_def", GraphDefinition)
@@ -149,9 +149,9 @@ class JobDefinition(PipelineDefinition):
         name = check_valid_name(check.opt_str_param(name, "name", default=graph_def.name))
 
         config = check.opt_inst_param(
-            config, "config", (Mapping, ConfigMapping, PartitionedConfig, RunConfig)
+            config, "config", (Mapping, ConfigMapping, PartitionedConfig, ConfigInput)
         )
-        config = convert_run_config(config)
+        config = convert_config_input(config)
 
         description = check.opt_str_param(description, "description")
         partitions_def = check.opt_inst_param(
@@ -295,7 +295,7 @@ class JobDefinition(PipelineDefinition):
     @public
     def execute_in_process(
         self,
-        run_config: Optional[Union[Mapping[str, Any], "RunConfig"]] = None,
+        run_config: Optional[Union[Mapping[str, Any], "ConfigInput"]] = None,
         instance: Optional["DagsterInstance"] = None,
         partition_key: Optional[str] = None,
         raise_on_error: bool = True,
@@ -338,10 +338,10 @@ class JobDefinition(PipelineDefinition):
 
         """
         from dagster._core.definitions.executor_definition import execute_in_process_executor
-        from dagster._core.definitions.run_config import convert_run_config
+        from dagster._core.definitions.run_config import convert_config_input
         from dagster._core.execution.execute_in_process import core_execute_in_process
 
-        run_config = check.opt_mapping_param(convert_run_config(run_config), "run_config")
+        run_config = check.opt_mapping_param(convert_config_input(run_config), "run_config")
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)
         asset_selection = check.opt_sequence_param(asset_selection, "asset_selection", AssetKey)
 

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -686,12 +686,12 @@ def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-class RunConfig:
+class ConfigInput:
     def __init__(
         self,
         loggers: Optional[Dict[str, Any]] = None,
         resources: Optional[Dict[str, Any]] = None,
-        ops: Optional[Dict[str, Any]] = None,
+        ops: Optional[Dict[str, Config]] = None,
     ):
         self.loggers = check.opt_dict_param(loggers, "loggers")
         self.resources = check.opt_dict_param(resources, "resources")
@@ -705,13 +705,13 @@ class RunConfig:
         }
 
 
-CoercibleToRunConfig: TypeAlias = Union[Dict[str, Any], RunConfig]
+CoercibleToConfigInput: TypeAlias = Union[Dict[str, Any], ConfigInput]
 
 T = TypeVar("T")
 
 
-def convert_run_config(input: Union[CoercibleToRunConfig, T]) -> Union[T, Mapping[str, Any]]:
-    if isinstance(input, RunConfig):
+def convert_config_input(input: Union[CoercibleToConfigInput, T]) -> Union[T, Mapping[str, Any]]:
+    if isinstance(input, ConfigInput):
         return input.to_config_dict()
     else:
         return input

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -689,13 +689,13 @@ def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
 class RunConfig:
     def __init__(
         self,
+        ops: Optional[Dict[str, Config]] = None,
         loggers: Optional[Dict[str, Any]] = None,
         resources: Optional[Dict[str, Any]] = None,
-        ops: Optional[Dict[str, Config]] = None,
     ):
+        self.ops = check.opt_dict_param(ops, "ops")
         self.loggers = check.opt_dict_param(loggers, "loggers")
         self.resources = check.opt_dict_param(resources, "resources")
-        self.ops = check.opt_dict_param(ops, "ops")
 
     def to_config_dict(self):
         return {

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -692,23 +692,16 @@ class RunConfig:
         loggers: Optional[Dict[str, Any]] = None,
         resources: Optional[Dict[str, Any]] = None,
         ops: Optional[Dict[str, Any]] = None,
-        assets: Optional[Dict[str, Any]] = None,
     ):
         self.loggers = check.opt_dict_param(loggers, "loggers")
         self.resources = check.opt_dict_param(resources, "resources")
-
-        check.invariant(
-            ops is None or assets is None, "Cannot specify both ops and assets config in RunConfig"
-        )
-        self.op_or_asset_config = (
-            check.opt_dict_param(ops, "ops") if ops else check.opt_dict_param(assets, "assets")
-        )
+        self.ops = check.opt_dict_param(ops, "ops")
 
     def to_config_dict(self):
         return {
             "loggers": self.loggers,
             "resources": _convert_config_classes(self.resources),
-            "ops": _convert_config_classes(self.op_or_asset_config),
+            "ops": _convert_config_classes(self.ops),
         }
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -14,7 +14,6 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel
 from typing_extensions import TypeAlias
 
 from dagster._config import (
@@ -689,13 +688,13 @@ def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
 class RunConfig:
     def __init__(
         self,
-        ops: Optional[Dict[str, Config]] = None,
-        loggers: Optional[Dict[str, Any]] = None,
+        ops: Optional[Dict[str, Any]] = None,
         resources: Optional[Dict[str, Any]] = None,
+        loggers: Optional[Dict[str, Any]] = None,
     ):
         self.ops = check.opt_dict_param(ops, "ops")
-        self.loggers = check.opt_dict_param(loggers, "loggers")
         self.resources = check.opt_dict_param(resources, "resources")
+        self.loggers = check.opt_dict_param(loggers, "loggers")
 
     def to_config_dict(self):
         return {

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -2,14 +2,20 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Dict,
     Iterator,
     Mapping,
     NamedTuple,
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
+    Union,
     cast,
 )
+
+from pydantic import BaseModel
+from typing_extensions import TypeAlias
 
 from dagster._config import (
     ALL_CONFIG_BUILTINS,
@@ -20,6 +26,7 @@ from dagster._config import (
     Selector,
     Shape,
 )
+from dagster._config.structured_config import Config
 from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.executor_definition import (
     ExecutorDefinition,
@@ -670,3 +677,48 @@ def construct_config_type_dictionary(
         type_dict_by_key[config_type.key] = config_type
 
     return type_dict_by_name, type_dict_by_key
+
+
+def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        k: {"config": v._as_config_dict() if isinstance(v, Config) else v}
+        for k, v in configs.items()
+    }
+
+
+class RunConfig:
+    def __init__(
+        self,
+        loggers: Optional[Dict[str, Any]] = None,
+        resources: Optional[Dict[str, Any]] = None,
+        ops: Optional[Dict[str, Any]] = None,
+        assets: Optional[Dict[str, Any]] = None,
+    ):
+        self.loggers = check.opt_dict_param(loggers, "loggers")
+        self.resources = check.opt_dict_param(resources, "resources")
+
+        check.invariant(
+            ops is None or assets is None, "Cannot specify both ops and assets config in RunConfig"
+        )
+        self.op_or_asset_config = (
+            check.opt_dict_param(ops, "ops") if ops else check.opt_dict_param(assets, "assets")
+        )
+
+    def to_config_dict(self):
+        return {
+            "loggers": self.loggers,
+            "resources": _convert_config_classes(self.resources),
+            "ops": _convert_config_classes(self.op_or_asset_config),
+        }
+
+
+CoercibleToRunConfig: TypeAlias = Union[Dict[str, Any], RunConfig]
+
+T = TypeVar("T")
+
+
+def convert_run_config(input: Union[CoercibleToRunConfig, T]) -> Union[T, Mapping[str, Any]]:
+    if isinstance(input, RunConfig):
+        return input.to_config_dict()
+    else:
+        return input

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -686,7 +686,7 @@ def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-class ConfigInput:
+class RunConfig:
     def __init__(
         self,
         loggers: Optional[Dict[str, Any]] = None,
@@ -705,13 +705,13 @@ class ConfigInput:
         }
 
 
-CoercibleToConfigInput: TypeAlias = Union[Dict[str, Any], ConfigInput]
+CoercibleToRunConfig: TypeAlias = Union[Dict[str, Any], RunConfig]
 
 T = TypeVar("T")
 
 
-def convert_config_input(input: Union[CoercibleToConfigInput, T]) -> Union[T, Mapping[str, Any]]:
-    if isinstance(input, ConfigInput):
+def convert_config_input(input: Union[CoercibleToRunConfig, T]) -> Union[T, Mapping[str, Any]]:
+    if isinstance(input, RunConfig):
         return input.to_config_dict()
     else:
         return input

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Optional, Sequ
 
 import dagster._check as check
 from dagster._core.definitions import AssetKey
-from dagster._core.definitions.run_config import RunConfig, convert_run_config
+from dagster._core.definitions.run_config import ConfigInput, convert_config_input
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.selector.subset_selector import parse_clause
@@ -48,7 +48,7 @@ class UnresolvedAssetJobDefinition(
         name: str,
         selection: "AssetSelection",
         config: Optional[
-            Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig", RunConfig]
+            Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig", ConfigInput]
         ] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
@@ -65,7 +65,7 @@ class UnresolvedAssetJobDefinition(
             cls,
             name=check.str_param(name, "name"),
             selection=check.inst_param(selection, "selection", AssetSelection),
-            config=convert_run_config(config),
+            config=convert_config_input(config),
             description=check.opt_str_param(description, "description"),
             tags=check.opt_mapping_param(tags, "tags"),
             partitions_def=check.opt_inst_param(
@@ -232,7 +232,7 @@ def define_asset_job(
         ]
     ] = None,
     config: Optional[
-        Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]", RunConfig]
+        Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]", ConfigInput]
     ] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Optional, Sequ
 
 import dagster._check as check
 from dagster._core.definitions import AssetKey
+from dagster._core.definitions.run_config import RunConfig, convert_run_config
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.selector.subset_selector import parse_clause
@@ -31,7 +32,10 @@ class UnresolvedAssetJobDefinition(
         [
             ("name", str),
             ("selection", "AssetSelection"),
-            ("config", Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]]),
+            (
+                "config",
+                Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]],
+            ),
             ("description", Optional[str]),
             ("tags", Optional[Mapping[str, Any]]),
             ("partitions_def", Optional["PartitionsDefinition"]),
@@ -43,7 +47,9 @@ class UnresolvedAssetJobDefinition(
         cls,
         name: str,
         selection: "AssetSelection",
-        config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]] = None,
+        config: Optional[
+            Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig", RunConfig]
+        ] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
@@ -59,7 +65,7 @@ class UnresolvedAssetJobDefinition(
             cls,
             name=check.str_param(name, "name"),
             selection=check.inst_param(selection, "selection", AssetSelection),
-            config=config,
+            config=convert_run_config(config),
             description=check.opt_str_param(description, "description"),
             tags=check.opt_mapping_param(tags, "tags"),
             partitions_def=check.opt_inst_param(
@@ -225,7 +231,9 @@ def define_asset_job(
             str, Sequence[str], Sequence[AssetKey], Sequence["AssetsDefinition"], "AssetSelection"
         ]
     ] = None,
-    config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"]] = None,
+    config: Optional[
+        Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]", RunConfig]
+    ] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
     partitions_def: Optional["PartitionsDefinition[Any]"] = None,

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Optional, Sequ
 
 import dagster._check as check
 from dagster._core.definitions import AssetKey
-from dagster._core.definitions.run_config import ConfigInput, convert_config_input
+from dagster._core.definitions.run_config import convert_config_input
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.selector.subset_selector import parse_clause
@@ -47,9 +47,7 @@ class UnresolvedAssetJobDefinition(
         cls,
         name: str,
         selection: "AssetSelection",
-        config: Optional[
-            Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig", ConfigInput]
-        ] = None,
+        config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
         partitions_def: Optional["PartitionsDefinition"] = None,
@@ -231,9 +229,7 @@ def define_asset_job(
             str, Sequence[str], Sequence[AssetKey], Sequence["AssetsDefinition"], "AssetSelection"
         ]
     ] = None,
-    config: Optional[
-        Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]", ConfigInput]
-    ] = None,
+    config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"]] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
     partitions_def: Optional["PartitionsDefinition[Any]"] = None,

--- a/python_modules/dagster/dagster/_core/execution/validate_run_config.py
+++ b/python_modules/dagster/dagster/_core/execution/validate_run_config.py
@@ -1,13 +1,14 @@
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Mapping, Optional, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions import JobDefinition, PipelineDefinition
+from dagster._core.definitions.run_config import RunConfig, convert_run_config
 from dagster._core.system_config.objects import ResolvedRunConfig
 
 
 def validate_run_config(
     job_def: Optional[JobDefinition] = None,
-    run_config: Optional[Mapping[str, Any]] = None,
+    run_config: Optional[Union[Mapping[str, Any], RunConfig]] = None,
     mode: Optional[str] = None,
     pipeline_def: Optional[PipelineDefinition] = None,
 ) -> Mapping[str, Any]:
@@ -30,7 +31,7 @@ def validate_run_config(
     """
     job_def = check.opt_inst_param(job_def, "job_def", (JobDefinition, PipelineDefinition))
     pipeline_def = check.opt_inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
-    run_config = check.opt_mapping_param(run_config, "run_config", key_type=str)
+    run_config = check.opt_mapping_param(convert_run_config(run_config), "run_config", key_type=str)
 
     if job_def and pipeline_def:
         check.failed("Cannot specify both a job_def and a pipeline_def")

--- a/python_modules/dagster/dagster/_core/execution/validate_run_config.py
+++ b/python_modules/dagster/dagster/_core/execution/validate_run_config.py
@@ -1,14 +1,14 @@
-from typing import Any, Mapping, Optional, Union, cast
+from typing import Any, Mapping, Optional, cast
 
 import dagster._check as check
 from dagster._core.definitions import JobDefinition, PipelineDefinition
-from dagster._core.definitions.run_config import ConfigInput, convert_config_input
+from dagster._core.definitions.run_config import convert_config_input
 from dagster._core.system_config.objects import ResolvedRunConfig
 
 
 def validate_run_config(
     job_def: Optional[JobDefinition] = None,
-    run_config: Optional[Union[Mapping[str, Any], ConfigInput]] = None,
+    run_config: Optional[Mapping[str, Any]] = None,
     mode: Optional[str] = None,
     pipeline_def: Optional[PipelineDefinition] = None,
 ) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_core/execution/validate_run_config.py
+++ b/python_modules/dagster/dagster/_core/execution/validate_run_config.py
@@ -2,13 +2,13 @@ from typing import Any, Mapping, Optional, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions import JobDefinition, PipelineDefinition
-from dagster._core.definitions.run_config import RunConfig, convert_run_config
+from dagster._core.definitions.run_config import ConfigInput, convert_config_input
 from dagster._core.system_config.objects import ResolvedRunConfig
 
 
 def validate_run_config(
     job_def: Optional[JobDefinition] = None,
-    run_config: Optional[Union[Mapping[str, Any], RunConfig]] = None,
+    run_config: Optional[Union[Mapping[str, Any], ConfigInput]] = None,
     mode: Optional[str] = None,
     pipeline_def: Optional[PipelineDefinition] = None,
 ) -> Mapping[str, Any]:
@@ -31,7 +31,9 @@ def validate_run_config(
     """
     job_def = check.opt_inst_param(job_def, "job_def", (JobDefinition, PipelineDefinition))
     pipeline_def = check.opt_inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
-    run_config = check.opt_mapping_param(convert_run_config(run_config), "run_config", key_type=str)
+    run_config = check.opt_mapping_param(
+        convert_config_input(run_config), "run_config", key_type=str
+    )
 
     if job_def and pipeline_def:
         check.failed("Cannot specify both a job_def and a pipeline_def")

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -25,7 +25,7 @@ from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_output import Resource
-from dagster._core.definitions.run_config import RunConfig
+from dagster._core.definitions.run_config import ConfigInput
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.init import InitResourceContext
@@ -370,7 +370,7 @@ def test_runtime_config_run_config_obj():
 
     out_txt = []
 
-    class WriterResource(Resource):
+    class WriterResource(ConfigurableResource):
         prefix: str
 
         def output(self, text: str) -> None:
@@ -387,7 +387,7 @@ def test_runtime_config_run_config_obj():
 
     assert (
         defs.get_implicit_global_asset_job_def()
-        .execute_in_process(RunConfig(resources={"writer": WriterResource(prefix="greeting: ")}))
+        .execute_in_process(ConfigInput(resources={"writer": WriterResource(prefix="greeting: ")}))
         .success
     )
     assert out_txt == ["greeting: hello, world!"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, List, Mapping
 
 import pytest
+
 from dagster import IOManager, asset, job, op, resource
 from dagster._check import CheckError
 from dagster._config.field import Field
@@ -24,6 +25,7 @@ from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_output import Resource
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.init import InitResourceContext
@@ -357,6 +359,35 @@ def test_structured_resource_runtime_config():
     assert (
         defs.get_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"writer": {"config": {"prefix": "greeting: "}}}})
+        .success
+    )
+    assert out_txt == ["greeting: hello, world!"]
+
+
+def test_runtime_config_run_config_obj():
+    # Use RunConfig to specify resource config
+    # in a structured format at runtime rather than using a dict
+
+    out_txt = []
+
+    class WriterResource(Resource):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    @asset
+    def hello_world_asset(writer: WriterResource):
+        writer.output("hello, world!")
+
+    defs = Definitions(
+        assets=[hello_world_asset],
+        resources={"writer": WriterResource.configure_at_launch()},
+    )
+
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(RunConfig(resources={"writer": WriterResource(prefix="greeting: ")}))
         .success
     )
     assert out_txt == ["greeting: hello, world!"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_output import Resource
-from dagster._core.definitions.run_config import ConfigInput
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.init import InitResourceContext
@@ -386,7 +386,7 @@ def test_runtime_config_run_config_obj():
 
     assert (
         defs.get_implicit_global_asset_job_def()
-        .execute_in_process(ConfigInput(resources={"writer": WriterResource(prefix="greeting: ")}))
+        .execute_in_process(RunConfig(resources={"writer": WriterResource(prefix="greeting: ")}))
         .success
     )
     assert out_txt == ["greeting: hello, world!"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -8,7 +8,6 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, List, Mapping
 
 import pytest
-
 from dagster import IOManager, asset, job, op, resource
 from dagster._check import CheckError
 from dagster._config.field import Field

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -23,7 +23,7 @@ from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.run_config import ConfigInput
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
 from dagster._core.execution.context.invocation import build_op_context
@@ -361,12 +361,12 @@ def test_validate_run_config():
     }
 
     result_with_runconfig = validate_run_config(
-        pipeline_requires_config, ConfigInput(ops={"requires_config": {"foo": "bar"}})
+        pipeline_requires_config, RunConfig(ops={"requires_config": {"foo": "bar"}})
     )
     assert result_with_runconfig == result
 
     result_with_structured_in = validate_run_config(
-        pipeline_requires_config, ConfigInput(ops={"requires_config": MyBasicOpConfig(foo="bar")})
+        pipeline_requires_config, RunConfig(ops={"requires_config": MyBasicOpConfig(foo="bar")})
     )
     assert result_with_structured_in == result
 
@@ -653,7 +653,7 @@ def test_structured_run_config_ops():
         a_struct_config_op()
 
     a_job.execute_in_process(
-        ConfigInput(ops={"a_struct_config_op": ANewConfigOpConfig(a_string="foo", an_int=2)})
+        RunConfig(ops={"a_struct_config_op": ANewConfigOpConfig(a_string="foo", an_int=2)})
     )
     assert executed["yes"]
 
@@ -676,7 +676,7 @@ def test_structured_run_config_multi_asset():
         build_assets_job(
             "blah",
             [two_assets],
-            config=ConfigInput(ops={"two_assets": AMultiAssetConfig(a_string="foo", an_int=2)}),
+            config=RunConfig(ops={"two_assets": AMultiAssetConfig(a_string="foo", an_int=2)}),
         )
         .execute_in_process()
         .success
@@ -701,7 +701,7 @@ def test_structured_run_config_assets():
         build_assets_job(
             "blah",
             [my_asset],
-            config=ConfigInput(
+            config=RunConfig(
                 ops={
                     "my_asset": AnAssetConfig(a_string="foo", an_int=2),
                 }
@@ -717,7 +717,7 @@ def test_structured_run_config_assets():
     my_asset_job = define_asset_job(
         "my_asset_job",
         selection="my_asset",
-        config=ConfigInput(
+        config=RunConfig(
             ops={
                 "my_asset": AnAssetConfig(a_string="foo", an_int=2),
             }
@@ -734,7 +734,7 @@ def test_structured_run_config_assets():
     del executed["yes"]
     asset_result = materialize(
         [my_asset],
-        run_config=ConfigInput(
+        run_config=RunConfig(
             ops={
                 "my_asset": AnAssetConfig(a_string="foo", an_int=2),
             }

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -21,6 +21,7 @@ from dagster._config.structured_config import Config, infer_schema_from_config_c
 from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.run_config import RunConfig
 from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
 from dagster._core.execution.context.invocation import build_op_context
 from dagster._legacy import pipeline
@@ -147,7 +148,13 @@ def test_with_assets():
         build_assets_job(
             "blah",
             [my_asset],
-            config={"ops": {"my_asset": {"config": {"a_string": "foo", "an_int": 2}}}},
+            config={
+                "ops": {
+                    "my_asset": {
+                        "config": {"a_string": "foo", "an_int": 2},
+                    },
+                },
+            },
         )
         .execute_in_process()
         .success
@@ -349,6 +356,16 @@ def test_validate_run_config():
         "resources": {"io_manager": {"config": None}},
         "loggers": {},
     }
+
+    result_with_runconfig = validate_run_config(
+        pipeline_requires_config, RunConfig(ops={"requires_config": {"foo": "bar"}})
+    )
+    assert result_with_runconfig == result
+
+    result_with_structured_in = validate_run_config(
+        pipeline_requires_config, RunConfig(ops={"requires_config": MyBasicOpConfig(foo="bar")})
+    )
+    assert result_with_structured_in == result
 
     result_with_storage = validate_run_config(
         pipeline_requires_config,
@@ -613,3 +630,33 @@ def test_env_var():
     finally:
         del os.environ["ENV_VARIABLE_FOR_TEST"]
         del os.environ["ENV_VARIABLE_FOR_TEST_INT"]
+
+
+def test_structured_run_config():
+    class AnAssetConfig(Config):
+        a_string: str
+        an_int: int
+
+    executed = {}
+
+    @asset
+    def my_asset(config: AnAssetConfig):
+        assert config.a_string == "foo"
+        assert config.an_int == 2
+        executed["yes"] = True
+
+    assert (
+        build_assets_job(
+            "blah",
+            [my_asset],
+            config=RunConfig(
+                assets={
+                    "my_asset": AnAssetConfig(a_string="foo", an_int=2),
+                }
+            ),
+        )
+        .execute_in_process()
+        .success
+    )
+
+    assert executed["yes"]

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -23,7 +23,7 @@ from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.run_config import RunConfig
+from dagster._core.definitions.run_config import ConfigInput
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
 from dagster._core.execution.context.invocation import build_op_context
@@ -361,12 +361,12 @@ def test_validate_run_config():
     }
 
     result_with_runconfig = validate_run_config(
-        pipeline_requires_config, RunConfig(ops={"requires_config": {"foo": "bar"}})
+        pipeline_requires_config, ConfigInput(ops={"requires_config": {"foo": "bar"}})
     )
     assert result_with_runconfig == result
 
     result_with_structured_in = validate_run_config(
-        pipeline_requires_config, RunConfig(ops={"requires_config": MyBasicOpConfig(foo="bar")})
+        pipeline_requires_config, ConfigInput(ops={"requires_config": MyBasicOpConfig(foo="bar")})
     )
     assert result_with_structured_in == result
 
@@ -653,7 +653,7 @@ def test_structured_run_config_ops():
         a_struct_config_op()
 
     a_job.execute_in_process(
-        RunConfig(ops={"a_struct_config_op": ANewConfigOpConfig(a_string="foo", an_int=2)})
+        ConfigInput(ops={"a_struct_config_op": ANewConfigOpConfig(a_string="foo", an_int=2)})
     )
     assert executed["yes"]
 
@@ -676,7 +676,7 @@ def test_structured_run_config_multi_asset():
         build_assets_job(
             "blah",
             [two_assets],
-            config=RunConfig(ops={"two_assets": AMultiAssetConfig(a_string="foo", an_int=2)}),
+            config=ConfigInput(ops={"two_assets": AMultiAssetConfig(a_string="foo", an_int=2)}),
         )
         .execute_in_process()
         .success
@@ -701,7 +701,7 @@ def test_structured_run_config_assets():
         build_assets_job(
             "blah",
             [my_asset],
-            config=RunConfig(
+            config=ConfigInput(
                 ops={
                     "my_asset": AnAssetConfig(a_string="foo", an_int=2),
                 }
@@ -717,7 +717,7 @@ def test_structured_run_config_assets():
     my_asset_job = define_asset_job(
         "my_asset_job",
         selection="my_asset",
-        config=RunConfig(
+        config=ConfigInput(
             ops={
                 "my_asset": AnAssetConfig(a_string="foo", an_int=2),
             }
@@ -734,7 +734,7 @@ def test_structured_run_config_assets():
     del executed["yes"]
     asset_result = materialize(
         [my_asset],
-        run_config=RunConfig(
+        run_config=ConfigInput(
             ops={
                 "my_asset": AnAssetConfig(a_string="foo", an_int=2),
             }


### PR DESCRIPTION
## Summary

In order to make ergonomics of configuring jobs etc easier, adds a new `RunConfig` object which takes and converts structured config into dict config.

Before:
```python
build_assets_job(
    "my_job",
    [my_asset],
    config={
        "ops": {
            "my_asset": {
                "config": {"a_string": "foo", "an_int": 2},
            },
        },
    },
)    
```

After:
```python
build_assets_job(
    "my_job",
    [my_asset],
    config=RunConfig(
        ops={
            "my_asset": AnAssetConfig(a_string="foo", an_int=2),
        }
    ),
)
```


## Test Plan

Unit tests.
