### PR TITLE
[db io managers] connection refactor

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -126,9 +126,10 @@ class DbIOManager(IOManager):
                 self._db_client.ensure_schema_exists(context, table_slice, conn)
                 self._db_client.delete_table_slice(context, table_slice, conn)
 
-            handler_metadata = (
-                self._handlers_by_type[obj_type].handle_output(context, table_slice, obj) or {}
-            )
+                handler_metadata = (
+                    self._handlers_by_type[obj_type].handle_output(context, table_slice, obj, conn)
+                    or {}
+                )
         else:
             check.invariant(
                 context.dagster_type.is_nothing,

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import (
     Any,
     Dict,
@@ -50,12 +51,12 @@ class TableSlice(NamedTuple):
 class DbTypeHandler(ABC, Generic[T]):
     @abstractmethod
     def handle_output(
-        self, context: OutputContext, table_slice: TableSlice, obj: T
+        self, context: OutputContext, table_slice: TableSlice, obj: T, connection
     ) -> Optional[Mapping[str, RawMetadataValue]]:
         """Stores the given object at the given table in the given schema."""
 
     @abstractmethod
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> T:
+    def load_input(self, context: InputContext, table_slice: TableSlice, connection) -> T:
         """Loads the contents of the given table in the given schema."""
 
     @property
@@ -67,7 +68,7 @@ class DbTypeHandler(ABC, Generic[T]):
 class DbClient:
     @staticmethod
     @abstractmethod
-    def delete_table_slice(context: OutputContext, table_slice: TableSlice) -> None:
+    def delete_table_slice(context: OutputContext, table_slice: TableSlice, connection) -> None:
         ...
 
     @staticmethod
@@ -77,6 +78,11 @@ class DbClient:
 
     @staticmethod
     def ensure_schema_exists(context: OutputContext, table_slice: TableSlice) -> None:
+        ...
+
+    @staticmethod
+    @contextmanager
+    def connect(context: Union[OutputContext, InputContext], table_slice: TableSlice):
         ...
 
 
@@ -115,12 +121,21 @@ class DbIOManager(IOManager):
             obj_type = type(obj)
             self._check_supported_type(obj_type)
 
-            self._db_client.delete_table_slice(context, table_slice)
+            with self._db_client.connect(context, table_slice) as conn:
+                self._db_client.delete_table_slice(context, table_slice, conn)
 
+<<<<<<< HEAD
             self._db_client.ensure_schema_exists(context, table_slice)
             handler_metadata = (
                 self._handlers_by_type[obj_type].handle_output(context, table_slice, obj) or {}
             )
+=======
+                self._db_client.create_schema(context, table_slice, conn)
+                handler_metadata = (
+                    self._handlers_by_type[obj_type].handle_output(context, table_slice, obj, conn)
+                    or {}
+                )
+>>>>>>> 1c5d4db795 (refactor to pass connection around)
         else:
             check.invariant(
                 context.dagster_type.is_nothing,
@@ -140,9 +155,10 @@ class DbIOManager(IOManager):
         obj_type = context.dagster_type.typing_type
         self._check_supported_type(obj_type)
 
-        return self._handlers_by_type[obj_type].load_input(
-            context, self._get_table_slice(context, cast(OutputContext, context.upstream_output))
-        )
+        table_slice = self._get_table_slice(context, cast(OutputContext, context.upstream_output))
+
+        with self._db_client.connect(context, table_slice) as conn:
+            return self._handlers_by_type[obj_type].load_input(context, table_slice, conn)
 
     def _get_partition_value(
         self, partition_def: PartitionsDefinition, partition_key: str

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -77,7 +77,8 @@ class DbClient:
         ...
 
     @staticmethod
-    def ensure_schema_exists(context: OutputContext, table_slice: TableSlice) -> None:
+    @abstractmethod
+    def ensure_schema_exists(context: OutputContext, table_slice: TableSlice, connection) -> None:
         ...
 
     @staticmethod
@@ -122,20 +123,12 @@ class DbIOManager(IOManager):
             self._check_supported_type(obj_type)
 
             with self._db_client.connect(context, table_slice) as conn:
+                self._db_client.ensure_schema_exists(context, table_slice, conn)
                 self._db_client.delete_table_slice(context, table_slice, conn)
 
-<<<<<<< HEAD
-            self._db_client.ensure_schema_exists(context, table_slice)
             handler_metadata = (
                 self._handlers_by_type[obj_type].handle_output(context, table_slice, obj) or {}
             )
-=======
-                self._db_client.create_schema(context, table_slice, conn)
-                handler_metadata = (
-                    self._handlers_by_type[obj_type].handle_output(context, table_slice, obj, conn)
-                    or {}
-                )
->>>>>>> 1c5d4db795 (refactor to pass connection around)
         else:
             check.invariant(
                 context.dagster_type.is_nothing,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -73,7 +73,10 @@ def build_db_io_manager(type_handlers, db_client, resource_config_override=None)
 
 def test_asset_out():
     handler = IntHandler()
-    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    connect_mock = MagicMock()
+    db_client = MagicMock(
+        spec=DbClient, get_select_statement=MagicMock(return_value=""), connect=connect_mock
+    )
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
     asset_key = AssetKey(["schema1", "table1"])
     output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
@@ -93,7 +96,9 @@ def test_asset_out():
         database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
-    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+    db_client.delete_table_slice.assert_called_once_with(
+        output_context, table_slice, connect_mock().__enter__()
+    )
 
     assert len(handler.handle_input_calls) == 1
     assert handler.handle_input_calls[0][1] == table_slice
@@ -101,7 +106,10 @@ def test_asset_out():
 
 def test_asset_out_columns():
     handler = IntHandler()
-    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    connect_mock = MagicMock()
+    db_client = MagicMock(
+        spec=DbClient, get_select_statement=MagicMock(return_value=""), connect=connect_mock
+    )
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
     asset_key = AssetKey(["schema1", "table1"])
     output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
@@ -121,7 +129,9 @@ def test_asset_out_columns():
         database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
-    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+    db_client.delete_table_slice.assert_called_once_with(
+        output_context, table_slice, connect_mock().__enter__()
+    )
 
     assert len(handler.handle_input_calls) == 1
     assert handler.handle_input_calls[0][1] == TableSlice(
@@ -135,7 +145,10 @@ def test_asset_out_columns():
 
 def test_asset_out_partitioned():
     handler = IntHandler()
-    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    connect_mock = MagicMock()
+    db_client = MagicMock(
+        spec=DbClient, get_select_statement=MagicMock(return_value=""), connect=connect_mock
+    )
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
     asset_key = AssetKey(["schema1", "table1"])
     partitions_def = DailyPartitionsDefinition(start_date="2020-01-02")
@@ -176,7 +189,9 @@ def test_asset_out_partitioned():
         ],
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
-    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+    db_client.delete_table_slice.assert_called_once_with(
+        output_context, table_slice, connect_mock().__enter__()
+    )
 
     assert len(handler.handle_input_calls) == 1
     assert handler.handle_input_calls[0][1] == table_slice
@@ -184,7 +199,10 @@ def test_asset_out_partitioned():
 
 def test_asset_out_static_partitioned():
     handler = IntHandler()
-    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    connect_mock = MagicMock()
+    db_client = MagicMock(
+        spec=DbClient, get_select_statement=MagicMock(return_value=""), connect=connect_mock
+    )
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
     asset_key = AssetKey(["schema1", "table1"])
     partitions_def = StaticPartitionsDefinition(["red", "yellow", "blue"])
@@ -220,7 +238,9 @@ def test_asset_out_static_partitioned():
         ],
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
-    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+    db_client.delete_table_slice.assert_called_once_with(
+        output_context, table_slice, connect_mock().__enter__()
+    )
 
     assert len(handler.handle_input_calls) == 1
     assert handler.handle_input_calls[0][1] == table_slice
@@ -229,7 +249,10 @@ def test_asset_out_static_partitioned():
 def test_different_output_and_input_types():
     int_handler = IntHandler()
     str_handler = StringHandler()
-    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    connect_mock = MagicMock()
+    db_client = MagicMock(
+        spec=DbClient, get_select_statement=MagicMock(return_value=""), connect=connect_mock
+    )
     manager = build_db_io_manager(type_handlers=[int_handler, str_handler], db_client=db_client)
     asset_key = AssetKey(["schema1", "table1"])
     output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
@@ -240,7 +263,9 @@ def test_different_output_and_input_types():
         database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert int_handler.handle_output_calls[0][1:] == (table_slice, 5)
-    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+    db_client.delete_table_slice.assert_called_once_with(
+        output_context, table_slice, connect_mock().__enter__()
+    )
 
     input_context = MagicMock(
         asset_key=asset_key,
@@ -259,7 +284,10 @@ def test_different_output_and_input_types():
 
 def test_non_asset_out():
     handler = IntHandler()
-    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    connect_mock = MagicMock()
+    db_client = MagicMock(
+        spec=DbClient, get_select_statement=MagicMock(return_value=""), connect=connect_mock
+    )
     manager = build_db_io_manager(type_handlers=[handler], db_client=db_client)
     output_context = build_output_context(
         name="table1", metadata={"schema": "schema1"}, resource_config=resource_config
@@ -280,7 +308,9 @@ def test_non_asset_out():
         database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
     )
     assert handler.handle_output_calls[0][1:] == (table_slice, 5)
-    db_client.delete_table_slice.assert_called_once_with(output_context, table_slice)
+    db_client.delete_table_slice.assert_called_once_with(
+        output_context, table_slice, connect_mock().__enter__()
+    )
 
     assert len(handler.handle_input_calls) == 1
     assert handler.handle_input_calls[0][1] == table_slice

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -31,10 +31,10 @@ class IntHandler(DbTypeHandler[int]):
         self.handle_input_calls = []
         self.handle_output_calls = []
 
-    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: int):
+    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: int, connection):
         self.handle_output_calls.append((context, table_slice, obj))
 
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> int:
+    def load_input(self, context: InputContext, table_slice: TableSlice, connection) -> int:
         self.handle_input_calls.append((context, table_slice))
         return 7
 
@@ -48,10 +48,10 @@ class StringHandler(DbTypeHandler[str]):
         self.handle_input_calls = []
         self.handle_output_calls = []
 
-    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: str):
+    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: str, connection):
         self.handle_output_calls.append((context, table_slice, obj))
 
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> str:
+    def load_input(self, context: InputContext, table_slice: TableSlice, connection) -> str:
         self.handle_input_calls.append((context, table_slice))
         return "8"
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
-from dagster_duckdb.io_manager import DuckDbClient, _connect_duckdb, build_duckdb_io_manager
+from dagster_duckdb.io_manager import DuckDbClient, build_duckdb_io_manager
 
 
 class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
@@ -30,17 +30,19 @@ class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
 
     """
 
-    def handle_output(self, context: OutputContext, table_slice: TableSlice, obj: pd.DataFrame):
+    def handle_output(
+        self, context: OutputContext, table_slice: TableSlice, obj: pd.DataFrame, connection
+    ):
         """Stores the pandas DataFrame in duckdb."""
-        conn = _connect_duckdb(context).cursor()
-
-        conn.execute(
+        connection.execute(
             f"create table if not exists {table_slice.schema}.{table_slice.table} as select * from"
             " obj;"
         )
-        if not conn.fetchall():
+        if not connection.fetchall():
             # table was not created, therefore already exists. Insert the data
-            conn.execute(f"insert into {table_slice.schema}.{table_slice.table} select * from obj")
+            connection.execute(
+                f"insert into {table_slice.schema}.{table_slice.table} select * from obj"
+            )
 
         context.add_output_metadata(
             {
@@ -56,10 +58,11 @@ class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             }
         )
 
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> pd.DataFrame:
+    def load_input(
+        self, context: InputContext, table_slice: TableSlice, connection
+    ) -> pd.DataFrame:
         """Loads the input as a Pandas DataFrame."""
-        conn = _connect_duckdb(context).cursor()
-        return conn.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
+        return connection.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
 
     @property
     def supported_types(self):

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -2,7 +2,7 @@ import pyspark
 import pyspark.sql
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
-from dagster_duckdb.io_manager import DuckDbClient, _connect_duckdb, build_duckdb_io_manager
+from dagster_duckdb.io_manager import DuckDbClient, build_duckdb_io_manager
 from pyspark.sql import SparkSession
 
 
@@ -34,19 +34,21 @@ class DuckDBPySparkTypeHandler(DbTypeHandler[pyspark.sql.DataFrame]):
     """
 
     def handle_output(
-        self, context: OutputContext, table_slice: TableSlice, obj: pyspark.sql.DataFrame
+        self,
+        context: OutputContext,
+        table_slice: TableSlice,
+        obj: pyspark.sql.DataFrame,
+        connection,
     ):
         """Stores the given object at the provided filepath."""
-        conn = _connect_duckdb(context).cursor()
-
         pd_df = obj.toPandas()  # noqa: F841
-        conn.execute(
+        connection.execute(
             f"create table if not exists {table_slice.schema}.{table_slice.table} as select * from"
             " pd_df;"
         )
-        if not conn.fetchall():
+        if not connection.fetchall():
             # table was not created, therefore already exists. Insert the data
-            conn.execute(
+            connection.execute(
                 f"insert into {table_slice.schema}.{table_slice.table} select * from pd_df"
             )
 
@@ -63,10 +65,11 @@ class DuckDBPySparkTypeHandler(DbTypeHandler[pyspark.sql.DataFrame]):
             }
         )
 
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> pyspark.sql.DataFrame:
+    def load_input(
+        self, context: InputContext, table_slice: TableSlice, connection
+    ) -> pyspark.sql.DataFrame:
         """Loads the return of the query as the correct type."""
-        conn = _connect_duckdb(context).cursor()
-        pd_df = conn.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
+        pd_df = connection.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
         spark = SparkSession.builder.getOrCreate()
         return spark.createDataFrame(pd_df)
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -1,36 +1,13 @@
-from typing import Mapping, Union, cast
+from typing import Mapping
 
 import pandas as pd
 import pandas.core.dtypes.common as pd_core_dtypes_common
-from dagster import (
-    InputContext,
-    MetadataValue,
-    OutputContext,
-    TableColumn,
-    TableSchema,
-)
+from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_snowflake import build_snowflake_io_manager
-from dagster_snowflake.resources import SnowflakeConnection
 from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient
 from snowflake.connector.pandas_tools import pd_writer
-
-
-def _connect_snowflake(context: Union[InputContext, OutputContext], table_slice: TableSlice):
-    no_schema_config = (
-        {k: v for k, v in context.resource_config.items() if k != "schema"}
-        if context.resource_config
-        else {}
-    )
-    return SnowflakeConnection(
-        dict(
-            schema=table_slice.schema,
-            connector="sqlalchemy",
-            **cast(Mapping[str, str], no_schema_config),
-        ),
-        context.log,
-    ).get_connection(raw_conn=False)
 
 
 def _convert_timestamp_to_string(s: pd.Series) -> pd.Series:
@@ -79,23 +56,20 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     """
 
     def handle_output(
-        self, context: OutputContext, table_slice: TableSlice, obj: pd.DataFrame
+        self, context: OutputContext, table_slice: TableSlice, obj: pd.DataFrame, connection
     ) -> Mapping[str, RawMetadataValue]:
         from snowflake import connector  # pylint: disable=no-name-in-module
 
         connector.paramstyle = "pyformat"
-        with _connect_snowflake(context, table_slice) as con:
-            with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
-            with_uppercase_cols = with_uppercase_cols.apply(
-                _convert_timestamp_to_string, axis="index"
-            )
-            with_uppercase_cols.to_sql(
-                table_slice.table,
-                con=con.engine,
-                if_exists="append",
-                index=False,
-                method=pd_writer,
-            )
+        with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
+        with_uppercase_cols = with_uppercase_cols.apply(_convert_timestamp_to_string, axis="index")
+        with_uppercase_cols.to_sql(
+            table_slice.table,
+            con=connection.engine,
+            if_exists="append",
+            index=False,
+            method=pd_writer,
+        )
 
         return {
             "row_count": obj.shape[0],
@@ -109,12 +83,15 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             ),
         }
 
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> pd.DataFrame:
-        with _connect_snowflake(context, table_slice) as con:
-            result = pd.read_sql(sql=SnowflakeDbClient.get_select_statement(table_slice), con=con)
-            result = result.apply(_convert_string_to_timestamp, axis="index")
-            result.columns = map(str.lower, result.columns)  # type: ignore  # (bad stubs)
-            return result
+    def load_input(
+        self, context: InputContext, table_slice: TableSlice, connection
+    ) -> pd.DataFrame:
+        result = pd.read_sql(
+            sql=SnowflakeDbClient.get_select_statement(table_slice), con=connection
+        )
+        result = result.apply(_convert_string_to_timestamp, axis="index")
+        result.columns = map(str.lower, result.columns)  # type: ignore  # (bad stubs)
+        return result
 
     @property
     def supported_types(self):

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -84,7 +84,7 @@ def test_handle_output():
             partition_dimensions=[],
         ),
         df,
-        connection
+        connection,
     )
 
     assert metadata == {

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -63,7 +63,7 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
     """
 
     def handle_output(
-        self, context: OutputContext, table_slice: TableSlice, obj: DataFrame
+        self, context: OutputContext, table_slice: TableSlice, obj: DataFrame, _
     ) -> Mapping[str, RawMetadataValue]:
         options = _get_snowflake_options(context.resource_config, table_slice)
 
@@ -84,7 +84,7 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
             ),
         }
 
-    def load_input(self, context: InputContext, table_slice: TableSlice) -> DataFrame:
+    def load_input(self, context: InputContext, table_slice: TableSlice, _) -> DataFrame:
         options = _get_snowflake_options(context.resource_config, table_slice)
 
         spark = SparkSession.builder.getOrCreate()

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -94,6 +94,7 @@ def test_handle_output():
                 partition_dimensions=None,
             ),
             df,
+            None,
         )
 
         assert metadata == {
@@ -127,6 +128,7 @@ def test_load_input():
                 columns=None,
                 partition_dimensions=None,
             ),
+            None,
         )
         assert mock_read.called
 

--- a/python_modules/libraries/dagster-snowflake-pyspark/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/setup.py
@@ -39,6 +39,8 @@ setup(
         f"dagster-snowflake{pin}",
         "pyspark",
         "requests",
+        "sqlalchemy!=1.4.42",  # workaround for https://github.com/snowflakedb/snowflake-sqlalchemy/issues/350
+        "snowflake-sqlalchemy>=1.2",
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -1,4 +1,5 @@
-from typing import Sequence, cast
+from contextlib import contextmanager
+from typing import Mapping, Sequence, cast
 
 from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -140,32 +141,33 @@ def build_snowflake_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOMana
 
 class SnowflakeDbClient(DbClient):
     @staticmethod
-    def ensure_schema_exists(context: OutputContext, table_slice: TableSlice) -> None:
+    @contextmanager
+    def connect(context, table_slice):
         no_schema_config = (
             {k: v for k, v in context.resource_config.items() if k != "schema"}
             if context.resource_config
             else {}
         )
-        with SnowflakeConnection(
-            dict(schema=table_slice.schema, **no_schema_config), context.log
-        ).get_connection() as con:
-            con.execute_string(f"create schema if not exists {table_slice.schema};")
+        yield SnowflakeConnection(
+            dict(
+                schema=table_slice.schema,
+                connector="sqlalchemy",
+                **cast(Mapping[str, str], no_schema_config),
+            ),
+            context.log,
+        ).get_connection(raw_conn=False)
 
     @staticmethod
-    def delete_table_slice(context: OutputContext, table_slice: TableSlice) -> None:
-        no_schema_config = (
-            {k: v for k, v in context.resource_config.items() if k != "schema"}
-            if context.resource_config
-            else {}
-        )
-        with SnowflakeConnection(
-            dict(schema=table_slice.schema, **no_schema_config), context.log
-        ).get_connection() as con:
-            try:
-                con.execute_string(_get_cleanup_statement(table_slice))
-            except ProgrammingError:
-                # table doesn't exist yet, so ignore the error
-                pass
+    def ensure_schema_exists(context: OutputContext, table_slice: TableSlice, connection) -> None:
+        connection.execute(f"create schema if not exists {table_slice.schema};")
+
+    @staticmethod
+    def delete_table_slice(context: OutputContext, table_slice: TableSlice, connection) -> None:
+        try:
+            connection.execute(_get_cleanup_statement(table_slice))
+        except ProgrammingError:
+            # table doesn't exist yet, so ignore the error
+            pass
 
     @staticmethod
     def get_select_statement(table_slice: TableSlice) -> str:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -148,14 +148,15 @@ class SnowflakeDbClient(DbClient):
             if context.resource_config
             else {}
         )
-        yield SnowflakeConnection(
+        with SnowflakeConnection(
             dict(
                 schema=table_slice.schema,
                 connector="sqlalchemy",
                 **cast(Mapping[str, str], no_schema_config),
             ),
             context.log,
-        ).get_connection(raw_conn=False)
+        ).get_connection(raw_conn=False) as conn:
+            yield conn
 
     @staticmethod
     def ensure_schema_exists(context: OutputContext, table_slice: TableSlice, connection) -> None:


### PR DESCRIPTION
### Summary & Motivation
The DB IO managers make connections to the database a lot - this refactors it so that a single connection is made and passed to the various functions. I'm not tied to this approach so if there's a reason that passing the connection around is worse than making it multiple times, I'm happy to keep things as is

### How I Tested These Changes
