### PR TITLE
[dagster-airflow] refactor airflow_db resources

### DIFF
--- a/examples/with_airflow/with_airflow/assets_repository.py
+++ b/examples/with_airflow/with_airflow/assets_repository.py
@@ -38,7 +38,7 @@ simple_assets = load_assets_from_airflow_dag(
 )
 
 
-assets = Definitions(
+sda_examples = Definitions(
     assets=[*simple_assets, new_upstream_asset_1, new_upstream_asset_2],
     resources={"airflow_db": make_ephemeral_airflow_db_resource()},
 )

--- a/examples/with_airflow/with_airflow/assets_repository.py
+++ b/examples/with_airflow/with_airflow/assets_repository.py
@@ -1,7 +1,6 @@
 from dagster import AssetKey, asset, repository
 
-# start_repo_marker_0
-from dagster_airflow import load_assets_from_airflow_dag
+from dagster_airflow import load_assets_from_airflow_dag, make_ephemeral_airflow_db_resource
 
 from with_airflow.airflow_simple_dag import simple_dag
 
@@ -40,6 +39,8 @@ simple_assets = load_assets_from_airflow_dag(
 )
 
 
-@repository
+@repository(
+    top_level_resources={"airflow_db": make_ephemeral_airflow_db_resource()},
+)
 def sda_examples():
     return [*simple_assets, new_upstream_asset_1, new_upstream_asset_2]

--- a/examples/with_airflow/with_airflow/assets_repository.py
+++ b/examples/with_airflow/with_airflow/assets_repository.py
@@ -1,5 +1,4 @@
-from dagster import AssetKey, asset, repository
-
+from dagster import AssetKey, Definitions, asset
 from dagster_airflow import load_assets_from_airflow_dag, make_ephemeral_airflow_db_resource
 
 from with_airflow.airflow_simple_dag import simple_dag
@@ -39,8 +38,7 @@ simple_assets = load_assets_from_airflow_dag(
 )
 
 
-@repository(
-    top_level_resources={"airflow_db": make_ephemeral_airflow_db_resource()},
+assets = Definitions(
+    assets=[*simple_assets, new_upstream_asset_1, new_upstream_asset_2],
+    resources={"airflow_db": make_ephemeral_airflow_db_resource()},
 )
-def sda_examples():
-    return [*simple_assets, new_upstream_asset_1, new_upstream_asset_2]

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
@@ -19,6 +19,7 @@ from .operators.dagster_operator import (
     DagsterCloudOperator as DagsterCloudOperator,
     DagsterOperator as DagsterOperator,
 )
+from .resources import make_ephemeral_airflow_db_resource as make_ephemeral_airflow_db_resource
 from .version import __version__ as __version__
 
 check_dagster_package_version("dagster-airflow", __version__)
@@ -29,6 +30,7 @@ __all__ = [
     "make_schedules_and_jobs_from_airflow_dag_bag",
     "make_dagster_job_from_airflow_dag",
     "load_assets_from_airflow_dag",
+    "make_ephemeral_airflow_db_resource",
     "DagsterHook",
     "DagsterLink",
     "DagsterOperator",
@@ -45,7 +47,7 @@ class DagsterAirflowPlugin(AirflowPlugin):
     ]
 
 
-def get_provider_info():
+def get_provider_info() -> dict:
     return {
         "package-name": "dagster-airflow",
         "name": "Dagster Airflow",

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -178,7 +178,6 @@ def load_assets_from_airflow_dag(
         )
         if cron_schedule is not None
         else None,
-        resource_defs=job.resource_defs,
         group_name=dag.dag_id,
         keys_by_output_name=keys_by_output_name,
         internal_asset_deps=internal_asset_deps,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -1,165 +1,22 @@
-import datetime
-import importlib
-import os
-import tempfile
 from typing import List, Mapping, Optional
 
-import airflow
-import pytz
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
-from airflow.models.dagrun import DagRun
-from airflow.utils import db
 from dagster import (
-    Array,
-    DagsterInvariantViolationError,
-    Field,
     GraphDefinition,
-    InitResourceContext,
     JobDefinition,
-    ResourceDefinition,
     _check as check,
 )
 from dagster._core.definitions.utils import validate_tags
-from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR, IS_AIRFLOW_INGEST_PIPELINE_STR
-from dateutil.parser import parse
+from dagster._core.instance import IS_AIRFLOW_INGEST_PIPELINE_STR
 
 from dagster_airflow.airflow_dag_converter import get_graph_definition_args
-from dagster_airflow.utils import (
-    Locker,
-    create_airflow_connections,
-    is_airflow_2_loaded_in_environment,
-    normalized_name,
-    serialize_connections,
+from dagster_airflow.resources import (
+    make_ephemeral_airflow_db_resource as make_ephemeral_airflow_db_resource,
 )
-
-# pylint: disable=no-name-in-module,import-error
-if is_airflow_2_loaded_in_environment():
-    from airflow.utils.state import DagRunState
-    from airflow.utils.types import DagRunType
-else:
-    from airflow.utils.state import State
-
-    # pylint: enable=no-name-in-module,import-error
-
-
-def _parse_execution_date_for_job(
-    dag: DAG, run_tags: Mapping[str, str]
-) -> Optional[datetime.datetime]:
-    execution_date_str = run_tags.get(AIRFLOW_EXECUTION_DATE_STR)
-    if not execution_date_str:
-        raise DagsterInvariantViolationError("Expected execution_date_str to be set in run tags.")
-    check.str_param(execution_date_str, "execution_date_str")
-    try:
-        execution_date = parse(execution_date_str)
-        execution_date = execution_date.replace(tzinfo=pytz.timezone(dag.timezone.name))
-    except ValueError:
-        raise DagsterInvariantViolationError(
-            'Could not parse execution_date "{execution_date_str}". Please use datetime'
-            " format compatible with  dateutil.parser.parse.".format(
-                execution_date_str=execution_date_str,
-            )
-        )
-    except OverflowError:
-        raise DagsterInvariantViolationError(
-            'Date "{execution_date_str}" exceeds the largest valid C integer on the system.'.format(
-                execution_date_str=execution_date_str,
-            )
-        )
-    return execution_date
-
-
-def _parse_execution_date_for_asset(
-    dag: DAG, run_tags: Mapping[str, str]
-) -> Optional[datetime.datetime]:
-    execution_date_str = run_tags.get("dagster/partition")
-    if not execution_date_str:
-        raise DagsterInvariantViolationError("dagster/partition is not set")
-    execution_date = parse(execution_date_str)
-    execution_date = execution_date.replace(tzinfo=pytz.timezone(dag.timezone.name))
-    return execution_date
-
-
-def airflow_db(context: InitResourceContext) -> None:
-    airflow_home_path = os.path.join(tempfile.gettempdir(), f"dagster_airflow_{context.run_id}")
-    os.environ["AIRFLOW_HOME"] = airflow_home_path
-    os.makedirs(airflow_home_path, exist_ok=True)
-    with Locker(airflow_home_path):
-        airflow_initialized = os.path.exists(f"{airflow_home_path}/airflow.db")
-        # because AIRFLOW_HOME has been overriden airflow needs to be reloaded
-        if is_airflow_2_loaded_in_environment():
-            importlib.reload(airflow.configuration)
-            importlib.reload(airflow.settings)
-            importlib.reload(airflow)
-        else:
-            importlib.reload(airflow)
-        if not airflow_initialized:
-            db.initdb()
-            create_airflow_connections(
-                [Connection(**c) for c in context.resource_config["connections"]]
-            )
-
-
-def _create_airflow_db_resource(connections: Optional[List[Connection]] = None):
-    serialized_connections = serialize_connections(connections)
-    airflow_db_resource_def = ResourceDefinition(
-        resource_fn=airflow_db,
-        required_resource_keys={"dag"},
-        config_schema={
-            "connections": Field(
-                Array(inner_type=dict),
-                default_value=serialized_connections,
-                is_required=False,
-            ),
-        },
-        description="Airflow DB used by wrapped airflow tasks",
-    )
-    return airflow_db_resource_def
-
-
-def get_dagrun(context: InitResourceContext) -> DagRun:
-    airflow_home_path = os.path.join(tempfile.gettempdir(), f"dagster_airflow_{context.run_id}")
-    os.makedirs(airflow_home_path, exist_ok=True)
-    with Locker(airflow_home_path):
-        dag = context.resources.dag
-        run_tags = context.dagster_run.tags if context.dagster_run else {}
-        if AIRFLOW_EXECUTION_DATE_STR in run_tags:
-            execution_date = _parse_execution_date_for_job(dag, run_tags)
-        elif "dagster/partition" in run_tags:
-            execution_date = _parse_execution_date_for_asset(dag, run_tags)
-        else:
-            raise DagsterInvariantViolationError(
-                'Could not find "{AIRFLOW_EXECUTION_DATE_STR}" in tags "{tags}". Please '
-                'add "{AIRFLOW_EXECUTION_DATE_STR}" to tags before executing'.format(
-                    AIRFLOW_EXECUTION_DATE_STR=AIRFLOW_EXECUTION_DATE_STR,
-                    tags=run_tags,
-                )
-            )
-        dagrun = dag.get_dagrun(execution_date=execution_date)
-        if not dagrun:
-            if is_airflow_2_loaded_in_environment():
-                dagrun = dag.create_dagrun(
-                    state=DagRunState.RUNNING,
-                    execution_date=execution_date,
-                    run_type=DagRunType.MANUAL,
-                )
-            else:
-                dagrun = dag.create_dagrun(
-                    run_id=f"dagster_airflow_run_{execution_date}",
-                    state=State.RUNNING,
-                    execution_date=execution_date,
-                )
-        return dagrun
-
-
-def _create_dagrun_resource() -> ResourceDefinition:
-    airflow_db_resource_def = ResourceDefinition(
-        resource_fn=get_dagrun,
-        required_resource_keys={"dag", "airflow_db"},
-        config_schema={},
-        description="DagRun Airflow model",
-    )
-    return airflow_db_resource_def
+from dagster_airflow.utils import (
+    normalized_name,
+)
 
 
 def make_dagster_job_from_airflow_dag(
@@ -222,12 +79,6 @@ def make_dagster_job_from_airflow_dag(
 
     node_dependencies, node_defs = get_graph_definition_args(dag=dag)
 
-    dag_resource = ResourceDefinition.hardcoded_resource(value=dag, description="DAG Airflow model")
-    airflow_db_resource_def = _create_airflow_db_resource(
-        connections=connections,
-    )
-    dagrun_resource = _create_dagrun_resource()
-
     graph_def = GraphDefinition(
         name=normalized_name(dag.dag_id),
         description="",
@@ -236,15 +87,13 @@ def make_dagster_job_from_airflow_dag(
         tags=mutated_tags,
     )
 
+    airflow_database_resource = make_ephemeral_airflow_db_resource(connections=connections)
+
     job_def = JobDefinition(
         name=normalized_name(dag.dag_id),
         description="",
-        resource_defs={
-            "airflow_db": airflow_db_resource_def,
-            "dag": dag_resource,
-            "dagrun": dagrun_resource,
-        },
         graph_def=graph_def,
+        resource_defs={"airflow_db": airflow_database_resource},
         tags=mutated_tags,
         metadata={},
         op_retry_policy=None,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/__init__.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/__init__.py
@@ -1,0 +1,7 @@
+from .airflow_ephemeral_db import (
+    make_ephemeral_airflow_db_resource as make_ephemeral_airflow_db_resource,
+)
+
+__all__ = [
+    "make_ephemeral_airflow_db_resource",
+]

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
@@ -2,7 +2,7 @@ import datetime
 import importlib
 import os
 import tempfile
-from typing import Generator, List, Mapping, Optional
+from typing import List, Mapping, Optional
 
 import airflow
 import pytz
@@ -13,6 +13,7 @@ from airflow.utils import db
 from dagster import (
     Array,
     DagsterInvariantViolationError,
+    DagsterRun,
     Field,
     InitResourceContext,
     ResourceDefinition,
@@ -44,15 +45,18 @@ class AirflowEphemeralDatabase:
 
     """
 
-    def __init__(self, context: InitResourceContext):
-        self.airflow_home_path = os.path.join(
-            tempfile.gettempdir(), f"dagster_airflow_{context.run_id}"
-        )
-        self.context = context
-        os.environ["AIRFLOW_HOME"] = self.airflow_home_path
-        os.makedirs(self.airflow_home_path, exist_ok=True)
-        with Locker(self.airflow_home_path):
-            airflow_initialized = os.path.exists(f"{self.airflow_home_path}/airflow.db")
+    def __init__(self, airflow_home_path: str, dagster_run: DagsterRun):
+        self.airflow_home_path = airflow_home_path
+        self.dagster_run = dagster_run
+
+    @staticmethod
+    def from_resource_context(context: InitResourceContext) -> "AirflowEphemeralDatabase":
+        airflow_home_path = os.path.join(tempfile.gettempdir(), f"dagster_airflow_{context.run_id}")
+        # self.context = context
+        os.environ["AIRFLOW_HOME"] = airflow_home_path
+        os.makedirs(airflow_home_path, exist_ok=True)
+        with Locker(airflow_home_path):
+            airflow_initialized = os.path.exists(f"{airflow_home_path}/airflow.db")
             # because AIRFLOW_HOME has been overriden airflow needs to be reloaded
             if is_airflow_2_loaded_in_environment():
                 importlib.reload(airflow.configuration)
@@ -65,6 +69,11 @@ class AirflowEphemeralDatabase:
                 create_airflow_connections(
                     [Connection(**c) for c in context.resource_config["connections"]]
                 )
+
+        return AirflowEphemeralDatabase(
+            airflow_home_path=airflow_home_path,
+            dagster_run=check.not_none(context.dagster_run, "Context must have run"),
+        )
 
     def _parse_execution_date_for_job(
         self, dag: DAG, run_tags: Mapping[str, str]
@@ -106,11 +115,11 @@ class AirflowEphemeralDatabase:
 
     def get_dagrun(self, dag: DAG) -> DagRun:
         airflow_home_path = os.path.join(
-            tempfile.gettempdir(), f"dagster_airflow_{self.context.run_id}"
+            tempfile.gettempdir(), f"dagster_airflow_{self.dagster_run.run_id}"
         )
         os.makedirs(airflow_home_path, exist_ok=True)
         with Locker(airflow_home_path):
-            run_tags = self.context.dagster_run.tags if self.context.dagster_run else {}
+            run_tags = self.dagster_run.tags if self.dagster_run else {}
             if AIRFLOW_EXECUTION_DATE_STR in run_tags:
                 execution_date = self._parse_execution_date_for_job(dag, run_tags)
             elif "dagster/partition" in run_tags:
@@ -140,12 +149,6 @@ class AirflowEphemeralDatabase:
             return dagrun
 
 
-def airflow_ephemeral_db(
-    context: InitResourceContext,
-) -> Generator[AirflowEphemeralDatabase, None, None]:
-    yield AirflowEphemeralDatabase(context)
-
-
 def make_ephemeral_airflow_db_resource(connections: List[Connection] = []) -> ResourceDefinition:
     """
     Creates a Dagster resource that provides an ephemeral Airflow database.
@@ -159,7 +162,7 @@ def make_ephemeral_airflow_db_resource(connections: List[Connection] = []) -> Re
     """
     serialized_connections = serialize_connections(connections)
     airflow_db_resource_def = ResourceDefinition(
-        resource_fn=airflow_ephemeral_db,
+        resource_fn=AirflowEphemeralDatabase.from_resource_context,
         config_schema={
             "connections": Field(
                 Array(inner_type=dict),

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
@@ -1,0 +1,172 @@
+import datetime
+import importlib
+import os
+import tempfile
+from typing import Generator, List, Mapping, Optional
+
+import airflow
+import pytz
+from airflow.models.connection import Connection
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.utils import db
+from dagster import (
+    Array,
+    DagsterInvariantViolationError,
+    Field,
+    InitResourceContext,
+    ResourceDefinition,
+    _check as check,
+)
+from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR
+from dateutil.parser import parse
+
+from dagster_airflow.utils import (
+    Locker,
+    create_airflow_connections,
+    is_airflow_2_loaded_in_environment,
+    serialize_connections,
+)
+
+# pylint: disable=no-name-in-module,import-error
+if is_airflow_2_loaded_in_environment():
+    from airflow.utils.state import DagRunState
+    from airflow.utils.types import DagRunType
+else:
+    from airflow.utils.state import State
+
+    # pylint: enable=no-name-in-module,import-error
+
+
+class AirflowEphemeralDatabase:
+    """
+    A ephemeral Airflow database Dagster resource.
+
+    """
+
+    def __init__(self, context: InitResourceContext):
+        self.airflow_home_path = os.path.join(
+            tempfile.gettempdir(), f"dagster_airflow_{context.run_id}"
+        )
+        self.context = context
+        os.environ["AIRFLOW_HOME"] = self.airflow_home_path
+        os.makedirs(self.airflow_home_path, exist_ok=True)
+        with Locker(self.airflow_home_path):
+            airflow_initialized = os.path.exists(f"{self.airflow_home_path}/airflow.db")
+            # because AIRFLOW_HOME has been overriden airflow needs to be reloaded
+            if is_airflow_2_loaded_in_environment():
+                importlib.reload(airflow.configuration)
+                importlib.reload(airflow.settings)
+                importlib.reload(airflow)
+            else:
+                importlib.reload(airflow)
+            if not airflow_initialized:
+                db.initdb()
+                create_airflow_connections(
+                    [Connection(**c) for c in context.resource_config["connections"]]
+                )
+
+    def _parse_execution_date_for_job(
+        self, dag: DAG, run_tags: Mapping[str, str]
+    ) -> Optional[datetime.datetime]:
+        execution_date_str = run_tags.get(AIRFLOW_EXECUTION_DATE_STR)
+        if not execution_date_str:
+            raise DagsterInvariantViolationError(
+                "Expected execution_date_str to be set in run tags."
+            )
+        check.str_param(execution_date_str, "execution_date_str")
+        try:
+            execution_date = parse(execution_date_str)
+            execution_date = execution_date.replace(tzinfo=pytz.timezone(dag.timezone.name))
+        except ValueError:
+            raise DagsterInvariantViolationError(
+                'Could not parse execution_date "{execution_date_str}". Please use datetime'
+                " format compatible with  dateutil.parser.parse.".format(
+                    execution_date_str=execution_date_str,
+                )
+            )
+        except OverflowError:
+            raise DagsterInvariantViolationError(
+                'Date "{execution_date_str}" exceeds the largest valid C integer on the system.'
+                .format(
+                    execution_date_str=execution_date_str,
+                )
+            )
+        return execution_date
+
+    def _parse_execution_date_for_asset(
+        self, dag: DAG, run_tags: Mapping[str, str]
+    ) -> Optional[datetime.datetime]:
+        execution_date_str = run_tags.get("dagster/partition")
+        if not execution_date_str:
+            raise DagsterInvariantViolationError("dagster/partition is not set")
+        execution_date = parse(execution_date_str)
+        execution_date = execution_date.replace(tzinfo=pytz.timezone(dag.timezone.name))
+        return execution_date
+
+    def get_dagrun(self, dag: DAG) -> DagRun:
+        airflow_home_path = os.path.join(
+            tempfile.gettempdir(), f"dagster_airflow_{self.context.run_id}"
+        )
+        os.makedirs(airflow_home_path, exist_ok=True)
+        with Locker(airflow_home_path):
+            run_tags = self.context.dagster_run.tags if self.context.dagster_run else {}
+            if AIRFLOW_EXECUTION_DATE_STR in run_tags:
+                execution_date = self._parse_execution_date_for_job(dag, run_tags)
+            elif "dagster/partition" in run_tags:
+                execution_date = self._parse_execution_date_for_asset(dag, run_tags)
+            else:
+                raise DagsterInvariantViolationError(
+                    'Could not find "{AIRFLOW_EXECUTION_DATE_STR}" in tags "{tags}". Please '
+                    'add "{AIRFLOW_EXECUTION_DATE_STR}" to tags before executing'.format(
+                        AIRFLOW_EXECUTION_DATE_STR=AIRFLOW_EXECUTION_DATE_STR,
+                        tags=run_tags,
+                    )
+                )
+            dagrun = dag.get_dagrun(execution_date=execution_date)
+            if not dagrun:
+                if is_airflow_2_loaded_in_environment():
+                    dagrun = dag.create_dagrun(
+                        state=DagRunState.RUNNING,
+                        execution_date=execution_date,
+                        run_type=DagRunType.MANUAL,
+                    )
+                else:
+                    dagrun = dag.create_dagrun(
+                        run_id=f"dagster_airflow_run_{execution_date}",
+                        state=State.RUNNING,
+                        execution_date=execution_date,
+                    )
+            return dagrun
+
+
+def airflow_ephemeral_db(
+    context: InitResourceContext,
+) -> Generator[AirflowEphemeralDatabase, None, None]:
+    yield AirflowEphemeralDatabase(context)
+
+
+def make_ephemeral_airflow_db_resource(connections: List[Connection] = []) -> ResourceDefinition:
+    """
+    Creates a Dagster resource that provides an ephemeral Airflow database.
+
+    Args:
+        connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
+
+    Returns:
+        ResourceDefinition: The ephemeral Airflow DB resource
+
+    """
+    serialized_connections = serialize_connections(connections)
+    airflow_db_resource_def = ResourceDefinition(
+        resource_fn=airflow_ephemeral_db,
+        config_schema={
+            "connections": Field(
+                Array(inner_type=dict),
+                default_value=serialized_connections,
+                is_required=False,
+            ),
+        },
+        description="Ephemeral Airflow DB to be used by dagster-airflow ",
+    )
+    return airflow_db_resource_def

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/utils.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from contextlib import contextmanager
+from typing import Generator, List, Mapping, Optional
 
 from airflow import __version__ as airflow_version
 from airflow.models.connection import Connection
@@ -26,7 +27,7 @@ class DagsterAirflowError(Exception):
     pass
 
 
-def create_airflow_connections(connections):
+def create_airflow_connections(connections: List[Connection] = []) -> None:
     with create_session() as session:
         for connection in connections:
             if session.query(Connection).filter(Connection.conn_id == connection.conn_id).first():
@@ -43,7 +44,7 @@ def create_airflow_connections(connections):
 # Airflow DAG ids and Task ids allow a larger valid character set (alphanumeric characters,
 # dashes, dots and underscores) than Dagster's naming conventions (alphanumeric characters,
 # underscores), so Dagster will strip invalid characters and replace with '_'
-def normalized_name(dag_name, task_name=None):
+def normalized_name(dag_name, task_name=None) -> str:
     base_name = "".join(c if VALID_NAME_REGEX.match(c) else "_" for c in dag_name)
     if task_name:
         base_name += "__"
@@ -52,7 +53,7 @@ def normalized_name(dag_name, task_name=None):
 
 
 @contextmanager
-def replace_airflow_logger_handlers():
+def replace_airflow_logger_handlers() -> Generator[None, None, None]:
     prev_airflow_handlers = logging.getLogger("airflow.task").handlers
     try:
         # Redirect airflow handlers to stdout / compute logs
@@ -66,7 +67,7 @@ def replace_airflow_logger_handlers():
         logging.getLogger("airflow.task").handlers = prev_airflow_handlers
 
 
-def serialize_connections(connections):
+def serialize_connections(connections: List[Connection] = []) -> List[Mapping[str, Optional[str]]]:
     serialized_connections = []
     for c in connections:
         serialized_connection = {

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets.py
@@ -5,9 +5,7 @@ import pytest
 from airflow import __version__ as airflow_version
 from airflow.models import DagBag
 from dagster import AssetKey, asset, materialize
-from dagster_airflow import (
-    load_assets_from_airflow_dag,
-)
+from dagster_airflow import load_assets_from_airflow_dag, make_ephemeral_airflow_db_resource
 
 from dagster_airflow_tests.marks import requires_airflow_db
 
@@ -36,6 +34,13 @@ with models.DAG(
 
     baz = BashOperator(
         task_id="baz", bash_command="echo baz"
+    )
+
+with models.DAG(
+    dag_id="other_dag", default_args=default_args, schedule_interval='0 0 * * *', tags=['example'],
+) as other_dag:
+    foo = BashOperator(
+        task_id="foo", bash_command="echo foo"
     )
 """
 
@@ -70,8 +75,14 @@ def test_load_assets_from_airflow_dag():
             },
         )
 
+        other_dag = dag_bag.get_dag(dag_id="other_dag")
+        other_assets = load_assets_from_airflow_dag(
+            dag=other_dag,
+        )
+
         result = materialize(
-            [*assets, new_upstream_asset],
+            [*assets, new_upstream_asset, *other_assets],
             partition_key="2023-02-01T00:00:00",
+            resources={"airflow_db": make_ephemeral_airflow_db_resource()},
         )
         assert result.success

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_assets_airflow_2.py
@@ -5,9 +5,7 @@ import pytest
 from airflow import __version__ as airflow_version
 from airflow.models import DagBag
 from dagster import AssetKey, asset, materialize
-from dagster_airflow import (
-    load_assets_from_airflow_dag,
-)
+from dagster_airflow import load_assets_from_airflow_dag, make_ephemeral_airflow_db_resource
 
 from dagster_airflow_tests.marks import requires_airflow_db
 
@@ -38,6 +36,13 @@ with models.DAG(
     baz = BashOperator(
         task_id="baz", bash_command="echo baz"
     )
+
+with models.DAG(
+    dag_id="other_dag", default_args=default_args, schedule='0 0 * * *', tags=['example'],
+) as other_dag:
+    foo = BashOperator(
+        task_id="foo", bash_command="echo foo"
+    )
 """
 
 
@@ -67,9 +72,14 @@ def test_load_assets_from_airflow_dag():
                 },
             },
         )
+        other_dag = dag_bag.get_dag(dag_id="other_dag")
+        other_assets = load_assets_from_airflow_dag(
+            dag=other_dag,
+        )
 
         result = materialize(
-            [*assets, new_upstream_asset],
+            [*assets, new_upstream_asset, *other_assets],
             partition_key="2023-02-01T00:00:00",
+            resources={"airflow_db": make_ephemeral_airflow_db_resource()},
         )
         assert result.success

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/snapshots/snap_test_dependency_structure_translation.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/snapshots/snap_test_dependency_structure_translation.py
@@ -7,7 +7,9 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_complex_dag 1'] = '''{
+snapshots[
+    "test_complex_dag 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -876,9 +878,11 @@ snapshots['test_complex_dag 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""
 
-snapshots['test_diamond_task_dag 1'] = '''{
+snapshots[
+    "test_diamond_task_dag 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -965,9 +969,11 @@ snapshots['test_diamond_task_dag 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""
 
-snapshots['test_multi_leaf_dag 1'] = '''{
+snapshots[
+    "test_multi_leaf_dag 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -1049,9 +1055,11 @@ snapshots['test_multi_leaf_dag 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""
 
-snapshots['test_multi_root_dag 1'] = '''{
+snapshots[
+    "test_multi_root_dag 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -1131,9 +1139,11 @@ snapshots['test_multi_root_dag 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""
 
-snapshots['test_one_task_dag 1'] = '''{
+snapshots[
+    "test_one_task_dag 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -1152,9 +1162,11 @@ snapshots['test_one_task_dag 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""
 
-snapshots['test_two_task_dag_no_dep 1'] = '''{
+snapshots[
+    "test_two_task_dag_no_dep 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -1188,9 +1200,11 @@ snapshots['test_two_task_dag_no_dep 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""
 
-snapshots['test_two_task_dag_with_dep 1'] = '''{
+snapshots[
+    "test_two_task_dag_with_dep 1"
+] = """{
   "__class__": "DependencyStructureSnapshot",
   "solid_invocation_snaps": [
     {
@@ -1230,4 +1244,4 @@ snapshots['test_two_task_dag_with_dep 1'] = '''{
       "tags": {}
     }
   ]
-}'''
+}"""


### PR DESCRIPTION
### Summary & Motivation

This PR:
- adds a new api for creating an emphemeral airflowdb resource def `make_ephemeral_airflow_db_resource`
- drops setting any resource_defs from asset apis
- consolidates dag/dagrun resources into the op + airflowdb resource

### How I Tested These Changes
- existing unit coverage
