### PR TITLE
[dagit] Better Asset DAG states for source assets

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -262,7 +262,7 @@ export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
 export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
   stepKey: 'source_asset',
   unstartedRunIds: [],
-  inProgressRunIds: ['12345'],
+  inProgressRunIds: ['ABCDEF'],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
@@ -277,7 +277,7 @@ export const LiveDataForNodeSourceObservationRunning: LiveDataForNode = {
 export const LiveDataForNodeSourceObservedStale: LiveDataForNode = {
   stepKey: 'source_asset',
   unstartedRunIds: [],
-  inProgressRunIds: ['12345'],
+  inProgressRunIds: [],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: {
@@ -560,7 +560,7 @@ export const AssetNodeScenariosSource = [
     title: 'Source Asset - No Live Data',
     liveData: undefined,
     definition: AssetNodeFragmentSource,
-    expectedText: ['Observed', '–'],
+    expectedText: ['Loading'],
   },
 
   {
@@ -581,14 +581,14 @@ export const AssetNodeScenariosSource = [
     title: 'Source Asset - Never Observed',
     liveData: LiveDataForNodeSourceNeverObserved,
     definition: AssetNodeFragmentSource,
-    expectedText: ['Observed', '–'],
+    expectedText: ['Never observed', '–'],
   },
 
   {
     title: 'Source Asset - Observation Running',
     liveData: LiveDataForNodeSourceObservationRunning,
     definition: AssetNodeFragmentSource,
-    expectedText: ['Observed', '–'],
+    expectedText: ['Observing...', 'ABCDEF'],
   },
 
   {


### PR DESCRIPTION
Fixes #12119

### Summary & Motivation

New states more clearly indicate when a source asset has not been observed.

<img width="1446" alt="image" src="https://user-images.githubusercontent.com/1037212/217103271-558369a4-dfc3-4911-8540-667953582ad5.png">


### How I Tested These Changes

Full test coverage for this now! See updated tests + storybooks