### PR TITLE
[fix] Surface the correct description for multi-assets when a description is provided for the op

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1241,7 +1241,7 @@ def external_asset_graph_from_defs(
                 graph_name=graph_name,
                 op_names=op_names_by_asset_key[asset_key],
                 code_version=code_version_by_asset_key.get(asset_key),
-                op_description=node_def.description or output_def.description,
+                op_description=output_def.description or node_def.description,
                 node_definition_name=node_def.name,
                 job_names=job_names,
                 partitions_def_data=partitions_def_data,

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -372,6 +372,7 @@ def test_basic_multi_asset():
         }
     )
     def assets():
+        """Some docstring for this operation"""
         pass
 
     assets_job = build_assets_job("assets_job", [assets])


### PR DESCRIPTION
### Summary & Motivation

The ExternalAssetNode object has a lot of deprecated / misnamed fields. In this case, the `op_description` field is what is used to populate descriptions of assets, even if that op produces multiple assets. We populated this field correctly (i.e. using the output description instead) in cases where there was no actual op description, but that causes problems in cases like the (updated) test. Basically, if you add a docstring to your multi-asset op, then that docstring will be used as the description for all the assets created by the op.

This fixes that issue.

### How I Tested These Changes
