### PR TITLE
Keep dots in paths in UPathIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -62,9 +62,7 @@ class UPathIOManager(MemoizableIOManager):
         # Can't just call path.with_suffix(self.extension) because if
         # self.extension is "" then this trims off any extension that
         # was in the path previously.
-        if self.extension == "":
-            return path
-        return path.with_suffix(self.extension)
+        return path.parent / (path.name + self.extension)
 
     def _get_path_without_extension(self, context: Union[InputContext, OutputContext]) -> UPath:
         if context.has_asset_key:

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -58,6 +58,14 @@ class UPathIOManager(MemoizableIOManager):
     def has_output(self, context: OutputContext) -> bool:
         return self._get_path(context).exists()
 
+    def _with_extension(self, path: UPath) -> UPath:
+        # Can't just call path.with_suffix(self.extension) because if
+        # self.extension is "" then this trims off any extension that
+        # was in the path previously.
+        if self.extension == "":
+            return path
+        return path.with_suffix(self.extension)
+
     def _get_path_without_extension(self, context: Union[InputContext, OutputContext]) -> UPath:
         if context.has_asset_key:
             # we are dealing with an asset
@@ -75,7 +83,8 @@ class UPathIOManager(MemoizableIOManager):
         Returns the I/O path for a given context.
         Should not be used with partitions (use `_get_paths_for_partitions` instead).
         """
-        return self._get_path_without_extension(context).with_suffix(self.extension)
+        path = self._get_path_without_extension(context)
+        return self._with_extension(path)
 
     def _get_paths_for_partitions(
         self, context: Union[InputContext, OutputContext]
@@ -92,7 +101,7 @@ class UPathIOManager(MemoizableIOManager):
         partition_keys = context.asset_partition_keys
         asset_path = self._get_path_without_extension(context)
         return {
-            partition_key: (asset_path / partition_key).with_suffix(self.extension)
+            partition_key: self._with_extension(asset_path / partition_key)
             for partition_key in partition_keys
         }
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -241,7 +241,6 @@ def test_upath_io_manager_static_partitions_with_dot():
 
     assert dumped_path is not None
     assert "0.0-to-1.0" == dumped_path.name
-    assert "0.0-to-1.0" in str(dumped_path)
 
 
 def test_upath_io_manager_with_extension_static_partitions_with_dot():
@@ -279,7 +278,6 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
     assert dumped_path is not None
     assert "0.0-to-1.0.ext" == dumped_path.name
     assert ".ext" == dumped_path.suffix
-    assert "0.0-to-1.0.ext" in str(dumped_path)
     
 
 def test_partitioned_io_manager_preserves_single_partition_dependency(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -250,6 +250,7 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
 
     class TrackingIOManager(UPathIOManager):
         extension = ".ext"
+
         def dump_to_path(self, context: OutputContext, obj: List, path: UPath):
             nonlocal dumped_path
             dumped_path = path
@@ -278,7 +279,7 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
     assert dumped_path is not None
     assert "0.0-to-1.0.ext" == dumped_path.name
     assert ".ext" == dumped_path.suffix
-    
+
 
 def test_partitioned_io_manager_preserves_single_partition_dependency(
     daily: DailyPartitionsDefinition, dummy_io_manager: DummyIOManager

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -218,11 +218,12 @@ def test_upath_io_manager_static_partitions_with_dot():
             nonlocal dumped_path
             dumped_path = path
 
-        def load_from_path(self, context: InputContext, path: UPath) -> List:
+        def load_from_path(self, context: InputContext, path: UPath):
             pass
 
     @io_manager(config_schema={"base_path": Field(str, is_required=False)})
     def tracking_io_manager(init_context: InitResourceContext):
+        assert init_context.instance is not None
         base_path = UPath(
             init_context.resource_config.get("base_path", init_context.instance.storage_directory())
         )
@@ -235,7 +236,7 @@ def test_upath_io_manager_static_partitions_with_dot():
     my_job = build_assets_job(
         "my_job",
         assets=[my_asset],
-        resource_defs={"io_manager": tracking_io_manager},  # type: ignore[dict-item]
+        resource_defs={"io_manager": tracking_io_manager},
     )
     my_job.execute_in_process(partition_key="0.0-to-1.0")
 
@@ -255,11 +256,12 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
             nonlocal dumped_path
             dumped_path = path
 
-        def load_from_path(self, context: InputContext, path: UPath) -> List:
+        def load_from_path(self, context: InputContext, path: UPath):
             pass
 
     @io_manager(config_schema={"base_path": Field(str, is_required=False)})
     def tracking_io_manager(init_context: InitResourceContext):
+        assert init_context.instance is not None
         base_path = UPath(
             init_context.resource_config.get("base_path", init_context.instance.storage_directory())
         )
@@ -272,7 +274,7 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
     my_job = build_assets_job(
         "my_job",
         assets=[my_asset],
-        resource_defs={"io_manager": tracking_io_manager},  # type: ignore[dict-item]
+        resource_defs={"io_manager": tracking_io_manager},
     )
     my_job.execute_in_process(partition_key="0.0-to-1.0")
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -2,7 +2,7 @@ import json
 import pickle
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import pytest
 from dagster import (
@@ -206,6 +206,39 @@ def test_upath_io_manager_multiple_static_partitions(dummy_io_manager: DummyIOMa
     result = my_job.execute_in_process(partition_key="A")
     downstream_asset_data = result.output_for_node("downstream_asset", "result")
     assert set(downstream_asset_data.keys()) == {"A", "B"}
+
+
+def test_upath_io_manager_static_partitions_with_dot():
+    partitions_def = StaticPartitionsDefinition(["0.0-to-1.0", "1.0-to-2.0"])
+
+    dumped_path: Optional[UPath] = None
+
+    class TrackingIOManager(UPathIOManager):
+        def dump_to_path(self, context: OutputContext, obj: List, path: UPath):
+            nonlocal dumped_path
+            dumped_path = path
+
+        def load_from_path(self, context: InputContext, path: UPath) -> List:
+            pass
+
+    @io_manager
+    def tracking_io_manager(init_context: InitResourceContext):
+        base_path = UPath("memory://tmp/")
+        return TrackingIOManager(base_path=base_path)
+
+    @asset(partitions_def=partitions_def)
+    def my_asset(context: OpExecutionContext) -> str:
+        return context.partition_key
+
+    my_job = build_assets_job(
+        "my_job",
+        assets=[my_asset],
+        resource_defs={"io_manager": tracking_io_manager},  # type: ignore[dict-item]
+    )
+    my_job.execute_in_process(partition_key="0.0-to-1.0")
+
+    assert dumped_path is not None
+    assert "0.0-to-1.0" in str(dumped_path)
 
 
 def test_partitioned_io_manager_preserves_single_partition_dependency(


### PR DESCRIPTION
### Summary & Motivation

Fixes #12173 in the simplest way possible. But this doesn't really fix the underlying issue. If an extension is set, then partition keys will still be clobbered and overrun.

I think the use of `with_suffix` maybe needs to be removed entirely. It seems to me that the intended behavior is to tack on `self.extension`, not to replace any existing extension, which is what `with_suffix` does. But I don't know enough about the intended use of the `extension` class variable on `UPathIOManager`, so I held off.

### How I Tested These Changes

I wrote a test. I ran `python -m pytest python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py`. The tests fails before my change. It passes after my change.