### PR TITLE
Revamp intro of partitions concepts page

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -5,19 +5,19 @@ description: Partitioned assets and jobs enable launching backfills, where each 
 
 # Partitioned assets and jobs
 
-Partitioning allows a software-defined asset or job to correspond to a set of entities with identical structure but different parameters.
+A software-defined asset can represent a collection of _partitions_ that can be tracked and materialized independently. In many ways, each partition functions like its own mini-asset, but they all share a common materialization function and dependencies. Typically, each partition will correspond to a separate file, or a slice of a table in a database.
 
-A _partitioned asset_ is an asset that's composed of a set of partitions, which can be materialized and tracked independently. Most commonly, each partition represents all the records in a data set that fall within a particular time window. Depending on where the asset is stored, each partition might correspond to a file or a slice of a table in a database.
+A common use is for each partition to represent all the records in a data set that fall within a particular time window, e.g. hourly, daily or monthly. Alternatively, each partition can represent a region, a customer, an experiment - any dimension along which you want to be able to materialize and monitor independently. An asset can also be partitioned along multiple dimensions, e.g. by region and by hour.
 
-A _partitioned job_ is a job where each run corresponds to a partition key. Most commonly, each partition key represents a time window, so, when a job executes, it processes data within one of the time windows.
+A graph of assets with the same partitions implicitly forms a partitioned data pipeline, and you can launch a run that selects multiple assets and materializes the same partition in each asset.
 
-It's common to construct a partitioned job that materializes a particular set of partitioned assets every time it runs.
+Similarly, a _partitioned job_ is a job where each run corresponds to a partition. It's common to construct a partitioned job that materializes a single partition across a set of partitioned assets every time it runs.
 
-Having defined a partitioned job or asset, you can:
+Having defined a partitioned asset or job, you can:
 
 - View runs by partition in Dagit.
 - Define a [schedule](/concepts/partitions-schedules-sensors/schedules) that fills in a partition each time it runs. For example, a job might run each day and process the data that arrived during the previous day.
-- Launch [backfills](/concepts/partitions-schedules-sensors/backfills), which are sets of runs that each process a different partition. For example, after making a code change, you might want to run your job on all time windows instead of just one of them.
+- Launch [backfills](/concepts/partitions-schedules-sensors/backfills), which are sets of runs that each process a different partition. For example, after making a code change, you might want to run your job on all partitions instead of just one of them.
 
 ---
 


### PR DESCRIPTION
### Summary & Motivation

We've gotten feedback that the way we present partitions is too focused on time-partitions. Users feel discouraged from using non-time-partitions. This updates the partitions concepts page to give them equal weight.

I also tried to make the language a  little less fancy.

### How I Tested These Changes
