### PR TITLE
hide download links until logs are available

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -117,7 +117,7 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
         # check remote storage
         return self.cloud_storage_has_logs(log_key, ComputeIOType.STDERR)
 
-    def _log_data_for_type(self, log_key, io_type, offset, max_bytes):
+    def log_data_for_type(self, log_key, io_type, offset, max_bytes):
         if self._has_local_file(log_key, io_type):
             local_path = self.local_manager.get_captured_local_path(
                 log_key, IO_TYPE_EXTENSION[io_type]
@@ -145,10 +145,10 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
         max_bytes: Optional[int] = None,
     ) -> CapturedLogData:
         stdout_offset, stderr_offset = self.local_manager.parse_cursor(cursor)
-        stdout, new_stdout_offset = self._log_data_for_type(
+        stdout, new_stdout_offset = self.log_data_for_type(
             log_key, ComputeIOType.STDOUT, stdout_offset, max_bytes
         )
-        stderr, new_stderr_offset = self._log_data_for_type(
+        stderr, new_stderr_offset = self.log_data_for_type(
             log_key, ComputeIOType.STDERR, stderr_offset, max_bytes
         )
         return CapturedLogData(
@@ -242,7 +242,7 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
 
     def download_url(self, run_id, key, io_type):
         if not self.is_watch_completed(run_id, key):
-            return self.local_manager.download_url(run_id, key, io_type)
+            return None
 
         log_key = self.local_manager.build_log_key_for_run(run_id, key)
         return self.download_url_for_type(log_key, io_type)


### PR DESCRIPTION
### Summary & Motivation
In a multi-dagit replica world, it doesn't make sense to have the local compute log manager serve any downloadable content until the content is available on the remote storage.

Also, renamed `_log_data_for_type` => `log_data_for_type` so that we could more easily override in cloud to skip the local FS check.

### How I Tested These Changes
BK

https://user-images.githubusercontent.com/1040172/217363652-e0bfc10e-0174-4cec-b922-0882d26e8e84.mov


