### PR TITLE
Re-enable pyright in BK

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -28,7 +28,7 @@ def build_repo_wide_steps() -> List[BuildkiteStep]:
     return [
         *build_repo_wide_black_steps(),
         *build_repo_wide_check_manifest_steps(),
-        # *build_repo_wide_pyright_steps(),
+        *build_repo_wide_pyright_steps(),
         *build_repo_wide_ruff_steps(),
     ]
 
@@ -77,7 +77,11 @@ def build_repo_wide_ruff_steps() -> List[CommandStep]:
 def build_repo_wide_pyright_steps() -> List[CommandStep]:
     return [
         CommandStepBuilder(":pyright: pyright")
-        .run("pip install -e python_modules/dagster[pyright]", "make pyright")
+        .run(
+            "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y",
+            "pip install -e python_modules/dagster[pyright]",
+            "make pyright",
+        )
         .on_test_image(AvailablePythonVersion.get_default())
         .with_skip(skip_if_no_python_changes())
         .build(),

--- a/examples/with_wandb/tox.ini
+++ b/examples/with_wandb/tox.ini
@@ -7,7 +7,7 @@ setenv =
   VIRTUALENV_PIP=22.1.2
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE
 deps =
-  -e ../../python_modules/dagster[mypy,test]
+  -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagit
   -e ../../python_modules/dagster-graphql
   -e ../../python_modules/libraries/dagster-wandb

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -14,31 +14,6 @@
 #
 # NOTE: Paths are relative to repo root.
 
-### EXAMPLES
-
--e examples/assets_dbt_python
--e examples/assets_modern_data_stack
--e examples/assets_pandas_pyspark
-# -e examples/assets_pandas_type_metadata
-# -e examples/assets_smoke_test
--r examples/deploy_docker/requirements.txt
-# -r examples/deploy_ecs/requirements.txt  # (no reqs)
-# -r examples/deploy_k8s/requirements.txt  # (no reqs)
--e examples/development_to_production
--e examples/docs_snippets
-# -e examples/experimental/project_fully_featured_v2_resources
--e examples/feature_graph_backed_assets
-# -e examples/project_fully_featured
-# -e examples/quickstart_aws  # (analyzed but not installed)
-# -e examples/quickstart_etl  # (analyzed but not installed)
-# -e examples/quickstart_gcp  # (analyzed but not installed)
-# -e examples/quickstart_snowflake  # (analyzed but not installed)
--e examples/tutorial_dbt_dagster
--e examples/tutorial_notebook_assets
--e examples/with_airflow
--e examples/with_great_expectations
--e examples/with_pyspark
-
 ### HELM
 -e helm/dagster/schema
 
@@ -104,6 +79,28 @@
 pandas_gbq  # (quickstart_gcp)
 wordcloud  # (quickstart-*)
 
+### EXAMPLES
 
-### EXAMPLES that depend on the above editable installs
+-e examples/assets_dbt_python
+-e examples/assets_modern_data_stack
+-e examples/assets_pandas_pyspark
+# -e examples/assets_pandas_type_metadata
+# -e examples/assets_smoke_test
+# -r examples/deploy_docker/requirements.txt
+# -r examples/deploy_ecs/requirements.txt  # (no reqs)
+# -r examples/deploy_k8s/requirements.txt  # (no reqs)
+-e examples/development_to_production
+-e examples/docs_snippets
+# -e examples/experimental/project_fully_featured_v2_resources
+-e examples/feature_graph_backed_assets
+# -e examples/project_fully_featured
+# -e examples/quickstart_aws  # (analyzed but not installed)
+# -e examples/quickstart_etl  # (analyzed but not installed)
+# -e examples/quickstart_gcp  # (analyzed but not installed)
+# -e examples/quickstart_snowflake  # (analyzed but not installed)
+-e examples/tutorial_dbt_dagster
+-e examples/tutorial_notebook_assets
+-e examples/with_airflow
+-e examples/with_great_expectations
+-e examples/with_pyspark
 -e examples/with_wandb

--- a/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_nothing_dependencies.py
@@ -323,7 +323,7 @@ def test_nothing_infer():
     ):
 
         @op
-        def _bad(_previous_steps_complete: Nothing):
+        def _bad(_previous_steps_complete: Nothing):  # type: ignore
             pass
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
@@ -677,7 +677,7 @@ def test_compose_nothing():
         pass
 
     @graph(ins={"start": GraphIn()})
-    def _compose(start: Nothing):
+    def _compose(start: Nothing):  # type: ignore
         go(start)  # pylint: disable=too-many-function-args
 
 

--- a/python_modules/libraries/dagster-wandb/setup.py
+++ b/python_modules/libraries/dagster-wandb/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_wandb_tests*"]),
     install_requires=[
-        "dagster",
+        f"dagster{pin}",
         "wandb>=0.13.5",
     ],
     extras_require={"dev": ["cloudpickle", "joblib", "callee", "dill"]},


### PR DESCRIPTION
### Summary & Motivation

- Add `rustup` installation to pyright BK commands
- Re-enable pyright in BK
- Type-ignore two errors detected by pyright 1.1.293
- Move examples block under libraries block for pyright master env `requirements.txt`
- `dagster-wandb`
    - remove `mypy` reference
    - set correct pinning behavior

### How I Tested These Changes

BK
