### PR TITLE
[prototype] Link to asset definitions on GitHub from prod/Cloud Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -122,6 +122,7 @@ export type SidebarAssetFragment = {
     __typename: 'Repository';
     id: string;
     name: string;
+    displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
   };
   configField: {
@@ -15669,6 +15670,7 @@ export type SidebarAssetQuery = {
           __typename: 'Repository';
           id: string;
           name: string;
+          displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
           location: {__typename: 'RepositoryLocation'; id: string; name: string};
         };
         configField: {

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -269,11 +269,16 @@ class _Asset:
         asset_ins = build_asset_ins(fn, self.ins or {}, self.non_argument_deps)
 
         cwd = os.getcwd()
-        origin = (os.path.join(cwd, inspect.getsourcefile(fn)), inspect.getsourcelines(fn)[1])
+
+        source_file: str = os.path.join(cwd, inspect.getsourcefile(fn))
+        source_lines = inspect.getsourcelines(fn)[1]
+
+        module_name = inspect.getmodule(fn).__name__
+        path_from_module_root = source_file[source_file.index(module_name.replace(".", "/")) :]
 
         metadata = {
             **(self.metadata or {}),
-            "__code_origin": MetadataValue.json({"file": origin[0], "line": origin[1]}),
+            "__code_origin": MetadataValue.json({"file": source_file, "line": source_lines, "pathInModule": path_from_module_root}),
         }
 
         out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))


### PR DESCRIPTION
## Summary

Rough follow-up to #12009 which links out to asset definitions in GitHub for repositories which have `git` metadata configured (e.g. Cloud repos pushed to via GH action).

I think this could be especially neat for branch depls (to view changes in assets) and logged as part of history (e.g. being able to go back to an old materialization and jump to the exact version of code which it was built by)


https://user-images.githubusercontent.com/10215173/216195386-39fde623-0e69-4d2b-8117-6676ad3d6b08.mov



