### PR TITLE
[prototype] Link to asset definitions from local Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
@@ -13,7 +13,9 @@ export const metadataForAssetNode = (
   assetNode: AssetNodeOpMetadataFragment,
 ): {assetType?: DagsterTypeFragment; assetMetadata: MetadataEntryFragment[]} => {
   const assetType = assetNode.type ? assetNode.type : undefined;
-  const assetMetadata = assetNode.metadataEntries || [];
+  const assetMetadata = (assetNode.metadataEntries || []).filter(
+    (entry) => entry.label !== '__code_origin',
+  );
   return {assetType, assetMetadata};
 };
 


### PR DESCRIPTION
****Superseded/fleshed out in follow-up stack: https://github.com/dagster-io/dagster/pull/12097****


## Summary

Based on an idea that came out of our onboarding breakout group last week. Very quick & rough implementation of using `inspect` to find out where a user is defining assets in their code and forwarding the codepath to Dagit via a special metadata field. Not very resilient but works well enough for simple cases.



https://user-images.githubusercontent.com/10215173/215924265-5b27b93a-5f2c-45df-9354-595ec42d0e75.mov

