### PR TITLE
[ruff] Enable B018 (expression-not-assigned)

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/simple_example.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_type_factories/simple_example.py
@@ -1,4 +1,3 @@
-# pylint: disable=expression-not-assigned
 # one_off_type_start
 
 from dagster import DagsterType, check_dagster_type

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_ops.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_materialization_ops.py
@@ -17,7 +17,7 @@ def test_ops_compile_and_execute():
     ]
 
     for op, has_context_arg in ops:
-        op(None) if has_context_arg else op()  # pylint: disable=expression-not-assigned
+        op(None) if has_context_arg else op()
 
 
 def test_partition_config_ops_compile_and_execute():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,9 @@ select = [
   "A001",
   "A002",
 
+  # (useless expression): Expressions that aren't assigned to anything are typically bugs.
+  "B018",
+
   # (pydocstyle) Docstring-related rules. A large subset of these are ignored by the
   # "convention=google" setting, we set under tool.ruff.pydocstyle.
   "D",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -829,10 +829,10 @@ def test_filtered_runs_multiple_filters():
 def test_filtered_runs_count():
     with instance_for_test() as instance:
         repo = get_repo_at_time_1()
-        instance.create_run_for_pipeline(  # pylint: disable=expression-not-assigned
+        instance.create_run_for_pipeline(
             repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.STARTED
         ).run_id
-        instance.create_run_for_pipeline(  # pylint: disable=expression-not-assigned
+        instance.create_run_for_pipeline(
             repo.get_pipeline("foo_pipeline"), status=DagsterRunStatus.FAILURE
         ).run_id
         with define_out_of_process_context(__file__, "get_repo_at_time_1", instance) as context:

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -674,7 +674,7 @@ def test_invalid_properties_on_context(property_or_method_name, val_to_pass):
         result = getattr(context, property_or_method_name)
         # for the case where property_or_method_name is a method, getting an attribute won't cause
         # an error, but invoking the method should.
-        result(val_to_pass) if val_to_pass else result()  # pylint: disable=expression-not-assigned
+        result(val_to_pass) if val_to_pass else result()
 
     with pytest.raises(DagsterInvalidPropertyError):
         solid_fails_getting_property(None)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -104,7 +104,7 @@ def test_instance_access():
         DagsterInvariantViolationError,
         match="Attempted to initialize dagster instance, but no instance reference was provided.",
     ):
-        build_schedule_context().instance  # pylint: disable=expression-not-assigned
+        build_schedule_context().instance
 
     with instance_for_test() as instance:
         assert isinstance(build_schedule_context(instance).instance, DagsterInstance)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -163,7 +163,7 @@ def test_instance_access_built_sensor():
         DagsterInvariantViolationError,
         match="Attempted to initialize dagster instance, but no instance reference was provided.",
     ):
-        build_sensor_context().instance  # pylint: disable=expression-not-assigned
+        build_sensor_context().instance
 
     with instance_for_test() as instance:
         assert isinstance(build_sensor_context(instance).instance, DagsterInstance)


### PR DESCRIPTION
### Summary & Motivation

Enable ruff `B018` (`expression-not-assigned`). Replaces previously enabled pylint rule.

### How I Tested These Changes

BK