### PR TITLE
Add pre-push hook to run `make quick_pyright`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,16 @@ repos:
       entry: bash -c "cd docs && make mdx-format"
       pass_filenames: false
       files: ^docs/content
+
+    # We do not use pyright's provided pre-commit hook because we need the environment management
+    # supplied by `scripts/run-pyright.py`.
+    - id: pyright
+      name: pyright
+      description: "`scripts/run-pyright.py --diff` to run pyright against changed files."
+      entry: scripts/run-pyright.py
+      stages: [pre-push]
+      language: python
+      pass_filenames: false
+      types_or: [python, pyi]
+      require_serial: true
+      additional_dependencies: ['tomli', 'typing-extensions', 'pyright==1.1.349']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,10 @@ repos:
     # supplied by `scripts/run-pyright.py`.
     - id: pyright
       name: pyright
-      description: "`scripts/run-pyright.py --diff` to run pyright against changed files."
-      entry: scripts/run-pyright.py
+      entry: make quick_pyright
       stages: [pre-push]
-      language: python
+      # This means pre-commit will not try to install a new environment for this hook. It relies on
+      # having a pre-existing `make` installed (and scripts/run-pyright.py).
+      language: system
       pass_filenames: false
-      types_or: [python, pyi]
-      require_serial: true
-      additional_dependencies: ['tomli', 'typing-extensions', 'pyright==1.1.349']
+      types: [python]

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -159,8 +159,8 @@ class JobDefinition(IHasInternalInit):
         self._loggers = check.opt_nullable_mapping_param(
             logger_defs,
             "logger_defs",
-            key_type=str,
-            value_type=LoggerDefinition,
+            key_type=str,  # type: ignore
+            value_type=LoggerDefinition,  # type: ignore
         )
 
         config = check.opt_inst_param(

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -159,8 +159,8 @@ class JobDefinition(IHasInternalInit):
         self._loggers = check.opt_nullable_mapping_param(
             logger_defs,
             "logger_defs",
-            key_type=str,  # type: ignore
-            value_type=LoggerDefinition,  # type: ignore
+            key_type=str,
+            value_type=LoggerDefinition,
         )
 
         config = check.opt_inst_param(

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -220,7 +220,7 @@ def get_params(args: argparse.Namespace) -> Params:
             sys.exit(0)
     else:
         mode = "path"
-        targets = args.pathsBUILDKIT
+        targets = args.paths
 
     venv_python = (
         subprocess.run(["which", "python"], check=True, capture_output=True).stdout.decode().strip()
@@ -524,7 +524,9 @@ if __name__ == "__main__":
         normalize_env(env, params["rebuild"], params["update_pins"], params["venv_python"])
     if params["skip_typecheck"]:
         print("Successfully built environments. Skipping typecheck.")
-    if not params["skip_typecheck"]:
+    elif len(env_path_map) == 0:
+        print("No paths to analyze. Skipping typecheck.")
+    elif not params["skip_typecheck"]:
         run_results = [
             run_pyright(
                 env,


### PR DESCRIPTION
### Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/8967

This adds a pre-commit hook that runs scripts/run-pyright.py --diff on push only.

On my machine it takes ~2 seconds for a commit with several updated python files. Significantly slower than black/ruff but IMO worth it for push.

In order to active this, devs must run `pre-commit install --hook-type pre-push`.

### How I Tested These Changes

I tried to push a type error in this PR and the hook worked.