### PR TITLE
[dagit] Export GhostDaggy with tooltip for Cloud usage

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppTopNav.tsx
@@ -166,22 +166,28 @@ export const AppTopNavLogo: React.FC = () => {
         </ShortcutHandler>
       ) : null}
       <Box flex={{display: 'inline-flex'}} margin={{left: 8}}>
-        <DaggyTooltip
-          content={
-            <Box flex={{direction: 'row', gap: 4}}>
-              <WebSocketStatus />
-              <VersionNumber />
-            </Box>
-          }
-          placement="bottom"
-          modifiers={{offset: {enabled: true, options: {offset: [0, 18]}}}}
-        >
-          <Link to="/home" style={{outline: 0, display: 'flex'}}>
-            <GhostDaggy />
-          </Link>
-        </DaggyTooltip>
+        <GhostDaggyWithTooltip />
       </Box>
     </LogoContainer>
+  );
+};
+
+export const GhostDaggyWithTooltip = () => {
+  return (
+    <DaggyTooltip
+      content={
+        <Box flex={{direction: 'row', gap: 4}}>
+          <WebSocketStatus />
+          <VersionNumber />
+        </Box>
+      }
+      placement="bottom"
+      modifiers={{offset: {enabled: true, options: {offset: [0, 18]}}}}
+    >
+      <Link to="/home" style={{outline: 0, display: 'flex'}}>
+        <GhostDaggy />
+      </Link>
+    </DaggyTooltip>
   );
 };
 


### PR DESCRIPTION
### Summary & Motivation

Export "Ghost Daggy with tooltip" component for use in custom Cloud top nav for org settings.

### How I Tested These Changes

Lint/jest/ts in OSS.

Import component in custom top nav in Cloud, verify correct rendering and tooltip behavior.
