### PR TITLE
making erin the owner of all docs 👑

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/docs/ @erinkcochran87


### PR DESCRIPTION
### Summary & Motivation

I've noticed a couple of PRs from the community where they don't know who to tag, notably around docs. I'm a big fan of [Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) and figure why not have people prompted to have Erin as a default reviewer for all PRs related to docs.

We don't have to force it so that a code owner approval is _required_ for merging, but notifying Erin that someone wants to update the docs is nbd. I got her buy-in that she's okay with the notifications that come with this.

### How I Tested These Changes
