### PR TITLE
[gql] Add tags to AssetEventMixin

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -564,7 +564,13 @@ type MaterializationEvent implements MessageEvent & StepEvent & DisplayableEvent
   runOrError: RunOrError!
   stepStats: RunStepStats!
   partition: String
+  tags: [EventTag!]!
   assetLineage: [AssetLineageInfo!]!
+}
+
+type EventTag {
+  key: String!
+  value: String!
 }
 
 type AssetLineageInfo {
@@ -587,6 +593,7 @@ type ObservationEvent implements MessageEvent & StepEvent & DisplayableEvent {
   runOrError: RunOrError!
   stepStats: RunStepStats!
   partition: String
+  tags: [EventTag!]!
 }
 
 type TypeCheck implements DisplayableEvent {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1040,6 +1040,12 @@ export type EventConnection = {
 
 export type EventConnectionOrError = EventConnection | PythonError | RunNotFoundError;
 
+export type EventTag = {
+  __typename: 'EventTag';
+  key: Scalars['String'];
+  value: Scalars['String'];
+};
+
 export type ExecutionMetadata = {
   parentRunId?: InputMaybe<Scalars['String']>;
   rootRunId?: InputMaybe<Scalars['String']>;
@@ -1879,6 +1885,7 @@ export type MaterializationEvent = DisplayableEvent &
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
     stepStats: RunStepStats;
+    tags: Array<EventTag>;
     timestamp: Scalars['String'];
   };
 
@@ -2064,6 +2071,7 @@ export type ObservationEvent = DisplayableEvent &
     solidHandleID: Maybe<Scalars['String']>;
     stepKey: Maybe<Scalars['String']>;
     stepStats: RunStepStats;
+    tags: Array<EventTag>;
     timestamp: Scalars['String'];
   };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -351,8 +351,12 @@ class AssetEventMixin:
         return self._metadata.partition
 
     def resolve_tags(self, _graphene_info):
-        print("TAGS ARE: ", self._metadata.tags)
-        return self._metadata.tags
+        if self._metadata.tags is None:
+            return []
+        else:
+            return [
+                GrapheneEventTag(key=key, value=value) for key, value in self._metadata.tags.items()
+            ]
 
 
 class GrapheneMaterializationEvent(graphene.ObjectType, AssetEventMixin):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -7,6 +7,8 @@ from dagster._core.events import DagsterEventType
 from dagster._core.execution.plan.objects import ErrorSource
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot
 
+from dagster_graphql.schema.tags import GrapheneEventTag
+
 from ...implementation.events import construct_basic_params
 from ...implementation.fetch_runs import get_run_by_id, get_step_stats
 from ...implementation.loader import BatchRunLoader
@@ -314,6 +316,7 @@ class AssetEventMixin:
     runOrError = graphene.NonNull("dagster_graphql.schema.pipelines.pipeline.GrapheneRunOrError")
     stepStats = graphene.NonNull(lambda: GrapheneRunStepStats)
     partition = graphene.Field(graphene.String)
+    tags = non_null_list(GrapheneEventTag)
 
     def __init__(self, event, metadata):
         self._event = event
@@ -346,6 +349,9 @@ class AssetEventMixin:
 
     def resolve_partition(self, _graphene_info: ResolveInfo):
         return self._metadata.partition
+
+    def resolve_tags(self, _graphene_info):
+        return self._metadata.tags
 
 
 class GrapheneMaterializationEvent(graphene.ObjectType, AssetEventMixin):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/tags.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/tags.py
@@ -34,6 +34,17 @@ class GrapheneAssetTag(graphene.ObjectType):
         super().__init__(key=key, value=value)
 
 
+class GrapheneEventTag(graphene.ObjectType):
+    key = graphene.NonNull(graphene.String)
+    value = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "EventTag"
+
+    def __init__(self, key, value):
+        super().__init__(key=key, value=value)
+
+
 class GraphenePipelineTagAndValues(graphene.ObjectType):
     class Meta:
         description = """A run tag and the free-form values that have been associated

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -149,6 +149,12 @@ GET_ASSET_LOGICAL_VERSIONS = """
             id
             currentLogicalVersion
             projectedLogicalVersion
+            assetMaterializations {
+                tags {
+                    key
+                    value
+                }
+            }
         }
     }
 """

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
@@ -66,8 +66,9 @@ def test_logical_version_from_tags():
             assert _materialize_assets(context_v1, repo_v1)
             wait_for_runs_to_finish(context_v1.instance)
             result = _fetch_logical_versions(context_v1, repo_v1)
-            tags = result["assetNodes"][0]["assetMaterializations"][0]["tags"]
-            assert tags[LOGICAL_VERSION_TAG_KEY] == result["assetNodes"][0]["currentLogicalVersion"]
+            tags = result.data["assetNodes"][0]["assetMaterializations"][0]["tags"]
+            lv_tag = next(tag for tag in tags if tag["key"] == LOGICAL_VERSION_TAG_KEY)
+            assert lv_tag["value"] == result.data["assetNodes"][0]["currentLogicalVersion"]
 
 
 def get_repo_with_partitioned_self_dep_asset():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
@@ -6,6 +6,7 @@ from dagster import (
     asset,
     repository,
 )
+from dagster._core.definitions.logical_version import LOGICAL_VERSION_TAG_KEY
 from dagster._core.test_utils import instance_for_test, wait_for_runs_to_finish
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
@@ -56,6 +57,17 @@ def test_dependencies_changed():
             wait_for_runs_to_finish(context_v1.instance)
         with define_out_of_process_context(__file__, "get_repo_v2", instance) as context_v2:
             assert _fetch_logical_versions(context_v2, repo_v2)
+
+
+def test_logical_version_from_tags():
+    repo_v1 = get_repo_v1()
+    with instance_for_test() as instance:
+        with define_out_of_process_context(__file__, "get_repo_v1", instance) as context_v1:
+            assert _materialize_assets(context_v1, repo_v1)
+            wait_for_runs_to_finish(context_v1.instance)
+            result = _fetch_logical_versions(context_v1, repo_v1)
+            tags = result["assetNodes"][0]["assetMaterializations"][0]["tags"]
+            assert tags[LOGICAL_VERSION_TAG_KEY] == result["assetNodes"][0]["currentLogicalVersion"]
 
 
 def get_repo_with_partitioned_self_dep_asset():


### PR DESCRIPTION
### Summary & Motivation

Exposes tags to on `AssetEventMixin` (which is used for observations and materializations).

This is needed in order to pull the logical version off materialization/observation events for display in dagit-- see this [Slack thread](https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1675116079799869). cc @bengotow 

### How I Tested These Changes

Unit tests (in progress).