### PR TITLE
Revert "Test with a 64 bit after_cursor"

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1966,9 +1966,7 @@ class TestEventLogStorage:
                 assert len(materialization_count_by_key_after_run1.get(c)) == 2
 
                 materialization_count_by_key_after_everything = (
-                    storage.get_materialization_count_by_partition(
-                        [a, b, c], after_cursor=9999999999
-                    )
+                    storage.get_materialization_count_by_partition([a, b, c], after_cursor=9999999)
                 )
                 assert materialization_count_by_key_after_everything.get(a) == {}
                 assert materialization_count_by_key_after_everything.get(b) == {}


### PR DESCRIPTION
Reverts dagster-io/dagster#12093

To troubleshoot if this is the cause of our recent Buildkite build failures