### PR TITLE
Make Partition GRPC calls with `instance_ref` args optional

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -613,8 +613,9 @@ class DynamicPartitionsDefinition(
 
             if dynamic_partitions_store is None:
                 check.failed(
-                    "Must provide a dagster instance object or dynamic partitions store to fetch"
-                    " dynamic partitions"
+                    "The instance is not available to load partitions. You may be seeing this error"
+                    " when using dynamic partitions with a version of dagit or dagster-cloud that"
+                    " is older than 1.1.18."
                 )
 
             partitions = dynamic_partitions_store.get_dynamic_partitions(

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -20,7 +20,6 @@ from dagster._core.errors import (
     ScheduleExecutionError,
     SensorExecutionError,
     user_code_error_boundary,
-    DagsterInvalidInvocationError,
 )
 from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.api import create_execution_plan, execute_run_iterator

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -9,6 +9,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from multiprocessing.synchronize import Event as MPEvent
 from subprocess import Popen
 from threading import Event as ThreadingEventType
@@ -18,7 +19,6 @@ from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Seq
 import grpc
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
-from contextlib import nullcontext
 import dagster._check as check
 import dagster._seven as seven
 from dagster._core.code_pointer import CodePointer

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -368,7 +368,7 @@ class PartitionArgs(
             ("repository_origin", ExternalRepositoryOrigin),
             ("partition_set_name", str),
             ("partition_name", str),
-            ("instance_ref", InstanceRef),
+            ("instance_ref", Optional[InstanceRef]),
         ],
     )
 ):
@@ -377,7 +377,7 @@ class PartitionArgs(
         repository_origin: ExternalRepositoryOrigin,
         partition_set_name: str,
         partition_name: str,
-        instance_ref: InstanceRef,
+        instance_ref: Optional[InstanceRef] = None,
     ):
         return super(PartitionArgs, cls).__new__(
             cls,
@@ -388,7 +388,7 @@ class PartitionArgs(
             ),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
             partition_name=check.str_param(partition_name, "partition_name"),
-            instance_ref=check.inst_param(instance_ref, "instance_ref", InstanceRef),
+            instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
         )
 
 
@@ -417,7 +417,7 @@ class PartitionSetExecutionParamArgs(
             ("repository_origin", ExternalRepositoryOrigin),
             ("partition_set_name", str),
             ("partition_names", Sequence[str]),
-            ("instance_ref", InstanceRef),
+            ("instance_ref", Optional[InstanceRef]),
         ],
     )
 ):
@@ -426,7 +426,7 @@ class PartitionSetExecutionParamArgs(
         repository_origin: ExternalRepositoryOrigin,
         partition_set_name: str,
         partition_names: Sequence[str],
-        instance_ref: InstanceRef,
+        instance_ref: Optional[InstanceRef] = None,
     ):
         return super(PartitionSetExecutionParamArgs, cls).__new__(
             cls,
@@ -435,7 +435,7 @@ class PartitionSetExecutionParamArgs(
             ),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
             partition_names=check.sequence_param(partition_names, "partition_names", of_type=str),
-            instance_ref=check.inst_param(instance_ref, "instance_ref", InstanceRef),
+            instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -147,7 +147,7 @@ def test_dynamic_partitioned_asset_io_manager_context():
 def test_dynamic_partitions_no_instance_provided():
     partitions_def = DynamicPartitionsDefinition(name="fruits")
 
-    with pytest.raises(CheckError, match="provide a dagster instance"):
+    with pytest.raises(CheckError, match="instance"):
         partitions_def.get_partitions()
 
 


### PR DESCRIPTION
In order to support older versions of Dagit with Dagster 1.1.18 and above, makes the `instance_ref` argument optional on GRPC endpoints for partitions.

When using Dagster 1.1.18 and an older version of Dagit with dynamic partitions, throws a more informative error telling the user to upgrade their version of Dagit.