### PR TITLE
disable check_same_thread on in-memory sqlite storage

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/sqlite.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite.py
@@ -18,7 +18,7 @@ def create_in_memory_conn_string(db_name):
     # that multiple instances can share the same logical DB across connections, while maintaining
     # separate DBs for different db names.  The latter is required to have both the run / event_log
     # in-memory implementations within the same process
-    return f"sqlite:///file:{db_name}?mode=memory&uri=true"
+    return f"sqlite:///file:{db_name}?mode=memory&uri=true&check_same_thread=false"
 
 
 def get_sqlite_version():


### PR DESCRIPTION
I tried using `dagit-debug` for the first time in a while and ran in to this check causing all web requests to fail. I think its safe enough to disable this.

### How I Tested These Changes

run `dagit-debug <debug file`>` and look at a run
