### PR TITLE
[dagster-airbyte] add `DuckdbDestination` Class

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/destinations.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/destinations.py
@@ -1127,6 +1127,22 @@ class BigqueryDenormalizedDestination(GeneratedAirbyteDestination):
         super().__init__("Bigquery Denormalized", name)
 
 
+class DuckdbDestination(GeneratedAirbyteDestination):
+    @public
+    def __init__(self, name: str, path: str):
+        """
+        Airbyte Destination for DuckDB
+
+        Documentation can be found at https://docs.airbyte.com/integrations/destinations/duckdb
+
+        Args:
+            name (str): The name of the destination.
+            destination_path (str): Path to the local.duckdb file. The file will be placed inside that local mount. For more information check out our docs
+        """
+        self.destination_path = check.str_param(path, "path")
+        super().__init__("DuckDB", name)
+
+
 class SqliteDestination(GeneratedAirbyteDestination):
     @public
     def __init__(self, name: str, destination_path: str):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/destinations.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/generated/destinations.py
@@ -1129,7 +1129,7 @@ class BigqueryDenormalizedDestination(GeneratedAirbyteDestination):
 
 class DuckdbDestination(GeneratedAirbyteDestination):
     @public
-    def __init__(self, name: str, path: str):
+    def __init__(self, name: str, path: str, schema: Optional[str] = None):
         """
         Airbyte Destination for DuckDB
 
@@ -1137,9 +1137,11 @@ class DuckdbDestination(GeneratedAirbyteDestination):
 
         Args:
             name (str): The name of the destination.
-            destination_path (str): Path to the local.duckdb file. The file will be placed inside that local mount. For more information check out our docs
+            destination_path (str): Path to the bigdata.duckdb file. The file will be placed inside that local mount. For more information check out our docs
         """
         self.destination_path = check.str_param(path, "path")
+        if schema:
+            self.schema = check.str_param(schema, "schema")
         super().__init__("DuckDB", name)
 
 


### PR DESCRIPTION
### Summary & Motivation

I added the DuckDB Destination in https://github.com/airbytehq/airbyte/pull/17494/ and to dynamically create a DuckDB destination, this class is needed.

### How I Tested These Changes

I used `dagster-airbyte check/apply` with the https://github.com/airbytehq/open-data-stack/tree/main/dagster project and replaced Postgres with DuckDB to see if it works. Specifically on this line: https://github.com/airbytehq/open-data-stack/blob/132ad818bcc89619c4e69bd1599d4d1c27f91943/dagster/stargazer/assets_modern_data_stack/assets/stargazer.py#L130.
