### PR TITLE
[dagit] Add storybook coverage of Asset Table states

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.mocks.ts
@@ -1,0 +1,444 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {RunStatus} from '../graphql/types';
+import {SINGLE_ASSET_QUERY} from '../workspace/VirtualizedAssetRow';
+import {SingleAssetQuery} from '../workspace/types/VirtualizedAssetRow.types';
+
+import {ASSET_CATALOG_GROUP_TABLE_QUERY, ASSET_CATALOG_TABLE_QUERY} from './AssetsCatalogTable';
+import {
+  AssetCatalogGroupTableQuery,
+  AssetCatalogTableQuery,
+} from './types/AssetsCatalogTable.types';
+
+export const AssetCatalogGroupTableMock: MockedResponse<AssetCatalogGroupTableQuery> = {
+  request: {
+    query: ASSET_CATALOG_GROUP_TABLE_QUERY,
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodes: [],
+    },
+  },
+};
+
+export const SingleAssetQueryTrafficDashboard: MockedResponse<SingleAssetQuery> = {
+  request: {
+    query: SINGLE_ASSET_QUERY,
+    variables: {input: {path: ['dashboards', 'traffic_dashboard']}},
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: '["dashboards", "traffic_dashboard"]',
+        assetMaterializations: [],
+        definition: null,
+        __typename: 'Asset',
+        key: {
+          path: ['dashboards', 'traffic_dashboard'],
+          __typename: 'AssetKey',
+        },
+      },
+      assetsLatestInfo: [],
+    },
+  },
+};
+
+export const SingleAssetQueryMaterializedWithLatestRun: MockedResponse<SingleAssetQuery> = {
+  request: {
+    query: SINGLE_ASSET_QUERY,
+    variables: {input: {path: ['good_asset']}},
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: 'test.py.repo.["good_asset"]',
+        assetMaterializations: [
+          {
+            runId: 'db44ed48-0dca-4942-803b-5edc439c73eb',
+            timestamp: '1674603883946',
+            __typename: 'MaterializationEvent',
+          },
+        ],
+        definition: {
+          id: 'test.py.repo.["good_asset"]',
+          computeKind: 'duckdb',
+          opNames: ['good_asset'],
+          repository: {
+            id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+            __typename: 'Repository',
+            name: 'repo',
+            location: {
+              id: 'test.py',
+              name: 'test.py',
+              __typename: 'RepositoryLocation',
+            },
+          },
+          assetKey: {
+            path: ['good_asset'],
+            __typename: 'AssetKey',
+          },
+          assetMaterializations: [
+            {
+              timestamp: '1674603883946',
+              runId: 'db44ed48-0dca-4942-803b-5edc439c73eb',
+              __typename: 'MaterializationEvent',
+            },
+          ],
+          freshnessPolicy: null,
+          freshnessInfo: null,
+          assetObservations: [
+            {
+              timestamp: '1674764717707',
+              runId: 'ae107ad2-8827-44fb-bc62-a4cdacb78438',
+              __typename: 'ObservationEvent',
+            },
+          ],
+          currentLogicalVersion: '0abac660f8672d7951f8047bddfa4de61feaaeedffb0ff6df6ae398bb4ef4741',
+          projectedLogicalVersion:
+            '0abac660f8672d7951f8047bddfa4de61feaaeedffb0ff6df6ae398bb4ef4741',
+          __typename: 'AssetNode',
+          groupName: 'GROUP2',
+          isSource: false,
+          partitionDefinition: null,
+          description:
+            'This is a super long description that could involve some level of SQL and is just generally very long',
+        },
+        __typename: 'Asset',
+        key: {
+          path: ['good_asset'],
+          __typename: 'AssetKey',
+        },
+      },
+      assetsLatestInfo: [
+        {
+          assetKey: {
+            path: ['good_asset'],
+            __typename: 'AssetKey',
+          },
+          unstartedRunIds: [],
+          inProgressRunIds: [],
+          latestRun: {
+            id: 'db44ed48-0dca-4942-803b-5edc439c73eb',
+            status: RunStatus.SUCCESS,
+            endTime: 1674603891.34749,
+            __typename: 'Run',
+          },
+          __typename: 'AssetLatestInfo',
+        },
+      ],
+    },
+  },
+};
+
+export const SingleAssetQueryMaterializedStaleAndLate: MockedResponse<SingleAssetQuery> = {
+  request: {
+    query: SINGLE_ASSET_QUERY,
+    variables: {input: {path: ['late_asset']}},
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: 'test.py.repo.["late_asset"]',
+        assetMaterializations: [
+          {
+            runId: 'db44ed48-0dca-4942-803b-5edc439c73eb',
+            timestamp: '1674603891025',
+            __typename: 'MaterializationEvent',
+          },
+        ],
+        definition: {
+          id: 'test.py.repo.["late_asset"]',
+          computeKind: null,
+          opNames: ['late_asset'],
+          repository: {
+            id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+            __typename: 'Repository',
+            name: 'repo',
+            location: {
+              id: 'test.py',
+              name: 'test.py',
+              __typename: 'RepositoryLocation',
+            },
+          },
+          assetKey: {
+            path: ['late_asset'],
+            __typename: 'AssetKey',
+          },
+          assetMaterializations: [
+            {
+              timestamp: '1674603891025',
+              runId: 'db44ed48-0dca-4942-803b-5edc439c73eb',
+              __typename: 'MaterializationEvent',
+            },
+          ],
+          freshnessPolicy: {
+            maximumLagMinutes: 2,
+            cronSchedule: null,
+            __typename: 'FreshnessPolicy',
+          },
+          freshnessInfo: {
+            currentMinutesLate: 21657.2618512,
+            __typename: 'AssetFreshnessInfo',
+          },
+          assetObservations: [],
+          currentLogicalVersion: '8226fabb0255eda79f2152a5d12c7135e20c7d3fed6d0f25efecde0d2ab30194',
+          projectedLogicalVersion: 'UNKNOWN',
+          __typename: 'AssetNode',
+          groupName: 'GROUP2',
+          isSource: false,
+          partitionDefinition: null,
+          description: null,
+        },
+        __typename: 'Asset',
+        key: {
+          path: ['late_asset'],
+          __typename: 'AssetKey',
+        },
+      },
+      assetsLatestInfo: [
+        {
+          assetKey: {
+            path: ['late_asset'],
+            __typename: 'AssetKey',
+          },
+          unstartedRunIds: [],
+          inProgressRunIds: [],
+          latestRun: {
+            id: 'db44ed48-0dca-4942-803b-5edc439c73eb',
+            status: RunStatus.SUCCESS,
+            endTime: 1674603891.34749,
+            __typename: 'Run',
+          },
+          __typename: 'AssetLatestInfo',
+        },
+      ],
+    },
+  },
+};
+
+export const SingleAssetQueryLastRunFailed: MockedResponse<SingleAssetQuery> = {
+  request: {
+    query: SINGLE_ASSET_QUERY,
+    variables: {input: {path: ['run_failing_asset']}},
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: 'test.py.repo.["run_failing_asset"]',
+        assetMaterializations: [
+          {
+            runId: 'e23b2cd2-7a4e-43d2-bdc6-892125375e8f',
+            timestamp: '1666373060112',
+            __typename: 'MaterializationEvent',
+          },
+        ],
+        definition: {
+          id: 'test.py.repo.["run_failing_asset"]',
+          computeKind: 'snowflake',
+          opNames: ['run_failing_asset'],
+          repository: {
+            id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+            __typename: 'Repository',
+            name: 'repo',
+            location: {
+              id: 'test.py',
+              name: 'test.py',
+              __typename: 'RepositoryLocation',
+            },
+          },
+          assetKey: {
+            path: ['run_failing_asset'],
+            __typename: 'AssetKey',
+          },
+          assetMaterializations: [
+            {
+              timestamp: '1666373060112',
+              runId: 'e23b2cd2-7a4e-43d2-bdc6-892125375e8f',
+              __typename: 'MaterializationEvent',
+            },
+          ],
+          freshnessPolicy: null,
+          freshnessInfo: null,
+          assetObservations: [],
+          currentLogicalVersion: 'INITIAL',
+          projectedLogicalVersion: null,
+          __typename: 'AssetNode',
+          groupName: 'default',
+          isSource: false,
+          partitionDefinition: {
+            description:
+              "Multi-partitioned, with dimensions: \nAstate: 'TN', 'VA', 'GA', 'KY', 'PA', 'NC', 'SC', 'FL', 'OH', 'IL', 'WV' \nDate: Daily, starting 2021-05-05 UTC.",
+            __typename: 'PartitionDefinition',
+          },
+          description: 'This is a description!',
+        },
+        __typename: 'Asset',
+        key: {
+          path: ['run_failing_asset'],
+          __typename: 'AssetKey',
+        },
+      },
+      assetsLatestInfo: [
+        {
+          assetKey: {
+            path: ['run_failing_asset'],
+            __typename: 'AssetKey',
+          },
+          unstartedRunIds: [],
+          inProgressRunIds: [],
+          latestRun: {
+            id: '4678865f-6191-4a35-bb47-2122d57ec9a6',
+            status: RunStatus.FAILURE,
+            endTime: 1669067250.48091,
+            __typename: 'Run',
+          },
+          __typename: 'AssetLatestInfo',
+        },
+      ],
+    },
+  },
+};
+
+export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
+  request: {
+    query: ASSET_CATALOG_TABLE_QUERY,
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetsOrError: {
+        __typename: 'AssetConnection',
+        nodes: [
+          {
+            id: '["dashboards", "cost_dashboard"]',
+            __typename: 'Asset',
+            key: {
+              path: ['dashboards', 'cost_dashboard'],
+              __typename: 'AssetKey',
+            },
+            definition: null,
+          },
+          {
+            id: '["dashboards", "traffic_dashboard"]',
+            __typename: 'Asset',
+            key: {
+              path: ['dashboards', 'traffic_dashboard'],
+              __typename: 'AssetKey',
+            },
+            definition: null,
+          },
+          {
+            id: 'test.py.repo.["good_asset"]',
+            __typename: 'Asset',
+            key: {
+              path: ['good_asset'],
+              __typename: 'AssetKey',
+            },
+            definition: {
+              id: 'test.py.repo.["good_asset"]',
+              groupName: 'GROUP2',
+              isSource: false,
+              partitionDefinition: null,
+              description:
+                'This is a super long description that could involve some level of SQL and is just generally very long',
+              repository: {
+                id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+                name: 'repo',
+                location: {
+                  id: 'test.py',
+                  name: 'test.py',
+                  __typename: 'RepositoryLocation',
+                },
+                __typename: 'Repository',
+              },
+              __typename: 'AssetNode',
+            },
+          },
+          {
+            id: 'test.py.repo.["late_asset"]',
+            __typename: 'Asset',
+            key: {
+              path: ['late_asset'],
+              __typename: 'AssetKey',
+            },
+            definition: {
+              id: 'test.py.repo.["late_asset"]',
+              groupName: 'GROUP2',
+              isSource: false,
+              partitionDefinition: null,
+              description: null,
+              repository: {
+                id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+                name: 'repo',
+                location: {
+                  id: 'test.py',
+                  name: 'test.py',
+                  __typename: 'RepositoryLocation',
+                },
+                __typename: 'Repository',
+              },
+              __typename: 'AssetNode',
+            },
+          },
+          {
+            id: 'test.py.repo.["run_failing_asset"]',
+            __typename: 'Asset',
+            key: {
+              path: ['run_failing_asset'],
+              __typename: 'AssetKey',
+            },
+            definition: {
+              id: 'test.py.repo.["run_failing_asset"]',
+              groupName: 'GROUP4',
+              isSource: false,
+              partitionDefinition: null,
+              description: null,
+              repository: {
+                id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+                name: 'repo',
+                location: {
+                  id: 'test.py',
+                  name: 'test.py',
+                  __typename: 'RepositoryLocation',
+                },
+                __typename: 'Repository',
+              },
+              __typename: 'AssetNode',
+            },
+          },
+          {
+            id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
+            __typename: 'Asset',
+            key: {
+              path: ['asset_with_a_very_long_key_that_will_require_truncation'],
+              __typename: 'AssetKey',
+            },
+            definition: {
+              id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
+              groupName: 'GROUP4',
+              isSource: false,
+              partitionDefinition: null,
+              description: null,
+              repository: {
+                id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+                name: 'repo',
+                location: {
+                  id: 'test.py',
+                  name: 'test.py',
+                  __typename: 'RepositoryLocation',
+                },
+                __typename: 'Repository',
+              },
+              __typename: 'AssetNode',
+            },
+          },
+        ],
+      },
+    },
+  },
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.stories.tsx
@@ -1,0 +1,46 @@
+import {MockedProvider} from '@apollo/client/testing';
+import React from 'react';
+
+import {StorybookProvider} from '../testing/StorybookProvider';
+
+import {AssetsCatalogTable} from './AssetsCatalogTable';
+import {
+  AssetCatalogGroupTableMock,
+  AssetCatalogTableMock,
+  SingleAssetQueryLastRunFailed,
+  SingleAssetQueryMaterializedStaleAndLate,
+  SingleAssetQueryMaterializedWithLatestRun,
+  SingleAssetQueryTrafficDashboard,
+} from './AssetsCatalogTable.mocks';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AssetsCatalogTable};
+
+const MOCKS = [
+  AssetCatalogTableMock,
+  AssetCatalogGroupTableMock,
+  SingleAssetQueryTrafficDashboard,
+  SingleAssetQueryMaterializedWithLatestRun,
+  SingleAssetQueryMaterializedStaleAndLate,
+  SingleAssetQueryLastRunFailed,
+];
+
+export const NoPrefixPath = () => {
+  return (
+    <StorybookProvider routerProps={{initialEntries: ['/']}}>
+      <MockedProvider mocks={MOCKS}>
+        <AssetsCatalogTable prefixPath={[]} setPrefixPath={() => {}} />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};
+
+export const WithinAssetPath = () => {
+  return (
+    <StorybookProvider routerProps={{initialEntries: ['/']}}>
+      <MockedProvider mocks={MOCKS}>
+        <AssetsCatalogTable prefixPath={['dashboards']} setPrefixPath={() => {}} />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -242,7 +242,7 @@ const AssetGroupSuggest: React.FC<{
   );
 };
 
-const ASSET_CATALOG_TABLE_QUERY = gql`
+export const ASSET_CATALOG_TABLE_QUERY = gql`
   query AssetCatalogTableQuery {
     assetsOrError {
       __typename
@@ -260,7 +260,7 @@ const ASSET_CATALOG_TABLE_QUERY = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
-const ASSET_CATALOG_GROUP_TABLE_QUERY = gql`
+export const ASSET_CATALOG_GROUP_TABLE_QUERY = gql`
   query AssetCatalogGroupTableQuery($group: AssetGroupSelector) {
     assetNodes(group: $group) {
       id

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -259,7 +259,7 @@ const RowGrid = styled(Box)<{$showRepoColumn: boolean}>`
   height: 100%;
 `;
 
-const SINGLE_ASSET_QUERY = gql`
+export const SINGLE_ASSET_QUERY = gql`
   query SingleAssetQuery($input: AssetKeyInput!) {
     assetOrError(assetKey: $input) {
       ... on Asset {


### PR DESCRIPTION
### Summary & Motivation

One of our recent UI incidents was caused by a visual regression in the asset table -- I didn't have any assets with long descriptions and didn't notice that adding the "compute kind" icon changed the way they wrapped and truncated.

This PR adds storybooks for the asset catalog table and mock data that covers all of the important cases. I think this is good because it's fairly difficult to get your local assets into some of these states:

- Long asset keys
- Long asset descriptions
- Assets with a compute kind
- Asset where this is no recent run
- Asset where the most recent run failed
- Asset marked as stale
- Asset marked as "late" per it's freshness policy 
- Assets with multi-part keys (folder behavior in the catalog view)

One interesting caveat of this is that we may need to mock the current time in Storybook if we start using Chromatic or the "15 days late" will break all the time. 

### How I Tested These Changes

New tests!

<img width="1725" alt="image" src="https://user-images.githubusercontent.com/1037212/216728928-13c3cfe5-1d49-40ee-ba74-88160cf02eef.png">
