### PR TITLE
Fix black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
   rev: refs/tags/22.12.0:refs/tags/22.12.0
   hooks:
     - id: black-jupyter
+      # Make sure black reads its config from root `pyproject.toml`
+      args: ["--config", "pyproject.toml"]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.212
   hooks:


### PR DESCRIPTION
### Summary & Motivation

This adds args to the `black` pre-commit hook to ensure it always uses the config defined in the repo root `pyproject.toml`.
