### PR TITLE
Fix instructions for using serverless from the CLI without GitHub

### DIFF
--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -79,10 +79,10 @@ You can also configure the `dagster-cloud` tool noninteractively; see [the CLI d
 Add `dagster-cloud` as a dependency to `my-dagster-project/setup.py`:
 
 ```python
-  install_requires=[
-      "dagster",
-      "dagster-cloud",    # add this line
-      "dagster-airbyte",
+install_requires=[
+    "dagster",
+    "dagster-cloud",    # add this line
+    "dagster-airbyte",
 ```
 
 Finally, deploy your project with Dagster Cloud Serverless:

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -76,10 +76,19 @@ dagster-cloud configure
 
 You can also configure the `dagster-cloud` tool noninteractively; see [the CLI docs](/dagster-cloud/developing-testing/dagster-cloud-cli#environment-variables-and-cli-options) for more information.
 
+Add 'dagster-cloud' as a dependency to `my-dagster-project/setup.py`:
+
+```
+    install_requires=[
+        "dagster",
+        "dagster-cloud",    # add this line
+        "dagster-airbyte",
+```
+
 Finally, deploy your project with Dagster Cloud Serverless:
 
 ```shell
-dagster-cloud serverless deploy-python-executable \
+dagster-cloud serverless deploy-python-executable ./my-dagster-project \
   --location-name example \
   --package-name assets_modern_data_stack
 ```

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -76,13 +76,13 @@ dagster-cloud configure
 
 You can also configure the `dagster-cloud` tool noninteractively; see [the CLI docs](/dagster-cloud/developing-testing/dagster-cloud-cli#environment-variables-and-cli-options) for more information.
 
-Add 'dagster-cloud' as a dependency to `my-dagster-project/setup.py`:
+Add `dagster-cloud` as a dependency to `my-dagster-project/setup.py`:
 
-```
-    install_requires=[
-        "dagster",
-        "dagster-cloud",    # add this line
-        "dagster-airbyte",
+```python
+  install_requires=[
+      "dagster",
+      "dagster-cloud",    # add this line
+      "dagster-airbyte",
 ```
 
 Finally, deploy your project with Dagster Cloud Serverless:


### PR DESCRIPTION
### Summary & Motivation

The instructions didn't work out of the box. Added a note about the `dagster-cloud` dependency and updated the command to point it at the right directory. 
