### PR TITLE
[dagit] Mocks, storybooks and a test for BackfillTable

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.mocks.ts
@@ -1,0 +1,419 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {BulkActionStatus, RunStatus} from '../graphql/types';
+
+import {
+  SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
+  SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+} from './BackfillRow';
+import {SingleBackfillCountsQuery, SingleBackfillQuery} from './types/BackfillRow.types';
+import {BackfillTableFragment} from './types/BackfillTable.types';
+
+function buildTimePartitionNames(start: Date, count: number) {
+  const results: string[] = [];
+  for (let ii = 0; ii < count; ii++) {
+    start.setMinutes(start.getMinutes() + 15);
+    results.push(start.toISOString());
+  }
+  return results;
+}
+
+export const BackfillTableFragmentRequested2000AssetsPure: BackfillTableFragment = {
+  backfillId: 'qtpussca',
+  status: BulkActionStatus.REQUESTED,
+  numPartitions: 2000,
+  timestamp: 1675196684.587724,
+  partitionSetName: null,
+  partitionSet: null,
+  error: null,
+  numCancelable: 0,
+  partitionNames: buildTimePartitionNames(new Date('2020-01-01'), 2000),
+  assetSelection: [
+    {
+      path: ['global_graph_asset'],
+      __typename: 'AssetKey',
+    },
+  ],
+  __typename: 'PartitionBackfill',
+};
+
+export const BackfillTableFragmentRequested2000AssetsPureStatus: MockedResponse<SingleBackfillCountsQuery> = {
+  request: {
+    query: SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
+    variables: {
+      backfillId: 'qtpussca',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionBackfillOrError: {
+        backfillId: 'qtpussca',
+        partitionStatusCounts: [
+          {
+            runStatus: RunStatus.NOT_STARTED,
+            count: 108088,
+            __typename: 'PartitionStatusCounts',
+          },
+          {
+            runStatus: RunStatus.SUCCESS,
+            count: 71,
+            __typename: 'PartitionStatusCounts',
+          },
+          {
+            runStatus: RunStatus.FAILURE,
+            count: 10,
+            __typename: 'PartitionStatusCounts',
+          },
+        ],
+        __typename: 'PartitionBackfill',
+      },
+    },
+  },
+};
+
+export const BackfillTableFragmentCancelledAssetsPartitionSet: BackfillTableFragment = {
+  backfillId: 'tclwoggv',
+  status: BulkActionStatus.CANCELED,
+  numPartitions: 5000,
+  timestamp: 1675106258.398993,
+  partitionSetName: 'asset_job_partition_set',
+  partitionSet: {
+    id: '74c11a15d5d213176c83a7a71b50be0318103d8b',
+    name: 'asset_job_partition_set',
+    mode: 'default',
+    pipelineName: 'asset_job',
+    repositoryOrigin: {
+      id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    __typename: 'PartitionSet',
+  },
+  error: null,
+  numCancelable: 0,
+  partitionNames: buildTimePartitionNames(new Date('2020-01-01'), 5000),
+  assetSelection: [
+    {
+      path: ['whatever5'],
+      __typename: 'AssetKey',
+    },
+    {
+      path: ['multipartitioned_asset'],
+      __typename: 'AssetKey',
+    },
+  ],
+  __typename: 'PartitionBackfill',
+};
+
+export const BackfillTableFragmentCancelledAssetsPartitionSetStatus: MockedResponse<SingleBackfillCountsQuery> = {
+  request: {
+    query: SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
+    variables: {
+      backfillId: 'tclwoggv',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionBackfillOrError: {
+        backfillId: 'tclwoggv',
+        partitionStatusCounts: [
+          {runStatus: RunStatus.NOT_STARTED, count: 6524, __typename: 'PartitionStatusCounts'},
+        ],
+        __typename: 'PartitionBackfill',
+      },
+    },
+  },
+};
+
+export const BackfillTableFragmentFailedError: BackfillTableFragment = {
+  backfillId: 'sjqzcfhe',
+  status: BulkActionStatus.FAILED,
+  numPartitions: 100,
+  timestamp: 1674774274.343382,
+  partitionSetName: null,
+  partitionSet: null,
+  error: {
+    __typename: 'PythonError',
+    message:
+      'dagster._core.errors.DagsterLaunchFailedError: Tried to start a run on a server after telling it to shut down\n',
+    stack: [
+      '  File "/dagster/python_modules/dagster/dagster/_daemon/backfill.py", line 34, in execute_backfill_iteration\n    yield from execute_asset_backfill_iteration(backfill, workspace, instance)\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/execution/asset_backfill.py", line 193, in execute_asset_backfill_iteration\n    submit_run_request(\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/execution/asset_backfill.py", line 265, in submit_run_request\n    instance.submit_run(run.run_id, workspace)\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 1926, in submit_run\n    submitted_run = self._run_coordinator.submit_run(\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py", line 34, in submit_run\n    self._instance.launch_run(pipeline_run.run_id, context.workspace)\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 1979, in launch_run\n    self.run_launcher.launch_run(LaunchRunContext(pipeline_run=run, workspace=workspace))\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py", line 121, in launch_run\n    DefaultRunLauncher.launch_run_from_grpc_client(\n',
+      '  File "/dagster/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py", line 89, in launch_run_from_grpc_client\n    raise (\n',
+    ],
+    errorChain: [],
+  },
+  numCancelable: 0,
+  partitionNames: buildTimePartitionNames(new Date('2020-01-01'), 100),
+  assetSelection: [
+    {
+      path: ['multipartitioned_asset'],
+      __typename: 'AssetKey',
+    },
+  ],
+  __typename: 'PartitionBackfill',
+};
+
+export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfillQuery> = {
+  request: {
+    query: SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    variables: {
+      backfillId: 'sjqzcfhe',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionBackfillOrError: {
+        backfillId: 'sjqzcfhe',
+        partitionStatuses: {
+          results: BackfillTableFragmentFailedError.partitionNames.map((n) => ({
+            id: `__NO_PARTITION_SET__:${n}:ccpbwdbq`,
+            partitionName: n,
+            runId: null,
+            runStatus: null,
+            __typename: 'PartitionStatus',
+          })),
+          __typename: 'PartitionStatuses',
+        },
+        __typename: 'PartitionBackfill',
+      },
+    },
+  },
+};
+
+export const BackfillTableFragmentCompletedAssetJob: BackfillTableFragment = {
+  backfillId: 'pwgcpiwc',
+  status: BulkActionStatus.COMPLETED,
+  numPartitions: 11,
+  timestamp: 1674660450.942305,
+  partitionSetName: 'asset_job_partition_set',
+  partitionSet: {
+    id: '74c11a15d5d213176c83a7a71b50be0318103d8b',
+    name: 'asset_job_partition_set',
+    mode: 'default',
+    pipelineName: 'asset_job',
+    repositoryOrigin: {
+      id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    __typename: 'PartitionSet',
+  },
+  error: null,
+  numCancelable: 0,
+  partitionNames: [
+    'TN|2023-01-24',
+    'VA|2023-01-24',
+    'GA|2023-01-24',
+    'KY|2023-01-24',
+    'PA|2023-01-24',
+    'NC|2023-01-24',
+    'SC|2023-01-24',
+    'FL|2023-01-24',
+    'OH|2023-01-24',
+    'IL|2023-01-24',
+    'WV|2023-01-24',
+  ],
+  assetSelection: [
+    {
+      path: ['multipartitioned_asset'],
+      __typename: 'AssetKey',
+    },
+  ],
+  __typename: 'PartitionBackfill',
+};
+
+export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<SingleBackfillQuery> = {
+  request: {
+    query: SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    variables: {
+      backfillId: 'pwgcpiwc',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionBackfillOrError: {
+        backfillId: 'pwgcpiwc',
+        partitionStatuses: {
+          results: [
+            {
+              id: 'asset_job_partition_set:TN|2023-01-24:pwgcpiwc',
+              partitionName: 'TN|2023-01-24',
+              runId: 'f9060b59-44aa-4cc1-aac2-f1365ed3c4da',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:VA|2023-01-24:pwgcpiwc',
+              partitionName: 'VA|2023-01-24',
+              runId: '719b32bc-d345-40f2-acf1-99d99bbd8b7f',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:GA|2023-01-24:pwgcpiwc',
+              partitionName: 'GA|2023-01-24',
+              runId: 'c85345e4-ad71-47b7-9add-f73b02f57c65',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:KY|2023-01-24:pwgcpiwc',
+              partitionName: 'KY|2023-01-24',
+              runId: 'f0b90d88-5b33-4287-92af-8b6b9e934ff4',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:PA|2023-01-24:pwgcpiwc',
+              partitionName: 'PA|2023-01-24',
+              runId: 'cfa8f88a-5b65-486b-ab2c-841dd8c711fa',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:NC|2023-01-24:pwgcpiwc',
+              partitionName: 'NC|2023-01-24',
+              runId: '1b59a3a2-98c7-495c-8758-6c689ac14f05',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:SC|2023-01-24:pwgcpiwc',
+              partitionName: 'SC|2023-01-24',
+              runId: '0ac8630e-5467-48db-8fd1-c9d45bad382d',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:FL|2023-01-24:pwgcpiwc',
+              partitionName: 'FL|2023-01-24',
+              runId: 'efb4a01d-4187-40b8-b9be-8b683173698e',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:OH|2023-01-24:pwgcpiwc',
+              partitionName: 'OH|2023-01-24',
+              runId: '98778750-c49a-4896-9d39-6b36554f41ab',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:IL|2023-01-24:pwgcpiwc',
+              partitionName: 'IL|2023-01-24',
+              runId: '8bab80df-571a-4dbc-9a08-9c3c33c962a6',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'asset_job_partition_set:WV|2023-01-24:pwgcpiwc',
+              partitionName: 'WV|2023-01-24',
+              runId: 'fc54444c-4c28-485b-b581-53ea5ce287f2',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+          ],
+          __typename: 'PartitionStatuses',
+        },
+        __typename: 'PartitionBackfill',
+      },
+    },
+  },
+};
+
+export const BackfillTableFragmentCompletedOpJob: BackfillTableFragment = {
+  backfillId: 'pqdiepuf',
+  status: BulkActionStatus.COMPLETED,
+  numPartitions: 4,
+  timestamp: 1674660356.340658,
+  partitionSetName: 'op_job_partition_set',
+  partitionSet: {
+    id: 'a41b026cedcc5f871b4bf10db6e56ec1c63b8df0',
+    name: 'op_job_partition_set',
+    mode: 'default',
+    pipelineName: 'op_job',
+    repositoryOrigin: {
+      id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    __typename: 'PartitionSet',
+  },
+  error: null,
+  numCancelable: 0,
+  partitionNames: ['2022-07-01', '2022-08-01', '2022-09-01', '2022-10-01'],
+  assetSelection: null,
+  __typename: 'PartitionBackfill',
+};
+
+export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBackfillQuery> = {
+  request: {
+    query: SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    variables: {
+      backfillId: 'pqdiepuf',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionBackfillOrError: {
+        backfillId: 'pqdiepuf',
+        partitionStatuses: {
+          results: [
+            {
+              id: 'op_job_partition_set:2022-07-01:pqdiepuf',
+              partitionName: '2022-07-01',
+              runId: '5cb9f428-1721-45d5-979e-64e0376aad1a',
+              runStatus: RunStatus.FAILURE,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'op_job_partition_set:2022-08-01:pqdiepuf',
+              partitionName: '2022-08-01',
+              runId: '7d76bc38-db6c-4d77-b3c2-38b1a3b69ed9',
+              runStatus: RunStatus.FAILURE,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'op_job_partition_set:2022-09-01:pqdiepuf',
+              partitionName: '2022-09-01',
+              runId: 'ca54267a-225c-491a-ad71-f6f3e0e868eb',
+              runStatus: RunStatus.SUCCESS,
+              __typename: 'PartitionStatus',
+            },
+            {
+              id: 'op_job_partition_set:2022-10-01:pqdiepuf',
+              partitionName: '2022-10-01',
+              runId: '1baeadb4-7e7d-47e5-aeac-8a5f921cf27c',
+              runStatus: RunStatus.QUEUED,
+              __typename: 'PartitionStatus',
+            },
+          ],
+          __typename: 'PartitionStatuses',
+        },
+        __typename: 'PartitionBackfill',
+      },
+    },
+  },
+};
+
+export const BackfillTableFragments: BackfillTableFragment[] = [
+  BackfillTableFragmentRequested2000AssetsPure,
+  BackfillTableFragmentCancelledAssetsPartitionSet,
+  BackfillTableFragmentFailedError,
+  BackfillTableFragmentCompletedAssetJob,
+  BackfillTableFragmentCompletedOpJob,
+];

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.stories.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.stories.tsx
@@ -1,0 +1,35 @@
+import {MockedProvider} from '@apollo/client/testing';
+import React from 'react';
+
+import {StorybookProvider} from '../testing/StorybookProvider';
+
+import {BackfillTable} from './BackfillTable';
+import {
+  BackfillTableFragmentCancelledAssetsPartitionSetStatus,
+  BackfillTableFragmentCompletedAssetJobStatus,
+  BackfillTableFragmentCompletedOpJobStatus,
+  BackfillTableFragmentFailedErrorStatus,
+  BackfillTableFragmentRequested2000AssetsPureStatus,
+  BackfillTableFragments,
+} from './BackfillTable.mocks';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: BackfillTable};
+
+export const GeneralStates = () => {
+  return (
+    <StorybookProvider>
+      <MockedProvider
+        mocks={[
+          BackfillTableFragmentRequested2000AssetsPureStatus,
+          BackfillTableFragmentCancelledAssetsPartitionSetStatus,
+          BackfillTableFragmentCompletedOpJobStatus,
+          BackfillTableFragmentCompletedAssetJobStatus,
+          BackfillTableFragmentFailedErrorStatus,
+        ]}
+      >
+        <BackfillTable backfills={BackfillTableFragments} refetch={() => {}} />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.test.tsx
@@ -1,0 +1,37 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import * as Alerting from '../app/CustomAlertProvider';
+import {TestProvider} from '../testing/TestProvider';
+
+import {BackfillTable} from './BackfillTable';
+import {
+  BackfillTableFragmentFailedErrorStatus,
+  BackfillTableFragmentFailedError,
+} from './BackfillTable.mocks';
+
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../graph/asyncGraphLayout', () => ({}));
+
+describe('BackfillTable', () => {
+  it('allows you to click "Failed" backfills for error details', async () => {
+    jest.spyOn(Alerting, 'showCustomAlert');
+
+    render(
+      <TestProvider>
+        <Alerting.CustomAlertProvider />
+        <MockedProvider mocks={[BackfillTableFragmentFailedErrorStatus]}>
+          <BackfillTable backfills={[BackfillTableFragmentFailedError]} refetch={() => {}} />
+        </MockedProvider>
+      </TestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeVisible();
+      const statusLabel = screen.getByText('Failed');
+      statusLabel.click();
+      expect(Alerting.showCustomAlert).toHaveBeenCalled();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/testing/StorybookProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/StorybookProvider.tsx
@@ -2,6 +2,7 @@ import {loader} from 'graphql.macro';
 import * as React from 'react';
 import {MemoryRouter, MemoryRouterProps} from 'react-router-dom';
 
+import {CustomAlertProvider} from '../app/CustomAlertProvider';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
 import {ApolloTestProps, ApolloTestProvider} from './ApolloTestProvider';
@@ -19,6 +20,7 @@ export const StorybookProvider: React.FC<Props> = (props) => {
   return (
     <MemoryRouter {...routerProps}>
       <ApolloTestProvider {...apolloProps} typeDefs={typeDefs}>
+        <CustomAlertProvider />
         <WorkspaceProvider>{props.children}</WorkspaceProvider>
       </ApolloTestProvider>
     </MemoryRouter>


### PR DESCRIPTION
### Summary & Motivation

Hey gang, curious to get your thoughts about this. I added a storybook for BackfillTable that uses mock data to accurately test all of the different Backfill Target and Backfill Status states, along with the async loading of the per-row data.

This table isn't all that interactive - we could write jest tests that say "It renders 'complete' for a complete backfill", but I don't think they add much value over the storybook if we can wire up https://www.chromatic.com/features/test to put a snapshot of the Storybook file on this PR and highlight differences.

I wrote one test which tests that clicking a "Failed" status tag opens a modal showing the error, because that seemed like interactivity worthy of a test. SInce the mocks are broken out into a separate file, this test can re-use the test data from storybook which is kinda cool.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1037212/216718067-11828426-7e24-45a9-b5f2-07f2025eca34.png">

### How I Tested These Changes
