### PR TITLE
[typing/runtime] [gql] eliminate resolver **kwargs (2)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 import dagster._check as check
 import graphene
@@ -156,26 +156,29 @@ class GraphenePartition(graphene.ObjectType):
             self._partition_name,
         )
 
-    def resolve_runs(self, graphene_info: ResolveInfo, **kwargs):
-        filters = kwargs.get("filter")
+    def resolve_runs(
+        self,
+        graphene_info: ResolveInfo,
+        filter: Optional[GrapheneRunsFilter] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+    ):
         partition_tags = {
             PARTITION_SET_TAG: self._external_partition_set.name,
             PARTITION_NAME_TAG: self._partition_name,
         }
-        if filters is not None:
-            filters = filters.to_selector()
+        if filter is not None:
+            selector = filter.to_selector()
             runs_filter = RunsFilter(
-                run_ids=filters.run_ids,
-                pipeline_name=filters.job_name,
-                statuses=filters.statuses,
-                tags=merge_dicts(filters.tags, partition_tags),
+                run_ids=selector.run_ids,
+                pipeline_name=selector.job_name,
+                statuses=selector.statuses,
+                tags=merge_dicts(selector.tags, partition_tags),
             )
         else:
             runs_filter = RunsFilter(tags=partition_tags)
 
-        return get_runs(
-            graphene_info, runs_filter, cursor=kwargs.get("cursor"), limit=kwargs.get("limit")
-        )
+        return get_runs(graphene_info, runs_filter, cursor=cursor, limit=limit)
 
 
 class GraphenePartitions(graphene.ObjectType):
@@ -234,14 +237,20 @@ class GraphenePartitionSet(graphene.ObjectType):
     def resolve_id(self, _graphene_info: ResolveInfo):
         return self._external_partition_set.get_external_origin_id()
 
-    def resolve_partitionsOrError(self, graphene_info: ResolveInfo, **kwargs):
+    def resolve_partitionsOrError(
+        self,
+        graphene_info: ResolveInfo,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        reverse: Optional[bool] = None,
+    ):
         return get_partitions(
             graphene_info,
             self._external_repository_handle,
             self._external_partition_set,
-            cursor=kwargs.get("cursor"),
-            limit=kwargs.get("limit"),
-            reverse=kwargs.get("reverse") or False,
+            cursor=cursor,
+            limit=limit,
+            reverse=reverse or False,
         )
 
     def resolve_partition(self, graphene_info: ResolveInfo, partition_name):
@@ -265,11 +274,13 @@ class GraphenePartitionSet(graphene.ObjectType):
         origin = self._external_partition_set.get_external_origin().external_repository_origin
         return GrapheneRepositoryOrigin(origin)
 
-    def resolve_backfills(self, graphene_info: ResolveInfo, **kwargs):
+    def resolve_backfills(
+        self, graphene_info: ResolveInfo, cursor: Optional[str] = None, limit: Optional[int] = None
+    ):
         matching = [
             backfill
             for backfill in graphene_info.context.instance.get_backfills(
-                cursor=kwargs.get("cursor"),
+                cursor=cursor,
             )
             if backfill.partition_set_origin
             and backfill.partition_set_origin.partition_set_name
@@ -277,7 +288,7 @@ class GraphenePartitionSet(graphene.ObjectType):
             and backfill.partition_set_origin.external_repository_origin.repository_name
             == self._external_repository_handle.repository_name
         ]
-        return [GraphenePartitionBackfill(backfill) for backfill in matching[: kwargs.get("limit")]]
+        return [GraphenePartitionBackfill(backfill) for backfill in matching[:limit]]
 
 
 class GraphenePartitionSetOrError(graphene.Union):


### PR DESCRIPTION
### Summary & Motivation

Replace resolver `**kwargs` with typed keyword args. Part of a collection of PRs that eliminates resolver `**kwargs` across all resolvers.

### How I Tested These Changes

BK. Also, correctness of added args was confirmed by manually inspecting the field definition in the parent object.