### PR TITLE
Test with a 64 bit after_cursor

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1966,7 +1966,9 @@ class TestEventLogStorage:
                 assert len(materialization_count_by_key_after_run1.get(c)) == 2
 
                 materialization_count_by_key_after_everything = (
-                    storage.get_materialization_count_by_partition([a, b, c], after_cursor=9999999)
+                    storage.get_materialization_count_by_partition(
+                        [a, b, c], after_cursor=9999999999
+                    )
                 )
                 assert materialization_count_by_key_after_everything.get(a) == {}
                 assert materialization_count_by_key_after_everything.get(b) == {}


### PR DESCRIPTION
We have some dagster cloud tests that run this same test suite, but against a fork of event logs that uses a bigint instead of an int.

To flex that behavior, we first manually increment our event log id sequence beyond 32 bits. This test fails because under those conditions, there actually are events with ids above 9999999.

Introducing a breaking migration to use bigints in dagster's event log is well beyond the scope of this change. But incrementing this test value to something much much larger maintains the spirit of the test while accomodating our dagster cloud test suite.
