### PR TITLE
[dagit] Storybooks for asset partition and event details + dayJS fix

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
@@ -134,8 +134,8 @@ const MetadataEntriesRow: React.FC<{
                             <Link to={`/runs/${obs.runId}?timestamp=${obs.timestamp}`}>
                               <Mono>{titleForRun({runId: obs.runId})}</Mono>
                             </Link>
-                            {` (${dayjs(obs.timestamp).from(
-                              timestamp,
+                            {` (${dayjs(Number(obs.timestamp)).from(
+                              Number(timestamp),
                               true, // withoutSuffix
                             )} later)`}
                           </span>

--- a/js_modules/dagit/packages/core/src/assets/AssetEventDetail.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventDetail.mocks.ts
@@ -1,0 +1,298 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {RunStatus} from '../graphql/types';
+
+import {ASSET_MATERIALIZATION_UPSTREAM_QUERY} from './AssetMaterializationUpstreamData';
+import {ASSET_PARTITION_DETAIL_QUERY} from './AssetPartitionDetail';
+import {AssetMaterializationUpstreamQuery} from './types/AssetMaterializationUpstreamData.types';
+import {AssetPartitionDetailQuery} from './types/AssetPartitionDetail.types';
+import {
+  AssetMaterializationFragment,
+  AssetObservationFragment,
+} from './types/useRecentAssetEvents.types';
+
+export const Partition = '2022-02-02';
+export const MaterializationTimestamp = 1673996425523;
+
+const ONE_MIN = 60 * 1000;
+
+export const MaterializationEventOlder: AssetMaterializationFragment = {
+  partition: Partition,
+  tags: [
+    {
+      key: 'dagster/code_version',
+      value: '0b847814-4e03-82a6-cfab-d9431369974d',
+      __typename: 'EventTag',
+    },
+    {
+      key: 'dagster/logical_version',
+      value: '5133d9b282809abd0d1ae6ab5c1b6175af7cc4d91d7543bfa7141aef71fba39e',
+      __typename: 'EventTag',
+    },
+  ],
+  runOrError: {
+    id: '0b847814-4e03-82a6-cfab-d9431369974d',
+    runId: '0b847814-4e03-82a6-cfab-d9431369974d',
+    mode: 'default',
+    repositoryOrigin: {
+      id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    status: RunStatus.SUCCESS,
+    pipelineName: 'yoyoyoyoyojob',
+    pipelineSnapshotId: '33078455c88e4062615dabcbaf40773392470fc9',
+    __typename: 'Run',
+  },
+  runId: '0b847814-4e03-82a6-cfab-d9431369974d',
+  timestamp: `${MaterializationTimestamp - 60 * ONE_MIN}`,
+  stepKey: 'asset_1',
+  label: 'asset_1',
+  description: null,
+  metadataEntries: [
+    {
+      label: 'path',
+      description: null,
+      path: '/dagster-home/storage/storage/asset_1_old_path_bad',
+      __typename: 'PathMetadataEntry',
+    },
+    {
+      label: 'deprecated_key',
+      description: null,
+      path: '/should/not/appear/except/in/detailed/history',
+      __typename: 'PathMetadataEntry',
+    },
+    {
+      label: 'num_rows',
+      description: null,
+      intValue: 20,
+      intRepr: '20',
+      __typename: 'IntMetadataEntry',
+    },
+  ],
+  assetLineage: [],
+  __typename: 'MaterializationEvent',
+};
+
+export const MaterializationEventMinimal: AssetMaterializationFragment = {
+  partition: null,
+  tags: [],
+  runOrError: {
+    id: '1369974d-cfab-4e03-82a6-d9430b847814',
+    runId: '1369974d-cfab-4e03-82a6-d9430b847814',
+    mode: 'default',
+    repositoryOrigin: {
+      id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    status: RunStatus.FAILURE,
+    pipelineName: '__ASSET_JOB_0',
+    pipelineSnapshotId: '6e17dbde04cd1c5e3cec66a7d4d8a3e244bf27a6',
+    __typename: 'Run',
+  },
+  runId: '1369974d-cfab-4e03-82a6-d9430b847814',
+  timestamp: `${MaterializationTimestamp}`,
+  stepKey: 'asset_1',
+  label: 'asset_1',
+  description: null,
+  metadataEntries: [],
+  assetLineage: [],
+  __typename: 'MaterializationEvent',
+};
+
+export const MaterializationEventFull: AssetMaterializationFragment = {
+  partition: Partition,
+  tags: [
+    {
+      key: 'dagster/backfill',
+      value: 'difhnmkt',
+      __typename: 'EventTag',
+    },
+    {
+      key: 'dagster/code_version',
+      value: '1369974d-cfab-4e03-82a6-d9430b847814',
+      __typename: 'EventTag',
+    },
+    {
+      key: 'dagster/input_event_pointer/whatever4',
+      value: '197333',
+      __typename: 'EventTag',
+    },
+    {
+      key: 'dagster/input_logical_version/whatever4',
+      value: '8bf9bc307d655884c50036d758d74fdfa475f00a73df4ba95d9903a218cb827d',
+      __typename: 'EventTag',
+    },
+    {
+      key: 'dagster/logical_version',
+      value: '5133d9b282809abd0d1ae6ab5c1b6175af7cc4d91d7543bfa7141aef71fba39e',
+      __typename: 'EventTag',
+    },
+  ],
+  runOrError: {
+    id: '1369974d-cfab-4e03-82a6-d9430b847814',
+    runId: '1369974d-cfab-4e03-82a6-d9430b847814',
+    mode: 'default',
+    repositoryOrigin: {
+      id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    status: RunStatus.SUCCESS,
+    pipelineName: 'yoyoyoyoyojob',
+    pipelineSnapshotId: '33078455c88e4062615dabcbaf40773392470fc9',
+    __typename: 'Run',
+  },
+  runId: '1369974d-cfab-4e03-82a6-d9430b847814',
+  timestamp: `${MaterializationTimestamp}`,
+  stepKey: 'asset_1',
+  label: 'asset_1',
+  description: null,
+  metadataEntries: [
+    {
+      label: 'path',
+      description: null,
+      path: '/dagster-home/storage/storage/asset_1',
+      __typename: 'PathMetadataEntry',
+    },
+    {
+      label: 'num_rows',
+      description: null,
+      intValue: 50,
+      intRepr: '50',
+      __typename: 'IntMetadataEntry',
+    },
+  ],
+  assetLineage: [],
+  __typename: 'MaterializationEvent',
+};
+
+export const BasicObservationEvent: AssetObservationFragment = {
+  partition: Partition,
+  tags: [
+    {
+      key: 'dagster/code_version',
+      value: '1369974d-cfab-4e03-82a6-d9430b847814',
+      __typename: 'EventTag',
+    },
+    {
+      key: 'dagster/logical_version',
+      value: '5133d9b282809abd0d1ae6ab5c1b6175af7cc4d91d7543bfa7141aef71fba39e',
+      __typename: 'EventTag',
+    },
+  ],
+  runOrError: {
+    id: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
+    runId: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
+    mode: 'default',
+    repositoryOrigin: {
+      id: 'cc94e313d9025bbc796a3e7e46487eb305969b68',
+      repositoryName: 'repo',
+      repositoryLocationName: 'test.py',
+      __typename: 'RepositoryOrigin',
+    },
+    status: RunStatus.FAILURE,
+    pipelineName: '__ASSET_JOB_0',
+    pipelineSnapshotId: '6e17dbde04cd1c5e3cec66a7d4d8a3e244bf27a6',
+    __typename: 'Run',
+  },
+  runId: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
+  timestamp: `${MaterializationTimestamp + 5 * ONE_MIN}`,
+  stepKey: 'hobbyproject',
+  label: 'raw_country_populations',
+  description: null,
+  metadataEntries: [
+    {
+      label: 'correct_rows',
+      description: null,
+      intValue: 48,
+      intRepr: '48',
+      __typename: 'IntMetadataEntry',
+    },
+  ],
+  __typename: 'ObservationEvent',
+};
+
+export const MaterializationUpstreamDataFullMock: MockedResponse<AssetMaterializationUpstreamQuery> = {
+  request: {
+    operationName: 'AssetMaterializationUpstreamQuery',
+    variables: {assetKey: {path: ['asset_1']}, timestamp: '1673996425523'},
+    query: ASSET_MATERIALIZATION_UPSTREAM_QUERY,
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        __typename: 'AssetNode',
+        id: 'test.py.repo.["asset_1"]',
+        assetMaterializationUsedData: [
+          {
+            __typename: 'MaterializationUpstreamDataVersion',
+            timestamp: `${MaterializationTimestamp - 2 * ONE_MIN}`,
+            assetKey: {
+              path: ['inp2'],
+              __typename: 'AssetKey',
+            },
+            downstreamAssetKey: {
+              path: ['asset_1'],
+              __typename: 'AssetKey',
+            },
+          },
+          {
+            __typename: 'MaterializationUpstreamDataVersion',
+            timestamp: `${MaterializationTimestamp - 4 * ONE_MIN}`,
+            assetKey: {
+              path: ['inp3'],
+              __typename: 'AssetKey',
+            },
+            downstreamAssetKey: {
+              path: ['asset_1'],
+              __typename: 'AssetKey',
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const MaterializationUpstreamDataEmptyMock: MockedResponse<AssetMaterializationUpstreamQuery> = {
+  request: {
+    operationName: 'AssetMaterializationUpstreamQuery',
+    variables: {assetKey: {path: ['asset_1']}, timestamp: '1673996425523'},
+    query: ASSET_MATERIALIZATION_UPSTREAM_QUERY,
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        __typename: 'AssetNode',
+        id: 'test.py.repo.["asset_1"]',
+        assetMaterializationUsedData: [],
+      },
+    },
+  },
+};
+
+export const AssetPartitionDetailMock: MockedResponse<AssetPartitionDetailQuery> = {
+  request: {
+    operationName: 'AssetPartitionDetailQuery',
+    variables: {assetKey: {path: ['asset_1']}, partitionKey: Partition},
+    query: ASSET_PARTITION_DETAIL_QUERY,
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        __typename: 'AssetNode',
+        id: 'test.py.repo.["asset_1"]',
+        assetMaterializations: [MaterializationEventFull, MaterializationEventOlder],
+        assetObservations: [BasicObservationEvent],
+      },
+    },
+  },
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetEventDetail.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventDetail.stories.tsx
@@ -1,0 +1,61 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {Box} from '@dagster-io/ui';
+import React from 'react';
+
+import {createAppCache} from '../app/AppCache';
+import {StorybookProvider} from '../testing/StorybookProvider';
+import {WorkspaceProvider} from '../workspace/WorkspaceContext';
+
+import {AssetEventDetail, AssetEventDetailEmpty} from './AssetEventDetail';
+import {
+  BasicObservationEvent,
+  MaterializationEventFull,
+  MaterializationEventMinimal,
+  MaterializationUpstreamDataEmptyMock,
+  MaterializationUpstreamDataFullMock,
+} from './AssetEventDetail.mocks';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AssetEventDetail};
+
+export const EmptyState = () => {
+  return (
+    <Box style={{width: '950px'}}>
+      <AssetEventDetailEmpty />
+    </Box>
+  );
+};
+
+export const MaterializationMinimal = () => {
+  return (
+    <MockedProvider mocks={[MaterializationUpstreamDataEmptyMock]} cache={createAppCache()}>
+      <WorkspaceProvider>
+        <Box style={{width: '950px'}}>
+          <AssetEventDetail assetKey={{path: ['asset_1']}} event={MaterializationEventMinimal} />
+        </Box>
+      </WorkspaceProvider>
+    </MockedProvider>
+  );
+};
+
+export const MaterializationFull = () => {
+  return (
+    <MockedProvider mocks={[MaterializationUpstreamDataFullMock]} cache={createAppCache()}>
+      <WorkspaceProvider>
+        <Box style={{width: '950px', display: 'flex', flexDirection: 'column'}}>
+          <AssetEventDetail assetKey={{path: ['asset_1']}} event={MaterializationEventFull} />
+        </Box>
+      </WorkspaceProvider>
+    </MockedProvider>
+  );
+};
+
+export const Observation = () => {
+  return (
+    <StorybookProvider>
+      <Box style={{width: '800px', display: 'flex', flexDirection: 'column'}}>
+        <AssetEventDetail assetKey={{path: ['asset_1']}} event={BasicObservationEvent} />
+      </Box>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -66,7 +66,10 @@ export const AssetEventMetadataEntriesTable: React.FC<{
                       </span>
                     </Box>
                     <Caption style={{marginLeft: 24}}>
-                      {`(${dayjs(obs.timestamp).from(timestamp, true /* withoutSuffix */)} later)`}
+                      {`(${dayjs(Number(obs.timestamp)).from(
+                        Number(timestamp),
+                        true /* withoutSuffix */,
+                      )} later)`}
                     </Caption>
                     {entry.description}
                   </td>
@@ -101,6 +104,3 @@ const AssetEventMetadataTable = styled.table`
     vertical-align: top;
   }
 `;
-
-export const AssetEventDetailEmpty = () => <Box />;
-export const AssetPartitionDetailEmpty = () => <Box />;

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -112,7 +112,7 @@ export const AssetMaterializationUpstreamData: React.FC<{
   );
 };
 
-const ASSET_MATERIALIZATION_UPSTREAM_QUERY = gql`
+export const ASSET_MATERIALIZATION_UPSTREAM_QUERY = gql`
   query AssetMaterializationUpstreamQuery($assetKey: AssetKeyInput!, $timestamp: String!) {
     assetNodeOrError(assetKey: $assetKey) {
       __typename

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.stories.tsx
@@ -1,0 +1,44 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {Box} from '@dagster-io/ui';
+import React from 'react';
+
+import {createAppCache} from '../app/AppCache';
+import {WorkspaceProvider} from '../workspace/WorkspaceContext';
+
+import {
+  AssetPartitionDetailMock,
+  MaterializationUpstreamDataFullMock,
+} from './AssetEventDetail.mocks';
+import {
+  AssetPartitionDetail,
+  AssetPartitionDetailEmpty,
+  AssetPartitionDetailLoader,
+} from './AssetPartitionDetail';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AssetPartitionDetail};
+
+export const EmptyState = () => {
+  return (
+    <MockedProvider cache={createAppCache()}>
+      <Box style={{width: '950px'}}>
+        <AssetPartitionDetailEmpty />
+      </Box>
+    </MockedProvider>
+  );
+};
+
+export const MaterializationFollowedByObservation = () => {
+  return (
+    <MockedProvider
+      mocks={[AssetPartitionDetailMock, MaterializationUpstreamDataFullMock]}
+      cache={createAppCache()}
+    >
+      <WorkspaceProvider>
+        <Box style={{width: '950px'}}>
+          <AssetPartitionDetailLoader assetKey={{path: ['asset_1']}} partitionKey="2022-02-02" />
+        </Box>
+      </WorkspaceProvider>
+    </MockedProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -73,7 +73,7 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
   );
 };
 
-const ASSET_PARTITION_DETAIL_QUERY = gql`
+export const ASSET_PARTITION_DETAIL_QUERY = gql`
   query AssetPartitionDetailQuery($assetKey: AssetKeyInput!, $partitionKey: String!) {
     assetNodeOrError(assetKey: $assetKey) {
       __typename


### PR DESCRIPTION
### Summary & Motivation

This adds storybooks for the asset partition details and asset event details UI in Dagit. These components mostly display static data, but there are sections that are only populated in certain scenarios (eg: when a materialization is followed by an observation event that contains additional metadata entries). It can be difficult to see the entire thing without a nice asset graph.

In the process of building these I discovered that the dayjs constructor only handles timestamps properly if they're passed as numbers, and fixed all the callsites that were passing them as strings.

### How I Tested These Changes

I think that these should also get some jest tests that poke the rendering and verify text appears as expected using the same mock data as the storybooks, but it might be worth merging this now for the dayjs fix.

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/1037212/217566214-1614d25f-6e59-464f-9d67-4876c8665c9f.png">

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/1037212/217566290-84cfbd0c-267c-46e5-8bdd-5e2cc44d866b.png">

<img width="1183" alt="image" src="https://user-images.githubusercontent.com/1037212/217566244-062ecc74-a995-404f-978d-287f4c8b0976.png">
