### PR TITLE
[2/n][dagit]  Display link to open op/asset definitions in editor

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -13,7 +13,8 @@ import {CommunityNux} from './NUX/CommunityNux';
 import {extractInitializationData} from './extractInitializationData';
 import {telemetryLink} from './telemetryLink';
 
-const {pathPrefix, telemetryEnabled, liveDataPollRate} = extractInitializationData();
+const {pathPrefix, telemetryEnabled, liveDataPollRate, codeLinksEnabled} =
+  extractInitializationData();
 
 const apolloLinks = [logLink, errorLink, timeStartLink];
 
@@ -29,6 +30,7 @@ const config = {
   basePath: pathPrefix,
   origin: process.env.NEXT_PUBLIC_BACKEND_ORIGIN || document.location.origin,
   telemetryEnabled,
+  codeLinksEnabled,
   statusPolling: new Set<DeploymentStatusType>(['code-locations', 'daemons']),
 };
 

--- a/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
+++ b/js_modules/dagster-ui/packages/app-oss/src/extractInitializationData.ts
@@ -2,9 +2,16 @@ const ELEMENT_ID = 'initialization-data';
 const PREFIX_PLACEHOLDER = '__PATH_PREFIX__';
 const TELEMETRY_PLACEHOLDER = '__TELEMETRY_ENABLED__';
 const LIVE_DATA_POLL_RATE = '__LIVE_DATA_POLL_RATE__';
+const HAS_CODE_LINKS_PLACEHOLDER = '__CODE_LINKS_ENABLED__';
 
-let value: {pathPrefix: string; telemetryEnabled: boolean; liveDataPollRate?: number} | undefined =
-  undefined;
+let value:
+  | {
+      pathPrefix: string;
+      telemetryEnabled: boolean;
+      liveDataPollRate?: number;
+      codeLinksEnabled: boolean;
+    }
+  | undefined = undefined;
 
 // Determine the path prefix value, which is set server-side.
 // This value will be used for prefixing paths for the GraphQL
@@ -13,9 +20,10 @@ export const extractInitializationData = (): {
   pathPrefix: string;
   telemetryEnabled: boolean;
   liveDataPollRate?: number;
+  codeLinksEnabled: boolean;
 } => {
   if (!value) {
-    value = {pathPrefix: '', telemetryEnabled: false};
+    value = {pathPrefix: '', telemetryEnabled: false, codeLinksEnabled: false};
     const element = document.getElementById(ELEMENT_ID);
     if (element) {
       const parsed = JSON.parse(element.innerHTML);
@@ -27,6 +35,9 @@ export const extractInitializationData = (): {
       }
       if (parsed.liveDataPollRate !== LIVE_DATA_POLL_RATE) {
         value.liveDataPollRate = parsed.liveDataPollRate;
+      }
+      if (parsed.codeLinksEnabled !== HAS_CODE_LINKS_PLACEHOLDER) {
+        value.codeLinksEnabled = parsed.codeLinksEnabled;
       }
     }
   }

--- a/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
@@ -35,7 +35,9 @@ export default function Document() {
     {
       "pathPrefix": "__PATH_PREFIX__",
       "telemetryEnabled": "__TELEMETRY_ENABLED__",
+      "codeLinksEnabled": "__CODE_LINKS_ENABLED__",
       "liveDataPollRate": "__LIVE_DATA_POLL_RATE__"
+
     }
   `,
           }}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppContext.tsx
@@ -7,6 +7,7 @@ export type AppContextValue = {
   basePath: string;
   rootServerURI: string;
   telemetryEnabled: boolean;
+  codeLinksEnabled: boolean;
   statusPolling?: Set<DeploymentStatusType>;
 };
 
@@ -14,4 +15,5 @@ export const AppContext = createContext<AppContextValue>({
   basePath: '',
   rootServerURI: '',
   telemetryEnabled: false,
+  codeLinksEnabled: false,
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -38,6 +38,7 @@ import {migrateLocalStorageKeys} from './migrateLocalStorageKeys';
 import {TimeProvider} from './time/TimeContext';
 import {AssetLiveDataProvider} from '../asset-data/AssetLiveDataProvider';
 import {AssetRunLogObserver} from '../asset-graph/AssetRunLogObserver';
+import {CodeLinkProtocolProvider} from '../code-links/CodeLinkProtocol';
 import {DeploymentStatusProvider, DeploymentStatusType} from '../instance/DeploymentStatusProvider';
 import {InstancePageContext} from '../instance/InstancePageContext';
 import {JobFeatureProvider} from '../pipelines/JobFeatureContext';
@@ -122,6 +123,7 @@ export interface AppProviderProps {
     headers?: {[key: string]: string};
     origin: string;
     telemetryEnabled?: boolean;
+    codeLinksEnabled?: boolean;
     statusPolling: Set<DeploymentStatusType>;
   };
 }
@@ -134,6 +136,7 @@ export const AppProvider = (props: AppProviderProps) => {
     headers = {},
     origin,
     telemetryEnabled = false,
+    codeLinksEnabled = false,
     statusPolling,
   } = config;
 
@@ -188,8 +191,9 @@ export const AppProvider = (props: AppProviderProps) => {
       basePath,
       rootServerURI,
       telemetryEnabled,
+      codeLinksEnabled,
     }),
-    [basePath, rootServerURI, telemetryEnabled],
+    [basePath, rootServerURI, telemetryEnabled, codeLinksEnabled],
   );
 
   const analytics = React.useMemo(() => dummyAnalytics(), []);
@@ -218,22 +222,24 @@ export const AppProvider = (props: AppProviderProps) => {
               <BrowserRouter basename={basePath || ''}>
                 <CompatRouter>
                   <TimeProvider>
-                    <WorkspaceProvider>
-                      <DeploymentStatusProvider include={statusPolling}>
-                        <CustomConfirmationProvider>
-                          <AnalyticsContext.Provider value={analytics}>
-                            <InstancePageContext.Provider value={instancePageValue}>
-                              <JobFeatureProvider>
-                                <LayoutProvider>{props.children}</LayoutProvider>
-                              </JobFeatureProvider>
-                            </InstancePageContext.Provider>
-                          </AnalyticsContext.Provider>
-                        </CustomConfirmationProvider>
-                        <CustomTooltipProvider />
-                        <CustomAlertProvider />
-                        <AssetRunLogObserver />
-                      </DeploymentStatusProvider>
-                    </WorkspaceProvider>
+                    <CodeLinkProtocolProvider>
+                      <WorkspaceProvider>
+                        <DeploymentStatusProvider include={statusPolling}>
+                          <CustomConfirmationProvider>
+                            <AnalyticsContext.Provider value={analytics}>
+                              <InstancePageContext.Provider value={instancePageValue}>
+                                <JobFeatureProvider>
+                                  <LayoutProvider>{props.children}</LayoutProvider>
+                                </JobFeatureProvider>
+                              </InstancePageContext.Provider>
+                            </AnalyticsContext.Provider>
+                          </CustomConfirmationProvider>
+                          <CustomTooltipProvider />
+                          <CustomAlertProvider />
+                          <AssetRunLogObserver />
+                        </DeploymentStatusProvider>
+                      </WorkspaceProvider>
+                    </CodeLinkProtocolProvider>
                   </TimeProvider>
                 </CompatRouter>
               </BrowserRouter>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog.tsx
@@ -2,21 +2,25 @@ import {
   Box,
   Button,
   Checkbox,
+  Colors,
   Dialog,
   DialogBody,
   DialogFooter,
   Icon,
   Subheading,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import {DAGSTER_THEME_KEY, DagsterTheme} from '@dagster-io/ui-components/src/theme/theme';
 import * as React from 'react';
 
+import {AppContext} from './AppContext';
 import {FeatureFlagType, getFeatureFlags, setFeatureFlags} from './Flags';
 import {SHORTCUTS_STORAGE_KEY} from './ShortcutHandler';
 import {HourCycleSelect} from './time/HourCycleSelect';
 import {ThemeSelect} from './time/ThemeSelect';
 import {TimezoneSelect} from './time/TimezoneSelect';
 import {automaticLabel} from './time/browserTimezone';
+import {CodeLinkProtocolSelect} from '../code-links/CodeLinkProtocol';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
 type OnCloseFn = (event: React.SyntheticEvent<HTMLElement>) => void;
@@ -109,6 +113,56 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
     }
   };
 
+  let experimentalSettings = visibleFlags.map(({key, label, flagType}) => (
+    <Box
+      padding={{vertical: 8}}
+      flex={{justifyContent: 'space-between', alignItems: 'center'}}
+      key={key}
+    >
+      <div>{label || key}</div>
+      <Checkbox
+        format="switch"
+        checked={flags.includes(flagType)}
+        onChange={() => toggleFlag(flagType)}
+      />
+    </Box>
+  ));
+
+  const {codeLinksEnabled} = React.useContext(AppContext);
+
+  if (codeLinksEnabled) {
+    experimentalSettings = experimentalSettings.concat([
+      <Box
+        padding={{vertical: 8}}
+        flex={{
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          direction: 'column',
+          gap: 8,
+        }}
+        key="code-link"
+      >
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          Code link protocol
+          <Tooltip
+            content={
+              <>
+                URL protocol to use when linking to definitions in code
+                <br /> <br />
+                {'{'}FILE{'}'} and {'{'}LINE{'}'} replaced by filepath and line
+                <br />
+                number, respectively
+              </>
+            }
+          >
+            <Icon name="info" color={Colors.accentGray()} />
+          </Tooltip>
+        </Box>
+        <CodeLinkProtocolSelect />
+      </Box>,
+    ]);
+  }
+
   return (
     <>
       <DialogBody>
@@ -144,20 +198,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
           <Box padding={{bottom: 8}}>
             <Subheading>Experimental features</Subheading>
           </Box>
-          {visibleFlags.map(({key, label, flagType}) => (
-            <Box
-              padding={{vertical: 8}}
-              flex={{justifyContent: 'space-between', alignItems: 'center'}}
-              key={key}
-            >
-              <div>{label || key}</div>
-              <Checkbox
-                format="switch"
-                checked={flags.includes(flagType)}
-                onChange={() => toggleFlag(flagType)}
-              />
-            </Box>
-          ))}
+          {experimentalSettings}
         </Box>
       </DialogBody>
       <DialogFooter topBorder>

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
@@ -1,0 +1,24 @@
+import {ExternalAnchorButton} from '@dagster-io/ui-components/src/components/Button';
+import {Icon} from '@dagster-io/ui-components/src/components/Icon';
+import * as React from 'react';
+
+import {CodeLinkProtocolContext} from './CodeLinkProtocol';
+import {AppContext} from '../app/AppContext';
+
+export const CodeLink = ({file, lineNumber}: {file: string; lineNumber: number}) => {
+  const {codeLinksEnabled} = React.useContext(AppContext);
+  const [codeLinkProtocol, _] = React.useContext(CodeLinkProtocolContext);
+
+  if (!codeLinksEnabled) {
+    return null;
+  }
+
+  const codeLink = codeLinkProtocol.protocol
+    .replace('{FILE}', file)
+    .replace('{LINE}', lineNumber.toString());
+  return (
+    <ExternalAnchorButton icon={<Icon name="open_in_new" />} href={codeLink}>
+      Open in editor
+    </ExternalAnchorButton>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
@@ -1,0 +1,106 @@
+import {
+  Box,
+  Button,
+  CaptionMono,
+  Icon,
+  Menu,
+  MenuItem,
+  Select,
+  TextInput,
+} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+export const CodeLinkProtocolKey = 'CodeLinkProtocolPreference';
+
+const POPULAR_PROTOCOLS: {[name: string]: string} = {
+  'vscode://file/{FILE}:{LINE}': 'Visual Studio Code',
+  '': 'Custom',
+};
+
+const DEFAULT_PROTOCOL = {protocol: Object.keys(POPULAR_PROTOCOLS)[0]!, custom: false};
+
+type ProtocolData = {
+  protocol: string;
+  custom: boolean;
+};
+
+export const CodeLinkProtocolContext = React.createContext<
+  [ProtocolData, React.Dispatch<React.SetStateAction<ProtocolData | undefined>>]
+>([DEFAULT_PROTOCOL, () => '']);
+
+export const CodeLinkProtocolProvider = ({children}: {children: React.ReactNode}) => {
+  const state = useStateWithStorage<ProtocolData>(
+    CodeLinkProtocolKey,
+    (x) => x ?? DEFAULT_PROTOCOL,
+  );
+
+  return (
+    <CodeLinkProtocolContext.Provider value={state}>{children}</CodeLinkProtocolContext.Provider>
+  );
+};
+
+export const CodeLinkProtocolSelect = ({}) => {
+  const [codeLinkProtocol, setCodeLinkProtocol] = React.useContext(CodeLinkProtocolContext);
+  const isCustom = codeLinkProtocol.custom;
+
+  return (
+    <Box
+      flex={{direction: 'column', gap: 4, alignItems: 'stretch'}}
+      style={{width: 225, height: 55}}
+    >
+      <Select<string>
+        popoverProps={{
+          position: 'bottom-left',
+          modifiers: {offset: {enabled: true, offset: '-12px, 8px'}},
+        }}
+        activeItem={isCustom ? '' : codeLinkProtocol.protocol}
+        inputProps={{style: {width: '300px'}}}
+        items={Object.keys(POPULAR_PROTOCOLS)}
+        itemPredicate={(query: string, protocol: string) =>
+          protocol.toLowerCase().includes(query.toLowerCase())
+        }
+        itemRenderer={(protocol: string, props: any) => (
+          <MenuItem
+            active={props.modifiers.active}
+            onClick={props.handleClick}
+            label={protocol}
+            key={protocol}
+            text={POPULAR_PROTOCOLS[protocol]}
+          />
+        )}
+        itemListRenderer={({renderItem, filteredItems}) => {
+          const renderedItems = filteredItems.map(renderItem).filter(Boolean);
+          return <Menu>{renderedItems}</Menu>;
+        }}
+        noResults={<MenuItem disabled text="No results." />}
+        onItemSelect={(protocol: string) =>
+          setCodeLinkProtocol({protocol, custom: protocol === ''})
+        }
+      >
+        <Button rightIcon={<Icon name="expand_more" />} style={{width: '225px'}}>
+          <div style={{width: '225px', textAlign: 'left'}}>
+            {isCustom ? 'Custom' : POPULAR_PROTOCOLS[codeLinkProtocol.protocol]}
+          </div>
+        </Button>
+      </Select>
+      {isCustom ? (
+        <TextInput
+          value={codeLinkProtocol.protocol}
+          onChange={(e) =>
+            setCodeLinkProtocol({
+              protocol: e.target.value,
+              custom: true,
+            })
+          }
+          placeholder="protocol://{FILE}:{LINE}"
+        ></TextInput>
+      ) : (
+        <Box padding={{left: 8, top: 2}}>
+          <CaptionMono>{codeLinkProtocol.protocol}</CaptionMono>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpInvocation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpInvocation.tsx
@@ -42,7 +42,6 @@ export const SidebarOpInvocation = (props: ISidebarOpInvocationProps) => {
             <SidebarTitle>{breakOnUnderscores(solid.name)}</SidebarTitle>
             {codeLink}
           </Box>
-          <SidebarTitle>{breakOnUnderscores(solid.name)}</SidebarTitle>
           {showInputs || showOutputs ? (
             <DependencyTable>
               <tbody>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOp.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOp.types.ts
@@ -17,6 +17,7 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -35,7 +36,6 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -95,6 +95,7 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -650,7 +651,6 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -791,6 +791,7 @@ export type SidebarOpFragment_Graph_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -809,7 +810,6 @@ export type SidebarOpFragment_Graph_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -869,6 +869,7 @@ export type SidebarOpFragment_Graph_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -1424,7 +1425,6 @@ export type SidebarOpFragment_Graph_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -1565,6 +1565,7 @@ export type SidebarOpFragment_Job_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -1583,7 +1584,6 @@ export type SidebarOpFragment_Job_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -1643,6 +1643,7 @@ export type SidebarOpFragment_Job_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -2198,7 +2199,6 @@ export type SidebarOpFragment_Job_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -2339,6 +2339,7 @@ export type SidebarOpFragment_Pipeline_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -2357,7 +2358,6 @@ export type SidebarOpFragment_Pipeline_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -2417,6 +2417,7 @@ export type SidebarOpFragment_Pipeline_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -2972,7 +2973,6 @@ export type SidebarOpFragment_Pipeline_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -3113,6 +3113,7 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -3131,7 +3132,6 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -3191,6 +3191,7 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -3746,7 +3747,6 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -3903,6 +3903,11 @@ export type SidebarPipelineOpQuery = {
                   id: string;
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   inputMappings: Array<{
                     __typename: 'InputMapping';
                     definition: {__typename: 'InputDefinition'; name: string};
@@ -3920,11 +3925,6 @@ export type SidebarPipelineOpQuery = {
                       definition: {__typename: 'OutputDefinition'; name: string};
                       solid: {__typename: 'Solid'; name: string};
                     };
-                  }>;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
                   }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
@@ -3985,6 +3985,11 @@ export type SidebarPipelineOpQuery = {
                   __typename: 'SolidDefinition';
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   requiredResources: Array<{
                     __typename: 'ResourceRequirement';
                     resourceKey: string;
@@ -4543,11 +4548,6 @@ export type SidebarPipelineOpQuery = {
                           >;
                         };
                   } | null;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
-                  }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
                     id: string;
@@ -4699,6 +4699,11 @@ export type SidebarGraphOpQuery = {
                   id: string;
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   inputMappings: Array<{
                     __typename: 'InputMapping';
                     definition: {__typename: 'InputDefinition'; name: string};
@@ -4716,11 +4721,6 @@ export type SidebarGraphOpQuery = {
                       definition: {__typename: 'OutputDefinition'; name: string};
                       solid: {__typename: 'Solid'; name: string};
                     };
-                  }>;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
                   }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
@@ -4781,6 +4781,11 @@ export type SidebarGraphOpQuery = {
                   __typename: 'SolidDefinition';
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   requiredResources: Array<{
                     __typename: 'ResourceRequirement';
                     resourceKey: string;
@@ -5339,11 +5344,6 @@ export type SidebarGraphOpQuery = {
                           >;
                         };
                   } | null;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
-                  }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
                     id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOpInvocation.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOpInvocation.types.ts
@@ -71,4 +71,13 @@ export type SidebarOpInvocationFragment = {
       solid: {__typename: 'Solid'; name: string};
     }>;
   }>;
+  definition:
+    | {
+        __typename: 'CompositeSolidDefinition';
+        metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
+      }
+    | {
+        __typename: 'SolidDefinition';
+        metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
+      };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/TestProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/TestProvider.tsx
@@ -37,6 +37,7 @@ const testValue: AppContextValue = {
   basePath: '',
   rootServerURI: '',
   telemetryEnabled: false,
+  codeLinksEnabled: false,
 };
 
 const websocketValue: WebSocketContextType = {

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -239,6 +239,9 @@ class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                         '"__TELEMETRY_ENABLED__"', str(context.instance.telemetry_enabled).lower()
                     )
                     .replace("NONCE-PLACEHOLDER", nonce)
+                    .replace(
+                        '"__CODE_LINKS_ENABLED__"', str(context.instance.code_links_enabled).lower()
+                    )
                 )
 
                 if self._live_data_poll_rate:


### PR DESCRIPTION
## Summary

Second PR attempting to rework #12009 into something landable.

If enabled in Dagster config, attaches backlinks to a user's editor in Dagit from asset and op entries in the sidebar.

Users can customize which URL protocol is used - by default only VSCode is supplied (I couldn't find URL protocols for other major Python editors at a glance).

<img width="1297" alt="Screenshot 2024-01-24 at 11 35 28 AM" src="https://github.com/dagster-io/dagster/assets/10215173/660f73ef-4b20-4b80-9fd1-fc2097b80639">
<img width="1297" alt="Screenshot 2024-01-24 at 11 36 03 AM" src="https://github.com/dagster-io/dagster/assets/10215173/539e15ee-2f81-46ee-94d7-4e75d3096755">
<img width="1297" alt="Screenshot 2024-01-24 at 11 35 11 AM" src="https://github.com/dagster-io/dagster/assets/10215173/633f3187-9080-4022-8a78-864fe23b9f2a">

## Test Plan

Tested locally.
