### PR TITLE
Add resource support to observable source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Union, overload
+from typing import AbstractSet, Mapping, Optional, Union, overload
 
 from dagster._annotations import experimental
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
@@ -27,6 +27,7 @@ def observable_source_asset(
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     group_name: Optional[str] = None,
+    required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> "_ObservableSourceAsset":
     ...
@@ -44,6 +45,7 @@ def observable_source_asset(
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     group_name: Optional[str] = None,
+    required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
     """Create a `SourceAsset` with an associated observation function.
@@ -71,6 +73,7 @@ def observable_source_asset(
             compose the source asset.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If not provided,
             the name "default" is used.
+        required_resource_keys (Optional[Set[str]]): Set of resource handles required by the observe op.
         resource_defs (Optional[Mapping[str, ResourceDefinition]]): (Experimental) resource
             definitions that may be required by the :py:class:`dagster.IOManagerDefinition` provided in
             the `io_manager_def` argument.
@@ -88,6 +91,7 @@ def observable_source_asset(
         description,
         partitions_def,
         group_name,
+        required_resource_keys,
         resource_defs,
     )
 
@@ -103,6 +107,7 @@ class _ObservableSourceAsset:
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
+        required_resource_keys: Optional[AbstractSet[str]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ):
         self.name = name
@@ -117,6 +122,7 @@ class _ObservableSourceAsset:
         self.description = description
         self.partitions_def = partitions_def
         self.group_name = group_name
+        self.required_resource_keys = required_resource_keys
         self.resource_defs = resource_defs
 
     def __call__(self, observe_fn: SourceAssetObserveFunction) -> SourceAsset:
@@ -131,6 +137,7 @@ class _ObservableSourceAsset:
             description=self.description,
             partitions_def=self.partitions_def,
             group_name=self.group_name,
+            required_resource_keys=self.required_resource_keys,
             resource_defs=self.resource_defs,
             observe_fn=observe_fn,
         )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -73,7 +73,7 @@ def observable_source_asset(
             compose the source asset.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If not provided,
             the name "default" is used.
-        required_resource_keys (Optional[Set[str]]): Set of resource handles required by the observe op.
+        required_resource_keys (Optional[Set[str]]): Set of resource keys required by the observe op.
         resource_defs (Optional[Mapping[str, ResourceDefinition]]): (Experimental) resource
             definitions that may be required by the :py:class:`dagster.IOManagerDefinition` provided in
             the `io_manager_def` argument.
@@ -137,7 +137,7 @@ class _ObservableSourceAsset:
             description=self.description,
             partitions_def=self.partitions_def,
             group_name=self.group_name,
-            required_resource_keys=self.required_resource_keys,
+            _required_resource_keys=self.required_resource_keys,
             resource_defs=self.resource_defs,
             observe_fn=observe_fn,
         )

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -115,7 +115,7 @@ class SourceAsset(ResourceAddable):
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         observe_fn: Optional[SourceAssetObserveFunction] = None,
-        required_resource_keys: Optional[AbstractSet[str]] = None,
+        _required_resource_keys: Optional[AbstractSet[str]] = None,
         # Add additional fields to with_resources and with_group below
     ):
         if resource_defs is not None:
@@ -155,7 +155,7 @@ class SourceAsset(ResourceAddable):
         self.description = check.opt_str_param(description, "description")
         self.observe_fn = check.opt_callable_param(observe_fn, "observe_fn")
         self._required_resource_keys = check.opt_set_param(
-            required_resource_keys, "required_resource_keys", of_type=str
+            _required_resource_keys, "_required_resource_keys", of_type=str
         )
         self._node_def = None
 
@@ -279,7 +279,7 @@ class SourceAsset(ResourceAddable):
                 resource_defs=relevant_resource_defs,
                 group_name=self.group_name,
                 observe_fn=self.observe_fn,
-                required_resource_keys=self._required_resource_keys,
+                _required_resource_keys=self._required_resource_keys,
             )
 
     def with_group_name(self, group_name: str) -> "SourceAsset":
@@ -302,7 +302,7 @@ class SourceAsset(ResourceAddable):
                 group_name=group_name,
                 resource_defs=self.resource_defs,
                 observe_fn=self.observe_fn,
-                required_resource_keys=self._required_resource_keys,
+                _required_resource_keys=self._required_resource_keys,
             )
 
     def get_resource_requirements(self) -> Iterator[ResourceRequirement]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
+import pytest
 from dagster._core.definitions.data_version import (
     DataVersion,
     extract_data_version_from_entry,
 )
-import pytest
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.observe import observe
@@ -60,16 +60,14 @@ def test_observe_resource(is_valid, resource_defs):
         required_resource_keys={"bar"},
         resource_defs=resource_defs,
     )
-    def foo(context) -> LogicalVersion:
-        return LogicalVersion(f"{context.resources.bar}-alpha")
+    def foo(context) -> DataVersion:
+        return DataVersion(f"{context.resources.bar}-alpha")
 
     instance = DagsterInstance.ephemeral()
 
     if is_valid:
         observe([foo], instance=instance)
-        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
-            "bar-alpha"
-        )
+        assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar-alpha")
     else:
         with pytest.raises(
             DagsterInvalidDefinitionError,
@@ -88,16 +86,14 @@ def test_observe_config(is_valid, config_value):
         return context.resource_config["baz"]
 
     @observable_source_asset(required_resource_keys={"bar"}, resource_defs={"bar": bar})
-    def foo(context) -> LogicalVersion:
-        return LogicalVersion(f"{context.resources.bar}-alpha")
+    def foo(context) -> DataVersion:
+        return DataVersion(f"{context.resources.bar}-alpha")
 
     instance = DagsterInstance.ephemeral()
 
     if is_valid:
         observe([foo], instance=instance, run_config=config_value)
-        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
-            "baz-alpha"
-        )
+        assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("baz-alpha")
     else:
         with pytest.raises(DagsterInvalidConfigError, match="Error in config for job"):
             observe([foo], instance=instance, run_config=config_value)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -4,9 +4,12 @@ from dagster._core.definitions.data_version import (
     DataVersion,
     extract_data_version_from_entry,
 )
+import pytest
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.observe import observe
+from dagster._core.definitions.resource_definition import ResourceDefinition, resource
+from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
 
 
@@ -46,3 +49,55 @@ def test_observe_raise_on_error():
 
     instance = DagsterInstance.ephemeral()
     assert not observe([foo], raise_on_error=False, instance=instance).success
+
+
+@pytest.mark.parametrize(
+    "is_valid,resource_defs",
+    [(True, {"bar": ResourceDefinition.hardcoded_resource("bar")}), (False, {})],
+)
+def test_observe_resource(is_valid, resource_defs):
+    @observable_source_asset(
+        required_resource_keys={"bar"},
+        resource_defs=resource_defs,
+    )
+    def foo(context) -> LogicalVersion:
+        return LogicalVersion(f"{context.resources.bar}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    if is_valid:
+        observe([foo], instance=instance)
+        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
+            "bar-alpha"
+        )
+    else:
+        with pytest.raises(
+            DagsterInvalidDefinitionError,
+            match="resource with key 'bar' required by op 'foo' was not provided",
+        ):
+            observe([foo], instance=instance)
+
+
+@pytest.mark.parametrize(
+    "is_valid,config_value",
+    [(True, {"resources": {"bar": {"config": {"baz": "baz"}}}}), (False, {"fake": "fake"})],
+)
+def test_observe_config(is_valid, config_value):
+    @resource(config_schema={"baz": str})
+    def bar(context):
+        return context.resource_config["baz"]
+
+    @observable_source_asset(required_resource_keys={"bar"}, resource_defs={"bar": bar})
+    def foo(context) -> LogicalVersion:
+        return LogicalVersion(f"{context.resources.bar}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    if is_valid:
+        observe([foo], instance=instance, run_config=config_value)
+        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
+            "baz-alpha"
+        )
+    else:
+        with pytest.raises(DagsterInvalidConfigError, match="Error in config for job"):
+            observe([foo], instance=instance, run_config=config_value)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import pytest
 from dagster._check import CheckError
+from dagster._config.structured_config import ConfigurableResource
 from dagster._core.definitions.data_version import (
     DataVersion,
     extract_data_version_from_entry,
@@ -152,4 +153,48 @@ def test_source_asset_observation_job_with_resource(is_valid, resource_defs):
                 )
                 .get_job_def("source_asset_job")
                 .execute_in_process(instance=instance)
+            )
+
+
+class Bar(ConfigurableResource):
+    data_version: str
+
+
+@pytest.mark.parametrize(
+    "is_valid,resource_defs",
+    [(True, {"bar": Bar(data_version="bar")}), (False, {})],
+)
+def test_source_asset_observation_job_with_pythonic_resource(is_valid, resource_defs):
+    executed = {}
+
+    @observable_source_asset
+    def foo(bar: Bar) -> DataVersion:
+        executed["foo"] = True
+        return DataVersion(f"{bar.data_version}")
+
+    instance = DagsterInstance.ephemeral()
+
+    if is_valid:
+        result = (
+            Definitions(
+                assets=[foo],
+                jobs=[define_asset_job("source_asset_job", [foo])],
+                resources=resource_defs,
+            )
+            .get_job_def("source_asset_job")
+            .execute_in_process(instance=instance)
+        )
+
+        assert result.success
+        assert executed["foo"]
+        assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("bar")
+    else:
+        with pytest.raises(
+            DagsterInvalidDefinitionError,
+            match="resource with key 'bar' required by op 'foo' was not provided",
+        ):
+            Definitions(
+                assets=[foo],
+                jobs=[define_asset_job("source_asset_job", [foo])],
+                resources=resource_defs,
             )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -108,6 +108,7 @@ def test_mixed_source_asset_observation_job():
             jobs=[define_asset_job("mixed_job", [foo, bar])],
         )
 
+
 @pytest.mark.parametrize(
     "is_valid,resource_defs",
     [(True, {"bar": ResourceDefinition.hardcoded_resource("bar")}), (False, {})],
@@ -125,7 +126,6 @@ def test_source_asset_observation_job_with_resource(is_valid, resource_defs):
     instance = DagsterInstance.ephemeral()
 
     if is_valid:
-        print("RESOURCE DEFS", resource_defs)
         result = (
             Definitions(
                 assets=[foo],

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -231,8 +231,8 @@ def test_source_asset_no_manager_def():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "io manager with key 'foo' required by SourceAsset with key \[\"my_source_asset\"\] was"
-            " not provided"
+            "io manager with key 'foo' required by SourceAsset with key \\[\"my_source_asset\"\\]"
+            " was not provided"
         ),
     ):
         with_resources([the_source_asset], {})

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -230,7 +230,10 @@ def test_source_asset_no_manager_def():
     # Ensure error when io manager key is provided and resources don't satisfy.
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="requires IO manager with key 'foo', but none was provided.",
+        match=(
+            "io manager with key 'foo' required by SourceAsset with key \[\"my_source_asset\"\] was"
+            " not provided"
+        ),
     ):
         with_resources([the_source_asset], {})
 
@@ -323,10 +326,10 @@ def test_source_asset_partial_resources():
     my_source_asset = SourceAsset(key=AssetKey("my_source_asset"), io_manager_def=the_manager)
 
     with pytest.raises(
-        DagsterInvariantViolationError,
+        DagsterInvalidDefinitionError,
         match=(
-            "Resource with key 'foo' required by resource with key 'my_source_asset__io_manager',"
-            " but not provided."
+            "resource with key 'foo' required by resource with key 'my_source_asset__io_manager'"
+            " was not provided"
         ),
     ):
         with_resources([my_source_asset], resource_defs={})

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -619,8 +619,7 @@ def test_asset_missing_resources():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=re.escape(
-            "SourceAsset with asset key AssetKey(['foo']) requires IO manager with key 'foo', but"
-            " none was provided."
+            "io manager with key 'foo' required by SourceAsset with key [\"foo\"] was not provided"
         ),
     ):
         Definitions(assets=[source_asset_io_req])


### PR DESCRIPTION
### Summary & Motivation

Allows provision of resources to observable source assets via either `required_resource_keys` (old-style) or Pythonic resource args.

Threading `required_resource_keys` through both `@observable_source_asset` and `SourceAssetDefinition` was awkward. If we allow config schema for observation functions (which we should) it will only get worse. The solution used here is to make `_required_resource_keys` a private arg on `SourceAsset` to avoid committing on some API questions discussed below.

Another possible approach would be to allow source asset to take a `node_def` (matching the `AssetsDefinition` API) instead of an `observe_fn`. That would technically be a break we wouldn't normally make, since `observe_fn` is not marked as an experimental arg on `SourceAsset`-- but I'd argue it is widely understood to be experimental since `@observable_source_asset` is, which is probably what anyone using this feature is using anyway.

### How I Tested These Changes

New unit tests