### PR TITLE
Install dagster-managed-elements when appropriate

### DIFF
--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -46,6 +46,9 @@ setup(
     extras_require={
         "test": [
             "requests-mock",
-        ]
+        ],
+        "managed": [
+            f"dagster-managed-elements{pin}",
+        ],
     },
 )

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -39,4 +39,9 @@ setup(
             "dagster-fivetran = dagster_fivetran.cli:main",
         ]
     },
+    extras_require={
+        "managed": [
+            f"dagster-managed-elements{pin}",
+        ],
+    },
 )

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -46,6 +46,7 @@ def main(
         "-e python_modules/dagster-test",
         "-e python_modules/dagit",
         "-e python_modules/automation",
+        "-e python_modules/libraries/dagster-managed-elements",
         "-e python_modules/libraries/dagster-airbyte",
         "-e python_modules/libraries/dagster-airflow",
         "-e python_modules/libraries/dagster-aws[test]",


### PR DESCRIPTION
This adds extras to fivetran and airbyte integrations to make it possible to install `dagster-managed-elements`.

It also installs `dagster-managed-elements` via `make dev_install`.