### PR TITLE
nux examples in oss 1/: add dagster_cloud.yaml to prep cloud nux onboarding

### DIFF
--- a/examples/assets_dbt_python/dagster_cloud.yaml
+++ b/examples/assets_dbt_python/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: assets_dbt_python
+    code_source:
+      package_name: assets_dbt_python

--- a/examples/assets_modern_data_stack/dagster_cloud.yaml
+++ b/examples/assets_modern_data_stack/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: assets_modern_data_stack
+    code_source:
+      package_name: assets_modern_data_stack

--- a/examples/quickstart_aws/dagster_cloud.yaml
+++ b/examples/quickstart_aws/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: quickstart_aws
+    code_source:
+      package_name: quickstart_aws

--- a/examples/quickstart_etl/dagster_cloud.yaml
+++ b/examples/quickstart_etl/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: quickstart_etl
+    code_source:
+      package_name: quickstart_etl

--- a/examples/quickstart_gcp/dagster_cloud.yaml
+++ b/examples/quickstart_gcp/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: quickstart_gcp
+    code_source:
+      package_name: quickstart_gcp

--- a/examples/quickstart_snowflake/dagster_cloud.yaml
+++ b/examples/quickstart_snowflake/dagster_cloud.yaml
@@ -1,0 +1,4 @@
+locations:
+  - location_name: quickstart_snowflake
+    code_source:
+      package_name: quickstart_snowflake


### PR DESCRIPTION
### Summary & Motivation
add `dagster_cloud.yaml` to 6 examples which will be used by the cloud nux "start from a template"
this also helps users to "import an existing project" smoothier as when they start from an oss example which already has `dagster_cloud.yaml`, they don't need to construct the cloud yaml themselves to deploy to cloud thru "import an existing project".

unblock https://github.com/dagster-io/internal/pull/4791

### How I Tested These Changes
