### PR TITLE
Fix context.asset_partition_key for multidimensional partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -366,12 +366,12 @@ class PlanExecutionContext(IPlanContext):
         )
 
         tags = self._plan_data.pipeline_run.tags
-        partition_key = tags.get(PARTITION_NAME_TAG)
-        if partition_key is not None:
-            return PartitionKeyRange(partition_key, partition_key)
-
         if any([tag.startswith(MULTIDIMENSIONAL_PARTITION_PREFIX) for tag in tags.keys()]):
             partition_key = get_multipartition_key_from_tags(tags)
+            return PartitionKeyRange(partition_key, partition_key)
+
+        partition_key = tags.get(PARTITION_NAME_TAG)
+        if partition_key is not None:
             return PartitionKeyRange(partition_key, partition_key)
 
         partition_key_range_start = tags.get(ASSET_PARTITION_RANGE_START_TAG)

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -367,8 +367,8 @@ class PlanExecutionContext(IPlanContext):
 
         tags = self._plan_data.pipeline_run.tags
         if any([tag.startswith(MULTIDIMENSIONAL_PARTITION_PREFIX) for tag in tags.keys()]):
-            partition_key = get_multipartition_key_from_tags(tags)
-            return PartitionKeyRange(partition_key, partition_key)
+            multipartition_key = get_multipartition_key_from_tags(tags)
+            return PartitionKeyRange(multipartition_key, multipartition_key)
 
         partition_key = tags.get(PARTITION_NAME_TAG)
         if partition_key is not None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -6,13 +6,13 @@ from dagster import (
     DagsterEventType,
     DailyPartitionsDefinition,
     EventRecordsFilter,
+    IOManager,
     MultiPartitionKey,
     StaticPartitionsDefinition,
     asset,
     define_asset_job,
-    repository,
     materialize,
-    IOManager,
+    repository,
 )
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -11,6 +11,8 @@ from dagster import (
     asset,
     define_asset_job,
     repository,
+    materialize,
+    IOManager,
 )
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -313,4 +315,38 @@ def test_multipartitions_subset_addition(initial, added):
     )
     assert added_subset.get_partition_keys_not_in_subset(current_time=current_day) == set(
         expected_keys_not_in_updated_subset
+    )
+
+
+def test_asset_partition_key_is_multipartition_key():
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            assert isinstance(context.asset_partition_key, MultiPartitionKey)
+
+        def load_input(self, context):
+            assert isinstance(context.asset_partition_key, MultiPartitionKey)
+            return 1
+
+    partitions_def = MultiPartitionsDefinition(
+        {"a": StaticPartitionsDefinition(["a"]), "b": StaticPartitionsDefinition(["b"])}
+    )
+
+    @asset(
+        partitions_def=partitions_def,
+        io_manager_key="my_io_manager",
+    )
+    def my_asset(context):
+        return 1
+
+    @asset(
+        partitions_def=partitions_def,
+        io_manager_key="my_io_manager",
+    )
+    def asset2(context, my_asset):
+        return 2
+
+    materialize(
+        [my_asset, asset2],
+        resources={"my_io_manager": MyIOManager()},
+        partition_key="a|b",
     )


### PR DESCRIPTION
User reports that `context.asset_partition_key` is returning a `str` and not a `MultiPartitionKey` object when executing in Dagit:

> I am using context.asset_partition_key
> I see that context.asset_partitions_def is an instance of MultiPartitionsDefinition,
> however, context.asset_partition_key is a string of format key_1|key_2 and not MultiPartitionKey. This was previously working, but after I upgraded from 1.10 to 1.14, it does this behavior now.

This PR fixes this error.