### PR TITLE
[fix] Fix pyright error with external resource values

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -151,7 +151,7 @@ class ExternalRepository:
         return self._external_resources[resource_name]
 
     def get_external_resources(self) -> Sequence[ExternalResource]:
-        return self._external_resources.values()
+        return list(self._external_resources.values())
 
     @property
     @cached_method


### PR DESCRIPTION
## Summary

Small fix for the following pyright error

```python
/Users/ben/Documents/repos/dagster/python_modules/dagster/dagster/_core/host_representation/external.py:
  154:15: Expression of type "dict_values[str, ExternalResource]" cannot be assigned to return type "Sequence[ExternalResource]"
  "dict_values[str, ExternalResource]" is incompatible with "Sequence[ExternalResource]" (reportGeneralTypeIssues)
```