### PR TITLE
Fix doc op_version used instead of code_version

### DIFF
--- a/docs/content/guides/dagster/scheduling-assets.mdx
+++ b/docs/content/guides/dagster/scheduling-assets.mdx
@@ -366,7 +366,7 @@ width={2084}
 height={1362}
 />
 
-If you make a substantial change to your code, you can increment the `op_version`:
+If you make a substantial change to your code, you can increment the `code_version`:
 
 ```python file=/guides/dagster/scheduling/freshness_5b.py
 from dagster import (


### PR DESCRIPTION
### Summary & Motivation

Fix a simple mistake in the documentation where the parameter name `op_version` is used when it should have been `code_version`.
Page: https://docs.dagster.io/guides/dagster/scheduling-assets#step-5-change-code-versions

### How I Tested These Changes
