### PR TITLE
[pythonic config] Rename pythonic config classes

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
@@ -6,7 +6,7 @@ from dagster import (
     _check as check,
     asset,
 )
-from dagster._config.structured_config import Resource
+from dagster._config.structured_config import ConfigurableResource
 from dagster_graphql.test.utils import define_out_of_process_context
 
 
@@ -15,7 +15,7 @@ def my_asset():
     pass
 
 
-class MyResource(Resource):
+class MyResource(ConfigurableResource):
     """my description"""
 
     a_bool: bool

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -58,7 +58,7 @@ class BaseResourceMeta(pydantic.main.ModelMetaclass):
 
     .. code-block:: python
 
-        class FooResource(Resource):
+        class FooResource(ConfigurableResource):
             bar: BarResource
 
         # Types as PartialResource[BarResource]

--- a/python_modules/dagster/dagster/_core/definitions/resource_output.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_output.py
@@ -30,4 +30,4 @@ def _is_resource_annotated(param: Parameter) -> bool:
 
 
 T = TypeVar("T")
-ResourceOutput = Annotated[T, "resource_output"]
+Resource = Annotated[T, "resource_output"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -8,19 +8,19 @@ from dagster._config.structured_config import Config
 from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
-from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._core.definitions.resource_output import Resource
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 
 def test_filter_out_resources():
     @op
-    def requires_resource_a(context, a: ResourceOutput[str]):
+    def requires_resource_a(context, a: Resource[str]):
         assert a
         assert context.resources.a
         assert not hasattr(context.resources, "b")
 
     @op
-    def requires_resource_b(context, b: ResourceOutput[str]):
+    def requires_resource_b(context, b: Resource[str]):
         assert b
         assert not hasattr(context.resources, "a")
         assert context.resources.b
@@ -58,11 +58,11 @@ def test_init_resources():
         yield "B"
 
     @op
-    def consumes_resource_a(a: ResourceOutput[str]):
+    def consumes_resource_a(a: Resource[str]):
         assert a == "A"
 
     @op
-    def consumes_resource_b(b: ResourceOutput[str]):
+    def consumes_resource_b(b: Resource[str]):
         assert b == "B"
 
     @job(
@@ -84,13 +84,13 @@ def test_ops_with_dependencies():
     completed = set()
 
     @op
-    def first_op(foo: ResourceOutput[str]):
+    def first_op(foo: Resource[str]):
         assert foo == "foo"
         completed.add("first_op")
         return "hello"
 
     @op
-    def second_op(foo: ResourceOutput[str], first_op_result: str):
+    def second_op(foo: Resource[str], first_op_result: str):
         assert foo == "foo"
         assert first_op_result == "hello"
         completed.add("second_op")
@@ -104,7 +104,7 @@ def test_ops_with_dependencies():
     # Ensure ordering of resource args doesn't matter
     @op
     def fourth_op(
-        context, second_op_result: str, foo: ResourceOutput[str], third_op_result: str
+        context, second_op_result: str, foo: Resource[str], third_op_result: str
     ):  # pylint: disable=unused-argument
         assert foo == "foo"
         assert second_op_result == "hello world"
@@ -127,14 +127,14 @@ def test_assets():
     executed = {}
 
     @asset
-    def the_asset(context, foo: ResourceOutput[str]):
+    def the_asset(context, foo: Resource[str]):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         executed["the_asset"] = True
         return "hello"
 
     @asset
-    def the_other_asset(context, the_asset, foo: ResourceOutput[str]):
+    def the_other_asset(context, the_asset, foo: Resource[str]):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         assert the_asset == "hello"
@@ -143,7 +143,7 @@ def test_assets():
 
     # Ensure ordering of resource args doesn't matter
     @asset
-    def the_third_asset(context, the_asset, foo: ResourceOutput[str], the_other_asset):
+    def the_third_asset(context, the_asset, foo: Resource[str], the_other_asset):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         assert the_asset == "hello"
@@ -165,7 +165,7 @@ def test_multi_assets():
     executed = {}
 
     @multi_asset(outs={"a": AssetOut(key="asset_a"), "b": AssetOut(key="asset_b")})
-    def two_assets(context, foo: ResourceOutput[str]):
+    def two_assets(context, foo: Resource[str]):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         executed["two_assets"] = True
@@ -184,7 +184,7 @@ def test_multi_assets():
 def test_resource_not_provided():
     @asset
     def consumes_nonexistent_resource(
-        not_provided: ResourceOutput[str],  # pylint: disable=unused-argument
+        not_provided: Resource[str],  # pylint: disable=unused-argument
     ):
         pass
 
@@ -241,7 +241,7 @@ def test_both_decorator_and_argument_error():
     ):
 
         @asset(required_resource_keys={"foo"})
-        def my_asset(bar: ResourceOutput[Any]):  # pylint: disable=unused-argument
+        def my_asset(bar: Resource[Any]):  # pylint: disable=unused-argument
             pass
 
     with pytest.raises(
@@ -256,7 +256,7 @@ def test_both_decorator_and_argument_error():
             outs={"a": AssetOut(key="asset_a"), "b": AssetOut(key="asset_b")},
             required_resource_keys={"foo"},
         )
-        def my_assets(bar: ResourceOutput[Any]):  # pylint: disable=unused-argument
+        def my_assets(bar: Resource[Any]):  # pylint: disable=unused-argument
             pass
 
     with pytest.raises(
@@ -268,7 +268,7 @@ def test_both_decorator_and_argument_error():
     ):
 
         @op(required_resource_keys={"foo"})
-        def my_op(bar: ResourceOutput[Any]):  # pylint: disable=unused-argument
+        def my_op(bar: Resource[Any]):  # pylint: disable=unused-argument
             pass
 
 
@@ -280,7 +280,7 @@ def test_asset_with_structured_config():
     executed = {}
 
     @asset
-    def the_asset(context, config: AnAssetConfig, foo: ResourceOutput[str]):
+    def the_asset(context, config: AnAssetConfig, foo: Resource[str]):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         assert context.op_config["a_string"] == "foo"
@@ -316,14 +316,14 @@ def test_no_err_builtin_annotations():
     executed = {}
 
     @asset
-    def the_asset(context, foo: ResourceOutput[str]):
+    def the_asset(context, foo: Resource[str]):
         assert context.resources.foo == "blah"
         assert foo == "blah"
         executed["the_asset"] = True
         return [{"hello": "world"}]
 
     @asset
-    def the_other_asset(context, the_asset: list[dict[str, str]], foo: ResourceOutput[str]):  # type: ignore  # (python <3.9 compat)
+    def the_other_asset(context, the_asset: list[dict[str, str]], foo: Resource[str]):  # type: ignore  # (python <3.9 compat)
         assert context.resources.foo == "blah"
         assert foo == "blah"
         assert the_asset == [{"hello": "world"}]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -930,12 +930,12 @@ def test_type_signatures_constructor_nested_resource():
         with open(filename, "w") as f:
             f.write(
                 """
-from dagster._config.structured_config import Resource
+from dagster._config.structured_config import ConfigurableResource
 
-class InnerResource(Resource):
+class InnerResource(ConfigurableResource):
     a_string: str
 
-class OuterResource(Resource):
+class OuterResource(ConfigurableResource):
     inner: InnerResource
     a_bool: bool
 
@@ -971,9 +971,9 @@ def test_type_signatures_config_at_launch():
         with open(filename, "w") as f:
             f.write(
                 """
-from dagster._config.structured_config import Resource
+from dagster._config.structured_config import ConfigurableResource
 
-class MyResource(Resource):
+class MyResource(ConfigurableResource):
     a_string: str
 
 reveal_type(MyResource.configure_at_launch())
@@ -996,9 +996,9 @@ def test_type_signatures_constructor_resource_dependency():
         with open(filename, "w") as f:
             f.write(
                 """
-from dagster._config.structured_config import Resource, ResourceDependency
+from dagster._config.structured_config import ConfigurableResource, ResourceDependency
 
-class StringDependentResource(Resource):
+class StringDependentResource(ConfigurableResource):
     a_string: ResourceDependency[str]
 
 reveal_type(StringDependentResource.__init__)
@@ -1015,8 +1015,8 @@ reveal_type(my_str_resource.a_string)
         # resource function that returns a str
         assert (
             pyright_out[0]
-            == "(self: StringDependentResource, a_string: Resource[str] | PartialResource[str] |"
-            " ResourceDefinition | str) -> None"
+            == "(self: StringDependentResource, a_string: ConfigurableResource[str] |"
+            " PartialResource[str] | ResourceDefinition | str) -> None"
         )
 
         # Ensure that the retrieved type is str

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -13,16 +13,16 @@ from dagster._check import CheckError
 from dagster._config.field import Field
 from dagster._config.field_utils import EnvVar
 from dagster._config.structured_config import (
-    Resource,
+    ConfigurableIOManagerInjector,
+    ConfigurableResource,
+    ConfigurableResourceAdapter,
     ResourceDependency,
-    StructuredConfigIOManagerBase,
     StructuredIOManagerAdapter,
-    StructuredResourceAdapter,
 )
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._core.definitions.resource_output import Resource
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.context.init import InitResourceContext
@@ -34,7 +34,7 @@ from dagster._utils.cached_method import cached_method
 def test_basic_structured_resource():
     out_txt = []
 
-    class WriterResource(Resource):
+    class WriterResource(ConfigurableResource):
         prefix: str
 
         def output(self, text: str) -> None:
@@ -62,7 +62,7 @@ def test_basic_structured_resource():
 
 
 def test_invalid_config():
-    class MyResource(Resource):
+    class MyResource(ConfigurableResource):
         foo: int
 
     with pytest.raises(
@@ -77,7 +77,7 @@ def test_caching_within_resource():
 
     from functools import cached_property
 
-    class GreetingResource(Resource):
+    class GreetingResource(ConfigurableResource):
         name: str
 
         @cached_property
@@ -147,7 +147,7 @@ def test_caching_within_resource():
 def test_abc_resource():
     out_txt = []
 
-    class Writer(Resource, ABC):
+    class Writer(ConfigurableResource, ABC):
         @abstractmethod
         def output(self, text: str) -> None:
             pass
@@ -192,7 +192,7 @@ def test_abc_resource():
 def test_yield_in_resource_function():
     called = []
 
-    class ResourceWithCleanup(Resource):
+    class ResourceWithCleanup(ConfigurableResource):
         idx: int
 
         def create_object_to_pass_to_user_code(self, context):
@@ -202,7 +202,7 @@ def test_yield_in_resource_function():
 
     @op
     def check_resource_created(
-        resource_with_cleanup_1: ResourceOutput[bool], resource_with_cleanup_2: ResourceOutput[bool]
+        resource_with_cleanup_1: Resource[bool], resource_with_cleanup_2: Resource[bool]
     ):
         assert resource_with_cleanup_1 is True
         assert resource_with_cleanup_2 is True
@@ -234,7 +234,7 @@ def test_wrapping_function_resource():
 
         return output
 
-    class WriterResource(StructuredResourceAdapter):
+    class WriterResource(ConfigurableResourceAdapter):
         prefix: str
 
         @property
@@ -242,7 +242,7 @@ def test_wrapping_function_resource():
             return writer_resource
 
     @op
-    def hello_world_op(writer: ResourceOutput[Callable[[str], None]]):
+    def hello_world_op(writer: Resource[Callable[[str], None]]):
         writer("hello, world!")
 
     @job(resource_defs={"writer": WriterResource(prefix="")})
@@ -303,7 +303,7 @@ def test_io_manager_adapter():
 
 def test_io_manager_factory_class():
     # now test without the adapter
-    class AnIOManagerFactory(StructuredConfigIOManagerBase):
+    class AnIOManagerFactory(ConfigurableIOManagerInjector):
         a_config_value: str
 
         def create_io_manager_to_pass_to_user_code(self, _) -> IOManager:
@@ -329,7 +329,7 @@ def test_io_manager_factory_class():
 def test_structured_resource_runtime_config():
     out_txt = []
 
-    class WriterResource(Resource):
+    class WriterResource(ConfigurableResource):
         prefix: str
 
         def output(self, text: str) -> None:
@@ -369,7 +369,7 @@ def test_env_var():
         }
     ):
 
-        class ResourceWithString(Resource):
+        class ResourceWithString(ConfigurableResource):
             a_str: str
             a_int: int
 
@@ -398,7 +398,7 @@ def test_env_var_err():
     if "UNSET_ENV_VAR" in os.environ:
         del os.environ["UNSET_ENV_VAR"]
 
-    class ResourceWithString(Resource):
+    class ResourceWithString(ConfigurableResource):
         a_str: str
 
     with pytest.raises(
@@ -410,7 +410,7 @@ def test_env_var_err():
 def test_runtime_config_env_var():
     out_txt = []
 
-    class WriterResource(Resource):
+    class WriterResource(ConfigurableResource):
         prefix: str
 
         def output(self, text: str) -> None:
@@ -442,7 +442,7 @@ def test_runtime_config_env_var():
 def test_nested_resources():
     out_txt = []
 
-    class Writer(Resource, ABC):
+    class Writer(ConfigurableResource, ABC):
         @abstractmethod
         def output(self, text: str) -> None:
             pass
@@ -511,15 +511,15 @@ def test_nested_resources():
 
 
 def test_nested_resources_multiuse():
-    class AWSCredentialsResource(Resource):
+    class AWSCredentialsResource(ConfigurableResource):
         username: str
         password: str
 
-    class S3Resource(Resource):
+    class S3Resource(ConfigurableResource):
         aws_credentials: AWSCredentialsResource
         bucket_name: str
 
-    class EC2Resource(Resource):
+    class EC2Resource(ConfigurableResource):
         aws_credentials: AWSCredentialsResource
 
     completed = {}
@@ -549,15 +549,15 @@ def test_nested_resources_multiuse():
 
 
 def test_nested_resources_runtime_config():
-    class AWSCredentialsResource(Resource):
+    class AWSCredentialsResource(ConfigurableResource):
         username: str
         password: str
 
-    class S3Resource(Resource):
+    class S3Resource(ConfigurableResource):
         aws_credentials: AWSCredentialsResource
         bucket_name: str
 
-    class EC2Resource(Resource):
+    class EC2Resource(ConfigurableResource):
         aws_credentials: AWSCredentialsResource
 
     completed = {}
@@ -603,16 +603,16 @@ def test_nested_resources_runtime_config():
 
 
 def test_nested_resources_runtime_config_complex():
-    class CredentialsResource(Resource):
+    class CredentialsResource(ConfigurableResource):
         username: str
         password: str
 
-    class DBConfigResource(Resource):
+    class DBConfigResource(ConfigurableResource):
         creds: CredentialsResource
         host: str
         database: str
 
-    class DBResource(Resource):
+    class DBResource(ConfigurableResource):
         config: DBConfigResource
 
     completed = {}
@@ -694,13 +694,13 @@ def test_nested_resources_runtime_config_complex():
 
 
 def test_resources_which_return():
-    class StringResource(Resource[str]):
+    class StringResource(ConfigurableResource[str]):
         a_string: str
 
         def create_object_to_pass_to_user_code(self, context) -> str:
             return self.a_string
 
-    class MyResource(Resource):
+    class MyResource(ConfigurableResource):
         string_from_resource: ResourceDependency[str]
 
     completed = {}
@@ -762,7 +762,7 @@ def test_nested_function_resource():
 
         return output
 
-    class PostfixWriterResource(Resource[Callable[[str], None]]):
+    class PostfixWriterResource(ConfigurableResource[Callable[[str], None]]):
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
@@ -800,7 +800,7 @@ def test_nested_function_resource_configured():
 
         return output
 
-    class PostfixWriterResource(Resource[Callable[[str], None]]):
+    class PostfixWriterResource(ConfigurableResource[Callable[[str], None]]):
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
@@ -852,7 +852,7 @@ def test_nested_function_resource_runtime_config():
 
         return output
 
-    class PostfixWriterResource(Resource[Callable[[str], None]]):
+    class PostfixWriterResource(ConfigurableResource[Callable[[str], None]]):
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -1,11 +1,11 @@
 from dagster import Definitions, asset, job, op, repository
-from dagster._config.structured_config import Resource
+from dagster._config.structured_config import ConfigurableResource
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
     RepositoryDefinition,
 )
 from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.definitions.resource_output import ResourceOutput
+from dagster._core.definitions.resource_output import Resource
 from dagster._core.host_representation import (
     ExternalPipelineData,
     external_repository_data_from_def,
@@ -50,7 +50,7 @@ def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefi
 
 def test_repository_snap_definitions_resources_basic():
     @asset
-    def my_asset(foo: ResourceOutput[str]):
+    def my_asset(foo: Resource[str]):
         pass
 
     defs = Definitions(
@@ -69,7 +69,7 @@ def test_repository_snap_definitions_resources_basic():
 
 
 def test_repository_snap_definitions_resources_complex():
-    class MyStringResource(Resource):
+    class MyStringResource(ConfigurableResource):
         """my description"""
 
         my_string: str = "bar"

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager_structured_config.py
@@ -1,11 +1,11 @@
 # pylint: disable=unused-argument
 
 from dagster import Definitions, In, asset, job, op
-from dagster._config.structured_config import Resource, StructuredConfigIOManager
+from dagster._config.structured_config import ConfigurableIOManager, ConfigurableResource
 
 
 def test_load_input_handle_output():
-    class MyIOManager(StructuredConfigIOManager):
+    class MyIOManager(ConfigurableIOManager):
         def handle_output(self, context, obj):
             pass
 
@@ -49,7 +49,7 @@ def test_load_input_handle_output():
 def test_runtime_config():
     out_txt = []
 
-    class MyIOManager(StructuredConfigIOManager):
+    class MyIOManager(ConfigurableIOManager):
         prefix: str
 
         def handle_output(self, context, obj):
@@ -87,10 +87,10 @@ def test_runtime_config():
 def test_nested_resources():
     out_txt = []
 
-    class IOConfigResource(Resource):
+    class IOConfigResource(ConfigurableResource):
         prefix: str
 
-    class MyIOManager(StructuredConfigIOManager):
+    class MyIOManager(ConfigurableIOManager):
         config: IOConfigResource
 
         def handle_output(self, context, obj):
@@ -117,10 +117,10 @@ def test_nested_resources():
 def test_nested_resources_runtime_config():
     out_txt = []
 
-    class IOConfigResource(Resource):
+    class IOConfigResource(ConfigurableResource):
         prefix: str
 
-    class MyIOManager(StructuredConfigIOManager):
+    class MyIOManager(ConfigurableIOManager):
         config: IOConfigResource
 
         def handle_output(self, context, obj):


### PR DESCRIPTION
## Summary

Renames some of our Pythonic config classes based on offline discussion.

Naming feedback being collected at https://github.com/dagster-io/internal/discussions/4862.

`Resource` -> `ConfigurableResource`
`StructuredConfigIOManager` -> `ConfigurableIOManager`
`StructuredConfigIOManagerBase` -> `ConfigurableIOManagerInjector`
`ResourceOutput` -> `Resource`

## Test Plan

Existing unit tests.