### PR TITLE
[dagster-snowflake-pandas] snowflake-sqlalchemy pin

### DIFF
--- a/examples/assets_smoke_test/setup.py
+++ b/examples/assets_smoke_test/setup.py
@@ -16,9 +16,5 @@ setup(
     ],
     extras_require={
         "dev": ["dagit", "pytest"],
-        "test": [
-            # coerce a version resolution that causes pip backtracking related timeouts
-            "snowflake-connector-python==2.7.12",
-        ],
     },
 )

--- a/examples/assets_smoke_test/tox.ini
+++ b/examples/assets_smoke_test/tox.ini
@@ -14,7 +14,7 @@ deps =
   -e ../../python_modules/libraries/dagster-dbt/
   -e ../../python_modules/libraries/dagster-snowflake/
   -e ../../python_modules/libraries/dagster-snowflake-pandas/
-  -e .[test]
+  -e .
 allowlist_externals =
   /bin/bash
 commands =

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -37,9 +37,9 @@ setup(
         f"dagster-snowflake{pin}",
         "pandas",
         "requests",
-        "snowflake-connector-python[pandas]<3.0.0",
+        "snowflake-connector-python[pandas]",
         "sqlalchemy!=1.4.42",  # workaround for https://github.com/snowflakedb/snowflake-sqlalchemy/issues/350
-        "snowflake-sqlalchemy",
+        "snowflake-sqlalchemy>=1.2",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
### Summary & Motivation

Replace upper bound pin on `snowflake-connector-python` with lower bound pin on `snowflake-sqlalchemy`-- a lower bound pin on an old version will cause fewer conflicts than capping a recent version.

This also lets us remove the guide pin on `assets_smoke_test`.

### How I Tested These Changes

BK
