### PR TITLE
[dagster-snowflake-pandas] pandas timestamp conversion fix

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -63,7 +63,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                     method=pd_writer,
                 )
             except InterfaceError as e:
-                if "out of range" in e.__cause__:
+                if "out of range" in e.orig.msg:
                     raise DagsterInvalidInvocationError(
                         f"Could not store output {context.name} of step {context.step_key}. If the"
                         " DataFrame includes pandas Timestamp values, ensure that they have"
@@ -86,9 +86,11 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     def load_input(self, context: InputContext, table_slice: TableSlice) -> pd.DataFrame:
         with _connect_snowflake(context, table_slice) as con:
             try:
-                result = pd.read_sql(sql=SnowflakeDbClient.get_select_statement(table_slice), con=con)
+                result = pd.read_sql(
+                    sql=SnowflakeDbClient.get_select_statement(table_slice), con=con
+                )
             except InterfaceError as e:
-                if "out of range" in e.__cause__.msg:
+                if "out of range" in e.orig.msg:
                     raise DagsterInvalidInvocationError(
                         f"Could not load input {context.name} of {context.op_def.name}. If the"
                         " DataFrame includes pandas Timestamp values, ensure that they have"

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -46,13 +46,6 @@ SHARED_BUILDKITE_SNOWFLAKE_CONF = {
     "password": os.getenv("SNOWFLAKE_BUILDKITE_PASSWORD", ""),
 }
 
-# SHARED_BUILDKITE_SNOWFLAKE_CONF = {
-#     "account": os.getenv("SNOWFLAKE_ACCOUNT", ""),
-#     "user": "jamie@elementl.com",
-#     "password": os.getenv("SNOWFLAKE_PASSWORD", ""),
-# }
-
-
 
 @contextmanager
 def temporary_snowflake_table(schema_name: str, db_name: str, column_str: str) -> Iterator[str]:
@@ -65,7 +58,6 @@ def temporary_snowflake_table(schema_name: str, db_name: str, column_str: str) -
         try:
             yield table_name
         finally:
-            # pass
             conn.cursor().execute(f"drop table {schema_name}.{table_name}")
 
 
@@ -177,11 +169,6 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="foo string, date TIMESTAMP_NTZ(9)",
     ) as table_name:
-    # with temporary_snowflake_table(
-    #     schema_name="JAMIE",
-    #     db_name="SANDBOX",
-    #     column_str="foo string, date TIMESTAMP_NTZ(9)",
-    # ) as table_name:
         time_df = pandas.DataFrame(
             {
                 "foo": ["bar", "baz"],
@@ -235,11 +222,6 @@ def test_io_manager_with_snowflake_pandas_timestamp_data_error():
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="foo string, date TIMESTAMP_NTZ(9)",
     ) as table_name:
-    # with temporary_snowflake_table(
-    #     schema_name="JAMIE",
-    #     db_name="SANDBOX",
-    #     column_str="foo string, date TIMESTAMP_NTZ(9)",
-    # ) as table_name:
         time_df = pandas.DataFrame(
             {
                 "foo": ["bar", "baz"],
@@ -293,11 +275,6 @@ def test_time_window_partitioned_asset(tmp_path):
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="TIME TIMESTAMP_NTZ(9), A string, B int",
     ) as table_name:
-    # with temporary_snowflake_table(
-    #     schema_name="JAMIE",
-    #     db_name="SANDBOX",
-    #     column_str="TIME TIMESTAMP_NTZ(9), A string, B int",
-    # ) as table_name:
 
         @asset(
             partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
@@ -320,8 +297,6 @@ def test_time_window_partitioned_asset(tmp_path):
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
-        # asset_full_name = f"JAMIE__{table_name}"
-        # snowflake_table_path = f"JAMIE.{table_name}"
 
         snowflake_config = {
             **SHARED_BUILDKITE_SNOWFLAKE_CONF,

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -26,10 +26,6 @@ from dagster._core.storage.db_io_manager import TableSlice
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeConnection
 from dagster_snowflake_pandas import SnowflakePandasTypeHandler, snowflake_pandas_io_manager
-from dagster_snowflake_pandas.snowflake_pandas_type_handler import (
-    _convert_string_to_timestamp,
-    _convert_timestamp_to_string,
-)
 from pandas import DataFrame, Timestamp
 
 resource_config = {
@@ -61,7 +57,8 @@ def temporary_snowflake_table(schema_name: str, db_name: str, column_str: str) -
         try:
             yield table_name
         finally:
-            conn.cursor().execute(f"drop table {schema_name}.{table_name}")
+            pass
+            # conn.cursor().execute(f"drop table {schema_name}.{table_name}")
 
 
 def test_handle_output():
@@ -110,31 +107,6 @@ def test_load_input():
         )
         assert mock_read_sql.call_args_list[0][1]["sql"] == "SELECT * FROM my_db.my_schema.my_table"
         assert df.equals(DataFrame([{"col1": "a", "col2": 1}]))
-
-
-def test_type_conversions():
-    # no timestamp data
-    no_time = pandas.Series([1, 2, 3, 4, 5])
-    converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time))
-
-    assert (converted == no_time).all()
-
-    # timestamp data
-    with_time = pandas.Series(
-        [
-            pandas.Timestamp("2017-01-01T12:30:45.35"),
-            pandas.Timestamp("2017-02-01T12:30:45.35"),
-            pandas.Timestamp("2017-03-01T12:30:45.35"),
-        ]
-    )
-    time_converted = _convert_string_to_timestamp(_convert_timestamp_to_string(with_time))
-
-    assert (with_time == time_converted).all()
-
-    # string that isn't a time
-    string_data = pandas.Series(["not", "a", "timestamp"])
-
-    assert (_convert_string_to_timestamp(string_data) == string_data).all()
 
 
 def test_build_snowflake_pandas_io_manager():
@@ -190,7 +162,7 @@ def test_io_manager_with_snowflake_pandas():
         assert res.success
 
 
-@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_io_manager_with_snowflake_pandas_timestamp_data():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
@@ -201,8 +173,8 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
             {
                 "foo": ["bar", "baz"],
                 "date": [
-                    pandas.Timestamp("2017-01-01T12:30:45.350"),
-                    pandas.Timestamp("2017-02-01T12:30:45.350"),
+                    pandas.Timestamp("2017-01-01T12:30:15+00:00"),
+                    pandas.Timestamp("2017-02-01T01:30:15+00:00"),
                 ],
             }
         )
@@ -219,6 +191,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
 
         @op
         def read_time_df(df: pandas.DataFrame):
+            df["date"] = df["date"].dt.tz_localize("UTC")
             assert set(df.columns) == {"foo", "date"}
             assert (df["date"] == time_df["date"]).all()
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -46,11 +46,11 @@ SHARED_BUILDKITE_SNOWFLAKE_CONF = {
     "password": os.getenv("SNOWFLAKE_BUILDKITE_PASSWORD", ""),
 }
 
-SHARED_BUILDKITE_SNOWFLAKE_CONF = {
-    "account": os.getenv("SNOWFLAKE_ACCOUNT", ""),
-    "user": "jamie@elementl.com",
-    "password": os.getenv("SNOWFLAKE_PASSWORD", ""),
-}
+# SHARED_BUILDKITE_SNOWFLAKE_CONF = {
+#     "account": os.getenv("SNOWFLAKE_ACCOUNT", ""),
+#     "user": "jamie@elementl.com",
+#     "password": os.getenv("SNOWFLAKE_PASSWORD", ""),
+# }
 
 
 
@@ -65,8 +65,8 @@ def temporary_snowflake_table(schema_name: str, db_name: str, column_str: str) -
         try:
             yield table_name
         finally:
-            pass
-            # conn.cursor().execute(f"drop table {schema_name}.{table_name}")
+            # pass
+            conn.cursor().execute(f"drop table {schema_name}.{table_name}")
 
 
 def test_handle_output():
@@ -170,18 +170,18 @@ def test_io_manager_with_snowflake_pandas():
         assert res.success
 
 
-# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_io_manager_with_snowflake_pandas_timestamp_data():
-    # with temporary_snowflake_table(
-    #     schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
-    #     db_name="TEST_SNOWFLAKE_IO_MANAGER",
-    #     column_str="foo string, date TIMESTAMP_NTZ(9)",
-    # ) as table_name:
     with temporary_snowflake_table(
-        schema_name="JAMIE",
-        db_name="SANDBOX",
+        schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="foo string, date TIMESTAMP_NTZ(9)",
     ) as table_name:
+    # with temporary_snowflake_table(
+    #     schema_name="JAMIE",
+    #     db_name="SANDBOX",
+    #     column_str="foo string, date TIMESTAMP_NTZ(9)",
+    # ) as table_name:
         time_df = pandas.DataFrame(
             {
                 "foo": ["bar", "baz"],
@@ -195,7 +195,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
         @op(
             out={
                 table_name: Out(
-                    io_manager_key="snowflake", metadata={"schema": "JAMIE"}
+                    io_manager_key="snowflake", metadata={"schema": "SNOWFLAKE_IO_MANAGER_SCHEMA"}
                 )
             }
         )
@@ -215,7 +215,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
                     "snowflake": {
                         "config": {
                             **SHARED_BUILDKITE_SNOWFLAKE_CONF,
-                            "database": "SANDBOX",
+                            "database": "TEST_SNOWFLAKE_IO_MANAGER",
                         }
                     }
                 }
@@ -228,18 +228,18 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
         assert res.success
 
 
-# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_io_manager_with_snowflake_pandas_timestamp_data_error():
-    # with temporary_snowflake_table(
-    #     schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
-    #     db_name="TEST_SNOWFLAKE_IO_MANAGER",
-    #     column_str="foo string, date TIMESTAMP_NTZ(9)",
-    # ) as table_name:
     with temporary_snowflake_table(
-        schema_name="JAMIE",
-        db_name="SANDBOX",
+        schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="foo string, date TIMESTAMP_NTZ(9)",
     ) as table_name:
+    # with temporary_snowflake_table(
+    #     schema_name="JAMIE",
+    #     db_name="SANDBOX",
+    #     column_str="foo string, date TIMESTAMP_NTZ(9)",
+    # ) as table_name:
         time_df = pandas.DataFrame(
             {
                 "foo": ["bar", "baz"],
@@ -253,7 +253,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data_error():
         @op(
             out={
                 table_name: Out(
-                    io_manager_key="snowflake", metadata={"schema": "JAMIE"}
+                    io_manager_key="snowflake", metadata={"schema": "SNOWFLAKE_IO_MANAGER_SCHEMA"}
                 )
             }
         )
@@ -273,7 +273,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data_error():
                     "snowflake": {
                         "config": {
                             **SHARED_BUILDKITE_SNOWFLAKE_CONF,
-                            "database": "SANDBOX",
+                            "database": "TEST_SNOWFLAKE_IO_MANAGER",
                         }
                     }
                 }
@@ -286,24 +286,24 @@ def test_io_manager_with_snowflake_pandas_timestamp_data_error():
             io_manager_timestamp_test_job.execute_in_process()
 
 
-# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_time_window_partitioned_asset(tmp_path):
-    # with temporary_snowflake_table(
-    #     schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
-    #     db_name="TEST_SNOWFLAKE_IO_MANAGER",
-    #     column_str="TIME TIMESTAMP_NTZ(9), A string, B int",
-    # ) as table_name:
     with temporary_snowflake_table(
-        schema_name="JAMIE",
-        db_name="SANDBOX",
+        schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="TIME TIMESTAMP_NTZ(9), A string, B int",
     ) as table_name:
+    # with temporary_snowflake_table(
+    #     schema_name="JAMIE",
+    #     db_name="SANDBOX",
+    #     column_str="TIME TIMESTAMP_NTZ(9), A string, B int",
+    # ) as table_name:
 
         @asset(
             partitions_def=DailyPartitionsDefinition(start_date="2022-01-01"),
             metadata={"partition_expr": "time"},
             config_schema={"value": str},
-            key_prefix="JAMIE",
+            key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             name=table_name,
         )
         def daily_partitioned(context):
@@ -318,14 +318,14 @@ def test_time_window_partitioned_asset(tmp_path):
                 }
             )
 
-        # asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
-        # snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
-        asset_full_name = f"JAMIE__{table_name}"
-        snowflake_table_path = f"JAMIE.{table_name}"
+        asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
+        snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
+        # asset_full_name = f"JAMIE__{table_name}"
+        # snowflake_table_path = f"JAMIE.{table_name}"
 
         snowflake_config = {
             **SHARED_BUILDKITE_SNOWFLAKE_CONF,
-            "database": "SANDBOX",
+            "database": "TEST_SNOWFLAKE_IO_MANAGER",
         }
         snowflake_conn = SnowflakeConnection(
             snowflake_config, logging.getLogger("temporary_snowflake_table")

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -150,7 +150,6 @@ class SnowflakeDbClient(DbClient):
             dict(schema=table_slice.schema, **no_schema_config), context.log
         ).get_connection() as con:
             try:
-                print("DELETING DATA")
                 con.execute_string(_get_cleanup_statement(table_slice))
             except ProgrammingError:
                 # table doesn't exist yet, so ignore the error


### PR DESCRIPTION
### Summary & Motivation

There is an issue with storing pandas Timestamp values in snowflake where the year will get converted to a non-valid year (example 48399). In pr #8760 i got around this by storing pandas timestamps as strings, but i finally found this [github issue](https://github.com/snowflakedb/snowflake-connector-python/issues/319) that indicates that the real fix is to include timezone information in your pandas timestamps [link](https://github.com/snowflakedb/snowflake-connector-python/issues/319#issuecomment-764145625).

This PR proposes removing the timestamp -> string conversion, however there are still some things to consider:
* do we think this is the right approach, or should we stick with converting to strings. I think it is probably best for us to go down this route because then we store the user data as the user intended, rather than doing sneaky string conversions in the backend. However, we should have some erroring/alerting system that tells users to add timezone info to their data so they aren't left to figure this bug out for themselves (see the error messaging in this PR)
* this would likely be a breaking change, as users with timestamps without a timezone will begin to get the original error. And may run into issues where the column is a string type and suddenly gets timestamp data. One option for this would be to hold off on merging this PR until we promote dagster-snowflake to 1.0


### How I Tested These Changes
