### PR TITLE
[1/n] Optionally attach definition file & line number information to assets & ops

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/conftest.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/conftest.py
@@ -2,6 +2,9 @@ import os
 from typing import TYPE_CHECKING
 
 import pytest
+from dagster._core.definitions.decorators.op_decorator import (
+    do_not_attach_code_origin,
+)
 from syrupy.extensions.amber import AmberSnapshotExtension
 
 if TYPE_CHECKING:
@@ -34,3 +37,11 @@ class SharedSnapshotExtension(AmberSnapshotExtension):
 @pytest.fixture
 def snapshot(snapshot):
     return snapshot.use_extension(SharedSnapshotExtension)
+
+
+@pytest.fixture
+def ignore_code_origin():
+    # avoid attaching code origin metadata to ops/assets, because this can change from environment
+    # to environment and break snapshot tests
+    with do_not_attach_code_origin():
+        yield

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -186,1870 +186,1708 @@ def get_main_external_repo(instance: DagsterInstance) -> Iterator[ExternalReposi
         yield location.get_repository(main_repo_name())
 
 
-@op(
-    ins={"num": In(PoorMansDataFrame)},
-    out=Out(PoorMansDataFrame),
+from python_modules.dagster.dagster._core.definitions.decorators.op_decorator import (
+    do_not_attach_code_origin,
 )
-def sum_op(num):
-    sum_df = deepcopy(num)
-    for x in sum_df:
-        x["sum"] = int(x["num1"]) + int(x["num2"])
-    return sum_df
 
+with do_not_attach_code_origin():
 
-@op(
-    ins={"sum_df": In(PoorMansDataFrame)},
-    out=Out(PoorMansDataFrame),
-)
-def sum_sq_op(sum_df):
-    sum_sq_df = deepcopy(sum_df)
-    for x in sum_sq_df:
-        x["sum_sq"] = int(x["sum"]) ** 2
-    return sum_sq_df
-
-
-@op(
-    ins={"sum_df": In(PoorMansDataFrame)},
-    out=Out(PoorMansDataFrame),
-)
-def df_expectations_op(_context, sum_df):
-    yield ExpectationResult(label="some_expectation", success=True)
-    yield ExpectationResult(label="other_expectation", success=True)
-    yield Output(sum_df)
-
-
-def csv_hello_world_ops_config():
-    return {"ops": {"sum_op": {"inputs": {"num": file_relative_path(__file__, "../data/num.csv")}}}}
-
-
-@op(config_schema={"file": Field(String)})
-def loop(context):
-    with open(context.op_config["file"], "w", encoding="utf8") as ff:
-        ff.write("yup")
-
-    while True:
-        time.sleep(0.1)
-
-
-@job
-def infinite_loop_job():
-    loop()
-
-
-@op
-def noop_op(_):
-    pass
-
-
-# Won't pass cloud-webserver test suite without `in_process_executor`.
-@job(executor_def=in_process_executor)
-def noop_job():
-    noop_op()
-
-
-@op
-def op_asset_a(_):
-    yield AssetMaterialization(asset_key="a")
-    yield Output(1)
-
-
-@op
-def op_asset_b(_, num):
-    yield AssetMaterialization(asset_key="b")
-    time.sleep(0.1)
-    yield AssetMaterialization(asset_key="c")
-    yield Output(num)
-
-
-@op
-def op_partitioned_asset(_):
-    yield AssetMaterialization(asset_key="a", partition="partition_1")
-    yield Output(1)
-
-
-@op
-def tag_asset_op(_):
-    yield AssetMaterialization(asset_key="a")
-    yield Output(1)
-
-
-@job
-def single_asset_job():
-    op_asset_a()
-
-
-@job
-def multi_asset_job():
-    op_asset_b(op_asset_a())
-
-
-@job
-def partitioned_asset_job():
-    op_partitioned_asset()
-
-
-@job
-def asset_tag_job():
-    tag_asset_op()
-
-
-@job
-def job_with_expectations():
-    @op(out={})
-    def emit_successful_expectation(_context):
-        yield ExpectationResult(
-            success=True,
-            label="always_true",
-            description="Successful",
-            metadata={"data": {"reason": "Just because."}},
-        )
-
-    @op(out={})
-    def emit_failed_expectation(_context):
-        yield ExpectationResult(
-            success=False,
-            label="always_false",
-            description="Failure",
-            metadata={"data": {"reason": "Relentless pessimism."}},
-        )
-
-    @op(out={})
-    def emit_successful_expectation_no_metadata(_context):
-        yield ExpectationResult(success=True, label="no_metadata", description="Successful")
-
-    emit_successful_expectation()
-    emit_failed_expectation()
-    emit_successful_expectation_no_metadata()
-
-
-@job
-def more_complicated_config():
     @op(
-        config_schema={
-            "field_one": Field(String),
-            "field_two": Field(String, is_required=False),
-            "field_three": Field(String, is_required=False, default_value="some_value"),
+        ins={"num": In(PoorMansDataFrame)},
+        out=Out(PoorMansDataFrame),
+    )
+    def sum_op(num):
+        sum_df = deepcopy(num)
+        for x in sum_df:
+            x["sum"] = int(x["num1"]) + int(x["num2"])
+        return sum_df
+
+    @op(
+        ins={"sum_df": In(PoorMansDataFrame)},
+        out=Out(PoorMansDataFrame),
+    )
+    def sum_sq_op(sum_df):
+        sum_sq_df = deepcopy(sum_df)
+        for x in sum_sq_df:
+            x["sum_sq"] = int(x["sum"]) ** 2
+        return sum_sq_df
+
+    @op(
+        ins={"sum_df": In(PoorMansDataFrame)},
+        out=Out(PoorMansDataFrame),
+    )
+    def df_expectations_op(_context, sum_df):
+        yield ExpectationResult(label="some_expectation", success=True)
+        yield ExpectationResult(label="other_expectation", success=True)
+        yield Output(sum_df)
+
+    def csv_hello_world_ops_config():
+        return {
+            "ops": {"sum_op": {"inputs": {"num": file_relative_path(__file__, "../data/num.csv")}}}
         }
-    )
-    def op_with_three_field_config(_context):
-        return None
 
-    noop_op()
-    op_with_three_field_config()
+    @op(config_schema={"file": Field(String)})
+    def loop(context):
+        with open(context.op_config["file"], "w", encoding="utf8") as ff:
+            ff.write("yup")
 
+        while True:
+            time.sleep(0.1)
 
-@job
-def config_with_map():
-    @op(
-        config_schema={
-            "field_one": Field(Map(str, int, key_label_name="username")),
-            "field_two": Field({bool: int}, is_required=False),
-            "field_three": Field(
-                {str: {"nested": [Noneable(int)]}},
-                is_required=False,
-                default_value={"test": {"nested": [None, 1, 2]}},
-            ),
-        }
-    )
-    def op_with_map_config(_context):
-        return None
-
-    noop_op()
-    op_with_map_config()
-
-
-@job
-def more_complicated_nested_config():
-    @op(
-        name="op_with_multilayered_config",
-        config_schema={
-            "field_any": Any,
-            "field_one": String,
-            "field_two": Field(String, is_required=False),
-            "field_three": Field(String, is_required=False, default_value="some_value"),
-            "nested_field": {
-                "field_four_str": String,
-                "field_five_int": Int,
-                "field_six_nullable_int_list": Field([Noneable(int)], is_required=False),
-            },
-        },
-        out={},
-    )
-    def op_with_multilayered_config(_):
-        return None
-
-    op_with_multilayered_config()
-
-
-@job(executor_def=in_process_executor)
-def csv_hello_world():
-    sum_sq_op(sum_df=sum_op())
-
-
-@job
-def csv_hello_world_with_expectations():
-    ss = sum_op()
-    sum_sq_op(sum_df=ss)
-    df_expectations_op(sum_df=ss)
-
-
-@job
-def csv_hello_world_two():
-    sum_op()
-
-
-@op
-def op_that_gets_tags(context):
-    return context.run.tags
-
-
-@job(tags={"tag_key": "tag_value"})
-def hello_world_with_tags():
-    op_that_gets_tags()
-
-
-@op(name="op_with_list", ins={}, out={}, config_schema=[int])
-def op_def(_):
-    return None
-
-
-@job
-def job_with_input_output_metadata():
-    @op(
-        ins={"foo": In(Int, metadata={"a": "b"})},
-        out={"bar": Out(Int, metadata={"c": "d"})},
-    )
-    def op_with_input_output_metadata(foo):
-        return foo + 1
-
-    op_with_input_output_metadata()
-
-
-@job
-def job_with_list():
-    op_def()
-
-
-@job
-def csv_hello_world_df_input():
-    sum_sq_op(sum_op())
-
-
-integers_partitions = StaticPartitionsDefinition([str(i) for i in range(10)])
-
-integers_config = PartitionedConfig(
-    partitions_def=integers_partitions,
-    run_config_for_partition_fn=lambda partition: {},
-    tags_for_partition_fn=lambda partition: {"foo": partition.name},
-)
-
-
-@job(partitions_def=integers_partitions, config=integers_config)
-def integers():
-    @op
-    def return_integer():
-        return 1
-
-    return_integer()
-
-
-alpha_partitions = StaticPartitionsDefinition(list(string.ascii_lowercase))
-
-
-@job(partitions_def=alpha_partitions)
-def no_config_job():
-    @op
-    def return_hello():
-        return "Hello"
-
-    return_hello()
-
-
-@job
-def no_config_chain_job():
-    @op
-    def return_foo():
-        return "foo"
+    @job
+    def infinite_loop_job():
+        loop()
 
     @op
-    def return_hello_world(_foo):
-        return "Hello World"
-
-    return_hello_world(return_foo())
-
-
-@job
-def scalar_output_job():
-    @op(out=Out(String))
-    def return_str():
-        return "foo"
-
-    @op(out=Out(Int))
-    def return_int():
-        return 34234
-
-    @op(out=Out(Bool))
-    def return_bool():
-        return True
-
-    @op(out=Out(Any))
-    def return_any():
-        return "dkjfkdjfe"
-
-    return_str()
-    return_int()
-    return_bool()
-    return_any()
-
-
-@job
-def job_with_enum_config():
-    @op(
-        config_schema=Enum(
-            "TestEnum",
-            [
-                EnumValue(config_value="ENUM_VALUE_ONE", description="An enum value."),
-                EnumValue(config_value="ENUM_VALUE_TWO", description="An enum value."),
-                EnumValue(config_value="ENUM_VALUE_THREE", description="An enum value."),
-            ],
-        )
-    )
-    def takes_an_enum(_context):
+    def noop_op(_):
         pass
 
-    takes_an_enum()
+    # Won't pass cloud-webserver test suite without `in_process_executor`.
+    @job(executor_def=in_process_executor)
+    def noop_job():
+        noop_op()
 
-
-@job
-def naughty_programmer_job():
     @op
-    def throw_a_thing():
-        try:
+    def op_asset_a(_):
+        yield AssetMaterialization(asset_key="a")
+        yield Output(1)
+
+    @op
+    def op_asset_b(_, num):
+        yield AssetMaterialization(asset_key="b")
+        time.sleep(0.1)
+        yield AssetMaterialization(asset_key="c")
+        yield Output(num)
+
+    @op
+    def op_partitioned_asset(_):
+        yield AssetMaterialization(asset_key="a", partition="partition_1")
+        yield Output(1)
+
+    @op
+    def tag_asset_op(_):
+        yield AssetMaterialization(asset_key="a")
+        yield Output(1)
+
+    @job
+    def single_asset_job():
+        op_asset_a()
+
+    @job
+    def multi_asset_job():
+        op_asset_b(op_asset_a())
+
+    @job
+    def partitioned_asset_job():
+        op_partitioned_asset()
+
+    @job
+    def asset_tag_job():
+        tag_asset_op()
+
+    @job
+    def job_with_expectations():
+        @op(out={})
+        def emit_successful_expectation(_context):
+            yield ExpectationResult(
+                success=True,
+                label="always_true",
+                description="Successful",
+                metadata={"data": {"reason": "Just because."}},
+            )
+
+        @op(out={})
+        def emit_failed_expectation(_context):
+            yield ExpectationResult(
+                success=False,
+                label="always_false",
+                description="Failure",
+                metadata={"data": {"reason": "Relentless pessimism."}},
+            )
+
+        @op(out={})
+        def emit_successful_expectation_no_metadata(_context):
+            yield ExpectationResult(success=True, label="no_metadata", description="Successful")
+
+        emit_successful_expectation()
+        emit_failed_expectation()
+        emit_successful_expectation_no_metadata()
+
+    @job
+    def more_complicated_config():
+        @op(
+            config_schema={
+                "field_one": Field(String),
+                "field_two": Field(String, is_required=False),
+                "field_three": Field(String, is_required=False, default_value="some_value"),
+            }
+        )
+        def op_with_three_field_config(_context):
+            return None
+
+        noop_op()
+        op_with_three_field_config()
+
+    @job
+    def config_with_map():
+        @op(
+            config_schema={
+                "field_one": Field(Map(str, int, key_label_name="username")),
+                "field_two": Field({bool: int}, is_required=False),
+                "field_three": Field(
+                    {str: {"nested": [Noneable(int)]}},
+                    is_required=False,
+                    default_value={"test": {"nested": [None, 1, 2]}},
+                ),
+            }
+        )
+        def op_with_map_config(_context):
+            return None
+
+        noop_op()
+        op_with_map_config()
+
+    @job
+    def more_complicated_nested_config():
+        @op(
+            name="op_with_multilayered_config",
+            config_schema={
+                "field_any": Any,
+                "field_one": String,
+                "field_two": Field(String, is_required=False),
+                "field_three": Field(String, is_required=False, default_value="some_value"),
+                "nested_field": {
+                    "field_four_str": String,
+                    "field_five_int": Int,
+                    "field_six_nullable_int_list": Field([Noneable(int)], is_required=False),
+                },
+            },
+            out={},
+        )
+        def op_with_multilayered_config(_):
+            return None
+
+        op_with_multilayered_config()
+
+    @job(executor_def=in_process_executor)
+    def csv_hello_world():
+        sum_sq_op(sum_df=sum_op())
+
+    @job
+    def csv_hello_world_with_expectations():
+        ss = sum_op()
+        sum_sq_op(sum_df=ss)
+        df_expectations_op(sum_df=ss)
+
+    @job
+    def csv_hello_world_two():
+        sum_op()
+
+    @op
+    def op_that_gets_tags(context):
+        return context.run.tags
+
+    @job(tags={"tag_key": "tag_value"})
+    def hello_world_with_tags():
+        op_that_gets_tags()
+
+    @op(name="op_with_list", ins={}, out={}, config_schema=[int])
+    def op_def(_):
+        return None
+
+    @job
+    def job_with_input_output_metadata():
+        @op(
+            ins={"foo": In(Int, metadata={"a": "b"})},
+            out={"bar": Out(Int, metadata={"c": "d"})},
+        )
+        def op_with_input_output_metadata(foo):
+            return foo + 1
+
+        op_with_input_output_metadata()
+
+    @job
+    def job_with_list():
+        op_def()
+
+    @job
+    def csv_hello_world_df_input():
+        sum_sq_op(sum_op())
+
+    integers_partitions = StaticPartitionsDefinition([str(i) for i in range(10)])
+
+    integers_config = PartitionedConfig(
+        partitions_def=integers_partitions,
+        run_config_for_partition_fn=lambda partition: {},
+        tags_for_partition_fn=lambda partition: {"foo": partition.name},
+    )
+
+    @job(partitions_def=integers_partitions, config=integers_config)
+    def integers():
+        @op
+        def return_integer():
+            return 1
+
+        return_integer()
+
+    alpha_partitions = StaticPartitionsDefinition(list(string.ascii_lowercase))
+
+    @job(partitions_def=alpha_partitions)
+    def no_config_job():
+        @op
+        def return_hello():
+            return "Hello"
+
+        return_hello()
+
+    @job
+    def no_config_chain_job():
+        @op
+        def return_foo():
+            return "foo"
+
+        @op
+        def return_hello_world(_foo):
+            return "Hello World"
+
+        return_hello_world(return_foo())
+
+    @job
+    def scalar_output_job():
+        @op(out=Out(String))
+        def return_str():
+            return "foo"
+
+        @op(out=Out(Int))
+        def return_int():
+            return 34234
+
+        @op(out=Out(Bool))
+        def return_bool():
+            return True
+
+        @op(out=Out(Any))
+        def return_any():
+            return "dkjfkdjfe"
+
+        return_str()
+        return_int()
+        return_bool()
+        return_any()
+
+    @job
+    def job_with_enum_config():
+        @op(
+            config_schema=Enum(
+                "TestEnum",
+                [
+                    EnumValue(config_value="ENUM_VALUE_ONE", description="An enum value."),
+                    EnumValue(config_value="ENUM_VALUE_TWO", description="An enum value."),
+                    EnumValue(config_value="ENUM_VALUE_THREE", description="An enum value."),
+                ],
+            )
+        )
+        def takes_an_enum(_context):
+            pass
+
+        takes_an_enum()
+
+    @job
+    def naughty_programmer_job():
+        @op
+        def throw_a_thing():
             try:
                 try:
-                    raise Exception("The inner sanctum")
-                except:
-                    raise Exception("bad programmer, bad")
+                    try:
+                        raise Exception("The inner sanctum")
+                    except:
+                        raise Exception("bad programmer, bad")
+                except Exception as e:
+                    raise Exception("Outer exception") from e
             except Exception as e:
-                raise Exception("Outer exception") from e
-        except Exception as e:
-            # throw a Failure here so we can test metadata
-            raise Failure("Even more outer exception", metadata={"top_level": True}) from e
+                # throw a Failure here so we can test metadata
+                raise Failure("Even more outer exception", metadata={"top_level": True}) from e
 
-    throw_a_thing()
+        throw_a_thing()
 
+    @job
+    def job_with_invalid_definition_error():
+        @usable_as_dagster_type(name="InputTypeWithoutHydration")
+        class InputTypeWithoutHydration(int):
+            pass
 
-@job
-def job_with_invalid_definition_error():
-    @usable_as_dagster_type(name="InputTypeWithoutHydration")
-    class InputTypeWithoutHydration(int):
-        pass
+        @op(out=Out(InputTypeWithoutHydration))
+        def one(_):
+            return 1
 
-    @op(out=Out(InputTypeWithoutHydration))
-    def one(_):
+        @op(
+            ins={"some_input": In(InputTypeWithoutHydration)},
+            out=Out(int),
+        )
+        def fail_subset(_, some_input):
+            return some_input
+
+        fail_subset(one())
+
+    @resource(config_schema=Field(Int))
+    def adder_resource(init_context):
+        return lambda x: x + init_context.resource_config
+
+    @resource(config_schema=Field(Int))
+    def multer_resource(init_context):
+        return lambda x: x * init_context.resource_config
+
+    @resource(config_schema={"num_one": Field(Int), "num_two": Field(Int)})
+    def double_adder_resource(init_context):
+        return (
+            lambda x: x
+            + init_context.resource_config["num_one"]
+            + init_context.resource_config["num_two"]
+        )
+
+    @resource(config_schema=Field(Int, is_required=False))
+    def req_resource(_):
         return 1
 
-    @op(
-        ins={"some_input": In(InputTypeWithoutHydration)},
-        out=Out(int),
+    @op(required_resource_keys={"R1"})
+    def op_with_required_resource(_):
+        return 1
+
+    @job(resource_defs={"R1": req_resource})
+    def required_resource_job():
+        op_with_required_resource()
+
+    @resource(config_schema=Field(Int))
+    def req_resource_config(_):
+        return 1
+
+    @job(resource_defs={"R1": req_resource_config})
+    def required_resource_config_job():
+        op_with_required_resource()
+
+    @logger(config_schema=Field(str))
+    def foo_logger(init_context):
+        logger_ = logging.Logger("foo")
+        logger_.setLevel(coerce_valid_log_level(init_context.logger_config))
+        return logger_
+
+    @logger({"log_level": Field(str), "prefix": Field(str)})
+    def bar_logger(init_context):
+        class BarLogger(logging.Logger):
+            def __init__(self, name, prefix, *args, **kwargs):
+                self.prefix = prefix
+                super(BarLogger, self).__init__(name, *args, **kwargs)
+
+            def log(self, lvl, msg, *args, **kwargs):
+                msg = self.prefix + msg
+                super(BarLogger, self).log(lvl, msg, *args, **kwargs)
+
+        logger_ = BarLogger("bar", init_context.logger_config["prefix"])
+        logger_.setLevel(coerce_valid_log_level(init_context.logger_config["log_level"]))
+
+    @job(
+        logger_defs={"foo": foo_logger, "bar": bar_logger},
     )
-    def fail_subset(_, some_input):
-        return some_input
+    def loggers_job():
+        @op
+        def return_six(context):
+            context.log.critical("OMG!")
+            return 6
 
-    fail_subset(one())
+        return_six()
 
+    @job
+    def composites_job():
+        @op(ins={"num": In(Int)}, out=Out(Int))
+        def add_one(num):
+            return num + 1
 
-@resource(config_schema=Field(Int))
-def adder_resource(init_context):
-    return lambda x: x + init_context.resource_config
+        @op(ins={"num": In()})
+        def div_two(num):
+            return num / 2
 
+        @graph
+        def add_two(num: int) -> int:
+            return add_one.alias("adder_2")(add_one.alias("adder_1")(num))
 
-@resource(config_schema=Field(Int))
-def multer_resource(init_context):
-    return lambda x: x * init_context.resource_config
+        @graph
+        def add_four(num: int) -> int:
+            return add_two.alias("adder_2")(add_two.alias("adder_1")(num))
 
+        @graph
+        def div_four(num):
+            return div_two.alias("div_2")(div_two.alias("div_1")(num))
 
-@resource(config_schema={"num_one": Field(Int), "num_two": Field(Int)})
-def double_adder_resource(init_context):
-    return (
-        lambda x: x
-        + init_context.resource_config["num_one"]
-        + init_context.resource_config["num_two"]
-    )
+        div_four(add_four())
 
-
-@resource(config_schema=Field(Int, is_required=False))
-def req_resource(_):
-    return 1
-
-
-@op(required_resource_keys={"R1"})
-def op_with_required_resource(_):
-    return 1
-
-
-@job(resource_defs={"R1": req_resource})
-def required_resource_job():
-    op_with_required_resource()
-
-
-@resource(config_schema=Field(Int))
-def req_resource_config(_):
-    return 1
-
-
-@job(resource_defs={"R1": req_resource_config})
-def required_resource_config_job():
-    op_with_required_resource()
-
-
-@logger(config_schema=Field(str))
-def foo_logger(init_context):
-    logger_ = logging.Logger("foo")
-    logger_.setLevel(coerce_valid_log_level(init_context.logger_config))
-    return logger_
-
-
-@logger({"log_level": Field(str), "prefix": Field(str)})
-def bar_logger(init_context):
-    class BarLogger(logging.Logger):
-        def __init__(self, name, prefix, *args, **kwargs):
-            self.prefix = prefix
-            super(BarLogger, self).__init__(name, *args, **kwargs)
-
-        def log(self, lvl, msg, *args, **kwargs):
-            msg = self.prefix + msg
-            super(BarLogger, self).log(lvl, msg, *args, **kwargs)
-
-    logger_ = BarLogger("bar", init_context.logger_config["prefix"])
-    logger_.setLevel(coerce_valid_log_level(init_context.logger_config["log_level"]))
-
-
-@job(
-    logger_defs={"foo": foo_logger, "bar": bar_logger},
-)
-def loggers_job():
-    @op
-    def return_six(context):
-        context.log.critical("OMG!")
-        return 6
-
-    return_six()
-
-
-@job
-def composites_job():
-    @op(ins={"num": In(Int)}, out=Out(Int))
-    def add_one(num):
-        return num + 1
-
-    @op(ins={"num": In()})
-    def div_two(num):
-        return num / 2
-
-    @graph
-    def add_two(num: int) -> int:
-        return add_one.alias("adder_2")(add_one.alias("adder_1")(num))
-
-    @graph
-    def add_four(num: int) -> int:
-        return add_two.alias("adder_2")(add_two.alias("adder_1")(num))
-
-    @graph
-    def div_four(num):
-        return div_two.alias("div_2")(div_two.alias("div_1")(num))
-
-    div_four(add_four())
-
-
-@job
-def materialization_job():
-    @op
-    def materialize(_):
-        yield AssetMaterialization(
-            asset_key="all_types",
-            description="a materialization with all metadata types",
-            metadata={
-                "text": "text is cool",
-                "url": MetadataValue.url("https://bigty.pe/neato"),
-                "path": MetadataValue.path("/tmp/awesome"),
-                "json": {"is_dope": True},
-                "python class": MetadataValue.python_artifact(AssetMaterialization),
-                "python_function": MetadataValue.python_artifact(file_relative_path),
-                "float": 1.2,
-                "int": 1,
-                "float NaN": float("nan"),
-                "long int": LONG_INT,
-                "pipeline run": MetadataValue.dagster_run("fake_run_id"),
-                "my asset": AssetKey("my_asset"),
-                "table": MetadataValue.table(
-                    records=[
-                        TableRecord(dict(foo=1, bar=2)),
-                        TableRecord(dict(foo=3, bar=4)),
-                    ],
-                ),
-                "table_schema": TableSchema(
-                    columns=[
-                        TableColumn(
-                            name="foo",
-                            type="integer",
-                            constraints=TableColumnConstraints(unique=True),
-                        ),
-                        TableColumn(name="bar", type="string"),
-                    ],
-                    constraints=TableConstraints(
-                        other=["some constraint"],
+    @job
+    def materialization_job():
+        @op
+        def materialize(_):
+            yield AssetMaterialization(
+                asset_key="all_types",
+                description="a materialization with all metadata types",
+                metadata={
+                    "text": "text is cool",
+                    "url": MetadataValue.url("https://bigty.pe/neato"),
+                    "path": MetadataValue.path("/tmp/awesome"),
+                    "json": {"is_dope": True},
+                    "python class": MetadataValue.python_artifact(AssetMaterialization),
+                    "python_function": MetadataValue.python_artifact(file_relative_path),
+                    "float": 1.2,
+                    "int": 1,
+                    "float NaN": float("nan"),
+                    "long int": LONG_INT,
+                    "pipeline run": MetadataValue.dagster_run("fake_run_id"),
+                    "my asset": AssetKey("my_asset"),
+                    "table": MetadataValue.table(
+                        records=[
+                            TableRecord(dict(foo=1, bar=2)),
+                            TableRecord(dict(foo=3, bar=4)),
+                        ],
                     ),
-                ),
-                "my job": MetadataValue.job("materialization_job", location_name="test_location"),
-            },
+                    "table_schema": TableSchema(
+                        columns=[
+                            TableColumn(
+                                name="foo",
+                                type="integer",
+                                constraints=TableColumnConstraints(unique=True),
+                            ),
+                            TableColumn(name="bar", type="string"),
+                        ],
+                        constraints=TableConstraints(
+                            other=["some constraint"],
+                        ),
+                    ),
+                    "my job": MetadataValue.job(
+                        "materialization_job", location_name="test_location"
+                    ),
+                },
+            )
+            yield Output(None)
+
+        materialize()
+
+    @job
+    def spew_job():
+        @op
+        def spew(_):
+            print("HELLO WORLD")  # noqa: T201
+
+        spew()
+
+    def retry_config(count):
+        return {
+            "resources": {"retry_count": {"config": {"count": count}}},
+        }
+
+    @resource(config_schema={"count": Field(Int, is_required=False, default_value=0)})
+    def retry_config_resource(context):
+        return context.resource_config["count"]
+
+    @job(
+        resource_defs={
+            "io_manager": fs_io_manager,
+            "retry_count": retry_config_resource,
+        }
+    )
+    def eventually_successful():
+        @op
+        def spawn() -> int:
+            return 0
+
+        @op(
+            required_resource_keys={"retry_count"},
         )
-        yield Output(None)
+        def fail(context: OpExecutionContext, depth: int) -> int:
+            if context.resources.retry_count <= depth:
+                raise Exception("fail")
 
-    materialize()
+            return depth + 1
 
+        @op
+        def reset(depth: int) -> int:
+            return depth
 
-@job
-def spew_job():
-    @op
-    def spew(_):
-        print("HELLO WORLD")  # noqa: T201
+        @op
+        def collect(fan_in: List[int]):
+            if fan_in != [1, 2, 3]:
+                raise Exception(f"Fan in failed, expected [1, 2, 3] got {fan_in}")
 
-    spew()
+        s = spawn()
+        f1 = fail(s)
+        f2 = fail(f1)
+        f3 = fail(f2)
+        reset(f3)
+        collect([f1, f2, f3])
 
+    # The tests that use this rely on it using in-process execution.
+    @job(executor_def=in_process_executor)
+    def hard_failer():
+        @op(
+            config_schema={"fail": Field(Bool, is_required=False, default_value=False)},
+        )
+        def hard_fail_or_0(context) -> int:
+            if context.op_config["fail"]:
+                segfault()
+            return 0
 
-def retry_config(count):
-    return {
-        "resources": {"retry_count": {"config": {"count": count}}},
-    }
+        @op
+        def increment(_, n: int) -> int:
+            return n + 1
 
+        increment(hard_fail_or_0())
 
-@resource(config_schema={"count": Field(Int, is_required=False, default_value=0)})
-def retry_config_resource(context):
-    return context.resource_config["count"]
+    @resource
+    def resource_a(_):
+        return "A"
 
+    @resource
+    def resource_b(_):
+        return "B"
 
-@job(
-    resource_defs={
-        "io_manager": fs_io_manager,
-        "retry_count": retry_config_resource,
-    }
-)
-def eventually_successful():
-    @op
-    def spawn() -> int:
-        return 0
-
-    @op(
-        required_resource_keys={"retry_count"},
-    )
-    def fail(context: OpExecutionContext, depth: int) -> int:
-        if context.resources.retry_count <= depth:
-            raise Exception("fail")
-
-        return depth + 1
-
-    @op
-    def reset(depth: int) -> int:
-        return depth
-
-    @op
-    def collect(fan_in: List[int]):
-        if fan_in != [1, 2, 3]:
-            raise Exception(f"Fan in failed, expected [1, 2, 3] got {fan_in}")
-
-    s = spawn()
-    f1 = fail(s)
-    f2 = fail(f1)
-    f3 = fail(f2)
-    reset(f3)
-    collect([f1, f2, f3])
-
-
-# The tests that use this rely on it using in-process execution.
-@job(executor_def=in_process_executor)
-def hard_failer():
-    @op(
-        config_schema={"fail": Field(Bool, is_required=False, default_value=False)},
-    )
-    def hard_fail_or_0(context) -> int:
-        if context.op_config["fail"]:
-            segfault()
-        return 0
-
-    @op
-    def increment(_, n: int) -> int:
-        return n + 1
-
-    increment(hard_fail_or_0())
-
-
-@resource
-def resource_a(_):
-    return "A"
-
-
-@resource
-def resource_b(_):
-    return "B"
-
-
-@op(required_resource_keys={"a"})
-def start(context):
-    assert context.resources.a == "A"
-    return 1
-
-
-@op(required_resource_keys={"b"})
-def will_fail(context, num):
-    assert context.resources.b == "B"
-    raise Exception("fail")
-
-
-@job(
-    resource_defs={
-        "a": resource_a,
-        "b": resource_b,
-        "io_manager": fs_io_manager,
-    }
-)
-def retry_resource_job():
-    will_fail(start())
-
-
-@op(
-    config_schema={"fail": bool},
-    ins={"inp": In(str)},
-    out={
-        "start_fail": Out(str, is_required=False),
-        "start_skip": Out(str, is_required=False),
-    },
-)
-def can_fail(context, inp):
-    if context.op_config["fail"]:
-        raise Exception("blah")
-
-    yield Output("okay perfect", "start_fail")
-
-
-@op(
-    out={
-        "success": Out(str, is_required=False),
-        "skip": Out(str, is_required=False),
-    },
-)
-def multi(_):
-    yield Output("okay perfect", "success")
-
-
-@op
-def passthrough(_, value):
-    return value
-
-
-@op(ins={"start": In(Nothing)}, out={})
-def no_output(_):
-    yield ExpectationResult(True)
-
-
-@job
-def retry_multi_output_job():
-    multi_success, multi_skip = multi()
-    fail, skip = can_fail(multi_success)
-    no_output.alias("child_multi_skip")(multi_skip)
-    no_output.alias("child_skip")(skip)
-    no_output.alias("grandchild_fail")(passthrough.alias("child_fail")(fail))
-
-
-@job(tags={"foo": "bar"})
-def tagged_job():
-    @op
-    def simple_op():
-        return "Hello"
-
-    simple_op()
-
-
-@resource
-def disable_gc(_context):
-    # Workaround for termination signals being raised during GC and getting swallowed during
-    # tests
-    try:
-        print("Disabling GC")  # noqa: T201
-        gc.disable()
-        yield
-    finally:
-        print("Re-enabling GC")  # noqa: T201
-        gc.enable()
-
-
-# Using in-process executor prevents test flaking
-@job(
-    resource_defs={"io_manager": fs_io_manager, "disable_gc": disable_gc},
-    executor_def=in_process_executor,
-)
-def retry_multi_input_early_terminate_job():
-    @op(out=Out(Int))
-    def return_one():
+    @op(required_resource_keys={"a"})
+    def start(context):
+        assert context.resources.a == "A"
         return 1
 
+    @op(required_resource_keys={"b"})
+    def will_fail(context, num):
+        assert context.resources.b == "B"
+        raise Exception("fail")
+
+    @job(
+        resource_defs={
+            "a": resource_a,
+            "b": resource_b,
+            "io_manager": fs_io_manager,
+        }
+    )
+    def retry_resource_job():
+        will_fail(start())
+
     @op(
-        config_schema={"wait_to_terminate": bool},
-        required_resource_keys={"disable_gc"},
-    )
-    def get_input_one(context, one: int) -> int:
-        if context.op_config["wait_to_terminate"]:
-            while True:
-                time.sleep(0.1)
-        return one
-
-    @op(
-        config_schema={"wait_to_terminate": bool},
-        required_resource_keys={"disable_gc"},
-    )
-    def get_input_two(context, one: int) -> int:
-        if context.op_config["wait_to_terminate"]:
-            while True:
-                time.sleep(0.1)
-        return one
-
-    @op
-    def sum_inputs(input_one: int, input_two: int) -> int:
-        return input_one + input_two
-
-    step_one = return_one()
-    sum_inputs(input_one=get_input_one(step_one), input_two=get_input_two(step_one))
-
-
-@job
-def dynamic_job():
-    @op
-    def multiply_by_two(context, y):
-        context.log.info("multiply_by_two is returning " + str(y * 2))
-        return y * 2
-
-    @op
-    def multiply_inputs(context, y, ten, should_fail):
-        current_run = context.instance.get_run_by_id(context.run_id)
-        if should_fail:
-            if y == 2 and current_run.parent_run_id is None:
-                raise Exception()
-        context.log.info("multiply_inputs is returning " + str(y * ten))
-        return y * ten
-
-    @op
-    def emit_ten(_):
-        return 10
-
-    @op(out=DynamicOut())
-    def emit(_):
-        for i in range(3):
-            yield DynamicOutput(value=i, mapping_key=str(i))
-
-    @op
-    def sum_numbers(_, nums):
-        return sum(nums)
-
-    multiply_by_two.alias("double_total")(
-        sum_numbers(
-            emit()
-            .map(
-                lambda n: multiply_by_two(multiply_inputs(n, emit_ten())),
-            )
-            .collect(),
-        )
-    )
-
-
-@job
-def basic_job():
-    pass
-
-
-def get_retry_multi_execution_params(
-    graphql_context: WorkspaceRequestContext, should_fail: bool, retry_id: Optional[str] = None
-) -> Mapping[str, Any]:
-    selector = infer_job_selector(graphql_context, "retry_multi_output_job")
-    return {
-        "mode": "default",
-        "selector": selector,
-        "runConfigData": {
-            "ops": {"can_fail": {"config": {"fail": should_fail}}},
+        config_schema={"fail": bool},
+        ins={"inp": In(str)},
+        out={
+            "start_fail": Out(str, is_required=False),
+            "start_skip": Out(str, is_required=False),
         },
-        "executionMetadata": {
-            "rootRunId": retry_id,
-            "parentRunId": retry_id,
-            "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}] if retry_id else [],
-        },
-    }
-
-
-def define_schedules():
-    no_config_job_hourly_schedule = ScheduleDefinition(
-        name="no_config_job_hourly_schedule",
-        cron_schedule="0 0 * * *",
-        job_name="no_config_job",
     )
-
-    no_config_job_hourly_schedule_with_config_fn = ScheduleDefinition(
-        name="no_config_job_hourly_schedule_with_config_fn",
-        cron_schedule="0 0 * * *",
-        job_name="no_config_job",
-    )
-
-    no_config_should_execute = ScheduleDefinition(
-        name="no_config_should_execute",
-        cron_schedule="0 0 * * *",
-        job_name="no_config_job",
-        should_execute=lambda _context: False,
-    )
-
-    dynamic_config = ScheduleDefinition(
-        name="dynamic_config",
-        cron_schedule="0 0 * * *",
-        job_name="no_config_job",
-    )
-
-    def get_cron_schedule(
-        delta: datetime.timedelta, schedule_type: Literal["daily", "hourly"] = "daily"
-    ) -> str:
-        time = (datetime.datetime.now() + delta).time()
-        hour = time.hour if schedule_type == "daily" else "*"
-        return f"{time.minute} {hour} * * *"
-
-    def throw_error() -> Never:
-        raise Exception("This is an error")
-
-    @schedule(
-        cron_schedule=get_cron_schedule(datetime.timedelta(hours=2)),
-        job_name="no_config_job",
-        default_status=DefaultScheduleStatus.RUNNING,
-    )
-    def running_in_code_schedule(_context):
-        return {}
-
-    # Schedules for testing the user error boundary
-    @schedule(
-        cron_schedule="@daily",
-        job_name="no_config_job",
-        should_execute=lambda _: throw_error(),
-    )
-    def should_execute_error_schedule(_context):
-        return {}
-
-    @schedule(
-        cron_schedule="@daily",
-        job_name="no_config_job",
-        tags_fn=lambda _: throw_error(),
-    )
-    def tags_error_schedule(_context):
-        return {}
-
-    @schedule(
-        cron_schedule="@daily",
-        job_name="no_config_job",
-    )
-    def run_config_error_schedule(_context):
-        throw_error()
-
-    @schedule(
-        cron_schedule="@daily",
-        job_name="no_config_job",
-        execution_timezone="US/Central",
-    )
-    def timezone_schedule(_context):
-        return {}
-
-    tagged_job_schedule = ScheduleDefinition(
-        name="tagged_job_schedule",
-        cron_schedule="0 0 * * *",
-        job_name="tagged_job",
-    )
-
-    tagged_job_override_schedule = ScheduleDefinition(
-        name="tagged_job_override_schedule",
-        cron_schedule="0 0 * * *",
-        job_name="tagged_job",
-        tags={"foo": "notbar"},
-    )
-
-    invalid_config_schedule = ScheduleDefinition(
-        name="invalid_config_schedule",
-        cron_schedule="0 0 * * *",
-        job_name="job_with_enum_config",
-        run_config={"ops": {"takes_an_enum": {"config": "invalid"}}},
-    )
-
-    @schedule(
-        job_name="nested_job",
-        cron_schedule=["45 23 * * 6", "30 9 * * 0"],
-    )
-    def composite_cron_schedule(_context):
-        return {}
-
-    @schedule(
-        cron_schedule="* * * * *", job=basic_job, default_status=DefaultScheduleStatus.RUNNING
-    )
-    def past_tick_schedule():
-        return {}
-
-    @schedule(cron_schedule="* * * * *", job=req_config_job)
-    def provide_config_schedule():
-        return {"ops": {"the_op": {"config": {"foo": "bar"}}}}
-
-    @schedule(cron_schedule="* * * * *", job=req_config_job)
-    def always_error():
-        raise Exception("darnit")
-
-    return [
-        run_config_error_schedule,
-        no_config_job_hourly_schedule,
-        no_config_job_hourly_schedule_with_config_fn,
-        no_config_should_execute,
-        dynamic_config,
-        should_execute_error_schedule,
-        tagged_job_schedule,
-        tagged_job_override_schedule,
-        tags_error_schedule,
-        timezone_schedule,
-        invalid_config_schedule,
-        running_in_code_schedule,
-        composite_cron_schedule,
-        past_tick_schedule,
-        provide_config_schedule,
-        always_error,
-    ]
-
-
-def define_sensors():
-    @sensor(job_name="no_config_job")
-    def always_no_config_sensor(_):
-        return RunRequest(
-            run_key=None,
-            tags={"test": "1234"},
-        )
-
-    @sensor(job_name="no_config_job")
-    def always_error_sensor(_):
-        raise Exception("OOPS")
-
-    @sensor(job_name="no_config_job")
-    def update_cursor_sensor(context):
-        if not context.cursor:
-            cursor = 0
-        else:
-            cursor = int(context.cursor)
-        cursor += 1
-        context.update_cursor(str(cursor))
-
-    @sensor(job_name="no_config_job")
-    def once_no_config_sensor(_):
-        return RunRequest(
-            run_key="once",
-            tags={"test": "1234"},
-        )
-
-    @sensor(job_name="no_config_job")
-    def never_no_config_sensor(_):
-        return SkipReason("never")
-
-    @sensor(job_name="dynamic_partitioned_assets_job")
-    def dynamic_partition_requesting_sensor(_):
-        yield SensorResult(
-            run_requests=[RunRequest(partition_key="new_key")],
-            dynamic_partitions_requests=[
-                DynamicPartitionsDefinition(name="foo").build_add_request(
-                    ["new_key", "new_key2", "existent_key"]
-                ),
-                DynamicPartitionsDefinition(name="foo").build_delete_request(
-                    ["old_key", "nonexistent_key"]
-                ),
-            ],
-        )
-
-    @sensor(job_name="no_config_job")
-    def multi_no_config_sensor(_):
-        yield RunRequest(run_key="A")
-        yield RunRequest(run_key="B")
-
-    @sensor(job_name="no_config_job", minimum_interval_seconds=60)
-    def custom_interval_sensor(_):
-        return RunRequest(
-            run_key=None,
-            tags={"test": "1234"},
-        )
-
-    @sensor(job_name="no_config_job", default_status=DefaultSensorStatus.RUNNING)
-    def running_in_code_sensor(_):
-        return RunRequest(
-            run_key=None,
-            tags={"test": "1234"},
-        )
-
-    @sensor(job_name="no_config_job")
-    def logging_sensor(context):
-        context.log.info("hello hello")
-        return SkipReason()
-
-    @sensor(asset_selection=AssetSelection.all())
-    def every_asset_sensor(_):
-        return SkipReason("just kidding")
-
-    @run_status_sensor(run_status=DagsterRunStatus.SUCCESS, request_job=no_config_job)
-    def run_status(_):
-        return SkipReason("always skip")
-
-    @asset_sensor(asset_key=AssetKey("foo"), job=single_asset_job)
-    def single_asset_sensor():
-        pass
-
-    @multi_asset_sensor(monitored_assets=[], job=single_asset_job)
-    def many_asset_sensor(_):
-        pass
-
-    @freshness_policy_sensor(asset_selection=AssetSelection.all())
-    def fresh_sensor(_):
-        pass
-
-    @run_failure_sensor
-    def the_failure_sensor():
-        pass
-
-    automation_policy_sensor = AutomationPolicySensorDefinition(
-        "my_automation_policy_sensor",
-        asset_selection=AssetSelection.keys("fresh_diamond_bottom"),
-    )
-
-    return [
-        always_no_config_sensor,
-        always_error_sensor,
-        once_no_config_sensor,
-        never_no_config_sensor,
-        dynamic_partition_requesting_sensor,
-        multi_no_config_sensor,
-        custom_interval_sensor,
-        running_in_code_sensor,
-        logging_sensor,
-        update_cursor_sensor,
-        run_status,
-        single_asset_sensor,
-        many_asset_sensor,
-        fresh_sensor,
-        the_failure_sensor,
-        automation_policy_sensor,
-        every_asset_sensor,
-    ]
-
-
-# The tests that use this rely on it using in-process execution.
-@job(executor_def=in_process_executor, partitions_def=integers_partitions)
-def chained_failure_job():
-    @op
-    def always_succeed():
-        return "hello"
-
-    @op
-    def conditionally_fail(_upstream):
-        if os.path.isfile(
-            os.path.join(
-                get_system_temp_directory(),
-                "chained_failure_job_conditionally_fail",
-            )
-        ):
+    def can_fail(context, inp):
+        if context.op_config["fail"]:
             raise Exception("blah")
 
-        return "hello"
+        yield Output("okay perfect", "start_fail")
+
+    @op(
+        out={
+            "success": Out(str, is_required=False),
+            "skip": Out(str, is_required=False),
+        },
+    )
+    def multi(_):
+        yield Output("okay perfect", "success")
 
     @op
-    def after_failure(_upstream):
-        return "world"
+    def passthrough(_, value):
+        return value
 
-    after_failure(conditionally_fail(always_succeed()))
+    @op(ins={"start": In(Nothing)}, out={})
+    def no_output(_):
+        yield ExpectationResult(True)
 
+    @job
+    def retry_multi_output_job():
+        multi_success, multi_skip = multi()
+        fail, skip = can_fail(multi_success)
+        no_output.alias("child_multi_skip")(multi_skip)
+        no_output.alias("child_skip")(skip)
+        no_output.alias("grandchild_fail")(passthrough.alias("child_fail")(fail))
 
-@graph
-def simple_graph():
-    noop_op()
+    @job(tags={"foo": "bar"})
+    def tagged_job():
+        @op
+        def simple_op():
+            return "Hello"
 
+        simple_op()
 
-@graph
-def composed_graph():
-    simple_graph()
+    @resource
+    def disable_gc(_context):
+        # Workaround for termination signals being raised during GC and getting swallowed during
+        # tests
+        try:
+            print("Disabling GC")  # noqa: T201
+            gc.disable()
+            yield
+        finally:
+            print("Re-enabling GC")  # noqa: T201
+            gc.enable()
 
+    # Using in-process executor prevents test flaking
+    @job(
+        resource_defs={"io_manager": fs_io_manager, "disable_gc": disable_gc},
+        executor_def=in_process_executor,
+    )
+    def retry_multi_input_early_terminate_job():
+        @op(out=Out(Int))
+        def return_one():
+            return 1
 
-@job(config={"ops": {"op_with_config": {"config": {"one": "hullo"}}}})
-def job_with_default_config():
-    @op(config_schema={"one": Field(String)})
-    def op_with_config(context):
-        return context.op_config["one"]
+        @op(
+            config_schema={"wait_to_terminate": bool},
+            required_resource_keys={"disable_gc"},
+        )
+        def get_input_one(context, one: int) -> int:
+            if context.op_config["wait_to_terminate"]:
+                while True:
+                    time.sleep(0.1)
+            return one
 
-    op_with_config()
+        @op(
+            config_schema={"wait_to_terminate": bool},
+            required_resource_keys={"disable_gc"},
+        )
+        def get_input_two(context, one: int) -> int:
+            if context.op_config["wait_to_terminate"]:
+                while True:
+                    time.sleep(0.1)
+            return one
 
+        @op
+        def sum_inputs(input_one: int, input_two: int) -> int:
+            return input_one + input_two
 
-@resource(config_schema={"file": Field(String)})
-def hanging_asset_resource(context):
-    # Hack to allow asset to get value from run config
-    return context.resource_config.get("file")
+        step_one = return_one()
+        sum_inputs(input_one=get_input_one(step_one), input_two=get_input_two(step_one))
 
+    @job
+    def dynamic_job():
+        @op
+        def multiply_by_two(context, y):
+            context.log.info("multiply_by_two is returning " + str(y * 2))
+            return y * 2
 
-class DummyIOManager(IOManager):
-    def handle_output(self, context, obj):
+        @op
+        def multiply_inputs(context, y, ten, should_fail):
+            current_run = context.instance.get_run_by_id(context.run_id)
+            if should_fail:
+                if y == 2 and current_run.parent_run_id is None:
+                    raise Exception()
+            context.log.info("multiply_inputs is returning " + str(y * ten))
+            return y * ten
+
+        @op
+        def emit_ten(_):
+            return 10
+
+        @op(out=DynamicOut())
+        def emit(_):
+            for i in range(3):
+                yield DynamicOutput(value=i, mapping_key=str(i))
+
+        @op
+        def sum_numbers(_, nums):
+            return sum(nums)
+
+        multiply_by_two.alias("double_total")(
+            sum_numbers(
+                emit()
+                .map(
+                    lambda n: multiply_by_two(multiply_inputs(n, emit_ten())),
+                )
+                .collect(),
+            )
+        )
+
+    @job
+    def basic_job():
         pass
 
-    def load_input(self, context):
-        pass
-
-
-dummy_source_asset = SourceAsset(key=AssetKey("dummy_source_asset"))
-
-
-@asset
-def first_asset(
-    dummy_source_asset,
-):
-    return 1
-
-
-@asset(required_resource_keys={"hanging_asset_resource"})
-def hanging_asset(context, first_asset):
-    """Asset that hangs forever, used to test in-progress ops."""
-    with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
-        ff.write("yup")
-
-    while True:
-        time.sleep(0.1)
-
-
-@asset
-def never_runs_asset(
-    hanging_asset,
-):
-    pass
-
-
-hanging_job = build_assets_job(
-    name="hanging_job",
-    source_assets=[dummy_source_asset],
-    assets=[first_asset, hanging_asset, never_runs_asset],
-    resource_defs={
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
-        "hanging_asset_resource": hanging_asset_resource,
-    },
-)
-
-
-@op
-def my_op():
-    return 1
-
-
-@op(required_resource_keys={"hanging_asset_resource"})
-def hanging_op(context, my_op):
-    with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
-        ff.write("yup")
-
-    while True:
-        time.sleep(0.1)
-
-
-@op
-def never_runs_op(hanging_op):
-    pass
-
-
-@graph
-def hanging_graph():
-    return never_runs_op(hanging_op(my_op()))
-
-
-hanging_graph_asset = AssetsDefinition.from_graph(hanging_graph)
-
-
-@job(version_strategy=SourceHashVersionStrategy())
-def memoization_job():
-    my_op()
-
-
-@asset
-def downstream_asset(hanging_graph):
-    return 1
-
-
-hanging_graph_asset_job = build_assets_job(
-    name="hanging_graph_asset_job",
-    assets=[hanging_graph_asset, downstream_asset],
-    resource_defs={
-        "hanging_asset_resource": hanging_asset_resource,
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
-    },
-)
-
-
-@asset
-def asset_one():
-    return 1
-
-
-@asset
-def asset_two(asset_one):
-    return asset_one + 1
-
-
-two_assets_job = build_assets_job(name="two_assets_job", assets=[asset_one, asset_two])
-
-
-@asset
-def executable_asset() -> None:
-    pass
-
-
-unexecutable_asset = next(iter(external_assets_from_specs([AssetSpec("unexecutable_asset")])))
-
-executable_test_job = build_assets_job(
-    name="executable_test_job", assets=[executable_asset, unexecutable_asset]
-)
-
-static_partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d", "e", "f"])
-
-
-@asset(partitions_def=static_partitions_def)
-def upstream_static_partitioned_asset():
-    return 1
-
-
-@asset(partitions_def=static_partitions_def)
-def middle_static_partitioned_asset_1(upstream_static_partitioned_asset):
-    return 1
-
-
-@asset(partitions_def=static_partitions_def)
-def middle_static_partitioned_asset_2(upstream_static_partitioned_asset):
-    return 1
-
-
-@asset(partitions_def=static_partitions_def)
-def downstream_static_partitioned_asset(
-    middle_static_partitioned_asset_1, middle_static_partitioned_asset_2
-):
-    assert middle_static_partitioned_asset_1
-    assert middle_static_partitioned_asset_2
-
-
-@asset(partitions_def=DynamicPartitionsDefinition(name="foo"))
-def upstream_dynamic_partitioned_asset():
-    return 1
-
-
-@asset(partitions_def=DynamicPartitionsDefinition(name="foo"))
-def downstream_dynamic_partitioned_asset(
-    upstream_dynamic_partitioned_asset,
-):
-    assert upstream_dynamic_partitioned_asset
-
-
-dynamic_partitioned_assets_job = build_assets_job(
-    "dynamic_partitioned_assets_job",
-    assets=[upstream_dynamic_partitioned_asset, downstream_dynamic_partitioned_asset],
-)
-
-
-@static_partitioned_config(partition_keys=["1", "2", "3", "4", "5"])
-def my_static_partitioned_config(_partition_key: str):
-    return {}
-
-
-@job(config=my_static_partitioned_config)
-def static_partitioned_job():
-    my_op()
-
-
-hourly_partition = HourlyPartitionsDefinition(start_date="2021-05-05-01:00")
-
-
-@daily_partitioned_config(start_date=datetime.datetime(2022, 5, 1), minute_offset=15)
-def my_daily_partitioned_config(_start, _end):
-    return {}
-
-
-@job(config=my_daily_partitioned_config)
-def daily_partitioned_job():
-    my_op()
-
-
-@asset(partitions_def=hourly_partition)
-def upstream_time_partitioned_asset():
-    return 1
-
-
-@asset(
-    partitions_def=hourly_partition,
-    ins={
-        "upstream_time_partitioned_asset": AssetIn(partition_mapping=TimeWindowPartitionMapping())
-    },
-)
-def downstream_time_partitioned_asset(
-    upstream_time_partitioned_asset,
-):
-    return upstream_time_partitioned_asset + 1
-
-
-time_partitioned_assets_job = build_assets_job(
-    "time_partitioned_assets_job",
-    [upstream_time_partitioned_asset, downstream_time_partitioned_asset],
-)
-
-
-@asset
-def unpartitioned_upstream_of_partitioned():
-    return 1
-
-
-@asset(partitions_def=DailyPartitionsDefinition("2023-01-01"))
-def upstream_daily_partitioned_asset(unpartitioned_upstream_of_partitioned):
-    return unpartitioned_upstream_of_partitioned
-
-
-@asset(partitions_def=WeeklyPartitionsDefinition("2023-01-01"))
-def downstream_weekly_partitioned_asset(
-    upstream_daily_partitioned_asset,
-):
-    return upstream_daily_partitioned_asset + 1
-
-
-@asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]))
-def yield_partition_materialization():
-    yield Output(5)
-
-
-partition_materialization_job = build_assets_job(
-    "partition_materialization_job",
-    assets=[yield_partition_materialization],
-    executor_def=in_process_executor,
-)
-
-
-@asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]))
-def fail_partition_materialization(context):
-    if context.run.tags.get("fail") == "true":
-        raise Exception("fail_partition_materialization")
-    yield Output(5)
-
-
-fail_partition_materialization_job = build_assets_job(
-    "fail_partition_materialization_job",
-    assets=[fail_partition_materialization],
-    executor_def=in_process_executor,
-)
-
-
-@asset(
-    partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]),
-    required_resource_keys={"hanging_asset_resource"},
-)
-def hanging_partition_asset(context):
-    with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
-        ff.write("yup")
-
-    while True:
-        time.sleep(0.1)
-
-
-hanging_partition_asset_job = build_assets_job(
-    "hanging_partition_asset_job",
-    assets=[hanging_partition_asset],
-    executor_def=in_process_executor,
-    resource_defs={
-        "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
-        "hanging_asset_resource": hanging_asset_resource,
-    },
-)
-
-
-@asset
-def asset_yields_observation():
-    yield AssetObservation(asset_key=AssetKey("asset_yields_observation"), metadata={"text": "FOO"})
-    yield AssetMaterialization(asset_key=AssetKey("asset_yields_observation"))
-    yield Output(5)
-
-
-observation_job = build_assets_job(
-    "observation_job",
-    assets=[asset_yields_observation],
-    executor_def=in_process_executor,
-)
-
-
-@op
-def op_1():
-    return 1
-
-
-@op
-def op_2():
-    return 2
-
-
-@job
-def two_ins_job():
-    @op
-    def op_with_2_ins(in_1, in_2):
-        return in_1 + in_2
-
-    op_with_2_ins(op_1(), op_2())
-
-
-@job
-def nested_job():
-    @op
-    def adder(num1: int, num2: int):
-        return num1 + num2
-
-    @op
-    def plus_one(num: int):
-        return num + 1
+    def get_retry_multi_execution_params(
+        graphql_context: WorkspaceRequestContext, should_fail: bool, retry_id: Optional[str] = None
+    ) -> Mapping[str, Any]:
+        selector = infer_job_selector(graphql_context, "retry_multi_output_job")
+        return {
+            "mode": "default",
+            "selector": selector,
+            "runConfigData": {
+                "ops": {"can_fail": {"config": {"fail": should_fail}}},
+            },
+            "executionMetadata": {
+                "rootRunId": retry_id,
+                "parentRunId": retry_id,
+                "tags": [{"key": RESUME_RETRY_TAG, "value": "true"}] if retry_id else [],
+            },
+        }
+
+    def define_schedules():
+        no_config_job_hourly_schedule = ScheduleDefinition(
+            name="no_config_job_hourly_schedule",
+            cron_schedule="0 0 * * *",
+            job_name="no_config_job",
+        )
+
+        no_config_job_hourly_schedule_with_config_fn = ScheduleDefinition(
+            name="no_config_job_hourly_schedule_with_config_fn",
+            cron_schedule="0 0 * * *",
+            job_name="no_config_job",
+        )
+
+        no_config_should_execute = ScheduleDefinition(
+            name="no_config_should_execute",
+            cron_schedule="0 0 * * *",
+            job_name="no_config_job",
+            should_execute=lambda _context: False,
+        )
+
+        dynamic_config = ScheduleDefinition(
+            name="dynamic_config",
+            cron_schedule="0 0 * * *",
+            job_name="no_config_job",
+        )
+
+        def get_cron_schedule(
+            delta: datetime.timedelta, schedule_type: Literal["daily", "hourly"] = "daily"
+        ) -> str:
+            time = (datetime.datetime.now() + delta).time()
+            hour = time.hour if schedule_type == "daily" else "*"
+            return f"{time.minute} {hour} * * *"
+
+        def throw_error() -> Never:
+            raise Exception("This is an error")
+
+        @schedule(
+            cron_schedule=get_cron_schedule(datetime.timedelta(hours=2)),
+            job_name="no_config_job",
+            default_status=DefaultScheduleStatus.RUNNING,
+        )
+        def running_in_code_schedule(_context):
+            return {}
+
+        # Schedules for testing the user error boundary
+        @schedule(
+            cron_schedule="@daily",
+            job_name="no_config_job",
+            should_execute=lambda _: throw_error(),
+        )
+        def should_execute_error_schedule(_context):
+            return {}
+
+        @schedule(
+            cron_schedule="@daily",
+            job_name="no_config_job",
+            tags_fn=lambda _: throw_error(),
+        )
+        def tags_error_schedule(_context):
+            return {}
+
+        @schedule(
+            cron_schedule="@daily",
+            job_name="no_config_job",
+        )
+        def run_config_error_schedule(_context):
+            throw_error()
+
+        @schedule(
+            cron_schedule="@daily",
+            job_name="no_config_job",
+            execution_timezone="US/Central",
+        )
+        def timezone_schedule(_context):
+            return {}
+
+        tagged_job_schedule = ScheduleDefinition(
+            name="tagged_job_schedule",
+            cron_schedule="0 0 * * *",
+            job_name="tagged_job",
+        )
+
+        tagged_job_override_schedule = ScheduleDefinition(
+            name="tagged_job_override_schedule",
+            cron_schedule="0 0 * * *",
+            job_name="tagged_job",
+            tags={"foo": "notbar"},
+        )
+
+        invalid_config_schedule = ScheduleDefinition(
+            name="invalid_config_schedule",
+            cron_schedule="0 0 * * *",
+            job_name="job_with_enum_config",
+            run_config={"ops": {"takes_an_enum": {"config": "invalid"}}},
+        )
+
+        @schedule(
+            job_name="nested_job",
+            cron_schedule=["45 23 * * 6", "30 9 * * 0"],
+        )
+        def composite_cron_schedule(_context):
+            return {}
+
+        @schedule(
+            cron_schedule="* * * * *", job=basic_job, default_status=DefaultScheduleStatus.RUNNING
+        )
+        def past_tick_schedule():
+            return {}
+
+        @schedule(cron_schedule="* * * * *", job=req_config_job)
+        def provide_config_schedule():
+            return {"ops": {"the_op": {"config": {"foo": "bar"}}}}
+
+        @schedule(cron_schedule="* * * * *", job=req_config_job)
+        def always_error():
+            raise Exception("darnit")
+
+        return [
+            run_config_error_schedule,
+            no_config_job_hourly_schedule,
+            no_config_job_hourly_schedule_with_config_fn,
+            no_config_should_execute,
+            dynamic_config,
+            should_execute_error_schedule,
+            tagged_job_schedule,
+            tagged_job_override_schedule,
+            tags_error_schedule,
+            timezone_schedule,
+            invalid_config_schedule,
+            running_in_code_schedule,
+            composite_cron_schedule,
+            past_tick_schedule,
+            provide_config_schedule,
+            always_error,
+        ]
+
+    def define_sensors():
+        @sensor(job_name="no_config_job")
+        def always_no_config_sensor(_):
+            return RunRequest(
+                run_key=None,
+                tags={"test": "1234"},
+            )
+
+        @sensor(job_name="no_config_job")
+        def always_error_sensor(_):
+            raise Exception("OOPS")
+
+        @sensor(job_name="no_config_job")
+        def update_cursor_sensor(context):
+            if not context.cursor:
+                cursor = 0
+            else:
+                cursor = int(context.cursor)
+            cursor += 1
+            context.update_cursor(str(cursor))
+
+        @sensor(job_name="no_config_job")
+        def once_no_config_sensor(_):
+            return RunRequest(
+                run_key="once",
+                tags={"test": "1234"},
+            )
+
+        @sensor(job_name="no_config_job")
+        def never_no_config_sensor(_):
+            return SkipReason("never")
+
+        @sensor(job_name="dynamic_partitioned_assets_job")
+        def dynamic_partition_requesting_sensor(_):
+            yield SensorResult(
+                run_requests=[RunRequest(partition_key="new_key")],
+                dynamic_partitions_requests=[
+                    DynamicPartitionsDefinition(name="foo").build_add_request(
+                        ["new_key", "new_key2", "existent_key"]
+                    ),
+                    DynamicPartitionsDefinition(name="foo").build_delete_request(
+                        ["old_key", "nonexistent_key"]
+                    ),
+                ],
+            )
+
+        @sensor(job_name="no_config_job")
+        def multi_no_config_sensor(_):
+            yield RunRequest(run_key="A")
+            yield RunRequest(run_key="B")
+
+        @sensor(job_name="no_config_job", minimum_interval_seconds=60)
+        def custom_interval_sensor(_):
+            return RunRequest(
+                run_key=None,
+                tags={"test": "1234"},
+            )
+
+        @sensor(job_name="no_config_job", default_status=DefaultSensorStatus.RUNNING)
+        def running_in_code_sensor(_):
+            return RunRequest(
+                run_key=None,
+                tags={"test": "1234"},
+            )
+
+        @sensor(job_name="no_config_job")
+        def logging_sensor(context):
+            context.log.info("hello hello")
+            return SkipReason()
+
+        @sensor(asset_selection=AssetSelection.all())
+        def every_asset_sensor(_):
+            return SkipReason("just kidding")
+
+        @run_status_sensor(run_status=DagsterRunStatus.SUCCESS, request_job=no_config_job)
+        def run_status(_):
+            return SkipReason("always skip")
+
+        @asset_sensor(asset_key=AssetKey("foo"), job=single_asset_job)
+        def single_asset_sensor():
+            pass
+
+        @multi_asset_sensor(monitored_assets=[], job=single_asset_job)
+        def many_asset_sensor(_):
+            pass
+
+        @freshness_policy_sensor(asset_selection=AssetSelection.all())
+        def fresh_sensor(_):
+            pass
+
+        @run_failure_sensor
+        def the_failure_sensor():
+            pass
+
+        automation_policy_sensor = AutomationPolicySensorDefinition(
+            "my_automation_policy_sensor",
+            asset_selection=AssetSelection.keys("fresh_diamond_bottom"),
+        )
+
+        return [
+            always_no_config_sensor,
+            always_error_sensor,
+            once_no_config_sensor,
+            never_no_config_sensor,
+            dynamic_partition_requesting_sensor,
+            multi_no_config_sensor,
+            custom_interval_sensor,
+            running_in_code_sensor,
+            logging_sensor,
+            update_cursor_sensor,
+            run_status,
+            single_asset_sensor,
+            many_asset_sensor,
+            fresh_sensor,
+            the_failure_sensor,
+            automation_policy_sensor,
+            every_asset_sensor,
+        ]
+
+    # The tests that use this rely on it using in-process execution.
+    @job(executor_def=in_process_executor, partitions_def=integers_partitions)
+    def chained_failure_job():
+        @op
+        def always_succeed():
+            return "hello"
+
+        @op
+        def conditionally_fail(_upstream):
+            if os.path.isfile(
+                os.path.join(
+                    get_system_temp_directory(),
+                    "chained_failure_job_conditionally_fail",
+                )
+            ):
+                raise Exception("blah")
+
+            return "hello"
+
+        @op
+        def after_failure(_upstream):
+            return "world"
+
+        after_failure(conditionally_fail(always_succeed()))
 
     @graph
-    def subgraph():
-        return plus_one(adder(op_1(), op_2()))
+    def simple_graph():
+        noop_op()
 
-    plus_one(subgraph())
+    @graph
+    def composed_graph():
+        simple_graph()
 
+    @job(config={"ops": {"op_with_config": {"config": {"one": "hullo"}}}})
+    def job_with_default_config():
+        @op(config_schema={"one": Field(String)})
+        def op_with_config(context):
+            return context.op_config["one"]
 
-@job
-def req_config_job():
-    @op(config_schema={"foo": str})
-    def the_op():
+        op_with_config()
+
+    @resource(config_schema={"file": Field(String)})
+    def hanging_asset_resource(context):
+        # Hack to allow asset to get value from run config
+        return context.resource_config.get("file")
+
+    class DummyIOManager(IOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            pass
+
+    dummy_source_asset = SourceAsset(key=AssetKey("dummy_source_asset"))
+
+    @asset
+    def first_asset(
+        dummy_source_asset,
+    ):
+        return 1
+
+    @asset(required_resource_keys={"hanging_asset_resource"})
+    def hanging_asset(context, first_asset):
+        """Asset that hangs forever, used to test in-progress ops."""
+        with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
+            ff.write("yup")
+
+        while True:
+            time.sleep(0.1)
+
+    @asset
+    def never_runs_asset(
+        hanging_asset,
+    ):
         pass
 
-    the_op()
-
-
-@asset
-def asset_1():
-    yield Output(3)
-
-
-@asset(deps=[AssetKey("asset_1")])
-def asset_2():
-    raise Exception("foo")
-
-
-@asset(deps=[AssetKey("asset_2")])
-def asset_3():
-    yield Output(7)
-
-
-failure_assets_job = build_assets_job(
-    "failure_assets_job", [asset_1, asset_2, asset_3], executor_def=in_process_executor
-)
-
-
-@asset
-def foo(context: AssetExecutionContext):
-    assert context.job_def.asset_selection_data is not None
-    return 5
-
-
-@asset
-def bar(context: AssetExecutionContext):
-    assert context.job_def.asset_selection_data is not None
-    return 10
-
-
-@asset
-def foo_bar(context: AssetExecutionContext, foo, bar):
-    assert context.job_def.asset_selection_data is not None
-    return foo + bar
-
-
-@asset
-def baz(context: AssetExecutionContext, foo_bar):
-    assert context.job_def.asset_selection_data is not None
-    return foo_bar
-
-
-@asset
-def unconnected(context: AssetExecutionContext):
-    assert context.job_def.asset_selection_data is not None
-
-
-foo_job = build_assets_job("foo_job", [foo, bar, foo_bar, baz, unconnected])
-
-
-@asset(group_name="group_1")
-def grouped_asset_1():
-    return 1
-
-
-@asset(group_name="group_1")
-def grouped_asset_2():
-    return 1
-
-
-@asset
-def ungrouped_asset_3():
-    return 1
-
-
-@asset(group_name="group_2")
-def grouped_asset_4():
-    return 1
-
-
-@asset
-def ungrouped_asset_5():
-    return 1
-
-
-@multi_asset(outs={"int_asset": AssetOut(), "str_asset": AssetOut()})
-def typed_multi_asset() -> Tuple[int, str]:
-    return (1, "yay")
-
-
-@asset
-def typed_asset(int_asset) -> int:
-    return int_asset
-
-
-@asset
-def untyped_asset(typed_asset):
-    return typed_asset
-
-
-@asset(deps=[AssetKey("diamond_source")])
-def fresh_diamond_top():
-    return 1
-
-
-@asset
-def fresh_diamond_left(fresh_diamond_top):
-    return fresh_diamond_top + 1
-
-
-@asset
-def fresh_diamond_right(fresh_diamond_top):
-    return fresh_diamond_top + 1
-
-
-@asset(
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=30),
-    auto_materialize_policy=AutoMaterializePolicy.lazy(),
-)
-def fresh_diamond_bottom(fresh_diamond_left, fresh_diamond_right):
-    return fresh_diamond_left + fresh_diamond_right
-
-
-multipartitions_def = MultiPartitionsDefinition(
-    {
-        "date": DailyPartitionsDefinition(start_date="2022-01-01"),
-        "ab": StaticPartitionsDefinition(["a", "b", "c"]),
-    }
-)
-
-
-@asset(partitions_def=multipartitions_def)
-def multipartitions_1():
-    return 1
-
-
-@asset(partitions_def=multipartitions_def)
-def multipartitions_2(multipartitions_1):
-    return multipartitions_1
-
-
-@asset(partitions_def=multipartitions_def)
-def multipartitions_fail(context):
-    if context.run.tags.get("fail") == "true":
-        raise Exception("multipartitions_fail")
-    return 1
-
-
-no_partitions_multipartitions_def = MultiPartitionsDefinition(
-    {
-        "a": StaticPartitionsDefinition([]),
-        "b": StaticPartitionsDefinition([]),
-    }
-)
-
-
-@asset(partitions_def=no_partitions_multipartitions_def)
-def no_multipartitions_1():
-    return 1
-
-
-dynamic_in_multipartitions_def = MultiPartitionsDefinition(
-    {
-        "dynamic": DynamicPartitionsDefinition(name="dynamic"),
-        "static": StaticPartitionsDefinition(["a", "b", "c"]),
-    }
-)
-
-
-@asset(partitions_def=dynamic_in_multipartitions_def)
-def dynamic_in_multipartitions_success():
-    return 1
-
-
-@asset(partitions_def=dynamic_in_multipartitions_def)
-def dynamic_in_multipartitions_fail(context, dynamic_in_multipartitions_success):
-    raise Exception("oops")
-
-
-@asset(
-    partitions_def=DailyPartitionsDefinition("2023-01-01"),
-    backfill_policy=BackfillPolicy.single_run(),
-)
-def single_run_backfill_policy_asset(context):
-    pass
-
-
-@asset(
-    partitions_def=DailyPartitionsDefinition("2023-01-03"),
-    backfill_policy=BackfillPolicy.multi_run(10),
-)
-def multi_run_backfill_policy_asset(context):
-    pass
-
-
-named_groups_job = build_assets_job(
-    "named_groups_job",
-    [
-        grouped_asset_1,
-        grouped_asset_2,
-        ungrouped_asset_3,
-        grouped_asset_4,
-        ungrouped_asset_5,
-    ],
-)
-
-
-@repository
-def empty_repo():
-    return []
-
-
-def define_jobs():
-    return [
-        asset_tag_job,
-        basic_job,
-        composites_job,
-        csv_hello_world_df_input,
-        csv_hello_world_two,
-        csv_hello_world_with_expectations,
-        csv_hello_world,
-        daily_partitioned_job,
-        eventually_successful,
-        hard_failer,
-        hello_world_with_tags,
-        infinite_loop_job,
-        integers,
-        materialization_job,
-        more_complicated_config,
-        more_complicated_nested_config,
-        config_with_map,
-        multi_asset_job,
-        loggers_job,
-        naughty_programmer_job,
-        nested_job,
-        no_config_chain_job,
-        no_config_job,
-        noop_job,
-        partitioned_asset_job,
-        job_with_enum_config,
-        job_with_expectations,
-        job_with_input_output_metadata,
-        job_with_invalid_definition_error,
-        job_with_list,
-        required_resource_job,
-        required_resource_config_job,
-        retry_multi_input_early_terminate_job,
-        retry_multi_output_job,
-        retry_resource_job,
-        scalar_output_job,
-        single_asset_job,
-        spew_job,
-        static_partitioned_job,
-        tagged_job,
-        chained_failure_job,
-        dynamic_job,
-        simple_graph.to_job("simple_job_a"),
-        simple_graph.to_job("simple_job_b"),
-        composed_graph.to_job(),
-        job_with_default_config,
-        hanging_job,
-        two_ins_job,
-        two_assets_job,
-        dynamic_partitioned_assets_job,
-        time_partitioned_assets_job,
-        partition_materialization_job,
-        fail_partition_materialization_job,
-        hanging_partition_asset_job,
-        observation_job,
-        failure_assets_job,
-        asset_check_job,
-        foo_job,
-        hanging_graph_asset_job,
-        named_groups_job,
-        memoization_job,
-        req_config_job,
-        executable_test_job,
-    ]
-
-
-typed_assets_job = define_asset_job(
-    "typed_assets",
-    AssetSelection.assets(typed_multi_asset, typed_asset, untyped_asset),
-)
-
-
-@schedule(cron_schedule="* * * * *", job=typed_assets_job)
-def asset_job_schedule():
-    return {}
-
-
-def define_asset_jobs():
-    return [
-        untyped_asset,
-        typed_asset,
-        typed_multi_asset,
-        typed_assets_job,
-        multipartitions_1,
-        multipartitions_2,
-        define_asset_job(
-            "multipartitions_job",
-            AssetSelection.assets(multipartitions_1, multipartitions_2),
-            partitions_def=multipartitions_def,
-        ),
-        no_multipartitions_1,
-        define_asset_job(
-            "no_multipartitions_job",
-            AssetSelection.assets(no_multipartitions_1),
-            partitions_def=no_partitions_multipartitions_def,
-        ),
-        multipartitions_fail,
-        define_asset_job(
-            "multipartitions_fail_job",
-            AssetSelection.assets(multipartitions_fail),
-            partitions_def=multipartitions_def,
-        ),
-        dynamic_in_multipartitions_success,
-        dynamic_in_multipartitions_fail,
-        define_asset_job(
-            "dynamic_in_multipartitions_success_job",
-            AssetSelection.assets(
-                dynamic_in_multipartitions_success, dynamic_in_multipartitions_fail
-            ),
-            partitions_def=dynamic_in_multipartitions_def,
-        ),
-        SourceAsset("diamond_source"),
-        fresh_diamond_top,
-        fresh_diamond_left,
-        fresh_diamond_right,
-        fresh_diamond_bottom,
-        define_asset_job(
-            "fresh_diamond_assets", AssetSelection.assets(fresh_diamond_bottom).upstream()
-        ),
-        upstream_daily_partitioned_asset,
-        downstream_weekly_partitioned_asset,
-        unpartitioned_upstream_of_partitioned,
-        upstream_static_partitioned_asset,
-        middle_static_partitioned_asset_1,
-        middle_static_partitioned_asset_2,
-        downstream_static_partitioned_asset,
-        define_asset_job(
-            "static_partitioned_assets_job",
-            AssetSelection.assets(upstream_static_partitioned_asset).downstream(),
-        ),
-        with_resources(
-            [hanging_partition_asset],
-            {
-                "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
-                "hanging_asset_resource": hanging_asset_resource,
-            },
-        ),
-        subsettable_checked_multi_asset,
-        checked_multi_asset_job,
-        check_in_op_asset,
-        asset_check_job,
-        single_run_backfill_policy_asset,
-        multi_run_backfill_policy_asset,
-    ]
-
-
-@asset_check(asset=asset_1, description="asset_1 check")
-def my_check(asset_1):
-    return AssetCheckResult(
-        passed=True,
-        metadata={
-            "foo": "bar",
-            "baz": "quux",
+    hanging_job = build_assets_job(
+        name="hanging_job",
+        source_assets=[dummy_source_asset],
+        assets=[first_asset, hanging_asset, never_runs_asset],
+        resource_defs={
+            "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
+            "hanging_asset_resource": hanging_asset_resource,
         },
     )
 
+    @op
+    def my_op():
+        return 1
 
-@asset(check_specs=[AssetCheckSpec(asset="check_in_op_asset", name="my_check")])
-def check_in_op_asset():
-    yield Output(1)
-    yield AssetCheckResult(passed=True)
+    @op(required_resource_keys={"hanging_asset_resource"})
+    def hanging_op(context, my_op):
+        with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
+            ff.write("yup")
 
+        while True:
+            time.sleep(0.1)
 
-asset_check_job = build_assets_job(
-    "asset_check_job", [asset_1, check_in_op_asset], asset_checks=[my_check]
-)
+    @op
+    def never_runs_op(hanging_op):
+        pass
 
+    @graph
+    def hanging_graph():
+        return never_runs_op(hanging_op(my_op()))
 
-@multi_asset(
-    outs={
-        "one": AssetOut(key="one", is_required=False),
-        "two": AssetOut(key="two", is_required=False),
-    },
-    check_specs=[
-        AssetCheckSpec("my_check", asset="one"),
-        AssetCheckSpec("my_other_check", asset="one"),
-    ],
-    can_subset=True,
-)
-def subsettable_checked_multi_asset(context: OpExecutionContext):
-    if AssetKey("one") in context.selected_asset_keys:
-        yield Output(1, output_name="one")
-    if AssetKey("two") in context.selected_asset_keys:
-        yield Output(1, output_name="two")
-    if AssetCheckKey(AssetKey("one"), "my_check") in context.selected_asset_check_keys:
-        yield AssetCheckResult(check_name="my_check", passed=True)
-    if AssetCheckKey(AssetKey("one"), "my_other_check") in context.selected_asset_check_keys:
-        yield AssetCheckResult(check_name="my_other_check", passed=True)
+    hanging_graph_asset = AssetsDefinition.from_graph(hanging_graph)
 
+    @job(version_strategy=SourceHashVersionStrategy())
+    def memoization_job():
+        my_op()
 
-checked_multi_asset_job = define_asset_job(
-    "checked_multi_asset_job", AssetSelection.assets(subsettable_checked_multi_asset)
-)
+    @asset
+    def downstream_asset(hanging_graph):
+        return 1
 
+    hanging_graph_asset_job = build_assets_job(
+        name="hanging_graph_asset_job",
+        assets=[hanging_graph_asset, downstream_asset],
+        resource_defs={
+            "hanging_asset_resource": hanging_asset_resource,
+            "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
+        },
+    )
 
-def define_asset_checks():
-    return [
-        my_check,
-    ]
+    @asset
+    def asset_one():
+        return 1
 
+    @asset
+    def asset_two(asset_one):
+        return asset_one + 1
 
-@repository(default_executor_def=in_process_executor)
-def test_repo():
-    return [
-        *define_jobs(),
-        *define_schedules(),
-        asset_job_schedule,
-        *define_sensors(),
-        *define_asset_jobs(),
-        *define_asset_checks(),
-    ]
+    two_assets_job = build_assets_job(name="two_assets_job", assets=[asset_one, asset_two])
 
+    @asset
+    def executable_asset() -> None:
+        pass
 
-defs = Definitions()
+    unexecutable_asset = next(iter(external_assets_from_specs([AssetSpec("unexecutable_asset")])))
 
+    executable_test_job = build_assets_job(
+        name="executable_test_job", assets=[executable_asset, unexecutable_asset]
+    )
 
-@repository(default_executor_def=in_process_executor)
-def test_dict_repo():
-    return {
-        "jobs": {job.name: job for job in define_jobs()},
-        "schedules": {schedule.name: schedule for schedule in define_schedules()},
-        "sensors": {sensor.name: sensor for sensor in define_sensors()},
-    }
+    static_partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d", "e", "f"])
+
+    @asset(partitions_def=static_partitions_def)
+    def upstream_static_partitioned_asset():
+        return 1
+
+    @asset(partitions_def=static_partitions_def)
+    def middle_static_partitioned_asset_1(upstream_static_partitioned_asset):
+        return 1
+
+    @asset(partitions_def=static_partitions_def)
+    def middle_static_partitioned_asset_2(upstream_static_partitioned_asset):
+        return 1
+
+    @asset(partitions_def=static_partitions_def)
+    def downstream_static_partitioned_asset(
+        middle_static_partitioned_asset_1, middle_static_partitioned_asset_2
+    ):
+        assert middle_static_partitioned_asset_1
+        assert middle_static_partitioned_asset_2
+
+    @asset(partitions_def=DynamicPartitionsDefinition(name="foo"))
+    def upstream_dynamic_partitioned_asset():
+        return 1
+
+    @asset(partitions_def=DynamicPartitionsDefinition(name="foo"))
+    def downstream_dynamic_partitioned_asset(
+        upstream_dynamic_partitioned_asset,
+    ):
+        assert upstream_dynamic_partitioned_asset
+
+    dynamic_partitioned_assets_job = build_assets_job(
+        "dynamic_partitioned_assets_job",
+        assets=[upstream_dynamic_partitioned_asset, downstream_dynamic_partitioned_asset],
+    )
+
+    @static_partitioned_config(partition_keys=["1", "2", "3", "4", "5"])
+    def my_static_partitioned_config(_partition_key: str):
+        return {}
+
+    @job(config=my_static_partitioned_config)
+    def static_partitioned_job():
+        my_op()
+
+    hourly_partition = HourlyPartitionsDefinition(start_date="2021-05-05-01:00")
+
+    @daily_partitioned_config(start_date=datetime.datetime(2022, 5, 1), minute_offset=15)
+    def my_daily_partitioned_config(_start, _end):
+        return {}
+
+    @job(config=my_daily_partitioned_config)
+    def daily_partitioned_job():
+        my_op()
+
+    @asset(partitions_def=hourly_partition)
+    def upstream_time_partitioned_asset():
+        return 1
+
+    @asset(
+        partitions_def=hourly_partition,
+        ins={
+            "upstream_time_partitioned_asset": AssetIn(
+                partition_mapping=TimeWindowPartitionMapping()
+            )
+        },
+    )
+    def downstream_time_partitioned_asset(
+        upstream_time_partitioned_asset,
+    ):
+        return upstream_time_partitioned_asset + 1
+
+    time_partitioned_assets_job = build_assets_job(
+        "time_partitioned_assets_job",
+        [upstream_time_partitioned_asset, downstream_time_partitioned_asset],
+    )
+
+    @asset
+    def unpartitioned_upstream_of_partitioned():
+        return 1
+
+    @asset(partitions_def=DailyPartitionsDefinition("2023-01-01"))
+    def upstream_daily_partitioned_asset(unpartitioned_upstream_of_partitioned):
+        return unpartitioned_upstream_of_partitioned
+
+    @asset(partitions_def=WeeklyPartitionsDefinition("2023-01-01"))
+    def downstream_weekly_partitioned_asset(
+        upstream_daily_partitioned_asset,
+    ):
+        return upstream_daily_partitioned_asset + 1
+
+    @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]))
+    def yield_partition_materialization():
+        yield Output(5)
+
+    partition_materialization_job = build_assets_job(
+        "partition_materialization_job",
+        assets=[yield_partition_materialization],
+        executor_def=in_process_executor,
+    )
+
+    @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]))
+    def fail_partition_materialization(context):
+        if context.run.tags.get("fail") == "true":
+            raise Exception("fail_partition_materialization")
+        yield Output(5)
+
+    fail_partition_materialization_job = build_assets_job(
+        "fail_partition_materialization_job",
+        assets=[fail_partition_materialization],
+        executor_def=in_process_executor,
+    )
+
+    @asset(
+        partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]),
+        required_resource_keys={"hanging_asset_resource"},
+    )
+    def hanging_partition_asset(context):
+        with open(context.resources.hanging_asset_resource, "w", encoding="utf8") as ff:
+            ff.write("yup")
+
+        while True:
+            time.sleep(0.1)
+
+    hanging_partition_asset_job = build_assets_job(
+        "hanging_partition_asset_job",
+        assets=[hanging_partition_asset],
+        executor_def=in_process_executor,
+        resource_defs={
+            "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
+            "hanging_asset_resource": hanging_asset_resource,
+        },
+    )
+
+    @asset
+    def asset_yields_observation():
+        yield AssetObservation(
+            asset_key=AssetKey("asset_yields_observation"), metadata={"text": "FOO"}
+        )
+        yield AssetMaterialization(asset_key=AssetKey("asset_yields_observation"))
+        yield Output(5)
+
+    observation_job = build_assets_job(
+        "observation_job",
+        assets=[asset_yields_observation],
+        executor_def=in_process_executor,
+    )
+
+    @op
+    def op_1():
+        return 1
+
+    @op
+    def op_2():
+        return 2
+
+    @job
+    def two_ins_job():
+        @op
+        def op_with_2_ins(in_1, in_2):
+            return in_1 + in_2
+
+        op_with_2_ins(op_1(), op_2())
+
+    @job
+    def nested_job():
+        @op
+        def adder(num1: int, num2: int):
+            return num1 + num2
+
+        @op
+        def plus_one(num: int):
+            return num + 1
+
+        @graph
+        def subgraph():
+            return plus_one(adder(op_1(), op_2()))
+
+        plus_one(subgraph())
+
+    @job
+    def req_config_job():
+        @op(config_schema={"foo": str})
+        def the_op():
+            pass
+
+        the_op()
+
+    @asset
+    def asset_1():
+        yield Output(3)
+
+    @asset(deps=[AssetKey("asset_1")])
+    def asset_2():
+        raise Exception("foo")
+
+    @asset(deps=[AssetKey("asset_2")])
+    def asset_3():
+        yield Output(7)
+
+    failure_assets_job = build_assets_job(
+        "failure_assets_job", [asset_1, asset_2, asset_3], executor_def=in_process_executor
+    )
+
+    @asset
+    def foo(context: AssetExecutionContext):
+        assert context.job_def.asset_selection_data is not None
+        return 5
+
+    @asset
+    def bar(context: AssetExecutionContext):
+        assert context.job_def.asset_selection_data is not None
+        return 10
+
+    @asset
+    def foo_bar(context: AssetExecutionContext, foo, bar):
+        assert context.job_def.asset_selection_data is not None
+        return foo + bar
+
+    @asset
+    def baz(context: AssetExecutionContext, foo_bar):
+        assert context.job_def.asset_selection_data is not None
+        return foo_bar
+
+    @asset
+    def unconnected(context: AssetExecutionContext):
+        assert context.job_def.asset_selection_data is not None
+
+    foo_job = build_assets_job("foo_job", [foo, bar, foo_bar, baz, unconnected])
+
+    @asset(group_name="group_1")
+    def grouped_asset_1():
+        return 1
+
+    @asset(group_name="group_1")
+    def grouped_asset_2():
+        return 1
+
+    @asset
+    def ungrouped_asset_3():
+        return 1
+
+    @asset(group_name="group_2")
+    def grouped_asset_4():
+        return 1
+
+    @asset
+    def ungrouped_asset_5():
+        return 1
+
+    @multi_asset(outs={"int_asset": AssetOut(), "str_asset": AssetOut()})
+    def typed_multi_asset() -> Tuple[int, str]:
+        return (1, "yay")
+
+    @asset
+    def typed_asset(int_asset) -> int:
+        return int_asset
+
+    @asset
+    def untyped_asset(typed_asset):
+        return typed_asset
+
+    @asset(deps=[AssetKey("diamond_source")])
+    def fresh_diamond_top():
+        return 1
+
+    @asset
+    def fresh_diamond_left(fresh_diamond_top):
+        return fresh_diamond_top + 1
+
+    @asset
+    def fresh_diamond_right(fresh_diamond_top):
+        return fresh_diamond_top + 1
+
+    @asset(
+        freshness_policy=FreshnessPolicy(maximum_lag_minutes=30),
+        auto_materialize_policy=AutoMaterializePolicy.lazy(),
+    )
+    def fresh_diamond_bottom(fresh_diamond_left, fresh_diamond_right):
+        return fresh_diamond_left + fresh_diamond_right
+
+    multipartitions_def = MultiPartitionsDefinition(
+        {
+            "date": DailyPartitionsDefinition(start_date="2022-01-01"),
+            "ab": StaticPartitionsDefinition(["a", "b", "c"]),
+        }
+    )
+
+    @asset(partitions_def=multipartitions_def)
+    def multipartitions_1():
+        return 1
+
+    @asset(partitions_def=multipartitions_def)
+    def multipartitions_2(multipartitions_1):
+        return multipartitions_1
+
+    @asset(partitions_def=multipartitions_def)
+    def multipartitions_fail(context):
+        if context.run.tags.get("fail") == "true":
+            raise Exception("multipartitions_fail")
+        return 1
+
+    no_partitions_multipartitions_def = MultiPartitionsDefinition(
+        {
+            "a": StaticPartitionsDefinition([]),
+            "b": StaticPartitionsDefinition([]),
+        }
+    )
+
+    @asset(partitions_def=no_partitions_multipartitions_def)
+    def no_multipartitions_1():
+        return 1
+
+    dynamic_in_multipartitions_def = MultiPartitionsDefinition(
+        {
+            "dynamic": DynamicPartitionsDefinition(name="dynamic"),
+            "static": StaticPartitionsDefinition(["a", "b", "c"]),
+        }
+    )
+
+    @asset(partitions_def=dynamic_in_multipartitions_def)
+    def dynamic_in_multipartitions_success():
+        return 1
+
+    @asset(partitions_def=dynamic_in_multipartitions_def)
+    def dynamic_in_multipartitions_fail(context, dynamic_in_multipartitions_success):
+        raise Exception("oops")
+
+    @asset(
+        partitions_def=DailyPartitionsDefinition("2023-01-01"),
+        backfill_policy=BackfillPolicy.single_run(),
+    )
+    def single_run_backfill_policy_asset(context):
+        pass
+
+    @asset(
+        partitions_def=DailyPartitionsDefinition("2023-01-03"),
+        backfill_policy=BackfillPolicy.multi_run(10),
+    )
+    def multi_run_backfill_policy_asset(context):
+        pass
+
+    named_groups_job = build_assets_job(
+        "named_groups_job",
+        [
+            grouped_asset_1,
+            grouped_asset_2,
+            ungrouped_asset_3,
+            grouped_asset_4,
+            ungrouped_asset_5,
+        ],
+    )
+
+    @repository
+    def empty_repo():
+        return []
+
+    def define_jobs():
+        return [
+            asset_tag_job,
+            basic_job,
+            composites_job,
+            csv_hello_world_df_input,
+            csv_hello_world_two,
+            csv_hello_world_with_expectations,
+            csv_hello_world,
+            daily_partitioned_job,
+            eventually_successful,
+            hard_failer,
+            hello_world_with_tags,
+            infinite_loop_job,
+            integers,
+            materialization_job,
+            more_complicated_config,
+            more_complicated_nested_config,
+            config_with_map,
+            multi_asset_job,
+            loggers_job,
+            naughty_programmer_job,
+            nested_job,
+            no_config_chain_job,
+            no_config_job,
+            noop_job,
+            partitioned_asset_job,
+            job_with_enum_config,
+            job_with_expectations,
+            job_with_input_output_metadata,
+            job_with_invalid_definition_error,
+            job_with_list,
+            required_resource_job,
+            required_resource_config_job,
+            retry_multi_input_early_terminate_job,
+            retry_multi_output_job,
+            retry_resource_job,
+            scalar_output_job,
+            single_asset_job,
+            spew_job,
+            static_partitioned_job,
+            tagged_job,
+            chained_failure_job,
+            dynamic_job,
+            simple_graph.to_job("simple_job_a"),
+            simple_graph.to_job("simple_job_b"),
+            composed_graph.to_job(),
+            job_with_default_config,
+            hanging_job,
+            two_ins_job,
+            two_assets_job,
+            dynamic_partitioned_assets_job,
+            time_partitioned_assets_job,
+            partition_materialization_job,
+            fail_partition_materialization_job,
+            hanging_partition_asset_job,
+            observation_job,
+            failure_assets_job,
+            asset_check_job,
+            foo_job,
+            hanging_graph_asset_job,
+            named_groups_job,
+            memoization_job,
+            req_config_job,
+            executable_test_job,
+        ]
+
+    typed_assets_job = define_asset_job(
+        "typed_assets",
+        AssetSelection.assets(typed_multi_asset, typed_asset, untyped_asset),
+    )
+
+    @schedule(cron_schedule="* * * * *", job=typed_assets_job)
+    def asset_job_schedule():
+        return {}
+
+    def define_asset_jobs():
+        return [
+            untyped_asset,
+            typed_asset,
+            typed_multi_asset,
+            typed_assets_job,
+            multipartitions_1,
+            multipartitions_2,
+            define_asset_job(
+                "multipartitions_job",
+                AssetSelection.assets(multipartitions_1, multipartitions_2),
+                partitions_def=multipartitions_def,
+            ),
+            no_multipartitions_1,
+            define_asset_job(
+                "no_multipartitions_job",
+                AssetSelection.assets(no_multipartitions_1),
+                partitions_def=no_partitions_multipartitions_def,
+            ),
+            multipartitions_fail,
+            define_asset_job(
+                "multipartitions_fail_job",
+                AssetSelection.assets(multipartitions_fail),
+                partitions_def=multipartitions_def,
+            ),
+            dynamic_in_multipartitions_success,
+            dynamic_in_multipartitions_fail,
+            define_asset_job(
+                "dynamic_in_multipartitions_success_job",
+                AssetSelection.assets(
+                    dynamic_in_multipartitions_success, dynamic_in_multipartitions_fail
+                ),
+                partitions_def=dynamic_in_multipartitions_def,
+            ),
+            SourceAsset("diamond_source"),
+            fresh_diamond_top,
+            fresh_diamond_left,
+            fresh_diamond_right,
+            fresh_diamond_bottom,
+            define_asset_job(
+                "fresh_diamond_assets", AssetSelection.assets(fresh_diamond_bottom).upstream()
+            ),
+            upstream_daily_partitioned_asset,
+            downstream_weekly_partitioned_asset,
+            unpartitioned_upstream_of_partitioned,
+            upstream_static_partitioned_asset,
+            middle_static_partitioned_asset_1,
+            middle_static_partitioned_asset_2,
+            downstream_static_partitioned_asset,
+            define_asset_job(
+                "static_partitioned_assets_job",
+                AssetSelection.assets(upstream_static_partitioned_asset).downstream(),
+            ),
+            with_resources(
+                [hanging_partition_asset],
+                {
+                    "io_manager": IOManagerDefinition.hardcoded_io_manager(DummyIOManager()),
+                    "hanging_asset_resource": hanging_asset_resource,
+                },
+            ),
+            subsettable_checked_multi_asset,
+            checked_multi_asset_job,
+            check_in_op_asset,
+            asset_check_job,
+            single_run_backfill_policy_asset,
+            multi_run_backfill_policy_asset,
+        ]
+
+    @asset_check(asset=asset_1, description="asset_1 check")
+    def my_check(asset_1):
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "foo": "bar",
+                "baz": "quux",
+            },
+        )
+
+    @asset(check_specs=[AssetCheckSpec(asset="check_in_op_asset", name="my_check")])
+    def check_in_op_asset():
+        yield Output(1)
+        yield AssetCheckResult(passed=True)
+
+    asset_check_job = build_assets_job(
+        "asset_check_job", [asset_1, check_in_op_asset], asset_checks=[my_check]
+    )
+
+    @multi_asset(
+        outs={
+            "one": AssetOut(key="one", is_required=False),
+            "two": AssetOut(key="two", is_required=False),
+        },
+        check_specs=[
+            AssetCheckSpec("my_check", asset="one"),
+            AssetCheckSpec("my_other_check", asset="one"),
+        ],
+        can_subset=True,
+    )
+    def subsettable_checked_multi_asset(context: OpExecutionContext):
+        if AssetKey("one") in context.selected_asset_keys:
+            yield Output(1, output_name="one")
+        if AssetKey("two") in context.selected_asset_keys:
+            yield Output(1, output_name="two")
+        if AssetCheckKey(AssetKey("one"), "my_check") in context.selected_asset_check_keys:
+            yield AssetCheckResult(check_name="my_check", passed=True)
+        if AssetCheckKey(AssetKey("one"), "my_other_check") in context.selected_asset_check_keys:
+            yield AssetCheckResult(check_name="my_other_check", passed=True)
+
+    checked_multi_asset_job = define_asset_job(
+        "checked_multi_asset_job", AssetSelection.assets(subsettable_checked_multi_asset)
+    )
+
+    def define_asset_checks():
+        return [
+            my_check,
+        ]
+
+    @repository(default_executor_def=in_process_executor)
+    def test_repo():
+        return [
+            *define_jobs(),
+            *define_schedules(),
+            asset_job_schedule,
+            *define_sensors(),
+            *define_asset_jobs(),
+            *define_asset_checks(),
+        ]
+
+    defs = Definitions()
+
+    @repository(default_executor_def=in_process_executor)
+    def test_dict_repo():
+        return {
+            "jobs": {job.name: job for job in define_jobs()},
+            "schedules": {schedule.name: schedule for schedule in define_schedules()},
+            "sensors": {sensor.name: sensor for sensor in define_sensors()},
+        }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -186,9 +186,7 @@ def get_main_external_repo(instance: DagsterInstance) -> Iterator[ExternalReposi
         yield location.get_repository(main_repo_name())
 
 
-from python_modules.dagster.dagster._core.definitions.decorators.op_decorator import (
-    do_not_attach_code_origin,
-)
+from dagster._core.definitions.decorators.op_decorator import do_not_attach_code_origin
 
 with do_not_attach_code_origin():
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
@@ -4,7 +4,7 @@ from dagster._serdes import serialize_pp
 from .repo import get_main_external_repo
 
 
-def test_all_snapshot_ids(snapshot):
+def test_all_snapshot_ids(snapshot, ignore_code_origin):
     # This ensures that pipeline snapshots remain stable
     # If you 1) change any pipelines in dagster_graphql_test or 2) change the
     # schema of PipelineSnapshots you are free to rerecord

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
@@ -62,7 +62,7 @@ def pretty_dump(data) -> str:
 
 
 def test_fetch_snapshot_or_error_by_snapshot_id_success(
-    graphql_context: WorkspaceRequestContext, snapshot
+    graphql_context: WorkspaceRequestContext, snapshot, ignore_code_origin
 ):
     instance = graphql_context.instance
     result = noop_job.execute_in_process(instance=instance)
@@ -84,7 +84,7 @@ def test_fetch_snapshot_or_error_by_snapshot_id_success(
 
 
 def test_fetch_snapshot_or_error_by_snapshot_id_snapshot_not_found(
-    graphql_context: WorkspaceRequestContext, snapshot
+    graphql_context: WorkspaceRequestContext, snapshot, ignore_code_origin
 ):
     result = execute_dagster_graphql(
         graphql_context,
@@ -100,7 +100,7 @@ def test_fetch_snapshot_or_error_by_snapshot_id_snapshot_not_found(
 
 
 def test_fetch_snapshot_or_error_by_active_pipeline_name_success(
-    graphql_context: WorkspaceRequestContext, snapshot
+    graphql_context: WorkspaceRequestContext, snapshot, ignore_code_origin
 ):
     result = execute_dagster_graphql(
         graphql_context,
@@ -123,7 +123,7 @@ def test_fetch_snapshot_or_error_by_active_pipeline_name_success(
 
 
 def test_fetch_snapshot_or_error_by_active_pipeline_name_not_found(
-    graphql_context: WorkspaceRequestContext, snapshot
+    graphql_context: WorkspaceRequestContext, snapshot, ignore_code_origin
 ):
     result = execute_dagster_graphql(
         graphql_context,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -21,12 +21,18 @@ import dagster._check as check
 from dagster._annotations import deprecated_param, experimental_param
 from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
-from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
+from dagster._core.decorator_utils import (
+    get_function_params,
+    get_valid_name_permutations,
+)
 from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataUserInput
+from dagster._core.definitions.metadata import (
+    ArbitraryMetadataMapping,
+    MetadataUserInput,
+)
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -21,18 +21,12 @@ import dagster._check as check
 from dagster._annotations import deprecated_param, experimental_param
 from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
-from dagster._core.decorator_utils import (
-    get_function_params,
-    get_valid_name_permutations,
-)
+from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.metadata import (
-    ArbitraryMetadataMapping,
-    MetadataUserInput,
-)
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataUserInput
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -817,6 +817,11 @@ class DagsterInstance(DynamicPartitionsStore):
         return self.get_settings("sensors")
 
     @property
+    def code_links_enabled(self) -> bool:
+        code_links_settings = cast(Dict[str, Any], self.get_settings("code_links"))
+        return code_links_settings.get("enabled", False) is True
+
+    @property
     def telemetry_enabled(self) -> bool:
         if self.is_ephemeral:
             return False

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -347,6 +347,9 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
         "nux": Field(
             {"enabled": Field(Bool, is_required=False)},
         ),
+        "code_links": Field(
+            {"enabled": Field(Bool, is_required=False)},
+        ),
         "instance_class": config_field_for_configurable_class(),
         "python_logs": python_logs_config_schema(),
         "run_monitoring": Field(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_code_origin.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_code_origin.py
@@ -1,0 +1,44 @@
+import os
+
+from dagster import AssetsDefinition, load_assets_from_modules
+from dagster._core.definitions.decorators.op_decorator import CODE_ORIGIN_TAG_NAME
+from dagster._utils import file_relative_path
+
+
+def test_asset_code_origins():
+    from dagster_tests.asset_defs_tests import asset_package
+
+    from .asset_package import module_with_assets
+
+    collection_1 = load_assets_from_modules([asset_package, module_with_assets])
+
+    # path of the `dagster` module on the filesystem
+    dagster_module_path = os.path.normpath(file_relative_path(__file__, "../../")) + "/"
+
+    # path of the current file relative to the `dagster` module root
+    path_in_module = "dagster_tests/asset_defs_tests/"
+
+    # code origin format is
+    # {path to module}:{path to file relative to module root}:{line number}
+    expected_origins = {
+        "james_brown": dagster_module_path + ":" + path_in_module + "asset_package/__init__.py:12",
+        "chuck_berry": (
+            dagster_module_path + ":" + path_in_module + "asset_package/module_with_assets.py:11"
+        ),
+        "little_richard": (
+            dagster_module_path + ":" + path_in_module + "asset_package/__init__.py:4"
+        ),
+        "fats_domino": dagster_module_path + ":" + path_in_module + "asset_package/__init__.py:16",
+        "miles_davis": (
+            dagster_module_path
+            + ":"
+            + path_in_module
+            + "asset_package/asset_subpackage/another_module_with_assets.py:6"
+        ),
+    }
+
+    for asset in collection_1:
+        if isinstance(asset, AssetsDefinition):
+            op_name = asset.op.name
+            assert op_name in expected_origins, f"Missing expected origin for op {op_name}"
+            assert asset.op.tags[CODE_ORIGIN_TAG_NAME] == expected_origins[op_name]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -126,7 +126,7 @@ def test_multi_asset_with_config_schema():
         materialize_to_memory([my_asset])
 
 
-def test_asset_with_compute_kind():
+def test_asset_with_compute_kind(ignore_code_origin):
     @asset(compute_kind="sql")
     def my_asset(arg1):
         return arg1
@@ -134,7 +134,7 @@ def test_asset_with_compute_kind():
     assert my_asset.op.tags == {"kind": "sql"}
 
 
-def test_multi_asset_with_compute_kind():
+def test_multi_asset_with_compute_kind(ignore_code_origin):
     @multi_asset(outs={"o1": AssetOut()}, compute_kind="sql")
     def my_asset(arg1):
         return arg1
@@ -577,7 +577,7 @@ def test_partitions_def():
     assert my_asset.partitions_def == partitions_def
 
 
-def test_op_tags():
+def test_op_tags(ignore_code_origin):
     tags = {"apple": "banana", "orange": {"rind": "fsd", "segment": "fjdskl"}}
     tags_stringified = {"apple": "banana", "orange": '{"rind": "fsd", "segment": "fjdskl"}'}
 

--- a/python_modules/dagster/dagster_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/conftest.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 
 import dagster._seven as seven
+import pytest
+from dagster._core.definitions.decorators.op_decorator import do_not_attach_code_origin
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
@@ -11,3 +13,11 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 # Fixed in later versions of Python but never back-ported, see the bug for details.
 if seven.IS_WINDOWS and sys.version_info[0] == 3 and sys.version_info[1] == 6:
     subprocess._cleanup = lambda: None  # type: ignore # noqa: SLF001
+
+
+@pytest.fixture
+def ignore_code_origin():
+    # avoid attaching code origin metadata to ops/assets, because this can change from environment
+    # to environment and break snapshot tests
+    with do_not_attach_code_origin():
+        yield

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/active_data_repo.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/active_data_repo.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from dagster import daily_partitioned_config, job, op, repository
+from dagster._core.definitions.decorators.schedule_decorator import schedule
+
+
+@op
+def foo_op(_):
+    pass
+
+
+@schedule(
+    cron_schedule="@daily",
+    job_name="foo_job",
+    execution_timezone="US/Central",
+)
+def foo_schedule():
+    return {}
+
+
+@daily_partitioned_config(start_date=datetime(2020, 1, 1), minute_offset=15)
+def my_partitioned_config(_start: datetime, _end: datetime):
+    return {}
+
+
+@job(config=my_partitioned_config)
+def foo_job():
+    foo_op()
+
+
+@repository
+def a_repo():
+    return [foo_job]

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
@@ -4,7 +4,7 @@ from dagster._core.snap import create_job_snapshot_id, snapshot_from_execution_p
 from dagster._serdes import serialize_pp
 
 
-def test_create_noop_execution_plan(snapshot):
+def test_create_noop_execution_plan(snapshot, ignore_code_origin):
     @op
     def noop_op(_):
         pass
@@ -25,7 +25,7 @@ def test_create_noop_execution_plan(snapshot):
     )
 
 
-def test_create_execution_plan_with_dep(snapshot):
+def test_create_execution_plan_with_dep(snapshot, ignore_code_origin):
     @op
     def op_one(_):
         return 1
@@ -50,7 +50,7 @@ def test_create_execution_plan_with_dep(snapshot):
     )
 
 
-def test_create_with_graph(snapshot):
+def test_create_with_graph(snapshot, ignore_code_origin):
     @op(out={"out_num": Out(dagster_type=int)})
     def return_one(_):
         return 1
@@ -90,7 +90,7 @@ def test_create_with_graph(snapshot):
     )
 
 
-def test_create_noop_execution_plan_with_tags(snapshot):
+def test_create_noop_execution_plan_with_tags(snapshot, ignore_code_origin):
     @op(tags={"foo": "bar", "bar": "baaz"})
     def noop_op(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -39,11 +39,11 @@ def get_noop_pipeline():
     return noop_job
 
 
-def test_empty_job_snap_snapshot(snapshot):
+def test_empty_job_snap_snapshot(snapshot, ignore_code_origin):
     snapshot.assert_match(serialize_pp(JobSnapshot.from_job_def(get_noop_pipeline())))
 
 
-def test_empty_job_snap_props(snapshot):
+def test_empty_job_snap_props(snapshot, ignore_code_origin):
     job_snapshot = JobSnapshot.from_job_def(get_noop_pipeline())
 
     assert job_snapshot.name == "noop_job"
@@ -56,7 +56,7 @@ def test_empty_job_snap_props(snapshot):
     snapshot.assert_match(create_job_snapshot_id(job_snapshot))
 
 
-def test_job_snap_all_props(snapshot):
+def test_job_snap_all_props(snapshot, ignore_code_origin):
     @op
     def noop_op(_):
         pass
@@ -91,7 +91,7 @@ def test_noop_deps_snap():
     assert isinstance(invocations[0], NodeInvocationSnap)
 
 
-def test_two_invocations_deps_snap(snapshot):
+def test_two_invocations_deps_snap(snapshot, ignore_code_origin):
     @op
     def noop_op(_):
         pass
@@ -138,7 +138,7 @@ def test_basic_dep():
     assert outputs[0].output_name == "result"
 
 
-def test_basic_dep_fan_out(snapshot):
+def test_basic_dep_fan_out(snapshot, ignore_code_origin):
     @op
     def return_one(_):
         return 1
@@ -182,7 +182,7 @@ def test_basic_dep_fan_out(snapshot):
     snapshot.assert_match(create_job_snapshot_id(job_snapshot))
 
 
-def test_basic_fan_in(snapshot):
+def test_basic_fan_in(snapshot, ignore_code_origin):
     @op(out=Out(Nothing))
     def return_nothing(_):
         return None
@@ -437,7 +437,7 @@ def test_deserialize_node_def_snaps_noneable():
     assert isinstance(recevied_config_type.inner_type, String)
 
 
-def test_deserialize_node_def_snaps_multi_type_config(snapshot):
+def test_deserialize_node_def_snaps_multi_type_config(snapshot, ignore_code_origin):
     @op(
         config_schema=Field(
             Permissive(
@@ -502,7 +502,7 @@ def test_multi_type_config_array_dict_fields(dict_config_type, snapshot):
     )
 
 
-def test_multi_type_config_array_map(snapshot):
+def test_multi_type_config_array_map(snapshot, ignore_code_origin):
     @op(config_schema=Array(Map(str, int)))
     def fancy_op(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_node_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_node_def_snap.py
@@ -20,7 +20,7 @@ def test_basic_op_definition():
     assert deserialize_value(serialize_value(op_snap), OpDefSnap) == op_snap
 
 
-def test_op_definition_kitchen_sink():
+def test_op_definition_kitchen_sink(ignore_code_origin):
     @op(
         ins={"arg_one": In(str, description="desc1"), "arg_two": In(int)},
         out={

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -1,7 +1,7 @@
 from dagster import GraphDefinition, NodeInvocation, op
 
 
-def test_op_instance_tags():
+def test_op_instance_tags(ignore_code_origin):
     called = {}
 
     @op(tags={"foo": "bar", "baz": "quux"})

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_tags.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_tags.py
@@ -1,18 +1,37 @@
+import inspect
+import os
+
 from dagster import job, op
+from dagster._core.definitions.decorators.op_decorator import CODE_ORIGIN_TAG_NAME
+from dagster._utils import file_relative_path
+
+
+def _code_origin_tag(line_no: int) -> str:
+    dagster_module_path = os.path.normpath(file_relative_path(__file__, "../../")) + "/"
+    return f"{dagster_module_path}:dagster_tests/definitions_tests/test_tags.py:{line_no}"
 
 
 def test_op_tags():
+    expected_line = inspect.currentframe().f_lineno + 2
+
     @op(tags={"foo": "bar"})
     def tags_op(_):
         pass
 
-    assert tags_op.tags == {"foo": "bar"}
+    assert tags_op.tags == {
+        "foo": "bar",
+        CODE_ORIGIN_TAG_NAME: _code_origin_tag(expected_line),
+    }
+
+    expected_line = inspect.currentframe().f_lineno + 2
 
     @op()
     def no_tags_op(_):
         pass
 
-    assert no_tags_op.tags == {}
+    assert no_tags_op.tags == {
+        CODE_ORIGIN_TAG_NAME: _code_origin_tag(expected_line),
+    }
 
 
 def test_job_tags():

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -16,6 +16,7 @@ from dagster import (
 )
 from dagster._config import Permissive
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.definitions.decorators.op_decorator import CODE_ORIGIN_TAG_NAME
 from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
@@ -59,7 +60,11 @@ class TestStepHandler(StepHandler):
             TestStepHandler.verify_step_count += 1
         if step_handler_context.execute_step_args.step_keys_to_execute[0] == "baz_op":
             TestStepHandler.saw_baz_op = True
-            assert step_handler_context.step_tags["baz_op"] == {"foo": "bar"}
+            assert {
+                k: v
+                for k, v in step_handler_context.step_tags["baz_op"].items()
+                if k != CODE_ORIGIN_TAG_NAME
+            } == {"foo": "bar"}
 
         TestStepHandler.launch_step_count += 1
         print("TestStepHandler Launching Step!")  # noqa: T201

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
@@ -1,7 +1,9 @@
+import pytest
 from airflow import __version__ as airflow_version
 from airflow.models.dag import DAG
 from airflow.operators.dummy_operator import DummyOperator  # type: ignore
 from airflow.utils.dates import days_ago
+from dagster._core.definitions.decorators.op_decorator import do_not_attach_code_origin
 
 if airflow_version >= "2.0.0":
     from airflow.models.baseoperator import chain
@@ -21,8 +23,16 @@ default_args = {
 }
 
 
+@pytest.fixture
+def ignore_code_origin():
+    # avoid attaching code origin metadata to ops/assets, because this can change from environment
+    # to environment and break snapshot tests
+    with do_not_attach_code_origin():
+        yield
+
+
 @requires_no_db
-def test_one_task_dag(snapshot):
+def test_one_task_dag(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="one_task_dag",
@@ -50,7 +60,7 @@ def test_one_task_dag(snapshot):
 
 
 @requires_no_db
-def test_two_task_dag_no_dep(snapshot):
+def test_two_task_dag_no_dep(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="two_task_dag_no_dep",
@@ -82,7 +92,7 @@ def test_two_task_dag_no_dep(snapshot):
 
 
 @requires_no_db
-def test_two_task_dag_with_dep(snapshot):
+def test_two_task_dag_with_dep(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="two_task_dag_with_dep",
@@ -116,7 +126,7 @@ def test_two_task_dag_with_dep(snapshot):
 
 
 @requires_no_db
-def test_diamond_task_dag(snapshot):
+def test_diamond_task_dag(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="diamond_task_dag",
@@ -160,7 +170,7 @@ def test_diamond_task_dag(snapshot):
 
 
 @requires_no_db
-def test_multi_root_dag(snapshot):
+def test_multi_root_dag(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="multi_root_dag",
@@ -204,7 +214,7 @@ def test_multi_root_dag(snapshot):
 
 
 @requires_no_db
-def test_multi_leaf_dag(snapshot):
+def test_multi_leaf_dag(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="multi_leaf_dag",
@@ -247,7 +257,7 @@ def test_multi_leaf_dag(snapshot):
 
 
 @requires_no_db
-def test_complex_dag(snapshot):
+def test_complex_dag(snapshot, ignore_code_origin):
     if airflow_version >= "2.0.0":
         dag = DAG(
             dag_id="complex_dag",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 import pytest
+from dagster._core.definitions.decorators.op_decorator import do_not_attach_code_origin
 from dagster._utils import file_relative_path, pushd
 from dagster_dbt import DbtCliClientResource, DbtCliResource, dbt_cli_resource
 
@@ -81,3 +82,11 @@ def dbt_build(dbt_executable, dbt_config_dir):
     with pushd(TEST_PROJECT_DIR):
         subprocess.run([dbt_executable, "seed", "--profiles-dir", dbt_config_dir], check=True)
         subprocess.run([dbt_executable, "run", "--profiles-dir", dbt_config_dir], check=True)
+
+
+@pytest.fixture(autouse=True)
+def ignore_code_origin():
+    # avoid attaching code origin metadata to ops/assets, because this can change from environment
+    # to environment and break snapshot tests
+    with do_not_attach_code_origin():
+        yield


### PR DESCRIPTION
## Summary

First PR in a stack reworking #12009 into something landable, at least as an experiment.

If enabled in dagster config, uses `inspect` to attach metadata to Assets and Ops identifying where they were defined (line # and absolute filepath).

The intention is for this to be used locally, PRs later in the stack will add [editor backlinks from Dagit](https://github.com/dagster-io/dagster/pull/12097) which will show up in a local dev environment.

## Test Plan

tested locally, introduced unit tests
