### PR TITLE
Delete no-longer-needed type-ignores

### DIFF
--- a/examples/assets_dbt_python/assets_dbt_python/utils/__init__.py
+++ b/examples/assets_dbt_python/assets_dbt_python/utils/__init__.py
@@ -26,7 +26,7 @@ def _random_times(n: int):
             clipped_flipped_dist, clipped_flipped_dist[: n - len(clipped_flipped_dist)]
         )
 
-    return pd.to_datetime((clipped_flipped_dist * (end_u - start_u)) + start_u, unit="s")  # type: ignore  # (bad stubs)
+    return pd.to_datetime((clipped_flipped_dist * (end_u - start_u)) + start_u, unit="s")
 
 
 def random_data(extra_columns: Dict[str, Any], n: int) -> pd.DataFrame:

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/lib.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/lib.py
@@ -130,8 +130,8 @@ def compute_anomalous_events(df_prices: pd.DataFrame, df_bollinger: pd.DataFrame
     """Compute anomalous (high or low) price events for a set of stocks over time."""
     df = pd.concat([df_prices, df_bollinger.add_prefix("bol_")], axis=1)
     df["event"] = pd.Series(pd.NA, index=df.index, dtype=EVENT_TYPE)
-    df["event"][df["close"] > df["bol_upper"]] = "high"  # type: ignore
-    df["event"][df["close"] < df["bol_lower"]] = "low"  # type: ignore
+    df["event"][df["close"] > df["bol_upper"]] = "high"
+    df["event"][df["close"] < df["bol_lower"]] = "low"
     return df[df["event"].notna()][["name", "date", "event"]].reset_index()
 
 

--- a/examples/development_to_production/setup.py
+++ b/examples/development_to_production/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup  # type: ignore
+from setuptools import setup
 
 setup(
     name="development_to_production",

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -112,7 +112,7 @@ class BetterPandasIOManager(IOManager):
             obj.to_csv(file_path, index=False)
 
     def load_input(self, context) -> pd.DataFrame:
-        return pd.read_csv(self._get_path(context.upstream_output))  # type: ignore
+        return pd.read_csv(self._get_path(context.upstream_output))
 
 
 # write a subclass that uses _get_path for your custom loading logic

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -223,7 +223,7 @@ def the_db_connection(init_context):
     get_the_db_connection(init_context.resources.credentials)
 
 
-@sensor(job=the_job)  # type: ignore  # (didactic)
+@sensor(job=the_job)
 def uses_db_connection():
     with build_resources(
         {"db_connection": the_db_connection, "credentials": the_credentials}

--- a/examples/docs_snippets/docs_snippets/deploying/airflow/mounted.py
+++ b/examples/docs_snippets/docs_snippets/deploying/airflow/mounted.py
@@ -1,6 +1,6 @@
 from dagster_airflow.factory import make_airflow_dag  # type: ignore  # (old airflow)
 
-dag, steps = make_airflow_dag(  # type: ignore  # (unused code?)
+dag, steps = make_airflow_dag(
     module_name="docs_snippets.intro_tutorial.airflow",
     pipeline_name="hello_cereal_pipeline",
     run_config={"storage": {"filesystem": {"config": {"base_dir": "/container_tmp"}}}},

--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/parquet_io_manager.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/parquet_io_manager.py
@@ -60,7 +60,7 @@ class PartitionedParquetIOManager(IOManager):
         )
 
     def _get_path(self, context: Union[InputContext, OutputContext]):
-        key = context.asset_key.path[-1]  # type: ignore
+        key = context.asset_key.path[-1]
 
         if context.has_asset_partitions:
             start, end = context.asset_partitions_time_window

--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/snowflake_io_manager.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/snowflake_io_manager.py
@@ -46,7 +46,7 @@ class SnowflakeIOManager(IOManager):
         self._config = config
 
     def handle_output(self, context: OutputContext, obj: Union[PandasDataFrame, SparkDataFrame]):
-        schema, table = context.asset_key.path[-2], context.asset_key.path[-1]  # type: ignore
+        schema, table = context.asset_key.path[-2], context.asset_key.path[-1]
 
         time_window = context.asset_partitions_time_window if context.has_asset_partitions else None
         with connect_snowflake(config=self._config, schema=schema) as con:

--- a/examples/experimental/script_to_assets_branching_io_manager/hackernews.py
+++ b/examples/experimental/script_to_assets_branching_io_manager/hackernews.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import requests
 from tqdm import tqdm
-from wordcloud import STOPWORDS, WordCloud  # type: ignore
+from wordcloud import STOPWORDS, WordCloud
 
 
 def extract() -> pd.DataFrame:

--- a/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py
@@ -60,7 +60,7 @@ class PartitionedParquetIOManager(IOManager):
         )
 
     def _get_path(self, context: Union[InputContext, OutputContext]):
-        key = context.asset_key.path[-1]  # type: ignore
+        key = context.asset_key.path[-1]
 
         if context.has_asset_partitions:
             start, end = context.asset_partitions_time_window

--- a/examples/project_fully_featured/project_fully_featured/resources/snowflake_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/snowflake_io_manager.py
@@ -53,7 +53,7 @@ class SnowflakeIOManager(IOManager):
         self._config = config
 
     def handle_output(self, context: OutputContext, obj: Union[PandasDataFrame, SparkDataFrame]):
-        schema, table = context.asset_key.path[-2], context.asset_key.path[-1]  # type: ignore
+        schema, table = context.asset_key.path[-2], context.asset_key.path[-1]
 
         time_window = context.asset_partitions_time_window if context.has_asset_partitions else None
         with connect_snowflake(config=self._config, schema=schema) as con:

--- a/examples/project_fully_featured/project_fully_featured/utils/snapshot.py
+++ b/examples/project_fully_featured/project_fully_featured/utils/snapshot.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         results = list(tqdm(executor.map(client.fetch_item_by_id, ids), total=len(ids)))
 
     items = {}
-    for x in filter(None, results):  # type: ignore  # (mypy doesn't understand filter)
+    for x in filter(None, results):
         items[int(x["id"])] = x
 
     with gzip.open(file_relative_path(__file__, "../utils/snapshot.gzip"), "w") as f:

--- a/examples/with_airflow/with_airflow/airflow_complex_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_complex_dag.py
@@ -24,8 +24,8 @@ Example Airflow DAG that shows the complex DAG structure.
 # Type errors ignored because some of these imports target deprecated modules for compatibility with
 # airflow 1.x and 2.x.
 from airflow import models
-from airflow.operators.bash_operator import BashOperator  # type: ignore  # (airflow 1 compat)
-from airflow.operators.python_operator import PythonOperator  # type: ignore  # (airflow 1 compat)
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.helpers import chain
 

--- a/examples/with_airflow/with_airflow/airflow_simple_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_simple_dag.py
@@ -3,7 +3,7 @@
 # Type errors ignored because some of these imports target deprecated modules for compatibility with
 # airflow 1.x and 2.x.
 from airflow import models
-from airflow.operators.bash_operator import BashOperator  # type: ignore  # (airflow 1 compat)
+from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 

--- a/integration_tests/python_modules/dagster-k8s-test-infra/setup.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 setup(
     name="dagster-k8s-test-infra",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ reportInvalidStringEscapeSequence = false
 # for defining a public API.
 reportPrivateImportUsage = false
 
+# Since we only use pyright, there is no need to suppress type errors that pyright does not
+# recognize.
+reportUnnecessaryTypeIgnoreComment = "warning"
+
 # ########################
 # ##### PYTEST
 # ########################

--- a/python_modules/automation/automation/docker/dagster_docker.py
+++ b/python_modules/automation/automation/docker/dagster_docker.py
@@ -62,7 +62,7 @@ class DagsterDockerImage(
         images_path: Optional[str] = None,
         build_cm: Callable = do_nothing,
     ):
-        return super(DagsterDockerImage, cls).__new__(  # type: ignore
+        return super(DagsterDockerImage, cls).__new__(
             cls,
             check.str_param(image, "image"),
             check.opt_str_param(  # type: ignore

--- a/python_modules/dagit/dagit_tests/webserver/test_app.py
+++ b/python_modules/dagit/dagit_tests/webserver/test_app.py
@@ -113,7 +113,7 @@ def test_graphql_get(instance, test_client: TestClient):  # pylint: disable=unus
 def test_graphql_invalid_json(instance, test_client: TestClient):  # pylint: disable=unused-argument
     # base case
     response = test_client.post(
-        "/graphql", content='{"query": "foo}', headers={"Content-Type": "application/json"}  # type: ignore  # (post has no content param?)
+        "/graphql", content='{"query": "foo}', headers={"Content-Type": "application/json"}
     )
 
     print(str(response.text))
@@ -165,7 +165,7 @@ def test_graphql_post(test_client: TestClient):
     # application/graphql
     response = test_client.post(
         "/graphql",
-        content="{__typename}",  # type: ignore  # (post has no content param?)
+        content="{__typename}",
         headers={"Content-type": "application/graphql"},
     )
     assert response.status_code == 200, response.text

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -31,10 +31,7 @@ def get_unloadable_instigator_states_or_error(graphene_info: "ResolveInfo", inst
         )
     ]
 
-    instigator_selector_ids = {
-        instigator.selector_id  # type: ignore # mypy getting confused by chain
-        for instigator in external_instigators
-    }
+    instigator_selector_ids = {instigator.selector_id for instigator in external_instigators}
     unloadable_states = [
         instigator_state
         for instigator_state in instigator_states

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -311,7 +311,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             )
             self._node_definition_snap = self.get_external_pipeline().get_node_def_snap(node_key)
         # weird mypy bug causes mistyped _node_definition_snap
-        return check.not_none(self._node_definition_snap)  # type: ignore
+        return check.not_none(self._node_definition_snap)
 
     def get_partition_keys(
         self,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
@@ -43,7 +43,7 @@ class GrapheneExecutionStepInput(graphene.ObjectType):
         return self._step_input_snap.name
 
     def resolve_dependsOn(self, _graphene_info: ResolveInfo):
-        return [  # type: ignore  # fmt: skip
+        return [
             GrapheneExecutionStep(
                 self._external_execution_plan,
                 self._external_execution_plan.get_step_by_key(key),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -45,7 +45,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
 
         if self.statuses:
             statuses = [
-                DagsterRunStatus[status.value]  # type: ignore
+                DagsterRunStatus[status.value]
                 for status in self.statuses  # pylint: disable=not-an-iterable
             ]
         else:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -866,7 +866,7 @@ class GrapheneJob(GraphenePipeline):
 
     # doesn't inherit from base class
     def __init__(self, external_pipeline, batch_loader=None):
-        super().__init__()  # type: ignore  # (graphene weirdness)
+        super().__init__()
         self._external_pipeline = check.inst_param(
             external_pipeline, "external_pipeline", ExternalPipeline
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -738,7 +738,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
 
         # Filter down to requested asset keys
         # Build mapping of asset key to the step keys required to generate the asset
-        step_keys_by_asset: Dict[AssetKey, Sequence[str]] = {  # type: ignore
+        step_keys_by_asset: Dict[AssetKey, Sequence[str]] = {
             node.external_asset_node.asset_key: node.external_asset_node.op_names
             for node in results
             if node.assetKey in asset_keys

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -457,7 +457,7 @@ class GrapheneSolidDefinition(graphene.ObjectType, ISolidDefinitionMixin):
         if not isinstance(_solid_def_snap, SolidDefSnap):
             check.failed("Expected SolidDefSnap")
         self._solid_def_snap = _solid_def_snap
-        super().__init__(name=solid_def_name, description=self._solid_def_snap.description)  # type: ignore
+        super().__init__(name=solid_def_name, description=self._solid_def_snap.description)
         ISolidDefinitionMixin.__init__(self, represented_pipeline, solid_def_name)
 
     def resolve_config_field(self, _graphene_info):

--- a/python_modules/dagster-test/dagster_test/toys/input_managers.py
+++ b/python_modules/dagster-test/dagster_test/toys/input_managers.py
@@ -21,7 +21,7 @@ class PandasCsvIOManager(IOManager):
             obj.to_csv(file_path, index=False)
 
     def load_input(self, context) -> pd.DataFrame:
-        return pd.read_csv(self._get_path(context.upstream_output))  # type: ignore
+        return pd.read_csv(self._get_path(context.upstream_output))
 
 
 @io_manager(config_schema={"base_dir": Field(Noneable(str), default_value=None, is_required=False)})
@@ -49,7 +49,7 @@ class NumpyCsvIOManager(PandasCsvIOManager):
                     "strings": ["ten", "twenty", "thirty", "forty"],
                 }
             )
-            return df.to_numpy()  # type: ignore  # fmt: skip
+            return df.to_numpy()
 
 
 @io_manager(

--- a/python_modules/dagster-test/dagster_test_tests/test_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_toys.py
@@ -76,7 +76,7 @@ def test_many_events_subset_job(executor_def):
 
 def test_sleepy_job(executor_def):
     assert (
-        lambda: sleepy.to_job(  # type: ignore
+        lambda: sleepy.to_job(
             config={
                 "ops": {"giver": {"config": [2, 2, 2, 2]}},
             },

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -96,7 +96,7 @@ def experimental(obj: T_Annotatable, *, decorator: bool = False) -> T_Annotatabl
 
     if isinstance(obj, (property, staticmethod, classmethod)):
         # warning not currently supported for these cases
-        return obj  # type: ignore
+        return obj
 
     elif inspect.isfunction(target):
         warning_fn = experimental_decorator_warning if decorator else experimental_fn_warning

--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -283,7 +283,7 @@ def opt_dict_param(
 
 # pyright understands this overload but not mypy
 @overload
-def opt_nullable_dict_param(  # type: ignore
+def opt_nullable_dict_param(
     obj: None,
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = ...,
@@ -810,7 +810,7 @@ def opt_list_param(
 
 # pyright understands this overload but not mypy
 @overload
-def opt_nullable_list_param(  # type: ignore
+def opt_nullable_list_param(
     obj: None,
     param_name: str,
     of_type: Optional[TypeOrTupleOfTypes] = ...,
@@ -1014,7 +1014,7 @@ def opt_mapping_param(
 
 # pyright understands this overload but not mypy
 @overload
-def opt_nullable_mapping_param(  # type: ignore
+def opt_nullable_mapping_param(
     obj: None,
     param_name: str,
     key_type: Optional[TypeOrTupleOfTypes] = ...,
@@ -1458,7 +1458,7 @@ def tuple_param(
     defines a fixed-length tuple type-- each element must match the corresponding element in
     `of_shape`. Passing both `of_type` and `of_shape` will raise an error.
     """
-    if not isinstance(obj, tuple):  # type: ignore
+    if not isinstance(obj, tuple):
         raise _param_type_mismatch_exception(obj, tuple, param_name, additional_message)
 
     if of_type is None and of_shape is None:
@@ -1502,7 +1502,7 @@ def opt_tuple_param(
     """Ensures argument obj is a tuple or None; in the latter case, instantiates an empty tuple
     and returns it.
     """
-    if obj is not None and not isinstance(obj, tuple):  # type: ignore
+    if obj is not None and not isinstance(obj, tuple):
         raise _param_type_mismatch_exception(obj, tuple, param_name, additional_message)
 
     if obj is None:

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -134,7 +134,7 @@ class ConfigScalar(ConfigType):
     ):
         self.scalar_kind = check.inst_param(scalar_kind, "scalar_kind", ConfigScalarKind)
         super(ConfigScalar, self).__init__(
-            key, kind=ConfigTypeKind.SCALAR, given_name=given_name, **kwargs  # type: ignore
+            key, kind=ConfigTypeKind.SCALAR, given_name=given_name, **kwargs
         )
 
 
@@ -231,7 +231,7 @@ class Array(ConfigType):
             kind=ConfigTypeKind.ARRAY,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def description(self):
         return "List of {inner_type}".format(inner_type=self.key)
@@ -428,7 +428,7 @@ class ScalarUnion(ConfigType):
         )
 
     def type_iterator(self) -> Iterator["ConfigType"]:
-        yield from self.scalar_type.type_iterator()  # type: ignore
+        yield from self.scalar_type.type_iterator()
         yield from self.non_scalar_type.type_iterator()
         yield from super().type_iterator()
 

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -323,7 +323,7 @@ class Field:
                         "into of a config enum type {name}. You must pass in the underlying "
                         "string represention as the default value. One of {value_set}."
                     ).format(
-                        value_set=[ev.config_value for ev in self.config_type.enum_values],  # type: ignore
+                        value_set=[ev.config_value for ev in self.config_type.enum_values],
                         name=self.config_type.given_name,
                     )
                 )
@@ -353,12 +353,12 @@ class Field:
                 self._default_value = evr.value
         self._is_required = is_required
 
-    @public  # type: ignore
+    @public
     @property
     def is_required(self) -> bool:
         return self._is_required
 
-    @public  # type: ignore
+    @public
     @property
     def default_provided(self) -> bool:
         """Was a default value provided.
@@ -368,13 +368,13 @@ class Field:
         """
         return self._default_value != FIELD_NO_DEFAULT_PROVIDED
 
-    @public  # type: ignore
+    @public
     @property
     def default_value(self) -> Any:
         check.invariant(self.default_provided, "Asking for default value when none was provided")
         return self._default_value
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         return self._description

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -204,7 +204,7 @@ class Map(ConfigType):
             kind=ConfigTypeKind.MAP,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def key_label_name(self):
         return self.given_name

--- a/python_modules/dagster/dagster/_config/post_process.py
+++ b/python_modules/dagster/dagster/_config/post_process.py
@@ -44,7 +44,7 @@ def _recursively_process_config(
         return evr
 
 
-def _recursively_resolve_defaults(  # type: ignore # mypy missing check.failed NoReturn
+def _recursively_resolve_defaults(
     context: TraversalContext, config_value: Any
 ) -> EvaluateValueResult[Any]:
     kind = context.config_type.kind

--- a/python_modules/dagster/dagster/_config/primitive_mapping.py
+++ b/python_modules/dagster/dagster/_config/primitive_mapping.py
@@ -10,7 +10,7 @@ SUPPORTED_CONFIG_BUILTIN_MAP = {
     float: Float,
     bool: Bool,
     str: String,
-    list: Array(ConfigAnyInstance),  # type: ignore
+    list: Array(ConfigAnyInstance),
     dict: Permissive(),
 }
 

--- a/python_modules/dagster/dagster/_config/structured_config.py
+++ b/python_modules/dagster/dagster/_config/structured_config.py
@@ -14,7 +14,7 @@ try:
     from functools import cached_property  # type: ignore  # (py37 compat)
 except ImportError:
 
-    class cached_property:  # type: ignore[no-redef]
+    class cached_property:
         pass
 
 

--- a/python_modules/dagster/dagster/_config/validate.py
+++ b/python_modules/dagster/dagster/_config/validate.py
@@ -168,7 +168,7 @@ def validate_selector_config(
     # If there is a single field defined on the selector and if it is optional
     # it passes validation. (e.g. a single logger "console")
     if config_value == {}:
-        return _validate_empty_selector_config(context)  # type: ignore
+        return _validate_empty_selector_config(context)
 
     # Now we ensure that the used-provided config has only a a single entry
     # and then continue the validation pass
@@ -213,7 +213,7 @@ def validate_selector_config(
             frozendict({field_name: child_evaluate_value_result.value})
         )
     else:
-        return child_evaluate_value_result  # type: ignore
+        return child_evaluate_value_result
 
 
 def _validate_shape_config(
@@ -325,7 +325,7 @@ def validate_map_config(
         if not result.success:
             errors += cast(List, result.errors)
 
-    return EvaluateValueResult(not bool(errors), frozendict(config_value), errors)  # type: ignore
+    return EvaluateValueResult(not bool(errors), frozendict(config_value), errors)
 
 
 def validate_shape_config(
@@ -401,7 +401,7 @@ def validate_array_config(
         else:
             errors.extend(check.not_none(result.errors))
 
-    return EvaluateValueResult(not bool(errors), values, errors)  # type: ignore
+    return EvaluateValueResult(not bool(errors), values, errors)
 
 
 def validate_enum_config(

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -42,19 +42,19 @@ class AssetSelection(ABC):
             AssetSelection.all() - AssetSelection.groups("marketing")
     """
 
-    @public  # type: ignore
+    @public
     @staticmethod
     def all() -> "AllAssetSelection":
         """Returns a selection that includes all assets."""
         return AllAssetSelection()
 
-    @public  # type: ignore
+    @public
     @staticmethod
     def assets(*assets_defs: AssetsDefinition) -> "KeysAssetSelection":
         """Returns a selection that includes all of the provided assets."""
         return KeysAssetSelection(*(key for assets_def in assets_defs for key in assets_def.keys))
 
-    @public  # type: ignore
+    @public
     @staticmethod
     def keys(*asset_keys: CoercibleToAssetKey) -> "KeysAssetSelection":
         """
@@ -82,14 +82,14 @@ class AssetSelection(ABC):
         ]
         return KeysAssetSelection(*_asset_keys)
 
-    @public  # type: ignore
+    @public
     @staticmethod
     def groups(*group_strs) -> "GroupsAssetSelection":
         """Returns a selection that includes assets that belong to any of the provided groups."""
         check.tuple_param(group_strs, "group_strs", of_type=str)
         return GroupsAssetSelection(*group_strs)
 
-    @public  # type: ignore
+    @public
     def downstream(
         self, depth: Optional[int] = None, include_self: bool = True
     ) -> "DownstreamAssetSelection":
@@ -109,7 +109,7 @@ class AssetSelection(ABC):
         check.opt_bool_param(include_self, "include_self")
         return DownstreamAssetSelection(self, depth=depth, include_self=include_self)
 
-    @public  # type: ignore
+    @public
     def upstream(
         self, depth: Optional[int] = None, include_self: bool = True
     ) -> "UpstreamAssetSelection":
@@ -130,7 +130,7 @@ class AssetSelection(ABC):
         check.opt_bool_param(include_self, "include_self")
         return UpstreamAssetSelection(self, depth=depth, include_self=include_self)
 
-    @public  # type: ignore
+    @public
     def sinks(self) -> "SinkAssetSelection":
         """
         Given an asset selection, returns a new asset selection that contains all of the sink
@@ -141,7 +141,7 @@ class AssetSelection(ABC):
         """
         return SinkAssetSelection(self)
 
-    @public  # type: ignore
+    @public
     def sources(self) -> "SourceAssetSelection":
         """
         Given an asset selection, returns a new asset selection that contains all of the source

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -110,7 +110,7 @@ class AssetSensorDefinition(SensorDefinition):
             default_status=default_status,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def asset_key(self):
         return self._asset_key

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -459,17 +459,17 @@ class AssetsDefinition(ResourceAddable):
             can_subset=can_subset,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def can_subset(self) -> bool:
         return self._can_subset
 
-    @public  # type: ignore
+    @public
     @property
     def group_names_by_key(self) -> Mapping[AssetKey, str]:
         return self._group_names_by_key
 
-    @public  # type: ignore
+    @public
     @property
     def op(self) -> OpDefinition:
         check.invariant(
@@ -478,12 +478,12 @@ class AssetsDefinition(ResourceAddable):
         )
         return cast(OpDefinition, self._node_def)
 
-    @public  # type: ignore
+    @public
     @property
     def node_def(self) -> NodeDefinition:
         return self._node_def
 
-    @public  # type: ignore
+    @public
     @property
     def asset_deps(self) -> Mapping[AssetKey, AbstractSet[AssetKey]]:
         return self._asset_deps
@@ -492,7 +492,7 @@ class AssetsDefinition(ResourceAddable):
     def input_names(self) -> Iterable[str]:
         return self.keys_by_input_name.keys()
 
-    @public  # type: ignore
+    @public
     @property
     def key(self) -> AssetKey:
         check.invariant(
@@ -510,12 +510,12 @@ class AssetsDefinition(ResourceAddable):
         )
         return self.key
 
-    @public  # type: ignore
+    @public
     @property
     def resource_defs(self) -> Mapping[str, ResourceDefinition]:
         return dict(self._resource_defs)
 
-    @public  # type: ignore
+    @public
     @property
     def keys(self) -> AbstractSet[AssetKey]:
         return self._selected_asset_keys
@@ -527,7 +527,7 @@ class AssetsDefinition(ResourceAddable):
         )
         return self.keys
 
-    @public  # type: ignore
+    @public
     @property
     def dependency_keys(self) -> Iterable[AssetKey]:
         # the input asset keys that are directly upstream of a selected asset key
@@ -562,7 +562,7 @@ class AssetsDefinition(ResourceAddable):
     def freshness_policies_by_key(self) -> Mapping[AssetKey, FreshnessPolicy]:
         return self._freshness_policies_by_key
 
-    @public  # type: ignore
+    @public
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
         return self._partitions_def
@@ -849,7 +849,7 @@ class AssetsDefinition(ResourceAddable):
         for source_key, resource_def in self.resource_defs.items():
             yield from resource_def.get_resource_requirements(outer_context=source_key)
 
-    @public  # type: ignore
+    @public
     @property
     def required_resource_keys(self) -> Set[str]:
         return {requirement.key for requirement in self.get_resource_requirements()}

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -74,7 +74,7 @@ class AnonymousConfigurableDefinition(ConfigurableDefinition):
         config_or_config_fn: Any,
         config_schema: CoercableToConfigSchema = None,
         description: Optional[str] = None,
-    ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
+    ) -> Self:
         """
         Wraps this object in an object of the same type that provides configuration to the inner
         object.
@@ -107,7 +107,7 @@ class AnonymousConfigurableDefinition(ConfigurableDefinition):
         self,
         description: Optional[str],
         config_schema: IDefinitionConfigSchema,
-    ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
+    ) -> Self:
         raise NotImplementedError()
 
 
@@ -120,7 +120,7 @@ class NamedConfigurableDefinition(ConfigurableDefinition):
         name: str,
         config_schema: Optional[UserConfigSchema] = None,
         description: Optional[str] = None,
-    ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
+    ) -> Self:
         """
         Wraps this object in an object of the same type that provides configuration to the inner
         object.
@@ -158,7 +158,7 @@ class NamedConfigurableDefinition(ConfigurableDefinition):
         name: str,
         description: Optional[str],
         config_schema: IDefinitionConfigSchema,
-    ) -> Self:  # type: ignore [valid-type] # (until mypy supports Self)
+    ) -> Self:
         ...
 
 
@@ -255,7 +255,7 @@ def configured(
             name: str = check.not_none(kwargs.get("name") or fn_name)
             return configurable.configured(
                 config_or_config_fn=config_or_config_fn,
-                name=name,  # type: ignore [call-arg] # (mypy bug)
+                name=name,
                 config_schema=config_schema,
                 **{k: v for k, v in kwargs.items() if k != "name"},
             )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -419,7 +419,7 @@ def multi_asset(
         resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition
     )
     _config_schema = check.opt_mapping_param(
-        config_schema,  # type: ignore
+        config_schema,
         "config_schema",
         additional_message="Only dicts are supported for asset config_schema.",
     )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -148,8 +148,8 @@ def schedule(
                 ScheduleExecutionError,
                 lambda: f"Error occurred during the evaluation of schedule {schedule_name}",
             ):
-                if has_at_least_one_parameter(fn):  # type: ignore  # fmt: skip
-                    result = fn(context)  # type: ignore  # fmt: skip
+                if has_at_least_one_parameter(fn):
+                    result = fn(context)
                 else:
                     result = fn()  # type: ignore
 
@@ -173,7 +173,7 @@ def schedule(
                     # this is a run-request based decorated function
                     yield from cast(RunRequestIterator, ensure_gen(result))
 
-        has_context_arg = has_at_least_one_parameter(fn)  # type: ignore  # fmt: skip
+        has_context_arg = has_at_least_one_parameter(fn)
         evaluation_fn = DecoratedScheduleFunction(
             decorated_fn=fn,
             wrapped_fn=_wrapped_fn,
@@ -333,7 +333,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,  # type: ignore[arg-type]
+            pipeline_name=pipeline_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,
@@ -490,7 +490,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,  # type: ignore[arg-type]
+            pipeline_name=pipeline_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,
@@ -635,7 +635,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,  # type: ignore[arg-type]
+            pipeline_name=pipeline_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,
@@ -795,7 +795,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,  # type: ignore[arg-type]
+            pipeline_name=pipeline_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,

--- a/python_modules/dagster/dagster/_core/definitions/definition_config_schema.py
+++ b/python_modules/dagster/dagster/_core/definitions/definition_config_schema.py
@@ -118,9 +118,9 @@ class ConfiguredDefinitionConfigSchema(IDefinitionConfigSchema):
 
         # type-ignores for mypy "Cannot assign to a method" (pyright works)
         if not callable(config_or_config_fn):
-            self._config_fn = lambda _: config_or_config_fn  # type: ignore
+            self._config_fn = lambda _: config_or_config_fn
         else:
-            self._config_fn = config_or_config_fn  # type: ignore
+            self._config_fn = config_or_config_fn
 
     def as_field(self) -> Field:
         return check.not_none(self._current_field)

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -259,12 +259,12 @@ class Output(Generic[T]):
     def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
         return self._metadata_entries
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> Any:
         return self._value
 
-    @public  # type: ignore
+    @public
     @property
     def output_name(self) -> str:
         return self._output_name
@@ -326,17 +326,17 @@ class DynamicOutput(Generic[T]):
     def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
         return self._metadata_entries
 
-    @public  # type: ignore
+    @public
     @property
     def mapping_key(self) -> str:
         return self._mapping_key
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> T:
         return self._value
 
-    @public  # type: ignore
+    @public
     @property
     def output_name(self) -> str:
         return self._output_name
@@ -544,7 +544,7 @@ class AssetMaterialization(
             metadata={"path": MetadataValue.path(path)},
         )
 
-    @public  # type: ignore
+    @public
     @property
     def metadata(self) -> MetadataMapping:
         # PartitionMetadataEntry (unstable API) case is unhandled

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -104,13 +104,13 @@ class ExecutorDefinition(NamedConfigurableDefinition):
         )
         self._description = check.opt_str_param(description, "description")
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         """Name of the executor."""
         return self._name
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         """Description of executor, if provided."""
@@ -125,7 +125,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
     ) -> Sequence[ExecutorRequirement]:
         return self._requirements_fn(executor_config)
 
-    @public  # type: ignore
+    @public
     @property
     def executor_creation_fn(self) -> Optional[ExecutorCreationFunction]:
         return self._executor_creation_fn
@@ -157,7 +157,7 @@ class ExecutorDefinition(NamedConfigurableDefinition):
         name: Optional[str] = None,
         config_schema: Optional[UserConfigSchema] = None,
         description: Optional[str] = None,
-    ) -> Self:  # type: ignore  # fmt: skip
+    ) -> Self:
         """
         Wraps this object in an object of the same type that provides configuration to the inner
         object.

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -73,7 +73,7 @@ def _check_node_defs_arg(
 
     _node_defs = check.opt_sequence_param(node_defs, "node_defs")
     for node_def in _node_defs:
-        if isinstance(node_def, NodeDefinition):  # type: ignore
+        if isinstance(node_def, NodeDefinition):
             continue
         elif callable(node_def):
             raise DagsterInvalidDefinitionError(
@@ -230,7 +230,7 @@ class GraphDefinition(NodeDefinition):
             input_defs=input_defs,
             output_defs=output_defs,
             tags=tags,
-            **kwargs,  # type: ignore  # fmt: skip
+            **kwargs,
         )
 
         # must happen after base class construction as properties are assumed to be there
@@ -353,17 +353,17 @@ class GraphDefinition(NodeDefinition):
                 yield from graph_def.iterate_node_handles(cur_node_handle)
             yield cur_node_handle
 
-    @public  # type: ignore
+    @public
     @property
     def input_mappings(self) -> Sequence[InputMapping]:
         return self._input_mappings
 
-    @public  # type: ignore
+    @public
     @property
     def output_mappings(self) -> Sequence[OutputMapping]:
         return self._output_mappings
 
-    @public  # type: ignore
+    @public
     @property
     def config_mapping(self) -> Optional[ConfigMapping]:
         return self._config_mapping
@@ -420,7 +420,7 @@ class GraphDefinition(NodeDefinition):
         mapped_solid = self.solid_named(mapping.maps_from.solid_name)
         return mapped_solid.definition.resolve_output_to_origin(
             mapping.maps_from.output_name,
-            NodeHandle(mapped_solid.name, handle),  # type: ignore
+            NodeHandle(mapped_solid.name, handle),
         )
 
     def resolve_output_to_origin_op_def(self, output_name: str) -> "OpDefinition":
@@ -689,7 +689,7 @@ class GraphDefinition(NodeDefinition):
         run_config = run_config if run_config is not None else {}
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)
 
-        return ephemeral_job.execute_in_process(  # type: ignore  # fmt: skip
+        return ephemeral_job.execute_in_process(
             run_config=run_config,
             instance=instance,
             raise_on_error=raise_on_error,
@@ -713,12 +713,12 @@ class GraphDefinition(NodeDefinition):
         for dagster_type in self.all_dagster_types():
             yield from dagster_type.get_resource_requirements()
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         return super(GraphDefinition, self).name
 
-    @public  # type: ignore
+    @public
     @property
     def tags(self) -> Mapping[str, str]:
         return super(GraphDefinition, self).tags
@@ -815,7 +815,7 @@ def _validate_in_mappings(
 
     for mapping in input_mappings:
         # handle incorrect objects passed in as mappings
-        if not isinstance(mapping, InputMapping):  # type: ignore  # (isinstance check for error)
+        if not isinstance(mapping, InputMapping):
             if isinstance(mapping, InputDefinition):
                 raise DagsterInvalidDefinitionError(
                     f"In {class_name} '{name}' you passed an InputDefinition "
@@ -912,7 +912,7 @@ def _validate_out_mappings(
 ) -> Tuple[Sequence[OutputMapping], Sequence[OutputDefinition]]:
     output_defs: List[OutputDefinition] = []
     for mapping in output_mappings:
-        if isinstance(mapping, OutputMapping):  # type: ignore
+        if isinstance(mapping, OutputMapping):
             target_solid = solid_dict.get(mapping.maps_from.solid_name)
             if target_solid is None:
                 raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -540,7 +540,7 @@ class In(
             default_value=default_value,
             root_manager_key=check.opt_str_param(root_manager_key, "root_manager_key"),
             metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
-            asset_key=check.opt_inst_param(asset_key, "asset_key", (AssetKey, FunctionType)),  # type: ignore  # (mypy bug)
+            asset_key=check.opt_inst_param(asset_key, "asset_key", (AssetKey, FunctionType)),
             asset_partitions=asset_partitions,
             input_manager_key=check.opt_str_param(input_manager_key, "input_manager_key"),
         )

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -256,27 +256,27 @@ class JobDefinition(PipelineDefinition):
     def describe_target(self):
         return f"{self.target_type} '{self.name}'"
 
-    @public  # type: ignore
+    @public
     @property
     def executor_def(self) -> ExecutorDefinition:
         return self.get_mode_definition().executor_defs[0]
 
-    @public  # type: ignore
+    @public
     @property
     def resource_defs(self) -> Mapping[str, ResourceDefinition]:
         return self.get_mode_definition().resource_defs
 
-    @public  # type: ignore
+    @public
     @property
     def partitioned_config(self) -> Optional[PartitionedConfig]:
         return self.get_mode_definition().partitioned_config
 
-    @public  # type: ignore
+    @public
     @property
     def config_mapping(self) -> Optional[ConfigMapping]:
         return self.get_mode_definition().config_mapping
 
-    @public  # type: ignore
+    @public
     @property
     def loggers(self) -> Mapping[str, LoggerDefinition]:
         return self.get_mode_definition().loggers
@@ -430,7 +430,7 @@ class JobDefinition(PipelineDefinition):
         self,
         op_selection: Optional[Sequence[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ) -> Self:  # type: ignore  # fmt: skip
+    ) -> Self:
         check.invariant(
             not (op_selection and asset_selection),
             (
@@ -448,7 +448,7 @@ class JobDefinition(PipelineDefinition):
     def _get_job_def_for_asset_selection(
         self,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ) -> Self:  # type: ignore  # fmt: skip
+    ) -> Self:
         asset_selection = check.opt_set_param(asset_selection, "asset_selection", AssetKey)
 
         nonexistent_assets = [
@@ -494,7 +494,7 @@ class JobDefinition(PipelineDefinition):
     def _get_job_def_for_op_selection(
         self,
         op_selection: Optional[Sequence[str]] = None,
-    ) -> Self:  # type: ignore  # fmt: skip
+    ) -> Self:
         if not op_selection:
             return self
 
@@ -567,7 +567,7 @@ class JobDefinition(PipelineDefinition):
 
         return self._cached_partition_set
 
-    @public  # type: ignore
+    @public
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
         mode = self.get_mode_definition()
@@ -873,7 +873,7 @@ def default_job_io_manager(init_context: "InitResourceContext"):
                 ),
             )
             with build_resources({"io_manager": attr}, instance=init_context.instance) as resources:
-                return resources.io_manager  # type: ignore
+                return resources.io_manager
         except Exception as e:
             if not silence_failures:
                 raise
@@ -914,7 +914,7 @@ def default_job_io_manager_with_fs_io_manager_schema(init_context: "InitResource
                 ),
             )
             with build_resources({"io_manager": attr}, instance=init_context.instance) as resources:
-                return resources.io_manager  # type: ignore
+                return resources.io_manager
         except Exception as e:
             if not silence_failures:
                 raise

--- a/python_modules/dagster/dagster/_core/definitions/logger_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_definition.py
@@ -85,17 +85,17 @@ class LoggerDefinition(AnonymousConfigurableDefinition):
 
             return logger_invocation_result(self, context)
 
-    @public  # type: ignore
+    @public
     @property
     def logger_fn(self) -> "InitLoggerFunction":
         return self._logger_fn
 
-    @public  # type: ignore
+    @public
     @property
     def config_schema(self) -> Any:
         return self._config_schema
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         return self._description

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -208,7 +208,7 @@ class MetadataValue(ABC):
             )
     """
 
-    @public  # type: ignore
+    @public
     @property
     @abstractmethod
     def value(self) -> object:
@@ -571,7 +571,7 @@ class MetadataValue(ABC):
 
 
 @whitelist_for_serdes(storage_name="TextMetadataEntryData")
-class TextMetadataValue(  # type: ignore
+class TextMetadataValue(
     NamedTuple(
         "_TextMetadataValue",
         [
@@ -591,14 +591,14 @@ class TextMetadataValue(  # type: ignore
             cls, check.opt_str_param(text, "text", default="")
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> Optional[str]:
         return self.text
 
 
 @whitelist_for_serdes(storage_name="UrlMetadataEntryData")
-class UrlMetadataValue(  # type: ignore
+class UrlMetadataValue(
     NamedTuple(
         "_UrlMetadataValue",
         [
@@ -618,14 +618,14 @@ class UrlMetadataValue(  # type: ignore
             cls, check.opt_str_param(url, "url", default="")
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> Optional[str]:
         return self.url
 
 
 @whitelist_for_serdes(storage_name="PathMetadataEntryData")
-class PathMetadataValue(  # type: ignore
+class PathMetadataValue(
     NamedTuple("_PathMetadataValue", [("path", PublicAttr[Optional[str]])]), MetadataValue
 ):
     """Container class for path metadata entry data.
@@ -639,14 +639,14 @@ class PathMetadataValue(  # type: ignore
             cls, check.opt_path_param(path, "path", default="")
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> Optional[str]:
         return self.path
 
 
 @whitelist_for_serdes(storage_name="NotebookMetadataEntryData")
-class NotebookMetadataValue(  # type: ignore
+class NotebookMetadataValue(
     NamedTuple("_NotebookMetadataValue", [("path", PublicAttr[Optional[str]])]), MetadataValue
 ):
     """Container class for notebook metadata entry data.
@@ -660,7 +660,7 @@ class NotebookMetadataValue(  # type: ignore
             cls, check.opt_path_param(path, "path", default="")
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> Optional[str]:
         return self.path
@@ -691,7 +691,7 @@ class JsonMetadataValue(
             raise DagsterInvalidMetadata("Value is a dictionary but is not JSON serializable.")
         return super(JsonMetadataValue, cls).__new__(cls, data)
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> Optional[Union[Sequence[Any], Mapping[str, Any]]]:
         return self.data
@@ -746,7 +746,7 @@ class PythonArtifactMetadataValue(
             cls, check.str_param(module, "module"), check.str_param(name, "name")
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> object:
         return self
@@ -848,7 +848,7 @@ class DagsterAssetMetadataValue(
             cls, check.inst_param(asset_key, "asset_key", AssetKey)
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self) -> "AssetKey":
         return self.value
@@ -873,7 +873,7 @@ class TableMetadataValue(
         schema (Optional[TableSchema]): A schema for the table.
     """
 
-    @public  # type: ignore
+    @public
     @staticmethod
     def infer_column_type(value):
         if isinstance(value, bool):
@@ -910,7 +910,7 @@ class TableMetadataValue(
             schema,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def value(self):
         return self

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -753,12 +753,12 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         self._cursor_advance_state_mutation.advance_all_cursors_called = True
         self._cursor_has_been_updated = True
 
-    @public  # type: ignore
+    @public
     @property
     def assets_defs_by_key(self) -> Mapping[AssetKey, Optional[AssetsDefinition]]:
         return self._assets_by_key
 
-    @public  # type: ignore
+    @public
     @property
     def asset_keys(self) -> Sequence[AssetKey]:
         return self._monitored_asset_keys
@@ -1176,7 +1176,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     "invocation."
                 )
 
-            result = self._raw_asset_materialization_fn()  # type: ignore [TypeGuard limitation]
+            result = self._raw_asset_materialization_fn()
 
         context.update_cursor_after_evaluation()
         return result

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -184,17 +184,17 @@ class OpDefinition(NodeDefinition):
     def is_graph_job_op_node(self) -> bool:
         return True
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         return super(OpDefinition, self).name
 
-    @public  # type: ignore
+    @public
     @property
     def ins(self) -> Mapping[str, In]:
         return {input_def.name: In.from_definition(input_def) for input_def in self.input_defs}
 
-    @public  # type: ignore
+    @public
     @property
     def outs(self) -> Mapping[str, Out]:
         return {output_def.name: Out.from_definition(output_def) for output_def in self.output_defs}
@@ -203,28 +203,28 @@ class OpDefinition(NodeDefinition):
     def compute_fn(self) -> Union[Callable[..., Any], "DecoratedOpFunction"]:
         return self._compute_fn
 
-    @public  # type: ignore
+    @public
     @property
     def config_schema(self) -> IDefinitionConfigSchema:
         return self._config_schema
 
-    @public  # type: ignore
+    @public
     @property
     def required_resource_keys(self) -> AbstractSet[str]:
         return frozenset(self._required_resource_keys)
 
-    @public  # type: ignore
+    @public
     @property
     def version(self) -> Optional[str]:
         deprecation_warning("`version` property on OpDefinition", "2.0")
         return self._version
 
-    @public  # type: ignore
+    @public
     @property
     def retry_policy(self) -> Optional[RetryPolicy]:
         return self._retry_policy
 
-    @public  # type: ignore
+    @public
     @property
     def tags(self) -> Mapping[str, str]:
         return super(OpDefinition, self).tags

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -553,10 +553,10 @@ class PartitionSetDefinition(Generic[T]):
         )
         self._mode = check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME)
         # Type ignores workaround for mypy bug "cannot assign to a method"
-        self._user_defined_run_config_fn_for_partition = check.callable_param(  # type: ignore
+        self._user_defined_run_config_fn_for_partition = check.callable_param(
             run_config_fn_for_partition, "run_config_fn_for_partition"
         )
-        self._user_defined_tags_fn_for_partition = check.callable_param(  # type: ignore
+        self._user_defined_tags_fn_for_partition = check.callable_param(
             tags_fn_for_partition, "tags_fn_for_partition"
         )
         if partitions_def is not None:
@@ -587,7 +587,7 @@ class PartitionSetDefinition(Generic[T]):
             if not current_time:
                 current_time = pendulum.now("UTC")
 
-            check.callable_param(partition_fn, "partition_fn")  # type: ignore
+            check.callable_param(partition_fn, "partition_fn")
 
             if partition_fn_param_count == 1:
                 obj_list = cast(
@@ -631,11 +631,11 @@ class PartitionSetDefinition(Generic[T]):
         return self._partitions_def
 
     def run_config_for_partition(self, partition: Partition[T]) -> Mapping[str, Any]:
-        return copy.deepcopy(self._user_defined_run_config_fn_for_partition(partition))  # type: ignore
+        return copy.deepcopy(self._user_defined_run_config_fn_for_partition(partition))
 
     def tags_for_partition(self, partition: Partition[T]) -> Mapping[str, str]:
         user_tags = validate_tags(
-            self._user_defined_tags_fn_for_partition(partition), allow_reserved_tags=False  # type: ignore
+            self._user_defined_tags_fn_for_partition(partition), allow_reserved_tags=False
         )
         tags = merge_dicts(user_tags, DagsterRun.tags_for_partition_set(self, partition))
 
@@ -892,17 +892,17 @@ class PartitionedConfig(Generic[T]):
             tags_for_partition_fn, "tags_for_partition_fn"
         )
 
-    @public  # type: ignore
+    @public
     @property
     def partitions_def(self) -> PartitionsDefinition[T]:  # pylint: disable=unsubscriptable-object
         return self._partitions
 
-    @public  # type: ignore
+    @public
     @property
     def run_config_for_partition_fn(self) -> Callable[[Partition[T]], Mapping[str, Any]]:
         return self._run_config_for_partition_fn
 
-    @public  # type: ignore
+    @public
     @property
     def tags_for_partition_fn(self) -> Optional[Callable[[Partition[T]], Mapping[str, str]]]:
         return self._tags_for_partition_fn

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -224,7 +224,7 @@ class ReconstructablePipeline(
 
     # Keep the most recent 1 definition (globally since this is a NamedTuple method)
     # This allows repeated calls to get_definition in execution paths to not reload the job
-    @lru_cache(maxsize=1)  # type: ignore
+    @lru_cache(maxsize=1)
     def get_definition(self) -> Union[JobDefinition, "PipelineDefinition"]:
         return self.repository.get_definition().get_maybe_subset_job_def(
             self.pipeline_name,
@@ -268,7 +268,7 @@ class ReconstructablePipeline(
                 solids_to_execute=None,
                 asset_selection=asset_selection,
             )
-        elif isinstance(pipeline_def, PipelineDefinition):  # type: ignore
+        elif isinstance(pipeline_def, PipelineDefinition):
             # when subselecting a pipeline
             # * pipeline subselection depend on solids_to_excute rather than solid_selection
             # * we resolve a list of solid selection queries to a frozenset of qualified solid names
@@ -643,7 +643,7 @@ def _check_is_loadable(definition: T_LoadableDefinition) -> T_LoadableDefinition
             "Loadable attributes must be either a JobDefinition, GraphDefinition, "
             f"PipelineDefinition, AssetGroup, or RepositoryDefinition. Got {repr(definition)}."
         )
-    return definition  # type: ignore
+    return definition
 
 
 def load_def_in_module(
@@ -700,7 +700,7 @@ def def_from_pointer(
             )
         )
 
-    return _check_is_loadable(target())  # type: ignore
+    return _check_is_loadable(target())
 
 
 def pipeline_def_from_pointer(pointer: CodePointer) -> "PipelineDefinition":
@@ -719,7 +719,7 @@ def pipeline_def_from_pointer(pointer: CodePointer) -> "PipelineDefinition":
 
 @overload
 # NOTE: mypy can't handle these overloads but pyright can
-def repository_def_from_target_def(  # type: ignore
+def repository_def_from_target_def(
     target: Union["RepositoryDefinition", "PipelineDefinition", "GraphDefinition", "AssetGroup"],
     repository_load_data: Optional["RepositoryLoadData"] = None,
 ) -> "RepositoryDefinition":

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition.py
@@ -1275,12 +1275,12 @@ class RepositoryDefinition:
     def repository_load_data(self) -> Optional[RepositoryLoadData]:
         return self._repository_load_data
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         return self._name
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         return self._description
@@ -1294,7 +1294,7 @@ class RepositoryDefinition:
         """List[str]: Names of all pipelines/jobs in the repository."""
         return self._repository_data.get_pipeline_names()
 
-    @public  # type: ignore
+    @public
     @property
     def job_names(self) -> Sequence[str]:
         """List[str]: Names of all jobs in the repository."""
@@ -1340,7 +1340,7 @@ class RepositoryDefinition:
     def get_top_level_resources(self) -> Mapping[str, ResourceDefinition]:
         return self._repository_data.get_top_level_resources()
 
-    @public  # type: ignore
+    @public
     def has_job(self, name: str) -> bool:
         """Check if a job with a given name is present in the repository.
 
@@ -1352,7 +1352,7 @@ class RepositoryDefinition:
         """
         return self._repository_data.has_job(name)
 
-    @public  # type: ignore
+    @public
     def get_job(self, name: str) -> JobDefinition:
         """Get a job by name.
 
@@ -1388,29 +1388,29 @@ class RepositoryDefinition:
     def get_partition_set_def(self, name: str) -> PartitionSetDefinition:
         return self._repository_data.get_partition_set(name)
 
-    @public  # type: ignore
+    @public
     @property
     def schedule_defs(self) -> Sequence[ScheduleDefinition]:
         return self._repository_data.get_all_schedules()
 
-    @public  # type: ignore
+    @public
     def get_schedule_def(self, name: str) -> ScheduleDefinition:
         return self._repository_data.get_schedule(name)
 
-    @public  # type: ignore
+    @public
     def has_schedule_def(self, name: str) -> bool:
         return self._repository_data.has_schedule(name)
 
-    @public  # type: ignore
+    @public
     @property
     def sensor_defs(self) -> Sequence[SensorDefinition]:
         return self._repository_data.get_all_sensors()
 
-    @public  # type: ignore
+    @public
     def get_sensor_def(self, name: str) -> SensorDefinition:
         return self._repository_data.get_sensor(name)
 
-    @public  # type: ignore
+    @public
     def has_sensor_def(self, name: str) -> bool:
         return self._repository_data.has_sensor(name)
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -114,17 +114,17 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
     def config_schema(self) -> IDefinitionConfigSchema:
         return self._config_schema
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         return self._description
 
-    @public  # type: ignore
+    @public
     @property
     def version(self) -> Optional[str]:
         return self._version
 
-    @public  # type: ignore
+    @public
     @property
     def required_resource_keys(self) -> AbstractSet[str]:
         return self._required_resource_keys
@@ -265,7 +265,7 @@ class _ResourceDecoratorCallable:
     def __call__(self, resource_fn: ResourceFunction) -> ResourceDefinition:
         check.callable_param(resource_fn, "resource_fn")
 
-        any_name = ["*"] if has_at_least_one_parameter(resource_fn) else []  # type: ignore  # fmt: skip
+        any_name = ["*"] if has_at_least_one_parameter(resource_fn) else []
 
         params = get_function_params(resource_fn)
 
@@ -343,7 +343,7 @@ def resource(
     # This case is for when decorator is used bare, without arguments.
     # E.g. @resource versus @resource()
     if callable(config_schema) and not is_callable_valid_config_arg(config_schema):
-        return _ResourceDecoratorCallable()(config_schema)  # type: ignore
+        return _ResourceDecoratorCallable()(config_schema)
 
     def _wrap(resource_fn: ResourceFunction) -> "ResourceDefinition":
         return _ResourceDecoratorCallable(
@@ -383,5 +383,5 @@ def make_values_resource(**kwargs: Any) -> ResourceDefinition:
     """
     return ResourceDefinition(
         resource_fn=lambda init_context: init_context.resource_config,
-        config_schema=kwargs or Any,  # type: ignore
+        config_schema=kwargs or Any,
     )

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -29,8 +29,8 @@ def resource_invocation_result(
 
     resource_fn = resource_def.resource_fn
     val_or_gen = (
-        resource_fn(_init_context)  # type: ignore  # fmt: skip
-        if has_at_least_one_parameter(resource_fn)  # type: ignore  # fmt: skip
+        resource_fn(_init_context)
+        if has_at_least_one_parameter(resource_fn)
         else resource_fn()  # type: ignore  # (strict type guard)
     )
     if inspect.isgenerator(val_or_gen):
@@ -57,7 +57,7 @@ def _check_invocation_requirements(
         build_init_resource_context,
     )
 
-    context_provided = has_at_least_one_parameter(resource_def.resource_fn)  # type: ignore  # fmt: skip
+    context_provided = has_at_least_one_parameter(resource_def.resource_fn)
     if context_provided and resource_def.required_resource_keys and init_context is None:
         raise DagsterInvalidInvocationError(
             "Resource has required resources, but no context was provided. Use the "

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -136,27 +136,27 @@ class RunStatusSensorContext:
             context=self._context,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def sensor_name(self) -> str:
         return self._sensor_name
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_run(self) -> DagsterRun:
         return self._dagster_run
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_event(self) -> DagsterEvent:
         return self._dagster_event
 
-    @public  # type: ignore
+    @public
     @property
     def instance(self) -> DagsterInstance:
         return self._instance
 
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> logging.Logger:
         if self._context:
@@ -621,7 +621,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                         lambda: f'Error occurred during the execution sensor "{name}".',
                     ):
                         # one user code invocation maps to one failure event
-                        sensor_return = run_status_sensor_fn(  # type: ignore  # fmt: skip
+                        sensor_return = run_status_sensor_fn(
                             RunStatusSensorContext(  # type: ignore
                                 sensor_name=name,
                                 dagster_run=pipeline_run,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -152,7 +152,7 @@ class ScheduleEvaluationContext:
         self._exit_stack.close()
         self._logger = None
 
-    @public  # type: ignore
+    @public
     @property
     def instance(self) -> "DagsterInstance":
         # self._instance_ref should only ever be None when this ScheduleEvaluationContext was
@@ -167,7 +167,7 @@ class ScheduleEvaluationContext:
             )
         return cast(DagsterInstance, self._instance)
 
-    @public  # type: ignore
+    @public
     @property
     def scheduled_execution_time(self) -> Optional[datetime]:
         return self._scheduled_execution_time
@@ -408,7 +408,7 @@ class ScheduleDefinition:
                 )
             elif tags:
                 tags = validate_tags(tags, allow_reserved_tags=False)
-                tags_fn = lambda _context: tags  # type: ignore
+                tags_fn = lambda _context: tags
             else:
                 tags_fn = check.opt_callable_param(
                     tags_fn, "tags_fn", default=lambda _context: cast(Mapping[str, str], {})
@@ -439,8 +439,8 @@ class ScheduleDefinition:
                 ):
                     _run_config_fn = check.not_none(self._run_config_fn)
                     evaluated_run_config = copy.deepcopy(
-                        _run_config_fn(context)  # type: ignore  # fmt: skip
-                        if has_at_least_one_parameter(_run_config_fn)  # type: ignore  # fmt: skip
+                        _run_config_fn(context)
+                        if has_at_least_one_parameter(_run_config_fn)
                         else _run_config_fn()  # type: ignore  # (strict type guard)
                     )
 
@@ -448,11 +448,11 @@ class ScheduleDefinition:
                     ScheduleExecutionError,
                     lambda: f"Error occurred during the execution of tags_fn for schedule {name}",
                 ):
-                    evaluated_tags = validate_tags(tags_fn(context), allow_reserved_tags=False)  # type: ignore
+                    evaluated_tags = validate_tags(tags_fn(context), allow_reserved_tags=False)
 
                 yield RunRequest(
                     run_key=None,
-                    run_config=evaluated_run_config,  # type: ignore
+                    run_config=evaluated_run_config,
                     tags=evaluated_tags,
                 )
 
@@ -509,50 +509,50 @@ class ScheduleDefinition:
 
             context = context if context else build_schedule_context()
 
-            result = self._execution_fn.decorated_fn(context)  # type: ignore
+            result = self._execution_fn.decorated_fn(context)
         else:
             if len(args) + len(kwargs) > 0:
                 raise DagsterInvalidInvocationError(
                     "Decorated schedule function takes no arguments, but arguments were provided."
                 )
-            result = self._execution_fn.decorated_fn()  # type: ignore
+            result = self._execution_fn.decorated_fn()
 
         if isinstance(result, dict):
             return copy.deepcopy(result)
         else:
             return result
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         return self._name
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> str:
         return self._target.pipeline_name
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         return self._description
 
-    @public  # type: ignore
+    @public
     @property
     def cron_schedule(self) -> Union[str, Sequence[str]]:
         return self._cron_schedule  # type: ignore
 
-    @public  # type: ignore
+    @public
     @property
     def environment_vars(self) -> Mapping[str, str]:
         return self._environment_vars
 
-    @public  # type: ignore
+    @public
     @property
     def execution_timezone(self) -> Optional[str]:
         return self._execution_timezone
 
-    @public  # type: ignore
+    @public
     @property
     def job(self) -> Union[GraphDefinition, PipelineDefinition, UnresolvedAssetJobDefinition]:
         if isinstance(self._target, DirectTarget):
@@ -598,15 +598,15 @@ class ScheduleDefinition:
         else:
             # NOTE: mypy is not correctly reading this cast-- not sure why
             # (pyright reads it fine). Hence the type-ignores below.
-            result = cast(List[RunRequest], check.is_list(result, of_type=RunRequest))  # type: ignore
+            result = cast(List[RunRequest], check.is_list(result, of_type=RunRequest))
             check.invariant(
-                not any(not request.run_key for request in result),  # type: ignore
+                not any(not request.run_key for request in result),
                 (
                     "Schedules that return multiple RunRequests must specify a run_key in each"
                     " RunRequest"
                 ),
             )
-            run_requests = result  # type: ignore
+            run_requests = result
             skip_message = None
 
         # clone all the run requests with the required schedule tags
@@ -640,7 +640,7 @@ class ScheduleDefinition:
 
         check.failed("Target is not loadable")
 
-    @public  # type: ignore
+    @public
     @property
     def default_status(self) -> DefaultScheduleStatus:
         return self._default_status

--- a/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
@@ -84,7 +84,9 @@ class ScopedResourcesBuilder(
         if self.contains_generator:
 
             class _ScopedResourcesContainsGenerator(
-                namedtuple("_ScopedResourcesContainsGenerator", list(resource_instance_dict.keys())),  # type: ignore[misc]
+                namedtuple(
+                    "_ScopedResourcesContainsGenerator", list(resource_instance_dict.keys())
+                ),
                 Resources,
                 IContainsGenerator,
             ):
@@ -95,7 +97,7 @@ class ScopedResourcesBuilder(
         else:
 
             class _ScopedResources(
-                namedtuple("_ScopedResources", list(resource_instance_dict.keys())),  # type: ignore[misc]
+                namedtuple("_ScopedResources", list(resource_instance_dict.keys())),
                 Resources,
             ):
                 ...

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -122,7 +122,7 @@ class SensorEvaluationContext:
         self._exit_stack.close()
         self._logger = None
 
-    @public  # type: ignore
+    @public
     @property
     def instance(self) -> DagsterInstance:
         # self._instance_ref should only ever be None when this SensorEvaluationContext was
@@ -142,17 +142,17 @@ class SensorEvaluationContext:
     def instance_ref(self) -> Optional[InstanceRef]:
         return self._instance_ref
 
-    @public  # type: ignore
+    @public
     @property
     def last_completion_time(self) -> Optional[float]:
         return self._last_completion_time
 
-    @public  # type: ignore
+    @public
     @property
     def last_run_key(self) -> Optional[str]:
         return self._last_run_key
 
-    @public  # type: ignore
+    @public
     @property
     def cursor(self) -> Optional[str]:
         """The cursor value for this sensor, which was set in an earlier sensor evaluation."""
@@ -171,12 +171,12 @@ class SensorEvaluationContext:
         """
         self._cursor = check.opt_str_param(cursor, "cursor")
 
-    @public  # type: ignore
+    @public
     @property
     def repository_name(self) -> Optional[str]:
         return self._repository_name
 
-    @public  # type: ignore
+    @public
     @property
     def repository_def(self) -> Optional["RepositoryDefinition"]:
         return self._repository_def
@@ -368,17 +368,17 @@ class SensorDefinition:
 
             return self._raw_fn()
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         return self._name
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> Optional[str]:
         return self._description
 
-    @public  # type: ignore
+    @public
     @property
     def minimum_interval_seconds(self) -> Optional[int]:
         return self._min_interval
@@ -387,7 +387,7 @@ class SensorDefinition:
     def targets(self) -> Sequence[Union[DirectTarget, RepoRelativeTarget]]:
         return self._targets
 
-    @public  # type: ignore
+    @public
     @property
     def job(self) -> Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]:
         if self._targets:
@@ -509,7 +509,7 @@ class SensorDefinition:
     def _target(self) -> Optional[Union[DirectTarget, RepoRelativeTarget]]:
         return self._targets[0] if self._targets else None
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> Optional[str]:
         if len(self._targets) > 1:
@@ -519,7 +519,7 @@ class SensorDefinition:
             )
         return self._targets[0].pipeline_name
 
-    @public  # type: ignore
+    @public
     @property
     def default_status(self) -> DefaultSensorStatus:
         return self._default_status
@@ -575,8 +575,8 @@ def wrap_sensor_evaluation(
     fn: RawSensorEvaluationFunction,
 ) -> SensorEvaluationFunction:
     def _wrapped_fn(context: SensorEvaluationContext):
-        if has_at_least_one_parameter(fn):  # type: ignore  # fmt: skip
-            result = fn(context)  # type: ignore  # fmt: skip
+        if has_at_least_one_parameter(fn):
+            result = fn(context)
         else:
             result = fn()  # type: ignore
 

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -120,8 +120,8 @@ class SourceAsset(ResourceAddable):
             metadata, [], allow_invalid=True
         )
         self.resource_defs = dict(check.opt_mapping_param(resource_defs, "resource_defs"))
-        self._io_manager_def = check.opt_inst_param(  # type: ignore
-            io_manager_def, "io_manager_def", IOManagerDefinition  # type: ignore
+        self._io_manager_def = check.opt_inst_param(
+            io_manager_def, "io_manager_def", IOManagerDefinition
         )
         if self._io_manager_def:
             if not io_manager_key:
@@ -147,7 +147,7 @@ class SourceAsset(ResourceAddable):
         self.observe_fn = check.opt_callable_param(observe_fn, "observe_fn")
         self._node_def = None
 
-    @public  # type: ignore
+    @public
     @property
     def metadata(self) -> MetadataMapping:
         # PartitionMetadataEntry (unstable API) case is unhandled
@@ -164,7 +164,7 @@ class SourceAsset(ResourceAddable):
             self.resource_defs.get(io_manager_key) if io_manager_key else None,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def op(self) -> OpDefinition:
         check.invariant(
@@ -173,7 +173,7 @@ class SourceAsset(ResourceAddable):
         )
         return cast(OpDefinition, self.node_def)
 
-    @public  # type: ignore
+    @public
     @property
     def is_observable(self) -> bool:
         return self.node_def is not None
@@ -181,7 +181,7 @@ class SourceAsset(ResourceAddable):
     def _get_op_def_compute_fn(self, observe_fn: SourceAssetObserveFunction):
         from dagster._core.definitions.decorators.solid_decorator import DecoratedOpFunction
 
-        observe_fn_has_context = has_at_least_one_parameter(observe_fn)  # type: ignore # mypy-only error
+        observe_fn_has_context = has_at_least_one_parameter(observe_fn)
 
         def fn(context: OpExecutionContext):
             logical_version = observe_fn(context) if observe_fn_has_context else observe_fn()  # type: ignore

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -435,7 +435,7 @@ class TimeWindowPartitionsDefinition(
 
         return self.get_partition_keys_in_time_window(TimeWindow(start_time, end_time))
 
-    @public  # type: ignore
+    @public
     @property
     def schedule_type(self) -> Optional[ScheduleType]:
         if re.match(r"\d+ \* \* \* \*", self.cron_schedule):
@@ -449,7 +449,7 @@ class TimeWindowPartitionsDefinition(
         else:
             return None
 
-    @public  # type: ignore
+    @public
     @property
     def minute_offset(self) -> int:
         match = re.match(r"(\d+) (\d+|\*) (\d+|\*) (\d+|\*) (\d+|\*)", self.cron_schedule)
@@ -457,7 +457,7 @@ class TimeWindowPartitionsDefinition(
             check.failed(f"{self.cron_schedule} has no minute offset")
         return int(match.groups()[0])
 
-    @public  # type: ignore
+    @public
     @property
     def hour_offset(self) -> int:
         match = re.match(r"(\d+|\*) (\d+) (\d+|\*) (\d+|\*) (\d+|\*)", self.cron_schedule)
@@ -465,7 +465,7 @@ class TimeWindowPartitionsDefinition(
             check.failed(f"{self.cron_schedule} has no hour offset")
         return int(match.groups()[1])
 
-    @public  # type: ignore
+    @public
     @property
     def day_offset(self) -> int:
         schedule_type = self.schedule_type

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -84,7 +84,7 @@ class UnresolvedAssetJobDefinition(
         )
         run_config_fn = (
             partitioned_config
-            and partitioned_config.run_config_for_partition_fn  # type: ignore
+            and partitioned_config.run_config_for_partition_fn
             or (lambda _: cast(Dict[str, str], {}))
         )
         return PartitionSetDefinition(

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -127,10 +127,10 @@ class EventRecordsFilter(
             event_type=event_type,
             asset_key=check.opt_inst_param(asset_key, "asset_key", AssetKey),
             asset_partitions=asset_partitions,
-            after_cursor=check.opt_inst_param(  # type: ignore
+            after_cursor=check.opt_inst_param(
                 after_cursor, "after_cursor", (int, RunShardedEventsCursor)
             ),
-            before_cursor=check.opt_inst_param(  # type: ignore
+            before_cursor=check.opt_inst_param(
                 before_cursor, "before_cursor", (int, RunShardedEventsCursor)
             ),
             after_timestamp=check.opt_float_param(after_timestamp, "after_timestamp"),

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -510,23 +510,23 @@ class DagsterEvent(
         solid_handle = cast(NodeHandle, self.solid_handle)
         return solid_handle.name
 
-    @public  # type: ignore
+    @public
     @property
     def event_type(self) -> DagsterEventType:
         """DagsterEventType: The type of this event."""
         return DagsterEventType(self.event_type_value)
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_event(self) -> bool:
         return self.event_type in STEP_EVENTS
 
-    @public  # type: ignore
+    @public
     @property
     def is_hook_event(self) -> bool:
         return self.event_type in HOOK_EVENTS
 
-    @public  # type: ignore
+    @public
     @property
     def is_alert_event(self) -> bool:
         return self.event_type in ALERT_EVENTS
@@ -537,42 +537,42 @@ class DagsterEvent(
 
         return StepKind(self.step_kind_value)
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_success(self) -> bool:
         return self.event_type == DagsterEventType.STEP_SUCCESS
 
-    @public  # type: ignore
+    @public
     @property
     def is_successful_output(self) -> bool:
         return self.event_type == DagsterEventType.STEP_OUTPUT
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_start(self) -> bool:
         return self.event_type == DagsterEventType.STEP_START
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_failure(self) -> bool:
         return self.event_type == DagsterEventType.STEP_FAILURE
 
-    @public  # type: ignore
+    @public
     @property
     def is_resource_init_failure(self) -> bool:
         return self.event_type == DagsterEventType.RESOURCE_INIT_FAILURE
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_skipped(self) -> bool:
         return self.event_type == DagsterEventType.STEP_SKIPPED
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_up_for_retry(self) -> bool:
         return self.event_type == DagsterEventType.STEP_UP_FOR_RETRY
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_restarted(self) -> bool:
         return self.event_type == DagsterEventType.STEP_RESTARTED
@@ -589,7 +589,7 @@ class DagsterEvent(
     def is_run_failure(self) -> bool:
         return self.event_type == DagsterEventType.RUN_FAILURE
 
-    @public  # type: ignore
+    @public
     @property
     def is_failure(self) -> bool:
         return self.event_type in FAILURE_EVENTS
@@ -598,42 +598,42 @@ class DagsterEvent(
     def is_pipeline_event(self) -> bool:
         return self.event_type in PIPELINE_EVENTS
 
-    @public  # type: ignore
+    @public
     @property
     def is_engine_event(self) -> bool:
         return self.event_type == DagsterEventType.ENGINE_EVENT
 
-    @public  # type: ignore
+    @public
     @property
     def is_handled_output(self) -> bool:
         return self.event_type == DagsterEventType.HANDLED_OUTPUT
 
-    @public  # type: ignore
+    @public
     @property
     def is_loaded_input(self) -> bool:
         return self.event_type == DagsterEventType.LOADED_INPUT
 
-    @public  # type: ignore
+    @public
     @property
     def is_step_materialization(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_MATERIALIZATION
 
-    @public  # type: ignore
+    @public
     @property
     def is_expectation_result(self) -> bool:
         return self.event_type == DagsterEventType.STEP_EXPECTATION_RESULT
 
-    @public  # type: ignore
+    @public
     @property
     def is_asset_observation(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_OBSERVATION
 
-    @public  # type: ignore
+    @public
     @property
     def is_asset_materialization_planned(self) -> bool:
         return self.event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED
 
-    @public  # type: ignore
+    @public
     @property
     def asset_key(self) -> Optional[AssetKey]:
         if self.event_type == DagsterEventType.ASSET_MATERIALIZATION:
@@ -645,7 +645,7 @@ class DagsterEvent(
         else:
             return None
 
-    @public  # type: ignore
+    @public
     @property
     def partition(self) -> Optional[str]:
         if self.event_type == DagsterEventType.ASSET_MATERIALIZATION:

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -107,17 +107,17 @@ class EventLogEntry(
             check.opt_inst_param(dagster_event, "dagster_event", DagsterEvent),
         )
 
-    @public  # type: ignore
+    @public
     @property
     def is_dagster_event(self) -> bool:
         return bool(self.dagster_event)
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> Optional[str]:
         return self.pipeline_name
 
-    @public  # type: ignore
+    @public
     def get_dagster_event(self) -> DagsterEvent:
         if not isinstance(self.dagster_event, DagsterEvent):
             check.failed(
@@ -133,12 +133,12 @@ class EventLogEntry(
     def from_json(json_str):
         return deserialize_json_to_dagster_namedtuple(json_str)
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_event_type(self):
         return self.dagster_event.event_type if self.dagster_event else None
 
-    @public  # type: ignore
+    @public
     @property
     def message(self) -> str:
         """

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -116,7 +116,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     def solid_config(self) -> Any:
         return self._step_execution_context.op_config
 
-    @public  # type: ignore
+    @public
     @property
     def op_config(self) -> Any:
         return self.solid_config
@@ -131,13 +131,13 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """DagsterRun: The current run."""
         return cast(DagsterRun, self.pipeline_run)
 
-    @public  # type: ignore
+    @public
     @property
     def instance(self) -> DagsterInstance:
         """DagsterInstance: The current Dagster instance."""
         return self._step_execution_context.instance
 
-    @public  # type: ignore
+    @public
     @property
     def pdb(self) -> ForkedPdb:
         """dagster.utils.forked_pdb.ForkedPdb: Gives access to pdb debugging from within the op.
@@ -165,7 +165,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             " 0.10.0. Please access it via `context.resources.file_manager` instead."
         )
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> Any:
         """Resources: The currently available resources."""
@@ -176,13 +176,13 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """Optional[StepLauncher]: The current step launcher, if any."""
         return self._step_execution_context.step_launcher
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         """str: The id of the current execution's run."""
         return self._step_execution_context.run_id
 
-    @public  # type: ignore
+    @public
     @property
     def run_config(self) -> Mapping[str, object]:
         """dict: The run config for the current execution."""
@@ -193,7 +193,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """PipelineDefinition: The currently executing pipeline."""
         return self._step_execution_context.pipeline_def
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> JobDefinition:
         """JobDefinition: The currently executing job."""
@@ -211,7 +211,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """str: The name of the currently executing pipeline."""
         return self._step_execution_context.pipeline_name
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> str:
         """str: The name of the currently executing job."""
@@ -222,7 +222,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """ModeDefinition: The mode of the current execution."""
         return self._step_execution_context.mode_def
 
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> DagsterLogManager:
         """DagsterLogManager: The log manager available in the execution context."""
@@ -262,19 +262,19 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self.solid
 
-    @public  # type: ignore
+    @public
     @property
     def op_def(self) -> OpDefinition:
         """OpDefinition: The current op definition."""
         return cast(OpDefinition, self.op.definition)
 
-    @public  # type: ignore
+    @public
     @property
     def has_partition_key(self) -> bool:
         """Whether the current run is a partitioned run."""
         return self._step_execution_context.has_partition_key
 
-    @public  # type: ignore
+    @public
     @property
     def partition_key(self) -> str:
         """The partition key for the current run.
@@ -283,7 +283,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.partition_key
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
         """The asset partition key for the current run.
@@ -292,7 +292,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.asset_partition_key_range
 
-    @public  # type: ignore
+    @public
     @property
     def partition_time_window(self) -> str:
         """The partition time window for the current run.
@@ -302,7 +302,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context.partition_time_window
 
-    @public  # type: ignore
+    @public
     @property
     def selected_asset_keys(self) -> AbstractSet[AssetKey]:
         assets_def = self.job_def.asset_layer.assets_def_for_node(self.solid_handle)
@@ -310,7 +310,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             return set()
         return assets_def.keys
 
-    @public  # type: ignore
+    @public
     @property
     def selected_output_names(self) -> AbstractSet[str]:
         # map selected asset keys to the output names they correspond to
@@ -582,7 +582,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """
         return self._step_execution_context
 
-    @public  # type: ignore
+    @public
     @property
     def retry_number(self) -> int:
         """

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -75,17 +75,17 @@ class HookContext:
     def pipeline_name(self) -> str:
         return self.job_name
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> str:
         return self._step_execution_context.job_name
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         return self._step_execution_context.run_id
 
-    @public  # type: ignore
+    @public
     @property
     def hook_def(self) -> HookDefinition:
         return self._hook_def
@@ -102,17 +102,17 @@ class HookContext:
         )
         return self._step_execution_context.step
 
-    @public  # type: ignore
+    @public
     @property
     def step_key(self) -> str:
         return self._step_execution_context.step.key
 
-    @public  # type: ignore
+    @public
     @property
     def required_resource_keys(self) -> AbstractSet[str]:
         return self._required_resource_keys
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> "Resources":
         return self._resources
@@ -124,7 +124,7 @@ class HookContext:
         )
         return solid_config.config if solid_config else None
 
-    @public  # type: ignore
+    @public
     @property
     def op_config(self) -> Any:
         return self.solid_config
@@ -132,7 +132,7 @@ class HookContext:
     # Because of the fact that we directly use the log manager of the step, if a user calls
     # hook_context.log.with_tags, then they will end up mutating the step's logging tags as well.
     # This is not problematic because the hook only runs after the step has been completed.
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> DagsterLogManager:
         return self._step_execution_context.log
@@ -146,7 +146,7 @@ class HookContext:
         """
         return self.op_exception
 
-    @public  # type: ignore
+    @public
     @property
     def op_exception(self):
         exc = self._step_execution_context.step_exception
@@ -184,7 +184,7 @@ class HookContext:
 
         return results
 
-    @public  # type: ignore
+    @public
     @property
     def op_output_values(self):
         return self.solid_output_values
@@ -417,7 +417,7 @@ def build_hook_context(
 
     return UnboundHookContext(
         resources=check.opt_mapping_param(resources, "resources", key_type=str),
-        op=op,  # type: ignore[arg-type] # (mypy bug)
+        op=op,
         run_id=check.opt_str_param(run_id, "run_id"),
         job_name=check.opt_str_param(job_name, "job_name"),
         op_exception=check.opt_inst_param(op_exception, "op_exception", Exception),

--- a/python_modules/dagster/dagster/_core/execution/context/init.py
+++ b/python_modules/dagster/dagster/_core/execution/context/init.py
@@ -62,22 +62,22 @@ class InitResourceContext:
         self._resources = resources
         self._dagster_run = dagster_run
 
-    @public  # type: ignore
+    @public
     @property
     def resource_config(self) -> Any:
         return self._resource_config
 
-    @public  # type: ignore
+    @public
     @property
     def resource_def(self) -> Optional[ResourceDefinition]:
         return self._resource_def
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> Resources:
         return self._resources
 
-    @public  # type: ignore
+    @public
     @property
     def instance(self) -> Optional[DagsterInstance]:
         return self._instance
@@ -86,18 +86,18 @@ class InitResourceContext:
     def dagster_run(self) -> Optional[DagsterRun]:
         return self._dagster_run
 
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> Optional[DagsterLogManager]:
         return self._log_manager
 
     # backcompat: keep around this property from when InitResourceContext used to be a NamedTuple
-    @public  # type: ignore
+    @public
     @property
     def log_manager(self) -> Optional[DagsterLogManager]:
         return self._log_manager
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> Optional[str]:
         return self.dagster_run.run_id if self.dagster_run else None

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -162,7 +162,7 @@ class InputContext:
             )
         return self._instance
 
-    @public  # type: ignore
+    @public
     @property
     def has_input_name(self) -> bool:
         """If we're the InputContext is being used to load the result of a run from outside the run,
@@ -170,7 +170,7 @@ class InputContext:
         """
         return self._name is not None
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         if self._name is None:
@@ -204,7 +204,7 @@ class InputContext:
 
         return self._solid_def
 
-    @public  # type: ignore
+    @public
     @property
     def op_def(self) -> "OpDefinition":
         from dagster._core.definitions import OpDefinition
@@ -217,22 +217,22 @@ class InputContext:
 
         return cast(OpDefinition, self._solid_def)
 
-    @public  # type: ignore
+    @public
     @property
     def config(self) -> Any:
         return self._config
 
-    @public  # type: ignore
+    @public
     @property
     def metadata(self) -> Optional[Mapping[str, Any]]:
         return self._metadata
 
-    @public  # type: ignore
+    @public
     @property
     def upstream_output(self) -> Optional["OutputContext"]:
         return self._upstream_output
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_type(self) -> "DagsterType":
         if self._dagster_type is None:
@@ -243,7 +243,7 @@ class InputContext:
 
         return self._dagster_type
 
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> "DagsterLogManager":
         if self._log is None:
@@ -254,12 +254,12 @@ class InputContext:
 
         return self._log
 
-    @public  # type: ignore
+    @public
     @property
     def resource_config(self) -> Optional[Mapping[str, Any]]:
         return self._resource_config
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> Any:
         if self._resources is None:
@@ -276,12 +276,12 @@ class InputContext:
             )
         return self._resources
 
-    @public  # type: ignore
+    @public
     @property
     def has_asset_key(self) -> bool:
         return self._asset_key is not None
 
-    @public  # type: ignore
+    @public
     @property
     def asset_key(self) -> AssetKey:
         if self._asset_key is None:
@@ -291,7 +291,7 @@ class InputContext:
 
         return self._asset_key
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partitions_def(self) -> "PartitionsDefinition":
         """The PartitionsDefinition on the upstream asset corresponding to this input."""
@@ -319,13 +319,13 @@ class InputContext:
 
         return self._step_context
 
-    @public  # type: ignore
+    @public
     @property
     def has_partition_key(self) -> bool:
         """Whether the current run is a partitioned run."""
         return self._partition_key is not None
 
-    @public  # type: ignore
+    @public
     @property
     def partition_key(self) -> str:
         """The partition key for the current run.
@@ -339,12 +339,12 @@ class InputContext:
 
         return self._partition_key
 
-    @public  # type: ignore
+    @public
     @property
     def has_asset_partitions(self) -> bool:
         return self._asset_partitions_subset is not None
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_key(self) -> str:
         """The partition key for input asset.
@@ -366,7 +366,7 @@ class InputContext:
                 f"but the number of input partitions != 1: '{subset}'."
             )
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for input asset.
@@ -391,7 +391,7 @@ class InputContext:
 
         return partition_key_ranges[0]
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_keys(self) -> Sequence[str]:
         """The partition keys for input asset.
@@ -405,7 +405,7 @@ class InputContext:
 
         return list(self._asset_partitions_subset.get_partition_keys())
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partitions_time_window(self) -> TimeWindow:
         """The time window for the partitions of the input asset.

--- a/python_modules/dagster/dagster/_core/execution/context/logger.py
+++ b/python_modules/dagster/dagster/_core/execution/context/logger.py
@@ -48,7 +48,7 @@ class InitLoggerContext:
         self._logger_def = check.opt_inst_param(logger_def, "logger_def", LoggerDefinition)
         self._run_id = check.opt_str_param(run_id, "run_id")
 
-    @public  # type: ignore
+    @public
     @property
     def logger_config(self) -> Any:
         return self._logger_config
@@ -57,7 +57,7 @@ class InitLoggerContext:
     def pipeline_def(self) -> Optional[PipelineDefinition]:
         return self._pipeline_def
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> Optional[JobDefinition]:
         if not self._pipeline_def:
@@ -69,12 +69,12 @@ class InitLoggerContext:
             )
         return self._pipeline_def
 
-    @public  # type: ignore
+    @public
     @property
     def logger_def(self) -> Optional[LoggerDefinition]:
         return self._logger_def
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> Optional[str]:
         return self._run_id

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -182,7 +182,7 @@ class OutputContext:
         ):
             self._resources_cm.__exit__(None, None, None)  # pylint: disable=no-member
 
-    @public  # type: ignore
+    @public
     @property
     def step_key(self) -> str:
         if self._step_key is None:
@@ -193,7 +193,7 @@ class OutputContext:
 
         return self._step_key
 
-    @public  # type: ignore
+    @public
     @property
     def name(self) -> str:
         if self._name is None:
@@ -214,7 +214,7 @@ class OutputContext:
 
         return self._pipeline_name
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         if self._run_id is None:
@@ -225,22 +225,22 @@ class OutputContext:
 
         return self._run_id
 
-    @public  # type: ignore
+    @public
     @property
     def metadata(self) -> Optional[Mapping[str, object]]:
         return self._metadata
 
-    @public  # type: ignore
+    @public
     @property
     def mapping_key(self) -> Optional[str]:
         return self._mapping_key
 
-    @public  # type: ignore
+    @public
     @property
     def config(self) -> Any:
         return self._config
 
-    @public  # type: ignore
+    @public
     @property
     def op_def(self) -> "OpDefinition":
         from dagster._core.definitions import OpDefinition
@@ -253,7 +253,7 @@ class OutputContext:
 
         return cast(OpDefinition, self._op_def)
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_type(self) -> "DagsterType":
         if self._dagster_type is None:
@@ -264,7 +264,7 @@ class OutputContext:
 
         return self._dagster_type
 
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> "DagsterLogManager":
         if self._log is None:
@@ -275,17 +275,17 @@ class OutputContext:
 
         return self._log
 
-    @public  # type: ignore
+    @public
     @property
     def version(self) -> Optional[str]:
         return self._version
 
-    @public  # type: ignore
+    @public
     @property
     def resource_config(self) -> Optional[Mapping[str, object]]:
         return self._resource_config
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> Any:
         if self._resources is None:
@@ -306,12 +306,12 @@ class OutputContext:
     def asset_info(self) -> Optional[AssetOutputInfo]:
         return self._asset_info
 
-    @public  # type: ignore
+    @public
     @property
     def has_asset_key(self) -> bool:
         return self._asset_info is not None
 
-    @public  # type: ignore
+    @public
     @property
     def asset_key(self) -> AssetKey:
         if self._asset_info is None:
@@ -322,7 +322,7 @@ class OutputContext:
 
         return self._asset_info.key
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partitions_def(self) -> "PartitionsDefinition":
         """The PartitionsDefinition on the asset corresponding to this output."""
@@ -354,7 +354,7 @@ class OutputContext:
 
         return self._step_context
 
-    @public  # type: ignore
+    @public
     @property
     def has_partition_key(self) -> bool:
         """Whether the current run is a partitioned run."""
@@ -368,7 +368,7 @@ class OutputContext:
 
         return self._partition_key is not None
 
-    @public  # type: ignore
+    @public
     @property
     def partition_key(self) -> str:
         """The partition key for the current run.
@@ -390,7 +390,7 @@ class OutputContext:
 
         return self._partition_key
 
-    @public  # type: ignore
+    @public
     @property
     def has_asset_partitions(self) -> bool:
         if self._warn_on_step_context_use:
@@ -406,7 +406,7 @@ class OutputContext:
         else:
             return False
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_key(self) -> str:
         """The partition key for output asset.
@@ -424,7 +424,7 @@ class OutputContext:
 
         return self.step_context.asset_partition_key_for_output(self.name)
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for output asset.
@@ -441,7 +441,7 @@ class OutputContext:
 
         return self.step_context.asset_partition_key_range_for_output(self.name)
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partition_keys(self) -> Sequence[str]:
         """The partition keys for the output asset.
@@ -460,7 +460,7 @@ class OutputContext:
             self.step_context.asset_partition_key_range_for_output(self.name)
         )
 
-    @public  # type: ignore
+    @public
     @property
     def asset_partitions_time_window(self) -> TimeWindow:
         """The time window for the partitions of the output asset.

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1005,8 +1005,8 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         partition_key_range = self.asset_partition_key_range_for_output(output_name)
         return TimeWindow(
             # mypy thinks partitions_def is <nothing> here because ????
-            partitions_def.time_window_for_partition_key(partition_key_range.start).start,  # type: ignore
-            partitions_def.time_window_for_partition_key(partition_key_range.end).end,  # type: ignore
+            partitions_def.time_window_for_partition_key(partition_key_range.start).start,
+            partitions_def.time_window_for_partition_key(partition_key_range.end).end,
         )
 
     def get_input_lineage(self) -> Sequence[AssetLineageInfo]:
@@ -1084,17 +1084,17 @@ class TypeCheckContext:
         self._log = log_manager
         self._resources = scoped_resources_builder.build(dagster_type.required_resource_keys)
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> "Resources":
         return self._resources
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         return self._run_id
 
-    @public  # type: ignore
+    @public
     @property
     def log(self) -> DagsterLogManager:
         return self._log
@@ -1106,20 +1106,20 @@ class DagsterTypeMaterializerContext(StepExecutionContext):
     Users should not construct this object directly.
     """
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> "Resources":
         """The resources available to the type materializer, specified by the `required_resource_keys` argument of the decorator.
         """
         return super(DagsterTypeMaterializerContext, self).resources
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> "JobDefinition":
         """The underlying job definition being executed."""
         return super(DagsterTypeMaterializerContext, self).job_def
 
-    @public  # type: ignore
+    @public
     @property
     def op_def(self) -> "OpDefinition":
         """The op for which type materialization is occurring."""
@@ -1132,20 +1132,20 @@ class DagsterTypeLoaderContext(StepExecutionContext):
     Users should not construct this object directly.
     """
 
-    @public  # type: ignore
+    @public
     @property
     def resources(self) -> "Resources":
         """The resources available to the type loader, specified by the `required_resource_keys` argument of the decorator.
         """
         return super(DagsterTypeLoaderContext, self).resources
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> "JobDefinition":
         """The underlying job definition being executed."""
         return super(DagsterTypeLoaderContext, self).job_def
 
-    @public  # type: ignore
+    @public
     @property
     def op_def(self) -> "OpDefinition":
         """The op for which type loading is occurring."""

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process_result.py
@@ -47,23 +47,23 @@ class ExecuteInProcessResult(ExecutionResult):
             output_capture, "output_capture", key_type=StepOutputHandle
         )
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> JobDefinition:
         return self._job_def
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_run(self) -> DagsterRun:
         return self._dagster_run
 
-    @public  # type: ignore
+    @public
     @property
     def all_events(self) -> Sequence[DagsterEvent]:
         """List[DagsterEvent]: All dagster events emitted during execution."""
         return self._event_list
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         return self.dagster_run.run_id

--- a/python_modules/dagster/dagster/_core/execution/execute_job_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_job_result.py
@@ -41,22 +41,22 @@ class ExecuteJobResult(ExecutionResult):
         self._context = None
         return exit_result
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> JobDefinition:
         return self._job_def
 
-    @public  # type: ignore
+    @public
     @property
     def dagster_run(self) -> DagsterRun:
         return self._dagster_run
 
-    @public  # type: ignore
+    @public
     @property
     def all_events(self) -> Sequence[DagsterEvent]:
         return self._event_list
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         return self.dagster_run.run_id

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @resource(
     config_schema={
         "scratch_dir": Field(
-            StringSource,  # type: ignore  # (mypy bug)
+            StringSource,
             description="Directory used to pass files between the plan process and step process.",
         ),
     },

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -220,14 +220,14 @@ class FromSourceAsset(
         from ..resolve_versions import check_valid_version, resolve_config_version
 
         op = pipeline_def.get_solid(self.solid_handle)
-        input_manager_key = check.not_none(op.input_def_named(self.input_name).input_manager_key)  # type: ignore  # fmt: skip
+        input_manager_key = check.not_none(op.input_def_named(self.input_name).input_manager_key)
         io_manager_def = pipeline_def.get_mode_definition(resolved_run_config.mode).resource_defs[
             input_manager_key
         ]
 
-        op_config = check.not_none(resolved_run_config.solids.get(op.name))  # type: ignore  # fmt: skip
+        op_config = check.not_none(resolved_run_config.solids.get(op.name))
         input_config = op_config.inputs.get(self.input_name)
-        resource_entry = check.not_none(resolved_run_config.resources.get(input_manager_key))  # type: ignore  # fmt: skip
+        resource_entry = check.not_none(resolved_run_config.resources.get(input_manager_key))
         resource_config = resource_entry.config
 
         version_context = ResourceVersionContext(

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -1135,7 +1135,7 @@ class ExecutionPlan(
                         ttype=(StepHandle, ResolvedFromDynamicStepHandle),
                     ),
                     pipeline_name,
-                    step_inputs,  # type: ignore
+                    step_inputs,
                     step_outputs,
                     step_snap.tags,
                 )
@@ -1146,7 +1146,7 @@ class ExecutionPlan(
                         ttype=UnresolvedStepHandle,
                     ),
                     pipeline_name,
-                    step_inputs,  # type: ignore
+                    step_inputs,
                     step_outputs,
                     step_snap.tags,
                 )
@@ -1154,7 +1154,7 @@ class ExecutionPlan(
                 step = UnresolvedCollectExecutionStep(
                     check.inst(cast(StepHandle, step_snap.step_handle), ttype=StepHandle),
                     pipeline_name,
-                    step_inputs,  # type: ignore
+                    step_inputs,
                     step_outputs,
                     step_snap.tags,
                 )

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -221,7 +221,7 @@ class ExecutionStep(
         return None
 
 
-class UnresolvedMappedExecutionStep(  # type: ignore
+class UnresolvedMappedExecutionStep(
     NamedTuple(
         "_UnresolvedMappedExecutionStep",
         [
@@ -381,7 +381,7 @@ def _resolved_input(
     return step_input.resolve(map_key)
 
 
-class UnresolvedCollectExecutionStep(  # type: ignore
+class UnresolvedCollectExecutionStep(
     NamedTuple(
         "_UnresolvedCollectExecutionStep",
         [

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -309,7 +309,7 @@ def single_resource_generation_manager(
 ) -> EventGenerationManager:
     generator = single_resource_event_generator(context, resource_name, resource_def)
     # EventGenerationManager needs to be renamed/generalized so that it doesn't only take event generators
-    return EventGenerationManager(generator, InitializedResource)  # type: ignore
+    return EventGenerationManager(generator, InitializedResource)
 
 
 def single_resource_event_generator(
@@ -325,8 +325,8 @@ def single_resource_event_generator(
             try:
                 with time_execution_scope() as timer_result:
                     resource_or_gen = (
-                        resource_def.resource_fn(context)  # type: ignore  # fmt: skip
-                        if has_at_least_one_parameter(resource_def.resource_fn)  # type: ignore  # fmt: skip
+                        resource_def.resource_fn(context)
+                        if has_at_least_one_parameter(resource_def.resource_fn)
                         else resource_def.resource_fn()  # type: ignore[call-arg]
                     )
 

--- a/python_modules/dagster/dagster/_core/executor/base.py
+++ b/python_modules/dagster/dagster/_core/executor/base.py
@@ -23,7 +23,7 @@ class Executor(ABC):
             A stream of dagster events.
         """
 
-    @public  # type: ignore
+    @public
     @property
     @abstractmethod
     def retries(self) -> RetryMode:

--- a/python_modules/dagster/dagster/_core/executor/child_process_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/child_process_executor.py
@@ -114,7 +114,7 @@ def _poll_for_event(
             except queue.Empty:
                 # If the queue empty we know that there are no more events
                 # and that the process has died.
-                return PROCESS_DEAD_AND_QUEUE_EMPTY  # type: ignore  # fmt: skip
+                return PROCESS_DEAD_AND_QUEUE_EMPTY
     return None
 
 
@@ -164,7 +164,7 @@ def execute_child_process_command(
             if event == PROCESS_DEAD_AND_QUEUE_EMPTY:
                 break
 
-            yield event  # type: ignore  # fmt: skip
+            yield event
 
             if isinstance(event, (ChildProcessDoneEvent, ChildProcessSystemErrorEvent)):
                 completed_properly = True

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -225,7 +225,7 @@ class StepDelegatingExecutor(Executor):
                 for dagster_event in self._pop_events(
                     plan_context.instance,
                     plan_context.run_id,
-                ):  # type: ignore
+                ):
                     yield dagster_event
                     # STEP_SKIPPED events are only emitted by ActiveExecution, which already handles
                     # and yields them.

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -318,7 +318,7 @@ class ExternalPipeline(RepresentedPipeline):
                     self.external_pipeline_data.pipeline_snapshot,
                     self.external_pipeline_data.parent_pipeline_snapshot,
                 )
-            return self._index  # type: ignore
+            return self._index
 
     @property
     def name(self) -> str:

--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -238,7 +238,7 @@ class GrpcServerRegistry(AbstractContextManager):
             )
 
         return GrpcServerEndpoint(
-            server_id=active_entry.server_id,  # type: ignore
+            server_id=active_entry.server_id,
             host="localhost",
             port=active_entry.process.port,
             socket=active_entry.process.socket,

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -846,4 +846,4 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
 
     def get_external_notebook_data(self, notebook_path: str) -> bytes:
         check.str_param(notebook_path, "notebook_path")
-        return sync_get_streaming_external_notebook_data_grpc(self.client, notebook_path)  # type: ignore
+        return sync_get_streaming_external_notebook_data_grpc(self.client, notebook_path)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -170,7 +170,7 @@ class _EventListenerLogHandler(logging.Handler):
                 name=record.name,
                 message=record.msg,
                 level=record.levelno,
-                meta=record.dagster_meta,  # type: ignore
+                meta=record.dagster_meta,
                 record=record,
             )
         )
@@ -498,7 +498,7 @@ class DagsterInstance:
             unified_storage.schedule_storage if unified_storage else instance_ref.schedule_storage
         )
 
-        return klass(  # type: ignore
+        return klass(
             instance_type=InstanceType.PERSISTENT,
             local_artifact_storage=instance_ref.local_artifact_storage,
             run_storage=run_storage,
@@ -1491,7 +1491,7 @@ class DagsterInstance:
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Mapping[str, "RunGroupInfo"]:
-        return self._run_storage.get_run_groups(filters=filters, cursor=cursor, limit=limit)  # type: ignore  # fmt: skip
+        return self._run_storage.get_run_groups(filters=filters, cursor=cursor, limit=limit)
 
     @public
     @traced

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -53,7 +53,7 @@ class AssetValueLoader:
                     instance=self._instance,
                 )
             )
-            ._asdict()  # type: ignore
+            ._asdict()
             .items()
         ):
             self._resource_instance_cache[built_resource_key] = built_resource

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -29,7 +29,7 @@ class FileHandle(ABC):
     such as S3.
     """
 
-    @public  # type: ignore
+    @public
     @property
     @abstractmethod
     def path_desc(self) -> str:
@@ -43,13 +43,13 @@ class LocalFileHandle(FileHandle):
     def __init__(self, path: str):
         self._path = check.str_param(path, "path")
 
-    @public  # type: ignore
+    @public
     @property
     def path(self) -> str:
         """The file's path."""
         return self._path
 
-    @public  # type: ignore
+    @public
     @property
     def path_desc(self) -> str:
         """A representation of the file path for display purposes only."""
@@ -165,7 +165,7 @@ class FileManager(ABC):  # pylint: disable=no-init
         raise NotImplementedError()
 
 
-@resource(config_schema={"base_dir": Field(StringSource, is_required=False)})  # type: ignore  # (mypy bug)
+@resource(config_schema={"base_dir": Field(StringSource, is_required=False)})
 def local_file_manager(init_context):
     """FileManager that provides abstract access to a local filesystem.
 

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -18,7 +18,7 @@ from dagster._utils import PICKLE_PROTOCOL, mkdir_p
 
 
 @io_manager(
-    config_schema={"base_dir": Field(StringSource, is_required=False)},  # type: ignore  # mypy bug
+    config_schema={"base_dir": Field(StringSource, is_required=False)},
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
 )
 def fs_io_manager(init_context):
@@ -228,7 +228,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             return pickle.load(read_obj)
 
 
-@io_manager(config_schema={"base_dir": Field(StringSource, is_required=True)})  # type: ignore  # (mypy bug)
+@io_manager(config_schema={"base_dir": Field(StringSource, is_required=True)})
 @experimental
 def custom_path_fs_io_manager(init_context):
     """Built-in IO manager that allows users to custom output file path per output definition.

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -177,7 +177,7 @@ def input_manager(
 
     def _wrap(load_fn: InputLoadFn) -> InputManagerDefinition:
         return _InputManagerDecoratorCallable(
-            config_schema=config_schema,  # type: ignore  # fmt: skip
+            config_schema=config_schema,
             description=description,
             version=version,
             input_config_schema=input_config_schema,
@@ -201,8 +201,8 @@ class InputManagerWrapper(InputManager):
         # result is an InputManager. If so we call it's load_input method
         intermediate = (
             # type-ignore because function being used as attribute
-            self._load_fn(context)  # type: ignore  # fmt: skip
-            if has_at_least_one_parameter(self._load_fn)  # type: ignore  # fmt: skip
+            self._load_fn(context)
+            if has_at_least_one_parameter(self._load_fn)
             else self._load_fn()  # type: ignore  # (strict type guard)
         )
 

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -94,7 +94,7 @@ class IOManagerDefinition(ResourceDefinition, IInputManagerDefinition, IOutputMa
             output_config_schema=self.output_config_schema,
         )
 
-    @public  # type: ignore
+    @public
     @staticmethod
     def hardcoded_io_manager(
         value: "IOManager", description: Optional[str] = None
@@ -122,7 +122,7 @@ class IOManager(InputManager, OutputManager):
     ``handle_output`` to store an object and ``load_input`` to retrieve an object.
     """
 
-    @public  # type: ignore
+    @public
     @abstractmethod
     def load_input(self, context: "InputContext") -> Any:
         """User-defined method that loads an input to an op.
@@ -135,7 +135,7 @@ class IOManager(InputManager, OutputManager):
             Any: The data object.
         """
 
-    @public  # type: ignore
+    @public
     @abstractmethod
     def handle_output(self, context: "OutputContext", obj: Any) -> None:
         """User-defined method that stores an output of an op.

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -367,7 +367,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         )
         # Type checker says LegacyEventStorage is abstract and can't be instantiated. Not sure whether
         # type check is wrong, or is unused code path.
-        return LegacyEventLogStorage(storage, inst_data=inst_data)  # type: ignore
+        return LegacyEventLogStorage(storage, inst_data=inst_data)
 
     @property
     def _instance(self):

--- a/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/memoizable_io_manager.py
@@ -93,7 +93,7 @@ class VersionedPickledObjectFilesystemIOManager(MemoizableIOManager):
         return os.path.exists(filepath) and not os.path.isdir(filepath)
 
 
-@io_manager(config_schema={"base_dir": Field(StringSource, is_required=False)})  # type: ignore  # (mypy bug)
+@io_manager(config_schema={"base_dir": Field(StringSource, is_required=False)})
 @experimental
 def versioned_filesystem_io_manager(init_context):
     """Filesystem IO manager that utilizes versioning of stored objects.

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -429,7 +429,7 @@ class DagsterRun(
             ),
         )
 
-    def with_status(self, status: DagsterRunStatus) -> Self:  # type: ignore  # fmt: skip
+    def with_status(self, status: DagsterRunStatus) -> Self:
         if status == DagsterRunStatus.QUEUED:
             # Placing this with the other imports causes a cyclic import
             # https://github.com/dagster-io/dagster/issues/3181
@@ -443,16 +443,16 @@ class DagsterRun(
 
         return self._replace(status=status)
 
-    def with_job_origin(self, origin: "ExternalPipelineOrigin") -> Self:  # type: ignore  # fmt: skip
+    def with_job_origin(self, origin: "ExternalPipelineOrigin") -> Self:
         from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
         check.inst_param(origin, "origin", ExternalPipelineOrigin)
         return self._replace(external_pipeline_origin=origin)
 
-    def with_mode(self, mode: str) -> Self:  # type: ignore  # fmt: skip
+    def with_mode(self, mode: str) -> Self:
         return self._replace(mode=mode)
 
-    def with_tags(self, tags: Mapping[str, str]) -> Self:  # type: ignore  # fmt: skip
+    def with_tags(self, tags: Mapping[str, str]) -> Self:
         return self._replace(tags=tags)
 
     def get_root_run_id(self):
@@ -475,27 +475,27 @@ class DagsterRun(
 
         return {**repository_tags, **self.tags}
 
-    @public  # type: ignore
+    @public
     @property
     def is_finished(self):
         return self.status in FINISHED_STATUSES
 
-    @public  # type: ignore
+    @public
     @property
     def is_success(self) -> bool:
         return self.status == DagsterRunStatus.SUCCESS
 
-    @public  # type: ignore
+    @public
     @property
     def is_failure(self) -> bool:
         return self.status == DagsterRunStatus.FAILURE
 
-    @public  # type: ignore
+    @public
     @property
     def is_failure_or_canceled(self):
         return self.status == DagsterRunStatus.FAILURE or self.status == DagsterRunStatus.CANCELED
 
-    @public  # type: ignore
+    @public
     @property
     def is_resume_retry(self) -> bool:
         return self.tags.get(RESUME_RETRY_TAG) == "true"
@@ -505,7 +505,7 @@ class DagsterRun(
         # Compat
         return self.parent_run_id
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> str:
         return self.pipeline_name

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -483,7 +483,7 @@ def remove_none_recursively(obj):
         return obj
 
 
-default_mode_def_for_test = ModeDefinition(resource_defs={"io_manager": fs_io_manager})  # type: ignore[has-type]
+default_mode_def_for_test = ModeDefinition(resource_defs={"io_manager": fs_io_manager})
 
 
 def strip_ansi(input_str):

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -238,7 +238,7 @@ def dagster_type_loader(
             )
 
         return _create_type_loader_for_decorator(
-            config_type, func, required_resource_keys, loader_version, external_version_fn  # type: ignore  # mypy bug
+            config_type, func, required_resource_keys, loader_version, external_version_fn
         )
 
     return wrapper

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -166,7 +166,7 @@ class DagsterType(RequiresResources):
             check.opt_mapping_param(metadata, "metadata", key_type=str), metadata_entries
         )
 
-    @public  # type: ignore
+    @public
     def type_check(self, context: "TypeCheckContext", value: object) -> TypeCheck:
         retval = self._type_check_fn(context, value)
 
@@ -197,20 +197,20 @@ class DagsterType(RequiresResources):
 
     @property
     def metadata_entries(self) -> t.Sequence[MetadataEntry]:
-        return self._metadata_entries  # type: ignore
+        return self._metadata_entries
 
-    @public  # type: ignore
+    @public
     @property
     def required_resource_keys(self) -> TypingAbstractSet[str]:
         return self._required_resource_keys
 
-    @public  # type: ignore
+    @public
     @property
     def display_name(self) -> str:
         """Either the name or key (if name is `None`) of the type, overridden in many subclasses."""
         return cast(str, self._name or self.key)
 
-    @public  # type: ignore
+    @public
     @property
     def unique_name(self) -> t.Optional[str]:
         """The unique name of this type. Can be None if the type is not unique, such as container types.
@@ -222,22 +222,22 @@ class DagsterType(RequiresResources):
         )
         return self._name
 
-    @public  # type: ignore
+    @public
     @property
     def has_unique_name(self) -> bool:
         return self._name is not None
 
-    @public  # type: ignore
+    @public
     @property
     def typing_type(self) -> t.Any:
         return self._typing_type
 
-    @public  # type: ignore
+    @public
     @property
     def loader(self) -> t.Optional[DagsterTypeLoader]:
         return self._loader
 
-    @public  # type: ignore
+    @public
     @property
     def description(self) -> t.Optional[str]:
         return self._description
@@ -578,9 +578,9 @@ class PythonObjectDagsterType(DagsterType):
             typing_type = t.Union[python_type]  # type: ignore
 
         else:
-            self.python_type = check.class_param(python_type, "python_type")  # type: ignore
+            self.python_type = check.class_param(python_type, "python_type")
             self.type_str = cast(str, python_type.__name__)
-            typing_type = self.python_type  # type: ignore
+            typing_type = self.python_type
         name = check.opt_str_param(name, "name", self.type_str)
         key = check.opt_str_param(key, "key", name)
         super(PythonObjectDagsterType, self).__init__(
@@ -637,7 +637,7 @@ class OptionalType(DagsterType):
             type_check_fn=self.type_check_method,
             loader=_create_nullable_input_schema(inner_type),
             # This throws a type error with Py
-            typing_type=t.Optional[inner_type.typing_type],  # type: ignore
+            typing_type=t.Optional[inner_type.typing_type],
         )
 
     @property
@@ -699,7 +699,7 @@ class ListType(DagsterType):
             kind=DagsterTypeKind.LIST,
             type_check_fn=self.type_check_method,
             loader=_create_list_input_schema(inner_type),
-            typing_type=t.List[inner_type.typing_type],  # type: ignore
+            typing_type=t.List[inner_type.typing_type],
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/types/decorator.py
+++ b/python_modules/dagster/dagster/_core/types/decorator.py
@@ -27,7 +27,7 @@ def usable_as_dagster_type(
     ...
 
 
-def usable_as_dagster_type(  # type: ignore  # bug
+def usable_as_dagster_type(
     name: Optional[Union[str, T_Type]] = None,
     description: Optional[str] = None,
     loader: Optional["DagsterTypeLoader"] = None,

--- a/python_modules/dagster/dagster/_core/types/primitive_mapping.py
+++ b/python_modules/dagster/dagster/_core/types/primitive_mapping.py
@@ -15,10 +15,10 @@ SUPPORTED_RUNTIME_BUILTINS = {
     float: Float,
     bool: Bool,
     str: String,
-    list: List(RuntimeAny),  # type: ignore
-    tuple: PythonTuple,  # type: ignore
-    set: PythonSet,  # type: ignore
-    dict: PythonDict,  # type: ignore
+    list: List(RuntimeAny),
+    tuple: PythonTuple,
+    set: PythonSet,
+    dict: PythonDict,
 }
 
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -202,7 +202,7 @@ class BaseWorkspaceRequestContext(IWorkspace):
     def shutdown_repository_location(self, name: str):
         self.process_context.shutdown_repository_location(name)
 
-    def reload_workspace(self) -> Self:  # type: ignore  # fmt: skip
+    def reload_workspace(self) -> Self:
         self.process_context.reload_workspace()
         return self.process_context.create_request_context()
 
@@ -410,7 +410,7 @@ class IWorkspaceProcessContext(ABC):
     def instance(self) -> DagsterInstance:
         pass
 
-    def __enter__(self) -> Self:  # type: ignore  # fmt: skip
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -236,7 +236,7 @@ class DagsterApiServer(DagsterApiServicer):
         self._serializable_load_error = None
 
         self._entry_point = (
-            frozenlist(check.sequence_param(entry_point, "entry_point", of_type=str))  # type: ignore
+            frozenlist(check.sequence_param(entry_point, "entry_point", of_type=str))
             if entry_point is not None
             else DEFAULT_DAGSTER_ENTRY_POINT
         )
@@ -352,22 +352,22 @@ class DagsterApiServer(DagsterApiServicer):
             )
         return loaded_repos.definitions_by_name[external_repo_origin.repository_name]
 
-    def Ping(self, request, _context) -> api_pb2.PingReply:  # type: ignore  # fmt: skip
+    def Ping(self, request, _context) -> api_pb2.PingReply:
         echo = request.echo
         return api_pb2.PingReply(echo=echo)
 
-    def StreamingPing(self, request, _context) -> Iterator[api_pb2.StreamingPingEvent]:  # type: ignore  # fmt: skip
+    def StreamingPing(self, request, _context) -> Iterator[api_pb2.StreamingPingEvent]:
         sequence_length = request.sequence_length
         echo = request.echo
         for sequence_number in range(sequence_length):
             yield api_pb2.StreamingPingEvent(sequence_number=sequence_number, echo=echo)
 
-    def Heartbeat(self, request, _context) -> api_pb2.PingReply:  # type: ignore  # fmt: skip
+    def Heartbeat(self, request, _context) -> api_pb2.PingReply:
         self.__last_heartbeat_time = time.time()
         echo = request.echo
         return api_pb2.PingReply(echo=echo)
 
-    def GetServerId(self, _request, _context) -> api_pb2.GetServerIdReply:  # type: ignore  # fmt: skip
+    def GetServerId(self, _request, _context) -> api_pb2.GetServerIdReply:
         return api_pb2.GetServerIdReply(server_id=self._server_id)
 
     def ExecutionPlanSnapshot(self, request, _context):
@@ -389,9 +389,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ListRepositories(
-        self, request, _context
-    ) -> api_pb2.ListRepositoriesReply:  # type: ignore  # fmt: skip
+    def ListRepositories(self, request, _context) -> api_pb2.ListRepositoriesReply:
         if self._serializable_load_error:
             return api_pb2.ListRepositoriesReply(
                 serialized_list_repositories_response_or_error=serialize_dagster_namedtuple(
@@ -414,9 +412,7 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_list_repositories_response_or_error=serialize_dagster_namedtuple(response)
         )
 
-    def ExternalPartitionNames(
-        self, request, _context
-    ) -> api_pb2.ExternalPartitionNamesReply:  # type: ignore  # fmt: skip
+    def ExternalPartitionNames(self, request, _context) -> api_pb2.ExternalPartitionNamesReply:
         partition_names_args = deserialize_as(
             request.serialized_partition_names_args,
             PartitionNamesArgs,
@@ -430,9 +426,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ExternalNotebookData(
-        self, request, _context
-    ) -> api_pb2.ExternalNotebookDataReply:  # type: ignore  # fmt: skip
+    def ExternalNotebookData(self, request, _context) -> api_pb2.ExternalNotebookDataReply:
         notebook_path = request.notebook_path
         check.str_param(notebook_path, "notebook_path")
         return api_pb2.ExternalNotebookDataReply(content=get_notebook_data(notebook_path))
@@ -466,9 +460,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def ExternalPartitionTags(
-        self, request, _context
-    ) -> api_pb2.ExternalPartitionTagsReply:  # type: ignore  # fmt: skip
+    def ExternalPartitionTags(self, request, _context) -> api_pb2.ExternalPartitionTagsReply:
         partition_args = deserialize_as(request.serialized_partition_args, PartitionArgs)
 
         return api_pb2.ExternalPartitionTagsReply(
@@ -483,7 +475,7 @@ class DagsterApiServer(DagsterApiServicer):
 
     def ExternalPipelineSubsetSnapshot(
         self, request: Any, _context
-    ) -> api_pb2.ExternalPipelineSubsetSnapshotReply:  # type: ignore  # fmt: skip
+    ) -> api_pb2.ExternalPipelineSubsetSnapshotReply:
         pipeline_subset_snapshot_args = deserialize_as(
             request.serialized_pipeline_subset_snapshot_args,
             PipelineSubsetSnapshotArgs,
@@ -526,9 +518,7 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_external_repository_data=serialized_external_repository_data,
         )
 
-    def ExternalJob(
-        self, request, _context
-    ) -> api_pb2.ExternalJobReply:  # type: ignore  # fmt: skip
+    def ExternalJob(self, request, _context) -> api_pb2.ExternalJobReply:
         try:
             repository_origin = deserialize_as(
                 request.serialized_repository_origin,
@@ -616,7 +606,7 @@ class DagsterApiServer(DagsterApiServicer):
 
         yield from self._split_serialized_data_into_chunk_events(serialized_sensor_data)
 
-    def ShutdownServer(self, request, _context) -> api_pb2.ShutdownServerReply:  # type: ignore  # fmt: skip
+    def ShutdownServer(self, request, _context) -> api_pb2.ShutdownServerReply:
         try:
             self._shutdown_once_executions_finish_event.set()
             return api_pb2.ShutdownServerReply(
@@ -664,7 +654,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def CanCancelExecution(self, request, _context) -> api_pb2.CanCancelExecutionReply:  # type: ignore  # fmt: skip
+    def CanCancelExecution(self, request, _context) -> api_pb2.CanCancelExecutionReply:
         can_cancel_execution_request = deserialize_as(
             request.serialized_can_cancel_execution_request,
             CanCancelExecutionRequest,
@@ -681,7 +671,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def StartRun(self, request, _context) -> api_pb2.StartRunReply:  # type: ignore  # fmt: skip
+    def StartRun(self, request, _context) -> api_pb2.StartRunReply:
         if self._shutdown_once_executions_finish_event.is_set():
             return api_pb2.StartRunReply(
                 serialized_start_run_result=serialize_dagster_namedtuple(
@@ -806,7 +796,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
         )
 
-    def GetCurrentRuns(self, request, context) -> api_pb2.GetCurrentRunsReply:  # type: ignore  # fmt: skip
+    def GetCurrentRuns(self, request, context) -> api_pb2.GetCurrentRunsReply:
         with self._execution_lock:
             return api_pb2.GetCurrentRunsReply(
                 serialized_current_runs=serialize_dagster_namedtuple(

--- a/python_modules/dagster/dagster/_seven/json.py
+++ b/python_modules/dagster/dagster/_seven/json.py
@@ -9,7 +9,7 @@ from json import (
 try:
     from json import JSONDecodeError
 except ImportError:
-    JSONDecodeError = ValueError  # type: ignore[misc, assignment]
+    JSONDecodeError = ValueError
 
 dump = partial(dump_, sort_keys=True)
 

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -229,10 +229,10 @@ class frozendict(dict):
 
     __setitem__ = __readonly__
     __delitem__ = __readonly__
-    pop = __readonly__  # type: ignore[assignment]
+    pop = __readonly__
     popitem = __readonly__
     clear = __readonly__
-    update = __readonly__  # type: ignore[assignment]
+    update = __readonly__
     setdefault = __readonly__  # type: ignore[assignment]
     del __readonly__
 
@@ -256,7 +256,7 @@ class frozenlist(list):
     def __setstate__(self, state):
         self.__init__(state)
 
-    __setitem__ = __readonly__  # type: ignore[assignment]
+    __setitem__ = __readonly__
     __delitem__ = __readonly__
     append = __readonly__
     clear = __readonly__
@@ -272,12 +272,12 @@ class frozenlist(list):
 
 
 @overload
-def make_readonly_value(value: List[T]) -> Sequence[T]:  # type: ignore
+def make_readonly_value(value: List[T]) -> Sequence[T]:
     ...
 
 
 @overload
-def make_readonly_value(value: Dict[T, U]) -> Mapping[T, U]:  # type: ignore
+def make_readonly_value(value: Dict[T, U]) -> Mapping[T, U]:
     ...
 
 

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -76,7 +76,7 @@ class CachingInstanceQueryer:
         for asset_key in asset_keys:
             # we just prefetched all the asset records, so if it's not in the cache, there are
             # no materializations for this key
-            asset_record = self._asset_record_cache.get(asset_key)  # type: ignore
+            asset_record = self._asset_record_cache.get(asset_key)
             last_materialization_record = (
                 asset_record.asset_entry.last_materialization_record if asset_record else None
             )
@@ -394,7 +394,7 @@ class CachingInstanceQueryer:
 
             serialized_times = tags_list[0].get(USED_DATA_TAG, "{}")
             return {
-                AssetKey.from_user_string(key): tuple(value)  # type:ignore
+                AssetKey.from_user_string(key): tuple(value)
                 for key, value in json.loads(serialized_times).items()
             }
         return {}

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -14,7 +14,7 @@ from dagster._config import Enum, EnumValue
 from dagster._core.definitions.logger_definition import logger
 from dagster._core.utils import PYTHON_LOGGING_LEVELS_MAPPING, coerce_valid_log_level
 
-LogLevelEnum = Enum("log_level", list(map(EnumValue, PYTHON_LOGGING_LEVELS_MAPPING.keys())))  # type: ignore
+LogLevelEnum = Enum("log_level", list(map(EnumValue, PYTHON_LOGGING_LEVELS_MAPPING.keys())))
 
 
 class JsonFileHandler(logging.Handler):

--- a/python_modules/dagster/dagster/_utils/merger.py
+++ b/python_modules/dagster/dagster/_utils/merger.py
@@ -43,7 +43,7 @@ def deep_merge_dicts(
     dictionaries, the returned dictionary contains the value from from_dict.
     """
     onto_dict = copy.deepcopy(onto_dict if isinstance(onto_dict, dict) else dict(onto_dict))
-    return _deep_merge_dicts(onto_dict, from_dict)  # type: ignore # [mypy bug]
+    return _deep_merge_dicts(onto_dict, from_dict)
 
 
 def merge_dicts(*args: Mapping[Any, Any]) -> Dict[Any, Any]:

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -126,7 +126,7 @@ def build_pipeline_with_input_stubs(
                 input_value,
             )
             stub_solid_defs.append(stub_solid_def)
-            deps[_dep_key_of(solid)][input_name] = DependencyDefinition(stub_solid_def.name)  # type: ignore
+            deps[_dep_key_of(solid)][input_name] = DependencyDefinition(stub_solid_def.name)
 
     return PipelineDefinition(
         name=pipeline_def.name + "_stubbed",

--- a/python_modules/dagster/dagster/_utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/_utils/yaml_utils.py
@@ -15,7 +15,7 @@ YAML_STR_TAG = "tag:yaml.org,2002:str"
 class _CanRemoveImplicitResolver:
     # Adds a "remove_implicit_resolver" method that can be used to selectively
     # disable default PyYAML resolvers
-    # type: ignore
+
     @classmethod
     def remove_implicit_resolver(cls, tag):
         # See https://github.com/yaml/pyyaml/blob/master/lib/yaml/resolver.py#L26 for inspiration

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
@@ -1200,7 +1200,7 @@ def test_add_asset_groups_different_resources():
     )
 
     with pytest.raises(DagsterInvalidDefinitionError):
-        group1 + group2  # type: ignore  # (test error)
+        group1 + group2
 
 
 def test_add_asset_groups_different_executors():
@@ -1222,7 +1222,7 @@ def test_add_asset_groups_different_executors():
     )
 
     with pytest.raises(DagsterInvalidDefinitionError):
-        group1 + group2  # type: ignore  # (test error)
+        group1 + group2
 
 
 def test_to_source_assets():

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
@@ -283,7 +283,7 @@ def test_struct_config_nested_in_dict():
 )
 def test_struct_config_map_different_key_type(key_type: Type, keys: List[Any]):
     class AnOpConfig(Config):
-        my_dict: Dict[key_type, int]  # type: ignore
+        my_dict: Dict[key_type, int]
 
     executed = {}
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_logical_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_logical_versions.py
@@ -8,7 +8,7 @@ def test_logical_version_construction():
     assert ver.value == "foo"
 
     with pytest.raises(ParameterCheckError):
-        LogicalVersion(100)  # type: ignore
+        LogicalVersion(100)
 
 
 def test_logical_version_equality():

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -124,25 +124,25 @@ def config_pipeline():
 simple_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="simple_partition_set",
     pipeline_name="the_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
 )
 
 conditionally_fail_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="conditionally_fail_partition_set",
     pipeline_name="conditional_failure_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
 )
 
 partial_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="partial_partition_set",
     pipeline_name="partial_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
 )
 
 parallel_failure_partition_set: PartitionSetDefinition = PartitionSetDefinition(
     name="parallel_failure_partition_set",
     pipeline_name="parallel_failure_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
 )
 
 
@@ -168,7 +168,7 @@ def _large_partition_config(_):
 large_partition_set = PartitionSetDefinition(
     name="large_partition_set",
     pipeline_name="config_pipeline",
-    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],  # type: ignore
+    partition_fn=lambda: [Partition("one"), Partition("two"), Partition("three")],
     run_config_fn_for_partition=_large_partition_config,
 )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset.py
@@ -13,7 +13,7 @@ from dagster._core.storage.io_manager import io_manager
 def test_all_fields():
     partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
 
-    @io_manager(required_resource_keys={"baz"})  # type: ignore
+    @io_manager(required_resource_keys={"baz"})
     def foo_manager():
         pass
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_reconciliation_sensor.py
@@ -52,7 +52,7 @@ class AssetReconciliationScenario(NamedTuple):
     assets: Sequence[Union[SourceAsset, AssetsDefinition]]
     between_runs_delta: Optional[datetime.timedelta] = None
     evaluation_delta: Optional[datetime.timedelta] = None
-    cursor_from: Optional["AssetReconciliationScenario"] = None  # type: ignore
+    cursor_from: Optional["AssetReconciliationScenario"] = None
     current_time: Optional[datetime.datetime] = None
     asset_selection: Optional[AssetSelection] = None
 
@@ -403,9 +403,7 @@ overlapping_freshness = diamond + [
 overlapping_freshness_with_source = [
     SourceAsset("source_asset"),
     asset_def("asset1", ["source_asset"]),
-] + overlapping_freshness[
-    1:
-]  # type: ignore
+] + overlapping_freshness[1:]
 overlapping_freshness_inf = diamond + [
     asset_def("asset5", ["asset3"], freshness_policy=freshness_30m),
     asset_def("asset6", ["asset4"], freshness_policy=freshness_inf),
@@ -1059,7 +1057,7 @@ scenarios = {
         expected_run_requests=[],
     ),
     "freshness_overlapping_with_source": AssetReconciliationScenario(
-        assets=overlapping_freshness_with_source,  # type: ignore
+        assets=overlapping_freshness_with_source,
         unevaluated_runs=[run(["asset1", "asset3", "asset5"]), run(["asset2", "asset4", "asset6"])],
         expected_run_requests=[],
     ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
@@ -40,7 +40,7 @@ def test_create_pipeline_with_bad_solids_list():
         match=r'Param "node_defs" is not one of \[\'Sequence\'\]',
     ):
         GraphDefinition(
-            name="a_pipeline", node_defs=define_stub_solid("stub", [{"a key": "a value"}])  # type: ignore
+            name="a_pipeline", node_defs=define_stub_solid("stub", [{"a key": "a value"}])
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -58,7 +58,7 @@ def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefi
 
 
 def test_basic_asset():
-    assert Definitions  # type: ignore
+    assert Definitions
 
     @asset
     def an_asset():
@@ -262,7 +262,7 @@ def test_io_manager_coercion():
 def test_bad_executor():
     with pytest.raises(CheckError):
         # ignoring type to catch runtime error
-        Definitions(executor="not an executor")  # type: ignore
+        Definitions(executor="not an executor")
 
 
 def test_custom_executor_in_definitions():
@@ -304,13 +304,13 @@ def test_bad_logger_key():
 
     with pytest.raises(CheckError):
         # ignore type to catch runtime error
-        Definitions(loggers={1: a_logger})  # type: ignore
+        Definitions(loggers={1: a_logger})
 
 
 def test_bad_logger_value():
     with pytest.raises(CheckError):
         # ignore type to catch runtime error
-        Definitions(loggers={"not_a_logger": "not_a_logger"})  # type: ignore
+        Definitions(loggers={"not_a_logger": "not_a_logger"})
 
 
 def test_kitchen_sink_on_create_helper_and_definitions():
@@ -504,7 +504,7 @@ def test_implicit_global_job_with_partitioned_asset():
         [AssetKey("hourly_partition_asset"), AssetKey("unpartitioned_asset")]
     )
 
-    with pytest.raises(DagsterInvariantViolationError):  # type: ignore
+    with pytest.raises(DagsterInvariantViolationError):
         defs.get_implicit_global_asset_job_def()
 
 
@@ -566,4 +566,4 @@ def test_bare_executor():
     assert isinstance(job, JobDefinition)
 
     # ignore typecheck because we know our implementation doesn't use the context
-    assert job.executor_def.executor_creation_fn(None) is executor_inst  # type: ignore
+    assert job.executor_def.executor_creation_fn(None) is executor_inst

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_input_defaults.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_input_defaults.py
@@ -80,7 +80,7 @@ def test_early_fail():
 
 # we can't catch bad default_values except for scalars until runtime since the type_check function depends on
 # a context that has access to resources etc.
-@op(ins={"x": In(Optional[int], default_value="number")})  # type: ignore[arg-type]
+@op(ins={"x": In(Optional[int], default_value="number")})
 def bad_default(x):
     return x
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -1239,7 +1239,7 @@ def test_list_load():
 
     source = SourceAsset(key=AssetKey("a_source_asset"))
 
-    all_assets: Sequence[AssetsDefinition, SourceAsset] = [asset1, asset2, source]  # type: ignore
+    all_assets: Sequence[AssetsDefinition, SourceAsset] = [asset1, asset2, source]
 
     @repository
     def assets_repo():
@@ -1310,7 +1310,7 @@ def test_multi_nested_list():
 
     source = SourceAsset(key=AssetKey("a_source_asset"))
 
-    layer_1: Sequence[AssetsDefinition, SourceAsset] = [asset2, source]  # type: ignore
+    layer_1: Sequence[AssetsDefinition, SourceAsset] = [asset2, source]
     layer_2 = [layer_1, asset1]
 
     with pytest.raises(DagsterInvalidDefinitionError, match="Bad return value from repository"):

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_not_allowed.py
@@ -77,7 +77,7 @@ def test_multi_composite_out():
         @job
         def _should_fail():
             def _complex(item):
-                composed_echo().map(lambda y: add(y, item))  # type: ignore  # (test error)
+                composed_echo().map(lambda y: add(y, item))
 
             dynamic_solid().map(_complex)
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -41,12 +41,12 @@ from .retry_jobs import (
 class TestStepHandler(StepHandler):
     # This step handler waits for all processes to exit, because windows tests flake when processes
     # are left alive when the test ends. Non-test step handlers should not keep their own state in memory.
-    processes = []  # type: ignore
-    launch_step_count = 0  # type: ignore
+    processes = []
+    launch_step_count = 0
     saw_baz_op = False
-    check_step_health_count = 0  # type: ignore
-    terminate_step_count = 0  # type: ignore
-    verify_step_count = 0  # type: ignore
+    check_step_health_count = 0
+    terminate_step_count = 0
+    verify_step_count = 0
 
     @property
     def name(self):

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_deletegating_executor_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_deletegating_executor_retries.py
@@ -19,7 +19,7 @@ from dagster._utils.merger import merge_dicts
 class TestStepHandler(StepHandler):
     launched_first_attempt = False
     launched_second_attempt = False
-    processes = []  # type: ignore
+    processes = []
 
     @property
     def name(self):
@@ -50,7 +50,7 @@ class TestStepHandler(StepHandler):
     def check_step_health(self, step_handler_context) -> CheckStepHealthResult:
         assert step_handler_context.execute_step_args.step_keys_to_execute == ["retry_op"]
 
-        known_state = check.not_none(step_handler_context.execute_step_args.known_state)  # type: ignore  # fmt: skip
+        known_state = check.not_none(step_handler_context.execute_step_args.known_state)
         attempt_count = known_state.get_retry_state().get_attempt_count("retry_op")
         if attempt_count == 0:
             assert TestStepHandler.launched_first_attempt is True

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -105,7 +105,7 @@ def _define_failing_job(has_policy: bool, is_explicit: bool = True):
             if is_explicit:
                 raise Failure(description="some failure description", metadata={"foo": 1.23})
             else:
-                _ = "x" + 1  # type: ignore
+                _ = "x" + 1
         return context.retry_number
 
     @job(

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -80,7 +80,7 @@ def basic_graph():
     pass
 
 
-basic_job = basic_graph.to_job()  # type: ignore[union-attr]
+basic_job = basic_graph.to_job()
 
 
 def test_non_reconstructable_job_error():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -223,7 +223,7 @@ def test_table_metadata_value_schema_inference():
         ),
     )
 
-    schema = table_metadata_entry.entry_data.schema  # type: ignore
+    schema = table_metadata_entry.entry_data.schema
     assert isinstance(schema, TableSchema)
     assert schema.columns == [
         TableColumn(name="name", type="string"),
@@ -252,7 +252,7 @@ bad_values = frozendict(
 
 def test_table_column_keys():
     with pytest.raises(TypeError):
-        TableColumn(bad_key="foo", description="bar", type="string")  # type: ignore
+        TableColumn(bad_key="foo", description="bar", type="string")
 
 
 @pytest.mark.parametrize("key,value", list(bad_values["table_column"].items()))
@@ -270,7 +270,7 @@ def test_table_column_values(key, value):
 
 def test_table_constraints_keys():
     with pytest.raises(TypeError):
-        TableColumn(bad_key="foo")  # type: ignore
+        TableColumn(bad_key="foo")
 
 
 @pytest.mark.parametrize("key,value", list(bad_values["table_constraints"].items()))
@@ -283,7 +283,7 @@ def test_table_constraints(key, value):
 
 def test_table_column_constraints_keys():
     with pytest.raises(TypeError):
-        TableColumnConstraints(bad_key="foo")  # type: ignore
+        TableColumnConstraints(bad_key="foo")
 
 
 # minimum and maximum aren't checked because they depend on the type of the column
@@ -301,7 +301,7 @@ def test_table_column_constraints_values(key, value):
 
 def test_table_schema_keys():
     with pytest.raises(TypeError):
-        TableSchema(bad_key="foo")  # type: ignore
+        TableSchema(bad_key="foo")
 
 
 @pytest.mark.parametrize("key,value", list(bad_values["table_schema"].items()))

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -858,13 +858,13 @@ def test_opt_nullable_list_param():
     assert check.opt_nullable_list_param(obj_list, "list_param") == obj_list
 
     with pytest.raises(ParameterCheckError):
-        check.opt_nullable_list_param(0, "list_param")  # type: ignore
+        check.opt_nullable_list_param(0, "list_param")
 
     with pytest.raises(ParameterCheckError):
-        check.opt_nullable_list_param("", "list_param")  # type: ignore
+        check.opt_nullable_list_param("", "list_param")
 
     with pytest.raises(ParameterCheckError):
-        check.opt_nullable_list_param("3u4", "list_param")  # type: ignore
+        check.opt_nullable_list_param("3u4", "list_param")
 
 
 def test_typed_is_list():
@@ -991,7 +991,7 @@ def test_opt_mapping_param():
     assert check.opt_mapping_param(None, param_name="name") == dict()
 
     with pytest.raises(CheckError):
-        check.opt_mapping_param("foo", param_name="name")  # type: ignore
+        check.opt_mapping_param("foo", param_name="name")
 
 
 # ########################
@@ -1023,10 +1023,10 @@ def test_path_param():
         assert check.opt_path_param(Path("/a/b.csv"), "path_param") == "/a/b.csv"
 
     with pytest.raises(ParameterCheckError):
-        check.path_param(None, "path_param")  # type: ignore
+        check.path_param(None, "path_param")
 
     with pytest.raises(ParameterCheckError):
-        check.path_param(0, "path_param")  # type: ignore
+        check.path_param(0, "path_param")
 
 
 def test_opt_path_param():
@@ -1040,7 +1040,7 @@ def test_opt_path_param():
     assert check.opt_path_param(None, "path_param") is None
 
     with pytest.raises(ParameterCheckError):
-        check.opt_path_param(0, "path_param")  # type: ignore
+        check.opt_path_param(0, "path_param")
 
 
 # ########################
@@ -1053,10 +1053,10 @@ def test_set_param():
     assert check.set_param(frozenset(), "set_param") == set()
 
     with pytest.raises(ParameterCheckError):
-        check.set_param(None, "set_param")  # type: ignore
+        check.set_param(None, "set_param")
 
     with pytest.raises(ParameterCheckError):
-        check.set_param("3u4", "set_param")  # type: ignore
+        check.set_param("3u4", "set_param")
 
     obj_set = {1}
     assert check.set_param(obj_set, "set_param") == obj_set
@@ -1080,10 +1080,10 @@ def test_opt_set_param():
     assert check.opt_set_param({3}, "set_param") == {3}
 
     with pytest.raises(ParameterCheckError):
-        check.opt_set_param(0, "set_param")  # type: ignore
+        check.opt_set_param(0, "set_param")
 
     with pytest.raises(ParameterCheckError):
-        check.opt_set_param("3u4", "set_param")  # type: ignore
+        check.opt_set_param("3u4", "set_param")
 
 
 # ########################
@@ -1100,10 +1100,10 @@ def test_sequence_param():
     assert check.sequence_param("foo", "sequence_param", of_type=str) == "foo"
 
     with pytest.raises(ParameterCheckError):
-        check.sequence_param(None, "sequence_param")  # type: ignore
+        check.sequence_param(None, "sequence_param")
 
     with pytest.raises(CheckError):
-        check.sequence_param(1, "sequence_param", of_type=int)  # type: ignore
+        check.sequence_param(1, "sequence_param", of_type=int)
 
     with pytest.raises(CheckError):
         check.sequence_param(["foo"], "sequence_param", of_type=int)
@@ -1120,7 +1120,7 @@ def test_opt_sequence_param():
     assert check.opt_sequence_param(None, "sequence_param") == []
 
     with pytest.raises(CheckError):
-        check.opt_sequence_param(1, "sequence_param", of_type=int)  # type: ignore
+        check.opt_sequence_param(1, "sequence_param", of_type=int)
 
     with pytest.raises(CheckError):
         check.opt_sequence_param(["foo"], "sequence_param", of_type=int)
@@ -1137,7 +1137,7 @@ def test_opt_nullable_sequence_param():
     assert check.opt_nullable_sequence_param(None, "sequence_param") is None
 
     with pytest.raises(CheckError):
-        check.opt_nullable_sequence_param(1, "sequence_param", of_type=int)  # type: ignore
+        check.opt_nullable_sequence_param(1, "sequence_param", of_type=int)
 
     with pytest.raises(CheckError):
         check.opt_nullable_sequence_param(["foo"], "sequence_param", of_type=int)
@@ -1450,7 +1450,7 @@ def test_failed():
         check.failed("some desc")
 
     with pytest.raises(CheckError, match="must be a string"):
-        check.failed(0)  # type: ignore
+        check.failed(0)
 
 
 def test_not_implemented():
@@ -1458,7 +1458,7 @@ def test_not_implemented():
         check.not_implemented("some string")
 
     with pytest.raises(CheckError, match="desc argument must be a string"):
-        check.not_implemented(None)  # type: ignore
+        check.not_implemented(None)
 
 
 def test_iterable():
@@ -1473,10 +1473,10 @@ def test_iterable():
     check.iterable_param("lkjsdkf", "stringisiterable")
 
     with pytest.raises(CheckError, match="Iterable.*None"):
-        check.iterable_param(None, "nonenotallowed")  # type: ignore
+        check.iterable_param(None, "nonenotallowed")
 
     with pytest.raises(CheckError, match="Iterable.*int"):
-        check.iterable_param(1, "intnotallowed")  # type: ignore
+        check.iterable_param(1, "intnotallowed")
 
     with pytest.raises(CheckError, match="Member of iterable mismatches type"):
         check.iterable_param([1], "typemismatch", of_type=str)
@@ -1504,7 +1504,7 @@ def test_opt_iterable():
     check.opt_iterable_param(None, "noneisallowed")
 
     with pytest.raises(CheckError, match="Iterable.*int"):
-        check.opt_iterable_param(1, "intnotallowed")  # type: ignore
+        check.opt_iterable_param(1, "intnotallowed")
 
     with pytest.raises(CheckError, match="Member of iterable mismatches type"):
         check.opt_iterable_param([1], "typemismatch", of_type=str)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
@@ -113,7 +113,7 @@ def dynamic_echo(_, nums):
         ModeDefinition(
             resource_defs={
                 "io_manager": fs_io_manager,
-                "root_input_manager": fake_root_input_manager,  # type: ignore
+                "root_input_manager": fake_root_input_manager,
             }
         )
     ]

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_type_examples_py3.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_type_examples_py3.py
@@ -132,17 +132,17 @@ def sum_job():
 
 @op
 def repeat(_, spec: Dict) -> str:
-    return spec["word"] * spec["times"]  # type: ignore
+    return spec["word"] * spec["times"]
 
 
 @op
 def set_op(_, set_input: Set[String]) -> List[String]:
-    return sorted([x for x in set_input])  # type: ignore
+    return sorted([x for x in set_input])
 
 
 @op
 def tuple_op(_, tuple_input: Tuple[String, Int, Float]) -> List:
-    return [x for x in tuple_input]  # type: ignore
+    return [x for x in tuple_input]
 
 
 @op

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -65,7 +65,7 @@ def test_descent_path():
 
     # Arg is not actually a namedtuple but the function still works on it
     ser = _serialize_dagster_namedtuple(
-        {"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map  # type: ignore
+        {"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map
     )
 
     with pytest.raises(DeserializationError, match=re.escape("Descent path: <root:dict>.a.b[2].c")):
@@ -78,7 +78,7 @@ def test_forward_compat_serdes_new_field_with_default():
     @_whitelist_for_serdes(whitelist_map=test_map)
     class Quux(namedtuple("_Quux", "foo bar")):  # type: ignore
         def __new__(cls, foo, bar):
-            return super(Quux, cls).__new__(cls, foo, bar)  # type: ignore
+            return super(Quux, cls).__new__(cls, foo, bar)
 
     assert test_map.has_tuple_entry("Quux")
     klass, _, _ = test_map.get_tuple_entry("Quux")
@@ -88,7 +88,7 @@ def test_forward_compat_serdes_new_field_with_default():
 
     serialized = _serialize_dagster_namedtuple(quux, whitelist_map=test_map)
 
-    @_whitelist_for_serdes(whitelist_map=test_map)  # type: ignore
+    @_whitelist_for_serdes(whitelist_map=test_map)
     class Quux(namedtuple("_Quux", "foo bar baz")):
         def __new__(cls, foo, bar, baz=None):
             return super(Quux, cls).__new__(cls, foo, bar, baz=baz)
@@ -176,7 +176,7 @@ def test_backward_compat_serdes():
     @_whitelist_for_serdes(whitelist_map=test_map)
     class Quux(namedtuple("_Quux", "foo bar baz")):  # type: ignore
         def __new__(cls, foo, bar, baz):
-            return super(Quux, cls).__new__(cls, foo, bar, baz)  # type: ignore
+            return super(Quux, cls).__new__(cls, foo, bar, baz)
 
     quux = Quux("zip", "zow", "whoopie")
 
@@ -241,7 +241,7 @@ def test_wrong_first_arg():
         @serdes_test_class
         class NotCls(namedtuple("NotCls", "field_one field_two")):
             def __new__(not_cls, field_two, field_one):  # type: ignore
-                return super(NotCls, not_cls).__new__(field_one, field_two)  # type: ignore
+                return super(NotCls, not_cls).__new__(field_one, field_two)
 
     assert (
         str(exc_info.value)
@@ -255,7 +255,7 @@ def test_incorrect_order():
         @serdes_test_class
         class WrongOrder(namedtuple("WrongOrder", "field_one field_two")):
             def __new__(cls, field_two, field_one):
-                return super(WrongOrder, cls).__new__(field_one, field_two)  # type: ignore
+                return super(WrongOrder, cls).__new__(field_one, field_two)
 
     assert (
         str(exc_info.value)
@@ -272,9 +272,7 @@ def test_missing_one_parameter():
         @serdes_test_class
         class MissingFieldInNew(namedtuple("MissingFieldInNew", "field_one field_two field_three")):
             def __new__(cls, field_one, field_two):
-                return super(MissingFieldInNew, cls).__new__(
-                    field_one, field_two, None
-                )  # type: ignore
+                return super(MissingFieldInNew, cls).__new__(field_one, field_two, None)
 
     assert (
         str(exc_info.value)
@@ -471,7 +469,7 @@ def test_skip_when_empty():
     @_whitelist_for_serdes(whitelist_map=test_map)
     class SameSnapshotTuple(namedtuple("_Tuple", "foo")):  # type: ignore
         def __new__(cls, foo):
-            return super(SameSnapshotTuple, cls).__new__(cls, foo)  # type: ignore
+            return super(SameSnapshotTuple, cls).__new__(cls, foo)
 
     old_tuple = SameSnapshotTuple(foo="A")
     old_serialized = _serialize_dagster_namedtuple(old_tuple, whitelist_map=test_map)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -236,7 +236,7 @@ NUM_CALLS = {"sync": 0, "async": 0}
 
 
 def get_passes_on_retry_schedule(key):
-    @daily_schedule(  # type: ignore
+    @daily_schedule(
         pipeline_name="the_job",
         start_date=_COUPLE_DAYS_AGO,
         execution_timezone="UTC",

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -187,7 +187,7 @@ def test_upath_io_manager_multiple_time_partitions(
     assert len(downstream_asset_data) == 24, "downstream day should map to upstream 24 hours"
 
 
-def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOManager):  # type: ignore[no-redef]
+def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOManager):
     upstream_partitions_def = StaticPartitionsDefinition(["A", "B"])
 
     @asset(partitions_def=upstream_partitions_def)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -570,7 +570,7 @@ def reconcile_connections_post(
             # Enable or disable basic normalization based on config
             normalization_operation_id = reconcile_normalization(
                 res,
-                existing_connections.get("name", {}).get("connectionId"),  # type: ignore
+                existing_connections.get("name", {}).get("connectionId"),
                 destination,
                 config_conn.normalize_data,
                 workspace_id,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -165,7 +165,7 @@ class AirbyteResource:
     def get_default_workspace(self) -> str:
         workspaces = cast(
             List[Dict[str, Any]],
-            check.not_none(self.make_request_cached(endpoint="/workspaces/list", data={})).get(  # type: ignore  # fmt: skip
+            check.not_none(self.make_request_cached(endpoint="/workspaces/list", data={})).get(
                 "workspaces", []
             ),
         )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Optional, cast
 # airflow 1.x and 2.x.
 import requests
 from airflow.exceptions import AirflowException
-from airflow.hooks.base_hook import BaseHook  # type: ignore  # (airflow 1 compat)
+from airflow.hooks.base_hook import BaseHook
 from airflow.models import Connection
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/utils.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/utils.py
@@ -18,7 +18,7 @@ def is_airflow_2_loaded_in_environment() -> bool:
 if is_airflow_2_loaded_in_environment():
     from airflow.utils.session import create_session
 else:
-    from airflow.utils.db import create_session  # type: ignore  # (airflow 1 compat)
+    from airflow.utils.db import create_session
 # pylint: enable=no-name-in-module,import-error
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
@@ -9,15 +9,15 @@ from airflow import __version__ as airflow_version
 
 if airflow_version >= "2.0.0":
     from airflow.providers.apache.spark.operators.spark_submit import (
-        SparkSubmitOperator,  # type: ignore  # (airflow 1 compat)
+        SparkSubmitOperator,
     )
 else:
     from airflow.contrib.operators.spark_submit_operator import (
         SparkSubmitOperator,  # type: ignore  # (airflow 1 compat)
     )
 
-from airflow.models.dag import DAG  # type: ignore  # (airflow 1 compat)
-from airflow.operators.bash_operator import BashOperator  # type: ignore  # (airflow 1 compat)
+from airflow.models.dag import DAG
+from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
 from dagster import DagsterEventType

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
@@ -3,7 +3,7 @@ import os
 
 from airflow import __version__ as airflow_version
 from airflow.models.dag import DAG
-from airflow.operators.bash_operator import BashOperator  # type: ignore  # (airflow 1 compat)
+from airflow.operators.bash_operator import BashOperator
 from airflow.utils.dates import days_ago
 from dagster import DagsterEventType
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -450,7 +450,7 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
 
     def _get_run_task_definition_family(self, run) -> str:
         return sanitize_family(
-            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name  # type: ignore
+            run.external_pipeline_origin.external_repository_origin.repository_location_origin.location_name
         )
 
     def _get_container_name(self, container_context) -> str:

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_inclusion.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_inclusion.py
@@ -5,7 +5,7 @@ from dagster_celery_k8s_tests.example_celery_mode_def import celery_enabled_job
 
 
 def test_include_launcher_works():
-    assert CeleryK8sRunLauncher  # type: ignore
+    assert CeleryK8sRunLauncher
 
 
 def test_include_executor_works():

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -65,7 +65,7 @@ class DaskResource:
         self._client, self._cluster = None, None
 
 
-@resource(  # type: ignore
+@resource(
     description="Dask Client resource.",
     config_schema=Shape(
         {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -106,15 +106,15 @@ def _select_unique_ids_from_manifest_json(
     graph = graph_selector.Graph(DiGraph(incoming_graph_data=manifest_json["child_map"]))
     manifest = Manifest(
         # dbt expects dataclasses that can be accessed with dot notation, not bare dictionaries
-        nodes={unique_id: _DictShim(info) for unique_id, info in manifest_json["nodes"].items()},  # type: ignore
+        nodes={unique_id: _DictShim(info) for unique_id, info in manifest_json["nodes"].items()},
         sources={
-            unique_id: _DictShim(info) for unique_id, info in manifest_json["sources"].items()  # type: ignore
+            unique_id: _DictShim(info) for unique_id, info in manifest_json["sources"].items()
         },
         metrics={
-            unique_id: _DictShim(info) for unique_id, info in manifest_json["metrics"].items()  # type: ignore
+            unique_id: _DictShim(info) for unique_id, info in manifest_json["metrics"].items()
         },
         exposures={
-            unique_id: _DictShim(info) for unique_id, info in manifest_json["exposures"].items()  # type: ignore
+            unique_id: _DictShim(info) for unique_id, info in manifest_json["exposures"].items()
         },
     )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/ops.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/ops.py
@@ -38,7 +38,7 @@ Examples:
 # double-splatted, so we type-ignore the below op declarations.
 
 
-@op(  # type: ignore
+@op(
     **_DEFAULT_OP_PROPS,
     config_schema={
         "yield_asset_events": Field(
@@ -71,7 +71,7 @@ def dbt_build_op(context):
     yield Output(dbt_output)
 
 
-@op(  # type: ignore
+@op(
     **_DEFAULT_OP_PROPS,
     config_schema={
         "yield_materializations": Field(
@@ -101,32 +101,32 @@ def dbt_run_op(context):
     yield Output(dbt_output)
 
 
-@op(**_DEFAULT_OP_PROPS)  # type: ignore
+@op(**_DEFAULT_OP_PROPS)
 def dbt_compile_op(context):
     return context.resources.dbt.compile()
 
 
-@op(**_DEFAULT_OP_PROPS)  # type: ignore
+@op(**_DEFAULT_OP_PROPS)
 def dbt_ls_op(context):
     return context.resources.dbt.ls()
 
 
-@op(**_DEFAULT_OP_PROPS)  # type: ignore
+@op(**_DEFAULT_OP_PROPS)
 def dbt_test_op(context):
     return context.resources.dbt.test()
 
 
-@op(**_DEFAULT_OP_PROPS)  # type: ignore
+@op(**_DEFAULT_OP_PROPS)
 def dbt_snapshot_op(context):
     return context.resources.dbt.snapshot()
 
 
-@op(**_DEFAULT_OP_PROPS)  # type: ignore
+@op(**_DEFAULT_OP_PROPS)
 def dbt_seed_op(context):
     return context.resources.dbt.seed()
 
 
-@op(**_DEFAULT_OP_PROPS)  # type: ignore
+@op(**_DEFAULT_OP_PROPS)
 def dbt_docs_generate_op(context):
     return context.resources.dbt.generate_docs()
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,5 +1,5 @@
 from dagster import resource
-from google.cloud import bigquery  # type: ignore
+from google.cloud import bigquery
 
 from .configs import bq_resource_config
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -20,7 +20,7 @@ from dagster._core.storage.local_compute_log_manager import (
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import ensure_dir, ensure_file
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 
 class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/file_manager.py
@@ -10,7 +10,7 @@ from dagster._core.storage.file_manager import (
     TempfileManager,
     check_file_like_obj,
 )
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 
 class GCSFileHandle(FileHandle):

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -13,7 +13,7 @@ from dagster import (
 from dagster._utils import PICKLE_PROTOCOL
 from dagster._utils.backoff import backoff
 from google.api_core.exceptions import Forbidden, ServiceUnavailable, TooManyRequests
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 DEFAULT_LEASE_DURATION = 60  # One minute
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/resources.py
@@ -1,6 +1,6 @@
 from dagster import Field, Noneable, StringSource, resource
 from dagster._utils.merger import merge_dicts
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 from .file_manager import GCSFileManager
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_ops.py
@@ -22,7 +22,7 @@ from dagster_gcp import (
     import_gcs_paths_to_bq,
 )
 from dagster_pandas import DataFrame
-from google.cloud import bigquery  # type: ignore
+from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -16,7 +16,7 @@ from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import environ
 from dagster_gcp.gcs import GCSComputeLogManager
 from dagster_tests.storage_tests.test_captured_log_manager import TestCapturedLogManager
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 HELLO_WORLD = "Hello World"
 SEPARATOR = os.linesep if (os.name == "nt" and sys.version_info < (3,)) else "\n"

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_gcs_file_manager.py
@@ -3,7 +3,7 @@ from unittest import mock
 from dagster import configured, job, op
 from dagster_gcp.gcs.file_manager import GCSFileHandle, GCSFileManager
 from dagster_gcp.gcs.resources import gcs_file_manager
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 
 def test_gcs_file_manager_write():

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -32,7 +32,7 @@ from dagster._legacy import AssetGroup, DagsterRun
 from dagster_gcp.gcs import FakeGCSClient
 from dagster_gcp.gcs.io_manager import PickledObjectGCSIOManager, gcs_pickle_io_manager
 from dagster_gcp.gcs.resources import gcs_resource
-from google.cloud import storage  # type: ignore
+from google.cloud import storage
 
 
 @resource

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -64,7 +64,7 @@ def teams_on_failure(
             )
         card = Card()
         card.add_attachment(text_message=text)
-        context.resources.msteams.post_message(payload=card.payload)  # type: ignore
+        context.resources.msteams.post_message(payload=card.payload)
 
     return _hook
 
@@ -115,6 +115,6 @@ def teams_on_success(
             )
         card = Card()
         card.add_attachment(text_message=text)
-        context.resources.msteams.post_message(payload=card.payload)  # type: ignore
+        context.resources.msteams.post_message(payload=card.payload)
 
     return _hook

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -106,7 +106,7 @@ def retry_mysql_creation_fn(fn, retry_limit: int = 5, retry_wait: float = 0.2):
                 and exc.orig.errno == mysql_errorcode.ER_TABLE_EXISTS_ERROR
             ) or (
                 isinstance(exc, mysql.ProgrammingError)
-                and exc.errno == mysql_errorcode.ER_TABLE_EXISTS_ERROR  # type: ignore
+                and exc.errno == mysql_errorcode.ER_TABLE_EXISTS_ERROR
             ):
                 raise
             logging.warning("Retrying failed database creation")

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -69,7 +69,7 @@ def pagerduty_on_failure(
                     base_url=dagit_base_url, run_id=context.run_id
                 )
             }
-        context.resources.pagerduty.EventV2_create(  # type: ignore
+        context.resources.pagerduty.EventV2_create(
             summary=summary_fn(context),
             source=_source_fn(context),
             severity=severity,

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_config_driven_df.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_config_driven_df.py
@@ -10,8 +10,6 @@ from dagster_pandas import DataFrame
 
 def check_parquet_support():
     try:
-        import pyarrow  # type: ignore  # noqa: F401
-
         return
     except ImportError:
         pass

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -96,7 +96,7 @@ def pandera_schema_to_dagster_type(
 
     name = _extract_name_from_pandera_schema(schema)
     norm_schema = (
-        schema.to_schema()  # type: ignore[attr-defined]
+        schema.to_schema()
         if isinstance(schema, type) and issubclass(schema, pa.SchemaModel)
         else schema
     )
@@ -117,13 +117,13 @@ def pandera_schema_to_dagster_type(
 _anonymous_schema_name_generator = (f"DagsterPanderaDataframe{i}" for i in itertools.count(start=1))
 
 
-def _extract_name_from_pandera_schema(  # type: ignore[return]
+def _extract_name_from_pandera_schema(
     schema: Union[pa.DataFrameSchema, Type[pa.SchemaModel]],
 ) -> str:
     if isinstance(schema, type) and issubclass(schema, pa.SchemaModel):
         return (
-            getattr(schema.Config, "title", None)  # type: ignore[attr-defined]
-            or getattr(schema.Config, "name", None)  # type: ignore[attr-defined]
+            getattr(schema.Config, "title", None)
+            or getattr(schema.Config, "name", None)
             or schema.__name__
         )
     elif isinstance(schema, pa.DataFrameSchema):

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -66,7 +66,7 @@ def slack_on_failure(
                 base_url=dagit_base_url, run_id=context.run_id
             )
 
-        context.resources.slack.chat_postMessage(channel=channel, text=text)  # type: ignore
+        context.resources.slack.chat_postMessage(channel=channel, text=text)
 
     return _hook
 
@@ -116,6 +116,6 @@ def slack_on_success(
                 base_url=dagit_base_url, run_id=context.run_id
             )
 
-        context.resources.slack.chat_postMessage(channel=channel, text=text)  # type: ignore
+        context.resources.slack.chat_postMessage(channel=channel, text=text)
 
     return _hook

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -91,10 +91,10 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             )
             with_uppercase_cols.to_sql(
                 table_slice.table,
-                con=con.engine,  # type: ignore  # (bad stubs)
+                con=con.engine,
                 if_exists="append",
                 index=False,
-                method=pd_writer,  # pyright: ignore (bad stubs)
+                method=pd_writer,
             )
 
         return {

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -146,7 +146,7 @@ class SnowflakeDbClient(DbClient):
             else {}
         )
         with SnowflakeConnection(
-            dict(schema=table_slice.schema, **no_schema_config), context.log  # type: ignore
+            dict(schema=table_slice.schema, **no_schema_config), context.log
         ).get_connection() as con:
             try:
                 con.execute_string(_get_cleanup_statement(table_slice))

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -66,13 +66,13 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         check.str_param(key, "key")
         return self._pipeline_context.get_tag(key)
 
-    @public  # type: ignore
+    @public
     @property
     def run_id(self) -> str:
         """str: The run_id for the context."""
         return self._pipeline_context.run_id
 
-    @public  # type: ignore
+    @public
     @property
     def run_config(self) -> Mapping[str, Any]:
         """dict: The run_config for the context."""
@@ -83,13 +83,13 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         """:class:`dagster.ResolvedRunConfig`: The resolved_run_config for the context."""
         return self._pipeline_context.resolved_run_config
 
-    @public  # type: ignore
+    @public
     @property
     def logging_tags(self) -> Mapping[str, str]:
         """dict: The logging tags for the context."""
         return self._pipeline_context.logging_tags
 
-    @public  # type: ignore
+    @public
     @property
     def job_name(self) -> str:
         return self._pipeline_context.job_name
@@ -103,7 +103,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         )
         return self.job_name
 
-    @public  # type: ignore
+    @public
     @property
     def job_def(self) -> JobDefinition:
         """:class:`dagster.JobDefinition`: The job definition for the context.
@@ -141,7 +141,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
             required_resource_keys=self._resource_keys_to_init,
         )
 
-    @public  # type: ignore
+    @public
     @property
     def run(self) -> DagsterRun:
         """:class:`dagster.DagsterRun`: The job run for the context."""
@@ -164,7 +164,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         """
         return self._pipeline_context.log
 
-    @public  # type: ignore
+    @public
     @property
     def op_def(self) -> OpDefinition:
         """:class:`dagster.OpDefinition`: The op definition for the context.
@@ -202,7 +202,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         )
         return self.pipeline_def.get_solid(self.solid_handle)
 
-    @public  # type: ignore
+    @public
     @property
     def op_config(self) -> Any:
         """collections.namedtuple: A dynamically-created type whose properties allow access to

--- a/python_modules/libraries/dagstermill/dagstermill/engine.py
+++ b/python_modules/libraries/dagstermill/dagstermill/engine.py
@@ -75,9 +75,9 @@ if is_papermill_2():
             return DagstermillNotebookClient(nb_man, **final_kwargs).execute()
 
 else:
-    from papermill.engines import NBConvertEngine  # type: ignore  # (papermill 1 compat)
+    from papermill.engines import NBConvertEngine
     from papermill.preprocess import (  # type: ignore  # (papermill 1 compat)
-        PapermillExecutePreprocessor,  # type: ignore  # (papermill 1 compat)
+        PapermillExecutePreprocessor,
     )
 
     class DagstermillExecutePreprocessor(PapermillExecutePreprocessor):
@@ -110,7 +110,7 @@ else:
 
             return nb_man.nb, resources
 
-    class DagstermillEngine(NBConvertEngine):  # type: ignore  # (papermill 1 compat)
+    class DagstermillEngine(NBConvertEngine):
         @classmethod
         def execute_managed_notebook(
             cls,

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -73,7 +73,7 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
     def load_input(self, context) -> bytes:
         check.inst_param(context, "context", InputContext)
         # pass output notebook to downstream ops as File Object
-        output_context = check.not_none(context.upstream_output)  # type: ignore  # fmt: skip
+        output_context = check.not_none(context.upstream_output)
         with open(self._get_path(output_context), self.read_mode) as file_obj:
             return file_obj.read()
 

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -409,7 +409,7 @@ class Manager:
 
     def load_input_parameter(self, input_name: str):
         # load input from source
-        dm_context = check.not_none(self.context)  # type: ignore  # fmt: skip
+        dm_context = check.not_none(self.context)
         if not isinstance(dm_context, DagstermillRuntimeExecutionContext):
             check.failed("Expected DagstermillRuntimeExecutionContext")
         step_context = dm_context.step_context  # pylint: disable=protected-access


### PR DESCRIPTION
### Summary & Motivation

This turns on pyright's `reportUnnecessaryTypeIgnoreComment` rule and removes a very large number of type-ignores that we no longer need since we have dropped mypy.

### How I Tested These Changes

BK