### PR TITLE
fix: only inspect schema when we may create tables

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -84,14 +84,14 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         self._secondary_index_cache = {}
 
-        table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
-
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        if self.should_autocreate_tables and "event_logs" not in table_names:
-            retry_pg_creation_fn(self._init_db)
-            self.reindex_events()
-            self.reindex_assets()
+        if self.should_autocreate_tables:
+            table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
+            if "event_logs" not in table_names:
+                retry_pg_creation_fn(self._init_db)
+                self.reindex_events()
+                self.reindex_assets()
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -73,17 +73,17 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         )
 
         self._index_migration_cache = {}
-        table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        if self.should_autocreate_tables and "runs" not in table_names:
-            retry_pg_creation_fn(self._init_db)
-            self.migrate()
-            self.optimize()
-
-        elif "instance_info" not in table_names:
-            InstanceInfo.create(self._engine)
+        if self.should_autocreate_tables:
+            table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
+            if "runs" not in table_names:
+                retry_pg_creation_fn(self._init_db)
+                self.migrate()
+                self.optimize()
+            elif "instance_info" not in table_names:
+                InstanceInfo.create(self._engine)
 
         super().__init__()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -62,13 +62,13 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool
         )
 
-        table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
-
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
-        missing_main_table = "schedules" not in table_names and "jobs" not in table_names
-        if self.should_autocreate_tables and missing_main_table:
-            retry_pg_creation_fn(self._init_db)
+        if self.should_autocreate_tables:
+            table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
+            missing_main_table = "schedules" not in table_names and "jobs" not in table_names
+            if missing_main_table:
+                retry_pg_creation_fn(self._init_db)
 
         super().__init__()
 


### PR DESCRIPTION
### Summary & Motivation

Querying the database schema is only necessary when we're configured to possibly create missing tables. Given that this occurs in 3 different places when starting a dagster process, it becomes quite expensive.

### How I Tested These Changes

`python -m pytest python_modules/libraries/dagster-postgres/dagster_postgres_tests` not sure if there's a better approach