### PR TITLE
Rename `_core.decorator_utils.is_context_provided`

### DIFF
--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -87,6 +87,14 @@ def format_docstring_for_description(fn: Callable) -> Optional[str]:
 # When/if `StrictTypeGuard` is supported, we can drop `is_context_not_provided` since a False from
 # `is_context_provided` will be sufficient.
 def is_context_provided(
-    fn: Union[Callable[Concatenate[T, P], R], Callable[P, R]]
+    fn: Union[Callable[Concatenate[T, P], R], Callable[P, R]],
+    valid_names: Optional[Sequence[str]] = None,
 ) -> TypeGuard[Callable[Concatenate[T, P], R]]:
-    return len(get_function_params(fn)) >= 1
+    params = get_function_params(fn)
+    if valid_names is None:
+        return len(params) >= 1
+    else:
+        valid_name_permutations = [
+            x for name in valid_names for x in get_valid_name_permutations(name)
+        ]
+        return len(params) >= 1 and params[0].name in valid_name_permutations

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -86,15 +86,7 @@ def format_docstring_for_description(fn: Callable) -> Optional[str]:
 # error arising from assuming
 # When/if `StrictTypeGuard` is supported, we can drop `is_context_not_provided` since a False from
 # `is_context_provided` will be sufficient.
-def is_context_provided(
+def has_at_least_one_parameter(
     fn: Union[Callable[Concatenate[T, P], R], Callable[P, R]],
-    valid_names: Optional[Sequence[str]] = None,
 ) -> TypeGuard[Callable[Concatenate[T, P], R]]:
-    params = get_function_params(fn)
-    if valid_names is None:
-        return len(params) >= 1
-    else:
-        valid_name_permutations = [
-            x for name in valid_names for x in get_valid_name_permutations(name)
-        ]
-        return len(params) >= 1 and params[0].name in valid_name_permutations
+    return len(get_function_params(fn)) >= 1

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -45,7 +45,7 @@ from ..schedule_definition import (
     RunRequestIterator,
     ScheduleDefinition,
     ScheduleEvaluationContext,
-    is_context_provided,
+    has_at_least_one_parameter,
 )
 from ..target import ExecutableDefinition
 from ..utils import validate_tags
@@ -148,7 +148,7 @@ def schedule(
                 ScheduleExecutionError,
                 lambda: f"Error occurred during the evaluation of schedule {schedule_name}",
             ):
-                if is_context_provided(fn):  # type: ignore  # fmt: skip
+                if has_at_least_one_parameter(fn):  # type: ignore  # fmt: skip
                     result = fn(context)  # type: ignore  # fmt: skip
                 else:
                     result = fn()  # type: ignore
@@ -173,7 +173,7 @@ def schedule(
                     # this is a run-request based decorated function
                     yield from cast(RunRequestIterator, ensure_gen(result))
 
-        has_context_arg = is_context_provided(fn)  # type: ignore  # fmt: skip
+        has_context_arg = has_at_least_one_parameter(fn)  # type: ignore  # fmt: skip
         evaluation_fn = DecoratedScheduleFunction(
             decorated_fn=fn,
             wrapped_fn=_wrapped_fn,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -23,7 +23,7 @@ from dagster._core.types.dagster_type import DagsterTypeKind
 
 from ...decorator_utils import (
     get_function_params,
-    get_valid_name_permutations,
+    is_context_provided,
     param_is_var_keyword,
     positional_arg_name_list,
 )
@@ -41,7 +41,7 @@ class DecoratedOpFunction(NamedTuple):
 
     @lru_cache(maxsize=1)
     def has_context_arg(self) -> bool:
-        return is_context_provided(get_function_params(self.decorated_fn))
+        return is_context_provided(self.decorated_fn, valid_names=["context"])
 
     @lru_cache(maxsize=1)
     def _get_function_params(self) -> Sequence[Parameter]:
@@ -467,12 +467,6 @@ def resolve_checked_solid_fn_inputs(
     input_defs.extend(inferred_input_defs)
 
     return input_defs
-
-
-def is_context_provided(params: Sequence[Parameter]) -> bool:
-    if len(params) == 0:
-        return False
-    return params[0].name in get_valid_name_permutations("context")
 
 
 def lambda_solid(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/solid_decorator.py
@@ -23,7 +23,7 @@ from dagster._core.types.dagster_type import DagsterTypeKind
 
 from ...decorator_utils import (
     get_function_params,
-    is_context_provided,
+    get_valid_name_permutations,
     param_is_var_keyword,
     positional_arg_name_list,
 )
@@ -41,7 +41,7 @@ class DecoratedOpFunction(NamedTuple):
 
     @lru_cache(maxsize=1)
     def has_context_arg(self) -> bool:
-        return is_context_provided(self.decorated_fn, valid_names=["context"])
+        return is_context_provided(get_function_params(self.decorated_fn))
 
     @lru_cache(maxsize=1)
     def _get_function_params(self) -> Sequence[Parameter]:
@@ -467,6 +467,12 @@ def resolve_checked_solid_fn_inputs(
     input_defs.extend(inferred_input_defs)
 
     return input_defs
+
+
+def is_context_provided(params: Sequence[Parameter]) -> bool:
+    if len(params) == 0:
+        return False
+    return params[0].name in get_valid_name_permutations("context")
 
 
 def lambda_solid(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -29,7 +29,7 @@ from .sensor_definition import (
     SensorDefinition,
     SensorEvaluationContext,
     SkipReason,
-    is_context_provided,
+    has_at_least_one_parameter,
 )
 
 
@@ -278,7 +278,7 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
         )
 
     def __call__(self, *args, **kwargs):
-        if is_context_provided(self._freshness_policy_sensor_fn):
+        if has_at_least_one_parameter(self._freshness_policy_sensor_fn):
             if len(args) + len(kwargs) == 0:
                 raise DagsterInvalidInvocationError(
                     "Freshness policy sensor function expected context argument, but no context"

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -37,7 +37,7 @@ from .sensor_definition import (
     DefaultSensorStatus,
     SensorDefinition,
     SensorEvaluationContext,
-    is_context_provided,
+    has_at_least_one_parameter,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name
@@ -1138,7 +1138,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         )
 
     def __call__(self, *args, **kwargs):
-        if is_context_provided(self._raw_asset_materialization_fn):
+        if has_at_least_one_parameter(self._raw_asset_materialization_fn):
             if len(args) + len(kwargs) == 0:
                 raise DagsterInvalidInvocationError(
                     "Sensor evaluation function expected context argument, but no context argument "

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -25,7 +25,7 @@ from dagster._utils.backcompat import experimental_arg_warning
 
 from ..decorator_utils import (
     get_function_params,
-    is_context_provided,
+    has_at_least_one_parameter,
     is_required_param,
     positional_arg_name_list,
     validate_expected_params,
@@ -199,7 +199,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
     def __call__(self, *args, **kwargs):
         from dagster._core.execution.context.init import UnboundInitResourceContext
 
-        if is_context_provided(self.resource_fn):
+        if has_at_least_one_parameter(self.resource_fn):
             if len(args) + len(kwargs) == 0:
                 raise DagsterInvalidInvocationError(
                     "Resource initialization function has context argument, but no context was"
@@ -265,7 +265,7 @@ class _ResourceDecoratorCallable:
     def __call__(self, resource_fn: ResourceFunction) -> ResourceDefinition:
         check.callable_param(resource_fn, "resource_fn")
 
-        any_name = ["*"] if is_context_provided(resource_fn) else []  # type: ignore  # fmt: skip
+        any_name = ["*"] if has_at_least_one_parameter(resource_fn) else []  # type: ignore  # fmt: skip
 
         params = get_function_params(resource_fn)
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -18,7 +18,7 @@ def resource_invocation_result(
     resource_def: "ResourceDefinition", init_context: Optional["UnboundInitResourceContext"]
 ) -> Any:
     from ..execution.context.init import UnboundInitResourceContext
-    from .resource_definition import ResourceDefinition, is_context_provided
+    from .resource_definition import ResourceDefinition, has_at_least_one_parameter
 
     check.inst_param(resource_def, "resource_def", ResourceDefinition)
     check.opt_inst_param(init_context, "init_context", UnboundInitResourceContext)
@@ -30,7 +30,7 @@ def resource_invocation_result(
     resource_fn = resource_def.resource_fn
     val_or_gen = (
         resource_fn(_init_context)  # type: ignore  # fmt: skip
-        if is_context_provided(resource_fn)  # type: ignore  # fmt: skip
+        if has_at_least_one_parameter(resource_fn)  # type: ignore  # fmt: skip
         else resource_fn()  # type: ignore  # (strict type guard)
     )
     if inspect.isgenerator(val_or_gen):
@@ -51,13 +51,13 @@ def resource_invocation_result(
 def _check_invocation_requirements(
     resource_def: "ResourceDefinition", init_context: Optional["UnboundInitResourceContext"]
 ) -> "InitResourceContext":
-    from dagster._core.definitions.resource_definition import is_context_provided
+    from dagster._core.definitions.resource_definition import has_at_least_one_parameter
     from dagster._core.execution.context.init import (
         InitResourceContext,
         build_init_resource_context,
     )
 
-    context_provided = is_context_provided(resource_def.resource_fn)  # type: ignore  # fmt: skip
+    context_provided = has_at_least_one_parameter(resource_def.resource_fn)  # type: ignore  # fmt: skip
     if context_provided and resource_def.required_resource_keys and init_context is None:
         raise DagsterInvalidInvocationError(
             "Resource has required resources, but no context was provided. Use the "

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -52,7 +52,7 @@ from .sensor_definition import (
     SensorDefinition,
     SensorEvaluationContext,
     SkipReason,
-    is_context_provided,
+    has_at_least_one_parameter,
 )
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
@@ -678,7 +678,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         )
 
     def __call__(self, *args, **kwargs):
-        if is_context_provided(self._run_status_sensor_fn):
+        if has_at_least_one_parameter(self._run_status_sensor_fn):
             if len(args) + len(kwargs) == 0:
                 raise DagsterInvalidInvocationError(
                     "Run status sensor function expected context argument, but no context argument "

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -28,7 +28,7 @@ from dagster._utils import ensure_gen
 from dagster._utils.merger import merge_dicts
 from dagster._utils.schedules import is_valid_cron_schedule
 
-from ..decorator_utils import get_function_params, is_context_provided
+from ..decorator_utils import get_function_params, has_at_least_one_parameter
 from ..errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -440,7 +440,7 @@ class ScheduleDefinition:
                     _run_config_fn = check.not_none(self._run_config_fn)
                     evaluated_run_config = copy.deepcopy(
                         _run_config_fn(context)  # type: ignore  # fmt: skip
-                        if is_context_provided(_run_config_fn)  # type: ignore  # fmt: skip
+                        if has_at_least_one_parameter(_run_config_fn)  # type: ignore  # fmt: skip
                         else _run_config_fn()  # type: ignore  # (strict type guard)
                     )
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -29,7 +29,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._serdes import whitelist_for_serdes
 
-from ..decorator_utils import get_function_params, is_context_provided
+from ..decorator_utils import get_function_params, has_at_least_one_parameter
 from .asset_selection import AssetSelection
 from .graph_definition import GraphDefinition
 from .mode import DEFAULT_MODE_NAME
@@ -330,7 +330,7 @@ class SensorDefinition:
         )
 
     def __call__(self, *args, **kwargs):
-        if is_context_provided(self._raw_fn):
+        if has_at_least_one_parameter(self._raw_fn):
             if len(args) + len(kwargs) == 0:
                 raise DagsterInvalidInvocationError(
                     "Sensor evaluation function expected context argument, but no context argument "
@@ -575,7 +575,7 @@ def wrap_sensor_evaluation(
     fn: RawSensorEvaluationFunction,
 ) -> SensorEvaluationFunction:
     def _wrapped_fn(context: SensorEvaluationContext):
-        if is_context_provided(fn):  # type: ignore  # fmt: skip
+        if has_at_least_one_parameter(fn):  # type: ignore  # fmt: skip
             result = fn(context)  # type: ignore  # fmt: skip
         else:
             result = fn()  # type: ignore

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.resource_definition import (
     ResourceDefinition,
     ScopedResourcesBuilder,
-    is_context_provided,
+    has_at_least_one_parameter,
 )
 from dagster._core.errors import (
     DagsterInvariantViolationError,
@@ -326,7 +326,7 @@ def single_resource_event_generator(
                 with time_execution_scope() as timer_result:
                     resource_or_gen = (
                         resource_def.resource_fn(context)  # type: ignore  # fmt: skip
-                        if is_context_provided(resource_def.resource_fn)  # type: ignore  # fmt: skip
+                        if has_at_least_one_parameter(resource_def.resource_fn)  # type: ignore  # fmt: skip
                         else resource_def.resource_fn()  # type: ignore[call-arg]
                     )
 

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union, cast, 
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
-from dagster._core.decorator_utils import is_context_provided
+from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.config import is_callable_valid_config_arg
 from dagster._core.definitions.definition_config_schema import (
     CoercableToConfigSchema,
@@ -202,7 +202,7 @@ class InputManagerWrapper(InputManager):
         intermediate = (
             # type-ignore because function being used as attribute
             self._load_fn(context)  # type: ignore  # fmt: skip
-            if is_context_provided(self._load_fn)  # type: ignore  # fmt: skip
+            if has_at_least_one_parameter(self._load_fn)  # type: ignore  # fmt: skip
             else self._load_fn()  # type: ignore  # (strict type guard)
         )
 

--- a/python_modules/dagster/dagster/_core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/root_input_manager.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.definition_config_schema import (
 from dagster._core.definitions.resource_definition import (
     ResourceDefinition,
     ResourceFunction,
-    is_context_provided,
+    has_at_least_one_parameter,
 )
 from dagster._core.storage.input_manager import IInputManagerDefinition, InputLoadFn, InputManager
 from dagster._utils.backcompat import deprecation_warning
@@ -190,7 +190,7 @@ class RootInputManagerWrapper(RootInputManager):
 
     def load_input(self, context: "InputContext") -> object:
         # type-ignore because function being used as attribute
-        return self._load_fn(context) if is_context_provided(self._load_fn) else self._load_fn()  # type: ignore
+        return self._load_fn(context) if has_at_least_one_parameter(self._load_fn) else self._load_fn()  # type: ignore
 
 
 class _InputManagerDecoratorCallable:


### PR DESCRIPTION
### Summary & Motivation

Fixes #11980

From `_core.decorators_utils`: `is_context_provided` -> `has_at_least_one_parameter`

### How I Tested These Changes

Existing BK tests
