### PR TITLE
[dagster-airflow] kwargs for flowing through configuration to dagster objects

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, List, Mapping, Optional, Set, Tuple, Dict, Any
+from typing import AbstractSet, List, Mapping, Optional, Set, Tuple
 
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, List, Mapping, Optional, Set, Tuple
+from typing import AbstractSet, List, Mapping, Optional, Set, Tuple, Dict, Any
 
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -21,7 +21,7 @@ from dagster_airflow.utils import (
 def make_dagster_definitions_from_airflow_dag_bag(
     dag_bag: DagBag,
     connections: Optional[List[Connection]] = None,
-    kwargs: Optional[dict] = None,
+    definitions_kwargs: Optional[dict] = None,
 ) -> Definitions:
     """Construct a Dagster definition corresponding to Airflow DAGs in DagBag.
 
@@ -39,12 +39,12 @@ def make_dagster_definitions_from_airflow_dag_bag(
     Args:
         dag_bag (DagBag): Airflow DagBag Model
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
-        kwargs (Optional[dict]): kwargs to be passed to the Definitions constructor
+        definitions_kwargs (Optional[dict]): kwargs to be passed to the Definitions constructor
 
     Returns:
         Definitions
     """
-    kwargs = check.opt_dict_param(kwargs, "kwargs")
+    definitions_kwargs = check.opt_dict_param(definitions_kwargs, "definitions_kwargs")
     schedules, jobs = make_schedules_and_jobs_from_airflow_dag_bag(
         dag_bag,
         connections,
@@ -53,7 +53,7 @@ def make_dagster_definitions_from_airflow_dag_bag(
     return Definitions(
         schedules=schedules,
         jobs=jobs,
-        *kwargs if kwargs else (),
+        *definitions_kwargs if definitions_kwargs else (),
     )
 
 
@@ -61,7 +61,7 @@ def make_dagster_definitions_from_airflow_dags_path(
     dag_path: str,
     safe_mode: bool = True,
     connections: Optional[List[Connection]] = None,
-    kwargs: Optional[dict] = None,
+    definitions_kwargs: Optional[dict] = None,
 ) -> Definitions:
     """Construct a Dagster repository corresponding to Airflow DAGs in dag_path.
 
@@ -86,7 +86,7 @@ def make_dagster_definitions_from_airflow_dags_path(
         safe_mode (bool): True to use Airflow's default heuristic to find files that contain DAGs
             (ie find files that contain both b'DAG' and b'airflow') (default: True)
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
-        kwargs (Optional[dict]): kwargs to be passed to the Definitions constructor
+        definitions_kwargs (Optional[dict]): kwargs to be passed to the Definitions constructor
 
     Returns:
         Definitions
@@ -94,7 +94,7 @@ def make_dagster_definitions_from_airflow_dags_path(
     check.str_param(dag_path, "dag_path")
     check.bool_param(safe_mode, "safe_mode")
     connections = check.opt_list_param(connections, "connections", of_type=Connection)
-    kwargs = check.opt_dict_param(kwargs, "kwargs")
+    definitions_kwargs = check.opt_dict_param(definitions_kwargs, "definitions_kwargs")
     # add connections to airflow so that dag evaluation works
     create_airflow_connections(connections)
     dag_bag = DagBag(
@@ -106,7 +106,7 @@ def make_dagster_definitions_from_airflow_dags_path(
     return make_dagster_definitions_from_airflow_dag_bag(
         dag_bag=dag_bag,
         connections=connections,
-        kwargs=kwargs,
+        definitions_kwargs=definitions_kwargs,
     )
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -51,9 +51,9 @@ def make_dagster_definitions_from_airflow_dag_bag(
     )
 
     return Definitions(
+        *definitions_kwargs if definitions_kwargs else (),
         schedules=schedules,
         jobs=jobs,
-        *definitions_kwargs if definitions_kwargs else (),
     )
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -21,7 +21,8 @@ from dagster_airflow.utils import (
 def make_dagster_definitions_from_airflow_dag_bag(
     dag_bag: DagBag,
     connections: Optional[List[Connection]] = None,
-):
+    kwargs: Optional[dict] = None,
+) -> Definitions:
     """Construct a Dagster definition corresponding to Airflow DAGs in DagBag.
 
     Usage:
@@ -38,10 +39,12 @@ def make_dagster_definitions_from_airflow_dag_bag(
     Args:
         dag_bag (DagBag): Airflow DagBag Model
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
+        kwargs (Optional[dict]): kwargs to be passed to the Definitions constructor
 
     Returns:
         Definitions
     """
+    kwargs = check.opt_dict_param(kwargs, "kwargs")
     schedules, jobs = make_schedules_and_jobs_from_airflow_dag_bag(
         dag_bag,
         connections,
@@ -50,6 +53,7 @@ def make_dagster_definitions_from_airflow_dag_bag(
     return Definitions(
         schedules=schedules,
         jobs=jobs,
+        *kwargs if kwargs else (),
     )
 
 
@@ -57,7 +61,8 @@ def make_dagster_definitions_from_airflow_dags_path(
     dag_path: str,
     safe_mode: bool = True,
     connections: Optional[List[Connection]] = None,
-):
+    kwargs: Optional[dict] = None,
+) -> Definitions:
     """Construct a Dagster repository corresponding to Airflow DAGs in dag_path.
 
     Usage:
@@ -81,6 +86,7 @@ def make_dagster_definitions_from_airflow_dags_path(
         safe_mode (bool): True to use Airflow's default heuristic to find files that contain DAGs
             (ie find files that contain both b'DAG' and b'airflow') (default: True)
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
+        kwargs (Optional[dict]): kwargs to be passed to the Definitions constructor
 
     Returns:
         Definitions
@@ -88,6 +94,7 @@ def make_dagster_definitions_from_airflow_dags_path(
     check.str_param(dag_path, "dag_path")
     check.bool_param(safe_mode, "safe_mode")
     connections = check.opt_list_param(connections, "connections", of_type=Connection)
+    kwargs = check.opt_dict_param(kwargs, "kwargs")
     # add connections to airflow so that dag evaluation works
     create_airflow_connections(connections)
     dag_bag = DagBag(
@@ -99,10 +106,11 @@ def make_dagster_definitions_from_airflow_dags_path(
     return make_dagster_definitions_from_airflow_dag_bag(
         dag_bag=dag_bag,
         connections=connections,
+        kwargs=kwargs,
     )
 
 
-def make_dagster_definitions_from_airflow_example_dags():
+def make_dagster_definitions_from_airflow_example_dags() -> Definitions:
     """Construct a Dagster repository for Airflow's example DAGs.
 
     Usage:

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -166,7 +166,7 @@ def make_dagster_job_from_airflow_dag(
     dag: DAG,
     tags: Optional[Mapping[str, str]] = None,
     connections: Optional[List[Connection]] = None,
-    kwargs: Optional[dict] = None,
+    job_kwargs: Optional[dict] = None,
 ) -> JobDefinition:
     """Construct a Dagster job corresponding to a given Airflow DAG.
 
@@ -205,7 +205,7 @@ def make_dagster_job_from_airflow_dag(
             `tags={'airflow_execution_date': utc_date_string}` to specify execution_date used within
             execution of Airflow Operators.
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB.
-        kwargs (Optional[dict]): kwargs to be passed to the Job constructor
+        job_kwargs (Optional[dict]): kwargs to be passed to the Job constructor
 
     Returns:
         JobDefinition: The generated Dagster job
@@ -214,7 +214,7 @@ def make_dagster_job_from_airflow_dag(
     check.inst_param(dag, "dag", DAG)
     tags = check.opt_mapping_param(tags, "tags")
     connections = check.opt_list_param(connections, "connections", of_type=Connection)
-    kwargs = check.opt_dict_param(kwargs, "kwargs")
+    job_kwargs = check.opt_dict_param(job_kwargs, "job_kwargs")
 
     mutated_tags = dict(tags)
     if IS_AIRFLOW_INGEST_PIPELINE_STR not in tags:
@@ -246,6 +246,6 @@ def make_dagster_job_from_airflow_dag(
         },
         graph_def=graph_def,
         tags=mutated_tags,
-        *kwargs if kwargs else (),
+        *job_kwargs if job_kwargs else (),
     )
     return job_def

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -166,6 +166,7 @@ def make_dagster_job_from_airflow_dag(
     dag: DAG,
     tags: Optional[Mapping[str, str]] = None,
     connections: Optional[List[Connection]] = None,
+    kwargs: Optional[dict] = None,
 ) -> JobDefinition:
     """Construct a Dagster job corresponding to a given Airflow DAG.
 
@@ -203,8 +204,8 @@ def make_dagster_job_from_airflow_dag(
         tags (Dict[str, Field]): Job tags. Optionally include
             `tags={'airflow_execution_date': utc_date_string}` to specify execution_date used within
             execution of Airflow Operators.
-        connections (List[Connection]): List of Airflow Connections to be created in the Ephemeral
-            Airflow DB, if use_emphemeral_airflow_db is False this will be ignored.
+        connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB.
+        kwargs (Optional[dict]): kwargs to be passed to the Job constructor
 
     Returns:
         JobDefinition: The generated Dagster job
@@ -213,6 +214,7 @@ def make_dagster_job_from_airflow_dag(
     check.inst_param(dag, "dag", DAG)
     tags = check.opt_mapping_param(tags, "tags")
     connections = check.opt_list_param(connections, "connections", of_type=Connection)
+    kwargs = check.opt_dict_param(kwargs, "kwargs")
 
     mutated_tags = dict(tags)
     if IS_AIRFLOW_INGEST_PIPELINE_STR not in tags:
@@ -230,7 +232,6 @@ def make_dagster_job_from_airflow_dag(
 
     graph_def = GraphDefinition(
         name=normalized_name(dag.dag_id),
-        description="",
         node_defs=node_defs,
         dependencies=node_dependencies,
         tags=mutated_tags,
@@ -238,7 +239,6 @@ def make_dagster_job_from_airflow_dag(
 
     job_def = JobDefinition(
         name=normalized_name(dag.dag_id),
-        description="",
         resource_defs={
             "airflow_db": airflow_db_resource_def,
             "dag": dag_resource,
@@ -246,8 +246,6 @@ def make_dagster_job_from_airflow_dag(
         },
         graph_def=graph_def,
         tags=mutated_tags,
-        metadata={},
-        op_retry_policy=None,
-        version_strategy=None,
+        *kwargs if kwargs else (),
     )
     return job_def

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -238,6 +238,7 @@ def make_dagster_job_from_airflow_dag(
     )
 
     job_def = JobDefinition(
+        *job_kwargs if job_kwargs else (),
         name=normalized_name(dag.dag_id),
         resource_defs={
             "airflow_db": airflow_db_resource_def,
@@ -246,6 +247,5 @@ def make_dagster_job_from_airflow_dag(
         },
         graph_def=graph_def,
         tags=mutated_tags,
-        *job_kwargs if job_kwargs else (),
     )
     return job_def

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_schedule_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_schedule_factory.py
@@ -23,6 +23,7 @@ def make_dagster_schedule_from_airflow_dag(
     dag: DAG,
     tags: Optional[Mapping[str, str]] = None,
     connections: Optional[List[Connection]] = None,
+    kwargs: Optional[dict] = None,
 ) -> ScheduleDefinition:
     """Construct a Dagster schedule corresponding to an Airflow DAG.
 
@@ -32,11 +33,13 @@ def make_dagster_schedule_from_airflow_dag(
             `tags={'airflow_execution_date': utc_date_string}` to specify execution_date used within
             execution of Airflow Operators.
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
+        kwargs (Optional[dict]): kwargs to be passed to Schedule constructor
 
     Returns:
         ScheduleDefinition
     """
     check.inst_param(dag, "dag", DAG)
+    kwargs = check.opt_dict_param(kwargs, "kwargs")
 
     cron_schedule = dag.normalized_schedule_interval
     schedule_description = dag.description
@@ -48,4 +51,5 @@ def make_dagster_schedule_from_airflow_dag(
         cron_schedule=str(cron_schedule),
         description=schedule_description,
         execution_timezone=dag.timezone.name,
+        *kwargs if kwargs else (),
     )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_schedule_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_schedule_factory.py
@@ -23,7 +23,7 @@ def make_dagster_schedule_from_airflow_dag(
     dag: DAG,
     tags: Optional[Mapping[str, str]] = None,
     connections: Optional[List[Connection]] = None,
-    kwargs: Optional[dict] = None,
+    schedule_kwargs: Optional[dict] = None,
 ) -> ScheduleDefinition:
     """Construct a Dagster schedule corresponding to an Airflow DAG.
 
@@ -33,13 +33,13 @@ def make_dagster_schedule_from_airflow_dag(
             `tags={'airflow_execution_date': utc_date_string}` to specify execution_date used within
             execution of Airflow Operators.
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
-        kwargs (Optional[dict]): kwargs to be passed to Schedule constructor
+        schedule_kwargs (Optional[dict]): kwargs to be passed to Schedule constructor
 
     Returns:
         ScheduleDefinition
     """
     check.inst_param(dag, "dag", DAG)
-    kwargs = check.opt_dict_param(kwargs, "kwargs")
+    schedule_kwargs = check.opt_dict_param(schedule_kwargs, "schedule_kwargs")
 
     cron_schedule = dag.normalized_schedule_interval
     schedule_description = dag.description
@@ -51,5 +51,5 @@ def make_dagster_schedule_from_airflow_dag(
         cron_schedule=str(cron_schedule),
         description=schedule_description,
         execution_timezone=dag.timezone.name,
-        *kwargs if kwargs else (),
+        *schedule_kwargs if schedule_kwargs else (),
     )

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_schedule_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_schedule_factory.py
@@ -47,9 +47,9 @@ def make_dagster_schedule_from_airflow_dag(
     job_def = make_dagster_job_from_airflow_dag(dag=dag, tags=tags, connections=connections)
 
     return ScheduleDefinition(
+        *schedule_kwargs if schedule_kwargs else (),
         job=job_def,
         cron_schedule=str(cron_schedule),
         description=schedule_description,
         execution_timezone=dag.timezone.name,
-        *schedule_kwargs if schedule_kwargs else (),
     )


### PR DESCRIPTION
### Summary & Motivation

The dagster-airflow api's currently don't allow users to configure the returns from its api's, resulting in users having to extract and redefine things if they want to modify configuration. This pr adds kwargs for the following api's:

- `make_dagster_definitions_from_airflow_dag_bag`
- `make_dagster_definitions_from_airflow_dags_path`
- `make_dagster_job_from_airflow_dag`
- `make_dagster_schedule_from_airflow_dag`

`load_assets_from_airflow_dag` and `make_schedules_and_jobs_from_airflow_dag_bag` are omitted since flowing kwargs is not as obvious with each. The work for annotating Assets backed by dags is probably more substantial than kwargs anyways...

### How I Tested These Changes

- [ ] unit tests
