### PR TITLE
[dagit] Storybooks for MetadataEntry rendering

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.stories.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.stories.tsx
@@ -1,0 +1,267 @@
+import {Box, Checkbox} from '@dagster-io/ui';
+import React from 'react';
+
+import {assertUnreachable} from '../app/Util';
+import {
+  BoolMetadataEntry,
+  IntMetadataEntry,
+  JsonMetadataEntry,
+  TableSchemaMetadataEntry,
+} from '../graphql/types';
+
+import {MetadataEntries} from './MetadataEntry';
+import {MetadataEntryFragment} from './types/MetadataEntry.types';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: MetadataEntries};
+
+const MetadataEntryTypes: MetadataEntryFragment['__typename'][] = [
+  'PathMetadataEntry',
+  'JsonMetadataEntry',
+  'UrlMetadataEntry',
+  'TextMetadataEntry',
+  'MarkdownMetadataEntry',
+  'PythonArtifactMetadataEntry',
+  'FloatMetadataEntry',
+  'IntMetadataEntry',
+  'BoolMetadataEntry',
+  'NullMetadataEntry',
+  'PipelineRunMetadataEntry',
+  'AssetMetadataEntry',
+  'TableMetadataEntry',
+  'TableSchemaMetadataEntry',
+  'NotebookMetadataEntry',
+];
+
+const MetadataTableSchema: TableSchemaMetadataEntry['schema'] = {
+  __typename: 'TableSchema',
+  constraints: {
+    __typename: 'TableConstraints',
+    other: [],
+  },
+  columns: [
+    {
+      __typename: 'TableColumn',
+      name: 'id',
+      type: 'int4',
+      description: 'Id',
+      constraints: {
+        __typename: 'TableColumnConstraints',
+        nullable: false,
+        unique: true,
+        other: [],
+      },
+    },
+    {
+      __typename: 'TableColumn',
+      name: 'first_name',
+      type: 'First Name',
+      description: null,
+      constraints: {
+        __typename: 'TableColumnConstraints',
+        nullable: false,
+        unique: false,
+        other: [],
+      },
+    },
+    {
+      __typename: 'TableColumn',
+      name: 'last_name',
+      type: 'Last Name',
+      description: null,
+      constraints: {
+        __typename: 'TableColumnConstraints',
+        nullable: false,
+        unique: false,
+        other: [],
+      },
+    },
+  ],
+};
+
+function buildMockMetadataEntry(type: MetadataEntryFragment['__typename']): MetadataEntryFragment {
+  switch (type) {
+    case 'PathMetadataEntry':
+      return {
+        __typename: 'PathMetadataEntry',
+        description: 'This is the description',
+        label: 'my_path',
+        path: '/dagster-homee/this/asset/path',
+      };
+    case 'JsonMetadataEntry':
+      return {
+        __typename: 'JsonMetadataEntry',
+        description: 'This is the description',
+        label: 'my_json',
+        jsonString: JSON.stringify({
+          short_value: 12,
+          depth: 1235123.2315123,
+          a: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          b: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          c: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          d: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          e: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          f: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          g: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          h: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          i: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+          version: 'ff639e01c58132962daa912789317898f710ee9a491123f58f23569e0706570b',
+          other: 'ff639e01c58132962daa912789317898f710ee9a491123f58f23569e0706570b',
+          longer_value: 'hello_world',
+          another: {object: 'here', this_is_another: 'key_to_make_this_long'},
+          tags: [
+            {
+              key: 'external-system/code_version',
+              value: '1369974d-cfab-4e03-82a6-d9430b847814',
+            },
+            {
+              key: 'external-system/logical_version',
+              value: '5133d9b282809abd0d1ae6ab5c1b6175af7cc4d91d7543bfa7141aef71fba39e',
+            },
+          ],
+        }),
+      };
+
+    case 'UrlMetadataEntry':
+      return {
+        __typename: 'UrlMetadataEntry',
+        description: 'This is the description',
+        label: 'my_url',
+        url: 'http://localhost:3000/assets/yoyo_singledim_staticla?partition=GA',
+      };
+    case 'TextMetadataEntry':
+      return {
+        __typename: 'TextMetadataEntry',
+        description: 'This is the description',
+        label: 'my_text',
+        text: 'hello world',
+      };
+    case 'MarkdownMetadataEntry':
+      return {
+        __typename: 'MarkdownMetadataEntry',
+        description: 'This is the description',
+        label: 'my_markdown',
+        mdStr: '## Hello World\n\nCurious if [Visit Apple.com](https://apple.com/) really works.',
+      };
+    case 'PythonArtifactMetadataEntry':
+      return {
+        __typename: 'PythonArtifactMetadataEntry',
+        label: 'my_artifact',
+        name: 'artifact_name',
+        module: 'test.py',
+        description: 'This is my artifact descripton',
+      };
+    case 'FloatMetadataEntry':
+      return {
+        __typename: 'FloatMetadataEntry',
+        description: 'This is the description',
+        label: 'my_float',
+        floatValue: 1234.12,
+      };
+    case 'IntMetadataEntry':
+      return {
+        __typename: 'IntMetadataEntry',
+        description: 'This is the description',
+        label: 'my_int',
+        intValue: 12,
+        intRepr: '12',
+      };
+    case 'BoolMetadataEntry':
+      return {
+        __typename: 'BoolMetadataEntry',
+        description: 'This is the description',
+        label: 'my_bool',
+        boolValue: true,
+      };
+    case 'NullMetadataEntry':
+      return {
+        __typename: 'NullMetadataEntry',
+        description: 'This is the description',
+        label: 'always_null',
+      };
+    case 'PipelineRunMetadataEntry':
+      return {
+        __typename: 'PipelineRunMetadataEntry',
+        description: 'This is the description',
+        label: 'my_run',
+        runId: '2a85aae4-b31f-44db-bd1c-6161549e4a3e',
+      };
+    case 'AssetMetadataEntry':
+      return {
+        __typename: 'AssetMetadataEntry',
+        description: 'This is the description',
+        label: 'my_asset',
+        assetKey: {__typename: 'AssetKey', path: ['asset_1']},
+      };
+    case 'TableMetadataEntry':
+      return {
+        __typename: 'TableMetadataEntry',
+        description: 'This is the description',
+        label: 'my_table',
+        table: {
+          __typename: 'Table',
+          schema: MetadataTableSchema,
+          records: ['1\tBen\tGotow', '2\tOther\tUser', '3\tFirst\tLast'],
+        },
+      };
+    case 'TableSchemaMetadataEntry':
+      return {
+        __typename: 'TableSchemaMetadataEntry',
+        description: 'This is the description',
+        label: 'my_table_schema',
+        schema: MetadataTableSchema,
+      };
+    case 'NotebookMetadataEntry':
+      return {
+        __typename: 'NotebookMetadataEntry',
+        description: 'This is the description',
+        label: 'my_path',
+        path: '/this/is/a/notebook-path',
+      };
+    default:
+      return assertUnreachable(type);
+  }
+}
+
+const MetadataEntryMocks = [
+  // Ensure we have at least one mock for every metadata entry type
+  // using an exhaustive switch statement
+  ...MetadataEntryTypes.map(buildMockMetadataEntry),
+
+  // Explicitly add more test cases that are interesting
+  {
+    __typename: 'BoolMetadataEntry',
+    description: 'This is the description',
+    label: 'my_null_bool',
+    boolValue: null, // Null value
+  } as BoolMetadataEntry,
+
+  {
+    __typename: 'IntMetadataEntry',
+    description: 'This is the description',
+    label: 'my_huge_int',
+    intValue: null,
+    intRepr: '21474836472147483147483147483647', // Cannot be expressed in JS
+  } as IntMetadataEntry,
+
+  {
+    __typename: 'JsonMetadataEntry',
+    description: 'This is the description',
+    label: 'my_short_json',
+    jsonString: '{"short_value": 12}', // Very short JSON is inlined
+  } as JsonMetadataEntry,
+];
+
+export const EmptyState = () => {
+  const [expandSmallValues, setExpandSmallValues] = React.useState(false);
+  return (
+    <Box style={{width: '950px', display: 'flex', flexDirection: 'column', gap: 12}}>
+      <Checkbox
+        label="Expand small values"
+        checked={expandSmallValues}
+        onChange={() => setExpandSmallValues(!expandSmallValues)}
+      />
+      <MetadataEntries entries={MetadataEntryMocks} expandSmallValues={expandSmallValues} />
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -56,7 +56,8 @@ export const LogRowStructuredContentTable: React.FC<{
 
 export const MetadataEntries: React.FC<{
   entries?: MetadataEntryFragment[];
-}> = ({entries}) => {
+  expandSmallValues?: boolean;
+}> = ({entries, expandSmallValues}) => {
   if (!entries || !entries.length) {
     return null;
   }
@@ -64,7 +65,7 @@ export const MetadataEntries: React.FC<{
     <LogRowStructuredContentTable
       rows={entries.map((entry) => ({
         label: entry.label,
-        item: <MetadataEntry entry={entry} />,
+        item: <MetadataEntry entry={entry} expandSmallValues={expandSmallValues} />,
       }))}
     />
   );


### PR DESCRIPTION
### Summary & Motivation

I think this deserves a storybook preview because a few of the values are allowed to be null, which is confusing, and because the TableSchema type is difficult to repro locally without mocking.

Also: The "TableMetadataEntry" type doesn't render anything at all - I will verify separately that this is ok because it could be an oversight: https://github.com/dagster-io/dagster/blob/master/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx#L172

I structured the test data in a bit of a strange way so that I could assert exhaustiveness - if you add a new MetadataEntry union member you have to add an example :-)  

This seems like another good candidate for some sort of visual regression testing because there's not much to assert against.

<img width="976" alt="image" src="https://user-images.githubusercontent.com/1037212/217562931-abb595d5-6f26-4067-943e-4ac4f27505fa.png">

<img width="997" alt="image" src="https://user-images.githubusercontent.com/1037212/217562959-c6169a55-54e4-48ec-a50e-58b1b63f0390.png">


