### PR TITLE
[dagit] Fix build failure caused by mocks out of sync with query

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.mocks.ts
@@ -76,6 +76,7 @@ export const SingleAssetQueryMaterializedWithLatestRun: MockedResponse<SingleAss
               __typename: 'RepositoryLocation',
             },
           },
+          partitionStats: null,
           assetKey: {
             path: ['good_asset'],
             __typename: 'AssetKey',
@@ -164,6 +165,7 @@ export const SingleAssetQueryMaterializedStaleAndLate: MockedResponse<SingleAsse
               __typename: 'RepositoryLocation',
             },
           },
+          partitionStats: null,
           assetKey: {
             path: ['late_asset'],
             __typename: 'AssetKey',
@@ -250,6 +252,11 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<SingleAssetQuery> = {
               name: 'test.py',
               __typename: 'RepositoryLocation',
             },
+          },
+          partitionStats: {
+            __typename: 'PartitionStats',
+            numMaterialized: 8,
+            numPartitions: 11,
           },
           assetKey: {
             path: ['run_failing_asset'],


### PR DESCRIPTION
### Summary & Motivation

I merged two PRs, one that added storybooks, and mocks for this query and another that added a resolver field.

### How I Tested These Changes

Build no longer fails!