### PR TITLE
Use Definitions in the body of materialize functions (and other public-facing execution functions)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Set, Union
 
 import dagster._check as check
+from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._utils.merger import merge_dicts
 
 from ..errors import DagsterInvariantViolationError
@@ -8,10 +10,7 @@ from ..instance import DagsterInstance
 from ..storage.io_manager import IOManagerDefinition
 from ..storage.mem_io_manager import mem_io_manager
 from .assets import AssetsDefinition
-from .assets_job import build_assets_job
-from .job_definition import default_job_io_manager_with_fs_io_manager_schema
 from .source_asset import SourceAsset
-from .utils import DEFAULT_IO_MANAGER_KEY
 
 if TYPE_CHECKING:
     from ..execution.execute_in_process_result import ExecuteInProcessResult
@@ -47,24 +46,24 @@ def materialize(
     Returns:
         ExecuteInProcessResult: The result of the execution.
     """
-    from ..execution.build_resources import wrap_resources_for_execution
+    from dagster._core.definitions.definitions_class import Definitions
 
     assets = check.sequence_param(assets, "assets", of_type=(AssetsDefinition, SourceAsset))
-    assets_defs = [the_def for the_def in assets if isinstance(the_def, AssetsDefinition)]
-    source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
     instance = check.opt_inst_param(instance, "instance", DagsterInstance)
     partition_key = check.opt_str_param(partition_key, "partition_key")
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
-    resource_defs = wrap_resources_for_execution(resources)
-    resource_defs = merge_dicts(
-        {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema}, resource_defs
-    )
 
-    return build_assets_job(
-        "in_process_materialization_job",
-        assets=assets_defs,
-        source_assets=source_assets,
-        resource_defs=resource_defs,
+    all_executable_keys: Set[AssetKey] = set()
+    for asset in assets:
+        if isinstance(asset, AssetsDefinition):
+            all_executable_keys = all_executable_keys.union(set(asset.keys))
+
+    JOB_NAME = "__ephemeral_asset_job__"
+
+    defs = Definitions(jobs=[define_asset_job(name=JOB_NAME)], assets=assets, resources=resources)
+    return check.not_none(
+        defs.get_job_def(JOB_NAME),
+        "This should always return a job",
     ).execute_in_process(
         run_config=run_config,
         instance=instance,
@@ -106,18 +105,17 @@ def materialize_to_memory(
     Returns:
         ExecuteInProcessResult: The result of the execution.
     """
-    from dagster._core.execution.build_resources import wrap_resources_for_execution
-
     assets = check.sequence_param(assets, "assets", of_type=(AssetsDefinition, SourceAsset))
-    resource_defs = wrap_resources_for_execution(resources)
+
     # Gather all resource defs for the purpose of checking io managers.
-    all_resource_defs = dict(resource_defs)
+    resources_dict = resources or {}
+    all_resource_keys = set(resources_dict.keys())
     for asset in assets:
-        all_resource_defs = merge_dicts(asset.resource_defs, all_resource_defs)
+        all_resource_keys = all_resource_keys.union(asset.resource_defs.keys())
 
     io_manager_keys = _get_required_io_manager_keys(assets)
     for io_manager_key in io_manager_keys:
-        if io_manager_key in all_resource_defs:
+        if io_manager_key in all_resource_keys:
             raise DagsterInvariantViolationError(
                 "Attempted to call `materialize_to_memory` with a resource "
                 f"provided for io manager key '{io_manager_key}'. Do not "
@@ -125,20 +123,13 @@ def materialize_to_memory(
                 "`materialize_to_memory`, as it will override io management "
                 "behavior for all keys."
             )
-    resource_defs = merge_dicts({key: mem_io_manager for key in io_manager_keys}, resource_defs)
-    assets_defs = [the_def for the_def in assets if isinstance(the_def, AssetsDefinition)]
-    source_assets = [the_def for the_def in assets if isinstance(the_def, SourceAsset)]
 
-    instance = check.opt_inst_param(instance, "instance", DagsterInstance)
-    partition_key = check.opt_str_param(partition_key, "partition_key")
+    resource_defs = merge_dicts({key: mem_io_manager for key in io_manager_keys}, resources_dict)
 
-    return build_assets_job(
-        "in_process_materialization_job",
-        assets=assets_defs,
-        source_assets=source_assets,
-        resource_defs=resource_defs,
-    ).execute_in_process(
+    return materialize(
+        assets=assets,
         run_config=run_config,
+        resources=resource_defs,
         instance=instance,
         partition_key=partition_key,
         raise_on_error=raise_on_error,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -21,6 +21,7 @@ from dagster import (
     op,
     with_resources,
 )
+from dagster._core.errors import DagsterInvalidInvocationError
 
 
 def test_basic_materialize_to_memory():
@@ -116,11 +117,11 @@ def test_materialize_conflicting_resources():
         materialize_to_memory([first, second])
 
     with pytest.raises(
-        DagsterInvalidDefinitionError,
+        DagsterInvalidInvocationError,
         match=(
-            "resource with key 'foo' provided to job conflicts with resource provided to assets."
-            " When constructing a job, all resource definitions provided must match by reference"
-            " equality for a given key."
+            r'AssetsDefinition with key \["first"\] has conflicting resource definitions with'
+            r" provided resources for the following keys: foo. Either remove the existing"
+            r" resources from the asset or change the resource keys"
         ),
     ):
         materialize_to_memory(


### PR DESCRIPTION
### Summary & Motivation

I had suggested that we use `Definitions` in the body of a proposed `observe` function in https://github.com/dagster-io/dagster/pull/11996 and I think the most efficient path forward was to discuss this in the form of an RFC diff.

This has two advantages:

1) Marginally less code
2) More importantly. this funnels more of our public-facing execution APIs through a single choke point––`Definitions`––rather than having multiple execution paths call into the lower-level APIs that `Definitions` itself ends up invoking. I think this is nearly an unalloyed good, making error messages more consistent and also forcing us to be more consistent on execution behavior.

Re: 2) this diff itself exposed a couple instances of this, where we don't allow empty asset jobs, wheres both `materialize` and our core `@job` APIs are fine with empty jobs. And then the different exception type.


### How I Tested These Changes

BK
