### PR TITLE
[typing/runtime] [gql] eliminate resolver **kwargs (4)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -1,3 +1,5 @@
+from typing import Optional, Sequence, Union
+
 import dagster._check as check
 import graphene
 from dagster._core.definitions.events import AssetKey
@@ -41,6 +43,7 @@ from ..backfill import (
 from ..errors import (
     GrapheneAssetNotFoundError,
     GrapheneConflictingExecutionParamsError,
+    GrapheneError,
     GraphenePresetNotFoundError,
     GraphenePythonError,
     GrapheneReloadNotSupported,
@@ -59,6 +62,7 @@ from ..pipelines.pipeline import GrapheneRun
 from ..runs import (
     GrapheneLaunchRunReexecutionResult,
     GrapheneLaunchRunResult,
+    GrapheneLaunchRunSuccess,
     parse_run_config_input,
 )
 from ..schedule_dry_run import GrapheneScheduleDryRunMutation
@@ -180,9 +184,10 @@ class GrapheneDeleteRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.DELETE_PIPELINE_RUN)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        run_id = kwargs["runId"]
-        return delete_pipeline_run(graphene_info, run_id)
+    def mutate(
+        self, graphene_info: ResolveInfo, runId: str
+    ) -> Union[GrapheneRunNotFoundError, GrapheneDeletePipelineRunSuccess]:
+        return delete_pipeline_run(graphene_info, runId)
 
 
 class GrapheneTerminatePipelineExecutionSuccess(graphene.Interface):
@@ -267,10 +272,10 @@ class GrapheneLaunchRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PIPELINE_EXECUTION)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        return create_execution_params_and_launch_pipeline_exec(
-            graphene_info, kwargs["executionParams"]
-        )
+    def mutate(
+        self, graphene_info: ResolveInfo, executionParams: GrapheneExecutionParams
+    ) -> Union[GrapheneLaunchRunSuccess, GrapheneError, GraphenePythonError]:
+        return create_execution_params_and_launch_pipeline_exec(graphene_info, executionParams)
 
 
 class GrapheneLaunchBackfillMutation(graphene.Mutation):
@@ -286,8 +291,8 @@ class GrapheneLaunchBackfillMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        return create_and_launch_partition_backfill(graphene_info, kwargs["backfillParams"])
+    def mutate(self, graphene_info: ResolveInfo, backfillParams: GrapheneLaunchBackfillParams):
+        return create_and_launch_partition_backfill(graphene_info, backfillParams)
 
 
 class GrapheneCancelBackfillMutation(graphene.Mutation):
@@ -303,8 +308,8 @@ class GrapheneCancelBackfillMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.CANCEL_PARTITION_BACKFILL)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        return cancel_partition_backfill(graphene_info, kwargs["backfillId"])
+    def mutate(self, graphene_info: ResolveInfo, backfillId: str):
+        return cancel_partition_backfill(graphene_info, backfillId)
 
 
 class GrapheneResumeBackfillMutation(graphene.Mutation):
@@ -320,8 +325,8 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        return resume_partition_backfill(graphene_info, kwargs["backfillId"])
+    def mutate(self, graphene_info: ResolveInfo, backfillId: str):
+        return resume_partition_backfill(graphene_info, backfillId)
 
 
 @capture_error
@@ -351,24 +356,27 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PIPELINE_REEXECUTION)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        execution_params = kwargs.get("executionParams")
-        reexecution_params = kwargs.get("reexecutionParams")
+    def mutate(
+        self,
+        graphene_info: ResolveInfo,
+        executionParams: Optional[GrapheneExecutionParams] = None,
+        reexecutionParams: Optional[GrapheneReexecutionParams] = None,
+    ):
         check.invariant(
-            bool(execution_params) != bool(reexecution_params),
+            bool(executionParams) != bool(reexecutionParams),
             "Must only provide one of either executionParams or reexecutionParams",
         )
 
-        if execution_params:
+        if executionParams:
             return create_execution_params_and_launch_pipeline_reexec(
                 graphene_info,
-                execution_params_dict=kwargs["executionParams"],
+                execution_params_dict=executionParams,
             )
-        elif reexecution_params:
+        elif reexecutionParams:
             return launch_reexecution_from_parent_run(
                 graphene_info,
-                reexecution_params["parentRunId"],
-                reexecution_params["strategy"],
+                reexecutionParams["parentRunId"],
+                reexecutionParams["strategy"],
             )
         else:
             check.failed("Unreachable")
@@ -403,11 +411,16 @@ class GrapheneTerminateRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.TERMINATE_PIPELINE_EXECUTION)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
+    def mutate(
+        self,
+        graphene_info: ResolveInfo,
+        runId: str,
+        terminatePolicy: Optional[GrapheneTerminateRunPolicy] = None,
+    ):
         return terminate_pipeline_execution(
             graphene_info,
-            kwargs["runId"],
-            kwargs.get("terminatePolicy", GrapheneTerminateRunPolicy.SAFE_TERMINATE),
+            runId,
+            terminatePolicy or GrapheneTerminateRunPolicy.SAFE_TERMINATE,
         )
 
 
@@ -460,26 +473,31 @@ class GrapheneReloadRepositoryLocationMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.RELOAD_REPOSITORY_LOCATION)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        location_name = kwargs["repositoryLocationName"]
+    def mutate(
+        self, graphene_info: ResolveInfo, repositoryLocationName: str
+    ) -> Union[
+        GrapheneWorkspaceLocationEntry,
+        GrapheneReloadNotSupported,
+        GrapheneRepositoryLocationNotFound,
+    ]:
         assert_permission_for_location(
-            graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, location_name
+            graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, repositoryLocationName
         )
 
-        if not graphene_info.context.has_repository_location_name(location_name):
-            return GrapheneRepositoryLocationNotFound(location_name)
+        if not graphene_info.context.has_repository_location_name(repositoryLocationName):
+            return GrapheneRepositoryLocationNotFound(repositoryLocationName)
 
-        if not graphene_info.context.is_reload_supported(location_name):
-            return GrapheneReloadNotSupported(location_name)
+        if not graphene_info.context.is_reload_supported(repositoryLocationName):
+            return GrapheneReloadNotSupported(repositoryLocationName)
 
         # The current workspace context is a WorkspaceRequestContext, which contains a reference to the
         # repository locations that were present in the root IWorkspaceProcessContext the start of the
         # request. Reloading a repository location modifies the IWorkspaceProcessContext, rendeirng
         # our current WorkspaceRequestContext outdated. Therefore, `reload_repository_location` returns
         # an updated WorkspaceRequestContext for us to use.
-        new_context = graphene_info.context.reload_repository_location(location_name)
+        new_context = graphene_info.context.reload_repository_location(repositoryLocationName)
         return GrapheneWorkspaceLocationEntry(
-            check.not_none(new_context.get_location_entry(location_name))
+            check.not_none(new_context.get_location_entry(repositoryLocationName))
         )
 
 
@@ -496,19 +514,24 @@ class GrapheneShutdownRepositoryLocationMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.RELOAD_REPOSITORY_LOCATION)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
-        location_name = kwargs["repositoryLocationName"]
+    def mutate(
+        self, graphene_info: ResolveInfo, repositoryLocationName: str
+    ) -> Union[GrapheneRepositoryLocationNotFound, GrapheneShutdownRepositoryLocationSuccess]:
         assert_permission_for_location(
-            graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, location_name
+            graphene_info, Permissions.RELOAD_REPOSITORY_LOCATION, repositoryLocationName
         )
-        if not graphene_info.context.has_repository_location_name(location_name):
-            return GrapheneRepositoryLocationNotFound(location_name)
+        if not graphene_info.context.has_repository_location_name(repositoryLocationName):
+            return GrapheneRepositoryLocationNotFound(repositoryLocationName)
 
-        if not graphene_info.context.is_shutdown_supported(location_name):
-            raise Exception(f"Location {location_name} does not support shutting down via GraphQL")
+        if not graphene_info.context.is_shutdown_supported(repositoryLocationName):
+            raise Exception(
+                f"Location {repositoryLocationName} does not support shutting down via GraphQL"
+            )
 
-        graphene_info.context.shutdown_repository_location(location_name)
-        return GrapheneShutdownRepositoryLocationSuccess(repositoryLocationName=location_name)
+        graphene_info.context.shutdown_repository_location(repositoryLocationName)
+        return GrapheneShutdownRepositoryLocationSuccess(
+            repositoryLocationName=repositoryLocationName
+        )
 
 
 class GrapheneReloadWorkspaceMutationResult(graphene.Union):
@@ -533,7 +556,7 @@ class GrapheneReloadWorkspaceMutation(graphene.Mutation):
 
     @capture_error
     @check_permission(Permissions.RELOAD_WORKSPACE)
-    def mutate(self, graphene_info: ResolveInfo, **_kwargs):
+    def mutate(self, graphene_info: ResolveInfo):
         new_context = graphene_info.context.reload_workspace()
         return fetch_workspace(new_context)
 
@@ -573,10 +596,9 @@ class GrapheneAssetWipeMutation(graphene.Mutation):
 
     @capture_error
     @check_permission(Permissions.WIPE_ASSETS)
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
+    def mutate(self, graphene_info: ResolveInfo, assetKeys: Sequence[GrapheneAssetKeyInput]):
         return wipe_assets(
-            graphene_info,
-            [AssetKey.from_graphql_input(asset_key) for asset_key in kwargs["assetKeys"]],
+            graphene_info, [AssetKey.from_graphql_input(asset_key) for asset_key in assetKeys]
         )
 
 
@@ -615,13 +637,15 @@ class GrapheneLogTelemetryMutation(graphene.Mutation):
         name = "LogTelemetryMutation"
 
     @capture_error
-    def mutate(self, graphene_info: ResolveInfo, **kwargs):
+    def mutate(
+        self, graphene_info: ResolveInfo, action: str, clientTime: str, clientId: str, metadata: str
+    ):
         action = log_dagit_telemetry_event(
             graphene_info,
-            action=kwargs["action"],
-            client_time=kwargs["clientTime"],
-            client_id=kwargs["clientId"],
-            metadata=kwargs["metadata"],
+            action=action,
+            client_time=clientTime,
+            client_id=clientId,
+            metadata=metadata,
         )
         return action
 


### PR DESCRIPTION
### Summary & Motivation

Replace resolver `**kwargs` with typed keyword args. Part of a collection of PRs that eliminates resolver `**kwargs` across all resolvers.

### How I Tested These Changes

BK. Also, correctness of added args was confirmed by manually inspecting the field definition in the parent object.
