### PR TITLE
Allow observable source assets to have no context argument

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset.py
@@ -1,5 +1,10 @@
+from dagster import Definitions
+from dagster._core.definitions.assets_job import (
+    build_source_asset_observation_job,
+)
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.logical_version import LogicalVersion
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.storage.io_manager import io_manager
@@ -23,7 +28,7 @@ def test_all_fields():
         group_name="rho",
     )
     def foo_source_asset(context):
-        return {"foo": "bar"}
+        raise Exception("not executed")
 
     assert foo_source_asset.key == AssetKey(["delta", "alpha"])
     assert foo_source_asset.description == "beta"
@@ -33,3 +38,24 @@ def test_all_fields():
     assert foo_source_asset.resource_defs == {"lambda": foo_manager}
     assert foo_source_asset.io_manager_def == foo_manager
     assert foo_source_asset.metadata == {"epsilon": MetadataValue.text("gamma")}
+
+
+def test_no_context_observable_asset():
+    executed = {}
+
+    @observable_source_asset
+    def observable_asset_no_context():
+        executed["yes"] = True
+        return LogicalVersion("version-string")
+
+    asset_job = build_source_asset_observation_job(
+        "source_job", source_assets=[observable_asset_no_context]
+    )
+
+    defs = Definitions(jobs=[asset_job], assets=[observable_asset_no_context])
+
+    job_def = defs.get_job_def("source_job")
+
+    assert job_def.execute_in_process().success
+
+    assert executed["yes"]


### PR DESCRIPTION
### Summary & Motivation

Observable source assets required a context argument even though their type signature said otherwise. This fixes that.

Resolves https://github.com/dagster-io/dagster/issues/10716

### How I Tested These Changes

Included unit test.
