### PR TITLE
Avoid creating repo on each partitionStats gql call

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -31,8 +31,8 @@ from dagster._core.definitions.multi_dimensional_partitions import (
 )
 from dagster._core.definitions.partition import (
     DefaultPartitionsSubset,
-    PartitionsSubset,
     PartitionsDefinition,
+    PartitionsSubset,
 )
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -29,7 +29,11 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionsSubset,
 )
-from dagster._core.definitions.partition import DefaultPartitionsSubset, PartitionsSubset
+from dagster._core.definitions.partition import (
+    DefaultPartitionsSubset,
+    PartitionsSubset,
+    PartitionsDefinition,
+)
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -41,7 +45,7 @@ from dagster._core.host_representation.repository_location import RepositoryLoca
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.partition_status_cache import (
     CACHEABLE_PARTITION_TYPES,
-    get_and_update_asset_status_cache_values,
+    get_and_update_asset_status_cache_value,
     get_materialized_multipartitions,
     get_validated_partition_keys,
 )
@@ -320,24 +324,23 @@ def get_unique_asset_id(
 def get_materialized_partitions_subset(
     instance: DagsterInstance,
     asset_key: AssetKey,
-    asset_graph: ExternalAssetGraph,
     dynamic_partitions_loader: DynamicPartitionsStore,
+    partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Optional[PartitionsSubset]:
     """
     Returns the materialization status for each partition key. The materialization status
     is a boolean indicating whether the partition has been materialized: True if materialized,
     False if not.
     """
-    partitions_def = asset_graph.get_partitions_def(asset_key)
     if not partitions_def:
         return None
 
     if instance.can_cache_asset_status_data() and partitions_def in CACHEABLE_PARTITION_TYPES:
         # When the "cached_status_data" column exists in storage, update the column to contain
         # the latest partition status values
-        updated_cache_value = get_and_update_asset_status_cache_values(
-            instance, asset_graph, asset_key
-        ).get(asset_key)
+        updated_cache_value = get_and_update_asset_status_cache_value(
+            instance, asset_key, partitions_def
+        )
         materialized_subset = (
             updated_cache_value.deserialize_materialized_partition_subsets(partitions_def)
             if updated_cache_value

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -718,14 +718,18 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_materializedPartitions(
         self, graphene_info: ResolveInfo
     ) -> Union[GrapheneDefaultPartitions, GrapheneTimePartitions, GrapheneMultiPartitions]:
-        asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
         asset_key = self._external_asset_node.asset_key
 
         if not self._dynamic_partitions_loader:
             check.failed("dynamic_partitions_loader must be provided to get partition keys")
 
         materialized_partition_subset = get_materialized_partitions_subset(
-            graphene_info.context.instance, asset_key, asset_graph, self._dynamic_partitions_loader
+            graphene_info.context.instance,
+            asset_key,
+            self._dynamic_partitions_loader,
+            self._external_asset_node.partitions_def_data.get_partitions_definition()
+            if self._external_asset_node.partitions_def_data
+            else None,
         )
 
         return build_materialized_partitions(
@@ -737,7 +741,6 @@ class GrapheneAssetNode(graphene.ObjectType):
         partitions_def_data = self._external_asset_node.partitions_def_data
         if partitions_def_data:
             asset_key = self._external_asset_node.asset_key
-            asset_graph = ExternalAssetGraph.from_external_repository(self._external_repository)
 
             if not self._dynamic_partitions_loader:
                 check.failed("dynamic_partitions_loader must be provided to get partition keys")
@@ -745,8 +748,10 @@ class GrapheneAssetNode(graphene.ObjectType):
             materialized_partition_subset = get_materialized_partitions_subset(
                 graphene_info.context.instance,
                 asset_key,
-                asset_graph,
                 self._dynamic_partitions_loader,
+                self._external_asset_node.partitions_def_data.get_partitions_definition()
+                if self._external_asset_node.partitions_def_data
+                else None,
             )
 
             if materialized_partition_subset is None:

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -1,4 +1,4 @@
-from typing import List, Mapping, NamedTuple, Optional, Sequence, Set, cast
+from typing import List, NamedTuple, Optional, Sequence, Set, cast
 
 from dagster import (
     AssetKey,
@@ -7,7 +7,6 @@ from dagster import (
     EventRecordsFilter,
     _check as check,
 )
-from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -264,69 +264,63 @@ def _get_updated_status_cache(
     )
 
 
-def _fetch_stored_asset_status_cache_values(
-    instance: DagsterInstance, asset_key: Optional[AssetKey] = None
-) -> Mapping[AssetKey, Optional[AssetStatusCacheValue]]:
+def _fetch_stored_asset_status_cache_value(
+    instance: DagsterInstance, asset_key: AssetKey
+) -> Optional[AssetStatusCacheValue]:
     asset_records = (
         instance.get_asset_records()
         if not asset_key
         else instance.get_asset_records(asset_keys=[asset_key])
     )
-    return {
-        asset_record.asset_entry.asset_key: asset_record.asset_entry.cached_status
-        for asset_record in asset_records
-    }
+    if not asset_records:
+        return None
+    else:
+        return list(asset_records)[0].asset_entry.cached_status
 
 
-def _get_fresh_asset_status_cache_values(
+def _get_fresh_asset_status_cache_value(
     instance: DagsterInstance,
-    asset_graph: AssetGraph,
-    asset_key: Optional[AssetKey] = None,  # If not provided, fetches all asset cache values
-) -> Mapping[AssetKey, AssetStatusCacheValue]:
-    cached_status_data_by_asset_key = _fetch_stored_asset_status_cache_values(instance, asset_key)
+    asset_key: AssetKey,
+    partitions_def: Optional[PartitionsDefinition] = None,
+) -> Optional[AssetStatusCacheValue]:
+    cached_status_data = _fetch_stored_asset_status_cache_value(instance, asset_key)
 
-    updated_cache_values_by_asset_key = {}
-    for asset_key, cached_status_data in cached_status_data_by_asset_key.items():
-        if asset_key not in asset_graph.all_asset_keys:
-            # Do not calculate new value if asset not in graph
-            continue
-
-        partitions_def = asset_graph.get_partitions_def(asset_key)
-        if cached_status_data is None or cached_status_data.partitions_def_id != (
-            partitions_def.serializable_unique_identifier if partitions_def else None
-        ):
-            event_records = instance.get_event_records(
-                event_records_filter=EventRecordsFilter(
-                    event_type=DagsterEventType.ASSET_MATERIALIZATION,
-                    asset_key=asset_key,
-                ),
-                limit=1,
-            )
-            if event_records:
-                updated_cache_values_by_asset_key[asset_key] = _build_status_cache(
-                    instance=instance,
-                    asset_key=asset_key,
-                    partitions_def=partitions_def,
-                    latest_storage_id=next(iter(event_records)).storage_id,
-                )
-        else:
-            updated_cache_values_by_asset_key[asset_key] = _get_updated_status_cache(
+    updated_cache_value = None
+    if cached_status_data is None or cached_status_data.partitions_def_id != (
+        partitions_def.serializable_unique_identifier if partitions_def else None
+    ):
+        event_records = instance.get_event_records(
+            event_records_filter=EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+            ),
+            limit=1,
+        )
+        if event_records:
+            updated_cache_value = _build_status_cache(
                 instance=instance,
                 asset_key=asset_key,
                 partitions_def=partitions_def,
-                current_status_cache_value=cached_status_data,
+                latest_storage_id=next(iter(event_records)).storage_id,
             )
+    else:
+        updated_cache_value = _get_updated_status_cache(
+            instance=instance,
+            asset_key=asset_key,
+            partitions_def=partitions_def,
+            current_status_cache_value=cached_status_data,
+        )
 
-    return updated_cache_values_by_asset_key
+    return updated_cache_value
 
 
-def get_and_update_asset_status_cache_values(
-    instance: DagsterInstance, asset_graph: AssetGraph, asset_key: Optional[AssetKey] = None
-) -> Mapping[AssetKey, AssetStatusCacheValue]:
-    updated_cache_values_by_asset_key = _get_fresh_asset_status_cache_values(
-        instance, asset_graph, asset_key
-    )
-    for asset_key, status_cache_value in updated_cache_values_by_asset_key.items():
-        instance.update_asset_cached_status_data(asset_key, status_cache_value)
+def get_and_update_asset_status_cache_value(
+    instance: DagsterInstance,
+    asset_key: AssetKey,
+    partitions_def: Optional[PartitionsDefinition] = None,
+) -> Optional[AssetStatusCacheValue]:
+    updated_cache_value = _get_fresh_asset_status_cache_value(instance, asset_key, partitions_def)
+    if updated_cache_value:
+        instance.update_asset_cached_status_data(asset_key, updated_cache_value)
 
-    return updated_cache_values_by_asset_key
+    return updated_cache_value

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
@@ -12,7 +12,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.storage.partition_status_cache import (
-    get_and_update_asset_status_cache_values,
+    get_and_update_asset_status_cache_value,
 )
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import Counter, traced_counter
@@ -34,9 +34,9 @@ def test_get_cached_status_unpartitioned():
 
         asset_job.execute_in_process(instance=instance)
 
-        cached_status = get_and_update_asset_status_cache_values(instance, asset_graph, asset_key)[
-            asset_key
-        ]
+        cached_status = get_and_update_asset_status_cache_value(
+            instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
 
         assert cached_status
         assert (
@@ -82,9 +82,9 @@ def test_get_cached_partition_status_by_asset():
 
         asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-01")
 
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
         assert cached_status
         assert cached_status.latest_storage_id
         assert cached_status.partitions_def_id
@@ -101,9 +101,9 @@ def test_get_cached_partition_status_by_asset():
 
         asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-02")
 
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
         assert cached_status
         assert cached_status.latest_storage_id
         assert cached_status.partitions_def_id
@@ -126,9 +126,9 @@ def test_get_cached_partition_status_by_asset():
             static_partitions_def, asset1, asset_graph, asset_job
         )
         asset_job.execute_in_process(instance=created_instance, partition_key="a")
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
         assert cached_status
         assert cached_status.serialized_materialized_partition_subset
         materialized_partition_subset = static_partitions_def.deserialize_subset(
@@ -170,9 +170,9 @@ def test_multipartition_get_cached_partition_status():
             instance=created_instance, partition_key=MultiPartitionKey({"ab": "a", "12": "1"})
         )
 
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
         assert cached_status
         assert cached_status.latest_storage_id
         assert cached_status.partitions_def_id
@@ -190,9 +190,9 @@ def test_multipartition_get_cached_partition_status():
             instance=created_instance, partition_key=MultiPartitionKey({"ab": "a", "12": "2"})
         )
 
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
         assert cached_status
         assert cached_status.serialized_materialized_partition_subset
         materialized_keys = partitions_def.deserialize_subset(
@@ -228,9 +228,9 @@ def test_cached_status_on_wipe():
 
         asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-01")
 
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
         assert cached_status
         assert cached_status.serialized_materialized_partition_subset
         materialized_keys = list(
@@ -260,7 +260,8 @@ def test_dynamic_partitions_status_not_cached():
 
         asset_job.execute_in_process(instance=created_instance, partition_key="a_partition")
 
-        cached_status = get_and_update_asset_status_cache_values(
-            created_instance, asset_graph, asset_key
-        )[asset_key]
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
+        assert cached_status
         assert cached_status.serialized_materialized_partition_subset is None


### PR DESCRIPTION
We found that repeated calls to `ExternalAssetGraph.from_external_repository(repository)` can cause asset graph queries to timeout: https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1675455061006059

Currently the `partitionStats` and `materializedPartitions` resolvers make this call for each asset. Following https://github.com/dagster-io/dagster/pull/11914, which displays partition counts on each asset node, I'm worried that the current state will cause the asset graph to be unloadable for certain cloud customers.

This PR refactors existing code to use the external partitions definition to calculate partition state instead of relying on the external asset graph. This is a temporary stopgap to ensure these queries run successfully. Longer term, I will put together a batch loader that will create the asset graph once and bulk calculate the partition statuses of each asset instead of updating each asset one by one.

