### PR TITLE
Allow `dagster api grpc --max-workers`

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -499,7 +499,8 @@ def _execute_step_command_body(
     envvar="DAGSTER_GRPC_HOST",
 )
 @click.option(
-    "--max_workers",
+    "--max-workers",
+    "--max_workers",  # for backwards compatibility
     "-n",
     type=click.INT,
     required=False,


### PR DESCRIPTION
### Summary & Motivation

Confusing that this is the only option that uses "_" instead of "-". This adds an "-" variant while retaining the old for backcompat.

Inspired by: https://github.com/dagster-io/dagster/pull/12246

### How I Tested These Changes

There does not appear to be any unit tests for `dagster api grpc`, so I ran:

```
$ dagster api grpc -f some_file_with_defs.py -p 5487 --max-workers 4
$ dagster api grpc -f some_file_with_defs.py -p 5487 --max_workers 4
```

They both did the same thing.

