### PR TITLE
Pyright config/script fixes and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,17 @@ check_black:
 pyright:
 	python scripts/run-pyright.py --all
 
+install_pyright:
+	pip install -e 'python_modules/dagster[pyright]'
+
 rebuild_pyright:
 	python scripts/run-pyright.py --all --rebuild
 
 quick_pyright:
 	python scripts/run-pyright.py --diff
+
+unannotated_pyright:
+	python scripts/run-pyright.py --unannotated
 
 ruff:
 	ruff --fix .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ exclude = [
 # environment is defined in the `pyright` tox environment in the tox section below-- that
 # environment must be built before pyright can run correctly.
 venv = ".venv"
-venvPath = "pyright/envs/master"
+venvPath = "pyright/master"
 
 # Set to false to help us during the transition from mypy to pyright. Mypy does
 # not analyze unannotated functions by default, and so as of 2023-02 the codebase contains a large

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -126,7 +126,7 @@ setup(
             "mypy==0.991",
         ],
         "pyright": [
-            "pyright==1.1.292",
+            "pyright==1.1.293",
             ### Stub packages
             "pandas-stubs",  # version will be resolved against pandas
             "types-backports",  # version will be resolved against backports


### PR DESCRIPTION
### Summary & Motivation

Fix two issues:

- `pyproject.toml` `venvPath` setting was wrong, causing editor not to use same env as `make pyright`
- Regression in `paths` processing in script for directory targets

Add features:

- `--unannotated` flag for script (and `make unannotated_pyright`) runs pyright in unannotated mode
- `install_pyright` target installs the version of pyright pinned in Dagster
- script now warns if you are not using the right version of pyright

Also bumps pyright to `1.1.293`, which fixed a nasty bug that caused it to crash when analyzing some of our files in `--unannotated` mode.

### How I Tested These Changes

Using pylance in editor and `make pyright`.
