### PR TITLE
treat pyright warnings as errors for buildkite purposes

### DIFF
--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -280,6 +280,7 @@ def run_pyright(
                 f"--project={config_path}",
                 "--outputjson",
                 "--level=warning",
+                "--warnings",  # Error on warnings
             ]
         )
         shell_cmd = " \\\n".join([base_pyright_cmd, *[f"    {p}" for p in paths or []]])


### PR DESCRIPTION
Summary:
We are at zero warnings now in dagster and 2 easy warnings in internal, may as well keep it that way?

Test Plan: BK, make pyright locally

### Summary & Motivation

### How I Tested These Changes
