### PR TITLE
Add observe function (source asset analogue to materialize)

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -228,9 +228,6 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey as MultiPartitionKey,
     MultiPartitionsDefinition as MultiPartitionsDefinition,
 )
-from dagster._core.definitions.observe import (
-    observe as observe,
-)
 from dagster._core.definitions.op_definition import OpDefinition as OpDefinition
 from dagster._core.definitions.output import (
     DynamicOut as DynamicOut,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -228,6 +228,9 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey as MultiPartitionKey,
     MultiPartitionsDefinition as MultiPartitionsDefinition,
 )
+from dagster._core.definitions.observe import (
+    observe as observe,
+)
 from dagster._core.definitions.op_definition import OpDefinition as OpDefinition
 from dagster._core.definitions.output import (
     DynamicOut as DynamicOut,

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -1,0 +1,78 @@
+import warnings
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+
+import dagster._check as check
+from dagster._utils.backcompat import ExperimentalWarning
+from dagster._utils.merger import merge_dicts
+
+from ..instance import DagsterInstance
+from .assets import AssetsDefinition
+from .assets_job import build_assets_job
+from .job_definition import default_job_io_manager_with_fs_io_manager_schema
+from .source_asset import SourceAsset
+from .utils import DEFAULT_IO_MANAGER_KEY
+
+if TYPE_CHECKING:
+    from ..execution.execute_in_process_result import ExecuteInProcessResult
+
+
+def observe(
+    source_assets: Sequence[SourceAsset],
+    run_config: Any = None,
+    instance: Optional[DagsterInstance] = None,
+    resources: Optional[Mapping[str, object]] = None,
+    partition_key: Optional[str] = None,
+    raise_on_error: bool = True,
+    tags: Optional[Mapping[str, str]] = None,
+) -> "ExecuteInProcessResult":
+    """
+    Executes a single-threaded, in-process run which observes provided source assets.
+
+    By default, will materialize assets to the local filesystem.
+
+    Args:
+        assets (Sequence[Union[AssetsDefinition, SourceAsset]]):
+            The assets to materialize. Can also provide :py:class:`SourceAsset` objects to fill dependencies for asset defs.
+        resources (Optional[Mapping[str, object]]):
+            The resources needed for execution. Can provide resource instances
+            directly, or resource definitions. Note that if provided resources
+            conflict with resources directly on assets, an error will be thrown.
+        run_config (Optional[Any]): The run config to use for the run that materializes the assets.
+        partition_key: (Optional[str])
+            The string partition key that specifies the run config to execute. Can only be used
+            to select run config for assets with partitioned config.
+        tags (Optional[Mapping[str, str]]): Tags for the run.
+
+    Returns:
+        ExecuteInProcessResult: The result of the execution.
+    """
+    from ..execution.build_resources import wrap_resources_for_execution
+
+    assets = check.sequence_param(source_assets, "assets", of_type=(AssetsDefinition, SourceAsset))
+    assets_defs = [the_def for the_def in assets if isinstance(the_def, AssetsDefinition)]
+    source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
+    instance = check.opt_inst_param(instance, "instance", DagsterInstance)
+    partition_key = check.opt_str_param(partition_key, "partition_key")
+    resources = check.opt_mapping_param(resources, "resources", key_type=str)
+    resource_defs = wrap_resources_for_execution(resources)
+    resource_defs = merge_dicts(
+        {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema}, resource_defs
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", category=ExperimentalWarning, message=".*build_assets_job.*"
+        )
+
+        return build_assets_job(
+            "in_process_materialization_job",
+            assets=assets_defs,
+            source_assets=source_assets,
+            resource_defs=resource_defs,
+        ).execute_in_process(
+            run_config=run_config,
+            instance=instance,
+            partition_key=partition_key,
+            raise_on_error=raise_on_error,
+            tags=tags,
+        )

--- a/python_modules/dagster/dagster/_core/definitions/observe.py
+++ b/python_modules/dagster/dagster/_core/definitions/observe.py
@@ -31,7 +31,7 @@ def observe(
 
     Args:
         source_assets (Sequence[SourceAsset]):
-            The assets to materialize. Can also provide :py:class:`SourceAsset` objects to fill dependencies for asset defs.
+            The source assets to materialize.
         resources (Optional[Mapping[str, object]]):
             The resources needed for execution. Can provide resource instances
             directly, or resource definitions. Note that if provided resources

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -1,0 +1,105 @@
+from typing import Optional
+
+import pytest
+from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.logical_version import (
+    LogicalVersion,
+    extract_logical_version_from_entry,
+)
+from dagster._core.definitions.observe import observe
+from dagster._core.definitions.resource_definition import ResourceDefinition, resource
+from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
+from dagster._core.instance import DagsterInstance
+
+
+def _get_current_logical_version(
+    key: AssetKey, instance: DagsterInstance
+) -> Optional[LogicalVersion]:
+    record = instance.get_latest_logical_version_record(AssetKey("foo"))
+    assert record is not None
+    return extract_logical_version_from_entry(record.event_log_entry)
+
+
+def test_basic_observe():
+    @observable_source_asset
+    def foo(_context) -> LogicalVersion:
+        return LogicalVersion("alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    observe([foo], instance=instance)
+    assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion("alpha")
+
+
+@pytest.mark.parametrize(
+    "is_valid,resource_defs",
+    [(True, {"bar": ResourceDefinition.hardcoded_resource("bar")}), (False, {})],
+)
+def test_observe_resource(is_valid, resource_defs):
+    @observable_source_asset(
+        required_resource_keys={"bar"},
+        resource_defs=resource_defs,
+    )
+    def foo(context) -> LogicalVersion:
+        return LogicalVersion(f"{context.resources.bar}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    if is_valid:
+        observe([foo], instance=instance)
+        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
+            "bar-alpha"
+        )
+    else:
+        with pytest.raises(
+            DagsterInvalidDefinitionError,
+            match="resource with key 'bar' required by op 'foo' was not provided",
+        ):
+            observe([foo], instance=instance)
+
+
+@pytest.mark.parametrize(
+    "is_valid,config_value",
+    [(True, {"resources": {"bar": {"config": {"baz": "baz"}}}}), (False, {"fake": "fake"})],
+)
+def test_observe_config(is_valid, config_value):
+    @resource(config_schema={"baz": str})
+    def bar(context):
+        return context.resource_config["baz"]
+
+    @observable_source_asset(required_resource_keys={"bar"}, resource_defs={"bar": bar})
+    def foo(context) -> LogicalVersion:
+        return LogicalVersion(f"{context.resources.bar}-alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    if is_valid:
+        observe([foo], instance=instance, run_config=config_value)
+        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
+            "baz-alpha"
+        )
+    else:
+        with pytest.raises(DagsterInvalidConfigError, match="Error in config for job"):
+            observe([foo], instance=instance, run_config=config_value)
+
+
+def test_observe_tags():
+    @observable_source_asset
+    def foo(_context) -> LogicalVersion:
+        return LogicalVersion("alpha")
+
+    instance = DagsterInstance.ephemeral()
+
+    result = observe([foo], instance=instance, tags={"key1": "value1"})
+    assert result.success
+    assert result.dagster_run.tags == {"key1": "value1"}
+
+
+def test_observe_raise_on_error():
+    @observable_source_asset
+    def foo(_context) -> LogicalVersion:
+        raise ValueError()
+
+    instance = DagsterInstance.ephemeral()
+    assert not observe([foo], raise_on_error=False, instance=instance).success

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import pytest
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.logical_version import (
@@ -8,8 +7,6 @@ from dagster._core.definitions.logical_version import (
     extract_logical_version_from_entry,
 )
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.resource_definition import ResourceDefinition, resource
-from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
 
 
@@ -30,58 +27,6 @@ def test_basic_observe():
 
     observe([foo], instance=instance)
     assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion("alpha")
-
-
-@pytest.mark.parametrize(
-    "is_valid,resource_defs",
-    [(True, {"bar": ResourceDefinition.hardcoded_resource("bar")}), (False, {})],
-)
-def test_observe_resource(is_valid, resource_defs):
-    @observable_source_asset(
-        required_resource_keys={"bar"},
-        resource_defs=resource_defs,
-    )
-    def foo(context) -> LogicalVersion:
-        return LogicalVersion(f"{context.resources.bar}-alpha")
-
-    instance = DagsterInstance.ephemeral()
-
-    if is_valid:
-        observe([foo], instance=instance)
-        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
-            "bar-alpha"
-        )
-    else:
-        with pytest.raises(
-            DagsterInvalidDefinitionError,
-            match="resource with key 'bar' required by op 'foo' was not provided",
-        ):
-            observe([foo], instance=instance)
-
-
-@pytest.mark.parametrize(
-    "is_valid,config_value",
-    [(True, {"resources": {"bar": {"config": {"baz": "baz"}}}}), (False, {"fake": "fake"})],
-)
-def test_observe_config(is_valid, config_value):
-    @resource(config_schema={"baz": str})
-    def bar(context):
-        return context.resource_config["baz"]
-
-    @observable_source_asset(required_resource_keys={"bar"}, resource_defs={"bar": bar})
-    def foo(context) -> LogicalVersion:
-        return LogicalVersion(f"{context.resources.bar}-alpha")
-
-    instance = DagsterInstance.ephemeral()
-
-    if is_valid:
-        observe([foo], instance=instance, run_config=config_value)
-        assert _get_current_logical_version(AssetKey("foo"), instance) == LogicalVersion(
-            "baz-alpha"
-        )
-    else:
-        with pytest.raises(DagsterInvalidConfigError, match="Error in config for job"):
-            observe([foo], instance=instance, run_config=config_value)
 
 
 def test_observe_tags():


### PR DESCRIPTION
### Summary & Motivation

This adds an `observe` function directly analogous to `materialize`. The added tests also cover source asset APIs more generally that were not under test before.

### How I Tested These Changes

New unit tests.