### PR TITLE
validate time partition keys when adding to a TimeWindowPartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1344,7 +1344,6 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return result_windows, num_added_partitions
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "TimeWindowPartitionsSubset":
-
         # if we are representing things as a static set of keys, continue doing so
         if self._included_partition_keys is not None:
             new_partitions = {*self._included_partition_keys, *partition_keys}

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -639,6 +639,13 @@ class TimeWindowPartitionsDefinition(
     def deserialize_subset(self, serialized: str) -> "PartitionsSubset":
         return TimeWindowPartitionsSubset.from_serialized(self, serialized)
 
+    def is_valid_partition_key(self, partition_key: str) -> bool:
+        try:
+            datetime.strptime(partition_key, self.fmt)
+        except ValueError:
+            return False
+        return True
+
     @property
     def serializable_unique_identifier(self) -> str:
         return hashlib.sha1(self.__repr__().encode("utf-8")).hexdigest()
@@ -1337,14 +1344,6 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return result_windows, num_added_partitions
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "TimeWindowPartitionsSubset":
-        def _is_valid_key(key: str) -> bool:
-            try:
-                datetime.strptime(key, self._partitions_def.fmt)
-            except ValueError:
-                return False
-            return True
-
-        partition_keys = [key for key in partition_keys if _is_valid_key(key)]
 
         # if we are representing things as a static set of keys, continue doing so
         if self._included_partition_keys is not None:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1337,6 +1337,15 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
         return result_windows, num_added_partitions
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "TimeWindowPartitionsSubset":
+        def _is_valid_key(key: str) -> bool:
+            try:
+                datetime.strptime(key, self._partitions_def.fmt)
+            except ValueError:
+                return False
+            return True
+
+        partition_keys = [key for key in partition_keys if _is_valid_key(key)]
+
         # if we are representing things as a static set of keys, continue doing so
         if self._included_partition_keys is not None:
             new_partitions = {*self._included_partition_keys, *partition_keys}

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -154,8 +154,9 @@ def get_validated_partition_keys(
     else:
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Unexpected partitions definition type {partitions_def}")
-        # Time window partition subset construction will validate the partition keys
-        validated_partitions = partition_keys
+        validated_partitions = {
+            pk for pk in partition_keys if partitions_def.is_valid_partition_key(pk)
+        }
     return validated_partitions
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -589,6 +589,7 @@ def test_time_window_partitions_contains():
     assert "2015-01-09" not in subset
     assert "2015-01-11" not in subset
 
+
 def test_unique_identifier():
     assert (
         DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -590,6 +590,17 @@ def test_time_window_partitions_contains():
     assert "2015-01-11" not in subset
 
 
+def test_time_window_partitions_invalid_keys():
+    partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
+    valid_keys = ["2015-01-06", "2015-01-07", "2015-01-08", "2015-01-10"]
+    invalid_keys = ["abc", "2015-01-01T00:00", "12345-67-89"]
+    subset = partitions_def.empty_subset().with_partition_keys(valid_keys + invalid_keys)
+    for key in valid_keys:
+        assert key in subset
+    for key in invalid_keys:
+        assert key not in subset
+
+
 def test_unique_identifier():
     assert (
         DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -589,18 +589,6 @@ def test_time_window_partitions_contains():
     assert "2015-01-09" not in subset
     assert "2015-01-11" not in subset
 
-
-def test_time_window_partitions_invalid_keys():
-    partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
-    valid_keys = ["2015-01-06", "2015-01-07", "2015-01-08", "2015-01-10"]
-    invalid_keys = ["abc", "2015-01-01T00:00", "12345-67-89"]
-    subset = partitions_def.empty_subset().with_partition_keys(valid_keys + invalid_keys)
-    for key in valid_keys:
-        assert key in subset
-    for key in invalid_keys:
-        assert key not in subset
-
-
 def test_unique_identifier():
     assert (
         DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
@@ -11,6 +11,7 @@ from dagster import (
     define_asset_job,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
 from dagster._core.storage.partition_status_cache import (
     get_and_update_asset_status_cache_value,
 )
@@ -55,6 +56,56 @@ def test_get_cached_status_unpartitioned():
         )
         assert cached_status.partitions_def_id is None
         assert cached_status.serialized_materialized_partition_subset is None
+
+
+def test_get_cached_partition_status_changed_time_partitions():
+    original_partitions_def = HourlyPartitionsDefinition(start_date="2022-01-01-00:00")
+    new_partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
+
+    @asset(partitions_def=original_partitions_def)
+    def asset1():
+        return 1
+
+    asset_key = AssetKey("asset1")
+    asset_graph = AssetGraph.from_assets([asset1])
+    asset_job = define_asset_job("asset_job").resolve([asset1], [])
+
+    def _swap_partitions_def(new_partitions_def, asset, asset_graph, asset_job):
+        asset._partitions_def = new_partitions_def  # pylint: disable=protected-access
+        asset_job = define_asset_job("asset_job").resolve([asset], [])
+        asset_graph = AssetGraph.from_assets([asset])
+        return asset, asset_job, asset_graph
+
+    with instance_for_test() as created_instance:
+        traced_counter.set(Counter())
+
+        asset_records = list(created_instance.get_asset_records([asset_key]))
+        assert len(asset_records) == 0
+
+        asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-01-00:00")
+
+        # swap the partitions def and kick off a run before we try to get the cached status
+        asset1, asset_job, asset_graph = _swap_partitions_def(
+            new_partitions_def, asset1, asset_graph, asset_job
+        )
+        asset_job.execute_in_process(instance=created_instance, partition_key="2022-02-02")
+
+        cached_status = get_and_update_asset_status_cache_value(
+            created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
+        )
+
+        assert cached_status
+        assert cached_status.latest_storage_id
+        assert cached_status.partitions_def_id
+        assert cached_status.serialized_materialized_partition_subset
+        materialized_keys = list(
+            new_partitions_def.deserialize_subset(
+                cached_status.serialized_materialized_partition_subset
+            ).get_partition_keys()
+        )
+        assert set(materialized_keys) == {"2022-02-02"}
+        counts = traced_counter.get().counts()
+        assert counts.get("DagsterInstance.get_materialization_count_by_partition") == 1
 
 
 def test_get_cached_partition_status_by_asset():


### PR DESCRIPTION
### Summary & Motivation

Align with this comment: https://sourcegraph.com/github.com/dagster-io/dagster/-/blob/python_modules/dagster/dagster/_core/storage/partition_status_cache.py?L157&subtree=true

### How I Tested These Changes
