### PR TITLE
[docs] - Remove Pagination component from layout

### DIFF
--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -239,8 +239,7 @@ export const VersionedContentLayout = ({children, asPath = null}) => {
           <VersionNotice />
           <div className="py-4 px-4 sm:px-6 lg:px-8 w-full">
             {children}
-            <div className="mt-12 mb-12 border-t border-gray-200 px-4 flex items-center justify-between sm:px-0">
-            </div>
+            <div className="mt-12 mb-12 border-t border-gray-200 px-4 flex items-center justify-between sm:px-0"></div>
           </div>
           {/* End main area */}
         </div>

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -4,7 +4,7 @@ import {useVersion} from 'util/useVersion';
 import cx from 'classnames';
 import Icons from 'components/Icons';
 import Link from 'components/Link';
-import Pagination from 'components/Pagination';
+// import Pagination from 'components/Pagination';
 import VersionDropdown from 'components/VersionDropdown';
 import MDXComponents, {SearchIndexContext} from 'components/mdx/MDXComponents';
 import SidebarNavigation from 'components/mdx/SidebarNavigation';
@@ -239,7 +239,8 @@ export const VersionedContentLayout = ({children, asPath = null}) => {
           <VersionNotice />
           <div className="py-4 px-4 sm:px-6 lg:px-8 w-full">
             {children}
-            <Pagination />
+            <div className="mt-12 mb-12 border-t border-gray-200 px-4 flex items-center justify-between sm:px-0">
+            </div>
           </div>
           {/* End main area */}
         </div>

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -4,7 +4,6 @@ import {useVersion} from 'util/useVersion';
 import cx from 'classnames';
 import Icons from 'components/Icons';
 import Link from 'components/Link';
-// import Pagination from 'components/Pagination';
 import VersionDropdown from 'components/VersionDropdown';
 import MDXComponents, {SearchIndexContext} from 'components/mdx/MDXComponents';
 import SidebarNavigation from 'components/mdx/SidebarNavigation';


### PR DESCRIPTION
### Summary & Motivation

This removes the `Previous` and `Next` links from the site layout.

**Note**: This PR only removes the callsite, not the actual component.

### How I Tested These Changes

👀 and BK
