### PR TITLE
(tick-testing 2/6) Revamp dry run tick behavior

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2049,7 +2049,7 @@ type RunLauncher {
 }
 
 type DryRunInstigationTick {
-  timestamp: Float!
+  timestamp: Float
   evaluationResult: TickEvaluation
 }
 
@@ -2057,6 +2057,7 @@ type TickEvaluation {
   runRequests: [RunRequest]
   skipReason: String
   error: PythonError
+  cursor: String
 }
 
 type RunRequest {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2054,7 +2054,7 @@ type DryRunInstigationTick {
 }
 
 type TickEvaluation {
-  runRequests: [RunRequest]
+  runRequests: [RunRequest!]
   skipReason: String
   error: PythonError
   cursor: String

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3589,7 +3589,7 @@ export type TickEvaluation = {
   __typename: 'TickEvaluation';
   cursor: Maybe<Scalars['String']>;
   error: Maybe<PythonError>;
-  runRequests: Maybe<Array<Maybe<RunRequest>>>;
+  runRequests: Maybe<Array<RunRequest>>;
   skipReason: Maybe<Scalars['String']>;
 };
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -934,7 +934,7 @@ export type DisplayableEvent = {
 export type DryRunInstigationTick = {
   __typename: 'DryRunInstigationTick';
   evaluationResult: Maybe<TickEvaluation>;
-  timestamp: Scalars['Float'];
+  timestamp: Maybe<Scalars['Float']>;
 };
 
 export type DryRunInstigationTicks = {
@@ -3587,6 +3587,7 @@ export type TextMetadataEntry = MetadataEntry & {
 
 export type TickEvaluation = {
   __typename: 'TickEvaluation';
+  cursor: Maybe<Scalars['String']>;
   error: Maybe<PythonError>;
   runRequests: Maybe<Array<Maybe<RunRequest>>>;
   skipReason: Maybe<Scalars['String']>;

--- a/js_modules/dagit/packages/core/src/instance/NextTick.tsx
+++ b/js_modules/dagit/packages/core/src/instance/NextTick.tsx
@@ -25,7 +25,7 @@ export const NextTick = (props: Props) => {
       if (scheduleState.status === InstigationStatus.RUNNING) {
         return {
           executionTimezone,
-          earliest: Math.min(...futureTicks.results.map(({timestamp}) => timestamp)),
+          earliest: Math.min(...futureTicks.results.map(({timestamp}) => timestamp!)),
         };
       }
       return null;

--- a/js_modules/dagit/packages/core/src/instance/types/NextTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/NextTick.types.ts
@@ -9,6 +9,6 @@ export type ScheduleFutureTicksFragment = {
   scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
   futureTicks: {
     __typename: 'DryRunInstigationTicks';
-    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
   };
 };

--- a/js_modules/dagit/packages/core/src/instigation/LiveTickTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/LiveTickTimeline.tsx
@@ -36,12 +36,12 @@ export const LiveTickTimeline: React.FC<{
   });
 
   React.useEffect(() => {
-    if (!isPaused && (!nextTick || now < 1000 * nextTick.timestamp)) {
+    if (!isPaused && (!nextTick || now < 1000 * nextTick.timestamp!)) {
       setGraphNow(now);
     }
   }, [isPaused, nextTick, now]);
 
-  const isAtFutureTick = nextTick && 1000 * nextTick.timestamp <= now;
+  const isAtFutureTick = nextTick && 1000 * nextTick.timestamp! <= now;
   const PULSE_DURATION = 2000;
   const nextTickRadius = isAtFutureTick
     ? 4 + Math.sin((2 * Math.PI * (now % PULSE_DURATION)) / PULSE_DURATION)
@@ -52,7 +52,7 @@ export const LiveTickTimeline: React.FC<{
   const tickRadii = Array(ticks.length).fill(3);
 
   if (nextTick) {
-    tickData.push({x: 1000 * nextTick.timestamp, y: 0});
+    tickData.push({x: 1000 * nextTick.timestamp!, y: 0});
     tickColors.push(Colors.Gray200);
     tickRadii.push(nextTickRadius);
   }

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
@@ -17,7 +17,7 @@ export type TickHistoryQuery = {
         __typename: 'InstigationState';
         id: string;
         instigationType: Types.InstigationType;
-        nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
+        nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
         ticks: Array<{
           __typename: 'InstigationTick';
           id: string;

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
@@ -55,7 +55,10 @@ export type TickHistoryQuery = {
       };
 };
 
-export type NextTickForHistoryFragment = {__typename: 'DryRunInstigationTick'; timestamp: number};
+export type NextTickForHistoryFragment = {
+  __typename: 'DryRunInstigationTick';
+  timestamp: number | null;
+};
 
 export type HistoryTickFragment = {
   __typename: 'InstigationTick';

--- a/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
@@ -65,7 +65,7 @@ export type ScheduledRunsListQuery = {
             };
             futureTicks: {
               __typename: 'DryRunInstigationTicks';
-              results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+              results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
             };
           }>;
         }>;

--- a/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
@@ -94,7 +94,10 @@ export type RunTimelineQuery = {
                     };
                     futureTicks: {
                       __typename: 'DryRunInstigationTicks';
-                      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+                      results: Array<{
+                        __typename: 'DryRunInstigationTick';
+                        timestamp: number | null;
+                      }>;
                     };
                   }>;
                 }>;

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -125,7 +125,7 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
           for (const schedule of schedules) {
             if (schedule.scheduleState.status === InstigationStatus.RUNNING) {
               schedule.futureTicks.results.forEach(({timestamp}) => {
-                const startTime = timestamp * 1000;
+                const startTime = timestamp! * 1000;
                 if (startTime > now && overlap({start, end}, {start: startTime, end: startTime})) {
                   jobTicks.push({
                     id: `${schedule.pipelineName}-future-run-${timestamp}`,

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleDetails.tsx
@@ -86,7 +86,7 @@ export const ScheduleDetails: React.FC<{
               <Tag icon="timer">
                 Next tick:{' '}
                 <TimestampDisplay
-                  timestamp={futureTicks.results[0].timestamp}
+                  timestamp={futureTicks.results[0].timestamp!}
                   timezone={executionTimezone}
                   timeFormat={TIME_FORMAT}
                 />

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -85,14 +85,14 @@ export const SchedulesNextTicks: React.FC<{
     const minMaxTimestamp = Math.min(
       ...futureTickSchedules.map(
         (schedule) =>
-          schedule.futureTicks.results[schedule.futureTicks.results.length - 1].timestamp,
+          schedule.futureTicks.results[schedule.futureTicks.results.length - 1].timestamp!,
       ),
     );
 
     futureTickSchedules.forEach((schedule) => {
       schedule.futureTicks.results.forEach((tick) => {
-        if (tick.timestamp <= minMaxTimestamp) {
-          nextTicks.push({schedule, timestamp: tick.timestamp, repoAddress});
+        if (tick.timestamp! <= minMaxTimestamp) {
+          nextTicks.push({schedule, timestamp: tick.timestamp!, repoAddress});
         }
       });
     });

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesTable.tsx
@@ -176,7 +176,7 @@ const ScheduleRow: React.FC<{
       <td>
         {futureTicks.results.length && status === InstigationStatus.RUNNING ? (
           <TimestampDisplay
-            timestamp={futureTicks.results[0].timestamp}
+            timestamp={futureTicks.results[0].timestamp!}
             timezone={executionTimezone}
             timeFormat={{showSeconds: false, showTimezone: true}}
           />

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -76,7 +76,7 @@ export type ScheduleRootQuery = {
         };
         futureTicks: {
           __typename: 'DryRunInstigationTicks';
-          results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+          results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
         };
       }
     | {__typename: 'ScheduleNotFoundError'; message: string};

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
@@ -59,7 +59,7 @@ export type ScheduleFragment = {
   };
   futureTicks: {
     __typename: 'DryRunInstigationTicks';
-    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
   };
 };
 
@@ -125,7 +125,7 @@ export type RepositorySchedulesFragment = {
     };
     futureTicks: {
       __typename: 'DryRunInstigationTicks';
-      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
     };
   }>;
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
@@ -211,7 +211,7 @@ export type SchedulesRootQuery = {
           };
           futureTicks: {
             __typename: 'DryRunInstigationTicks';
-            results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+            results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
           };
         }>;
         displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
@@ -13,7 +13,7 @@ export type ScheduleNextFiveTicksFragment = {
   scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
   futureTicks: {
     __typename: 'DryRunInstigationTicks';
-    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+    results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
   };
 };
 
@@ -33,7 +33,7 @@ export type RepositoryForNextTicksFragment = {
     scheduleState: {__typename: 'InstigationState'; id: string; status: Types.InstigationStatus};
     futureTicks: {
       __typename: 'DryRunInstigationTicks';
-      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number}>;
+      results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
     };
   }>;
 };

--- a/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/SchedulesNextTicks.types.ts
@@ -60,7 +60,7 @@ export type ScheduleTickConfigQuery = {
               runKey: string | null;
               runConfigYaml: string;
               tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-            } | null> | null;
+            }> | null;
             error: {
               __typename: 'PythonError';
               message: string;
@@ -85,7 +85,7 @@ export type ScheduleFutureTickEvaluationResultFragment = {
     runKey: string | null;
     runConfigYaml: string;
     tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-  } | null> | null;
+  }> | null;
   error: {
     __typename: 'PythonError';
     message: string;

--- a/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorDetails.tsx
@@ -112,7 +112,7 @@ export const SensorDetails: React.FC<{
             </Tag>
             {sensor.nextTick && daemonHealth && status === InstigationStatus.RUNNING ? (
               <Tag icon="timer">
-                Next tick: <TimestampDisplay timestamp={sensor.nextTick.timestamp} />
+                Next tick: <TimestampDisplay timestamp={sensor.nextTick.timestamp!} />
               </Tag>
             ) : null}
           </>

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
@@ -9,7 +9,7 @@ export type SensorFragment = {
   name: string;
   description: string | null;
   minIntervalSeconds: number;
-  nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
+  nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
   sensorState: {
     __typename: 'InstigationState';
     id: string;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
@@ -26,7 +26,7 @@ export type SensorRootQuery = {
         name: string;
         description: string | null;
         minIntervalSeconds: number;
-        nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
+        nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
         sensorState: {
           __typename: 'InstigationState';
           id: string;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorsRoot.types.ts
@@ -30,7 +30,7 @@ export type SensorsRootQuery = {
           name: string;
           description: string | null;
           minIntervalSeconds: number;
-          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
+          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
           sensorState: {
             __typename: 'InstigationState';
             id: string;

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -150,7 +150,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
                   >
                     Next tick:&nbsp;
                     <TimestampDisplay
-                      timestamp={scheduleData.scheduleState.nextTick.timestamp}
+                      timestamp={scheduleData.scheduleState.nextTick.timestamp!}
                       timezone={scheduleData.executionTimezone}
                       timeFormat={{showSeconds: false, showTimezone: true}}
                     />

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -52,7 +52,7 @@ export type SingleScheduleQuery = {
             endTime: number | null;
             updateTime: number | null;
           }>;
-          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
+          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
         };
         partitionSet: {__typename: 'PartitionSet'; id: string; name: string} | null;
       }

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -56,7 +56,7 @@ export type SingleSensorQuery = {
             endTime: number | null;
             updateTime: number | null;
           }>;
-          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number} | null;
+          nextTick: {__typename: 'DryRunInstigationTick'; timestamp: number | null} | null;
         };
       }
     | {__typename: 'SensorNotFoundError'}

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -183,4 +183,4 @@ def get_schedule_next_tick(graphene_info: ResolveInfo, schedule_state):
     )
 
     next_timestamp = next(time_iter).timestamp()
-    return GrapheneDryRunInstigationTick(schedule_state, next_timestamp)
+    return GrapheneDryRunInstigationTick(external_schedule.schedule_selector, next_timestamp)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -211,7 +211,7 @@ def get_sensor_next_tick(graphene_info: ResolveInfo, sensor_state):
     next_timestamp = latest_tick.timestamp + external_sensor.min_interval_seconds
     if next_timestamp < get_timestamp_from_utc_datetime(get_current_datetime_in_utc()):
         return None
-    return GrapheneDryRunInstigationTick(sensor_state, next_timestamp)
+    return GrapheneDryRunInstigationTick(external_sensor.sensor_selector, next_timestamp)
 
 
 @capture_error

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -266,7 +266,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
 
 
 class GrapheneTickEvaluation(graphene.ObjectType):
-    runRequests = graphene.List(lambda: GrapheneRunRequest)
+    runRequests = graphene.List(lambda: graphene.NonNull(GrapheneRunRequest))
     skipReason = graphene.String()
     error = graphene.Field(GraphenePythonError)
     cursor = graphene.String()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -1,12 +1,14 @@
 import sys
 import warnings
-from typing import Union
+from typing import Optional, Union
 
 import dagster._check as check
 import graphene
 import pendulum
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.schedule_definition import ScheduleExecutionData
+from dagster._core.definitions.selector import ScheduleSelector, SensorSelector
+from dagster._core.definitions.sensor_definition import SensorExecutionData
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorTick,
@@ -25,7 +27,15 @@ from ..implementation.fetch_instigators import get_tick_log_events
 from ..implementation.fetch_schedules import get_schedule_next_tick
 from ..implementation.fetch_sensors import get_sensor_next_tick
 from ..implementation.loader import RepositoryScopedBatchLoader
-from .errors import GrapheneError, GraphenePythonError
+from ..implementation.utils import UserFacingGraphQLError
+from .errors import (
+    GrapheneError,
+    GraphenePythonError,
+    GrapheneRepositoryLocationNotFound,
+    GrapheneRepositoryNotFoundError,
+    GrapheneScheduleNotFoundError,
+    GrapheneSensorNotFoundError,
+)
 from .logs.log_level import GrapheneLogLevel
 from .repository_origin import GrapheneRepositoryOrigin
 from .tags import GraphenePipelineTag
@@ -169,87 +179,124 @@ class GrapheneInstigationTick(graphene.ObjectType):
 
 
 class GrapheneDryRunInstigationTick(graphene.ObjectType):
-    timestamp = graphene.NonNull(graphene.Float)
+    timestamp = graphene.Float()
     evaluationResult = graphene.Field(lambda: GrapheneTickEvaluation)
 
     class Meta:
         name = "DryRunInstigationTick"
 
-    def __init__(self, state, timestamp):
-        self._state = check.inst_param(state, "state", InstigatorState)
-        self._timestamp = timestamp
+    def __init__(
+        self,
+        selector: Union[ScheduleSelector, SensorSelector],
+        timestamp: Optional[float],
+        cursor: Optional[str] = None,
+    ):
+        self._selector = check.inst_param(selector, "selector", (ScheduleSelector, SensorSelector))
+        self._cursor = cursor
         super().__init__(
-            timestamp=check.float_param(timestamp, "timestamp"),
+            timestamp=check.opt_float_param(timestamp, "timestamp"),
         )
 
     def resolve_evaluationResult(self, graphene_info: ResolveInfo):
-        if not self._state.is_running or self._state.instigator_type != InstigatorType.SCHEDULE:
-            return None
-
-        repository_origin = self._state.origin.external_repository_origin
-        if not graphene_info.context.has_repository_location(
-            repository_origin.repository_location_origin.location_name
-        ):
-            return None
+        if not graphene_info.context.has_repository_location(self._selector.location_name):
+            raise UserFacingGraphQLError(
+                GrapheneRepositoryLocationNotFound(location_name=self._selector.location_name)
+            )
 
         repository_location = graphene_info.context.get_repository_location(
-            repository_origin.repository_location_origin.location_name
+            self._selector.location_name
         )
-        if not repository_location.has_repository(repository_origin.repository_name):
-            return None
-
-        repository = repository_location.get_repository(repository_origin.repository_name)
-
-        if not repository.has_external_schedule(self._state.name):
-            return None
-
-        external_schedule = repository.get_external_schedule(self._state.name)
-        timezone_str = external_schedule.execution_timezone
-        if not timezone_str:
-            timezone_str = "UTC"
-
-        next_tick_datetime = next(external_schedule.execution_time_iterator(self._timestamp))
-        schedule_time = to_timezone(pendulum.instance(next_tick_datetime), timezone_str)
-        schedule_data: Union[ScheduleExecutionData, SerializableErrorInfo]
-        try:
-            schedule_data = repository_location.get_external_schedule_execution_data(
-                instance=graphene_info.context.instance,
-                repository_handle=repository.handle,
-                schedule_name=external_schedule.name,
-                scheduled_execution_time=schedule_time,
+        if not repository_location.has_repository(self._selector.repository_name):
+            raise UserFacingGraphQLError(
+                GrapheneRepositoryNotFoundError(
+                    repository_location_name=self._selector.location_name,
+                    repository_name=self._selector.repository_name,
+                )
             )
-        except Exception:
-            schedule_data = serializable_error_info_from_exc_info(sys.exc_info())
 
-        return GrapheneTickEvaluation(schedule_data)
+        repository = repository_location.get_repository(self._selector.repository_name)
+
+        if isinstance(self._selector, SensorSelector):
+            if not repository.has_external_sensor(self._selector.sensor_name):
+                raise UserFacingGraphQLError(
+                    GrapheneSensorNotFoundError(self._selector.sensor_name)
+                )
+            sensor_data: Union[SensorExecutionData, SerializableErrorInfo]
+            try:
+                sensor_data = repository_location.get_external_sensor_execution_data(
+                    name=self._selector.sensor_name,
+                    instance=graphene_info.context.instance,
+                    repository_handle=repository.handle,
+                    cursor=self._cursor,
+                    last_completion_time=None,
+                    last_run_key=None,
+                )
+            except Exception:
+                sensor_data = serializable_error_info_from_exc_info(sys.exc_info())
+            return GrapheneTickEvaluation(sensor_data)
+        else:
+            if not repository.has_external_schedule(self._selector.schedule_name):
+                raise UserFacingGraphQLError(
+                    GrapheneScheduleNotFoundError(self._selector.schedule_name)
+                )
+            if not self.timestamp:
+                raise Exception(
+                    "No tick timestamp provided when attempting to dry-run schedule"
+                    f" {self._selector.schedule_name}."
+                )
+            external_schedule = repository.get_external_schedule(self._selector.schedule_name)
+            timezone_str = external_schedule.execution_timezone
+            if not timezone_str:
+                timezone_str = "UTC"
+
+            next_tick_datetime = next(external_schedule.execution_time_iterator(self.timestamp))
+            schedule_time = to_timezone(pendulum.instance(next_tick_datetime), timezone_str)
+            schedule_data: Union[ScheduleExecutionData, SerializableErrorInfo]
+            try:
+                schedule_data = repository_location.get_external_schedule_execution_data(
+                    instance=graphene_info.context.instance,
+                    repository_handle=repository.handle,
+                    schedule_name=external_schedule.name,
+                    scheduled_execution_time=schedule_time,
+                )
+            except Exception:
+                schedule_data = serializable_error_info_from_exc_info(sys.exc_info())
+
+            return GrapheneTickEvaluation(schedule_data)
 
 
 class GrapheneTickEvaluation(graphene.ObjectType):
     runRequests = graphene.List(lambda: GrapheneRunRequest)
     skipReason = graphene.String()
     error = graphene.Field(GraphenePythonError)
+    cursor = graphene.String()
 
     class Meta:
         name = "TickEvaluation"
 
-    def __init__(self, schedule_data):
+    def __init__(self, execution_data):
         check.inst_param(
-            schedule_data,
-            "schedule_data",
-            (ScheduleExecutionData, SerializableErrorInfo),
+            execution_data,
+            "execution_data",
+            (ScheduleExecutionData, SensorExecutionData, SerializableErrorInfo),
         )
         error = (
-            GraphenePythonError(schedule_data)
-            if isinstance(schedule_data, SerializableErrorInfo)
+            GraphenePythonError(execution_data)
+            if isinstance(execution_data, SerializableErrorInfo)
             else None
         )
         skip_reason = (
-            schedule_data.skip_message if isinstance(schedule_data, ScheduleExecutionData) else None
+            execution_data.skip_message
+            if not isinstance(execution_data, SerializableErrorInfo)
+            else None
         )
         self._run_requests = (
-            schedule_data.run_requests if isinstance(schedule_data, ScheduleExecutionData) else None
+            execution_data.run_requests
+            if not isinstance(execution_data, SerializableErrorInfo)
+            else None
         )
-        super().__init__(skipReason=skip_reason, error=error)
+        cursor = execution_data.cursor if isinstance(execution_data, SensorExecutionData) else None
+        super().__init__(skipReason=skip_reason, error=error, cursor=cursor)
 
     def resolve_runRequests(self, _graphene_info: ResolveInfo):
         if not self._run_requests:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -122,16 +122,18 @@ class GrapheneSchedule(graphene.ObjectType):
             for _ in range(limit):
                 tick_times.append(next(time_iter).timestamp())
 
+        schedule_selector = self._external_schedule.schedule_selector
         future_ticks = [
-            GrapheneDryRunInstigationTick(self._schedule_state, tick_time)
-            for tick_time in tick_times
+            GrapheneDryRunInstigationTick(schedule_selector, tick_time) for tick_time in tick_times
         ]
 
         new_cursor = tick_times[-1] + 1 if tick_times else cursor
         return GrapheneDryRunInstigationTicks(results=future_ticks, cursor=new_cursor)
 
     def resolve_futureTick(self, _graphene_info, tick_timestamp: int):
-        return GrapheneDryRunInstigationTick(self._schedule_state, float(tick_timestamp))
+        return GrapheneDryRunInstigationTick(
+            self._external_schedule.schedule_selector, float(tick_timestamp)
+        )
 
 
 class GrapheneScheduleOrError(graphene.Union):

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -22,7 +22,12 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
-from dagster._core.definitions.selector import InstigatorSelector, RepositorySelector
+from dagster._core.definitions.selector import (
+    InstigatorSelector,
+    RepositorySelector,
+    ScheduleSelector,
+    SensorSelector,
+)
 from dagster._core.definitions.sensor_definition import (
     DEFAULT_SENSOR_DAEMON_INTERVAL,
     DefaultSensorStatus,
@@ -628,6 +633,14 @@ class ExternalSchedule:
         )
 
     @property
+    def schedule_selector(self) -> ScheduleSelector:
+        return ScheduleSelector(
+            self.handle.location_name,
+            self.handle.repository_name,
+            self._external_schedule_data.name,
+        )
+
+    @property
     def selector_id(self) -> str:
         return create_snapshot_id(self.selector)
 
@@ -748,6 +761,14 @@ class ExternalSensor:
     @property
     def selector(self) -> InstigatorSelector:
         return InstigatorSelector(
+            self.handle.location_name,
+            self.handle.repository_name,
+            self._external_sensor_data.name,
+        )
+
+    @property
+    def sensor_selector(self) -> SensorSelector:
+        return SensorSelector(
             self.handle.location_name,
             self.handle.repository_name,
             self._external_sensor_data.name,


### PR DESCRIPTION
Makes some changes to the previously-renamed GrapheneDryRunInstigationTick API.
- No longer require that instigator be on/enabled in order for this to work. Each callsite can take care of this individually, since it's not actually a constraint that applies to the logic within the API.
- Support for evaluation of sensors
- Move away from storing instigatorstate -> move to using selector

No tests included on this PR that utilize the added sensor functionality but upstack PRs do so
