### PR TITLE
[dagster-airflow] use full timestamp for partition name

### DIFF
--- a/examples/with_airflow/with_airflow/airflow_simple_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_simple_dag.py
@@ -11,7 +11,7 @@ args = {
     "start_date": days_ago(2),
 }
 
-simple_dag = models.DAG(dag_id="simple_dag", default_args=args, schedule_interval="* * * * *")
+simple_dag = models.DAG(dag_id="simple_dag", default_args=args, schedule_interval="0 0 * * *")
 
 run_this_last = DummyOperator(
     task_id="sink_task_foo",

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -407,8 +407,8 @@ def load_assets_from_airflow_dag(
         partitions_def=TimeWindowPartitionsDefinition(
             cron_schedule=cron_schedule,
             timezone=dag.timezone.name,
-            start=start_date.strftime("%Y-%m-%d"),
-            fmt="%Y-%m-%d",
+            start=start_date.strftime("%Y-%m-%dT%H:%M:%S"),
+            fmt="%Y-%m-%dT%H:%M:%S",
         )
         if cron_schedule is not None
         else None,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
@@ -11,7 +11,34 @@ from dagster_airflow import (
 
 from dagster_airflow_tests.marks import requires_airflow_db
 
-from ..airflow_utils import COMPLEX_DAG_FILE_CONTENTS
+
+ASSET_DAG = """
+from airflow import models
+
+from airflow.operators.bash import BashOperator
+import datetime
+
+default_args = {"start_date": datetime.datetime(2023, 2, 1)}
+
+with models.DAG(
+    dag_id="asset_dag", default_args=default_args, schedule_interval='0 0 * * *', tags=['example'],
+) as asset_dag:
+    foo = BashOperator(
+        task_id="foo", bash_command="echo foo"
+    )
+
+    bar = BashOperator(
+        task_id="bar", bash_command="echo bar"
+    )
+
+    biz = BashOperator(
+        task_id="biz", bash_command="echo biz"
+    )
+
+    baz = BashOperator(
+        task_id="baz", bash_command="echo baz"
+    )
+"""
 
 
 @pytest.mark.skipif(airflow_version >= "2.0.0", reason="requires airflow 1")
@@ -19,23 +46,23 @@ from ..airflow_utils import COMPLEX_DAG_FILE_CONTENTS
 def test_load_assets_from_airflow_dag():
     with tempfile.TemporaryDirectory(suffix="assets") as tmpdir_path:
         with open(os.path.join(tmpdir_path, "dag.py"), "wb") as f:
-            f.write(bytes(COMPLEX_DAG_FILE_CONTENTS.encode("utf-8")))
+            f.write(bytes(ASSET_DAG.encode("utf-8")))
 
         dag_bag = DagBag(
             dag_folder=tmpdir_path,
             include_examples=False,
         )
-        complex_dag = dag_bag.get_dag(dag_id="example_complex")
+        asset_dag = dag_bag.get_dag(dag_id="asset_dag")
 
         @asset
         def new_upstream_asset():
             return 1
 
         assets = load_assets_from_airflow_dag(
-            dag=complex_dag,
+            dag=asset_dag,
             task_ids_by_asset_key={
-                AssetKey("foo_asset"): {"create_entry_group_result", "create_entry_group_result2"},
-                AssetKey("bar_asset"): {"create_entry_gcs_result", "create_entry_gcs_result2"},
+                AssetKey("foo_asset"): {"foo", "bar"},
+                AssetKey("biz_asset"): {"biz", "baz"},
             },
             upstream_dependencies_by_asset_key={
                 AssetKey("foo_asset"): {
@@ -46,6 +73,6 @@ def test_load_assets_from_airflow_dag():
 
         result = materialize(
             [*assets, new_upstream_asset],
-            partition_key="2023-02-01",
+            partition_key="2023-02-01T00:00:00",
         )
         assert result.success

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
@@ -11,11 +11,10 @@ from dagster_airflow import (
 
 from dagster_airflow_tests.marks import requires_airflow_db
 
-
 ASSET_DAG = """
 from airflow import models
 
-from airflow.operators.bash import BashOperator
+from airflow.operators.bash_operator import BashOperator
 import datetime
 
 default_args = {"start_date": datetime.datetime(2023, 2, 1)}

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
@@ -11,7 +11,35 @@ from dagster_airflow import (
 
 from dagster_airflow_tests.marks import requires_airflow_db
 
-from ..airflow_utils import COMPLEX_DAG_FILE_CONTENTS_AIRFLOW_2
+
+ASSET_DAG = """
+from airflow import models
+
+from airflow.operators.bash_operator import BashOperator
+
+import datetime
+
+default_args = {"start_date": datetime.datetime(2023, 2, 1)}
+
+with models.DAG(
+    dag_id="asset_dag", default_args=default_args, schedule='0 0 * * *', tags=['example'],
+) as asset_dag:
+    foo = BashOperator(
+        task_id="foo", bash_command="echo foo"
+    )
+
+    bar = BashOperator(
+        task_id="bar", bash_command="echo bar"
+    )
+
+    biz = BashOperator(
+        task_id="biz", bash_command="echo biz"
+    )
+
+    baz = BashOperator(
+        task_id="baz", bash_command="echo baz"
+    )
+"""
 
 
 @pytest.mark.skipif(airflow_version < "2.0.0", reason="requires airflow 2")
@@ -19,20 +47,20 @@ from ..airflow_utils import COMPLEX_DAG_FILE_CONTENTS_AIRFLOW_2
 def test_load_assets_from_airflow_dag():
     with tempfile.TemporaryDirectory(suffix="assets") as tmpdir_path:
         with open(os.path.join(tmpdir_path, "dag.py"), "wb") as f:
-            f.write(bytes(COMPLEX_DAG_FILE_CONTENTS_AIRFLOW_2.encode("utf-8")))
+            f.write(bytes(ASSET_DAG.encode("utf-8")))
 
         dag_bag = DagBag(dag_folder=tmpdir_path)
-        complex_dag = dag_bag.get_dag(dag_id="example_complex")
+        asset_dag = dag_bag.get_dag(dag_id="asset_dag")
 
         @asset
         def new_upstream_asset():
             return 1
 
         assets = load_assets_from_airflow_dag(
-            dag=complex_dag,
+            dag=asset_dag,
             task_ids_by_asset_key={
-                AssetKey("foo_asset"): {"create_entry_group_result", "create_entry_group_result2"},
-                AssetKey("bar_asset"): {"create_entry_gcs_result", "create_entry_gcs_result2"},
+                AssetKey("foo_asset"): {"foo", "bar"},
+                AssetKey("biz_asset"): {"biz", "baz"},
             },
             upstream_dependencies_by_asset_key={
                 AssetKey("foo_asset"): {
@@ -43,6 +71,6 @@ def test_load_assets_from_airflow_dag():
 
         result = materialize(
             [*assets, new_upstream_asset],
-            partition_key="2023-02-01",
+            partition_key="2023-02-01T00:00:00",
         )
         assert result.success

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
@@ -11,11 +11,10 @@ from dagster_airflow import (
 
 from dagster_airflow_tests.marks import requires_airflow_db
 
-
 ASSET_DAG = """
 from airflow import models
 
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 
 import datetime
 


### PR DESCRIPTION
### Summary & Motivation

the 1000s of partitions were coming from the combination of a 1min cron schedule and partition names that only used y/m/d

it might be worth making this configurable by users in the future.

### How I Tested These Changes
