### PR TITLE
Allow setting logical version inside op

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -23,6 +23,7 @@ from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.logical_version import LogicalVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._utils.backcompat import experimental_class_param_warning
 
 from .metadata import (
     MetadataEntry,
@@ -235,6 +236,8 @@ class Output(Generic[T]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
             list, and one of the data classes returned by a MetadataValue static method.
+        logical_version (Optional[LogicalVersion]): (Experimental) A logical version to manually set
+            for the asset.
     """
 
     def __init__(
@@ -254,6 +257,8 @@ class Output(Generic[T]):
         self._value = value
         self._output_name = check.str_param(output_name, "output_name")
         self._metadata_entries = normalize_metadata(metadata, metadata_entries)
+        if logical_version is not None:
+            experimental_class_param_warning("logical_version", "Output")
         self._logical_version = check.opt_inst_param(
             logical_version, "logical_version", LogicalVersion
         )

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -20,6 +20,7 @@ from typing import (
 import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, public
+from dagster._core.definitions.logical_version import LogicalVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
 
@@ -242,6 +243,7 @@ class Output(Generic[T]):
         output_name: Optional[str] = DEFAULT_OUTPUT,
         metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        logical_version: Optional[LogicalVersion] = None,
     ):
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
         metadata_entries = check.opt_sequence_param(
@@ -252,6 +254,9 @@ class Output(Generic[T]):
         self._value = value
         self._output_name = check.str_param(output_name, "output_name")
         self._metadata_entries = normalize_metadata(metadata, metadata_entries)
+        self._logical_version = check.opt_inst_param(
+            logical_version, "logical_version", LogicalVersion
+        )
 
     @property
     def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
@@ -266,6 +271,11 @@ class Output(Generic[T]):
     @property
     def output_name(self) -> str:
         return self._output_name
+
+    @public
+    @property
+    def logical_version(self) -> Optional[LogicalVersion]:
+        return self._logical_version
 
     def __eq__(self, other: object) -> bool:
         return (

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -15,7 +15,6 @@ from dagster._core.definitions.events import (
     UserEvent,
 )
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.logical_version import LogicalVersion
 from dagster._core.definitions.mode import ModeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -566,15 +565,6 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         return self._step_execution_context.get_output_metadata(
             output_name=output_name, mapping_key=mapping_key
         )
-
-    def set_output_logical_version(
-        self,
-        logical_version: LogicalVersion,
-        output_name: Optional[str] = None,
-    ):
-        """Set the logical version for one of the outputs of an op."""
-        asset_key = self.asset_key_for_output(output_name=output_name or "result")
-        self._step_execution_context.set_logical_version(asset_key, logical_version)
 
     def get_step_execution_context(self) -> StepExecutionContext:
         """Allows advanced users (e.g. framework authors) to punch through to the underlying

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.events import (
     UserEvent,
 )
 from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.logical_version import LogicalVersion
 from dagster._core.definitions.mode import ModeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -565,6 +566,15 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         return self._step_execution_context.get_output_metadata(
             output_name=output_name, mapping_key=mapping_key
         )
+
+    def set_output_logical_version(
+        self,
+        logical_version: LogicalVersion,
+        output_name: Optional[str] = None,
+    ):
+        """Set the logical version for one of the outputs of an op."""
+        asset_key = self.asset_key_for_output(output_name=output_name or "result")
+        self._step_execution_context.set_logical_version(asset_key, logical_version)
 
     def get_step_execution_context(self) -> StepExecutionContext:
         """Allows advanced users (e.g. framework authors) to punch through to the underlying

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -251,16 +251,16 @@ def validate_and_coerce_op_result_to_iterator(
                         f" output '{output_def.name}' which does not have an Output annotation."
                         f" Annotation has type {annotation}."
                     )
-                output = cast(Output, element)
-                _check_output_object_name(output, output_def, position)
+                _check_output_object_name(element, output_def, position)
 
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", category=DeprecationWarning)
 
                     yield Output(
                         output_name=output_def.name,
-                        value=output.value,
-                        metadata_entries=output.metadata_entries,
+                        value=element.value,
+                        metadata_entries=element.metadata_entries,
+                        logical_version=element.logical_version,
                     )
             else:
                 # If annotation indicates a generic output annotation, and an

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -557,7 +557,7 @@ def _get_output_asset_materializations(
 def _get_code_version(asset_key: AssetKey, step_context: StepExecutionContext) -> str:
     return (
         step_context.pipeline_def.asset_layer.code_version_for_asset(asset_key)
-        or step_context.pipeline_run.run_id
+        or step_context.dagster_run.run_id
     )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_file_in_directory/hello_world_repository.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_file_in_directory/hello_world_repository.py
@@ -1,7 +1,6 @@
 # type: ignore
 
 from dagster import repository
-
 from src.pipelines import hello_world_pipeline
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_logical_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_logical_versions.py
@@ -29,6 +29,7 @@ from dagster._core.definitions.logical_version import (
 )
 from dagster._core.definitions.observe import observe
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
+from dagster._core.instance_for_test import instance_for_test
 from typing_extensions import Literal
 
 # ########################
@@ -36,12 +37,22 @@ from typing_extensions import Literal
 # ########################
 
 
+class MaterializationTable:
+    def __init__(self, materializations: Mapping[AssetKey, AssetMaterialization]):
+        self.materializations = materializations
+
+    def __getitem__(self, key: Union[str, AssetKey]) -> AssetMaterialization:
+        asset_key = AssetKey([key]) if isinstance(key, str) else key
+        return self.materializations[asset_key]
+
+
+# Used to provide sorrce asset dependency
 class MockIOManager(IOManager):
     def handle_output(self, context, obj):
         pass
 
     def load_input(self, context):
-        pass
+        return 1
 
 
 @io_manager
@@ -57,13 +68,13 @@ def get_mat_from_result(result: ExecuteInProcessResult, node_str: str) -> AssetM
 
 def get_mats_from_result(
     result: ExecuteInProcessResult, assets: Sequence[AssetsDefinition]
-) -> Mapping[AssetKey, AssetMaterialization]:
+) -> MaterializationTable:
     mats: Dict[AssetKey, AssetMaterialization] = {}
     for asset_def in assets:
         node_str = asset_def.node_def.name if asset_def.node_def else asset_def.key.path[-1]
         for mat in result.asset_materializations_for_node(node_str):
             mats[mat.asset_key] = cast(AssetMaterialization, mat)
-    return mats
+    return MaterializationTable(mats)
 
 
 def get_upstream_version_from_mat_provenance(
@@ -78,9 +89,10 @@ def get_version_from_mat(mat: AssetMaterialization) -> str:
     return mat.tags[LOGICAL_VERSION_TAG_KEY]
 
 
-def assert_logical_version(mat: AssetMaterialization, version: LogicalVersion) -> None:
+def assert_logical_version(mat: AssetMaterialization, version: Union[str, LogicalVersion]) -> None:
+    value = version.value if isinstance(version, LogicalVersion) else version
     assert mat.tags
-    assert mat.tags[LOGICAL_VERSION_TAG_KEY] == version.value
+    assert mat.tags[LOGICAL_VERSION_TAG_KEY] == value
 
 
 def assert_code_version(mat: AssetMaterialization, version: str) -> None:
@@ -129,7 +141,7 @@ def materialize_asset(
     instance: DagsterInstance,
     *,
     is_multi: Literal[True],
-) -> Mapping[AssetKey, AssetMaterialization]:
+) -> MaterializationTable:
     ...
 
 
@@ -149,7 +161,7 @@ def materialize_asset(
     asset_to_materialize: AssetsDefinition,
     instance: DagsterInstance,
     is_multi: bool = False,
-) -> Union[AssetMaterialization, Mapping[AssetKey, AssetMaterialization]]:
+) -> Union[AssetMaterialization, MaterializationTable]:
     assets: List[Union[AssetsDefinition, SourceAsset]] = []
     for asset_def in all_assets:
         if isinstance(asset_def, SourceAsset):
@@ -171,7 +183,7 @@ def materialize_asset(
 
 def materialize_assets(
     assets: Sequence[AssetsDefinition], instance: DagsterInstance
-) -> Mapping[AssetKey, AssetMaterialization]:
+) -> MaterializationTable:
     result = materialize(assets, instance=instance, resources={"io_manager": mock_io_manager})
     return get_mats_from_result(result, assets)
 
@@ -400,69 +412,69 @@ def test_stale_status() -> None:
     # one cause per line for readability
 
     all_assets = [source1, asset1, asset2]
-    instance = DagsterInstance.ephemeral()
+    with instance_for_test() as instance:
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(source1.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset1.key) == StaleStatus.STALE
+        assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
+        assert status_resolver.get_status_causes(asset2.key)[0] == StaleStatusCause(
+            StaleStatus.STALE, asset2.key, "never materialized"
+        )
 
-    status_resolver = get_stale_status_resolver(instance, all_assets)
-    assert status_resolver.get_status(source1.key) == StaleStatus.FRESH
-    assert status_resolver.get_status(asset1.key) == StaleStatus.STALE
-    assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
-    assert status_resolver.get_status_causes(asset2.key)[0] == StaleStatusCause(
-        StaleStatus.STALE, asset2.key, "never materialized"
-    )
+        materialize_assets(all_assets, instance)
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key) == StaleStatus.FRESH
+        assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
 
-    materialize_assets(all_assets, instance)
-    status_resolver = get_stale_status_resolver(instance, all_assets)
-    assert status_resolver.get_status(asset1.key) == StaleStatus.FRESH
-    assert status_resolver.get_status(asset2.key) == StaleStatus.FRESH
+        observe([source1], instance=instance)
+        status_resolver = get_stale_status_resolver(instance, all_assets)
+        assert status_resolver.get_status(asset1.key) == StaleStatus.STALE
+        assert status_resolver.get_status_causes(asset1.key) == [
+            StaleStatusCause(StaleStatus.STALE, asset1.key, "updated input: source1"),
+        ]
+        assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
+        assert status_resolver.get_status_causes(asset2.key) == [
+            StaleStatusCause(StaleStatus.STALE, asset2.key, "stale input: asset1"),
+            StaleStatusCause(StaleStatus.STALE, asset1.key, "updated input: source1"),
+        ]
+        materialize_assets(all_assets, instance)
 
-    observe([source1], instance=instance)
-    status_resolver = get_stale_status_resolver(instance, all_assets)
-    assert status_resolver.get_status(asset1.key) == StaleStatus.STALE
-    assert status_resolver.get_status_causes(asset1.key) == [
-        StaleStatusCause(StaleStatus.STALE, asset1.key, "updated input: source1"),
-    ]
-    assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
-    assert status_resolver.get_status_causes(asset2.key) == [
-        StaleStatusCause(StaleStatus.STALE, asset2.key, "stale input: asset1"),
-        StaleStatusCause(StaleStatus.STALE, asset1.key, "updated input: source1"),
-    ]
-    materialize_assets(all_assets, instance)
+        # Simulate updating an asset with a new code version
+        @asset(name="asset1", code_version="def")
+        def asset1_v2(source1):
+            ...
 
-    # Simulate updating an asset with a new code version
-    @asset(name="asset1", code_version="def")
-    def asset1_v2(source1):
-        ...
+        all_assets_v2 = [source1, asset1_v2, asset2]
 
-    all_assets_v2 = [source1, asset1_v2, asset2]
+        status_resolver = get_stale_status_resolver(instance, all_assets_v2)
+        assert status_resolver.get_status(asset1.key) == StaleStatus.STALE
+        assert status_resolver.get_status_causes(asset1.key) == [
+            StaleStatusCause(StaleStatus.STALE, asset1.key, "updated code version"),
+        ]
+        assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
+        assert status_resolver.get_status_causes(asset2.key) == [
+            StaleStatusCause(StaleStatus.STALE, asset2.key, "stale input: asset1"),
+            StaleStatusCause(StaleStatus.STALE, asset1.key, "updated code version"),
+        ]
 
-    status_resolver = get_stale_status_resolver(instance, all_assets_v2)
-    assert status_resolver.get_status(asset1.key) == StaleStatus.STALE
-    assert status_resolver.get_status_causes(asset1.key) == [
-        StaleStatusCause(StaleStatus.STALE, asset1.key, "updated code version"),
-    ]
-    assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
-    assert status_resolver.get_status_causes(asset2.key) == [
-        StaleStatusCause(StaleStatus.STALE, asset2.key, "stale input: asset1"),
-        StaleStatusCause(StaleStatus.STALE, asset1.key, "updated code version"),
-    ]
+        @asset
+        def asset3():
+            ...
 
-    @asset
-    def asset3():
-        ...
+        @asset(name="asset2", code_version="xyz")
+        def asset2_v2(asset3):
+            ...
 
-    @asset(name="asset2", code_version="xyz")
-    def asset2_v2(asset3):
-        ...
+        all_assets_v3 = [source1, asset1_v2, asset2_v2, asset3]
 
-    all_assets_v3 = [source1, asset1_v2, asset2_v2, asset3]
+        status_resolver = get_stale_status_resolver(instance, all_assets_v3)
+        assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
+        assert status_resolver.get_status_causes(asset2.key) == [
+            StaleStatusCause(StaleStatus.STALE, asset2.key, "removed input: asset1"),
+            StaleStatusCause(StaleStatus.STALE, asset2.key, "new input: asset3"),
+            StaleStatusCause(StaleStatus.STALE, asset3.key, "never materialized"),
+        ]
 
-    status_resolver = get_stale_status_resolver(instance, all_assets_v3)
-    assert status_resolver.get_status(asset2.key) == StaleStatus.STALE
-    assert status_resolver.get_status_causes(asset2.key) == [
-        StaleStatusCause(StaleStatus.STALE, asset2.key, "removed input: asset1"),
-        StaleStatusCause(StaleStatus.STALE, asset2.key, "new input: asset3"),
-        StaleStatusCause(StaleStatus.STALE, asset3.key, "never materialized"),
-    ]
 
 def test_set_logical_version_inside_op():
     instance = DagsterInstance.ephemeral()

--- a/python_modules/dagster/dagster_tests/execution_tests/test_logical_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_logical_versions.py
@@ -463,3 +463,13 @@ def test_stale_status() -> None:
         StaleStatusCause(StaleStatus.STALE, asset2.key, "new input: asset3"),
         StaleStatusCause(StaleStatus.STALE, asset3.key, "never materialized"),
     ]
+
+def test_set_logical_version_inside_op():
+    instance = DagsterInstance.ephemeral()
+
+    @asset
+    def asset1():
+        return Output(1, logical_version=LogicalVersion("foo"))
+
+    mat = materialize_asset([asset1], asset1, instance)
+    assert_logical_version(mat, LogicalVersion("foo"))


### PR DESCRIPTION
### Summary & Motivation

Allow setting the `logical_version` via `Output` object. This will override the auto-generated logical version.

### How I Tested These Changes

New unit test