### PR TITLE
[telemetry] fix setting __TELEMETRY_ENABLED__ flag on Dagit

### DIFF
--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -211,7 +211,9 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                     rendered_template.replace('href="/', f'href="{self._app_path_prefix}/')
                     .replace('src="/', f'src="{self._app_path_prefix}/')
                     .replace("__PATH_PREFIX__", self._app_path_prefix)
-                    .replace("__TELEMETRY_ENABLED__", str(context.instance.telemetry_enabled))
+                    .replace(
+                        '"__TELEMETRY_ENABLED__"', str(context.instance.telemetry_enabled).lower()
+                    )
                     .replace("NONCE-PLACEHOLDER", nonce),
                     headers=headers,
                 )


### PR DESCRIPTION
## Summary

Noticed while trying to add another python-populated Dagit flag.

The `"__TELEMETRY_ENABLED__"` placeholder string  was being set to a string value `"True"` or `"False`", which the JS does not convert into a boolean value. This PR fixes the templating by replacing the entire placeholder string with a literal
`true` or `false `JS bool.

