### PR TITLE
[db io manager] Support MultiPartitions

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -28,7 +28,7 @@ from dagster._core.storage.io_manager import IOManager
 T = TypeVar("T")
 
 
-class TablePartition(NamedTuple):
+class PartitionDimension(NamedTuple):
     partition_expr: str
     partition: Union[TimeWindow, str]
 
@@ -38,7 +38,7 @@ class TableSlice(NamedTuple):
     schema: str
     database: Optional[str] = None
     columns: Optional[Sequence[str]] = None
-    partition: Optional[Sequence[TablePartition]] = None
+    partition: Optional[Sequence[PartitionDimension]] = None
 
 
 class DbTypeHandler(ABC, Generic[T]):
@@ -150,7 +150,7 @@ class DbIOManager(IOManager):
         schema: str
         table: str
         partition_value: Optional[Union[TimeWindow, str]] = None
-        partitions: List[TablePartition] = []
+        partitions: List[PartitionDimension] = []
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
             table = asset_key_path[-1]
@@ -195,7 +195,7 @@ class DbIOManager(IOManager):
                                 f" {part.name} partition."
                             )
                         partitions.append(
-                            TablePartition(
+                            PartitionDimension(
                                 partition_expr=partition_expr_str, partition=partition_value
                             )
                         )
@@ -207,7 +207,9 @@ class DbIOManager(IOManager):
                     )
 
                     partitions.append(
-                        TablePartition(partition_expr=partition_expr_str, partition=partition_value)
+                        PartitionDimension(
+                            partition_expr=partition_expr_str, partition=partition_value
+                        )
                     )
         else:
             table = output_context.name

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -18,6 +18,7 @@ import dagster._check as check
 from dagster._check import CheckError
 from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.execution.context.input import InputContext
@@ -132,7 +133,9 @@ class DbIOManager(IOManager):
             context, self._get_table_slice(context, cast(OutputContext, context.upstream_output))
         )
 
-    def _get_partition_value(self, partition_def, partition_key):
+    def _get_partition_value(
+        self, partition_def: PartitionsDefinition, partition_key: str
+    ) -> Union[TimeWindow, str]:
         try:
             return partition_def.time_window_for_partition_key(partition_key)
         except (ValueError, AttributeError):
@@ -175,14 +178,14 @@ class DbIOManager(IOManager):
                     )
 
                 if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):
-                    multi_partition_key_mapping = context.asset_partition_key.keys_by_dimension
+                    multi_partition_key_mapping = context.asset_partitions_def.keys_by_dimension
                     for part in context.asset_partitions_def.partitions_defs:
                         partition_key = multi_partition_key_mapping.get(part.name)
                         partition_value = self._get_partition_value(
                             part.partitions_def, partition_key
                         )
 
-                        partition_expr_str = partition_expr.get(part.name)
+                        partition_expr_str = cast(Mapping[str, str], partition_expr.get(part.name))
                         if partition_expr is None:
                             raise ValueError(
                                 f"Asset '{context.asset_key}' has partition {part.name}, but the"

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -178,7 +178,7 @@ class DbIOManager(IOManager):
                     )
 
                 if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):
-                    multi_partition_key_mapping = context.asset_partitions_def.keys_by_dimension
+                    multi_partition_key_mapping = context.asset_partition_key.keys_by_dimension
                     for part in context.asset_partitions_def.partitions_defs:
                         partition_key = multi_partition_key_mapping.get(part.name)
                         partition_value = self._get_partition_value(

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -17,6 +17,7 @@ import dagster._check as check
 from dagster._check import CheckError
 from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.definitions.partition import StaticPartitionsDefinition
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.execution.context.input import InputContext
@@ -36,7 +37,7 @@ class TableSlice(NamedTuple):
     schema: str
     database: Optional[str] = None
     columns: Optional[Sequence[str]] = None
-    partition: Optional[TablePartition] = None
+    partition: Optional[Sequence[TablePartition]] = None
 
 
 class DbTypeHandler(ABC, Generic[T]):
@@ -131,6 +132,7 @@ class DbIOManager(IOManager):
             context, self._get_table_slice(context, cast(OutputContext, context.upstream_output))
         )
 
+
     def _get_table_slice(
         self, context: Union[OutputContext, InputContext], output_context: OutputContext
     ) -> TableSlice:
@@ -139,6 +141,7 @@ class DbIOManager(IOManager):
         schema: str
         table: str
         partition_value: Optional[Union[TimeWindow, str]] = None
+        partitions: List[TablePartition] = []
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
             table = asset_key_path[-1]
@@ -156,10 +159,37 @@ class DbIOManager(IOManager):
             else:
                 schema = "public"
             if context.has_asset_partitions:
-                if isinstance(context.asset_partitions_def, StaticPartitionsDefinition):
-                    partition_value = context.asset_partition_key
+                partition_expr = output_context_metadata.get("partition_expr")
+                if partition_expr is None:
+                    raise ValueError(
+                        f"Asset '{context.asset_key}' has partitions, but no 'partition_expr' metadata"
+                        " value, so we don't know what column to filter it on. Specify which column(s) of"
+                        " the database contains partitioned data as the 'partition_expr' metadata."
+                    )
+
+                if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):
+                    multi_partition_key_mapping = context.asset_partition_key.keys_by_dimension
+                    for part in context.asset_partitions_def.partitions_defs:
+                        if isinstance(part.partitions_def, StaticPartitionsDefinition):
+                            partition_value = multi_partition_key_mapping.get(part.name)
+                        else:
+                            time_partition_key = multi_partition_key_mapping.get(part.name)
+                            partition_value = part.partitions_def.time_window_for_partition_key(time_partition_key)
+                        partition_expr_str = partition_expr.get(part.name)
+                        if partition_expr is None:
+                            raise ValueError(
+                                f"Asset '{context.asset_key}' has partition {part.name}, but the 'partition_expr' metadata"
+                                f" does not contain a {part.name} entry, so we don't know what column to filter it on. Specify which column of"
+                                f" the database contains data for the {part.name} partition."
+                            )
+                        partitions.append(TablePartition(partition_expr=partition_expr_str, partition=partition_value))
                 else:
-                    partition_value = context.asset_partitions_time_window
+                    partition_expr_str = cast(str, partition_expr)
+                    if isinstance(context.asset_partitions_def, StaticPartitionsDefinition):
+                        partition_value = context.asset_partition_key
+                    else:
+                        partition_value = context.asset_partitions_time_window
+                    partitions.append(TablePartition(partition_expr=partition_expr_str, partition=partition_value))
         else:
             table = output_context.name
             if output_context_metadata.get("schema") and self._schema:
@@ -176,23 +206,11 @@ class DbIOManager(IOManager):
             else:
                 schema = "public"
 
-        if partition_value is not None:
-            partition_expr = cast(str, output_context_metadata.get("partition_expr"))
-            if partition_expr is None:
-                raise ValueError(
-                    f"Asset '{context.asset_key}' has partitions, but no 'partition_expr' metadata"
-                    " value, so we don't know what column to filter it on. Specify which column of"
-                    " the  database contains partitioned data as the 'partition_expr' metadata."
-                )
-            partition = TablePartition(partition_expr=partition_expr, partition=partition_value)
-        else:
-            partition = None
-
         return TableSlice(
             table=table,
             schema=schema,
             database=self._database,
-            partition=partition,
+            partition=partitions,
             columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
         )
 

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -44,7 +44,7 @@ class TableSlice(NamedTuple):
     schema: str
     database: Optional[str] = None
     columns: Optional[Sequence[str]] = None
-    partition: Optional[Sequence[TablePartitionDimension]] = None
+    partition_dimensions: Optional[Sequence[TablePartitionDimension]] = None
 
 
 class DbTypeHandler(ABC, Generic[T]):
@@ -156,7 +156,7 @@ class DbIOManager(IOManager):
         schema: str
         table: str
         partition_value: Optional[Union[TimeWindow, str]] = None
-        partitions: List[TablePartitionDimension] = []
+        partition_dimensions: List[TablePartitionDimension] = []
         if context.has_asset_key:
             asset_key_path = context.asset_key.path
             table = asset_key_path[-1]
@@ -202,7 +202,7 @@ class DbIOManager(IOManager):
                                 " column of the database contains data for the"
                                 f" {part.name} partition."
                             )
-                        partitions.append(
+                        partition_dimensions.append(
                             TablePartitionDimension(
                                 partition_expr=cast(str, partition_expr_str),
                                 partition=partition_value,
@@ -215,7 +215,7 @@ class DbIOManager(IOManager):
                         context.asset_partitions_def, partition_key
                     )
 
-                    partitions.append(
+                    partition_dimensions.append(
                         TablePartitionDimension(
                             partition_expr=partition_expr_str, partition=partition_value
                         )
@@ -240,7 +240,7 @@ class DbIOManager(IOManager):
             table=table,
             schema=schema,
             database=self._database,
-            partition=partitions,
+            partition_dimensions=partition_dimensions,
             columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
         )
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -90,7 +90,7 @@ def test_asset_out():
 
     assert len(handler.handle_output_calls) == 1
     table_slice = TableSlice(
-        database="database_abc", schema="schema1", table="table1", partition=[]
+        database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
@@ -118,7 +118,7 @@ def test_asset_out_columns():
 
     assert len(handler.handle_output_calls) == 1
     table_slice = TableSlice(
-        database="database_abc", schema="schema1", table="table1", partition=[]
+        database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
@@ -129,7 +129,7 @@ def test_asset_out_columns():
         schema="schema1",
         table="table1",
         columns=["apple", "banana"],
-        partition=[],
+        partition_dimensions=[],
     )
 
 
@@ -168,7 +168,7 @@ def test_asset_out_partitioned():
         database="database_abc",
         schema="schema1",
         table="table1",
-        partition=[
+        partition_dimensions=[
             TablePartitionDimension(
                 partition=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
                 partition_expr="abc",
@@ -212,7 +212,7 @@ def test_asset_out_static_partitioned():
         database="database_abc",
         schema="schema1",
         table="table1",
-        partition=[
+        partition_dimensions=[
             TablePartitionDimension(
                 partition="red",
                 partition_expr="abc",
@@ -237,7 +237,7 @@ def test_different_output_and_input_types():
     assert len(int_handler.handle_output_calls) == 1
     assert len(str_handler.handle_output_calls) == 0
     table_slice = TableSlice(
-        database="database_abc", schema="schema1", table="table1", partition=[]
+        database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert int_handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
@@ -277,7 +277,7 @@ def test_non_asset_out():
 
     assert len(handler.handle_output_calls) == 1
     table_slice = TableSlice(
-        database="database_abc", schema="schema1", table="table1", partition=[]
+        database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -10,7 +10,7 @@ from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
-    TablePartition,
+    PartitionDimension,
     TableSlice,
 )
 from dagster._core.types.dagster_type import resolve_dagster_type
@@ -168,7 +168,7 @@ def test_asset_out_partitioned():
         schema="schema1",
         table="table1",
         partition=[
-            TablePartition(
+            PartitionDimension(
                 partition=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
                 partition_expr="abc",
             )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -10,7 +10,7 @@ from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
-    PartitionDimension,
+    TablePartitionDimension,
     TableSlice,
 )
 from dagster._core.types.dagster_type import resolve_dagster_type
@@ -168,7 +168,7 @@ def test_asset_out_partitioned():
         schema="schema1",
         table="table1",
         partition=[
-            PartitionDimension(
+            TablePartitionDimension(
                 partition=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
                 partition_expr="abc",
             )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -88,7 +88,9 @@ def test_asset_out():
     assert manager.load_input(input_context) == 7
 
     assert len(handler.handle_output_calls) == 1
-    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    table_slice = TableSlice(
+        database="database_abc", schema="schema1", table="table1", partition=[]
+    )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
 
@@ -114,13 +116,19 @@ def test_asset_out_columns():
     assert manager.load_input(input_context) == 7
 
     assert len(handler.handle_output_calls) == 1
-    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    table_slice = TableSlice(
+        database="database_abc", schema="schema1", table="table1", partition=[]
+    )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
 
     assert len(handler.handle_input_calls) == 1
     assert handler.handle_input_calls[0][1] == TableSlice(
-        database="database_abc", schema="schema1", table="table1", columns=["apple", "banana"]
+        database="database_abc",
+        schema="schema1",
+        table="table1",
+        columns=["apple", "banana"],
+        partition=[],
     )
 
 
@@ -129,12 +137,17 @@ def test_asset_out_partitioned():
     db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
     asset_key = AssetKey(["schema1", "table1"])
+    partitions_def = MagicMock()
+    partitions_def.time_window_for_partition_key = MagicMock(
+        return_value=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3))
+    )
     output_context = MagicMock(
         asset_key=asset_key,
         resource_config=resource_config,
         asset_partition_key="2020-01-02",
         asset_partitions_time_window=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
         metadata={"partition_expr": "abc"},
+        asset_partitions_def=partitions_def,
     )
     manager.handle_output(output_context, 5)
     input_context = MagicMock(
@@ -145,6 +158,7 @@ def test_asset_out_partitioned():
         asset_partition_key="2020-01-02",
         asset_partitions_time_window=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
         metadata=None,
+        asset_partitions_def=partitions_def,
     )
     assert manager.load_input(input_context) == 7
 
@@ -153,9 +167,12 @@ def test_asset_out_partitioned():
         database="database_abc",
         schema="schema1",
         table="table1",
-        partition=TablePartition(
-            partition=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)), partition_expr="abc"
-        ),
+        partition=[
+            TablePartition(
+                partition=TimeWindow(datetime(2020, 1, 2), datetime(2020, 1, 3)),
+                partition_expr="abc",
+            )
+        ],
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
@@ -174,7 +191,9 @@ def test_different_output_and_input_types():
     manager.handle_output(output_context, 5)
     assert len(int_handler.handle_output_calls) == 1
     assert len(str_handler.handle_output_calls) == 0
-    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    table_slice = TableSlice(
+        database="database_abc", schema="schema1", table="table1", partition=[]
+    )
     assert int_handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
 
@@ -212,7 +231,9 @@ def test_non_asset_out():
     assert manager.load_input(input_context) == 7
 
     assert len(handler.handle_output_calls) == 1
-    table_slice = TableSlice(database="database_abc", schema="schema1", table="table1")
+    table_slice = TableSlice(
+        database="database_abc", schema="schema1", table="table1", partition=[]
+    )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
     db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -212,8 +212,6 @@ def test_time_window_partitioned_asset(tmp_path):
     assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
     duckdb_conn.close()
 
-    assert False
-
 
 @asset(
     partitions_def=StaticPartitionsDefinition(["red", "yellow", "blue"]),

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -315,7 +315,6 @@ def test_multi_partitioned_asset(tmp_path):
 
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
-    duckdb_conn.execute("EXPORT DATABASE '/Users/jamie/dev/duckdb_out/1' (FORMAT CSV, DELIMITER '|');")
     print(out_df)
     assert out_df["a"].tolist() == ["1", "1", "1"]
     duckdb_conn.close()
@@ -330,7 +329,6 @@ def test_multi_partitioned_asset(tmp_path):
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
     print(out_df)
-    duckdb_conn.execute("EXPORT DATABASE '/Users/jamie/dev/duckdb_out/2' (FORMAT CSV, DELIMITER '|');")
     assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
     duckdb_conn.close()
 
@@ -344,7 +342,6 @@ def test_multi_partitioned_asset(tmp_path):
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
     print(out_df)
-    duckdb_conn.execute("EXPORT DATABASE '/Users/jamie/dev/duckdb_out/3' (FORMAT CSV, DELIMITER '|');")
     assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
     duckdb_conn.close()
 
@@ -355,10 +352,7 @@ def test_multi_partitioned_asset(tmp_path):
         run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "4"}}}},
     )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-
-    duckdb_conn.execute("EXPORT DATABASE '/Users/jamie/dev/duckdb_out/4' (FORMAT CSV, DELIMITER '|');")
-
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))gi
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
     print(out_df)
     assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -65,7 +65,7 @@ def b_df() -> pd.DataFrame:
 
 
 @asset(key_prefix=["my_schema"])
-def b_plus_one(b_df: pd.DataFrame):
+def b_plus_one(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
@@ -93,7 +93,7 @@ def test_duckdb_io_manager_with_assets(tmp_path):
 
 
 @asset(key_prefix=["my_schema"], ins={"b_df": AssetIn("b_df", metadata={"columns": ["a"]})})
-def b_plus_one_columns(b_df: pd.DataFrame):
+def b_plus_one_columns(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
@@ -154,7 +154,7 @@ def test_not_supported_type(tmp_path):
     metadata={"partition_expr": "time"},
     config_schema={"value": str},
 )
-def daily_partitioned(context):
+def daily_partitioned(context) -> pd.DataFrame:
     partition = pd.Timestamp(context.asset_partition_key_for_output())
     value = context.op_config["value"]
 
@@ -219,7 +219,7 @@ def test_time_window_partitioned_asset(tmp_path):
     metadata={"partition_expr": "color"},
     config_schema={"value": str},
 )
-def static_partitioned(context):
+def static_partitioned(context) -> pd.DataFrame:
     partition = context.asset_partition_key_for_output()
     value = context.op_config["value"]
     return pd.DataFrame(
@@ -285,7 +285,7 @@ def test_static_partitioned_asset(tmp_path):
     metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
     config_schema={"value": str},
 )
-def multi_partitioned(context):
+def multi_partitioned(context) -> pd.DataFrame:
     partition = context.partition_key.keys_by_dimension
     value = context.op_config["value"]
     return pd.DataFrame(

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -182,7 +182,7 @@ def test_time_window_partitioned_asset(tmp_path):
 
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
-    print(out_df)
+
     assert out_df["a"].tolist() == ["1", "1", "1"]
     duckdb_conn.close()
 
@@ -195,7 +195,7 @@ def test_time_window_partitioned_asset(tmp_path):
 
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
-    print(out_df)
+
     assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
     duckdb_conn.close()
 
@@ -208,7 +208,7 @@ def test_time_window_partitioned_asset(tmp_path):
 
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
-    print(out_df)
+
     assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
     duckdb_conn.close()
 

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pytest
 from dagster import (
     DailyPartitionsDefinition,
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
     asset,
@@ -249,4 +251,85 @@ def test_static_partitioned_asset(tmp_path):
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
     assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+    duckdb_conn.close()
+
+
+@asset(
+    partitions_def=MultiPartitionsDefinition(
+        {
+            "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+            "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+        }
+    ),
+    key_prefix=["my_schema"],
+    metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+    config_schema={"value": str},
+)
+def multi_partitioned(context):
+    partition = context.partition_key.keys_by_dimension
+    value = context.op_config["value"]
+    pd_df = pd.DataFrame(
+        {
+            "color": [partition["color"], partition["color"], partition["color"]],
+            "time": [partition["time"], partition["time"], partition["time"]],
+            "a": [value, value, value],
+        }
+    )
+
+    spark = SparkSession.builder.getOrCreate()
+    return spark.createDataFrame(pd_df)
+
+
+def test_multi_partitioned_asset(tmp_path):
+    duckdb_io_manager = duckdb_pyspark_io_manager.configured(
+        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    )
+    resource_defs = {"io_manager": duckdb_io_manager}
+
+    materialize(
+        [multi_partitioned],
+        partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+    assert out_df["a"].tolist() == ["1", "1", "1"]
+    duckdb_conn.close()
+
+    materialize(
+        [multi_partitioned],
+        partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "2"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+    assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+    duckdb_conn.close()
+
+    materialize(
+        [multi_partitioned],
+        partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "3"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+    assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
+    duckdb_conn.close()
+
+    materialize(
+        [multi_partitioned],
+        partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "4"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+    assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
     duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -196,7 +196,7 @@ def test_partitioned_asset(tmp_path):
     metadata={"partition_expr": "color"},
     config_schema={"value": str},
 )
-def static_partitioned(context):
+def static_partitioned(context) -> SparkDF:
     partition = context.asset_partition_key_for_output()
     value = context.op_config["value"]
     pd_df = pd.DataFrame(
@@ -265,7 +265,7 @@ def test_static_partitioned_asset(tmp_path):
     metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
     config_schema={"value": str},
 )
-def multi_partitioned(context):
+def multi_partitioned(context) -> SparkDF:
     partition = context.partition_key.keys_by_dimension
     value = context.op_config["value"]
     pd_df = pd.DataFrame(

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -7,7 +7,7 @@ from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
-    TablePartition,
+    PartitionDimension,
     TableSlice,
 )
 from dagster._utils.backoff import backoff
@@ -167,7 +167,7 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"DELETE FROM {table_slice.schema}.{table_slice.table}"
 
 
-def _time_window_where_clause(table_partition: TablePartition) -> str:
+def _time_window_where_clause(table_partition: PartitionDimension) -> str:
     partition = cast(TimeWindow, table_partition.partition)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
@@ -175,5 +175,5 @@ def _time_window_where_clause(table_partition: TablePartition) -> str:
     return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
 
 
-def _static_where_clause(table_partition: TablePartition) -> str:
+def _static_where_clause(table_partition: PartitionDimension) -> str:
     return f"""{table_partition.partition_expr} = '{table_partition.partition}'"""

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -7,7 +7,7 @@ from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
-    PartitionDimension,
+    TablePartitionDimension,
     TableSlice,
 )
 from dagster._utils.backoff import backoff
@@ -167,7 +167,7 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"DELETE FROM {table_slice.schema}.{table_slice.table}"
 
 
-def _time_window_where_clause(table_partition: PartitionDimension) -> str:
+def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     partition = cast(TimeWindow, table_partition.partition)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
@@ -175,5 +175,5 @@ def _time_window_where_clause(table_partition: PartitionDimension) -> str:
     return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
 
 
-def _static_where_clause(table_partition: PartitionDimension) -> str:
+def _static_where_clause(table_partition: TablePartitionDimension) -> str:
     return f"""{table_partition.partition_expr} = '{table_partition.partition}'"""

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -116,21 +116,15 @@ class DuckDbClient(DbClient):
     def get_select_statement(table_slice: TableSlice) -> str:
         col_str = ", ".join(table_slice.columns) if table_slice.columns else "*"
 
-        if table_slice.partition and len(table_slice.partition) > 0:
+        if table_slice.partition_dimensions and len(table_slice.partition_dimensions) > 0:
             query = f"SELECT {col_str} FROM {table_slice.schema}.{table_slice.table} WHERE\n"
-            for i in range(len(table_slice.partition)):
-                part = table_slice.partition[i]
-                partition_where = (
-                    _static_where_clause(part)
-                    if isinstance(part.partition, str)
-                    else _time_window_where_clause(part)
-                )
-                query += partition_where
-
-                if i < len(table_slice.partition) - 1:
-                    query += " AND\n"
-
-            return query
+            partition_where = " AND\n".join(
+                _static_where_clause(partition_dimension)
+                if isinstance(partition_dimension.partition, str)
+                else _time_window_where_clause(partition_dimension)
+                for partition_dimension in table_slice.partition_dimensions
+            )
+            return query + partition_where
         else:
             return f"""SELECT {col_str} FROM {table_slice.schema}.{table_slice.table}"""
 
@@ -149,20 +143,16 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
     Returns a SQL statement that deletes data in the given table to make way for the output data
     being written.
     """
-    if table_slice.partition and len(table_slice.partition) > 0:
+    if table_slice.partition_dimensions and len(table_slice.partition_dimensions) > 0:
         query = f"DELETE FROM {table_slice.schema}.{table_slice.table} WHERE\n"
-        for i in range(len(table_slice.partition)):
-            part = table_slice.partition[i]
-            partition_where = (
-                _static_where_clause(part)
-                if isinstance(part.partition, str)
-                else _time_window_where_clause(part)
-            )
-            query += partition_where
 
-            if i < len(table_slice.partition) - 1:
-                query += " AND\n"
-        return query
+        partition_where = " AND\n".join(
+            _static_where_clause(partition_dimension)
+            if isinstance(partition_dimension.partition, str)
+            else _time_window_where_clause(partition_dimension)
+            for partition_dimension in table_slice.partition_dimensions
+        )
+        return query + partition_where
     else:
         return f"DELETE FROM {table_slice.schema}.{table_slice.table}"
 

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -153,23 +153,23 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
     being written.
     """
     if len(table_slice.partition) > 0:
-            query = f"DELETE FROM {table_slice.schema}.{table_slice.table} WHERE \n"
-            for i in range(len(table_slice.partition)):
-                part = table_slice.partition[i]
-                partition_where = (
-                    _static_where_clause(part)
-                    if isinstance(part.partition, str)
-                    else _time_window_where_clause(part)
-                )
-                query += partition_where
+        query = f"DELETE FROM {table_slice.schema}.{table_slice.table} WHERE \n"
+        for i in range(len(table_slice.partition)):
+            part = table_slice.partition[i]
+            partition_where = (
+                _static_where_clause(part)
+                if isinstance(part.partition, str)
+                else _time_window_where_clause(part)
+            )
+            query += partition_where
 
-                if i < len(table_slice.partition) - 1:
-                    query += " AND\n"
+            if i < len(table_slice.partition) - 1:
+                query += " AND\n"
 
-            print("DELETE STATEMENT")
-            print(query)
+        print("DELETE STATEMENT")
+        print(query)
 
-            return query
+        return query
     else:
         query = f"DELETE FROM {table_slice.schema}.{table_slice.table}"
         print("DELETE STATEMENT")

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -107,9 +107,6 @@ class DuckDbClient(DbClient):
         conn = _connect_duckdb(context).cursor()
         try:
             conn.execute(_get_cleanup_statement(table_slice))
-            df = conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
-            print("JUST DELETED")
-            print(df)
         except duckdb.CatalogException:
             # table doesn't exist yet, so ignore the error
             pass
@@ -165,16 +162,9 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
 
             if i < len(table_slice.partition) - 1:
                 query += " AND\n"
-
-        print("DELETE STATEMENT")
-        print(query)
-
         return query
     else:
-        query = f"DELETE FROM {table_slice.schema}.{table_slice.table}"
-        print("DELETE STATEMENT")
-        print(query)
-        return query
+        return f"DELETE FROM {table_slice.schema}.{table_slice.table}"
 
 
 def _time_window_where_clause(table_partition: TablePartition) -> str:

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -107,6 +107,9 @@ class DuckDbClient(DbClient):
         conn = _connect_duckdb(context).cursor()
         try:
             conn.execute(_get_cleanup_statement(table_slice))
+            df = conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+            print("JUST DELETED")
+            print(df)
         except duckdb.CatalogException:
             # table doesn't exist yet, so ignore the error
             pass

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -119,7 +119,7 @@ class DuckDbClient(DbClient):
     def get_select_statement(table_slice: TableSlice) -> str:
         col_str = ", ".join(table_slice.columns) if table_slice.columns else "*"
 
-        if len(table_slice.partition) > 0:
+        if table_slice.partition and len(table_slice.partition) > 0:
             query = f"SELECT {col_str} FROM {table_slice.schema}.{table_slice.table} WHERE\n"
             for i in range(len(table_slice.partition)):
                 part = table_slice.partition[i]
@@ -152,8 +152,8 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
     Returns a SQL statement that deletes data in the given table to make way for the output data
     being written.
     """
-    if len(table_slice.partition) > 0:
-        query = f"DELETE FROM {table_slice.schema}.{table_slice.table} WHERE \n"
+    if table_slice.partition and len(table_slice.partition) > 0:
+        query = f"DELETE FROM {table_slice.schema}.{table_slice.table} WHERE\n"
         for i in range(len(table_slice.partition)):
             part = table_slice.partition[i]
             partition_where = (

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dagster._core.storage.db_io_manager import PartitionDimension, TableSlice
+from dagster._core.storage.db_io_manager import TablePartitionDimension, TableSlice
 from dagster_duckdb.io_manager import DuckDbClient, _get_cleanup_statement
 
 
@@ -31,7 +31,7 @@ def test_get_select_statement_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -50,7 +50,9 @@ def test_get_select_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
+                partition=[
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
+                ],
                 columns=["apple", "banana"],
             )
         )
@@ -65,8 +67,8 @@ def test_get_select_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
-                    PartitionDimension(
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),
@@ -92,7 +94,7 @@ def test_get_cleanup_statement_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -110,7 +112,9 @@ def test_get_cleanup_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
+                partition=[
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
+                ],
             )
         )
         == "DELETE FROM schema1.table1 WHERE\nmy_fruit_col = 'apple'"
@@ -124,8 +128,8 @@ def test_get_cleanup_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
-                    PartitionDimension(
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
@@ -30,7 +30,7 @@ def test_get_select_statement_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
@@ -50,7 +50,7 @@ def test_get_select_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
                 ],
                 columns=["apple", "banana"],
@@ -66,7 +66,7 @@ def test_get_select_statement_multi_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
@@ -93,7 +93,7 @@ def test_get_cleanup_statement_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
@@ -112,7 +112,7 @@ def test_get_cleanup_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
                 ],
             )
@@ -127,7 +127,7 @@ def test_get_cleanup_statement_multi_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
@@ -30,14 +30,16 @@ def test_get_select_statement_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(
-                    partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
-                    partition_expr="my_timestamp_col",
-                ),
+                partition=[
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    )
+                ],
                 columns=["apple", "banana"],
             )
         )
-        == "SELECT apple, banana FROM schema1.table1\nWHERE my_timestamp_col >= '2020-01-02"
+        == "SELECT apple, banana FROM schema1.table1 WHERE\nmy_timestamp_col >= '2020-01-02"
         " 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )
 
@@ -48,11 +50,31 @@ def test_get_select_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
                 columns=["apple", "banana"],
             )
         )
-        == "SELECT apple, banana FROM schema1.table1\nWHERE my_fruit_col = 'apple'"
+        == "SELECT apple, banana FROM schema1.table1 WHERE\nmy_fruit_col = 'apple'"
+    )
+
+
+def test_get_select_statement_multi_partitioned():
+    assert (
+        DuckDbClient.get_select_statement(
+            TableSlice(
+                schema="schema1",
+                table="table1",
+                partition=[
+                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    ),
+                ],
+            )
+        )
+        == "SELECT * FROM schema1.table1 WHERE\nmy_fruit_col = 'apple' AND\nmy_timestamp_col >="
+        " '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )
 
 
@@ -69,13 +91,15 @@ def test_get_cleanup_statement_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(
-                    partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
-                    partition_expr="my_timestamp_col",
-                ),
+                partition=[
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    )
+                ],
             )
         )
-        == "DELETE FROM schema1.table1\nWHERE my_timestamp_col >= '2020-01-02 00:00:00' AND"
+        == "DELETE FROM schema1.table1 WHERE\nmy_timestamp_col >= '2020-01-02 00:00:00' AND"
         " my_timestamp_col < '2020-02-03 00:00:00'"
     )
 
@@ -86,8 +110,28 @@ def test_get_cleanup_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
             )
         )
-        == "DELETE FROM schema1.table1\nWHERE my_fruit_col = 'apple'"
+        == "DELETE FROM schema1.table1 WHERE\nmy_fruit_col = 'apple'"
+    )
+
+
+def test_get_cleanup_statement_multi_partitioned():
+    assert (
+        _get_cleanup_statement(
+            TableSlice(
+                schema="schema1",
+                table="table1",
+                partition=[
+                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    ),
+                ],
+            )
+        )
+        == "DELETE FROM schema1.table1 WHERE\nmy_fruit_col = 'apple' AND\nmy_timestamp_col >="
+        " '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dagster._core.storage.db_io_manager import TablePartition, TableSlice
+from dagster._core.storage.db_io_manager import PartitionDimension, TableSlice
 from dagster_duckdb.io_manager import DuckDbClient, _get_cleanup_statement
 
 
@@ -31,7 +31,7 @@ def test_get_select_statement_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -50,7 +50,7 @@ def test_get_select_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
+                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
                 columns=["apple", "banana"],
             )
         )
@@ -65,8 +65,8 @@ def test_get_select_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
-                    TablePartition(
+                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),
@@ -92,7 +92,7 @@ def test_get_cleanup_statement_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -110,7 +110,7 @@ def test_get_cleanup_statement_static_partitioned():
             TableSlice(
                 schema="schema1",
                 table="table1",
-                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
+                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
             )
         )
         == "DELETE FROM schema1.table1 WHERE\nmy_fruit_col = 'apple'"
@@ -124,8 +124,8 @@ def test_get_cleanup_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
-                    TablePartition(
+                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -86,9 +86,9 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         connector.paramstyle = "pyformat"
         with _connect_snowflake(context, table_slice) as con:
             with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
-            # with_uppercase_cols = with_uppercase_cols.apply(
-            #     _convert_timestamp_to_string, axis="index"
-            # )
+            with_uppercase_cols = with_uppercase_cols.apply(
+                _convert_timestamp_to_string, axis="index"
+            )
             with_uppercase_cols.to_sql(
                 table_slice.table,
                 con=con.engine,
@@ -112,7 +112,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     def load_input(self, context: InputContext, table_slice: TableSlice) -> pd.DataFrame:
         with _connect_snowflake(context, table_slice) as con:
             result = pd.read_sql(sql=SnowflakeDbClient.get_select_statement(table_slice), con=con)
-            # result = result.apply(_convert_string_to_timestamp, axis="index")
+            result = result.apply(_convert_string_to_timestamp, axis="index")
             result.columns = map(str.lower, result.columns)  # type: ignore  # (bad stubs)
             return result
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -86,9 +86,9 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         connector.paramstyle = "pyformat"
         with _connect_snowflake(context, table_slice) as con:
             with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
-            with_uppercase_cols = with_uppercase_cols.apply(
-                _convert_timestamp_to_string, axis="index"
-            )
+            # with_uppercase_cols = with_uppercase_cols.apply(
+            #     _convert_timestamp_to_string, axis="index"
+            # )
             with_uppercase_cols.to_sql(
                 table_slice.table,
                 con=con.engine,
@@ -112,7 +112,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     def load_input(self, context: InputContext, table_slice: TableSlice) -> pd.DataFrame:
         with _connect_snowflake(context, table_slice) as con:
             result = pd.read_sql(sql=SnowflakeDbClient.get_select_statement(table_slice), con=con)
-            result = result.apply(_convert_string_to_timestamp, axis="index")
+            # result = result.apply(_convert_string_to_timestamp, axis="index")
             result.columns = map(str.lower, result.columns)  # type: ignore  # (bad stubs)
             return result
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -403,7 +403,7 @@ def test_multi_partitioned_asset(tmp_path):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str=" COLOR string, A string, B int",
+        column_str=" COLOR string, TIME TIMESTAMP_NTZ(9), A string",
     ) as table_name:
 
         @asset(

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -79,7 +79,7 @@ def test_handle_output():
                 schema="my_schema",
                 database="my_db",
                 columns=None,
-                partition=[],
+                partition_dimensions=[],
             ),
             df,
         )
@@ -107,7 +107,7 @@ def test_load_input():
                 schema="my_schema",
                 database="my_db",
                 columns=None,
-                partition=[],
+                partition_dimensions=[],
             ),
         )
         assert mock_read_sql.call_args_list[0][1]["sql"] == "SELECT * FROM my_db.my_schema.my_table"

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -259,7 +259,7 @@ def test_time_window_partitioned_asset(tmp_path):
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             name=table_name,
         )
-        def daily_partitioned(context):
+        def daily_partitioned(context) -> DataFrame:
             partition = Timestamp(context.asset_partition_key_for_output())
             value = context.op_config["value"]
 
@@ -337,7 +337,7 @@ def test_static_partitioned_asset(tmp_path):
             config_schema={"value": str},
             name=table_name,
         )
-        def static_partitioned(context):
+        def static_partitioned(context) -> DataFrame:
             partition = context.asset_partition_key_for_output()
             value = context.op_config["value"]
             return DataFrame(
@@ -418,7 +418,7 @@ def test_multi_partitioned_asset(tmp_path):
             config_schema={"value": str},
             name=table_name,
         )
-        def multi_partitioned(context):
+        def multi_partitioned(context) -> DataFrame:
             partition = context.partition_key.keys_by_dimension
             value = context.op_config["value"]
             return DataFrame(

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -75,7 +75,7 @@ def test_handle_output():
                 schema="my_schema",
                 database="my_db",
                 columns=None,
-                partition=None,
+                partition=[],
             ),
             df,
         )
@@ -103,7 +103,7 @@ def test_load_input():
                 schema="my_schema",
                 database="my_db",
                 columns=None,
-                partition=None,
+                partition=[],
             ),
         )
         assert mock_read_sql.call_args_list[0][1]["sql"] == "SELECT * FROM my_db.my_schema.my_table"
@@ -409,7 +409,7 @@ def test_multi_partitioned_asset(tmp_path):
                     "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
                 }
             ),
-            key_prefix=["JAMIE"],
+            key_prefix=["SNOWFLAKE_IO_MANAGER_SCHEMA"],
             metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
             config_schema={"value": str},
             name=table_name,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -11,6 +11,8 @@ from dagster import (
     DailyPartitionsDefinition,
     IOManagerDefinition,
     MetadataValue,
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
     TableColumn,
@@ -26,10 +28,6 @@ from dagster._core.storage.db_io_manager import TableSlice
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeConnection
 from dagster_snowflake_pandas import SnowflakePandasTypeHandler, snowflake_pandas_io_manager
-from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
-    _convert_string_to_timestamp,
-    _convert_timestamp_to_string,
-)
 from pandas import DataFrame, Timestamp
 
 resource_config = {
@@ -112,29 +110,29 @@ def test_load_input():
         assert df.equals(DataFrame([{"col1": "a", "col2": 1}]))
 
 
-def test_type_conversions():
-    # no timestamp data
-    no_time = pandas.Series([1, 2, 3, 4, 5])
-    converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time))
+# def test_type_conversions():
+#     # no timestamp data
+#     no_time = pandas.Series([1, 2, 3, 4, 5])
+#     converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time))
 
-    assert (converted == no_time).all()
+#     assert (converted == no_time).all()
 
-    # timestamp data
-    with_time = pandas.Series(
-        [
-            pandas.Timestamp("2017-01-01T12:30:45.35"),
-            pandas.Timestamp("2017-02-01T12:30:45.35"),
-            pandas.Timestamp("2017-03-01T12:30:45.35"),
-        ]
-    )
-    time_converted = _convert_string_to_timestamp(_convert_timestamp_to_string(with_time))
+#     # timestamp data
+#     with_time = pandas.Series(
+#         [
+#             pandas.Timestamp("2017-01-01T12:30:45.35"),
+#             pandas.Timestamp("2017-02-01T12:30:45.35"),
+#             pandas.Timestamp("2017-03-01T12:30:45.35"),
+#         ]
+#     )
+#     time_converted = _convert_string_to_timestamp(_convert_timestamp_to_string(with_time))
 
-    assert (with_time == time_converted).all()
+#     assert (with_time == time_converted).all()
 
-    # string that isn't a time
-    string_data = pandas.Series(["not", "a", "timestamp"])
+#     # string that isn't a time
+#     string_data = pandas.Series(["not", "a", "timestamp"])
 
-    assert (_convert_string_to_timestamp(string_data) == string_data).all()
+#     assert (_convert_string_to_timestamp(string_data) == string_data).all()
 
 
 def test_build_snowflake_pandas_io_manager():
@@ -394,3 +392,105 @@ def test_static_partitioned_asset(tmp_path):
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+def test_multi_partitioned_asset(tmp_path):
+    with temporary_snowflake_table(
+        schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
+        column_str=" COLOR string, A string, B int",
+    ) as table_name:
+
+        @asset(
+            partitions_def=MultiPartitionsDefinition(
+                {
+                    "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+                    "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+                }
+            ),
+            key_prefix=["JAMIE"],
+            metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def multi_partitioned(context):
+            partition = context.partition_key.keys_by_dimension
+            value = context.op_config["value"]
+            return DataFrame(
+                {
+                    "color": [partition["color"], partition["color"], partition["color"]],
+                    "time": [partition["time"], partition["time"], partition["time"]],
+                    "a": [value, value, value],
+                }
+            )
+
+        asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
+        snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
+
+        snowflake_config = {
+            **SHARED_BUILDKITE_SNOWFLAKE_CONF,
+            "database": "TEST_SNOWFLAKE_IO_MANAGER",
+        }
+        snowflake_conn = SnowflakeConnection(
+            snowflake_config, logging.getLogger("temporary_snowflake_table")
+        )
+
+        snowflake_io_manager = snowflake_pandas_io_manager.configured(snowflake_config)
+        resource_defs = {"io_manager": snowflake_io_manager}
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["1", "1", "1"]
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "2"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2"]
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "3"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "4"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -245,7 +245,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_time_window_partitioned_asset(tmp_path):
+def test_time_window_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
@@ -323,7 +323,7 @@ def test_time_window_partitioned_asset(tmp_path):
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_static_partitioned_asset(tmp_path):
+def test_static_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
@@ -399,7 +399,7 @@ def test_static_partitioned_asset(tmp_path):
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_multi_partitioned_asset(tmp_path):
+def test_multi_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -469,7 +469,7 @@ def test_multi_partitioned_asset(tmp_path):
         )
         print("TABLE IS")
         print(out_df)
-        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2"]
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
         materialize(
             [multi_partitioned],
@@ -483,7 +483,7 @@ def test_multi_partitioned_asset(tmp_path):
         )
         print("TABLE IS")
         print(out_df)
-        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
 
         materialize(
             [multi_partitioned],
@@ -497,4 +497,4 @@ def test_multi_partitioned_asset(tmp_path):
         )
         print("TABLE IS")
         print(out_df)
-        assert out_df["A"].tolist() == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
+        assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -28,6 +28,10 @@ from dagster._core.storage.db_io_manager import TableSlice
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeConnection
 from dagster_snowflake_pandas import SnowflakePandasTypeHandler, snowflake_pandas_io_manager
+from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
+    _convert_string_to_timestamp,
+    _convert_timestamp_to_string,
+)
 from pandas import DataFrame, Timestamp
 
 resource_config = {
@@ -110,29 +114,29 @@ def test_load_input():
         assert df.equals(DataFrame([{"col1": "a", "col2": 1}]))
 
 
-# def test_type_conversions():
-#     # no timestamp data
-#     no_time = pandas.Series([1, 2, 3, 4, 5])
-#     converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time))
+def test_type_conversions():
+    # no timestamp data
+    no_time = pandas.Series([1, 2, 3, 4, 5])
+    converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time))
 
-#     assert (converted == no_time).all()
+    assert (converted == no_time).all()
 
-#     # timestamp data
-#     with_time = pandas.Series(
-#         [
-#             pandas.Timestamp("2017-01-01T12:30:45.35"),
-#             pandas.Timestamp("2017-02-01T12:30:45.35"),
-#             pandas.Timestamp("2017-03-01T12:30:45.35"),
-#         ]
-#     )
-#     time_converted = _convert_string_to_timestamp(_convert_timestamp_to_string(with_time))
+    # timestamp data
+    with_time = pandas.Series(
+        [
+            pandas.Timestamp("2017-01-01T12:30:45.35"),
+            pandas.Timestamp("2017-02-01T12:30:45.35"),
+            pandas.Timestamp("2017-03-01T12:30:45.35"),
+        ]
+    )
+    time_converted = _convert_string_to_timestamp(_convert_timestamp_to_string(with_time))
 
-#     assert (with_time == time_converted).all()
+    assert (with_time == time_converted).all()
 
-#     # string that isn't a time
-#     string_data = pandas.Series(["not", "a", "timestamp"])
+    # string that isn't a time
+    string_data = pandas.Series(["not", "a", "timestamp"])
 
-#     assert (_convert_string_to_timestamp(string_data) == string_data).all()
+    assert (_convert_string_to_timestamp(string_data) == string_data).all()
 
 
 def test_build_snowflake_pandas_io_manager():

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -453,8 +453,6 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
         materialize(
@@ -467,8 +465,6 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
         materialize(
@@ -481,8 +477,6 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
 
         materialize(
@@ -495,6 +489,4 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -26,9 +26,6 @@ def _get_snowflake_options(config, table_slice: TableSlice) -> Mapping[str, str]
         "dbtable": table_slice.table,
     }
 
-    print("THIS IS THE CONF")
-    print(conf)
-
     return conf
 
 
@@ -69,8 +66,6 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
         self, context: OutputContext, table_slice: TableSlice, obj: DataFrame
     ) -> Mapping[str, RawMetadataValue]:
         options = _get_snowflake_options(context.resource_config, table_slice)
-        print("OPTIONS")
-        print(options)
 
         with_uppercase_cols = obj.toDF(*[c.upper() for c in obj.columns])
 

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -446,7 +446,7 @@ def test_multi_partitioned_asset(tmp_path):
         )
         print("TABLE IS")
         print(out_df)
-        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2"]
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
         materialize(
             [multi_partitioned],
@@ -460,7 +460,7 @@ def test_multi_partitioned_asset(tmp_path):
         )
         print("TABLE IS")
         print(out_df)
-        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
 
         materialize(
             [multi_partitioned],
@@ -474,4 +474,4 @@ def test_multi_partitioned_asset(tmp_path):
         )
         print("TABLE IS")
         print(out_df)
-        assert out_df["A"].tolist() == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
+        assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -184,7 +184,7 @@ def test_io_manager_with_snowflake_pyspark():
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_time_window_partitioned_asset(tmp_path):
+def test_time_window_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
@@ -276,7 +276,7 @@ def test_time_window_partitioned_asset(tmp_path):
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_static_partitioned_asset(tmp_path):
+def test_static_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
@@ -361,7 +361,7 @@ def test_static_partitioned_asset(tmp_path):
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_multi_partitioned_asset(tmp_path):
+def test_multi_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -430,8 +430,6 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
         materialize(
@@ -444,8 +442,6 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
         materialize(
@@ -458,8 +454,6 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
 
         materialize(
@@ -472,6 +466,4 @@ def test_multi_partitioned_asset(tmp_path):
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
-        print("TABLE IS")
-        print(out_df)
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -365,7 +365,7 @@ def test_multi_partitioned_asset(tmp_path):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="COLOR string, RAW_TIME string, A string, TIME TIMESTAMP_NTZ(9)",
+        column_str="COLOR string, RAW_TIME string, A string, TIME DATE",
     ) as table_name:
 
         @asset(

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -89,7 +89,7 @@ def test_handle_output():
                 schema="my_schema",
                 database="my_db",
                 columns=None,
-                partition=None,
+                partition_dimensions=None,
             ),
             df,
         )
@@ -123,7 +123,7 @@ def test_load_input():
                 schema="my_schema",
                 database="my_db",
                 columns=None,
-                partition=None,
+                partition_dimensions=None,
             ),
         )
         assert mock_read.called

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -10,6 +10,8 @@ from dagster import (
     DailyPartitionsDefinition,
     IOManagerDefinition,
     MetadataValue,
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
     TableColumn,
@@ -27,12 +29,7 @@ from dagster_snowflake.resources import SnowflakeConnection
 from dagster_snowflake_pyspark import SnowflakePySparkTypeHandler, snowflake_pyspark_io_manager
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col, to_date
-from pyspark.sql.types import (
-    LongType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql.types import LongType, StringType, StructField, StructType
 
 resource_config = {
     "database": "database_abc",
@@ -361,3 +358,120 @@ def test_static_partitioned_asset(tmp_path):
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+def test_multi_partitioned_asset(tmp_path):
+    with temporary_snowflake_table(
+        schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
+        column_str="COLOR string, RAW_TIME string, A string, TIME TIMESTAMP_NTZ(9)",
+    ) as table_name:
+
+        @asset(
+            partitions_def=MultiPartitionsDefinition(
+                {
+                    "time": DailyPartitionsDefinition(start_date="2022-01-01"),
+                    "color": StaticPartitionsDefinition(["red", "yellow", "blue"]),
+                }
+            ),
+            key_prefix=["SNOWFLAKE_IO_MANAGER_SCHEMA"],
+            metadata={"partition_expr": {"time": "CAST(time as TIMESTAMP)", "color": "color"}},
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def multi_partitioned(context):
+            partition = context.partition_key.keys_by_dimension
+            value = context.op_config["value"]
+
+            spark = SparkSession.builder.config(
+                key="spark.jars.packages",
+                value=SNOWFLAKE_JARS,
+            ).getOrCreate()
+
+            schema = StructType(
+                [
+                    StructField("COLOR", StringType()),
+                    StructField("RAW_TIME", StringType()),
+                    StructField("A", StringType()),
+                ]
+            )
+            data = [
+                (partition["color"], partition["time"], value),
+                (partition["color"], partition["time"], value),
+                (partition["color"], partition["time"], value),
+            ]
+            df = spark.createDataFrame(data, schema=schema)
+            df = df.withColumn("TIME", to_date(col("RAW_TIME")))
+
+            return df
+
+        asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
+        snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
+
+        snowflake_config = {
+            **SHARED_BUILDKITE_SNOWFLAKE_CONF,
+            "database": "TEST_SNOWFLAKE_IO_MANAGER",
+        }
+        snowflake_conn = SnowflakeConnection(
+            snowflake_config, logging.getLogger("temporary_snowflake_table")
+        )
+
+        snowflake_io_manager = snowflake_pyspark_io_manager.configured(snowflake_config)
+        resource_defs = {"io_manager": snowflake_io_manager}
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["1", "1", "1"]
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "2"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2"]
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "3"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
+
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "4"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        print("TABLE IS")
+        print(out_df)
+        assert out_df["A"].tolist() == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -198,7 +198,7 @@ def test_time_window_partitioned_asset(tmp_path):
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             name=table_name,
         )
-        def daily_partitioned(context):
+        def daily_partitioned(context) -> DataFrame:
             partition = context.asset_partition_key_for_output()
             value = context.op_config["value"]
 
@@ -290,7 +290,7 @@ def test_static_partitioned_asset(tmp_path):
             config_schema={"value": str},
             name=table_name,
         )
-        def static_partitioned(context):
+        def static_partitioned(context) -> DataFrame:
             partition = context.asset_partition_key_for_output()
             value = context.op_config["value"]
 
@@ -380,7 +380,7 @@ def test_multi_partitioned_asset(tmp_path):
             config_schema={"value": str},
             name=table_name,
         )
-        def multi_partitioned(context):
+        def multi_partitioned(context) -> DataFrame:
             partition = context.partition_key.keys_by_dimension
             value = context.op_config["value"]
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -160,8 +160,11 @@ class SnowflakeDbClient(DbClient):
     @staticmethod
     def get_select_statement(table_slice: TableSlice) -> str:
         col_str = ", ".join(table_slice.columns) if table_slice.columns else "*"
-        if len(table_slice.partition) > 0:
-            query = f"SELECT {col_str} FROM {table_slice.schema}.{table_slice.table} WHERE\n"
+        if table_slice.partition and len(table_slice.partition) > 0:
+            query = (
+                f"SELECT {col_str} FROM"
+                f" {table_slice.database}.{table_slice.schema}.{table_slice.table} WHERE\n"
+            )
             for i in range(len(table_slice.partition)):
                 part = table_slice.partition[i]
                 partition_where = (
@@ -184,8 +187,10 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
     Returns a SQL statement that deletes data in the given table to make way for the output data
     being written.
     """
-    if len(table_slice.partition) > 0:
-        query = f"DELETE FROM  {table_slice.schema}.{table_slice.table} WHERE\n"
+    if table_slice.partition and len(table_slice.partition) > 0:
+        query = (
+            f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table} WHERE\n"
+        )
         for i in range(len(table_slice.partition)):
             part = table_slice.partition[i]
             partition_where = (

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -6,7 +6,7 @@ from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
-    TablePartition,
+    PartitionDimension,
     TableSlice,
 )
 from snowflake.connector import ProgrammingError
@@ -205,7 +205,7 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
 
 
-def _time_window_where_clause(table_partition: TablePartition) -> str:
+def _time_window_where_clause(table_partition: PartitionDimension) -> str:
     partition = cast(TimeWindow, table_partition.partition)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
@@ -215,5 +215,5 @@ def _time_window_where_clause(table_partition: TablePartition) -> str:
     return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
 
 
-def _static_where_clause(table_partition: TablePartition) -> str:
+def _static_where_clause(table_partition: PartitionDimension) -> str:
     return f"""{table_partition.partition_expr} = '{table_partition.partition}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -6,7 +6,7 @@ from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,
     DbTypeHandler,
-    PartitionDimension,
+    TablePartitionDimension,
     TableSlice,
 )
 from snowflake.connector import ProgrammingError
@@ -205,7 +205,7 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
 
 
-def _time_window_where_clause(table_partition: PartitionDimension) -> str:
+def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     partition = cast(TimeWindow, table_partition.partition)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
@@ -215,5 +215,5 @@ def _time_window_where_clause(table_partition: PartitionDimension) -> str:
     return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
 
 
-def _static_where_clause(table_partition: PartitionDimension) -> str:
+def _static_where_clause(table_partition: TablePartitionDimension) -> str:
     return f"""{table_partition.partition_expr} = '{table_partition.partition}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -150,11 +150,9 @@ class SnowflakeDbClient(DbClient):
             dict(schema=table_slice.schema, **no_schema_config), context.log
         ).get_connection() as con:
             try:
-                print("DELETING DATA")
                 con.execute_string(_get_cleanup_statement(table_slice))
-            except ProgrammingError as e:
+            except ProgrammingError:
                 # table doesn't exist yet, so ignore the error
-                print(e)
                 pass
 
     @staticmethod
@@ -202,8 +200,6 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
 
             if i < len(table_slice.partition) - 1:
                 query += " AND\n"
-        print("DELETE STATEMENT")
-        print(query)
         return query
     else:
         return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dagster._core.storage.db_io_manager import TablePartition, TableSlice
+from dagster._core.storage.db_io_manager import PartitionDimension, TableSlice
 from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient, _get_cleanup_statement
 
 
@@ -35,7 +35,7 @@ def test_get_select_statement_time_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -55,7 +55,7 @@ def test_get_select_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
+                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
                 columns=["apple", "banana"],
             )
         )
@@ -71,8 +71,8 @@ def test_get_select_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
-                    TablePartition(
+                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),
@@ -102,7 +102,7 @@ def test_get_cleanup_statement_time_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -121,7 +121,7 @@ def test_get_cleanup_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
+                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
             )
         )
         == "DELETE FROM database_abc.schema1.table1 WHERE\nmy_fruit_col = 'apple'"
@@ -136,8 +136,8 @@ def test_get_cleanup_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
-                    TablePartition(
+                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    PartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dagster._core.storage.db_io_manager import PartitionDimension, TableSlice
+from dagster._core.storage.db_io_manager import TablePartitionDimension, TableSlice
 from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient, _get_cleanup_statement
 
 
@@ -35,7 +35,7 @@ def test_get_select_statement_time_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -55,7 +55,9 @@ def test_get_select_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
+                partition=[
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
+                ],
                 columns=["apple", "banana"],
             )
         )
@@ -71,8 +73,8 @@ def test_get_select_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
-                    PartitionDimension(
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),
@@ -102,7 +104,7 @@ def test_get_cleanup_statement_time_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     )
@@ -121,7 +123,9 @@ def test_get_cleanup_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[PartitionDimension(partition_expr="my_fruit_col", partition="apple")],
+                partition=[
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
+                ],
             )
         )
         == "DELETE FROM database_abc.schema1.table1 WHERE\nmy_fruit_col = 'apple'"
@@ -136,8 +140,8 @@ def test_get_cleanup_statement_multi_partitioned():
                 schema="schema1",
                 table="table1",
                 partition=[
-                    PartitionDimension(partition_expr="my_fruit_col", partition="apple"),
-                    PartitionDimension(
+                    TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
                     ),

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -34,14 +34,16 @@ def test_get_select_statement_time_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(
-                    partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
-                    partition_expr="my_timestamp_col",
-                ),
+                partition=[
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    )
+                ],
                 columns=["apple", "banana"],
             )
         )
-        == "SELECT apple, banana FROM database_abc.schema1.table1\nWHERE my_timestamp_col >="
+        == "SELECT apple, banana FROM database_abc.schema1.table1 WHERE\nmy_timestamp_col >="
         " '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )
 
@@ -53,11 +55,33 @@ def test_get_select_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
                 columns=["apple", "banana"],
             )
         )
-        == "SELECT apple, banana FROM database_abc.schema1.table1\nWHERE my_fruit_col = 'apple'"
+        == "SELECT apple, banana FROM database_abc.schema1.table1 WHERE\nmy_fruit_col = 'apple'"
+    )
+
+
+def test_get_select_statement_multi_partitioned():
+    assert (
+        SnowflakeDbClient.get_select_statement(
+            TableSlice(
+                database="database_abc",
+                schema="schema1",
+                table="table1",
+                partition=[
+                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    ),
+                ],
+            )
+        )
+        == "SELECT * FROM database_abc.schema1.table1 WHERE\nmy_fruit_col = 'apple'"
+        " AND\nmy_timestamp_col >= '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03"
+        " 00:00:00'"
     )
 
 
@@ -77,13 +101,15 @@ def test_get_cleanup_statement_time_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(
-                    partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
-                    partition_expr="my_timestamp_col",
-                ),
+                partition=[
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    )
+                ],
             )
         )
-        == "DELETE FROM database_abc.schema1.table1\nWHERE my_timestamp_col >= '2020-01-02"
+        == "DELETE FROM database_abc.schema1.table1 WHERE\nmy_timestamp_col >= '2020-01-02"
         " 00:00:00' AND my_timestamp_col < '2020-02-03 00:00:00'"
     )
 
@@ -95,8 +121,30 @@ def test_get_cleanup_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                partition=[TablePartition(partition_expr="my_fruit_col", partition="apple")],
             )
         )
-        == "DELETE FROM database_abc.schema1.table1\nWHERE my_fruit_col = 'apple'"
+        == "DELETE FROM database_abc.schema1.table1 WHERE\nmy_fruit_col = 'apple'"
+    )
+
+
+def test_get_cleanup_statement_multi_partitioned():
+    assert (
+        _get_cleanup_statement(
+            TableSlice(
+                database="database_abc",
+                schema="schema1",
+                table="table1",
+                partition=[
+                    TablePartition(partition_expr="my_fruit_col", partition="apple"),
+                    TablePartition(
+                        partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+                        partition_expr="my_timestamp_col",
+                    ),
+                ],
+            )
+        )
+        == "DELETE FROM database_abc.schema1.table1 WHERE\nmy_fruit_col = 'apple'"
+        " AND\nmy_timestamp_col >= '2020-01-02 00:00:00' AND my_timestamp_col < '2020-02-03"
+        " 00:00:00'"
     )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -34,7 +34,7 @@ def test_get_select_statement_time_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
@@ -55,7 +55,7 @@ def test_get_select_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
                 ],
                 columns=["apple", "banana"],
@@ -72,7 +72,7 @@ def test_get_select_statement_multi_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
@@ -103,7 +103,7 @@ def test_get_cleanup_statement_time_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),
                         partition_expr="my_timestamp_col",
@@ -123,7 +123,7 @@ def test_get_cleanup_statement_static_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple")
                 ],
             )
@@ -139,7 +139,7 @@ def test_get_cleanup_statement_multi_partitioned():
                 database="database_abc",
                 schema="schema1",
                 table="table1",
-                partition=[
+                partition_dimensions=[
                     TablePartitionDimension(partition_expr="my_fruit_col", partition="apple"),
                     TablePartitionDimension(
                         partition=(datetime(2020, 1, 2), datetime(2020, 2, 3)),


### PR DESCRIPTION
### Summary & Motivation

Adds support for multi partitions for DB io managers (snowflake and duckdb). Additionally updates the snowflake and duckdb io managers to also handle multi partitions

Docs plan - will have a future PR updating API docs and guides

### How I Tested These Changes
bk + new unit tests