### PR TITLE
Fix broken doc link for Snowflake credential setup

### DIFF
--- a/examples/quickstart_snowflake/README.md
+++ b/examples/quickstart_snowflake/README.md
@@ -57,7 +57,7 @@ To connect to Snowflake, you'll need to set up your credentials in Dagster.
 
 Dagster allows using environment variables to handle sensitive information. You can define various configuration options and access environment variables through them. This also allows you to parameterize your pipeline without modifying code.
 
-In this example, we use [snowflake_io_manager](https://docs.dagster.io/_apidocs/libraries/dagster-snowflake#dagster_snowflake.build_snowflake_io_manager) to write outputs to Snowflake and read inputs from it. The configurations of the Snowflake connection are defined [in `quickstart_snowflake/repository.py`](./quickstart_snowflake/repository.py), which requires the following environment variables:
+In this example, we use [snowflake_io_manager](https://docs.dagster.io/_apidocs/libraries/dagster-snowflake#dagster_snowflake.build_snowflake_io_manager) to write outputs to Snowflake and read inputs from it. The configurations of the Snowflake connection are defined [in `quickstart_snowflake/__init__.py`](./quickstart_snowflake/__init__.py), which requires the following environment variables:
 - `SNOWFLAKE_ACCOUNT`
 - `SNOWFLAKE_USER`
 - `SNOWFLAKE_PASSWORD`


### PR DESCRIPTION
The link for configuring Snowflake environment variables pointed to a non-existent file. This corrects the link.

### Summary & Motivation

Documentation was broken.

### How I Tested These Changes

I clicked the new link to make sure it works properly.