### PR TITLE
Add pyright_rebuild Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ check_black:
 pyright:
 	python scripts/run-pyright.py --all
 
+pyright_rebuild:
+	python scripts/run-pyright.py --all --rebuild
+
 ruff:
 	ruff --fix .
 


### PR DESCRIPTION
### Summary & Motivation

Adds a `pyright_rebuild` Makefile target to run pyright with rebuild of venvs.

### How I Tested These Changes

`make pyright_rebuild`
