### PR TITLE
[dagster-fivetran] Add option to force-create materializations for tables not in API response

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -42,6 +42,7 @@ def _build_fivetran_assets(
     table_to_asset_key_map: Optional[Mapping[str, AssetKey]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     group_name: Optional[str] = None,
+    materialize_missing_tables: bool = False,
 ) -> Sequence[AssetsDefinition]:
     asset_key_prefix = check.opt_sequence_param(asset_key_prefix, "asset_key_prefix", of_type=str)
 
@@ -75,6 +76,8 @@ def _build_fivetran_assets(
             poll_interval=poll_interval,
             poll_timeout=poll_timeout,
         )
+
+        materialized_asset_keys = set()
         for materialization in generate_materializations(
             fivetran_output, asset_key_prefix=asset_key_prefix
         ):
@@ -88,8 +91,18 @@ def _build_fivetran_assets(
                         entry.label: entry.entry_data for entry in materialization.metadata_entries
                     },
                 )
+                materialized_asset_keys.add(materialization.asset_key)
+
             else:
                 yield materialization
+
+        unmaterialized_asset_keys = set(tracked_asset_keys.values()) - materialized_asset_keys
+        if unmaterialized_asset_keys and materialize_missing_tables:
+            for asset_key in unmaterialized_asset_keys:
+                yield Output(
+                    value=None,
+                    output_name="_".join(asset_key.path),
+                )
 
     return [_assets]
 
@@ -104,6 +117,7 @@ def build_fivetran_assets(
     asset_key_prefix: Optional[Sequence[str]] = None,
     metadata_by_table_name: Optional[Mapping[str, MetadataUserInput]] = None,
     group_name: Optional[str] = None,
+    materialize_missing_tables: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
     Build a set of assets for a given Fivetran connector.
@@ -129,6 +143,10 @@ def build_fivetran_assets(
             table name to user-supplied metadata that should be associated with the asset for that table.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. This
             group name will be applied to all assets produced by this multi_asset.
+        materialize_missing_tables (bool): If True, will create asset materializations for tables specified
+            in destination_tables even if they are not present in the Fivetran sync output. This is useful
+            in cases where Fivetran does not sync any data for a table and therefore does not include it
+            in the sync output API response.
 
     **Examples:**
 
@@ -174,6 +192,7 @@ def build_fivetran_assets(
         asset_key_prefix=asset_key_prefix,
         metadata_by_table_name=metadata_by_table_name,
         group_name=group_name,
+        materialize_missing_tables=materialize_missing_tables,
     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -42,7 +42,7 @@ def _build_fivetran_assets(
     table_to_asset_key_map: Optional[Mapping[str, AssetKey]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     group_name: Optional[str] = None,
-    materialize_missing_tables: bool = False,
+    infer_missing_tables: bool = False,
 ) -> Sequence[AssetsDefinition]:
     asset_key_prefix = check.opt_sequence_param(asset_key_prefix, "asset_key_prefix", of_type=str)
 
@@ -97,7 +97,7 @@ def _build_fivetran_assets(
                 yield materialization
 
         unmaterialized_asset_keys = set(tracked_asset_keys.values()) - materialized_asset_keys
-        if unmaterialized_asset_keys and materialize_missing_tables:
+        if unmaterialized_asset_keys and infer_missing_tables:
             for asset_key in unmaterialized_asset_keys:
                 yield Output(
                     value=None,
@@ -117,7 +117,7 @@ def build_fivetran_assets(
     asset_key_prefix: Optional[Sequence[str]] = None,
     metadata_by_table_name: Optional[Mapping[str, MetadataUserInput]] = None,
     group_name: Optional[str] = None,
-    materialize_missing_tables: bool = False,
+    infer_missing_tables: bool = False,
 ) -> Sequence[AssetsDefinition]:
     """
     Build a set of assets for a given Fivetran connector.
@@ -143,7 +143,7 @@ def build_fivetran_assets(
             table name to user-supplied metadata that should be associated with the asset for that table.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. This
             group name will be applied to all assets produced by this multi_asset.
-        materialize_missing_tables (bool): If True, will create asset materializations for tables specified
+        infer_missing_tables (bool): If True, will create asset materializations for tables specified
             in destination_tables even if they are not present in the Fivetran sync output. This is useful
             in cases where Fivetran does not sync any data for a table and therefore does not include it
             in the sync output API response.
@@ -192,7 +192,7 @@ def build_fivetran_assets(
         asset_key_prefix=asset_key_prefix,
         metadata_by_table_name=metadata_by_table_name,
         group_name=group_name,
-        materialize_missing_tables=materialize_missing_tables,
+        infer_missing_tables=infer_missing_tables,
     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -46,16 +46,17 @@ def test_fivetran_group_label(group_name, expected_group_name):
 
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix"])
 @pytest.mark.parametrize(
-    "tables,should_error",
+    "tables,materialize_missing_tables,should_error",
     [
-        ([], False),
-        (["schema1.tracked"], False),
-        (["schema1.tracked", "schema2.tracked"], False),
-        (["does.not_exist"], True),
-        (["schema1.tracked", "does.not_exist"], True),
+        ([], False, False),
+        (["schema1.tracked"], False, False),
+        (["schema1.tracked", "schema2.tracked"], False, False),
+        (["does.not_exist"], False, True),
+        (["schema1.tracked", "does.not_exist"], False, True),
+        (["schema1.tracked", "does.not_exist"], True, False),
     ],
 )
-def test_fivetran_asset_run(tables, should_error, schema_prefix):
+def test_fivetran_asset_run(tables, materialize_missing_tables, should_error, schema_prefix):
     ft_resource = fivetran_resource.configured({"api_key": "foo", "api_secret": "bar"})
     final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
     api_prefix = f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION_PATH}{FIVETRAN_CONNECTOR_PATH}{DEFAULT_CONNECTOR_ID}"
@@ -68,6 +69,7 @@ def test_fivetran_asset_run(tables, should_error, schema_prefix):
         destination_tables=tables,
         poll_interval=0.1,
         poll_timeout=10,
+        materialize_missing_tables=materialize_missing_tables,
     )
 
     # expect the multi asset to have one asset key and one output for each specified asset key
@@ -128,7 +130,7 @@ def test_fivetran_asset_run(tables, should_error, schema_prefix):
                 for event in result.events_for_node(f"fivetran_sync_{DEFAULT_CONNECTOR_ID}")
                 if event.event_type_value == "ASSET_MATERIALIZATION"
             ]
-            assert len(asset_materializations) == 3
+            assert len(asset_materializations) == 4 if materialize_missing_tables else 3
             found_asset_keys = set(
                 mat.event_specific_data.materialization.asset_key for mat in asset_materializations
             )
@@ -137,10 +139,14 @@ def test_fivetran_asset_run(tables, should_error, schema_prefix):
                     AssetKey(["the_prefix_schema1", "tracked"]),
                     AssetKey(["the_prefix_schema1", "untracked"]),
                     AssetKey(["the_prefix_schema2", "tracked"]),
-                }
+                } | (
+                    {AssetKey(["the_prefix_does", "not_exist"])}
+                    if materialize_missing_tables
+                    else set()
+                )
             else:
                 assert found_asset_keys == {
                     AssetKey(["schema1", "tracked"]),
                     AssetKey(["schema1", "untracked"]),
                     AssetKey(["schema2", "tracked"]),
-                }
+                } | ({AssetKey(["does", "not_exist"])} if materialize_missing_tables else set())


### PR DESCRIPTION
## Summary

Occasionally Fivetran seems not to include tables associated with a sync in the API response if no rows are actually synced. This can cause Dagster to error because no asset materialization is output when one is expected. See https://dagster.slack.com/archives/C01U954MEER/p1674732294303889 for report.

Adds a new `materialize_missing_tables` parameter which creates asset materializations for all tables that a user expects to sync, even if Fivetran does not return API information on those tables after a sync completes. 


## Test Plan

Added a unit test of this behavior.
