### PR TITLE
Remove restart-on-failure from local docker agent guide

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/docker/configuring-running-docker-agent.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/docker/configuring-running-docker-agent.mdx
@@ -82,7 +82,6 @@ docker run \
   --network=dagster_cloud_agent \
   --volume $PWD/dagster.yaml:/opt/dagster/app/dagster.yaml:ro \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --restart on-failure \
   -it docker.io/dagster/dagster-cloud-agent:latest \
   dagster-cloud agent run /opt/dagster/app
 ```
@@ -90,7 +89,7 @@ docker run \
 This command:
 
 - Starts the agent with your local `dagster.yaml` mounted as a volume
-- Starts the system Docker socket mounted as a volume, allowing the agent to launch containers. The `--restart-on-failure` argument will ensure that if it fails, Docker will restart it.
+- Starts the system Docker socket mounted as a volume, allowing the agent to launch containers.
 
 To view the agent in Dagster Cloud, navigate to the **Status** page and click the **Agents** tab. You should see the agent running in the **Agent statuses** section:
 
@@ -118,7 +117,6 @@ These credential helpers generally are configured in `~/.docker.config.json`. To
     --volume $PWD/dagster.yaml:/opt/dagster/app/dagster.yaml:ro \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume ~/.docker/config.json:/root/.docker/config.json:ro \
-    --restart on-failure \
     -it docker.io/dagster/dagster-cloud-agent:latest \
     dagster-cloud agent run /opt/dagster/app
 ```


### PR DESCRIPTION
Summary:
This causes confusing situations when running the agent locally - you ctrl-C but the agent is still running in the background. Docker experts will know how to configure this themselves if they want it.

### Summary & Motivation

### How I Tested These Changes
