### PR TITLE
Test with a 64 bit after_cursor

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1998,7 +1998,7 @@ class TestEventLogStorage:
                         _fetch_counts(storage, after_cursor=cursor_run1)
                         == materialization_count_by_partition
                     )
-                    assert _fetch_counts(storage, after_cursor=9999999) == {c: {}, d: {}}
+                    assert _fetch_counts(storage, after_cursor=9999999999) == {c: {}, d: {}}
 
     def test_get_observation(self, storage, test_run_id):
         a = AssetKey(["key_a"])


### PR DESCRIPTION
Same as https://github.com/dagster-io/dagster/pull/12093 but I missed this assertion in the first PR.