### PR TITLE
[dagit] In development, render toasts for unhandled promise exceptions

### DIFF
--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -3,7 +3,7 @@ import './publicPath';
 
 import {App} from '@dagster-io/dagit-core/app/App';
 import {createAppCache} from '@dagster-io/dagit-core/app/AppCache';
-import {errorLink} from '@dagster-io/dagit-core/app/AppError';
+import {errorLink, setupErrorToasts} from '@dagster-io/dagit-core/app/AppError';
 import {AppProvider} from '@dagster-io/dagit-core/app/AppProvider';
 import {AppTopNav} from '@dagster-io/dagit-core/app/AppTopNav';
 import {ContentRoot} from '@dagster-io/dagit-core/app/ContentRoot';
@@ -23,6 +23,9 @@ const apolloLinks = [logLink, errorLink, timeStartLink];
 
 if (telemetryEnabled) {
   apolloLinks.unshift(telemetryLink(pathPrefix));
+}
+if (process.env.NODE_ENV === 'development') {
+  setupErrorToasts();
 }
 
 const config = {

--- a/js_modules/dagit/packages/core/src/app/AppError.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppError.tsx
@@ -139,3 +139,41 @@ const AppStackTraceLink = ({error, operationName}: AppStackTraceLinkProps) => {
     </span>
   );
 };
+
+const IGNORED_CONSOLE_ERRORS = [
+  'The above error occurred',
+  'NetworkError when attempting to fetch resource',
+  "Can't perform a React state update on an unmounted component",
+];
+
+export const setupErrorToasts = () => {
+  const original = console.error;
+  Object.defineProperty(console, 'error', {
+    value: (...args: any[]) => {
+      original.apply(console, args);
+
+      const msg = `${args[0]}`;
+      if (!IGNORED_CONSOLE_ERRORS.some((ignored) => msg.includes(ignored))) {
+        ErrorToaster.show({
+          intent: 'danger',
+          message: (
+            <div
+              style={{whiteSpace: 'pre-wrap', maxHeight: 400, overflow: 'hidden'}}
+            >{`console.error: ${msg}`}</div>
+          ),
+        });
+      }
+    },
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    ErrorToaster.show({
+      intent: 'danger',
+      message: (
+        <div
+          style={{whiteSpace: 'pre-wrap'}}
+        >{`Unhandled Rejection: ${event.reason}\nView console for details.`}</div>
+      ),
+    });
+  });
+};


### PR DESCRIPTION
### Summary & Motivation

Demo: https://www.loom.com/share/909567defc984b83864c51e18b361765

This morning we have an error coming in through datadog that is being console.error’d in Dagit but not otherwise interrupting the UI. I think it can be hard to spot these errors since you’d have to have the console open during development to see them.  Curious if this might help streamline our dev workflow to avoid this in the future.

Trying to make sure "serious in datadog" is also "serious during development"!

### How I Tested These Changes

<img width="988" alt="image" src="https://user-images.githubusercontent.com/1037212/216684698-48efa607-4bac-4700-9f50-e7737a760cd1.png">
