### PR TITLE
Removed typo from install.mdx

### DIFF
--- a/docs/content/getting-started/install.mdx
+++ b/docs/content/getting-started/install.mdx
@@ -5,7 +5,7 @@ description: Install Dagster
 
 # Installation
 
-Dagster is a a data orchestrator. Learn what Dagster is all about on our [homepage](/getting-started) or in the [Tutorial](/tutorial).
+Dagster is a data orchestrator. Learn what Dagster is all about on our [homepage](/getting-started) or in the [Tutorial](/tutorial).
 
 ---
 


### PR DESCRIPTION
There was a duplicate 'a' in the first sentence.
