### PR TITLE
Lazy load ExternalAssetGraph for CachingStaleStatusResolver

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -169,7 +169,7 @@ def get_asset_nodes_by_asset_key(
 
     stale_status_loader = StaleStatusLoader(
         instance=graphene_info.context.instance,
-        asset_graph=ExternalAssetGraph.from_workspace(graphene_info.context),
+        asset_graph=lambda: ExternalAssetGraph.from_workspace(graphene_info.context),
     )
 
     asset_nodes_by_asset_key: Dict[AssetKey, GrapheneAssetNode] = {}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -231,7 +231,7 @@ class GrapheneRepository(graphene.ObjectType):
         self._batch_loader = RepositoryScopedBatchLoader(instance, repository)
         self._stale_status_loader = StaleStatusLoader(
             instance=instance,
-            asset_graph=ExternalAssetGraph.from_external_repository(repository),
+            asset_graph=lambda: ExternalAssetGraph.from_external_repository(repository),
         )
         super().__init__(name=repository.name)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -641,14 +641,15 @@ class GrapheneDagitQuery(graphene.ObjectType):
 
         depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
 
-        if repo is not None:
-            asset_graph = ExternalAssetGraph.from_external_repository(repo)
-        else:
-            asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        def load_asset_graph() -> ExternalAssetGraph:
+            if repo is not None:
+                return ExternalAssetGraph.from_external_repository(repo)
+            else:
+                return ExternalAssetGraph.from_workspace(graphene_info.context)
 
         stale_status_loader = StaleStatusLoader(
             instance=graphene_info.context.instance,
-            asset_graph=asset_graph,
+            asset_graph=load_asset_graph,
         )
 
         return [


### PR DESCRIPTION
### Summary & Motivation

#11951 caused performance to severely degrade for certain GQL queries due to eager construction of `ExternalAssetGraph` in `GrapheneRepository`. This PR updates `CachingStaleStatusResolver` to allow passing a function that resolves to an `ExternalAssetGraph` instead of an `ExternalAssetGraph`. This prevents repeated unnecessary constructions of `ExternalAssetGraph`.

### How I Tested These Changes

`shadow-dagit` test of affected customers, who were seeing cloud timeouts as a result of performance degradation.