### PR TITLE
More helpful asset key mismatch errors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import AbstractSet, Dict, Iterable, List, Mapping, Tuple, cast
+from typing import AbstractSet, Dict, Iterable, List, Mapping, Sequence, Tuple, cast
 
 from thefuzz import fuzz
 
@@ -43,10 +43,10 @@ class ResolvedAssetDependencies:
         )
 
 
-def _resolve_similar_asset_names(
+def resolve_similar_asset_names(
     target_asset_key: AssetKey,
     assets_defs: Iterable[AssetsDefinition],
-) -> List[AssetKey]:
+) -> Sequence[AssetKey]:
     """
     Given a target asset key (an upstream dependency which we can't find), produces a list of
     similar asset keys from the list of asset definitions. We use this list to produce a helpful
@@ -160,10 +160,12 @@ def resolve_assets_def_deps(
                     "produced by any of the provided asset ops and is not one of the provided "
                     "sources."
                 )
-                similar_names = _resolve_similar_asset_names(upstream_key, assets_defs)
+                similar_names = resolve_similar_asset_names(upstream_key, assets_defs)
                 if similar_names:
+                    # Arbitrarily limit to 10 similar names to avoid a huge error message
+                    subset_similar_names = similar_names[:10]
                     similar_to_string = ", ".join(
-                        (similar.to_string() for similar in similar_names)
+                        (similar.to_string() for similar in subset_similar_names)
                     )
                     msg += f" Did you mean one of the following?\n\t{similar_to_string}"
                 raise DagsterInvalidDefinitionError(msg)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -1,0 +1,157 @@
+import re
+
+import pytest
+from dagster import AssetIn, AssetKey, Definitions, asset
+from dagster._core.errors import DagsterInvalidDefinitionError
+
+
+@pytest.mark.parametrize("group_name", [None, "my_group"])
+@pytest.mark.parametrize("asset_key_prefix", [[], ["my_prefix"]])
+def test_typo_upstream_asset_one_similar(group_name, asset_key_prefix):
+    @asset(group_name=group_name, key_prefix=asset_key_prefix)
+    def asset1():
+        ...
+
+    @asset(
+        group_name=group_name,
+        key_prefix=asset_key_prefix,
+        ins={"asst1": AssetIn(asset_key_prefix + ["asst1"])},
+    )
+    def asset2(asst1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"asst1\".* is not produced by any of the provided asset ops and is"
+            r" not one of the provided sources. Did you mean one of the following\?"
+            rf"\n\t{re.escape(asset1.asset_key.to_string())}"
+        ),
+    ):
+        Definitions(assets=[asset1, asset2])
+
+
+def test_typo_upstream_asset_no_similar():
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def asset2(not_close_to_asset1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"not_close_to_asset1\".* is not produced by any of the provided asset"
+            r" ops and is not one of the provided sources."
+        ),
+    ):
+        Definitions(assets=[asset1, asset2])
+
+
+def test_typo_upstream_asset_many_similar():
+    @asset
+    def asset1():
+        ...
+
+    @asset
+    def assets1():
+        ...
+
+    @asset
+    def asst():
+        ...
+
+    @asset
+    def asset2(asst1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"asst1\".* is not produced by any of the provided asset ops and is"
+            r" not one of the provided sources. Did you mean one of the following\?"
+            rf"\n\t{re.escape(asst.asset_key.to_string())},"
+            rf" {re.escape(asset1.asset_key.to_string())},"
+            rf" {re.escape(assets1.asset_key.to_string())}"
+        ),
+    ):
+        Definitions(assets=[asst, asset1, assets1, asset2])
+
+
+def test_typo_upstream_asset_wrong_prefix():
+    @asset(key_prefix=["my", "prefix"])
+    def asset1():
+        ...
+
+    @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "prfix", "asset1"]))})
+    def asset2(asset1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"asset1\".* is not produced by any of the provided asset ops and is"
+            r" not one of the provided sources. Did you mean one of the following\?"
+            rf"\n\t{re.escape(asset1.asset_key.to_string())}"
+        ),
+    ):
+        Definitions(assets=[asset1, asset2])
+
+
+def test_typo_upstream_asset_wrong_prefix_and_wrong_key():
+    # In the case that the user has a typo in the key and the prefix, we don't suggest the asset since it's too different.
+
+    @asset(key_prefix=["my", "prefix"])
+    def asset1():
+        ...
+
+    @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "prfix", "asset4"]))})
+    def asset2(asset1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"asset4\".* is not produced by any of the provided asset ops and is"
+            r" not one of the provided sources."
+        ),
+    ):
+        Definitions(assets=[asset1, asset2])
+
+
+def test_one_off_component_prefix():
+    @asset(key_prefix=["my", "prefix"])
+    def asset1():
+        ...
+
+    # One more component in the prefix
+    @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "prefix", "nested", "asset1"]))})
+    def asset2(asset1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"asset1\".* is not produced by any of the provided asset ops and is"
+            r" not one of the provided sources. Did you mean one of the following\?"
+            rf"\n\t{re.escape(asset1.asset_key.to_string())}"
+        ),
+    ):
+        Definitions(assets=[asset1, asset2])
+
+    # One fewer component in the prefix
+    @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "asset1"]))})
+    def asset3(asset1):
+        ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            r"Input asset .*\"asset1\".* is not produced by any of the provided asset ops and is"
+            r" not one of the provided sources. Did you mean one of the following\?"
+            rf"\n\t{re.escape(asset1.asset_key.to_string())}"
+        ),
+    ):
+        Definitions(assets=[asset1, asset3])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -161,8 +161,8 @@ def test_one_off_component_prefix():
 
 
 NUM_ASSETS_TO_TEST_PERF = 5000
-# As of 2/16/2023, `avg_elapsed_time_secs` is ~0.024 on a MBP
-PERF_CUTOFF_SECS = 0.05
+# As of 2/16/2023, `avg_elapsed_time_secs` is ~0.024s on a MBP, ~0.15s on BK
+PERF_CUTOFF_SECS = 0.3
 NUM_PERF_TRIALS = 10
 
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -75,6 +75,7 @@ setup(
         "croniter>=0.3.34",
         # grpcio>=1.48.1 has hanging/crashing issues: https://github.com/grpc/grpc/issues/30843 and https://github.com/grpc/grpc/issues/31885
         # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
+        "fuzzywuzzy",
         "grpcio>=1.32.0,<1.48.1",
         "grpcio-health-checking>=1.32.0,<1.44.0",
         "packaging>=20.9",

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -75,7 +75,7 @@ setup(
         "croniter>=0.3.34",
         # grpcio>=1.48.1 has hanging/crashing issues: https://github.com/grpc/grpc/issues/30843 and https://github.com/grpc/grpc/issues/31885
         # ensure version we require is >= that with which we generated the grpc code (set in dev-requirements)
-        "fuzzywuzzy",
+        "thefuzz",
         "grpcio>=1.32.0,<1.48.1",
         "grpcio-health-checking>=1.32.0,<1.44.0",
         "packaging>=20.9",


### PR DESCRIPTION
## Summary

A little QoL idea that came out of our onboarding breakout group last week. Adds a suggestion to the error message when an upstream asset dep is not found, listing any assets with similar keys:

```python
dagster._core.errors.DagsterInvalidDefinitionError: Input asset '["my", "asset1"]' for asset '["asset3"]' 
is not produced by any of the provided asset ops and is not one of the provided sources. 
Did you mean one of the following?
    ["my", "prefix", "asset1"]
```

Right now, uses three heuristics for finding potential candiates:
- Same asset name, similar prefix
- Similar asset name, same prefix
- Same asset name, prefix is off-by-one component (e.g. `["snowflake', "elementl", "prod", "my_asset"] vs ["snowflake", "elementl", "my_asset"]`

Currently the candidates are unordered and there's no limit to the number shown because this is a quick impl/rfc. Can flesh it out if we find it interesting.

## Test Plan

Added a few unit tests to showcase behavior.
