### PR TITLE
[dagit] System tags (code + logical versions) on asset graph + details

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
@@ -12,6 +12,7 @@ import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
+import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetLineageElements} from './AssetLineageElements';
 import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {
@@ -32,7 +33,7 @@ export const AssetEventDetail: React.FC<{
   const assetLineage = event.__typename === 'MaterializationEvent' ? event.assetLineage : [];
 
   return (
-    <Box padding={{horizontal: 24}} style={{flex: 1}}>
+    <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
       <Box
         padding={{vertical: 24}}
         border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
@@ -118,14 +119,19 @@ export const AssetEventDetail: React.FC<{
 
       {event.__typename === 'MaterializationEvent' && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-          <Subheading>Source Data</Subheading>
+          <Subheading>Source data</Subheading>
           <AssetMaterializationUpstreamData timestamp={event.timestamp} assetKey={assetKey} />
         </Box>
       )}
 
+      <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
+        <Subheading>System tags</Subheading>
+        <AssetEventSystemTags event={event} collapsible />
+      </Box>
+
       {assetLineage.length > 0 && (
         <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-          <Subheading>Parent Materializations</Subheading>
+          <Subheading>Parent materializations</Subheading>
           <AssetLineageElements elements={assetLineage} timestamp={event.timestamp} />
         </Box>
       )}

--- a/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -43,7 +43,6 @@ export const AssetEventMetadataEntriesTable: React.FC<{
               <td style={{opacity: 0.7}}>{entry.description}</td>
             </tr>
           ))}
-
           {(observations || []).map((obs) => (
             <React.Fragment key={obs.timestamp}>
               {obs.metadataEntries.map((entry) => (

--- a/js_modules/dagit/packages/core/src/assets/AssetEventSystemTags.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventSystemTags.tsx
@@ -1,0 +1,86 @@
+import {Box, ButtonLink, Caption, Colors, Icon, Mono} from '@dagster-io/ui';
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import {DagsterTag} from '../runs/RunTag';
+
+import {AssetEventGroup} from './groupByPartition';
+
+// There can be other keys in the event tags, but we want to show these two
+// at the top consistently regardless of their alphabetical / backend ordering.
+const ORDER = ['dagster/logical_version', 'dagster/code_version'];
+
+export const AssetEventSystemTags: React.FC<{
+  event: AssetEventGroup['latest'] | null;
+  paddingLeft?: number;
+  collapsible?: boolean;
+}> = ({event, paddingLeft, collapsible}) => {
+  const [shown, setShown] = useStateWithStorage('show-asset-system-tags', Boolean);
+
+  if (collapsible && !shown) {
+    return (
+      <Caption>
+        <ButtonLink onClick={() => setShown(true)}>
+          <Box flex={{alignItems: 'center'}}>
+            <span>Show tags ({event?.tags.length || 0})</span>
+            <Icon name="arrow_drop_down" style={{transform: 'rotate(0deg)'}} />
+          </Box>
+        </ButtonLink>
+      </Caption>
+    );
+  }
+
+  return (
+    <>
+      <AssetEventSystemTagsTable>
+        <tbody>
+          {event?.tags.length ? (
+            [...event.tags]
+              .sort((a, b) => ORDER.indexOf(b.key) - ORDER.indexOf(a.key))
+              .map((t) => (
+                <tr key={t.key}>
+                  <td style={{paddingLeft}}>
+                    <Mono>{t.key.replace(DagsterTag.Namespace, '')}</Mono>
+                  </td>
+                  <td>{t.value}</td>
+                </tr>
+              ))
+          ) : (
+            <tr>
+              <td>No tags to display.</td>
+            </tr>
+          )}
+        </tbody>
+      </AssetEventSystemTagsTable>
+      {collapsible && (
+        <Caption>
+          <ButtonLink onClick={() => setShown(false)}>
+            <Box flex={{alignItems: 'center'}}>
+              <span>Hide tags</span>
+              <Icon name="arrow_drop_down" style={{transform: 'rotate(180deg)'}} />
+            </Box>
+          </ButtonLink>
+        </Caption>
+      )}
+    </>
+  );
+};
+
+const AssetEventSystemTagsTable = styled.table`
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+
+  tr td:first-child {
+    max-width: 300px;
+    word-wrap: break-word;
+    width: 25%;
+  }
+  tr td {
+    border: 1px solid ${Colors.KeylineGray};
+    padding: 8px 12px;
+    font-size: 14px;
+    vertical-align: top;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -158,8 +158,8 @@ export const AssetEvents: React.FC<Props> = ({
         </Box>
 
         <Box
-          style={{flex: 3, minWidth: 0}}
           flex={{direction: 'column'}}
+          style={{flex: 3, minWidth: 0, overflowY: 'auto'}}
           border={{side: 'left', color: Colors.KeylineGray, width: 1}}
         >
           <ErrorBoundary region="event" resetErrorOnChange={[focused]}>

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -13,6 +13,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {AllIndividualEventsLink} from './AllIndividualEventsLink';
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
+import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {AssetEventGroup} from './groupByPartition';
 import {AssetKey} from './types';
@@ -121,7 +122,7 @@ export const AssetPartitionDetail: React.FC<{
       : [];
 
   return (
-    <Box padding={{horizontal: 24}} style={{flex: 1}}>
+    <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
       <Box
         padding={{vertical: 24}}
         border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
@@ -139,7 +140,7 @@ export const AssetPartitionDetail: React.FC<{
             )}
           </Box>
         ) : (
-          <Heading color={Colors.Gray400}>No Partition Selected</Heading>
+          <Heading color={Colors.Gray400}>No partition selected</Heading>
         )}
         <div style={{flex: 1}} />
       </Box>
@@ -149,7 +150,7 @@ export const AssetPartitionDetail: React.FC<{
         padding={{vertical: 16}}
       >
         <Box flex={{gap: 4, direction: 'column'}}>
-          <Subheading>Latest Event</Subheading>
+          <Subheading>Latest event</Subheading>
           {!latest ? (
             <Box flex={{gap: 4}}>
               <Icon name="materialization" />
@@ -215,8 +216,12 @@ export const AssetPartitionDetail: React.FC<{
         <AssetEventMetadataEntriesTable event={latest} observations={observationsAboutLatest} />
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>Source Data</Subheading>
+        <Subheading>Source data</Subheading>
         <AssetMaterializationUpstreamData timestamp={latest?.timestamp} assetKey={assetKey} />
+      </Box>
+      <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
+        <Subheading>System tags</Subheading>
+        <AssetEventSystemTags event={latest} collapsible />
       </Box>
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -201,7 +201,7 @@ export const AssetPartitions: React.FC<Props> = ({
           </Box>
         ))}
 
-        <Box style={{flex: 3, minWidth: 0}} flex={{direction: 'column'}}>
+        <Box style={{flex: 3, minWidth: 0, overflowY: 'auto'}} flex={{direction: 'column'}}>
           {params.partition && focusedDimensionKeys.length === ranges.length ? (
             <AssetPartitionDetailLoader assetKey={assetKey} partitionKey={params.partition} />
           ) : (

--- a/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {LiveDataForNode} from '../asset-graph/Utils';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 
+import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetMaterializationGraphs} from './AssetMaterializationGraphs';
 import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
 import {CurrentRunsBanner} from './CurrentRunsBanner';
@@ -66,7 +67,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
       />
 
       {liveData?.freshnessPolicy && (
-        <SidebarSection title="Freshness Policy">
+        <SidebarSection title="Freshness policy">
           <Box margin={{horizontal: 24, vertical: 12}} flex={{gap: 12, alignItems: 'center'}}>
             <CurrentMinutesLateTag liveData={liveData} />
             <Body>{freshnessPolicyDescription(liveData.freshnessPolicy)}</Body>
@@ -74,7 +75,7 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
         </SidebarSection>
       )}
 
-      <SidebarSection title="Materialization in Last Run">
+      <SidebarSection title="Materialization in last run">
         {materializations[0] ? (
           <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
             <LatestMaterializationMetadata latest={materializations[0]} liveData={liveData} />
@@ -88,7 +89,21 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
           </Box>
         )}
       </SidebarSection>
-      <SidebarSection title="Metadata Plots">
+      <SidebarSection title="Materialization system tags" collapsedByDefault>
+        {materializations[0] ? (
+          <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
+            <AssetEventSystemTags event={materializations[0]} paddingLeft={24} />
+          </div>
+        ) : (
+          <Box
+            margin={{horizontal: 24, vertical: 12}}
+            style={{color: Colors.Gray500, fontSize: '0.8rem'}}
+          >
+            No materializations found
+          </Box>
+        )}
+      </SidebarSection>
+      <SidebarSection title="Metadata plots">
         <AssetMaterializationGraphs
           xAxis={xAxis}
           asSidebarSection

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -78,11 +78,13 @@ export const LatestMaterializationMetadata: React.FC<{
               'No materialization events'
             )}
           </td>
+          <td />
         </tr>
         {latest?.partition ? (
           <tr>
-            <td>Latest partition</td>
+            <td>Partition</td>
             <td>{latest ? latest.partition : 'No materialization events'}</td>
+            <td />
           </tr>
         ) : null}
         <tr>
@@ -97,6 +99,7 @@ export const LatestMaterializationMetadata: React.FC<{
               {liveData && <StaleTag liveData={liveData} />}
             </Box>
           </td>
+          <td />
         </tr>
         {latestAssetLineage?.length ? (
           <tr>
@@ -107,6 +110,7 @@ export const LatestMaterializationMetadata: React.FC<{
                 timestamp={latestEvent.timestamp}
               />
             </td>
+            <td />
           </tr>
         ) : null}
         {latestEvent?.metadataEntries.map((entry) => (
@@ -141,6 +145,10 @@ const MetadataTable = styled(Table)`
 export const LATEST_MATERIALIZATION_METADATA_FRAGMENT = gql`
   fragment LatestMaterializationMetadataFragment on MaterializationEvent {
     partition
+    tags {
+      key
+      value
+    }
     runOrError {
       ... on PipelineRun {
         id

--- a/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
@@ -21,6 +21,7 @@ export type AssetPartitionDetailQuery = {
           stepKey: string | null;
           label: string | null;
           description: string | null;
+          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
           runOrError:
             | {__typename: 'PythonError'}
             | {
@@ -176,6 +177,7 @@ export type AssetPartitionDetailQuery = {
           stepKey: string | null;
           label: string | null;
           description: string | null;
+          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
           runOrError:
             | {__typename: 'PythonError'}
             | {

--- a/js_modules/dagit/packages/core/src/assets/types/LastMaterializationMetadata.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LastMaterializationMetadata.types.ts
@@ -8,6 +8,7 @@ export type LatestMaterializationMetadataFragment = {
   runId: string;
   timestamp: string;
   stepKey: string | null;
+  tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
   runOrError:
     | {__typename: 'PythonError'}
     | {

--- a/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
@@ -10,6 +10,7 @@ export type AssetMaterializationFragment = {
   stepKey: string | null;
   label: string | null;
   description: string | null;
+  tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
   runOrError:
     | {__typename: 'PythonError'}
     | {
@@ -146,6 +147,7 @@ export type AssetObservationFragment = {
   stepKey: string | null;
   label: string | null;
   description: string | null;
+  tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
   runOrError:
     | {__typename: 'PythonError'}
     | {
@@ -291,6 +293,7 @@ export type AssetEventsQuery = {
           stepKey: string | null;
           label: string | null;
           description: string | null;
+          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
           runOrError:
             | {__typename: 'PythonError'}
             | {
@@ -441,6 +444,7 @@ export type AssetEventsQuery = {
           stepKey: string | null;
           label: string | null;
           description: string | null;
+          tags: Array<{__typename: 'EventTag'; key: string; value: string}>;
           runOrError:
             | {__typename: 'PythonError'}
             | {

--- a/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
@@ -85,6 +85,10 @@ export function useRecentAssetEvents(
 export const ASSET_MATERIALIZATION_FRAGMENT = gql`
   fragment AssetMaterializationFragment on MaterializationEvent {
     partition
+    tags {
+      key
+      value
+    }
     runOrError {
       ... on PipelineRun {
         id
@@ -120,6 +124,10 @@ export const ASSET_MATERIALIZATION_FRAGMENT = gql`
 export const ASSET_OBSERVATION_FRAGMENT = gql`
   fragment AssetObservationFragment on ObservationEvent {
     partition
+    tags {
+      key
+      value
+    }
     runOrError {
       ... on PipelineRun {
         id

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -18,6 +18,8 @@ export enum DagsterTag {
   SensorName = 'dagster/sensor_name',
   AssetPartitionRangeStart = 'dagster/asset_partition_range_start',
   AssetPartitionRangeEnd = 'dagster/asset_partition_range_end',
+  AssetEventLogicalVersion = 'dagster/logical_version',
+  AssetEventCodeVersion = 'dagster/code_version',
 
   // Hidden tags (using ".dagster" HIDDEN_TAG_PREFIX)
   RepositoryLabelTag = '.dagster/repository',


### PR DESCRIPTION
### Summary & Motivation

Based on https://github.com/dagster-io/dagster/pull/11973 

Summary of changes: https://www.loom.com/share/01361cda0e224f61a7551c8ab54a7bdb
Relevant discussion: https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1675726478215309

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/217151128-0f70fa01-1b30-41ac-8b70-a40824589f29.png">

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/217151152-dc211a46-2bb5-4258-a48d-17fbca9ffd2b.png">

### How I Tested These Changes

I will write tests + storybooks for the asset details page and asset sidebar this week, but I've put this up without tests because it may take some scaffolding to get them built and it's important that this ship in Thursday's release. I think this is a fairly safe addition to the existing because it's just displaying largely static data from the backend.