### PR TITLE
Fall back to self._instance_ref in any grpc api calls that pass in an instance ref

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -406,6 +406,7 @@ def get_partition_tags(
 def get_external_execution_plan_snapshot(
     repo_def: RepositoryDefinition,
     job_name: str,
+    instance_ref: Optional[InstanceRef],
     args: ExecutionPlanSnapshotArgs,
 ):
     try:
@@ -422,7 +423,7 @@ def get_external_execution_plan_snapshot(
                 mode=args.mode,
                 step_keys_to_execute=args.step_keys_to_execute,
                 known_state=args.known_state,
-                instance_ref=args.instance_ref,
+                instance_ref=instance_ref,
                 repository_load_data=repo_def.repository_load_data,
             ),
             args.pipeline_snapshot_id,


### PR DESCRIPTION
Summary:
Gives us a back-compat path for existing API calls that pass in instance refs - in certain situations (notably cloud) you can count on self._instance_ref being set, and don't have to do weird transformations to ensure that an instance_ref is actually passed in.

### Summary & Motivation

### How I Tested These Changes
