### PR TITLE
[pythonic config] Alternate impl. of nested resources w/o setter

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -103,24 +103,8 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources):
             required_resource_keys, "required_resource_keys"
         )
         self._version = check.opt_str_param(version, "version")
-        self._top_level_key: Optional[str] = None
         if version:
             experimental_arg_warning("version", "ResourceDefinition.__init__")
-
-    def set_top_level_key(self, key: str):
-        """
-        Sets the top-level resource key for this resource, when passed
-        into the Definitions object.
-        """
-        self._top_level_key = key
-
-    @property
-    def top_level_key(self) -> Optional[str]:
-        """
-        Gets the top-level resource key for this resource which was associated with it
-        in the Definitions object.
-        """
-        return self._top_level_key
 
     @property
     def resource_fn(self) -> ResourceFunction:


### PR DESCRIPTION
## Summary

Alternate approach stacked on #11645 which removes the `top_level_key` shenanigans.

The goal of this PR is to allow for the following pattern:

```python
foo = FooResource.configure_at_runtime()
bar = BarResource(inner=foo)

defs = Definitions(
    ...
    resources={
        "my_foo": foo,
        "my_bar": bar,
    }
)
```

Here, `bar` has a pointer to a `ResourceDefinition` for `foo`, but has no knowledge that `foo` is tied to the resource key `"my_foo"` (this is only specified at `Definitions` time). However, any pipeline which depends on `"my_bar"` as a required resource key must also depend on `"my_foo"`, so `bar.required_resource_keys` must return `{"my_foo"}`.

Getting this information (that `foo` has `"my_foo"` as a resource key) to `required_resource_keys` is tricky. 

This PR adds a new wrapper `ResourceDefinition` called `ResourceWithKeyMapping` which pairs the wrapped resource with mapping that takes `ResourceDefinition` IDs to resource keys (e.g. allowing us to map `foo`->`"my_foo"`). It catches any calls to `required_resource_keys` and instead forwards them to `_resolve_required_resource_keys`, which takes the mapping.

## Test Plan

Existing unit tests.