### PR TITLE
Store the instance ref on the grpc server class if it's present, so that grpc api calls can use it if it's there

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -244,6 +244,15 @@ class DagsterApiServer(DagsterApiServicer):
         self._container_image = check.opt_str_param(container_image, "container_image")
         self._container_context = check.opt_dict_param(container_context, "container_context")
 
+        # When will this be set in a gRPC server?
+        #  - When running `dagster dev` (or `dagit`) in the gRPC server subprocesses that are spun up
+        #  - When running code in Dagster Cloud on 1.1 or later
+        # When will it not be set?
+        #  - When running your own grpc server with `dagster api grpc`
+        #  - When using an integration that spins up gRPC servers (for example, the Dagster Helm
+        #    chart or the deploy_docker example)
+        self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
+
         try:
             if inject_env_vars_from_instance:
                 # If arguments indicate it wants to load env vars, use the passed-in instance


### PR DESCRIPTION
Summary:
This gives us a better back-compat path for api calls that use instance refs - on newer versions of cloud and whenever running dagster dev, this instance ref will be set and can be incorporated into grpc api calls. You'll still have to account for the case where there is no instance in your code for back-compat reasons, but it can just raise an exception that says "please upgrade to a later version of Dagster to use this feature"

### Summary & Motivation

### How I Tested These Changes
