### PR TITLE
Consolidate GrpcServerRegistry/ProcessGrpcServerRegistry

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import sys
 import threading
 import uuid
-from abc import abstractmethod
 from contextlib import AbstractContextManager
 from typing import (
     TYPE_CHECKING,
     Dict,
-    Generic,
     List,
     NamedTuple,
     Optional,
@@ -70,31 +68,6 @@ T_GrpcRepositoryLocationOrigin = TypeVar(
 )
 
 
-# Daemons in different threads can use a shared GrpcServerRegistry to ensure that
-# a single GrpcServerProcess is created for each origin
-class GrpcServerRegistry(AbstractContextManager, Generic[T_GrpcRepositoryLocationOrigin]):
-    @abstractmethod
-    def supports_origin(self, repository_location_origin: RepositoryLocationOrigin) -> bool:
-        pass
-
-    @abstractmethod
-    def get_grpc_endpoint(
-        self, repository_location_origin: T_GrpcRepositoryLocationOrigin
-    ) -> GrpcServerEndpoint:
-        pass
-
-    @abstractmethod
-    def reload_grpc_endpoint(
-        self, repository_location_origin: T_GrpcRepositoryLocationOrigin
-    ) -> GrpcServerEndpoint:
-        pass
-
-    @property
-    @abstractmethod
-    def supports_reload(self) -> bool:
-        pass
-
-
 class ProcessRegistryEntry(
     NamedTuple(
         "_ProcessRegistryEntry",
@@ -126,9 +99,9 @@ class ProcessRegistryEntry(
         )
 
 
-# GrpcServerRegistry that creates local gRPC python processes from
-# ManagedGrpcPythonEnvRepositoryLocationOrigins and shares them between threads.
-class ProcessGrpcServerRegistry(GrpcServerRegistry[ManagedGrpcPythonEnvRepositoryLocationOrigin]):
+# Creates local gRPC python processes from ManagedGrpcPythonEnvRepositoryLocationOrigins and shares
+# them between threads.
+class GrpcServerRegistry(AbstractContextManager):
     def __init__(
         self,
         instance: DagsterInstance,

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -246,10 +246,10 @@ class ManagedGrpcPythonEnvRepositoryLocationOrigin(
     ) -> Generator["RepositoryLocation", None, None]:
         from dagster._core.workspace.context import DAGIT_GRPC_SERVER_HEARTBEAT_TTL
 
-        from .grpc_server_registry import ProcessGrpcServerRegistry
+        from .grpc_server_registry import GrpcServerRegistry
         from .repository_location import GrpcServerRepositoryLocation
 
-        with ProcessGrpcServerRegistry(
+        with GrpcServerRegistry(
             instance=instance,
             reload_interval=0,
             heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -214,7 +214,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
 
     def dispose(self):
         # defer for perf
-        from dagster._core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
+        from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
         from dagster._core.host_representation.repository_location import (
             GrpcServerRepositoryLocation,
         )
@@ -224,6 +224,6 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
 
         for location in self._locations_to_wait_for:
             if isinstance(location, GrpcServerRepositoryLocation) and isinstance(
-                location.grpc_server_registry, ProcessGrpcServerRegistry
+                location.grpc_server_registry, GrpcServerRegistry
             ):
                 location.grpc_server_registry.wait_for_processes()

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -29,7 +29,6 @@ from dagster._core.host_representation import (
 )
 from dagster._core.host_representation.grpc_server_registry import (
     GrpcServerRegistry,
-    ProcessGrpcServerRegistry,
 )
 from dagster._core.host_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
@@ -472,7 +471,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
             )
         else:
             self._grpc_server_registry = self._stack.enter_context(
-                ProcessGrpcServerRegistry(
+                GrpcServerRegistry(
                     instance=self._instance,
                     reload_interval=0,
                     heartbeat_ttl=DAGIT_GRPC_SERVER_HEARTBEAT_TTL,

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -9,7 +9,7 @@ from typing import Callable, Iterator, Sequence
 import pendulum
 
 import dagster._check as check
-from dagster._core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
+from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.instance import DagsterInstance
 from dagster._core.workspace.context import IWorkspaceProcessContext, WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
@@ -60,7 +60,7 @@ def create_daemons_from_instance(instance):
 
 
 def create_daemon_grpc_server_registry(instance, code_server_log_level="INFO"):
-    return ProcessGrpcServerRegistry(
+    return GrpcServerRegistry(
         instance=instance,
         reload_interval=DAEMON_GRPC_SERVER_RELOAD_INTERVAL,
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -5,7 +5,7 @@ import time
 import pytest
 from dagster import file_relative_path, repository
 from dagster._core.errors import DagsterUserCodeProcessError
-from dagster._core.host_representation.grpc_server_registry import ProcessGrpcServerRegistry
+from dagster._core.host_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.host_representation.origin import (
     ManagedGrpcPythonEnvRepositoryLocationOrigin,
     RegisteredRepositoryLocationOrigin,
@@ -60,7 +60,7 @@ def test_error_repo_in_registry(instance):
             python_file=file_relative_path(__file__, "error_repo.py"),
         ),
     )
-    with ProcessGrpcServerRegistry(
+    with GrpcServerRegistry(
         instance=instance, reload_interval=5, heartbeat_ttl=10, startup_timeout=5
     ) as registry:
         # Repository with a loading error does not raise an exception
@@ -91,7 +91,7 @@ def test_error_repo_in_registry(instance):
                 pass
 
 
-def test_process_server_registry(instance):
+def test_server_registry(instance):
     origin = ManagedGrpcPythonEnvRepositoryLocationOrigin(
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
@@ -100,7 +100,7 @@ def test_process_server_registry(instance):
         ),
     )
 
-    with ProcessGrpcServerRegistry(
+    with GrpcServerRegistry(
         instance=instance, reload_interval=5, heartbeat_ttl=10, startup_timeout=5
     ) as registry:
         endpoint_one = registry.get_grpc_endpoint(origin)
@@ -165,7 +165,7 @@ def test_registry_multithreading(instance):
         ),
     )
 
-    with ProcessGrpcServerRegistry(
+    with GrpcServerRegistry(
         instance=instance, reload_interval=300, heartbeat_ttl=600, startup_timeout=30
     ) as registry:
         endpoint = registry.get_grpc_endpoint(origin)
@@ -193,7 +193,7 @@ def test_registry_multithreading(instance):
     assert not _can_connect(origin, endpoint)
 
 
-class TestMockProcessGrpcServerRegistry(ProcessGrpcServerRegistry):
+class TestMockProcessGrpcServerRegistry(GrpcServerRegistry):
     def __init__(self, instance):
         self.mocked_loadable_target_origin = None
         super(TestMockProcessGrpcServerRegistry, self).__init__(


### PR DESCRIPTION
### Summary & Motivation

`GrpcServerRegistry` is currently an abstract class with a single subclass, `ProcessGrpcServerRegistry`. Apparently in the past it used to have multiple subclasses (see [Slack](https://elementl-workspace.slack.com/archives/C03A0D72A6T/p1675098009000699)).

This PR folds `ProcessGrpcServerRegistry` into `GrpcServerRegistry` so there is now only one class: `GrpcServerRegistry`.

### How I Tested These Changes

Existing BK tests.
