### PR TITLE
[docs] Add note about multi-dimensionally partitioned assets requiring database migration

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -94,6 +94,9 @@ If you're using the default I/O manager, materializing partition `2022-07-23` of
 <Note>
   This feature is <strong>experimental</strong>.
 </Note>
+<Note>
+  If your Dagster instance is older than 1.1.1, you will need to migrate Dagster's internal database schema with `dagster instance migrate` to enable enable multi-dimensional asset partitions. Otherwise, loading the asset will fail with a GraphQL error.
+</Note>
 
 The <PyObject object="MultiPartitionsDefinition" /> class accepts a mapping of dimension name to partitions definition, creating a partition for each unique combination of dimension partitions. For example, the asset below would contain a partition for each combination of color and date: `red|2022-01-01`, `yellow|2022-01-01`, `blue|2022-01-01`, `red|2022-01-02` and so on.
 


### PR DESCRIPTION
### Summary & Motivation

If some pre 1.1.1 user wants to try multi-dimensionally partitioned assets, Dagit will fail displaying the description of the asset with a GraphQL error and the user won't be able to select partitions for materialization.
This is because it requires migrating the instance as stated in https://github.com/dagster-io/dagster/releases/tag/1.1.1.
The GraphQL error does mention the need to run the migration, but the reason is not clear.

I think it would be very helpful to add this information in the documentation as a note, hence this PR.

https://docs.dagster.io/concepts/partitions-schedules-sensors/partitions#multi-dimensionally-partitioned-assets

### How I Tested These Changes

Please make sure the formatting is correctly displayed on the website, especially the backticks.
