### PR TITLE
Fix define_asset_job for pure observable_source_asset jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -769,9 +769,6 @@ def build_asset_selection_job(
                 ),
             )
 
-    # We should disallow simultaneous selection of assets and source assets (but for
-    # backcompat we will simply ignore the source asset selection if any regular assets are
-    # selected).
     if len(included_assets) > 0:
         asset_job = build_assets_job(
             name=name,

--- a/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset_graph.py
@@ -108,9 +108,7 @@ class ExternalAssetGraph(AssetGraph):
             if not node.is_source
         }
         job_names_by_key = {
-            node.asset_key: node.job_names
-            for _, node in repo_handle_external_asset_nodes
-            if not node.is_source
+            node.asset_key: node.job_names for _, node in repo_handle_external_asset_nodes
         }
         code_versions_by_key = {
             node.asset_key: node.code_version

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -235,7 +235,11 @@ def define_asset_job(
     name: str,
     selection: Optional[
         Union[
-            str, Sequence[str], Sequence[AssetKey], Sequence["AssetsDefinition"], "AssetSelection"
+            str,
+            Sequence[str],
+            Sequence[AssetKey],
+            Sequence[Union["AssetsDefinition", "SourceAsset"]],
+            "AssetSelection",
         ]
     ] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"]] = None,
@@ -244,14 +248,15 @@ def define_asset_job(
     partitions_def: Optional["PartitionsDefinition[Any]"] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
 ) -> UnresolvedAssetJobDefinition:
-    """Creates a definition of a job which will materialize a selection of assets. This will only be
-    resolved to a JobDefinition once placed in a code location.
+    """Creates a definition of a job which will either materialize a selection of assets or observe
+    a selection of source assets. This will only be resolved to a JobDefinition once placed in a
+    code location.
 
     Args:
         name (str):
             The name for the job.
-        selection (Union[str, Sequence[str], Sequence[AssetKey], Sequence[AssetsDefinition], AssetSelection]):
-            The assets that will be materialized when the job is run.
+        selection (Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]):
+            The assets that will be materialized or observed when the job is run.
 
             The selected assets must all be included in the assets that are passed to the assets
             argument of the Definitions object that this job is included on.
@@ -260,7 +265,12 @@ def define_asset_job(
             location. A list of strings represents the union of all assets selected by strings
             within the list.
 
-            The selection will be resolved to a set of assets once the when location is loaded.
+            The selection will be resolved to a set of assets when the location is loaded. If the
+            selection resolves to all source assets, the created job will perform source asset
+            observations. If the selection resolves to all regular assets, the created job will
+            materialize assets. If the selection resolves to a mixed set of source assets and
+            regular assets, an error will be thrown.
+
         config:
             Describes how the Job is parameterized at runtime.
 
@@ -323,6 +333,16 @@ def define_asset_job(
                 jobs=[define_asset_job("marketing_job", selection=AssetSelection.groups("marketing"))],
             )
 
+            @observable_source_asset
+            def source_asset():
+                ...
+
+            # A job that observes a source asset:
+            defs = Definitions(
+                assets=assets,
+                jobs=[define_asset_job("observation_job", selection=[source_asset])],
+            )
+
             # Resources are supplied to the assets, not the job:
             @asset(required_resource_keys={"slack_client"})
             def asset1():
@@ -333,8 +353,9 @@ def define_asset_job(
                 jobs=[define_asset_job("all_assets")],
                 resources={"slack_client": prod_slack_client},
             )
+
     """
-    from dagster._core.definitions import AssetsDefinition, AssetSelection
+    from dagster._core.definitions import AssetsDefinition, AssetSelection, SourceAsset
 
     # convert string-based selections to AssetSelection objects
     resolved_selection: AssetSelection
@@ -348,14 +369,19 @@ def define_asset_job(
         resolved_selection = reduce(
             operator.or_, [_selection_from_string(cast(str, s)) for s in selection]
         )
-    elif isinstance(selection, list) and all(isinstance(el, AssetsDefinition) for el in selection):
-        resolved_selection = AssetSelection.assets(*cast(Sequence[AssetsDefinition], selection))
+    elif isinstance(selection, list) and all(
+        isinstance(el, (AssetsDefinition, SourceAsset)) for el in selection
+    ):
+        resolved_selection = AssetSelection.keys(
+            *(el.key for el in cast(Sequence[Union[AssetsDefinition, SourceAsset]], selection))
+        )
     elif isinstance(selection, list) and all(isinstance(el, AssetKey) for el in selection):
         resolved_selection = AssetSelection.keys(*cast(Sequence[AssetKey], selection))
     else:
         check.failed(
             "selection argument must be one of str, Sequence[str], Sequence[AssetKey],"
-            f" Sequence[AssetsDefinition], AssetSelection. Was {type(selection)}."
+            " Sequence[AssetsDefinition], Sequence[SourceAsset], AssetSelection. Was"
+            f" {type(selection)}."
         )
 
     return UnresolvedAssetJobDefinition(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -66,7 +66,8 @@ def check_experimental_warnings():
                 "resource_defs" in w.message.args[0]
                 or "io_manager_def" in w.message.args[0]
                 or "build_assets_job" in w.message.args[0]
-                or "SQLALCHEMY" in w.message.args[0]  # SqlAlchemy 2.0 deprecation warnings
+                or "source_asset" in w.message.args[0]
+                or "SQLAlchemy" in w.message.args[0]  # deprecation API usage warnings
             ):
                 continue
             assert False, f"Unexpected warning: {w.message.args[0]}"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -1,0 +1,69 @@
+from typing import Optional
+
+import pytest
+from dagster._check import CheckError
+from dagster._core.definitions.data_version import (
+    DataVersion,
+    extract_data_version_from_entry,
+)
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster._core.instance import DagsterInstance
+
+
+def _get_current_data_version(key: AssetKey, instance: DagsterInstance) -> Optional[DataVersion]:
+    record = instance.get_latest_data_version_record(key)
+    assert record is not None
+    return extract_data_version_from_entry(record.event_log_entry)
+
+
+def test_execute_source_asset_observation_job():
+    executed = {}
+
+    @observable_source_asset
+    def foo(_context) -> DataVersion:
+        executed["foo"] = True
+        return DataVersion("alpha")
+
+    @observable_source_asset
+    def bar(context):
+        executed["bar"] = True
+        return DataVersion("beta")
+
+    instance = DagsterInstance.ephemeral()
+
+    result = (
+        Definitions(
+            assets=[foo, bar],
+            jobs=[define_asset_job("source_asset_job", [foo, bar])],
+        )
+        .get_job_def("source_asset_job")
+        .execute_in_process(instance=instance)
+    )
+
+    assert result.success
+    assert executed["foo"]
+    assert _get_current_data_version(AssetKey("foo"), instance) == DataVersion("alpha")
+    assert executed["bar"]
+    assert _get_current_data_version(AssetKey("bar"), instance) == DataVersion("beta")
+
+
+def test_mixed_source_asset_observation_job():
+    @observable_source_asset
+    def foo(_context) -> DataVersion:
+        return DataVersion("alpha")
+
+    @asset(non_argument_deps={"foo"})
+    def bar(context):
+        return 1
+
+    with pytest.raises(
+        CheckError, match=r"Asset selection specified both regular assets and source assets"
+    ):
+        Definitions(
+            assets=[foo, bar],
+            jobs=[define_asset_job("mixed_job", [foo, bar])],
+        )


### PR DESCRIPTION
### Summary & Motivation

Allow `define_asset_job` to build source asset observation jobs.

### How I Tested These Changes

New unit tests, including one that makes sure an observable source asset job works on a schedule.