### PR TITLE
[dagit] Add more truncation test cases for Firefox, change const

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/MiddleTruncate.stories.tsx
@@ -48,7 +48,12 @@ export const Simple = () => {
 export const FlexboxContainerUsage = () => {
   return (
     <Box>
+      <em style={{display: 'block', marginBottom: 10}}>
+        Note: When testing this in Firefox, view it on both a Retina and non-Retina display. Some
+        rounding issues only seem to happen on Retina displays.
+      </em>
       {[
+        'asset_0',
         'asset1',
         'example',
         'test1234',
@@ -58,7 +63,12 @@ export const FlexboxContainerUsage = () => {
         'example_123',
         'otherstring',
         'example_1234',
+        'a_source_asset',
         'variable_width',
+        'yoyo_multidim',
+        'yoyo_multidim_other_order',
+        'activity_daily_stats',
+        'asset_that_supports_partition_ranges',
       ].map((text) => (
         <Box key={text} style={{maxWidth: '100%'}} flex={{direction: 'row', gap: 8}}>
           <Box>

--- a/js_modules/dagit/packages/ui/src/components/calculateMiddleTruncation.tsx
+++ b/js_modules/dagit/packages/ui/src/components/calculateMiddleTruncation.tsx
@@ -1,7 +1,7 @@
 // We've observed that Firefox's DOM APIs and Canvas APIs do not return
 // identical values given the same rendered text, in particular when the DOM
 // element is inside a flexbox. They're floating point numbers off by ~0.05.
-const FIREFOX_WIDTH_VARIANCE = 0.1;
+const FIREFOX_WIDTH_VARIANCE = 0.33;
 
 /**
  * Binary search to find the maximum middle-truncated text that will fit within the specified target width.


### PR DESCRIPTION
### Summary & Motivation

I have still been seeing unnecessarily truncated assets in Firefox. It turns out that our storybook test suite wasn't exhaustive. I added the problematic strings and then changed the allowed variance constant until all of them rendered correctly.

I also noticed that you can only reproduce this on a retina display, so I added a note about that to the storybook.

Before: (all truncation are errors)

<img width="1385" alt="Screen Shot 2023-01-31 at 2 12 54 PM" src="https://user-images.githubusercontent.com/1037212/215872474-4275fe5e-418c-4506-8cc9-a909fbc931d6.png">

After:

<img width="1299" alt="Screen Shot 2023-01-31 at 2 12 42 PM" src="https://user-images.githubusercontent.com/1037212/215872517-c1fc110c-06c1-4160-820f-f0238c65b1c2.png">
