### PR TITLE
[3/n] Add default-off dagster dev flag to enable code backlinks in Dagit

### DIFF
--- a/js_modules/dagit/packages/app/public/index.html
+++ b/js_modules/dagit/packages/app/public/index.html
@@ -7,7 +7,7 @@
 
     <!-- A target element to insert a custom path prefix, replaced server-side. -->
     <script type="application/json" id="initialization-data">
-      {"pathPrefix": "__PATH_PREFIX__", "telemetryEnabled": "__TELEMETRY_ENABLED__"}
+      {"pathPrefix": "__PATH_PREFIX__", "telemetryEnabled": "__TELEMETRY_ENABLED__", "codeLinksEnabled": "__CODE_LINKS_ENABLED__"}
     </script>
     <script nonce="NONCE-PLACEHOLDER">
       __webpack_nonce__ = 'NONCE-PLACEHOLDER';

--- a/js_modules/dagit/packages/app/src/extractInitializationData.ts
+++ b/js_modules/dagit/packages/app/src/extractInitializationData.ts
@@ -1,8 +1,11 @@
 const ELEMENT_ID = 'initialization-data';
 const PREFIX_PLACEHOLDER = '__PATH_PREFIX__';
 const TELEMETRY_PLACEHOLDER = '__TELEMETRY_ENABLED__';
+const HAS_CODE_LINKS_PLACEHOLDER = '__CODE_LINKS_ENABLED__';
 
-let value: {pathPrefix: string; telemetryEnabled: boolean} | undefined = undefined;
+let value:
+  | {pathPrefix: string; telemetryEnabled: boolean; codeLinksEnabled: boolean}
+  | undefined = undefined;
 
 // Determine the path prefix value, which is set server-side.
 // This value will be used for prefixing paths for the GraphQL
@@ -10,9 +13,10 @@ let value: {pathPrefix: string; telemetryEnabled: boolean} | undefined = undefin
 export const extractInitializationData = (): {
   pathPrefix: string;
   telemetryEnabled: boolean;
+  codeLinksEnabled: boolean;
 } => {
   if (!value) {
-    value = {pathPrefix: '', telemetryEnabled: false};
+    value = {pathPrefix: '', telemetryEnabled: false, codeLinksEnabled: false};
     const element = document.getElementById(ELEMENT_ID);
     if (element) {
       const parsed = JSON.parse(element.innerHTML);
@@ -21,6 +25,9 @@ export const extractInitializationData = (): {
       }
       if (parsed.telemetryEnabled !== TELEMETRY_PLACEHOLDER) {
         value.telemetryEnabled = parsed.telemetryEnabled;
+      }
+      if (parsed.codeLinksEnabled !== HAS_CODE_LINKS_PLACEHOLDER) {
+        value.codeLinksEnabled = parsed.codeLinksEnabled;
       }
     }
   }

--- a/js_modules/dagit/packages/app/src/extractInitializationData.ts
+++ b/js_modules/dagit/packages/app/src/extractInitializationData.ts
@@ -31,5 +31,6 @@ export const extractInitializationData = (): {
       }
     }
   }
+  value.codeLinksEnabled = true;
   return value;
 };

--- a/js_modules/dagit/packages/app/src/extractInitializationData.ts
+++ b/js_modules/dagit/packages/app/src/extractInitializationData.ts
@@ -31,6 +31,5 @@ export const extractInitializationData = (): {
       }
     }
   }
-  value.codeLinksEnabled = true;
   return value;
 };

--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -17,7 +17,7 @@ import {CommunityNux} from './NUX/CommunityNux';
 import {extractInitializationData} from './extractInitializationData';
 import {telemetryLink} from './telemetryLink';
 
-const {pathPrefix, telemetryEnabled} = extractInitializationData();
+const {pathPrefix, telemetryEnabled, codeLinksEnabled} = extractInitializationData();
 
 const apolloLinks = [logLink, errorLink, timeStartLink];
 
@@ -31,6 +31,7 @@ const config = {
   origin: process.env.REACT_APP_BACKEND_ORIGIN || document.location.origin,
   staticPathRoot: `${pathPrefix}/`,
   telemetryEnabled,
+  codeLinksEnabled,
   statusPolling: new Set<DeploymentStatusType>(['code-locations', 'daemons']),
 };
 

--- a/js_modules/dagit/packages/core/src/app/AppContext.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppContext.tsx
@@ -13,6 +13,7 @@ export type AppContextValue = {
   // WebWorkers to import other files.
   staticPathRoot?: string;
   telemetryEnabled: boolean;
+  codeLinksEnabled: boolean;
   statusPolling?: Set<DeploymentStatusType>;
 };
 
@@ -21,4 +22,5 @@ export const AppContext = React.createContext<AppContextValue>({
   rootServerURI: '',
   staticPathRoot: '/',
   telemetryEnabled: false,
+  codeLinksEnabled: false,
 });

--- a/js_modules/dagit/packages/core/src/app/AppProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppProvider.tsx
@@ -1,6 +1,6 @@
 import {
-  ApolloLink,
   ApolloClient,
+  ApolloLink,
   ApolloProvider,
   HttpLink,
   InMemoryCache,
@@ -10,15 +10,15 @@ import {WebSocketLink} from '@apollo/client/link/ws';
 import {getMainDefinition} from '@apollo/client/utilities';
 import {
   Colors,
+  CustomTooltipProvider,
+  FontFamily,
   GlobalDialogStyle,
+  GlobalInconsolata,
+  GlobalInter,
   GlobalPopoverStyle,
   GlobalSuggestStyle,
   GlobalToasterStyle,
   GlobalTooltipStyle,
-  FontFamily,
-  CustomTooltipProvider,
-  GlobalInter,
-  GlobalInconsolata,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {BrowserRouter} from 'react-router-dom';
@@ -31,6 +31,7 @@ import {InstancePageContext} from '../instance/InstancePageContext';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext';
 
 import {AppContext} from './AppContext';
+import {CodeLinkProtocolProvider} from './CodeLinkProtocol';
 import {CustomAlertProvider} from './CustomAlertProvider';
 import {CustomConfirmationProvider} from './CustomConfirmationProvider';
 import {LayoutProvider} from './LayoutProvider';
@@ -39,7 +40,6 @@ import {patchCopyToRemoveZeroWidthUnderscores} from './Util';
 import {WebSocketProvider} from './WebSocketProvider';
 import {AnalyticsContext, dummyAnalytics} from './analytics';
 import {TimezoneProvider} from './time/TimezoneContext';
-
 import './blueprint.css';
 
 // The solid sidebar and other UI elements insert zero-width spaces so solid names
@@ -103,6 +103,7 @@ export interface AppProviderProps {
     origin: string;
     staticPathRoot?: string;
     telemetryEnabled?: boolean;
+    codeLinksEnabled?: boolean;
     statusPolling?: Set<DeploymentStatusType>;
   };
 }
@@ -116,6 +117,7 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
     origin,
     staticPathRoot = '/',
     telemetryEnabled = false,
+    codeLinksEnabled = false,
     statusPolling,
   } = config;
 
@@ -164,8 +166,9 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
       rootServerURI,
       staticPathRoot,
       telemetryEnabled,
+      codeLinksEnabled,
     }),
-    [basePath, rootServerURI, staticPathRoot, telemetryEnabled],
+    [basePath, rootServerURI, staticPathRoot, telemetryEnabled, codeLinksEnabled],
   );
 
   const analytics = React.useMemo(() => dummyAnalytics(), []);
@@ -199,19 +202,21 @@ export const AppProvider: React.FC<AppProviderProps> = (props) => {
             <BrowserRouter basename={basePath || ''}>
               <CompatRouter>
                 <TimezoneProvider>
-                  <WorkspaceProvider>
-                    <DeploymentStatusProvider include={deploymentStatuses}>
-                      <CustomConfirmationProvider>
-                        <AnalyticsContext.Provider value={analytics}>
-                          <InstancePageContext.Provider value={instancePageValue}>
-                            <LayoutProvider>{props.children}</LayoutProvider>
-                          </InstancePageContext.Provider>
-                        </AnalyticsContext.Provider>
-                      </CustomConfirmationProvider>
-                      <CustomTooltipProvider />
-                      <CustomAlertProvider />
-                    </DeploymentStatusProvider>
-                  </WorkspaceProvider>
+                  <CodeLinkProtocolProvider>
+                    <WorkspaceProvider>
+                      <DeploymentStatusProvider include={deploymentStatuses}>
+                        <CustomConfirmationProvider>
+                          <AnalyticsContext.Provider value={analytics}>
+                            <InstancePageContext.Provider value={instancePageValue}>
+                              <LayoutProvider>{props.children}</LayoutProvider>
+                            </InstancePageContext.Provider>
+                          </AnalyticsContext.Provider>
+                        </CustomConfirmationProvider>
+                        <CustomTooltipProvider />
+                        <CustomAlertProvider />
+                      </DeploymentStatusProvider>
+                    </WorkspaceProvider>
+                  </CodeLinkProtocolProvider>
                 </TimezoneProvider>
               </CompatRouter>
             </BrowserRouter>

--- a/js_modules/dagit/packages/core/src/app/CodeLink.tsx
+++ b/js_modules/dagit/packages/core/src/app/CodeLink.tsx
@@ -1,0 +1,23 @@
+import {Icon, ExternalAnchorButton} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {AppContext} from './AppContext';
+import {CodeLinkProtocolContext} from './CodeLinkProtocol';
+
+export const CodeLink: React.FC<{file: string; lineNumber: number}> = ({file, lineNumber}) => {
+  const {codeLinksEnabled} = React.useContext(AppContext);
+  const [codeLinkProtocol, _] = React.useContext(CodeLinkProtocolContext);
+
+  if (!codeLinksEnabled) {
+    return null;
+  }
+
+  const codeLink = codeLinkProtocol.protocol
+    .replace('{FILE}', file)
+    .replace('{LINE}', lineNumber.toString());
+  return (
+    <ExternalAnchorButton icon={<Icon name="open_in_new" />} href={codeLink}>
+      Open in editor
+    </ExternalAnchorButton>
+  );
+};

--- a/js_modules/dagit/packages/core/src/app/CodeLinkProtocol.tsx
+++ b/js_modules/dagit/packages/core/src/app/CodeLinkProtocol.tsx
@@ -1,0 +1,94 @@
+import {MenuItem, Menu, Select, TextInput, Box, Button, Icon, CaptionMono} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+export const CodeLinkProtocolKey = 'CodeLinkProtocolPreference';
+
+const POPULAR_PROTOCOLS = {
+  'vscode://file/{FILE}:{LINE}': 'Visual Studio Code',
+  '': 'Custom',
+};
+
+const DEFAULT_PROTOCOL = {protocol: Object.keys(POPULAR_PROTOCOLS)[0], custom: false};
+
+type ProtocolData = {
+  protocol: string;
+  custom: boolean;
+};
+
+export const CodeLinkProtocolContext = React.createContext<
+  [ProtocolData, React.Dispatch<React.SetStateAction<ProtocolData | undefined>>]
+>([DEFAULT_PROTOCOL, () => '']);
+
+export const CodeLinkProtocolProvider: React.FC = (props) => {
+  const state = useStateWithStorage<ProtocolData>(CodeLinkProtocolKey, (x) =>
+    x === undefined ? DEFAULT_PROTOCOL : x,
+  );
+
+  return (
+    <CodeLinkProtocolContext.Provider value={state}>
+      {props.children}
+    </CodeLinkProtocolContext.Provider>
+  );
+};
+
+export const CodeLinkProtocolSelect: React.FC = ({}) => {
+  const [codeLinkProtocol, setCodeLinkProtocol] = React.useContext(CodeLinkProtocolContext);
+  const isCustom = codeLinkProtocol.custom;
+
+  return (
+    <Box
+      flex={{direction: 'column', gap: 4, alignItems: 'stretch'}}
+      style={{width: 225, height: 55}}
+    >
+      <Select<string>
+        popoverProps={{
+          position: 'bottom-left',
+          modifiers: {offset: {enabled: true, offset: '-12px, 8px'}},
+        }}
+        activeItem={isCustom ? '' : codeLinkProtocol.protocol}
+        inputProps={{style: {width: '300px'}}}
+        items={Object.keys(POPULAR_PROTOCOLS)}
+        itemPredicate={(query, protocol) => protocol.toLowerCase().includes(query.toLowerCase())}
+        itemRenderer={(protocol, props) => (
+          <MenuItem
+            active={props.modifiers.active}
+            onClick={props.handleClick}
+            label={protocol}
+            key={protocol}
+            text={POPULAR_PROTOCOLS[protocol]}
+          />
+        )}
+        itemListRenderer={({renderItem, filteredItems}) => {
+          const renderedItems = filteredItems.map(renderItem).filter(Boolean);
+          return <Menu>{renderedItems}</Menu>;
+        }}
+        noResults={<MenuItem disabled text="No results." />}
+        onItemSelect={(protocol) => setCodeLinkProtocol({protocol, custom: protocol === ''})}
+      >
+        <Button rightIcon={<Icon name="expand_more" />} style={{width: '225px'}}>
+          <div style={{width: '225px', textAlign: 'left'}}>
+            {isCustom ? 'Custom' : POPULAR_PROTOCOLS[codeLinkProtocol.protocol]}
+          </div>
+        </Button>
+      </Select>
+      {isCustom ? (
+        <TextInput
+          value={codeLinkProtocol.protocol}
+          onChange={(e) =>
+            setCodeLinkProtocol({
+              protocol: e.target.value,
+              custom: true,
+            })
+          }
+          placeholder="protocol://{FILE}:{LINE}"
+        ></TextInput>
+      ) : (
+        <Box padding={{left: 8, top: 2}}>
+          <CaptionMono>{codeLinkProtocol.protocol}</CaptionMono>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/app/UserSettingsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/app/UserSettingsDialog.tsx
@@ -7,13 +7,18 @@ import {
   Dialog,
   DialogBody,
   DialogFooter,
+  Icon,
   MetadataTable,
+  MetadataTableRow,
   Subheading,
+  Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
 
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
+import {AppContext} from './AppContext';
+import {CodeLinkProtocolSelect} from './CodeLinkProtocol';
 import {FeatureFlagType, getFeatureFlags, setFeatureFlags} from './Flags';
 import {SHORTCUTS_STORAGE_KEY} from './ShortcutHandler';
 import {TimezoneSelect} from './time/TimezoneSelect';
@@ -98,6 +103,50 @@ export const UserSettingsDialogContent: React.FC<DialogContentProps> = ({
     }
   };
 
+  let experimentalRows: MetadataTableRow[] = visibleFlags.map(({key, flagType}) => ({
+    key,
+    value: (
+      <Checkbox
+        format="switch"
+        checked={flags.includes(flagType)}
+        onChange={() => toggleFlag(flagType)}
+      />
+    ),
+  }));
+
+  const {codeLinksEnabled, telemetryEnabled} = React.useContext(AppContext);
+
+  if (codeLinksEnabled) {
+    experimentalRows = experimentalRows.concat([
+      {
+        key: 'Code link protocol',
+        label: (
+          <Box margin={{top: 8}} flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+            Code link protocol
+            <Tooltip
+              content={
+                <>
+                  URL protocol to use when linking to definitions in code
+                  <br /> <br />
+                  {'{'}FILE{'}'} and {'{'}LINE{'}'} replaced by filepath and line
+                  <br />
+                  number, respectively
+                </>
+              }
+            >
+              <Icon name="info" color={Colors.Gray600} />
+            </Tooltip>
+          </Box>
+        ),
+        value: (
+          <Box margin={{bottom: 4}}>
+            <CodeLinkProtocolSelect />
+          </Box>
+        ),
+      },
+    ]);
+  }
+
   return (
     <>
       <DialogBody>
@@ -132,18 +181,7 @@ export const UserSettingsDialogContent: React.FC<DialogContentProps> = ({
           <Box padding={{bottom: 8}}>
             <Subheading>Experimental features</Subheading>
           </Box>
-          <MetadataTable
-            rows={visibleFlags.map(({key, flagType}) => ({
-              key,
-              value: (
-                <Checkbox
-                  format="switch"
-                  checked={flags.includes(flagType)}
-                  onChange={() => toggleFlag(flagType)}
-                />
-              ),
-            }))}
-          />
+          <MetadataTable rows={experimentalRows} />
         </Box>
       </DialogBody>
       <DialogFooter topBorder>

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -1,9 +1,11 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Colors, ConfigTypeSchema, Icon, Spinner} from '@dagster-io/ui';
+import {Box, Colors, ConfigTypeSchema, ExternalAnchorButton, Icon, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {AppContext} from '../app/AppContext';
+import {CodeLinkProtocolContext} from '../app/CodeLinkProtocol';
 import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from '../assets/AssetDefinedInMultipleReposNotice';
 import {
@@ -56,12 +58,18 @@ export const SidebarAssetInfo: React.FC<{
   const {assetMetadata, assetType} = metadataForAssetNode(asset);
   const hasAssetMetadata = assetType || assetMetadata.length > 0;
   const assetConfigSchema = asset.configField?.configType;
+  const codeOriginInfo = asset.metadataEntries.find((e) => e.label === '__code_origin');
+
+  const codeOrigin =
+    codeOriginInfo &&
+    codeOriginInfo.__typename === 'JsonMetadataEntry' &&
+    JSON.parse(codeOriginInfo.jsonString);
 
   const OpMetadataPlugin = asset.op?.metadata && pluginForMetadata(asset.op.metadata);
 
   return (
     <>
-      <Header assetKey={assetKey} opName={asset.op?.name} />
+      <Header assetKey={assetKey} opName={asset.op?.name} codeOrigin={codeOrigin} />
 
       <AssetDefinedInMultipleReposNotice
         assetKey={assetKey}
@@ -142,27 +150,48 @@ const TypeSidebarSection: React.FC<{
   );
 };
 
-const Header: React.FC<{assetKey: AssetKey; opName?: string}> = ({assetKey, opName}) => {
+const Header: React.FC<{
+  assetKey: AssetKey;
+  opName?: string;
+  codeOrigin?: {file: string; line: number};
+}> = ({assetKey, opName, codeOrigin}) => {
   const displayName = displayNameForAssetKey(assetKey);
+
+  const {codeLinksEnabled} = React.useContext(AppContext);
+  const [codeLinkProtocol, _] = React.useContext(CodeLinkProtocolContext);
+
+  let codeLink = null;
+  if (codeLinksEnabled && codeOrigin) {
+    codeLink = codeLinkProtocol.protocol
+      .replace('{FILE}', codeOrigin.file)
+      .replace('{LINE}', codeOrigin.line.toString());
+  }
 
   return (
     <Box flex={{gap: 4, direction: 'column'}} margin={{left: 24, right: 12, vertical: 16}}>
-      <SidebarTitle
-        style={{
-          marginBottom: 0,
-          display: 'flex',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-        }}
-      >
-        <Box>{displayName}</Box>
-        {displayName !== opName ? (
-          <Box style={{opacity: 0.5}} flex={{gap: 6, alignItems: 'center'}}>
-            <Icon name="op" size={16} />
-            {opName}
-          </Box>
-        ) : undefined}
-      </SidebarTitle>
+      <Box flex={{gap: 4, direction: 'row', justifyContent: 'space-between'}}>
+        <SidebarTitle
+          style={{
+            marginBottom: 0,
+            display: 'flex',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+          }}
+        >
+          <Box>{displayName}</Box>
+          {displayName !== opName ? (
+            <Box style={{opacity: 0.5}} flex={{gap: 6, alignItems: 'center'}}>
+              <Icon name="op" size={16} />
+              {opName}
+            </Box>
+          ) : undefined}
+        </SidebarTitle>
+        {codeLink && (
+          <ExternalAnchorButton icon={<Icon name="open_in_new" />} href={codeLink}>
+            Open in editor
+          </ExternalAnchorButton>
+        )}
+      </Box>
       <AssetCatalogLink to={assetDetailsPathForKey(assetKey)}>
         {'View in Asset Catalog '}
         <Icon name="open_in_new" color={Colors.Link} />

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -1,11 +1,10 @@
 import {gql, useQuery} from '@apollo/client';
-import {Box, Colors, ConfigTypeSchema, ExternalAnchorButton, Icon, Spinner} from '@dagster-io/ui';
+import {Box, Colors, ConfigTypeSchema, Icon, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {AppContext} from '../app/AppContext';
-import {CodeLinkProtocolContext} from '../app/CodeLinkProtocol';
+import {CodeLink} from '../app/CodeLink';
 import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from '../assets/AssetDefinedInMultipleReposNotice';
 import {
@@ -157,16 +156,6 @@ const Header: React.FC<{
 }> = ({assetKey, opName, codeOrigin}) => {
   const displayName = displayNameForAssetKey(assetKey);
 
-  const {codeLinksEnabled} = React.useContext(AppContext);
-  const [codeLinkProtocol, _] = React.useContext(CodeLinkProtocolContext);
-
-  let codeLink = null;
-  if (codeLinksEnabled && codeOrigin) {
-    codeLink = codeLinkProtocol.protocol
-      .replace('{FILE}', codeOrigin.file)
-      .replace('{LINE}', codeOrigin.line.toString());
-  }
-
   return (
     <Box flex={{gap: 4, direction: 'column'}} margin={{left: 24, right: 12, vertical: 16}}>
       <Box flex={{gap: 4, direction: 'row', justifyContent: 'space-between'}}>
@@ -186,11 +175,7 @@ const Header: React.FC<{
             </Box>
           ) : undefined}
         </SidebarTitle>
-        {codeLink && (
-          <ExternalAnchorButton icon={<Icon name="open_in_new" />} href={codeLink}>
-            Open in editor
-          </ExternalAnchorButton>
-        )}
+        {codeOrigin && <CodeLink file={codeOrigin.file} lineNumber={codeOrigin.line} />}
       </Box>
       <AssetCatalogLink to={assetDetailsPathForKey(assetKey)}>
         {'View in Asset Catalog '}

--- a/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
@@ -13,7 +13,9 @@ export const metadataForAssetNode = (
   assetNode: AssetNodeOpMetadataFragment,
 ): {assetType?: DagsterTypeFragment; assetMetadata: MetadataEntryFragment[]} => {
   const assetType = assetNode.type ? assetNode.type : undefined;
-  const assetMetadata = assetNode.metadataEntries || [];
+  const assetMetadata = (assetNode.metadataEntries || []).filter(
+    (entry) => entry.label !== '__code_origin',
+  );
   return {assetType, assetMetadata};
 };
 

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpInvocation.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpInvocation.tsx
@@ -2,6 +2,7 @@ import {gql} from '@apollo/client';
 import {Box, Button, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {CodeLink} from '../app/CodeLink';
 import {breakOnUnderscores} from '../app/Util';
 import {OpNameOrPath} from '../ops/OpNameOrPath';
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT} from '../typeexplorer/TypeWithTooltip';
@@ -20,11 +21,18 @@ export const SidebarOpInvocation: React.FC<ISidebarOpInvocationProps> = (props) 
   const showInputs = solid.inputs.some((o) => o.dependsOn.length);
   const showOutputs = solid.outputs.some((o) => o.dependedBy.length);
 
+  const codeLinkMetadata = solid.definition.metadata.find((m) => m.key === '__code_origin')?.value;
+  let codeLink = null;
+  if (codeLinkMetadata) {
+    const [codeLinkFile, codeLinkLineNumber] = codeLinkMetadata.split(':');
+    codeLink = <CodeLink file={codeLinkFile} lineNumber={parseInt(codeLinkLineNumber)} />;
+  }
   return (
     <div>
       <SidebarSection title="Invocation">
         <Box padding={{vertical: 16, horizontal: 24}}>
           <SidebarTitle>{breakOnUnderscores(solid.name)}</SidebarTitle>
+          {codeLink}
           {showInputs || showOutputs ? (
             <DependencyTable>
               <tbody>
@@ -114,6 +122,12 @@ export const SIDEBAR_OP_INVOCATION_FRAGMENT = gql`
         solid {
           name
         }
+      }
+    }
+    definition {
+      metadata {
+        key
+        value
       }
     }
   }

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarOp.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarOp.types.ts
@@ -17,6 +17,7 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -35,7 +36,6 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -95,6 +95,7 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -650,7 +651,6 @@ export type SidebarOpFragment_CompositeSolidDefinition_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -791,6 +791,7 @@ export type SidebarOpFragment_Graph_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -809,7 +810,6 @@ export type SidebarOpFragment_Graph_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -869,6 +869,7 @@ export type SidebarOpFragment_Graph_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -1424,7 +1425,6 @@ export type SidebarOpFragment_Graph_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -1565,6 +1565,7 @@ export type SidebarOpFragment_Job_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -1583,7 +1584,6 @@ export type SidebarOpFragment_Job_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -1643,6 +1643,7 @@ export type SidebarOpFragment_Job_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -2198,7 +2199,6 @@ export type SidebarOpFragment_Job_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -2339,6 +2339,7 @@ export type SidebarOpFragment_Pipeline_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -2357,7 +2358,6 @@ export type SidebarOpFragment_Pipeline_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -2417,6 +2417,7 @@ export type SidebarOpFragment_Pipeline_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -2972,7 +2973,6 @@ export type SidebarOpFragment_Pipeline_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -3113,6 +3113,7 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
             id: string;
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             inputMappings: Array<{
               __typename: 'InputMapping';
               definition: {__typename: 'InputDefinition'; name: string};
@@ -3131,7 +3132,6 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
                 solid: {__typename: 'Solid'; name: string};
               };
             }>;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -3191,6 +3191,7 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
             __typename: 'SolidDefinition';
             name: string;
             description: string | null;
+            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
             configField: {
               __typename: 'ConfigTypeField';
@@ -3746,7 +3747,6 @@ export type SidebarOpFragment_PipelineSnapshot_ = {
                     >;
                   };
             } | null;
-            metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
             assetNodes: Array<{
               __typename: 'AssetNode';
               id: string;
@@ -3903,6 +3903,11 @@ export type SidebarPipelineOpQuery = {
                   id: string;
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   inputMappings: Array<{
                     __typename: 'InputMapping';
                     definition: {__typename: 'InputDefinition'; name: string};
@@ -3920,11 +3925,6 @@ export type SidebarPipelineOpQuery = {
                       definition: {__typename: 'OutputDefinition'; name: string};
                       solid: {__typename: 'Solid'; name: string};
                     };
-                  }>;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
                   }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
@@ -3985,6 +3985,11 @@ export type SidebarPipelineOpQuery = {
                   __typename: 'SolidDefinition';
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   requiredResources: Array<{
                     __typename: 'ResourceRequirement';
                     resourceKey: string;
@@ -4543,11 +4548,6 @@ export type SidebarPipelineOpQuery = {
                           >;
                         };
                   } | null;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
-                  }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
                     id: string;
@@ -4699,6 +4699,11 @@ export type SidebarGraphOpQuery = {
                   id: string;
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   inputMappings: Array<{
                     __typename: 'InputMapping';
                     definition: {__typename: 'InputDefinition'; name: string};
@@ -4716,11 +4721,6 @@ export type SidebarGraphOpQuery = {
                       definition: {__typename: 'OutputDefinition'; name: string};
                       solid: {__typename: 'Solid'; name: string};
                     };
-                  }>;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
                   }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
@@ -4781,6 +4781,11 @@ export type SidebarGraphOpQuery = {
                   __typename: 'SolidDefinition';
                   name: string;
                   description: string | null;
+                  metadata: Array<{
+                    __typename: 'MetadataItemDefinition';
+                    key: string;
+                    value: string;
+                  }>;
                   requiredResources: Array<{
                     __typename: 'ResourceRequirement';
                     resourceKey: string;
@@ -5339,11 +5344,6 @@ export type SidebarGraphOpQuery = {
                           >;
                         };
                   } | null;
-                  metadata: Array<{
-                    __typename: 'MetadataItemDefinition';
-                    key: string;
-                    value: string;
-                  }>;
                   assetNodes: Array<{
                     __typename: 'AssetNode';
                     id: string;

--- a/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpInvocation.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/SidebarOpInvocation.types.ts
@@ -71,4 +71,13 @@ export type SidebarOpInvocationFragment = {
       solid: {__typename: 'Solid'; name: string};
     }>;
   }>;
+  definition:
+    | {
+        __typename: 'CompositeSolidDefinition';
+        metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
+      }
+    | {
+        __typename: 'SolidDefinition';
+        metadata: Array<{__typename: 'MetadataItemDefinition'; key: string; value: string}>;
+      };
 };

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -38,6 +38,7 @@ const testValue: AppContextValue = {
   rootServerURI: '',
   staticPathRoot: '/',
   telemetryEnabled: false,
+  codeLinksEnabled: false,
 };
 
 const websocketValue: WebSocketContextType = {

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -211,7 +211,12 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                     rendered_template.replace('href="/', f'href="{self._app_path_prefix}/')
                     .replace('src="/', f'src="{self._app_path_prefix}/')
                     .replace("__PATH_PREFIX__", self._app_path_prefix)
-                    .replace("__TELEMETRY_ENABLED__", str(context.instance.telemetry_enabled))
+                    .replace(
+                        '"__TELEMETRY_ENABLED__"', str(context.instance.telemetry_enabled).lower()
+                    )
+                    .replace(
+                        '"__CODE_LINKS_ENABLED__"', str(context.instance.code_links_enabled).lower()
+                    )
                     .replace("NONCE-PLACEHOLDER", nonce),
                     headers=headers,
                 )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1,3 +1,5 @@
+import inspect
+import os
 import warnings
 from inspect import Parameter
 from typing import (
@@ -19,6 +21,7 @@ from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.resource_output import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.io_manager import IOManagerDefinition
@@ -265,6 +268,18 @@ class _Asset:
 
         asset_ins = build_asset_ins(fn, self.ins or {}, self.non_argument_deps)
 
+        metadata = self.metadata or {}
+
+        if os.getenv("DAGSTER_ENABLE_CODE_LINKS", "false").lower() == "true":
+            cwd = os.getcwd()
+            origin_file = os.path.join(cwd, inspect.getsourcefile(fn))
+            origin_line = inspect.getsourcelines(fn)[1]
+
+            metadata = {
+                **(metadata),
+                "__code_origin": MetadataValue.json({"file": origin_file, "line": origin_line}),
+            }
+
         out_asset_key = AssetKey(list(filter(None, [*(self.key_prefix or []), asset_name])))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
@@ -293,7 +308,7 @@ class _Asset:
                 io_manager_key = DEFAULT_IO_MANAGER_KEY
 
             out = Out(
-                metadata=self.metadata or {},
+                metadata=metadata,
                 io_manager_key=io_manager_key,
                 dagster_type=self.dagster_type if self.dagster_type else NoValueSentinel,
                 description=self.description,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -1,6 +1,6 @@
-from functools import update_wrapper
 import inspect
 import os
+from functools import update_wrapper
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Set, Union, overload
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -676,6 +676,10 @@ class DagsterInstance:
         return {}
 
     @property
+    def code_links_enabled(self) -> bool:
+        return os.getenv("DAGSTER_ENABLE_CODE_LINKS", "false").lower() == "true"
+
+    @property
     def telemetry_enabled(self) -> bool:
         if self.is_ephemeral:
             return False


### PR DESCRIPTION
## Summary

Adds an `--enable-code-links` flag to `dagster dev`, which simply sets the `DAGSTER_ENABLE_CODE_LINKS` env var on to enable backlinks from Dagit.
