### PR TITLE
[Docs] Removed sneaky citation mark in title on docs

### DIFF
--- a/docs/content/deployment/guides/running-locally.mdx
+++ b/docs/content/deployment/guides/running-locally.mdx
@@ -1,5 +1,5 @@
 ---
-title: Running Dagster Locally | Dagster"
+title: Running Dagster Locally | Dagster
 description: How to run Dagster on your local machine.
 ---
 


### PR DESCRIPTION
### Summary & Motivation
I just saw the citation mark on the docs and wanted to fix them for you lovely people.

https://docs.dagster.io/deployment/guides/running-locally#run-and-asset-storage

