### PR TITLE
Bump Postgres to 14.6

### DIFF
--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -741,7 +741,7 @@ postgresql:
   # Used by init container to check that db is running. (Even if enabled:false)
   image:
     repository: "library/postgres"
-    tag: "9.6.21"
+    tag: "14.6"
     pullPolicy: IfNotPresent
 
   # set this PostgreSQL hostname when using an external PostgreSQL database


### PR DESCRIPTION
### Summary & Motivation
Postgres v9.6.21 reached end of life a few years back. Let's bring the version up to a supported one.

### How I Tested These Changes
I overrode this tag value in our Helm chart in dev and production, and all seems fine.  I will say, though, that we're using an external postgres DB, so only our init container is going to run this image.