### PR TITLE
Fix serdes on FreshnessPolicy object

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -77,7 +77,7 @@ class FreshnessPolicy(
 
     """
 
-    def __new__(cls, *, maximum_lag_minutes: float, cron_schedule: Optional[str] = None):
+    def __new__(cls, maximum_lag_minutes: float, cron_schedule: Optional[str] = None):
         return super(FreshnessPolicy, cls).__new__(
             cls,
             maximum_lag_minutes=float(

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -77,7 +77,7 @@ class FreshnessPolicy(
 
     """
 
-    def __new__(cls, maximum_lag_minutes: float, cron_schedule: Optional[str] = None):
+    def __new__(cls, *, maximum_lag_minutes: float, cron_schedule: Optional[str] = None):
         return super(FreshnessPolicy, cls).__new__(
             cls,
             maximum_lag_minutes=float(
@@ -85,6 +85,18 @@ class FreshnessPolicy(
             ),
             cron_schedule=check.opt_str_param(cron_schedule, "cron_schedule"),
         )
+
+    @classmethod
+    def _create(cls, *args):
+        """
+        Pickle requires a method with positional arguments to construct
+        instances of a class. Since the constructor for this class has
+        keyword arguments only, we define this method to be used by pickle.
+        """
+        return cls(maximum_lag_minutes=args[0], cron_schedule=args[1])
+
+    def __reduce__(self):
+        return (self._create, (self.maximum_lag_minutes, self.cron_schedule))
 
     @property
     def maximum_lag_delta(self) -> datetime.timedelta:


### PR DESCRIPTION
## Summary

Fixes pickling/unpickling of `FreshnessPolicies` due to the `__new__` signature, which was previously leading to this error:

```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/ben/.pyenv/versions/3.8.12/lib/python3.8/multiprocessing/spawn.py", line 128, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/Users/ben/.pyenv/versions/3.8.12/lib/python3.8/multiprocessing/spawn.py", line 141, in _main
    self = reduction.pickle.load(from_parent)
TypeError: __new__() takes 1 positional argument but 3 were given
```

This appears to be the root cause of e.g. #11822