### PR TITLE
(tick-testing 5/6) Add SensorType

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2463,6 +2463,7 @@ type Sensor {
   description: String
   nextTick: DryRunInstigationTick
   metadata: SensorMetadata!
+  sensorType: SensorType!
 }
 
 type Target {
@@ -2473,6 +2474,15 @@ type Target {
 
 type SensorMetadata {
   assetKeys: [AssetKey!]
+}
+
+enum SensorType {
+  STANDARD
+  RUN_STATUS
+  ASSET
+  MULTI_ASSET
+  FRESHNESS_POLICY
+  UNKNOWN
 }
 
 union SensorOrError = Sensor | SensorNotFoundError | UnauthorizedError | PythonError

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3269,6 +3269,7 @@ export type Sensor = {
   name: Scalars['String'];
   nextTick: Maybe<DryRunInstigationTick>;
   sensorState: InstigationState;
+  sensorType: SensorType;
   targets: Maybe<Array<Target>>;
 };
 
@@ -3299,6 +3300,15 @@ export type SensorSelector = {
   repositoryName: Scalars['String'];
   sensorName: Scalars['String'];
 };
+
+export enum SensorType {
+  ASSET = 'ASSET',
+  FRESHNESS_POLICY = 'FRESHNESS_POLICY',
+  MULTI_ASSET = 'MULTI_ASSET',
+  RUN_STATUS = 'RUN_STATUS',
+  STANDARD = 'STANDARD',
+  UNKNOWN = 'UNKNOWN',
+}
 
 export type Sensors = {
   __typename: 'Sensors';

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -56,6 +56,18 @@ class GrapheneSensorMetadata(graphene.ObjectType):
         name = "SensorMetadata"
 
 
+class GrapheneSensorType(graphene.Enum):
+    STANDARD = "STANDARD"
+    RUN_STATUS = "RUN_STATUS"
+    ASSET = "ASSET"
+    MULTI_ASSET = "MULTI_ASSET"
+    FRESHNESS_POLICY = "FRESHNESS_POLICY"
+    UNKNOWN = "UNKNOWN"
+
+    class Meta:
+        name = "SensorType"
+
+
 class GrapheneSensor(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
     jobOriginId = graphene.NonNull(graphene.String)
@@ -66,6 +78,7 @@ class GrapheneSensor(graphene.ObjectType):
     description = graphene.String()
     nextTick = graphene.Field(GrapheneDryRunInstigationTick)
     metadata = graphene.NonNull(GrapheneSensorMetadata)
+    sensorType = graphene.NonNull(GrapheneSensorType)
 
     class Meta:
         name = "Sensor"
@@ -89,6 +102,7 @@ class GrapheneSensor(graphene.ObjectType):
             metadata=GrapheneSensorMetadata(
                 assetKeys=external_sensor.metadata.asset_keys if external_sensor.metadata else None
             ),
+            sensorType=external_sensor.sensor_type.value,
         )
 
     def resolve_id(self, _):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -53,17 +53,22 @@ from dagster import (
     TableSchema,
     _check as check,
     asset,
+    asset_sensor,
     dagster_type_loader,
     dagster_type_materializer,
     daily_partitioned_config,
     define_asset_job,
+    freshness_policy_sensor,
     graph,
     job,
     logger,
     multi_asset,
+    multi_asset_sensor,
     op,
     repository,
     resource,
+    run_failure_sensor,
+    run_status_sensor,
     schedule,
     static_partitioned_config,
     usable_as_dagster_type,
@@ -1347,6 +1352,26 @@ def define_sensors():
         context.log.info("hello hello")
         return SkipReason()
 
+    @run_status_sensor(run_status=DagsterRunStatus.SUCCESS, request_job=no_config_pipeline)
+    def run_status(_):
+        return SkipReason("always skip")
+
+    @asset_sensor(asset_key=AssetKey("foo"), job=single_asset_pipeline)
+    def single_asset_sensor():
+        pass
+
+    @multi_asset_sensor(monitored_assets=[], job=single_asset_pipeline)
+    def many_asset_sensor(_):
+        pass
+
+    @freshness_policy_sensor(asset_selection=AssetSelection.all())
+    def fresh_sensor(_):
+        pass
+
+    @run_failure_sensor
+    def the_failure_sensor():
+        pass
+
     return [
         always_no_config_sensor,
         always_error_sensor,
@@ -1357,6 +1382,11 @@ def define_sensors():
         running_in_code_sensor,
         logging_sensor,
         update_cursor_sensor,
+        run_status,
+        single_asset_sensor,
+        many_asset_sensor,
+        fresh_sensor,
+        the_failure_sensor,
     ]
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
@@ -20,6 +20,7 @@ snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_deployed_g
         'ticks': [
         ]
     },
+    'sensorType': 'STANDARD',
     'targets': [
         {
             'mode': 'default',
@@ -42,6 +43,7 @@ snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_lazy_repos
         'ticks': [
         ]
     },
+    'sensorType': 'STANDARD',
     'targets': [
         {
             'mode': 'default',
@@ -64,6 +66,7 @@ snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_managed_gr
         'ticks': [
         ]
     },
+    'sensorType': 'STANDARD',
     'targets': [
         {
             'mode': 'default',
@@ -86,6 +89,7 @@ snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_multi_loca
         'ticks': [
         ]
     },
+    'sensorType': 'STANDARD',
     'targets': [
         {
             'mode': 'default',
@@ -159,6 +163,21 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'logging_sensor',
         'sensorState': {
             'runs': [
@@ -172,6 +191,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
             {
                 'mode': 'default',
                 'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
                 'solidSelection': None
             }
         ]
@@ -239,6 +278,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'running_in_code_sensor',
         'sensorState': {
             'runs': [
@@ -254,6 +313,41 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
         ]
     },
     {
@@ -342,6 +436,21 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repo
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'logging_sensor',
         'sensorState': {
             'runs': [
@@ -355,6 +464,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repo
             {
                 'mode': 'default',
                 'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
                 'solidSelection': None
             }
         ]
@@ -422,6 +551,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repo
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'running_in_code_sensor',
         'sensorState': {
             'runs': [
@@ -437,6 +586,41 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repo
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
         ]
     },
     {
@@ -525,6 +709,21 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'logging_sensor',
         'sensorState': {
             'runs': [
@@ -538,6 +737,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
             {
                 'mode': 'default',
                 'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
                 'solidSelection': None
             }
         ]
@@ -605,6 +824,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'running_in_code_sensor',
         'sensorState': {
             'runs': [
@@ -620,6 +859,41 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_g
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
         ]
     },
     {
@@ -708,6 +982,21 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_loc
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'logging_sensor',
         'sensorState': {
             'runs': [
@@ -721,6 +1010,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_loc
             {
                 'mode': 'default',
                 'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
                 'solidSelection': None
             }
         ]
@@ -788,6 +1097,26 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_loc
     {
         'description': None,
         'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
         'name': 'running_in_code_sensor',
         'sensorState': {
             'runs': [
@@ -803,6 +1132,41 @@ snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_loc
                 'pipelineName': 'no_config_pipeline',
                 'solidSelection': None
             }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
+    },
+    {
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
         ]
     },
     {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -122,6 +122,7 @@ query SensorQuery($sensorSelector: SensorSelector!) {
             }
         }
       }
+      sensorType
     }
   }
 }
@@ -491,6 +492,7 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
         assert result.data["sensorOrError"]["__typename"] == "Sensor"
         sensor = result.data["sensorOrError"]
         snapshot.assert_match(sensor)
+        assert sensor["sensorType"] == "STANDARD"
 
 
 class TestReadonlySensorPermissions(ReadonlyGraphQLContextTestMatrix):

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -11,6 +11,7 @@ from .sensor_definition import (
     RawSensorEvaluationFunctionReturn,
     SensorDefinition,
     SensorEvaluationContext,
+    SensorType,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name
@@ -114,3 +115,7 @@ class AssetSensorDefinition(SensorDefinition):
     @property
     def asset_key(self):
         return self._asset_key
+
+    @property
+    def sensor_type(self) -> SensorType:
+        return SensorType.ASSET

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -27,6 +27,7 @@ from .sensor_definition import (
     DefaultSensorStatus,
     SensorDefinition,
     SensorEvaluationContext,
+    SensorType,
     SkipReason,
     has_at_least_one_parameter,
 )
@@ -325,6 +326,10 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
             raise DagsterInvalidDefinitionError(
                 "Freshness policy sensor must accept a context argument."
             )
+
+    @property
+    def sensor_type(self) -> SensorType:
+        return SensorType.FRESHNESS_POLICY
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -37,6 +37,7 @@ from .sensor_definition import (
     DefaultSensorStatus,
     SensorDefinition,
     SensorEvaluationContext,
+    SensorType,
     has_at_least_one_parameter,
 )
 from .target import ExecutableDefinition
@@ -1183,3 +1184,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
 
         context.update_cursor_after_evaluation()
         return result
+
+    @property
+    def sensor_type(self) -> SensorType:
+        return SensorType.MULTI_ASSET

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -50,6 +50,7 @@ from .sensor_definition import (
     RunRequest,
     SensorDefinition,
     SensorEvaluationContext,
+    SensorType,
     SkipReason,
     has_at_least_one_parameter,
 )
@@ -718,6 +719,10 @@ class RunStatusSensorDefinition(SensorDefinition):
                 )
 
             return self._run_status_sensor_fn()
+
+    @property
+    def sensor_type(self) -> SensorType:
+        return SensorType.RUN_STATUS
 
 
 def run_status_sensor(

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -49,6 +49,16 @@ class DefaultSensorStatus(Enum):
     STOPPED = "STOPPED"
 
 
+@whitelist_for_serdes
+class SensorType(Enum):
+    STANDARD = "STANDARD"
+    RUN_STATUS = "RUN_STATUS"
+    ASSET = "ASSET"
+    MULTI_ASSET = "MULTI_ASSET"
+    FRESHNESS_POLICY = "FRESHNESS_POLICY"
+    UNKNOWN = "UNKNOWN"
+
+
 DEFAULT_SENSOR_DAEMON_INTERVAL = 30
 
 
@@ -398,6 +408,10 @@ class SensorDefinition:
                     "Job property not available when SensorDefinition has multiple jobs."
                 )
         raise DagsterInvalidDefinitionError("No job was provided to SensorDefinition.")
+
+    @property
+    def sensor_type(self) -> SensorType:
+        return SensorType.STANDARD
 
     def evaluate_tick(self, context: "SensorEvaluationContext") -> "SensorExecutionData":
         """Evaluate sensor using the provided context.

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.selector import (
 from dagster._core.definitions.sensor_definition import (
     DEFAULT_SENSOR_DAEMON_INTERVAL,
     DefaultSensorStatus,
+    SensorType,
 )
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
 from dagster._core.host_representation.origin import (
@@ -777,6 +778,10 @@ class ExternalSensor:
     @property
     def selector_id(self) -> str:
         return create_snapshot_id(self.selector)
+
+    @property
+    def sensor_type(self) -> SensorType:
+        return self._external_sensor_data.sensor_type or SensorType.UNKNOWN
 
     def get_current_instigator_state(
         self, stored_state: Optional["InstigatorState"]

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -51,7 +51,11 @@ from dagster._core.definitions.partition_mapping import (
 )
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
-from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorDefinition
+from dagster._core.definitions.sensor_definition import (
+    DefaultSensorStatus,
+    SensorDefinition,
+    SensorType,
+)
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -436,6 +440,7 @@ class ExternalSensorData(
             ("target_dict", Mapping[str, ExternalTargetData]),
             ("metadata", Optional[ExternalSensorMetadata]),
             ("default_status", Optional[DefaultSensorStatus]),
+            ("sensor_type", Optional[SensorType]),
         ],
     )
 ):
@@ -450,6 +455,7 @@ class ExternalSensorData(
         target_dict: Optional[Mapping[str, ExternalTargetData]] = None,
         metadata: Optional[ExternalSensorMetadata] = None,
         default_status: Optional[DefaultSensorStatus] = None,
+        sensor_type: Optional[SensorType] = None,
     ):
         if pipeline_name and not target_dict:
             # handle the legacy case where the ExternalSensorData was constructed from an earlier
@@ -483,6 +489,7 @@ class ExternalSensorData(
             default_status=DefaultSensorStatus.RUNNING
             if default_status == DefaultSensorStatus.RUNNING
             else None,
+            sensor_type=sensor_type,
         )
 
 
@@ -1480,6 +1487,7 @@ def external_sensor_data_from_def(
         description=sensor_def.description,
         metadata=ExternalSensorMetadata(asset_keys=asset_keys),
         default_status=sensor_def.default_status,
+        sensor_type=sensor_def.sensor_type,
     )
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -423,7 +423,10 @@ class ExternalSensorMetadata(
 class ExternalSensorDataSerializer(DefaultNamedTupleSerializer):
     @classmethod
     def skip_when_empty(cls) -> Set[str]:
-        return {"default_status"}  # Maintain stable snapshot ID for back-compat purposes
+        return {
+            "default_status",
+            "sensor_type",
+        }  # Maintain stable snapshot ID for back-compat purposes
 
 
 @whitelist_for_serdes(serializer=ExternalSensorDataSerializer)


### PR DESCRIPTION
Adds an enum for differentiating between different types of sensors. This will be useful for different UI treatments of different types of sensors going forward. 
I chose to add a SensorType.UNKNOWN value for the case where no sensor type was reached across the endpoint, but could just as easily use a null value for that.
