### PR TITLE
Include logs in failure message for ECS monitoring failures

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import warnings
 from collections import namedtuple
@@ -36,7 +37,7 @@ from .tasks import (
     get_task_definition_dict_from_current_task,
     get_task_kwargs_from_current_task,
 )
-from .utils import sanitize_family, task_definitions_match
+from .utils import get_task_logs, sanitize_family, task_definitions_match
 
 Tags = namedtuple("Tags", ["arn", "cluster", "cpu", "memory"])
 
@@ -591,6 +592,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
 
     def check_run_worker_health(self, run: DagsterRun):
         tags = self._get_run_tags(run.run_id)
+        container_context = EcsContainerContext.create_for_run(run, self)
 
         if not (tags.arn and tags.cluster):
             return CheckRunHealthResult(WorkerStatus.UNKNOWN, "")
@@ -613,13 +615,37 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     container_str = "Containers"
                 else:
                     container_str = "Container"
+
+                logs = []
+
+                try:
+                    logs = get_task_logs(
+                        self.ecs,
+                        logs_client=self.logs,
+                        cluster=tags.cluster,
+                        task_arn=tags.arn,
+                        container_name=self._get_container_name(container_context),
+                    )
+                except:
+                    logging.exception(
+                        "Error trying to get logs for failed task {task_arn}".format(
+                            task_arn=tags.arn,
+                        )
+                    )
+
+                logs_text = (
+                    ("Task logs:\n" + "\n".join(logs))
+                    if logs
+                    else "Check the logs for the failed task for details."
+                )
+
                 return CheckRunHealthResult(
                     WorkerStatus.FAILED,
                     (
-                        f"ECS task failed. Stop code: {t.get('stopCode')}. Stop reason:"
-                        f" {t.get('stoppedReason')}."
+                        f"ECS task {t.get('taskArn')} failed. Stop code: {t.get('stopCode')}. Stop"
+                        f" reason: {t.get('stoppedReason')}."
                         f" {container_str} {[c.get('name') for c in failed_containers]} failed."
-                        f" Check the logs for task {t.get('taskArn')} for details."
+                        f" {logs_text}"
                     ),
                 )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1,6 +1,7 @@
 # pylint: disable=protected-access
 
 import copy
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 import dagster_aws
@@ -9,6 +10,7 @@ from botocore.exceptions import ClientError
 from dagster._check import CheckError
 from dagster._core.code_pointer import FileCodePointer
 from dagster._core.events import MetadataEntry
+from dagster._core.launcher import LaunchRunContext
 from dagster._core.launcher.base import WorkerStatus
 from dagster._core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
 from dagster_aws.ecs import EcsEventualConsistencyTimeout
@@ -767,8 +769,25 @@ def test_memory_and_cpu(ecs, instance, workspace, run, task_definition):
         instance.launch_run(run.run_id, workspace)
 
 
-def test_status(ecs, instance, workspace, run):
-    instance.launch_run(run.run_id, workspace)
+def test_status(
+    ecs,
+    instance_with_log_group,
+    pipeline,
+    external_pipeline,
+    cloudwatch_client,
+    log_group,
+):
+    instance = instance_with_log_group
+
+    run = instance.create_run_for_pipeline(
+        pipeline,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )
+
+    instance.run_launcher.launch_run(LaunchRunContext(pipeline_run=run, workspace=None))
+
+    assert instance.run_launcher.logs == cloudwatch_client
 
     # Reach into StubbedEcs and grab the task
     # so we can modify its status. This is kind of complicated
@@ -777,6 +796,8 @@ def test_status(ecs, instance, workspace, run):
     # using cluster and arn as keys - instead of a dict of lists?
     task_arn = instance.get_run_by_id(run.run_id).tags["ecs/task_arn"]
     task = [task for task in ecs.storage.tasks["default"] if task["taskArn"] == task_arn][0]
+
+    task_id = task_arn.split("/")[-1]
 
     for status in RUNNING_STATUSES:
         task["lastStatus"] = status
@@ -789,7 +810,41 @@ def test_status(ecs, instance, workspace, run):
         assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.SUCCESS
 
         task["containers"][0]["exitCode"] = 1
-        assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.FAILED
+        # Without logs (or on a failure fetching logs) the health check sitll fails
+
+        failure_health_check = instance.run_launcher.check_run_worker_health(run)
+        assert failure_health_check.status == WorkerStatus.FAILED
+        assert (
+            failure_health_check.msg
+            == f"ECS task {task_arn} failed. Stop code: None. Stop reason: None. Container ['run']"
+            " failed. Check the logs for the failed task for details."
+        )
+
+        # with logs, the failure includes the run worker logs
+
+        family = instance.run_launcher._get_run_task_definition_family(run)
+        log_stream = f"{family}/run/{task_id}"
+        cloudwatch_client.create_log_stream(logGroupName=log_group, logStreamName=log_stream)
+
+        cloudwatch_client.put_log_events(
+            logGroupName=log_group,
+            logStreamName=log_stream,
+            logEvents=[
+                {"timestamp": int(time.time() * 1000), "message": "Oops something bad happened"}
+            ],
+        )
+
+        failure_health_check = instance.run_launcher.check_run_worker_health(run)
+        assert failure_health_check.status == WorkerStatus.FAILED
+
+        assert (
+            failure_health_check.msg
+            == f"ECS task {task_arn} failed. Stop code: None. Stop reason: None. Container ['run']"
+            " failed. Task logs:\nOops something bad happened"
+        )
+
+        # Failure includes logs
+        assert "Task logs:\nOops something bad happened" in failure_health_check.msg
 
     task["lastStatus"] = "foo"
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.UNKNOWN


### PR DESCRIPTION
Helps diagnose issues without needing to check ECS logs.
