### PR TITLE
Fix dagster-wandb placeholder

### DIFF
--- a/python_modules/libraries/dagster-wandb/dagster_wandb/version.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/version.py
@@ -1,1 +1,1 @@
-__version__ = "0+dev"
+__version__ = "1!0+dev"


### PR DESCRIPTION
### Summary & Motivation

This needs to be `1!0+dev` instead of just `0+dev`
