### PR TITLE
nux examples in oss 2/: add required env vars in README's front matter

### DIFF
--- a/examples/assets_dbt_python/README.md
+++ b/examples/assets_dbt_python/README.md
@@ -1,3 +1,7 @@
+---
+requiredEnvVars: null
+---
+
 # Dagster + dbt starter kit
 
 This starter demonstrates using Python alongside a medium-sized dbt project. It uses dbt's [`jaffle_shop`](https://github.com/dbt-labs/jaffle_shop), [`dagster-dbt`](https://docs.dagster.io/_apidocs/libraries/dagster-dbt), and [DuckDB](https://duckdb.org/).

--- a/examples/assets_modern_data_stack/README.md
+++ b/examples/assets_modern_data_stack/README.md
@@ -1,3 +1,16 @@
+---
+requiredEnvVars:
+- "AIRBYTE_CONNECTION_ID"
+- "AIRBYTE_HOST"
+- "AIRBYTE_PORT"
+- "PG_USERNAME"
+- "PG_PASSWORD"
+- "PG_HOST"
+- "PG_PORT"
+- "PG_SOURCE_DATABASE"
+- "PG_DESTINATION_DATABASE"
+---
+
 # Dagster + Modern Data Stack starter kit
 
 This starter kit shows how to build the Dagster's [Software-Defined Assets](https://docs.dagster.io/concepts/assets/software-defined-assets) alongside Modern Data Stack tools (specifically, [Airbyte](https://github.com/airbytehq/airbyte) and [dbt](https://github.com/dbt-labs/dbt-core)).

--- a/examples/quickstart_aws/README.md
+++ b/examples/quickstart_aws/README.md
@@ -1,3 +1,10 @@
+---
+requiredEnvVars:
+- "AWS_ACCESS_KEY_ID"
+- "AWS_SECRET_ACCESS_KEY"
+- "S3_BUCKET"
+---
+
 # Dagster + AWS starter kit
 
 This example builds a daily ETL pipeline that stores data in S3. At a high level, this project shows how to ingest data from external sources to S3, explore and transform the data, and materialize outputs that help visualize the data.

--- a/examples/quickstart_etl/README.md
+++ b/examples/quickstart_etl/README.md
@@ -1,3 +1,7 @@
+---
+requiredEnvVars: null
+---
+
 # Dagster starter kit
 
 This example is a starter kit for building a daily ETL pipeline. At a high level, this project shows how to ingest data from external sources, explore and transform the data, and materialize outputs that help visualize the data.

--- a/examples/quickstart_gcp/README.md
+++ b/examples/quickstart_gcp/README.md
@@ -1,3 +1,9 @@
+---
+requiredEnvVars:
+- "BIGQUERY_SERVICE_ACCOUNT_CREDENTIALS"
+- "BIGQUERY_PROJECT_ID"
+---
+
 # Dagster + GCP starter kit
 
 This example builds a daily ETL pipeline that interacts with Google Cloud Platform (GCP). At a high level, this project shows how to ingest data from external sources to BigQuery, explore and transform the data, and materialize outputs that help visualize the data.

--- a/examples/quickstart_snowflake/README.md
+++ b/examples/quickstart_snowflake/README.md
@@ -1,3 +1,13 @@
+---
+requiredEnvVars:
+- "SNOWFLAKE_ACCOUNT"
+- "SNOWFLAKE_USER"
+- "SNOWFLAKE_PASSWORD"
+- "SNOWFLAKE_WAREHOUSE"
+- "SNOWFLAKE_DATABASE"
+- "SNOWFLAKE_SCHEMA"
+---
+
 # Dagster + Snowflake starter kit
 
 This example builds a daily ETL pipeline that materializes tables in Snowflake. At a high level, this project shows how to ingest data from external sources to Snowflake, explore and transform the data, and materialize outputs that help visualize the data.


### PR DESCRIPTION
### Summary & Motivation
add "requiredEnvVars" field in front matter of example's README. this will be used by nux to tell which env vars to pre-populate

### How I Tested These Changes
