### PR TITLE
feat(dbt-cloud): compile run only if job has environment variable cache

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/cli.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/cli.py
@@ -30,9 +30,24 @@ def cache_compile_references(
     # Compile each job with an override
     for dbt_cloud_job in dbt_cloud_jobs:
         job_id: int = dbt_cloud_job["id"]
-        job_commands: List[str] = dbt_cloud_job["execute_steps"]
+
+        # Only run on jobs with the Dagster dbt Cloud compile run id env var set
+        compile_run_environment_variable_response = (
+            dbt_cloud_resource.get_job_environment_variables(project_id=project_id, job_id=job_id)
+            .get(DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR, {})
+            .get("job")
+        )
+
+        if not compile_run_environment_variable_response:
+            typer.echo(
+                f"Skipping cache for job id `{job_id}` as it does not have a job override for the"
+                f" environment variable `{DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR}`. To start the cache,"
+                " set this environment variable to `-1`."
+            )
+            continue
 
         # Retrieve the filters for the compile override step
+        job_commands: List[str] = dbt_cloud_job["execute_steps"]
         job_materialization_command_step = (
             DbtCloudCacheableAssetsDefinition.get_job_materialization_command_step(
                 execute_steps=job_commands
@@ -57,12 +72,7 @@ def cache_compile_references(
 
         # Cache the compile run as a reference in the dbt Cloud job's env var
         dbt_cloud_compile_run_id = str(dbt_cloud_compile_run["id"])
-        dbt_cloud_job_env_vars = dbt_cloud_resource.get_job_environment_variables(
-            project_id=project_id, job_id=job_id
-        )
-        compile_run_environment_variable_id = dbt_cloud_job_env_vars[
-            DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR
-        ]["job"]["id"]
+        compile_run_environment_variable_id = compile_run_environment_variable_response["id"]
 
         typer.echo(
             f"Updating the value of environment variable `{DAGSTER_DBT_COMPILE_RUN_ID_ENV_VAR}`"


### PR DESCRIPTION
### Summary & Motivation
Some user feedback on the caching mechanism:
> Will this compile all jobs within that project ID - isn’t that a bit unnecessary since that means all of my staging, testing jobs will be compiled as well? Or will it reference my dagster repo code for only the jobs necessary to compile?

> we have jobs just hanging around from tests (branch tests for complex changes) , others that are ad hoc jobs (for people to manually update and run), jobs just for when I test dbt upgrades, etc etc :slightly_smiling_face:  None of those need to be run

> All jobs must comply to your "dagster" expectations meaning - I'm getting the below which as is, would be an issue unless I "fixed" and ran all jobs via Dagster

A dbt project could potentially have many jobs (for testing, managed by Dagster, manual use, etc). Rather than trying to manage all of this, only manage the jobs that are explicitly labeled by the user.

Here, we use the presence of the environment variable cache to determine whether or not we should populate its cache.

### How I Tested These Changes
pytest, local
