### PR TITLE
[dagit] Memoize some Intl behavior

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -1,3 +1,4 @@
+import memoize from 'lodash/memoize';
 import LRU from 'lru-cache';
 
 import {featureEnabled, FeatureFlag} from './Flags';
@@ -61,15 +62,19 @@ export const withMiddleTruncation = (text: string, options: {maxLength: number})
   return result;
 };
 
+const msecFormatter = memoize((locale: string) => {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3,
+  });
+});
+
 /**
  * Return an i18n-formatted millisecond in seconds as a decimal, with no leading zero.
  */
 const formatMsecMantissa = (msec: number) =>
-  (msec / 1000)
-    .toLocaleString(navigator.language, {
-      minimumFractionDigits: 3,
-      maximumFractionDigits: 3,
-    })
+  msecFormatter(navigator.language)
+    .format(msec / 1000)
     .slice(-4);
 
 /**

--- a/js_modules/dagit/packages/core/src/app/time/browserTimezone.ts
+++ b/js_modules/dagit/packages/core/src/app/time/browserTimezone.ts
@@ -1,6 +1,8 @@
-export const browserTimezone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
-export const browserTimezoneAbbreviation = () => timezoneAbbreviation(browserTimezone());
-export const timezoneAbbreviation = (timeZone: string) => {
+import memoize from 'lodash/memoize';
+
+export const browserTimezone = memoize(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+export const browserTimezoneAbbreviation = memoize(() => timezoneAbbreviation(browserTimezone()));
+export const timezoneAbbreviation = memoize((timeZone: string) => {
   const dateString = new Date().toLocaleDateString('en-US', {
     year: 'numeric',
     timeZone,
@@ -8,5 +10,5 @@ export const timezoneAbbreviation = (timeZone: string) => {
   });
   const [_, abbreviation] = dateString.split(', ');
   return abbreviation;
-};
-export const automaticLabel = () => `Automatic (${browserTimezoneAbbreviation()})`;
+});
+export const automaticLabel = memoize(() => `Automatic (${browserTimezoneAbbreviation()})`);

--- a/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRowComponents.tsx
@@ -1,4 +1,5 @@
 import {Colors, FontFamily, MetadataTable, Tooltip} from '@dagster-io/ui';
+import memoize from 'lodash/memoize';
 import qs from 'qs';
 import * as React from 'react';
 import {Link, useLocation} from 'react-router-dom';
@@ -113,6 +114,23 @@ const OpColumnTooltipStyle = JSON.stringify({
   left: 1,
 });
 
+const timestampFormat = memoize((timezone: string) => {
+  return new Intl.DateTimeFormat(navigator.language, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+    timeZone: timezone === 'Automatic' ? browserTimezone() : timezone,
+  });
+});
+
+const fractionalSecondFormat = memoize((locale: string) => {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3,
+  });
+});
+
 // Timestamp Column
 
 export const TimestampColumn: React.FC<{
@@ -129,21 +147,9 @@ export const TimestampColumn: React.FC<{
   const timeString = () => {
     if (time) {
       const timeNumber = Number(time);
-      const locale = navigator.language;
-      const main = new Date(timeNumber).toLocaleTimeString(locale, {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hourCycle: 'h23',
-        timeZone: timezone === 'Automatic' ? browserTimezone() : timezone,
-      });
+      const main = timestampFormat(timezone).format(new Date(timeNumber));
       const fractionalSec = (timeNumber % 1000) / 1000;
-      return `${main}${fractionalSec
-        .toLocaleString(locale, {
-          minimumFractionDigits: 3,
-          maximumFractionDigits: 3,
-        })
-        .slice(1)}`;
+      return `${main}${fractionalSecondFormat(navigator.language).format(fractionalSec).slice(1)}`;
     }
     return '';
   };


### PR DESCRIPTION
### Summary & Motivation

We're spending more time than necessary formatting timestamp strings on the Run log view. Add some memoization to make this a little more efficient.

### How I Tested These Changes

Jest to ensure that formatting output is still correct.

Launch a run, verify in Performance tab that `timeString()` is less expensive.
