### PR TITLE
in docs navigation, make partitions independent from schedules

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -144,7 +144,8 @@
         ]
       },
       {
-        "title": "Schedules, Sensors, & Partitions",
+        "title": "Schedules & Sensors",
+        "path": "/concepts/partitions-schedules-sensors/schedules",
         "children": [
           {
             "title": "Schedules",
@@ -157,7 +158,13 @@
           {
             "title": "Asset Sensors",
             "path": "/concepts/partitions-schedules-sensors/asset-sensors"
-          },
+          }
+        ]
+      },
+      {
+        "title": "Partitions & Backfills",
+        "path": "/concepts/partitions-schedules-sensors/partitions",
+        "children": [
           {
             "title": "Partitions",
             "path": "/concepts/partitions-schedules-sensors/partitions"

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -100,9 +100,9 @@ Jobs are the main unit of execution and monitoring in Dagster. The core of a job
 
 ---
 
-## Schedules
+## Schedules and sensors
 
-Schedules launch runs on a fixed interval, while sensors allow you to do so based on an external state change. These features also support partitioning and backfilling.
+Schedules launch runs on a fixed interval, while sensors allow you to do so based on an external state change.
 
 <ArticleList>
   <ArticleListItem
@@ -113,6 +113,15 @@ Schedules launch runs on a fixed interval, while sensors allow you to do so base
     title="Sensors"
     href="/concepts/partitions-schedules-sensors/sensors"
   ></ArticleListItem>
+</ArticleList>
+
+---
+
+## Partitions and backfills
+
+A software-defined asset or job can represent a collection of _partitions_ that can be tracked and executed independently.
+
+<ArticleList>
   <ArticleListItem
     title="Partitions"
     href="/concepts/partitions-schedules-sensors/partitions"

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -5,19 +5,19 @@ description: Partitioned assets and jobs enable launching backfills, where each 
 
 # Partitioned assets and jobs
 
-Partitioning allows a software-defined asset or job to correspond to a set of entities with identical structure but different parameters.
+A software-defined asset can represent a collection of _partitions_ that can be tracked and materialized independently. In many ways, each partition functions like its own mini-asset, but they all share a common materialization function and dependencies. Typically, each partition will correspond to a separate file, or a slice of a table in a database.
 
-A _partitioned asset_ is an asset that's composed of a set of partitions, which can be materialized and tracked independently. Most commonly, each partition represents all the records in a data set that fall within a particular time window. Depending on where the asset is stored, each partition might correspond to a file or a slice of a table in a database.
+A common use is for each partition to represent all the records in a data set that fall within a particular time window, e.g. hourly, daily or monthly. Alternatively, each partition can represent a region, a customer, an experiment - any dimension along which you want to be able to materialize and monitor independently. An asset can also be partitioned along multiple dimensions, e.g. by region and by hour.
 
-A _partitioned job_ is a job where each run corresponds to a partition key. Most commonly, each partition key represents a time window, so, when a job executes, it processes data within one of the time windows.
+A graph of assets with the same partitions implicitly forms a partitioned data pipeline, and you can launch a run that selects multiple assets and materializes the same partition in each asset.
 
-It's common to construct a partitioned job that materializes a particular set of partitioned assets every time it runs.
+Similarly, a _partitioned job_ is a job where each run corresponds to a partition. It's common to construct a partitioned job that materializes a single partition across a set of partitioned assets every time it runs.
 
-Having defined a partitioned job or asset, you can:
+Having defined a partitioned asset or job, you can:
 
 - View runs by partition in Dagit.
 - Define a [schedule](/concepts/partitions-schedules-sensors/schedules) that fills in a partition each time it runs. For example, a job might run each day and process the data that arrived during the previous day.
-- Launch [backfills](/concepts/partitions-schedules-sensors/backfills), which are sets of runs that each process a different partition. For example, after making a code change, you might want to run your job on all time windows instead of just one of them.
+- Launch [backfills](/concepts/partitions-schedules-sensors/backfills), which are sets of runs that each process a different partition. For example, after making a code change, you might want to run your job on all partitions instead of just one of them.
 
 ---
 


### PR DESCRIPTION
### Summary & Motivation

The fact that we bucket partitions with schedules makes users think that we discourage use of non-time-window partitions.

### How I Tested These Changes
