### PR TITLE
[dagit] add full serialized error to graphql errors

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppError.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppError.tsx
@@ -7,9 +7,20 @@ import * as React from 'react';
 
 import {showCustomAlert} from './CustomAlertProvider';
 
+interface DagsterSerializableErrorInfo {
+  message: string;
+  stack: string[];
+  cls_name: string | null;
+  cause: DagsterSerializableErrorInfo | null;
+  context: DagsterSerializableErrorInfo | null;
+}
+
 interface DagsterGraphQLError extends GraphQLError {
-  stack_trace: string[];
-  cause?: DagsterGraphQLError;
+  extensions:
+    | {
+        errorInfo?: DagsterSerializableErrorInfo;
+      }
+    | undefined;
 }
 
 const ErrorToaster = Toaster.create({position: 'top-right'});
@@ -53,24 +64,26 @@ interface AppStackTraceLinkProps {
 
 const AppStackTraceLink = ({error, operationName}: AppStackTraceLinkProps) => {
   const title = 'Error';
-  const stackTraceContent = error.stack_trace ? (
+  const stackTrace = error?.extensions?.errorInfo?.stack;
+  const cause = error?.extensions?.errorInfo?.cause;
+  const stackTraceContent = stackTrace ? (
     <>
       {'\n\n'}
       Stack Trace:
       {'\n'}
-      {error.stack_trace.join('')}
+      {stackTrace.join('')}
     </>
   ) : null;
-  const causeContent = error.cause ? (
+  const causeContent = cause ? (
     <>
       {'\n'}
       The above exception was the direct cause of the following exception:
       {'\n\n'}
-      Message: {error.cause.message}
+      Message: {cause.message}
       {'\n\n'}
       Stack Trace:
       {'\n'}
-      {error.cause.stack_trace.join('')}
+      {cause.stack.join('')}
     </>
   ) : null;
   const instructions = (

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2741,6 +2741,7 @@ type DagitQuery {
   capturedLogsMetadata(logKey: [String!]!): CapturedLogsMetadata!
   capturedLogs(logKey: [String!]!, cursor: String, limit: Int): CapturedLogs!
   shouldShowNux: Boolean!
+  test: TestFields
 }
 
 union WorkspaceOrError = Workspace | PythonError
@@ -2827,6 +2828,10 @@ type CapturedLogsMetadata {
   stdoutLocation: String
   stderrDownloadUrl: String
   stderrLocation: String
+}
+
+type TestFields {
+  alwaysException: String
 }
 
 type DagitMutation {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -591,6 +591,7 @@ export type DagitQuery = {
   sensorOrError: SensorOrError;
   sensorsOrError: SensorsOrError;
   shouldShowNux: Scalars['Boolean'];
+  test: Maybe<TestFields>;
   topLevelResourceDetailsOrError: ResourceDetailsOrError;
   unloadableInstigationStatesOrError: InstigationStatesOrError;
   version: Scalars['String'];
@@ -3610,6 +3611,11 @@ export type TerminateRunResult =
 export type TerminateRunSuccess = TerminatePipelineExecutionSuccess & {
   __typename: 'TerminateRunSuccess';
   run: Run;
+};
+
+export type TestFields = {
+  __typename: 'TestFields';
+  alwaysException: Maybe<Scalars['String']>;
 };
 
 export type TextMetadataEntry = MetadataEntry & {

--- a/python_modules/dagit/dagit/graphql.py
+++ b/python_modules/dagit/dagit/graphql.py
@@ -4,7 +4,9 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import dagster._check as check
+from dagster._serdes import pack_value
 from dagster._seven import json
+from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster_graphql.implementation.utils import ErrorCapture
 from graphene import Schema
 from graphql import GraphQLError, GraphQLFormattedError
@@ -66,7 +68,25 @@ class GraphQLServer(ABC):
         ...
 
     def handle_graphql_errors(self, errors: Sequence[GraphQLError]):
-        return [err.formatted for err in errors]
+        results = []
+        for err in errors:
+            fmtd = err.formatted
+            if err.original_error and err.original_error.__traceback__:
+                serializable_error = serializable_error_info_from_exc_info(
+                    exc_info=(
+                        type(err.original_error),
+                        err.original_error,
+                        err.original_error.__traceback__,
+                    )
+                )
+                fmtd["extensions"] = {
+                    **fmtd.get("extensions", {}),
+                    "errorInfo": pack_value(serializable_error),
+                }
+
+            results.append(fmtd)
+
+        return results
 
     async def graphql_http_endpoint(self, request: Request):
         """

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -126,6 +126,7 @@ from ..runs import (
 from ..schedules import GrapheneScheduleOrError, GrapheneSchedulerOrError, GrapheneSchedulesOrError
 from ..sensors import GrapheneSensorOrError, GrapheneSensorsOrError
 from ..tags import GraphenePipelineTagAndValues
+from ..test import GrapheneTestFields
 from ..util import ResolveInfo, get_compute_log_manager, non_null_list
 from .assets import GrapheneAssetOrError, GrapheneAssetsOrError
 from .execution_plan import GrapheneExecutionPlanOrError
@@ -429,6 +430,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
     shouldShowNux = graphene.Field(
         graphene.NonNull(graphene.Boolean),
         description="Whether or not the NUX should be shown to the user",
+    )
+
+    test = graphene.Field(
+        GrapheneTestFields,
+        description="Provides fields for testing behavior",
     )
 
     def resolve_repositoriesOrError(
@@ -869,3 +875,6 @@ class GrapheneDagitQuery(graphene.ObjectType):
 
     def resolve_shouldShowNux(self, graphene_info):
         return graphene_info.context.instance.nux_enabled and not get_has_seen_nux()
+
+    def resolve_test(self, _):
+        return GrapheneTestFields()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/test.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/test.py
@@ -1,0 +1,11 @@
+import graphene
+
+
+class GrapheneTestFields(graphene.ObjectType):
+    class Meta:
+        name = "TestFields"
+
+    alwaysException = graphene.String()
+
+    def resolve_alwaysException(self, _):
+        raise Exception("as advertised")


### PR DESCRIPTION
Use the extensions field on the error contents to include the full `SerializableErrorInfo` object for the original exception. This allows us to see the stack trace / cause when an exception occurs in a resolver.

### How I Tested These Changes

added test, screenshot:
<img width="841" alt="Screen Shot 2023-02-09 at 3 17 59 PM" src="https://user-images.githubusercontent.com/202219/217941619-9b9a9431-1994-4bf7-b92d-7e8cd5a7708a.png">

