### PR TITLE
[dagit] Repair markdownToPlaintext test failure

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/markdownToPlaintext.ts
+++ b/js_modules/dagit/packages/core/src/ui/markdownToPlaintext.ts
@@ -15,7 +15,7 @@ export const markdownToPlaintext = (md: string) => {
   }
 
   // Clean up escaping left behind.
-  const str = Remark.processSync(md).toString().replaceAll(/\\/g, '').trim();
+  const str = Remark.processSync(md).toString().replace(/\\/g, '').trim();
   markdownCache.set(md, str);
 
   return str;


### PR DESCRIPTION
### Summary & Motivation

For some reason, `replaceAll()` is missing in Buildkite runs. I'm not sure what changed here, but we can just use `replace()` with a global regex instead. (It already has a global regex...why did I use `replaceAll()` at all?)

### How I Tested These Changes

Test `markdownToPlaintext` locally and in BK.
