### PR TITLE
Ruff 0.0.212 -> 0.0.241

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,6 @@ repos:
       # Make sure black reads its config from root `pyproject.toml`
       args: ["--config", "pyproject.toml"]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.212
+  rev: v0.0.241
   hooks:
     - id: ruff
-      # Respect `exclude` and `extend-exclude` settings.
-      args: ["--force-exclude"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ ignore = [
   "D106",
   "D107",
 
+  # (docstring imperative mood) Overly restrictive.
+  "D401",
+
   # (module level import not at top) There are several places where we use e.g.
   # warnings.filterwarings calls before imports.
   "E402",
@@ -140,8 +143,8 @@ ignore = [
   # (no redundant alias) Allow redundant import aliases for explicit re-exports.
   "PLC0414",
 
-  # (use from for submodule imports) Sometimes it is clearer to import a submodule directly.
-  "PLR0402",
+  # (no concatenation) Existing codebase has many concatentations, no reason to disallow them.
+  "RUF005",
 
   ##### TEMPORARY DISABLES
 
@@ -192,7 +195,6 @@ select = [
   # pylint's rules)
   "PLC",
   "PLE",
-  "PLR",
   "PLW",
 
   # (no commented out code) keep commented out code blocks out of the codebase
@@ -208,7 +210,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.0.212"
+required-version = "0.0.241"
 
 [tool.ruff.isort]
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -146,7 +146,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.0.212",
+            "ruff==0.0.241",
         ],
     },
     entry_points={


### PR DESCRIPTION
### Summary & Motivation

Bump Ruff version-- performance/bugfix/autofix improvements. Inspired by some weird behavior @gibsondan was noticing and that @alangenfeld also noticed with `ruff` removing noqas.

There were some new rules implemented that flagged many errors/warnings
in our codebase, but I ignored them all-- I don't think any of them add
value. They are:

- `PLR*`: Several pylint "refactor" checker ports, which flags fuzzy stylistic things like "too many arguments" or "too many conditional branches".
- `RUF005`: Enforces `[foo, *bar]` instead of `[foo] + bar`. But the latter is already used throughout the codebase.
- `D401`: First line docstring "imperative mood". Too fuzzy and too many existing violations.

### How I Tested These Changes

BK
