### PR TITLE
[pyright] --find-links for gprcio wheels

### DIFF
--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -192,7 +192,11 @@ def normalize_env(env: str, rebuild: bool) -> None:
             [
                 f"python -m venv {venv_path}",
                 f"{venv_path}/bin/pip install -U pip setuptools wheel",
-                f"{venv_path}/bin/pip install -r {requirements_path}",
+                (
+                    f"{venv_path}/bin/pip install -r"
+                    # find-links for M1 lookup of grpcio wheels
+                    f" {requirements_path} --find-links=https://github.com/dagster-io/build-grpcio/wiki/Wheels"
+                ),
             ]
         )
         try:


### PR DESCRIPTION
`grpcio` installed fine in my dev venv but for whatever reason it was failing to compile in the venv created by this script. 

### How I Tested These Changes

`python scripts/run-pyright.py --rebuild`
