### PR TITLE
[typing/static] storage

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1,5 +1,3 @@
-# pyright: strict reportPrivateUsage=off
-
 import hashlib
 import json
 import warnings

--- a/python_modules/dagster/dagster/_core/definitions/policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/policy.py
@@ -92,7 +92,9 @@ class RetryPolicy(
         )
 
 
-def calculate_delay(attempt_num, backoff, jitter, base_delay):
+def calculate_delay(
+    attempt_num: int, backoff: Optional[Backoff], jitter: Optional[Jitter], base_delay: float
+) -> float:
     if backoff is Backoff.EXPONENTIAL:
         calc_delay = ((2**attempt_num) - 1) * base_delay
     elif backoff is Backoff.LINEAR:

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from typing import Mapping, NamedTuple, Optional, Sequence, Union
+from typing import Callable, Mapping, NamedTuple, Optional, Sequence, Union
+
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
@@ -8,6 +10,8 @@ from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._serdes import whitelist_for_serdes
+
+EventHandlerFn: TypeAlias = Callable[[EventLogEntry, str], None]
 
 
 class RunShardedEventsCursor(NamedTuple):

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 from abc import ABC, abstractmethod
 from typing import AbstractSet, Callable, List, Optional, Sequence, Set, Union, cast
 

--- a/python_modules/dagster/dagster/_core/execution/stats.py
+++ b/python_modules/dagster/dagster/_core/execution/stats.py
@@ -1,5 +1,3 @@
-# pyright: strict reportUnnecessaryIsInstance=false
-
 from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, Iterable, NamedTuple, Optional, Sequence, cast

--- a/python_modules/dagster/dagster/_core/execution/stats.py
+++ b/python_modules/dagster/dagster/_core/execution/stats.py
@@ -1,3 +1,5 @@
+# pyright: strict reportUnnecessaryIsInstance=false
+
 from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, Iterable, NamedTuple, Optional, Sequence, cast
@@ -11,7 +13,9 @@ from dagster._serdes import whitelist_for_serdes
 from dagster._utils import datetime_as_float
 
 
-def build_run_stats_from_events(run_id, records):
+def build_run_stats_from_events(
+    run_id: str, records: Iterable[EventLogEntry]
+) -> PipelineRunStatsSnapshot:
     try:
         iter(records)
     except TypeError as exc:

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -24,7 +24,14 @@ class IDagsterMeta(Protocol):
         ...
 
 
-# We type-ignore because this is a stub class, we only ever cast log records to this.
+# The type-checker complains here that DagsterLogRecord does not implement the `dagster_meta`
+# property of `IDagsterMeta`. We ignore this error because we don't need to implement this method--
+# `DagsterLogRecord` is a stub class that is never instantiated. We only ever cast
+# `logging.LogRecord` objects to `DagsterLogRecord`, because it gives us typed access to the
+# `dagster_meta` property. `dagster_meta` itself is set on these `logging.LogRecord` objects via the
+# `extra` argument to `logging.Logger.log` (see `DagsterLogManager.log_dagster_event`), but
+# `logging.LogRecord` has no way of exposing to the type-checker the attributes that are dynamically
+# defined via `extra`.
 class DagsterLogRecord(logging.LogRecord, IDagsterMeta):  # type: ignore
     pass
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
+
+from typing_extensions import Protocol
 
 import dagster._check as check
 from dagster._core.utils import coerce_valid_log_level, make_new_run_id
@@ -14,6 +16,17 @@ if TYPE_CHECKING:
     from dagster._legacy import DagsterRun
 
 DAGSTER_META_KEY = "dagster_meta"
+
+
+class IDagsterMeta(Protocol):
+    @property
+    def dagster_meta(self) -> DagsterLoggingMetadata:
+        ...
+
+
+# We type-ignore because this is a stub class, we only ever cast log records to this.
+class DagsterLogRecord(logging.LogRecord, IDagsterMeta):  # type: ignore
+    pass
 
 
 class DagsterMessageProps(
@@ -123,7 +136,7 @@ class DagsterLoggingMetadata(
         )
 
     @property
-    def log_source(self):
+    def log_source(self) -> str:
         if self.resource_name is None:
             return self.pipeline_name or "system"
         return f"resource:{self.resource_name}"
@@ -160,7 +173,7 @@ def construct_log_string(
 
 def get_dagster_meta_dict(
     logging_metadata: DagsterLoggingMetadata, dagster_message_props: DagsterMessageProps
-) -> Mapping[str, Any]:
+) -> Mapping[str, object]:
     # combine all dagster meta information into a single dictionary
     meta_dict = {
         **logging_metadata._asdict(),
@@ -197,7 +210,7 @@ class DagsterLogHandler(logging.Handler):
         super().__init__()
 
     @property
-    def logging_metadata(self):
+    def logging_metadata(self) -> DagsterLoggingMetadata:
         return self._logging_metadata
 
     def with_tags(self, **new_tags: str) -> DagsterLogHandler:
@@ -219,7 +232,7 @@ class DagsterLogHandler(logging.Handler):
         ]
         return {k: v for k, v in record.__dict__.items() if k not in ref_attrs}
 
-    def _convert_record(self, record: logging.LogRecord) -> logging.LogRecord:
+    def _convert_record(self, record: logging.LogRecord) -> DagsterLogRecord:
         # we store the originating DagsterEvent in the DAGSTER_META_KEY field, if applicable
         dagster_meta = getattr(record, DAGSTER_META_KEY, None)
 
@@ -239,7 +252,8 @@ class DagsterLogHandler(logging.Handler):
         record.msg = construct_log_string(self._logging_metadata, dagster_message_props)
         record.args = ()
 
-        return record
+        # DagsterLogRecord is a LogRecord with a `dagster_meta` field
+        return cast(DagsterLogRecord, record)
 
     def filter(self, record: logging.LogRecord) -> bool:
         """If you list multiple levels of a python logging hierarchy as managed loggers, and do not
@@ -251,7 +265,7 @@ class DagsterLogHandler(logging.Handler):
             getattr(record, DAGSTER_META_KEY, None), dict
         )
 
-    def emit(self, record: logging.LogRecord):
+    def emit(self, record: logging.LogRecord) -> None:
         """For any received record, add Dagster metadata, and have handlers handle it."""
         try:
             # to prevent the potential for infinite loops in which a handler produces log messages

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -28,7 +28,7 @@ from dagster._utils.error import SerializableErrorInfo
 CURRENT_SNAPSHOT_VERSION = 1
 
 
-def create_execution_plan_snapshot_id(execution_plan_snapshot) -> str:
+def create_execution_plan_snapshot_id(execution_plan_snapshot: "ExecutionPlanSnapshot") -> str:
     check.inst_param(execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot)
     return create_snapshot_id(execution_plan_snapshot)
 

--- a/python_modules/dagster/dagster/_core/storage/alembic/env.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/env.py
@@ -12,6 +12,6 @@ config = context.config
 target_metadata = [SqlEventLogStorageMetadata, SqlRunStorage, SqlScheduleStorage]
 
 if context.is_offline_mode():
-    run_migrations_offline(context, config, target_metadata)
+    run_migrations_offline(context, config, target_metadata)  # type: ignore  # (bad stubs)
 else:
-    run_migrations_online(context, config, target_metadata)
+    run_migrations_online(context, config, target_metadata)  # type: ignore  # (bad stubs)

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -63,7 +63,7 @@ class AssetValueLoader:
         self,
         asset_key: CoercibleToAssetKey,
         *,
-        python_type: Optional[Type] = None,
+        python_type: Optional[Type[object]] = None,
         partition_key: Optional[str] = None,
     ) -> object:
         """

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -134,6 +134,7 @@ class CapturedLogSubscription:
 
 
 def _has_max_data(chunk: Optional[bytes]) -> bool:
+    # function is used as predicate but does not actually return a boolean
     return chunk and len(chunk) >= MAX_BYTES_CHUNK_READ  # type: ignore
 
 

--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -5,7 +5,9 @@ import time
 from abc import abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import IO, Generator, Optional, Sequence, Union
+from typing import IO, Iterator, Optional, Sequence, Union
+
+from typing_extensions import TypeAlias
 
 from dagster import _check as check
 from dagster._core.storage.captured_log_manager import (
@@ -28,6 +30,8 @@ from dagster._core.storage.local_compute_log_manager import (
 )
 
 SUBSCRIPTION_POLLING_INTERVAL = 5
+
+LogSubscription: TypeAlias = Union[CapturedLogSubscription, ComputeLogSubscription]
 
 
 class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
@@ -52,19 +56,19 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
     @abstractmethod
     def delete_logs(
         self, log_key: Optional[Sequence[str]] = None, prefix: Optional[Sequence[str]] = None
-    ):
+    ) -> None:
         """
         Deletes logs for a given log_key or prefix.
         """
 
     @abstractmethod
-    def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+    def download_url_for_type(self, log_key: Sequence[str], io_type: ComputeIOType) -> str:
         """
         Calculates a download url given a log key and compute io type.
         """
 
     @abstractmethod
-    def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType):
+    def display_path_for_type(self, log_key: Sequence[str], io_type: ComputeIOType) -> str:
         """
         Returns a display path given a log key and compute io type.
         """
@@ -79,21 +83,21 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
 
     @abstractmethod
     def upload_to_cloud_storage(
-        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
-    ):
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
+    ) -> None:
         """
         Uploads the logs for a given log key from local storage to cloud storage.
         """
 
     def download_from_cloud_storage(
-        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
-    ):
+        self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
+    ) -> None:
         """
         Downloads the logs for a given log key from cloud storage to local storage.
         """
 
     @contextmanager
-    def capture_logs(self, log_key: Sequence[str]) -> Generator[CapturedLogContext, None, None]:
+    def capture_logs(self, log_key: Sequence[str]) -> Iterator[CapturedLogContext]:
         with self._poll_for_local_upload(log_key):
             with self.local_manager.capture_logs(log_key) as context:
                 yield context
@@ -102,7 +106,7 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
     @contextmanager
     def open_log_stream(
         self, log_key: Sequence[str], io_type: ComputeIOType
-    ) -> Generator[Optional[IO], None, None]:
+    ) -> Iterator[Optional[IO]]:
         with self.local_manager.open_log_stream(log_key, io_type) as f:
             yield f
         self._on_capture_complete(log_key)
@@ -117,7 +121,9 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
         # check remote storage
         return self.cloud_storage_has_logs(log_key, ComputeIOType.STDERR)
 
-    def log_data_for_type(self, log_key, io_type, offset, max_bytes):
+    def log_data_for_type(
+        self, log_key: Sequence[str], io_type: ComputeIOType, offset: int, max_bytes: Optional[int]
+    ):
         if self._has_local_file(log_key, io_type):
             local_path = self.local_manager.get_captured_local_path(
                 log_key, IO_TYPE_EXTENSION[io_type]
@@ -178,23 +184,23 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
         self, log_key: Sequence[str], cursor: Optional[str] = None
     ) -> CapturedLogSubscription:
         subscription = CapturedLogSubscription(self, log_key, cursor)
-        self.on_subscribe(subscription)
+        self.on_subscribe(subscription)  # type: ignore
         return subscription
 
     def unsubscribe(self, subscription):
         self.on_unsubscribe(subscription)
 
-    def _has_local_file(self, log_key, io_type):
+    def _has_local_file(self, log_key: Sequence[str], io_type: ComputeIOType):
         local_path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
         return os.path.exists(local_path)
 
-    def _should_download(self, log_key, io_type):
+    def _should_download(self, log_key: Sequence[str], io_type: ComputeIOType):
         return not self._has_local_file(log_key, io_type) and self.cloud_storage_has_logs(
             log_key, io_type
         )
 
     @contextmanager
-    def _poll_for_local_upload(self, log_key):
+    def _poll_for_local_upload(self, log_key: Sequence[str]) -> Iterator[None]:
         if not self.upload_interval:
             yield
             return
@@ -303,7 +309,7 @@ class PollingComputeLogSubscriptionManager:
         self._shutdown_event = None
         self._polling_thread = None
 
-    def _log_key(self, subscription):
+    def _log_key(self, subscription: LogSubscription) -> Sequence[str]:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -315,7 +321,7 @@ class PollingComputeLogSubscriptionManager:
     def _watch_key(self, log_key: Sequence[str]) -> str:
         return json.dumps(log_key)
 
-    def _start_polling_thread(self):
+    def _start_polling_thread(self) -> None:
         if self._polling_thread:
             return
 
@@ -328,18 +334,16 @@ class PollingComputeLogSubscriptionManager:
         self._polling_thread.daemon = True
         self._polling_thread.start()
 
-    def _stop_polling_thread(self):
+    def _stop_polling_thread(self) -> None:
         if not self._polling_thread:
             return
 
         old_shutdown_event = self._shutdown_event
-        old_shutdown_event.set()  # set to signal to the old thread to die
+        old_shutdown_event.set()  # set to signal to the old thread to die  # type: ignore
         self._polling_thread = None
         self._shutdown_event = None
 
-    def add_subscription(
-        self, subscription: Union[ComputeLogSubscription, CapturedLogSubscription]
-    ):
+    def add_subscription(self, subscription: LogSubscription) -> None:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -355,7 +359,7 @@ class PollingComputeLogSubscriptionManager:
             watch_key = self._watch_key(log_key)
             self._subscriptions[watch_key].append(subscription)
 
-    def is_complete(self, subscription: Union[ComputeLogSubscription, CapturedLogSubscription]):
+    def is_complete(self, subscription: LogSubscription) -> bool:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -364,7 +368,7 @@ class PollingComputeLogSubscriptionManager:
             return self._manager.is_watch_completed(subscription.run_id, subscription.key)
         return self._manager.is_capture_complete(subscription.log_key)
 
-    def remove_subscription(self, subscription):
+    def remove_subscription(self, subscription: LogSubscription) -> None:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -380,7 +384,7 @@ class PollingComputeLogSubscriptionManager:
         if not len(self._subscriptions) and self._polling_thread:
             self._stop_polling_thread()
 
-    def remove_all_subscriptions(self, log_key):
+    def remove_all_subscriptions(self, log_key: Sequence[str]) -> None:
         watch_key = self._watch_key(log_key)
         for subscription in self._subscriptions.pop(watch_key, []):
             subscription.complete()
@@ -388,12 +392,12 @@ class PollingComputeLogSubscriptionManager:
         if not len(self._subscriptions) and self._polling_thread:
             self._stop_polling_thread()
 
-    def notify_subscriptions(self, log_key):
+    def notify_subscriptions(self, log_key: Sequence[str]) -> None:
         watch_key = self._watch_key(log_key)
         for subscription in self._subscriptions[watch_key]:
             subscription.fetch()
 
-    def _poll(self, shutdown_event):
+    def _poll(self, shutdown_event: threading.Event) -> None:
         while True:
             if shutdown_event.is_set():
                 return
@@ -405,7 +409,7 @@ class PollingComputeLogSubscriptionManager:
                     subscription.fetch()
             time.sleep(SUBSCRIPTION_POLLING_INTERVAL)
 
-    def dispose(self):
+    def dispose(self) -> None:
         if self._shutdown_event:
             self._shutdown_event.set()
 
@@ -415,7 +419,7 @@ def _upload_partial_logs(
     log_key: Sequence[str],
     thread_exit: threading.Event,
     interval: int,
-):
+) -> None:
     while True:
         time.sleep(interval)
         if thread_exit.is_set() or compute_log_manager.is_capture_complete(log_key):

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -211,11 +211,11 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         check.opt_str_param(cursor, "cursor")
 
         if cursor:
-            cursor = int(cursor)  # type: ignore
+            cursor = int(cursor)  # type: ignore   # (var reassigned diff type)
         else:
-            cursor = 0  # type: ignore
+            cursor = 0  # type: ignore  # (var reassigned diff type)
 
-        subscription = ComputeLogSubscription(self, run_id, key, io_type, cursor)  # type: ignore
+        subscription = ComputeLogSubscription(self, run_id, key, io_type, cursor)  # type: ignore  # (var reassigned diff type)
         self.on_subscribe(subscription)
         return subscription
 

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from enum import Enum
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, Iterator, NamedTuple, Optional
+
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._core.instance import MayHaveInstanceWeakref
@@ -49,7 +51,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
     """
 
     @contextmanager
-    def watch(self, pipeline_run, step_key=None):
+    def watch(self, pipeline_run: DagsterRun, step_key: Optional[str] = None) -> Iterator[None]:
         """
         Watch the stdout/stderr for a given execution for a given run_id / step_key and persist it.
 
@@ -71,7 +73,9 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
 
     @contextmanager
     @abstractmethod
-    def _watch_logs(self, pipeline_run, step_key=None):
+    def _watch_logs(
+        self, pipeline_run: DagsterRun, step_key: Optional[str] = None
+    ) -> Iterator[None]:
         """
         Method to watch the stdout/stderr logs for a given run_id / step_key.  Kept separate from
         blessed `watch` method, which triggers all the start/finish hooks that are necessary to
@@ -99,7 +103,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         ...
 
     @abstractmethod
-    def is_watch_completed(self, run_id, key):
+    def is_watch_completed(self, run_id: str, key: str) -> bool:
         """Flag indicating when computation for a given execution step has completed.
 
         Args:
@@ -111,7 +115,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def on_watch_start(self, pipeline_run, step_key):
+    def on_watch_start(self, pipeline_run: DagsterRun, step_key: Optional[str]) -> None:
         """Hook called when starting to watch compute logs.
 
         Args:
@@ -120,7 +124,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def on_watch_finish(self, pipeline_run, step_key):
+    def on_watch_finish(self, pipeline_run: DagsterRun, step_key: Optional[str]) -> None:
         """Hook called when computation for a given execution step is finished.
 
         Args:
@@ -129,7 +133,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def download_url(self, run_id, key, io_type):
+    def download_url(self, run_id: str, key: str, io_type: ComputeIOType) -> str:
         """Get a URL where the logs can be downloaded.
 
         Args:
@@ -143,7 +147,12 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
 
     @abstractmethod
     def read_logs_file(
-        self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ
+        self,
+        run_id: str,
+        key: str,
+        io_type: ComputeIOType,
+        cursor: int = 0,
+        max_bytes: int = MAX_BYTES_FILE_READ,
     ) -> ComputeLogFileData:
         """Get compute log data for a given compute step.
 
@@ -158,7 +167,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
             ComputeLogFileData
         """
 
-    def enabled(self, _pipeline_run, _step_key):
+    def enabled(self, _pipeline_run: DagsterRun, _step_key: Optional[str]) -> bool:
         """Hook for disabling compute log capture.
 
         Args:
@@ -170,7 +179,7 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         return True
 
     @abstractmethod
-    def on_subscribe(self, subscription):
+    def on_subscribe(self, subscription: "ComputeLogSubscription") -> None:
         """Hook for managing streaming subscriptions for log data from `dagit`.
 
         Args:
@@ -178,10 +187,12 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
                 back data to the subscriber
         """
 
-    def on_unsubscribe(self, subscription):
+    def on_unsubscribe(self, subscription: "ComputeLogSubscription") -> None:
         pass
 
-    def observable(self, run_id, key, io_type, cursor=None) -> "ComputeLogSubscription":
+    def observable(
+        self, run_id: str, key: str, io_type: ComputeIOType, cursor: Optional[str] = None
+    ) -> "ComputeLogSubscription":
         """Return a ComputeLogSubscription which streams back log data from the execution logs for a given
         compute step.
 
@@ -200,13 +211,13 @@ class ComputeLogManager(ABC, MayHaveInstanceWeakref):
         check.opt_str_param(cursor, "cursor")
 
         if cursor:
-            cursor = int(cursor)
+            cursor = int(cursor)  # type: ignore
         else:
-            cursor = 0
+            cursor = 0  # type: ignore
 
-        subscription = ComputeLogSubscription(self, run_id, key, io_type, cursor)
+        subscription = ComputeLogSubscription(self, run_id, key, io_type, cursor)  # type: ignore
         self.on_subscribe(subscription)
-        return subscription  # pylint: disable=E1101
+        return subscription
 
     def dispose(self):
         pass
@@ -220,10 +231,10 @@ class ComputeLogSubscription:
     def __init__(
         self,
         manager: ComputeLogManager,
-        run_id,
-        key,
-        io_type,
-        cursor,
+        run_id: str,
+        key: str,
+        io_type: ComputeIOType,
+        cursor: int,
     ):
         self.manager = manager
         self.run_id = run_id
@@ -233,19 +244,19 @@ class ComputeLogSubscription:
         self.observer: Optional[Callable[[ComputeLogFileData], None]] = None
         self.is_complete = False
 
-    def __call__(self, observer: Callable[[ComputeLogFileData], None]):
+    def __call__(self, observer: Callable[[ComputeLogFileData], None]) -> Self:
         self.observer = observer
         self.fetch()
         if self.manager.is_watch_completed(self.run_id, self.key):
             self.complete()
         return self
 
-    def dispose(self):
+    def dispose(self) -> None:
         # called when the connection gets closed, allowing the observer to get GC'ed
         self.observer = None
         self.manager.on_unsubscribe(self)
 
-    def fetch(self):
+    def fetch(self) -> None:
         if not self.observer:
             return
 
@@ -263,7 +274,7 @@ class ComputeLogSubscription:
                 self.cursor = update.cursor
             should_fetch = update.data and len(update.data.encode("utf-8")) >= MAX_BYTES_CHUNK_READ
 
-    def complete(self):
+    def complete(self) -> None:
         self.is_complete = True
         if not self.observer:
             return

--- a/python_modules/dagster/dagster/_core/storage/config.py
+++ b/python_modules/dagster/dagster/_core/storage/config.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 from typing import Dict
 
 from typing_extensions import TypedDict

--- a/python_modules/dagster/dagster/_core/storage/config.py
+++ b/python_modules/dagster/dagster/_core/storage/config.py
@@ -1,7 +1,27 @@
+# pyright: strict
+
+from typing import Dict
+
+from typing_extensions import TypedDict
+
 from dagster._config import Field, IntSource, Permissive, Selector, StringSource
+from dagster._config.config_schema import UserConfigSchema
 
 
-def mysql_config():
+class MySqlStorageConfig(TypedDict):
+    mysql_url: str
+    mysql_db: "MySqlStorageConfigDb"
+
+
+class MySqlStorageConfigDb(TypedDict):
+    username: str
+    password: str
+    hostname: str
+    db_name: str
+    port: int
+
+
+def mysql_config() -> UserConfigSchema:
     return Selector(
         {
             "mysql_url": StringSource,
@@ -16,7 +36,22 @@ def mysql_config():
     )
 
 
-def pg_config():
+class PostgresStorageConfig(TypedDict):
+    postgres_url: str
+    postgres_db: "PostgresStorageConfigDb"
+
+
+class PostgresStorageConfigDb(TypedDict):
+    username: str
+    password: str
+    hostname: str
+    db_name: str
+    port: int
+    params: Dict[str, object]
+    scheme: str
+
+
+def pg_config() -> UserConfigSchema:
     return {
         "postgres_url": Field(StringSource, is_required=False),
         "postgres_db": Field(

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -52,7 +52,7 @@ class DbTypeHandler(ABC, Generic[T]):
 
     @property
     @abstractmethod
-    def supported_types(self) -> Sequence[Type]:
+    def supported_types(self) -> Sequence[Type[object]]:
         pass
 
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -6,23 +6,29 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Iterator, Optional, Sequence
 
 import sqlalchemy as db
+import sqlalchemy.exc as db_exc
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.pool import NullPool
 from tqdm import tqdm
-from watchdog.events import PatternMatchingEventHandler
+from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
 from watchdog.observers import Observer
 
 import dagster._check as check
 import dagster._seven as seven
 from dagster._config import StringSource
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.event_api import EventHandlerFn
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
 from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     get_alembic_config,
@@ -40,6 +46,8 @@ from dagster._utils import mkdir_p
 from ..schema import SqlEventLogStorageMetadata, SqlEventLogStorageTable
 from ..sql_event_log import RunShardedEventsCursor, SqlEventLogStorage
 
+if TYPE_CHECKING:
+    from dagster._core.storage.sqlite_storage import SqliteStorageConfig
 INDEX_SHARD_NAME = "index"
 
 
@@ -68,7 +76,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     run.
     """
 
-    def __init__(self, base_dir, inst_data=None):
+    def __init__(self, base_dir: str, inst_data: Optional[ConfigurableClassData] = None):
         """Note that idempotent initialization of the SQLite database is done on a per-run_id
         basis in the body of connect, since each run is stored in a separate database.
         """
@@ -96,7 +104,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         super().__init__()
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         all_run_ids = self.get_all_run_ids()
         print(  # pylint: disable=print-call
             f"Updating event log storage for {len(all_run_ids)} runs on disk..."
@@ -114,18 +122,20 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         self._initialized_dbs = set()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: "SqliteStorageConfig"
+    ) -> "SqliteEventLogStorage":
         return SqliteEventLogStorage(inst_data=inst_data, **config_value)
 
-    def get_all_run_ids(self):
+    def get_all_run_ids(self) -> Sequence[str]:
         all_filenames = glob.glob(os.path.join(self._base_dir, "*.db"))
         return [
             os.path.splitext(os.path.basename(filename))[0]
@@ -138,14 +148,14 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         engine = create_engine(conn_string, poolclass=NullPool)
         return bool(engine.dialect.has_table(engine.connect(), table_name))
 
-    def path_for_shard(self, run_id):
+    def path_for_shard(self, run_id: str) -> str:
         return os.path.join(self._base_dir, "{run_id}.db".format(run_id=run_id))
 
-    def conn_string_for_shard(self, shard_name):
+    def conn_string_for_shard(self, shard_name: str) -> str:
         check.str_param(shard_name, "shard_name")
         return create_db_conn_string(self._base_dir, shard_name)
 
-    def _initdb(self, engine):
+    def _initdb(self, engine: Engine) -> None:
         alembic_config = get_alembic_config(__file__)
 
         retry_limit = 10
@@ -161,7 +171,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                         stamp_alembic_rev(alembic_config, connection)
 
                 break
-            except (db.exc.DatabaseError, sqlite3.DatabaseError, sqlite3.OperationalError) as exc:
+            except (db_exc.DatabaseError, sqlite3.DatabaseError, sqlite3.OperationalError) as exc:
                 # This is SQLite-specific handling for concurrency issues that can arise when
                 # multiple processes (e.g. the dagit process and user code process) contend with
                 # each other to init the db. When we hit the following errors, we know that another
@@ -194,7 +204,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     retry_limit -= 1
 
     @contextmanager
-    def _connect(self, shard):
+    def _connect(self, shard: str) -> Iterator[Connection]:
         with self._db_lock:
             check.str_param(shard, "shard")
 
@@ -214,12 +224,12 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             engine.dispose()
 
     def run_connection(self, run_id: Optional[str] = None) -> Any:
-        return self._connect(run_id)
+        return self._connect(run_id)  # type: ignore  # bad sig
 
-    def index_connection(self):
+    def index_connection(self) -> ContextManager[Connection]:
         return self._connect(INDEX_SHARD_NAME)
 
-    def store_event(self, event):
+    def store_event(self, event: EventLogEntry) -> None:
         """
         Overridden method to replicate asset events in a central assets.db sqlite shard, enabling
         cross-run asset queries.
@@ -234,7 +244,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         with self.run_connection(run_id) as conn:
             conn.execute(insert_event_statement)
 
-        if event.is_dagster_event and event.dagster_event.asset_key:
+        if event.is_dagster_event and event.dagster_event.asset_key:  # type: ignore
             check.invariant(
                 event.dagster_event_type in ASSET_EVENTS,
                 (
@@ -354,10 +364,10 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         return event_records[:limit]
 
-    def supports_event_consumer_queries(self):
+    def supports_event_consumer_queries(self) -> bool:
         return False
 
-    def delete_events(self, run_id):
+    def delete_events(self, run_id: str) -> None:
         with self.run_connection(run_id) as conn:
             self.delete_events_for_run(conn, run_id)
 
@@ -365,7 +375,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         with self.index_connection() as conn:
             self.delete_events_for_run(conn, run_id)
 
-    def wipe(self):
+    def wipe(self) -> None:
         # should delete all the run-sharded dbs as well as the index db
         for filename in (
             glob.glob(os.path.join(self._base_dir, "*.db"))
@@ -376,7 +386,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         self._initialized_dbs = set()
 
-    def _delete_mirrored_events_for_asset_key(self, asset_key):
+    def _delete_mirrored_events_for_asset_key(self, asset_key: AssetKey) -> None:
         with self.index_connection() as conn:
             conn.execute(
                 SqlEventLogStorageTable.delete().where(  # pylint: disable=no-value-for-parameter
@@ -387,14 +397,14 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 )
             )
 
-    def wipe_asset(self, asset_key):
+    def wipe_asset(self, asset_key: AssetKey) -> None:
         # default implementation will update the event_logs in the sharded dbs, and the asset_key
         # table in the asset shard, but will not remove the mirrored event_log events in the asset
         # shard
         super(SqliteEventLogStorage, self).wipe_asset(asset_key)
         self._delete_mirrored_events_for_asset_key(asset_key)
 
-    def watch(self, run_id, cursor, callback):
+    def watch(self, run_id: str, cursor: Optional[str], callback: EventHandlerFn) -> None:
         if not self._obs:
             self._obs = Observer()
             self._obs.start()
@@ -405,29 +415,36 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             self._obs.schedule(watchdog, self._base_dir, True),
         )
 
-    def end_watch(self, run_id, handler):
+    def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
         if handler in self._watchers[run_id]:
             event_handler, watch = self._watchers[run_id][handler]
-            self._obs.remove_handler_for_watch(event_handler, watch)
+            self._obs.remove_handler_for_watch(event_handler, watch)  # type: ignore
             del self._watchers[run_id][handler]
 
-    def dispose(self):
+    def dispose(self) -> None:
         if self._obs:
             self._obs.stop()
             self._obs.join(timeout=15)
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = get_alembic_config(__file__)
         with self.index_connection() as conn:
             return check_alembic_revision(alembic_config, conn)
 
     @property
-    def is_run_sharded(self):
+    def is_run_sharded(self) -> bool:
         return True
 
 
 class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
-    def __init__(self, event_log_storage, run_id, callback, cursor, **kwargs):
+    def __init__(
+        self,
+        event_log_storage: SqliteEventLogStorage,
+        run_id: str,
+        callback: EventHandlerFn,
+        cursor: Optional[str],
+        **kwargs: object,
+    ):
         self._event_log_storage = check.inst_param(
             event_log_storage, "event_log_storage", SqliteEventLogStorage
         )
@@ -437,7 +454,7 @@ class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
         self._cursor = cursor
         super(SqliteEventLogStorageWatchdog, self).__init__(patterns=[self._log_path], **kwargs)
 
-    def _process_log(self):
+    def _process_log(self) -> None:
         connection = self._event_log_storage.get_records_for_run(self._run_id, self._cursor)
         if connection.cursor:
             self._cursor = connection.cursor
@@ -457,6 +474,6 @@ class SqliteEventLogStorageWatchdog(PatternMatchingEventHandler):
             ):
                 self._event_log_storage.end_watch(self._run_id, self._cb)
 
-    def on_modified(self, event):
+    def on_modified(self, event: FileSystemEvent) -> None:
         check.invariant(event.src_path == self._log_path)
         self._process_log()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -418,7 +418,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
         if handler in self._watchers[run_id]:
             event_handler, watch = self._watchers[run_id][handler]
-            self._obs.remove_handler_for_watch(event_handler, watch)  # type: ignore
+            self._obs.remove_handler_for_watch(event_handler, watch)  # type: ignore  # (possible none)
             del self._watchers[run_id][handler]
 
     def dispose(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -223,7 +223,7 @@ def local_file_manager(init_context: InitResourceContext) -> "LocalFileManager":
     """
     return LocalFileManager(
         base_dir=init_context.resource_config.get(
-            "base_dir", os.path.join(init_context.instance.storage_directory(), "file_manager")  # type: ignore
+            "base_dir", os.path.join(init_context.instance.storage_directory(), "file_manager")  # type: ignore  # (possible none)
         )
     )
 
@@ -253,7 +253,7 @@ class LocalFileManager(FileManager):
 
     def copy_handle_to_local_temp(self, file_handle: FileHandle) -> str:
         check.inst_param(file_handle, "file_handle", FileHandle)
-        with self.read(file_handle, "rb") as handle_obj:  # type: ignore
+        with self.read(file_handle, "rb") as handle_obj:  # type: ignore  # (??)
             temp_file_obj = self._temp_file_manager.tempfile()
             temp_file_obj.write(handle_obj.read())
             temp_name = temp_file_obj.name
@@ -268,11 +268,11 @@ class LocalFileManager(FileManager):
 
         encoding = None if mode == "rb" else "utf8"
         with open(file_handle.path, mode, encoding=encoding) as file_obj:
-            yield file_obj  # type: ignore
+            yield file_obj  # type: ignore  # (??)
 
     def read_data(self, file_handle: LocalFileHandle) -> bytes:
         with self.read(file_handle, mode="rb") as file_obj:
-            return file_obj.read()  # type: ignore
+            return file_obj.read()  # type: ignore  # (??)
 
     def write_data(self, data: bytes, ext: Optional[str] = None):
         check.inst_param(data, "data", bytes)
@@ -292,7 +292,7 @@ class LocalFileManager(FileManager):
 
         encoding = None if "b" in mode else "utf8"
         with open(dest_file_path, mode, encoding=encoding) as dest_file_obj:
-            shutil.copyfileobj(file_obj, dest_file_obj)  # type: ignore
+            shutil.copyfileobj(file_obj, dest_file_obj)  # type: ignore  # (??)
             return LocalFileHandle(dest_file_path)
 
     def delete_local_temp(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/file_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/file_manager.py
@@ -4,19 +4,23 @@ import shutil
 import uuid
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import BinaryIO, Optional, TextIO, Union
+from typing import BinaryIO, ContextManager, Iterator, Optional, TextIO, Union
+
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
 from dagster._config import Field, StringSource
 from dagster._core.definitions.resource_definition import resource
+from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.instance import DagsterInstance
 from dagster._utils import mkdir_p
 
 from .temp_file_manager import TempfileManager
 
+IOStream: TypeAlias = Union[TextIO, BinaryIO]
 
-# pylint: disable=no-init
+
 class FileHandle(ABC):
     """A reference to a file as manipulated by a FileManager.
 
@@ -91,7 +95,7 @@ class FileManager(ABC):  # pylint: disable=no-init
 
     @public
     @abstractmethod
-    def delete_local_temp(self):
+    def delete_local_temp(self) -> None:
         """Delete all local temporary files created by previous calls to
         :py:meth:`~dagster._core.storage.file_manager.FileManager.copy_handle_to_local_temp`.
 
@@ -101,7 +105,7 @@ class FileManager(ABC):  # pylint: disable=no-init
 
     @public
     @abstractmethod
-    def read(self, file_handle: FileHandle, mode: str = "rb") -> Union[TextIO, BinaryIO]:
+    def read(self, file_handle: FileHandle, mode: str = "rb") -> ContextManager[IOStream]:
         """Return a file-like stream for the file handle.
 
         This may incur an expensive network call for file managers backed by object stores
@@ -132,9 +136,7 @@ class FileManager(ABC):  # pylint: disable=no-init
 
     @public
     @abstractmethod
-    def write(
-        self, file_obj: Union[TextIO, BinaryIO], mode: str = "wb", ext: Optional[str] = None
-    ) -> FileHandle:
+    def write(self, file_obj: IOStream, mode: str = "wb", ext: Optional[str] = None) -> FileHandle:
         """Write the bytes contained within the given file object into the file manager.
 
         Args:
@@ -166,7 +168,7 @@ class FileManager(ABC):  # pylint: disable=no-init
 
 
 @resource(config_schema={"base_dir": Field(StringSource, is_required=False)})
-def local_file_manager(init_context):
+def local_file_manager(init_context: InitResourceContext) -> "LocalFileManager":
     """FileManager that provides abstract access to a local filesystem.
 
     By default, files will be stored in `<local_artifact_storage>/storage/file_manager` where
@@ -221,27 +223,27 @@ def local_file_manager(init_context):
     """
     return LocalFileManager(
         base_dir=init_context.resource_config.get(
-            "base_dir", os.path.join(init_context.instance.storage_directory(), "file_manager")
+            "base_dir", os.path.join(init_context.instance.storage_directory(), "file_manager")  # type: ignore
         )
     )
 
 
-def check_file_like_obj(obj):
+def check_file_like_obj(obj: object) -> None:
     check.invariant(obj and hasattr(obj, "read") and hasattr(obj, "write"))
 
 
 class LocalFileManager(FileManager):
-    def __init__(self, base_dir):
+    def __init__(self, base_dir: str):
         self.base_dir = base_dir
         self._base_dir_ensured = False
         self._temp_file_manager = TempfileManager()
 
     @staticmethod
-    def for_instance(instance, run_id):
+    def for_instance(instance: DagsterInstance, run_id: str) -> "LocalFileManager":
         check.inst_param(instance, "instance", DagsterInstance)
         return LocalFileManager(instance.file_manager_directory(run_id))
 
-    def ensure_base_dir_exists(self):
+    def ensure_base_dir_exists(self) -> None:
         if self._base_dir_ensured:
             return
 
@@ -249,9 +251,9 @@ class LocalFileManager(FileManager):
 
         self._base_dir_ensured = True
 
-    def copy_handle_to_local_temp(self, file_handle):
+    def copy_handle_to_local_temp(self, file_handle: FileHandle) -> str:
         check.inst_param(file_handle, "file_handle", FileHandle)
-        with self.read(file_handle, "rb") as handle_obj:
+        with self.read(file_handle, "rb") as handle_obj:  # type: ignore
             temp_file_obj = self._temp_file_manager.tempfile()
             temp_file_obj.write(handle_obj.read())
             temp_name = temp_file_obj.name
@@ -259,24 +261,26 @@ class LocalFileManager(FileManager):
             return temp_name
 
     @contextmanager
-    def read(self, file_handle, mode="rb"):
+    def read(self, file_handle: LocalFileHandle, mode: str = "rb") -> Iterator[IOStream]:
         check.inst_param(file_handle, "file_handle", LocalFileHandle)
         check.str_param(mode, "mode")
         check.param_invariant(mode in {"r", "rb"}, "mode")
 
         encoding = None if mode == "rb" else "utf8"
         with open(file_handle.path, mode, encoding=encoding) as file_obj:
-            yield file_obj
+            yield file_obj  # type: ignore
 
-    def read_data(self, file_handle):
+    def read_data(self, file_handle: LocalFileHandle) -> bytes:
         with self.read(file_handle, mode="rb") as file_obj:
-            return file_obj.read()
+            return file_obj.read()  # type: ignore
 
-    def write_data(self, data, ext=None):
+    def write_data(self, data: bytes, ext: Optional[str] = None):
         check.inst_param(data, "data", bytes)
         return self.write(io.BytesIO(data), mode="wb", ext=ext)
 
-    def write(self, file_obj, mode="wb", ext=None):
+    def write(
+        self, file_obj: IOStream, mode: str = "wb", ext: Optional[str] = None
+    ) -> LocalFileHandle:
         check_file_like_obj(file_obj)
         check.opt_str_param(ext, "ext")
 
@@ -288,8 +292,8 @@ class LocalFileManager(FileManager):
 
         encoding = None if "b" in mode else "utf8"
         with open(dest_file_path, mode, encoding=encoding) as dest_file_obj:
-            shutil.copyfileobj(file_obj, dest_file_obj)
+            shutil.copyfileobj(file_obj, dest_file_obj)  # type: ignore
             return LocalFileHandle(dest_file_path)
 
-    def delete_local_temp(self):
+    def delete_local_temp(self) -> None:
         self._temp_file_manager.close()

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import Any
+from typing import Any, Optional
 
 from upath import UPath
 
@@ -10,6 +10,7 @@ from dagster._annotations import experimental
 from dagster._config import Field, StringSource
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
+from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
 from dagster._core.storage.io_manager import IOManager, io_manager
@@ -21,7 +22,7 @@ from dagster._utils import PICKLE_PROTOCOL, mkdir_p
     config_schema={"base_dir": Field(StringSource, is_required=False)},
     description="Built-in filesystem IO manager that stores and retrieves values using pickling.",
 )
-def fs_io_manager(init_context):
+def fs_io_manager(init_context: InitResourceContext) -> "PickledObjectFilesystemIOManager":
     """Built-in filesystem IO manager that stores and retrieves values using pickling.
 
     The base directory that the pickle files live inside is determined by:
@@ -119,7 +120,7 @@ def fs_io_manager(init_context):
 
     """
     base_dir = init_context.resource_config.get(
-        "base_dir", init_context.instance.storage_directory()
+        "base_dir", init_context.instance.storage_directory()  # type: ignore
     )
 
     return PickledObjectFilesystemIOManager(base_dir=base_dir)
@@ -182,15 +183,15 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             manager will be stored in.
     """
 
-    def __init__(self, base_dir=None):
+    def __init__(self, base_dir: Optional[str] = None):
         self.base_dir = check.opt_str_param(base_dir, "base_dir")
         self.write_mode = "wb"
         self.read_mode = "rb"
 
-    def _get_path(self, path):
-        return os.path.join(self.base_dir, path)
+    def _get_path(self, path: str) -> str:
+        return os.path.join(self.base_dir, path)  # type: ignore
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj: object):
         """Pickle the data and store the object to a custom file path.
 
         This method emits an AssetMaterialization event so the assets will be tracked by the
@@ -198,7 +199,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
         """
         check.inst_param(context, "context", OutputContext)
         metadata = context.metadata
-        path = check.str_param(metadata.get("path"), "metadata.path")
+        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore
 
         filepath = self._get_path(path)
 
@@ -216,11 +217,11 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
             ],
         )
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext) -> object:
         """Unpickle the file from a given file path and Load it to a data object."""
         check.inst_param(context, "context", InputContext)
-        metadata = context.upstream_output.metadata
-        path = check.str_param(metadata.get("path"), "metadata.path")
+        metadata = context.upstream_output.metadata  # type: ignore
+        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore
         filepath = self._get_path(path)
         context.log.debug(f"Loading file from: {filepath}")
 
@@ -230,7 +231,9 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
 
 @io_manager(config_schema={"base_dir": Field(StringSource, is_required=True)})
 @experimental
-def custom_path_fs_io_manager(init_context):
+def custom_path_fs_io_manager(
+    init_context: InitResourceContext,
+) -> CustomPathPickledObjectFilesystemIOManager:
     """Built-in IO manager that allows users to custom output file path per output definition.
 
     It requires users to specify a base directory where all the step output will be stored in. It

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -189,7 +189,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
         self.read_mode = "rb"
 
     def _get_path(self, path: str) -> str:
-        return os.path.join(self.base_dir, path)  # type: ignore
+        return os.path.join(self.base_dir, path)  # type: ignore  # (possible none)
 
     def handle_output(self, context: OutputContext, obj: object):
         """Pickle the data and store the object to a custom file path.
@@ -199,7 +199,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
         """
         check.inst_param(context, "context", OutputContext)
         metadata = context.metadata
-        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore
+        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore  # (possible none)
 
         filepath = self._get_path(path)
 
@@ -220,8 +220,8 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
     def load_input(self, context: InputContext) -> object:
         """Unpickle the file from a given file path and Load it to a data object."""
         check.inst_param(context, "context", InputContext)
-        metadata = context.upstream_output.metadata  # type: ignore
-        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore
+        metadata = context.upstream_output.metadata  # type: ignore  # (possible none)
+        path = check.str_param(metadata.get("path"), "metadata.path")  # type: ignore  # (possible none)
         filepath = self._get_path(path)
         context.log.debug(f"Loading file from: {filepath}")
 

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -4,8 +4,9 @@ import shutil
 import sys
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import IO, Generator, Optional, Sequence, Tuple, Union
+from typing import IO, TYPE_CHECKING, Generator, Iterator, Mapping, Optional, Sequence, Tuple
 
+from typing_extensions import Final
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers.polling import PollingObserver
 
@@ -15,6 +16,7 @@ from dagster import (
     StringSource,
     _check as check,
 )
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.execution.compute_logs import mirror_stream_to_file
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
@@ -36,17 +38,28 @@ from .compute_log_manager import (
     ComputeLogSubscription,
 )
 
-DEFAULT_WATCHDOG_POLLING_TIMEOUT = 2.5
+if TYPE_CHECKING:
+    from dagster._core.storage.cloud_storage_compute_log_manager import LogSubscription
 
-IO_TYPE_EXTENSION = {ComputeIOType.STDOUT: "out", ComputeIOType.STDERR: "err"}
+DEFAULT_WATCHDOG_POLLING_TIMEOUT: Final = 2.5
 
-MAX_FILENAME_LENGTH = 255
+IO_TYPE_EXTENSION: Final[Mapping[ComputeIOType, str]] = {
+    ComputeIOType.STDOUT: "out",
+    ComputeIOType.STDERR: "err",
+}
+
+MAX_FILENAME_LENGTH: Final = 255
 
 
 class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, ConfigurableClass):
     """Stores copies of stdout & stderr for each compute step locally on disk."""
 
-    def __init__(self, base_dir, polling_timeout=None, inst_data=None):
+    def __init__(
+        self,
+        base_dir: str,
+        polling_timeout: Optional[float] = None,
+        inst_data: Optional[ConfigurableClassData] = None,
+    ):
         self._base_dir = base_dir
         self._polling_timeout = check.opt_float_param(
             polling_timeout, "polling_timeout", DEFAULT_WATCHDOG_POLLING_TIMEOUT
@@ -55,22 +68,24 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @property
-    def polling_timeout(self):
+    def polling_timeout(self) -> float:
         return self._polling_timeout
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {
             "base_dir": StringSource,
             "polling_timeout": Field(Float, is_required=False),
         }
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value
+    ) -> "LocalComputeLogManager":
         return LocalComputeLogManager(inst_data=inst_data, **config_value)
 
     @contextmanager
@@ -86,13 +101,13 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
     @contextmanager
     def open_log_stream(
         self, log_key: Sequence[str], io_type: ComputeIOType
-    ) -> Generator[Optional[IO], None, None]:
+    ) -> Iterator[Optional[IO]]:
         path = self.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
         ensure_file(path)
         with open(path, "+a", encoding="utf-8") as f:
             yield f
 
-    def is_capture_complete(self, log_key: Sequence[str]):
+    def is_capture_complete(self, log_key: Sequence[str]) -> bool:
         return os.path.exists(self.complete_artifact_path(log_key))
 
     def get_log_data(
@@ -229,7 +244,9 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
     #
     ###############################################
     @contextmanager
-    def _watch_logs(self, pipeline_run, step_key=None):
+    def _watch_logs(
+        self, pipeline_run: DagsterRun, step_key: Optional[str] = None
+    ) -> Iterator[None]:
         check.inst_param(pipeline_run, "pipeline_run", DagsterRun)
         check.opt_str_param(step_key, "step_key")
 
@@ -239,13 +256,20 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         with self.capture_logs(log_key):
             yield
 
-    def get_local_path(self, run_id, key, io_type):
+    def get_local_path(self, run_id: str, key: str, io_type: ComputeIOType) -> str:
         """Legacy adapter from compute log manager to more generic captured log manager API."""
         check.inst_param(io_type, "io_type", ComputeIOType)
         log_key = self.build_log_key_for_run(run_id, key)
         return self.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
 
-    def read_logs_file(self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ):
+    def read_logs_file(
+        self,
+        run_id: str,
+        key: str,
+        io_type: ComputeIOType,
+        cursor: int = 0,
+        max_bytes: int = MAX_BYTES_FILE_READ,
+    ) -> ComputeLogFileData:
         path = self.get_local_path(run_id, key, io_type)
 
         if not os.path.exists(path) or not os.path.isfile(path):
@@ -268,19 +292,19 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             download_url=download_url,
         )
 
-    def get_key(self, pipeline_run, step_key):
+    def get_key(self, pipeline_run: DagsterRun, step_key: Optional[str]):
         check.inst_param(pipeline_run, "pipeline_run", DagsterRun)
         check.opt_str_param(step_key, "step_key")
         return step_key or pipeline_run.pipeline_name
 
-    def is_watch_completed(self, run_id, key):
+    def is_watch_completed(self, run_id: str, key: str) -> bool:
         log_key = self.build_log_key_for_run(run_id, key)
         return self.is_capture_complete(log_key)
 
-    def on_watch_start(self, pipeline_run, step_key):
+    def on_watch_start(self, pipeline_run: DagsterRun, step_key: Optional[str]):
         pass
 
-    def on_watch_finish(self, pipeline_run, step_key=None):
+    def on_watch_finish(self, pipeline_run: DagsterRun, step_key: Optional[str] = None):
         check.inst_param(pipeline_run, "pipeline_run", DagsterRun)
         check.opt_str_param(step_key, "step_key")
         log_key = self.build_log_key_for_run(
@@ -289,17 +313,17 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         touchpath = self.complete_artifact_path(log_key)
         touch_file(touchpath)
 
-    def download_url(self, run_id, key, io_type):
+    def download_url(self, run_id: str, key: str, io_type: ComputeIOType):
         check.inst_param(io_type, "io_type", ComputeIOType)
         return "/download/{}/{}/{}".format(run_id, key, io_type.value)
 
-    def on_subscribe(self, subscription):
+    def on_subscribe(self, subscription: "LogSubscription") -> None:
         self._subscription_manager.add_subscription(subscription)
 
-    def on_unsubscribe(self, subscription):
+    def on_unsubscribe(self, subscription: "LogSubscription") -> None:
         self._subscription_manager.remove_subscription(subscription)
 
-    def dispose(self):
+    def dispose(self) -> None:
         self._subscription_manager.dispose()
 
 
@@ -310,9 +334,7 @@ class LocalComputeLogSubscriptionManager:
         self._watchers = {}
         self._observer = None
 
-    def add_subscription(
-        self, subscription: Union[ComputeLogSubscription, CapturedLogSubscription]
-    ):
+    def add_subscription(self, subscription: "LogSubscription") -> None:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -326,7 +348,7 @@ class LocalComputeLogSubscriptionManager:
             self._subscriptions[watch_key].append(subscription)
             self.watch(subscription)
 
-    def is_complete(self, subscription: Union[ComputeLogSubscription, CapturedLogSubscription]):
+    def is_complete(self, subscription: "LogSubscription") -> bool:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -335,7 +357,7 @@ class LocalComputeLogSubscriptionManager:
             return self._manager.is_watch_completed(subscription.run_id, subscription.key)
         return self._manager.is_capture_complete(subscription.log_key)
 
-    def remove_subscription(self, subscription):
+    def remove_subscription(self, subscription: "LogSubscription") -> None:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -345,7 +367,7 @@ class LocalComputeLogSubscriptionManager:
             self._subscriptions[watch_key].remove(subscription)
             subscription.complete()
 
-    def _log_key(self, subscription):
+    def _log_key(self, subscription: "LogSubscription") -> Sequence[str]:
         check.inst_param(
             subscription, "subscription", (ComputeLogSubscription, CapturedLogSubscription)
         )
@@ -357,12 +379,12 @@ class LocalComputeLogSubscriptionManager:
     def _watch_key(self, log_key: Sequence[str]) -> str:
         return json.dumps(log_key)
 
-    def remove_all_subscriptions(self, log_key):
+    def remove_all_subscriptions(self, log_key: Sequence[str]) -> None:
         watch_key = self._watch_key(log_key)
         for subscription in self._subscriptions.pop(watch_key, []):
             subscription.complete()
 
-    def watch(self, subscription):
+    def watch(self, subscription: "LogSubscription") -> None:
         log_key = self._log_key(subscription)
         watch_key = self._watch_key(log_key)
         if watch_key in self._watchers:
@@ -394,18 +416,18 @@ class LocalComputeLogSubscriptionManager:
             str(directory),
         )
 
-    def notify_subscriptions(self, log_key):
+    def notify_subscriptions(self, log_key: Sequence[str]) -> None:
         watch_key = self._watch_key(log_key)
         for subscription in self._subscriptions[watch_key]:
             subscription.fetch()
 
-    def unwatch(self, log_key, handler):
+    def unwatch(self, log_key: Sequence[str], handler) -> None:
         watch_key = self._watch_key(log_key)
         if watch_key in self._watchers:
-            self._observer.remove_handler_for_watch(handler, self._watchers[watch_key])
+            self._observer.remove_handler_for_watch(handler, self._watchers[watch_key])  # type: ignore
         del self._watchers[watch_key]
 
-    def dispose(self):
+    def dispose(self) -> None:
         if self._observer:
             self._observer.stop()
             self._observer.join(15)

--- a/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/mem_io_manager.py
@@ -1,20 +1,24 @@
+from typing import Dict, Tuple
+
+from dagster._core.execution.context.input import InputContext
+from dagster._core.execution.context.output import OutputContext
 from dagster._core.storage.io_manager import IOManager, io_manager
 
 
 class InMemoryIOManager(IOManager):
     def __init__(self):
-        self.values = {}
+        self.values: Dict[Tuple[object, ...], object] = {}
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: InputContext, obj: object):
         keys = tuple(context.get_identifier())
         self.values[keys] = obj
 
-    def load_input(self, context):
+    def load_input(self, context: OutputContext) -> object:
         keys = tuple(context.get_identifier())
         return self.values[keys]
 
 
 @io_manager(description="Built-in IO manager that stores and retrieves values in memory.")
-def mem_io_manager(_):
+def mem_io_manager(_) -> InMemoryIOManager:
     """Built-in IO manager that stores and retrieves values in memory."""
     return InMemoryIOManager()

--- a/python_modules/dagster/dagster/_core/storage/root.py
+++ b/python_modules/dagster/dagster/_core/storage/root.py
@@ -1,41 +1,53 @@
+# pyright: strict
+
 import os
+from typing import Optional
+
+from typing_extensions import TypedDict
 
 from dagster import (
     StringSource,
     _check as check,
 )
+from dagster._config.config_schema import UserConfigSchema
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 
 
+class LocalArtifactStorageConfig(TypedDict):
+    base_dir: str
+
+
 class LocalArtifactStorage(ConfigurableClass):
-    def __init__(self, base_dir, inst_data=None):
+    def __init__(self, base_dir: str, inst_data: Optional[ConfigurableClassData] = None):
         self._base_dir = base_dir
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @property
-    def base_dir(self):
+    def base_dir(self) -> str:
         return self._base_dir
 
-    def file_manager_dir(self, run_id):
+    def file_manager_dir(self, run_id: str) -> str:
         check.str_param(run_id, "run_id")
         return os.path.join(self.base_dir, "storage", run_id, "files")
 
     @property
-    def storage_dir(self):
+    def storage_dir(self) -> str:
         return os.path.join(self.base_dir, "storage")
 
     @property
-    def schedules_dir(self):
+    def schedules_dir(self) -> str:
         return os.path.join(self.base_dir, "schedules")
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: LocalArtifactStorageConfig
+    ) -> "LocalArtifactStorage":
         return LocalArtifactStorage(inst_data=inst_data, **config_value)
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}

--- a/python_modules/dagster/dagster/_core/storage/root.py
+++ b/python_modules/dagster/dagster/_core/storage/root.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 import os
 from typing import Optional
 

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -1,14 +1,17 @@
 from contextlib import ExitStack
+from typing import AbstractSet, Any, Callable, Iterator, Mapping, Optional
 
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
+from sqlalchemy.engine import Connection
 from tqdm import tqdm
+from typing_extensions import Final, TypeAlias
 
 import dagster._check as check
 from dagster._serdes import deserialize_as
 
 from ...execution.job_backfill import PartitionBackfill
-from ..pipeline_run import DagsterRun, DagsterRunStatus
+from ..pipeline_run import DagsterRun, DagsterRunStatus, RunRecord
 from ..runs.base import RunStorage
 from ..runs.schema import BulkActionsTable, RunsTable, RunTagsTable
 from ..tags import PARTITION_NAME_TAG, PARTITION_SET_TAG, REPOSITORY_LABEL_TAG
@@ -20,20 +23,23 @@ RUN_START_END = (  # was run_start_end, but renamed to overwrite bad timestamps 
 RUN_REPO_LABEL_TAGS = "run_repo_label_tags"
 BULK_ACTION_TYPES = "bulk_action_types"
 
+PrintFn: TypeAlias = Callable[[Any], None]
+MigrationFn: TypeAlias = Callable[[RunStorage, Optional[PrintFn]], None]
+
 # for `dagster instance migrate`, paired with schema changes
-REQUIRED_DATA_MIGRATIONS = {
+REQUIRED_DATA_MIGRATIONS: Final[Mapping[str, Callable[[], MigrationFn]]] = {
     RUN_PARTITIONS: lambda: migrate_run_partition,
     RUN_REPO_LABEL_TAGS: lambda: migrate_run_repo_tags,
     BULK_ACTION_TYPES: lambda: migrate_bulk_actions,
 }
 # for `dagster instance reindex`, optionally run for better read performance
-OPTIONAL_DATA_MIGRATIONS = {
+OPTIONAL_DATA_MIGRATIONS: Final[Mapping[str, Callable[[], MigrationFn]]] = {
     RUN_START_END: lambda: migrate_run_start_end,
 }
 
 CHUNK_SIZE = 100
 
-UNSTARTED_RUN_STATUSES = {
+UNSTARTED_RUN_STATUSES: Final[AbstractSet[DagsterRunStatus]] = {
     DagsterRunStatus.QUEUED,
     DagsterRunStatus.NOT_STARTED,
     DagsterRunStatus.MANAGED,
@@ -41,7 +47,9 @@ UNSTARTED_RUN_STATUSES = {
 }
 
 
-def chunked_run_iterator(storage, print_fn=None, chunk_size=CHUNK_SIZE):
+def chunked_run_iterator(
+    storage: RunStorage, print_fn: Optional[PrintFn] = None, chunk_size: int = CHUNK_SIZE
+) -> Iterator[DagsterRun]:
     with ExitStack() as stack:
         if print_fn:
             run_count = storage.get_runs_count()
@@ -54,17 +62,19 @@ def chunked_run_iterator(storage, print_fn=None, chunk_size=CHUNK_SIZE):
 
         while has_more:
             chunk = storage.get_runs(cursor=cursor, limit=chunk_size)
-            has_more = chunk_size and len(chunk) >= chunk_size
+            has_more = chunk_size and len(chunk) >= chunk_size  # type: ignore
 
             for run in chunk:
                 cursor = run.run_id
                 yield run
 
             if progress:
-                progress.update(len(chunk))  # pylint: disable=no-member
+                progress.update(len(chunk))  # type: ignore
 
 
-def chunked_run_records_iterator(storage, print_fn=None, chunk_size=CHUNK_SIZE):
+def chunked_run_records_iterator(
+    storage: RunStorage, print_fn: Optional[PrintFn] = None, chunk_size: int = CHUNK_SIZE
+) -> Iterator[RunRecord]:
     with ExitStack() as stack:
         if print_fn:
             run_count = storage.get_runs_count()
@@ -87,7 +97,7 @@ def chunked_run_records_iterator(storage, print_fn=None, chunk_size=CHUNK_SIZE):
                 progress.update(len(chunk))  # pylint: disable=no-member
 
 
-def migrate_run_partition(storage, print_fn=None):
+def migrate_run_partition(storage: RunStorage, print_fn: Optional[PrintFn] = None) -> None:
     """
     Utility method to build an asset key index from the data in existing event log records.
     Takes in event_log_storage, and a print_fn to keep track of progress.
@@ -104,7 +114,7 @@ def migrate_run_partition(storage, print_fn=None):
         storage.add_run_tags(run.run_id, run.tags)
 
 
-def migrate_run_start_end(storage, print_fn=None):
+def migrate_run_start_end(storage: RunStorage, print_fn: Optional[PrintFn] = None) -> None:
     """
     Utility method that updates the start and end times of historical runs using the completed event log.
     """
@@ -133,9 +143,7 @@ def add_run_stats(run_storage: RunStorage, run_id: str) -> None:
     if not isinstance(run_storage, SqlRunStorage):
         return
 
-    instance = check.inst_param(
-        run_storage._instance, "instance", DagsterInstance  # pylint: disable=protected-access
-    )
+    instance = check.inst_param(run_storage._instance, "instance", DagsterInstance)
     run_stats = instance.get_run_stats(run_id)
 
     with run_storage.connect() as conn:
@@ -149,7 +157,7 @@ def add_run_stats(run_storage: RunStorage, run_id: str) -> None:
         )
 
 
-def migrate_run_repo_tags(run_storage: RunStorage, print_fn=None):
+def migrate_run_repo_tags(run_storage: RunStorage, print_fn: Optional[PrintFn] = None) -> None:
     from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
 
     if not isinstance(run_storage, SqlRunStorage):
@@ -193,7 +201,7 @@ def migrate_run_repo_tags(run_storage: RunStorage, print_fn=None):
                 write_repo_tag(conn, run)
 
 
-def write_repo_tag(conn, run: DagsterRun):
+def write_repo_tag(conn: Connection, run: DagsterRun) -> None:
     if not run.external_pipeline_origin:
         # nothing to do
         return
@@ -212,7 +220,7 @@ def write_repo_tag(conn, run: DagsterRun):
         pass
 
 
-def migrate_bulk_actions(run_storage: RunStorage, print_fn=None):
+def migrate_bulk_actions(run_storage: RunStorage, print_fn: Optional[PrintFn] = None) -> None:
     from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
 
     if not isinstance(run_storage, SqlRunStorage):

--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -1,15 +1,19 @@
 import os
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator, Optional
 from urllib.parse import urljoin, urlparse
 
 import sqlalchemy as db
+from sqlalchemy.engine import Connection
 from sqlalchemy.pool import NullPool
 
 from dagster import (
     StringSource,
     _check as check,
 )
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     get_alembic_config,
@@ -24,6 +28,8 @@ from dagster._utils import mkdir_p
 from ..schema import InstanceInfo, RunsTable, RunStorageSqlMetadata, RunTagsTable
 from ..sql_run_storage import SqlRunStorage
 
+if TYPE_CHECKING:
+    from dagster._core.storage.sqlite_storage import SqliteStorageConfig
 MINIMUM_SQLITE_BUCKET_VERSION = [3, 25, 0]
 
 
@@ -50,26 +56,30 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
     The ``base_dir`` param tells the run storage where on disk to store the database.
     """
 
-    def __init__(self, conn_string, inst_data=None):
+    def __init__(self, conn_string: str, inst_data: Optional[ConfigurableClassData] = None):
         check.str_param(conn_string, "conn_string")
         self._conn_string = conn_string
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         super().__init__()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: "SqliteStorageConfig"
+    ) -> "SqliteRunStorage":
         return SqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
     @classmethod
-    def from_local(cls, base_dir, inst_data=None):
+    def from_local(
+        cls, base_dir: str, inst_data: Optional[ConfigurableClassData] = None
+    ) -> "SqliteRunStorage":
         check.str_param(base_dir, "base_dir")
         mkdir_p(base_dir)
         conn_string = create_db_conn_string(base_dir, "runs")
@@ -98,7 +108,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         return run_storage
 
     @contextmanager
-    def connect(self):
+    def connect(self) -> Iterator[Connection]:
         engine = create_engine(self._conn_string, poolclass=NullPool)
         conn = engine.connect()
         try:
@@ -106,18 +116,18 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
         finally:
             conn.close()
 
-    def _alembic_upgrade(self, rev="head"):
+    def _alembic_upgrade(self, rev: str = "head") -> None:
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_upgrade(alembic_config, conn, rev=rev)
 
-    def _alembic_downgrade(self, rev="head"):
+    def _alembic_downgrade(self, rev: str = "head") -> None:
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_downgrade(alembic_config, conn, rev=rev)
 
     @property
-    def supports_bucket_queries(self):
+    def supports_bucket_queries(self) -> bool:
         parts = get_sqlite_version().split(".")
         try:
             for i in range(min(len(parts), len(MINIMUM_SQLITE_BUCKET_VERSION))):
@@ -131,14 +141,14 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
 
         return False
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         self._check_for_version_066_migration_and_perform()
         self._alembic_upgrade()
 
     # In version 0.6.6, we changed the layout of the of the sqllite dbs on disk
     # to move from the root of DAGSTER_HOME/runs.db to DAGSTER_HOME/history/runs.bd
     # This function checks for that condition and does the move
-    def _check_for_version_066_migration_and_perform(self):
+    def _check_for_version_066_migration_and_perform(self) -> None:
         old_conn_string = "sqlite://" + urljoin(urlparse(self._conn_string).path, "../runs.db")
         path_to_old_db = urlparse(old_conn_string).path
         # sqlite URLs look like `sqlite:///foo/bar/baz on Unix/Mac` but on Windows they look like
@@ -152,7 +162,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
                 self.add_run(run)
             os.unlink(path_to_old_db)
 
-    def delete_run(self, run_id):
+    def delete_run(self, run_id: str) -> None:
         """Override the default sql delete run implementation until we can get full
         support on cascading deletes.
         """
@@ -163,7 +173,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
             conn.execute(remove_tags)
             conn.execute(remove_run)
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Callable, Iterable, Mapping, Optional, Sequence
+from typing import Iterable, Mapping, Optional, Sequence
 
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref
@@ -9,13 +9,15 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
+from dagster._core.storage.sql import AlembicVersion
+from dagster._utils import PrintFn
 
 
 class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
     """Abstract class for managing persistance of scheduler artifacts."""
 
     @abc.abstractmethod
-    def wipe(self):
+    def wipe(self) -> None:
         """Delete all schedules from storage."""
 
     @abc.abstractmethod
@@ -59,7 +61,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def delete_instigator_state(self, origin_id: str, selector_id: str):
+    def delete_instigator_state(self, origin_id: str, selector_id: str) -> None:
         """Delete a state in storage.
 
         Args:
@@ -68,7 +70,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @property
-    def supports_batch_queries(self):
+    def supports_batch_queries(self) -> bool:
         return False
 
     def get_batch_ticks(
@@ -97,7 +99,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def create_tick(self, tick_data: TickData):
+    def create_tick(self, tick_data: TickData) -> InstigatorTick:
         """Add a tick to storage.
 
         Args:
@@ -105,7 +107,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def update_tick(self, tick: InstigatorTick):
+    def update_tick(self, tick: InstigatorTick) -> InstigatorTick:
         """Update a tick already in storage.
 
         Args:
@@ -119,7 +121,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         selector_id: str,
         before: float,
         tick_statuses: Optional[Sequence[TickStatus]] = None,
-    ):
+    ) -> None:
         """Wipe ticks for an instigator for a certain status and timestamp.
 
         Args:
@@ -130,21 +132,21 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref):
         """
 
     @abc.abstractmethod
-    def upgrade(self):
+    def upgrade(self) -> None:
         """Perform any needed migrations."""
 
-    def migrate(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):
+    def migrate(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         """Call this method to run any required data migrations."""
 
-    def optimize(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):
+    def optimize(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         """Call this method to run any optional data migrations for optimized reads."""
 
-    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         """Allows for optimizing database connection / use in the context of a long lived dagit process.
         """
 
-    def alembic_version(self):
+    def alembic_version(self) -> Optional[AlembicVersion]:
         return None
 
-    def dispose(self):
+    def dispose(self) -> None:
         """Explicit lifecycle management."""

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -1,11 +1,21 @@
 from abc import abstractmethod
 from collections import defaultdict
 from datetime import datetime
-from typing import Callable, Iterable, Mapping, Optional, Sequence, cast
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    cast,
+)
 
 import pendulum
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
+from sqlalchemy.engine import Connection
 
 import dagster._check as check
 from dagster._core.definitions.run_request import InstigatorType
@@ -16,8 +26,9 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
+from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
 from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
-from dagster._utils import utc_datetime_from_timestamp
+from dagster._utils import PrintFn, utc_datetime_from_timestamp
 
 from .base import ScheduleStorage
 from .migration import (
@@ -33,10 +44,10 @@ class SqlScheduleStorage(ScheduleStorage):
     """Base class for SQL backed schedule storage."""
 
     @abstractmethod
-    def connect(self):
+    def connect(self) -> ContextManager[Connection]:
         """Context manager yielding a sqlalchemy.engine.Connection."""
 
-    def execute(self, query):
+    def execute(self, query: SqlAlchemyQuery) -> Sequence[SqlAlchemyRow]:
         with self.connect() as conn:
             result_proxy = conn.execute(query)
             res = result_proxy.fetchall()
@@ -44,12 +55,15 @@ class SqlScheduleStorage(ScheduleStorage):
 
         return res
 
-    def _deserialize_rows(self, rows):
+    def _deserialize_rows(self, rows: Sequence[SqlAlchemyRow]) -> Sequence[object]:
         return list(map(lambda r: deserialize_json_to_dagster_namedtuple(r[0]), rows))
 
     def all_instigator_state(
-        self, repository_origin_id=None, repository_selector_id=None, instigator_type=None
-    ):
+        self,
+        repository_origin_id: Optional[str] = None,
+        repository_selector_id: Optional[str] = None,
+        instigator_type: Optional[InstigatorType] = None,
+    ) -> Sequence[InstigatorState]:
         check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
 
         if self.has_instigators_table() and self.has_built_index(SCHEDULE_JOBS_SELECTOR_ID):
@@ -68,9 +82,9 @@ class SqlScheduleStorage(ScheduleStorage):
                 query = query.where(JobTable.c.job_type == instigator_type.value)
 
         rows = self.execute(query)
-        return self._deserialize_rows(rows)
+        return [cast(InstigatorState, r) for r in self._deserialize_rows(rows)]
 
-    def get_instigator_state(self, origin_id, selector_id):
+    def get_instigator_state(self, origin_id: str, selector_id: str) -> Optional[InstigatorState]:
         check.str_param(origin_id, "origin_id")
         check.str_param(selector_id, "selector_id")
 
@@ -88,9 +102,9 @@ class SqlScheduleStorage(ScheduleStorage):
             )
 
         rows = self.execute(query)
-        return self._deserialize_rows(rows[:1])[0] if len(rows) else None
+        return cast(InstigatorState, self._deserialize_rows(rows[:1])[0]) if len(rows) else None
 
-    def _has_instigator_state_by_selector(self, selector_id):
+    def _has_instigator_state_by_selector(self, selector_id: str) -> bool:
         check.str_param(selector_id, "selector_id")
 
         query = (
@@ -100,9 +114,9 @@ class SqlScheduleStorage(ScheduleStorage):
         )
 
         rows = self.execute(query)
-        return self._deserialize_rows(rows[:1])[0] if len(rows) else None
+        return self._deserialize_rows(rows[:1])[0] if len(rows) else None  # type: ignore
 
-    def _add_or_update_instigators_table(self, conn, state):
+    def _add_or_update_instigators_table(self, conn: Connection, state: InstigatorState) -> None:
         selector_id = state.selector_id
         try:
             conn.execute(
@@ -126,7 +140,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 )
             )
 
-    def add_instigator_state(self, state) -> InstigatorState:
+    def add_instigator_state(self, state: InstigatorState) -> InstigatorState:
         check.inst_param(state, "state", InstigatorState)
         with self.connect() as conn:
             try:
@@ -150,7 +164,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
         return state
 
-    def update_instigator_state(self, state) -> InstigatorState:
+    def update_instigator_state(self, state: InstigatorState) -> InstigatorState:
         check.inst_param(state, "state", InstigatorState)
         if not self.get_instigator_state(state.instigator_origin_id, state.selector_id):
             raise DagsterInvariantViolationError(
@@ -178,7 +192,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
         return state
 
-    def delete_instigator_state(self, origin_id, selector_id):
+    def delete_instigator_state(self, origin_id: str, selector_id: str) -> None:
         check.str_param(origin_id, "origin_id")
         check.str_param(selector_id, "selector_id")
 
@@ -202,7 +216,7 @@ class SqlScheduleStorage(ScheduleStorage):
                         )
                     )
 
-    def _jobs_has_selector_state(self, conn, selector_id):
+    def _jobs_has_selector_state(self, conn: Connection, selector_id: str) -> bool:
         query = (
             db.select([db.func.count()])
             .select_from(JobTable)
@@ -211,9 +225,16 @@ class SqlScheduleStorage(ScheduleStorage):
         result = conn.execute(query)
         row = result.fetchone()
         result.close()
-        return row[0] > 0
+        return row[0] > 0  # type: ignore
 
-    def _add_filter_limit(self, query, before=None, after=None, limit=None, statuses=None):
+    def _add_filter_limit(
+        self,
+        query: SqlAlchemyQuery,
+        before: Optional[float] = None,
+        after: Optional[float] = None,
+        limit: Optional[int] = None,
+        statuses=None,
+    ) -> SqlAlchemyQuery:
         check.opt_float_param(before, "before")
         check.opt_float_param(after, "after")
         check.opt_int_param(limit, "limit")
@@ -230,14 +251,14 @@ class SqlScheduleStorage(ScheduleStorage):
         return query
 
     @property
-    def supports_batch_queries(self):
+    def supports_batch_queries(self) -> bool:
         return self.has_instigators_table() and self.has_built_index(SCHEDULE_TICKS_SELECTOR_ID)
 
-    def has_instigators_table(self):
+    def has_instigators_table(self) -> bool:
         with self.connect() as conn:
             return self._has_instigators_table(conn)
 
-    def _has_instigators_table(self, conn):
+    def _has_instigators_table(self, conn: Connection) -> bool:
         table_names = db.inspect(conn).get_table_names()
         return "instigators" in table_names
 
@@ -292,7 +313,15 @@ class SqlScheduleStorage(ScheduleStorage):
             results[selector_id].append(InstigatorTick(tick_id, tick_data))
         return results
 
-    def get_ticks(self, origin_id, selector_id, before=None, after=None, limit=None, statuses=None):
+    def get_ticks(
+        self,
+        origin_id: str,
+        selector_id: str,
+        before: Optional[float] = None,
+        after: Optional[float] = None,
+        limit: Optional[int] = None,
+        statuses: Optional[Sequence[TickStatus]] = None,
+    ) -> Sequence[InstigatorTick]:
         check.str_param(origin_id, "origin_id")
         check.opt_float_param(before, "before")
         check.opt_float_param(after, "after")
@@ -323,10 +352,10 @@ class SqlScheduleStorage(ScheduleStorage):
 
         rows = self.execute(query)
         return list(
-            map(lambda r: InstigatorTick(r[0], deserialize_json_to_dagster_namedtuple(r[1])), rows)
+            map(lambda r: InstigatorTick(r[0], deserialize_json_to_dagster_namedtuple(r[1])), rows)  # type: ignore
         )
 
-    def create_tick(self, tick_data):
+    def create_tick(self, tick_data: TickData) -> InstigatorTick:
         check.inst_param(tick_data, "tick_data", TickData)
 
         values = {
@@ -353,7 +382,7 @@ class SqlScheduleStorage(ScheduleStorage):
                     " storage"
                 ) from exc
 
-    def update_tick(self, tick):
+    def update_tick(self, tick: InstigatorTick) -> InstigatorTick:
         check.inst_param(tick, "tick", InstigatorTick)
 
         values = {
@@ -374,7 +403,13 @@ class SqlScheduleStorage(ScheduleStorage):
 
         return tick
 
-    def purge_ticks(self, origin_id, selector_id, before, tick_statuses=None):
+    def purge_ticks(
+        self,
+        origin_id: str,
+        selector_id: str,
+        before: float,
+        tick_statuses: Optional[Sequence[TickStatus]] = None,
+    ) -> None:
         check.str_param(origin_id, "origin_id")
         check.float_param(before, "before")
         check.opt_list_param(tick_statuses, "tick_statuses", of_type=TickStatus)
@@ -405,7 +440,7 @@ class SqlScheduleStorage(ScheduleStorage):
         with self.connect() as conn:
             conn.execute(query)
 
-    def wipe(self):
+    def wipe(self) -> None:
         """Clears the schedule storage."""
         with self.connect() as conn:
             # https://stackoverflow.com/a/54386260/324449
@@ -416,7 +451,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
     # MIGRATIONS
 
-    def has_secondary_index_table(self):
+    def has_secondary_index_table(self) -> bool:
         with self.connect() as conn:
             return "secondary_indexes" in db.inspect(conn).get_table_names()
 
@@ -435,7 +470,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
         return len(results) > 0
 
-    def mark_index_built(self, migration_name: str):
+    def mark_index_built(self, migration_name: str) -> None:
         query = (
             SecondaryIndexMigrationTable.insert().values(  # pylint: disable=no-value-for-parameter
                 name=migration_name,
@@ -453,8 +488,11 @@ class SqlScheduleStorage(ScheduleStorage):
                 )
 
     def _execute_data_migrations(
-        self, migrations, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False
-    ):
+        self,
+        migrations: Mapping[str, Callable[..., Any]],
+        print_fn: Optional[Callable] = None,
+        force_rebuild_all: bool = False,
+    ) -> None:
         for migration_name, migration_fn in migrations.items():
             if self.has_built_index(migration_name):
                 if not force_rebuild_all:
@@ -468,12 +506,12 @@ class SqlScheduleStorage(ScheduleStorage):
             if print_fn:
                 print_fn(f"Finished data migration: {migration_name}")
 
-    def migrate(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):
+    def migrate(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         self._execute_data_migrations(
             REQUIRED_SCHEDULE_DATA_MIGRATIONS, print_fn, force_rebuild_all
         )
 
-    def optimize(self, print_fn: Optional[Callable] = None, force_rebuild_all: bool = False):
+    def optimize(self, print_fn: Optional[PrintFn] = None, force_rebuild_all: bool = False) -> None:
         self._execute_data_migrations(
             OPTIONAL_SCHEDULE_DATA_MIGRATIONS, print_fn, force_rebuild_all
         )

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -225,7 +225,7 @@ class SqlScheduleStorage(ScheduleStorage):
         result = conn.execute(query)
         row = result.fetchone()
         result.close()
-        return row[0] > 0  # type: ignore
+        return row[0] > 0  # type: ignore  # (possible none)
 
     def _add_filter_limit(
         self,

--- a/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -1,13 +1,17 @@
 from contextlib import contextmanager
+from typing import Iterator, Optional
 
 from packaging.version import parse
+from sqlalchemy.engine import Connection
 from sqlalchemy.pool import NullPool
 
 from dagster import (
     StringSource,
     _check as check,
 )
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     get_alembic_config,
@@ -27,7 +31,7 @@ MINIMUM_SQLITE_BATCH_VERSION = "3.25.0"
 class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     """Local SQLite backed schedule storage."""
 
-    def __init__(self, conn_string, inst_data=None):
+    def __init__(self, conn_string: str, inst_data: Optional[ConfigurableClassData] = None):
         check.str_param(conn_string, "conn_string")
         self._conn_string = conn_string
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
@@ -35,19 +39,23 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         super().__init__()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value
+    ) -> "SqliteScheduleStorage":
         return SqliteScheduleStorage.from_local(inst_data=inst_data, **config_value)
 
     @classmethod
-    def from_local(cls, base_dir, inst_data=None):
+    def from_local(
+        cls, base_dir: str, inst_data: Optional[ConfigurableClassData] = None
+    ) -> "SqliteScheduleStorage":
         check.str_param(base_dir, "base_dir")
         mkdir_p(base_dir)
         conn_string = create_db_conn_string(base_dir, "schedules")
@@ -71,7 +79,7 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         return schedule_storage
 
     @contextmanager
-    def connect(self):
+    def connect(self) -> Iterator[Connection]:
         engine = create_engine(self._conn_string, poolclass=NullPool)
         conn = engine.connect()
         try:
@@ -80,7 +88,7 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             conn.close()
 
     @property
-    def supports_batch_queries(self):
+    def supports_batch_queries(self) -> bool:
         if not super().supports_batch_queries:
             return False
 
@@ -88,12 +96,12 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             MINIMUM_SQLITE_BATCH_VERSION
         )
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_upgrade(alembic_config, conn)
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = get_alembic_config(__file__)
         with self.connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -1,13 +1,16 @@
 import threading
 from functools import lru_cache
-from typing import Optional
+from typing import Any, Optional, Tuple, Union
 
 import sqlalchemy as db
 from alembic.command import downgrade, stamp, upgrade
 from alembic.config import Config
+from alembic.runtime.environment import EnvironmentContext
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.compiler import compiles
+from typing_extensions import TypeAlias
 
 from dagster._utils import file_relative_path
 from dagster._utils.log import quieten
@@ -16,6 +19,14 @@ create_engine = db.create_engine  # exported
 
 
 ALEMBIC_SCRIPTS_LOCATION = "dagster:_core/storage/alembic"
+
+# Stand-in for a typed query object, which is only available in sqlalchemy 2+
+SqlAlchemyQuery: TypeAlias = Any
+
+# Stand-in for a typed row object, which is only available in sqlalchemy 2+
+SqlAlchemyRow: TypeAlias = Any
+
+AlembicVersion: TypeAlias = Tuple[Optional[str], Optional[Union[str, Tuple[str, ...]]]]
 
 
 @lru_cache(maxsize=3)  # run, event, and schedule storages
@@ -32,13 +43,17 @@ def get_alembic_config(
     return alembic_config
 
 
-def run_alembic_upgrade(alembic_config, conn, run_id=None, rev="head"):
+def run_alembic_upgrade(
+    alembic_config: Config, conn: Connection, run_id: Optional[str] = None, rev: str = "head"
+) -> None:
     alembic_config.attributes["connection"] = conn
     alembic_config.attributes["run_id"] = run_id
     upgrade(alembic_config, rev)
 
 
-def run_alembic_downgrade(alembic_config, conn, rev, run_id=None):
+def run_alembic_downgrade(
+    alembic_config: Config, conn: Connection, rev: str, run_id: Optional[str] = None
+) -> None:
     alembic_config.attributes["connection"] = conn
     alembic_config.attributes["run_id"] = run_id
     downgrade(alembic_config, rev)
@@ -48,13 +63,15 @@ def run_alembic_downgrade(alembic_config, conn, rev, run_id=None):
 _alembic_lock = threading.Lock()
 
 
-def stamp_alembic_rev(alembic_config, conn, rev="head", quiet=True):
+def stamp_alembic_rev(
+    alembic_config: Config, conn: Connection, rev: str = "head", quiet: bool = True
+) -> None:
     with _alembic_lock, quieten(quiet):
         alembic_config.attributes["connection"] = conn
         stamp(alembic_config, rev)
 
 
-def check_alembic_revision(alembic_config, conn):
+def check_alembic_revision(alembic_config: Config, conn: Connection) -> AlembicVersion:
     with _alembic_lock:
         migration_context = MigrationContext.configure(conn)
         db_revision = migration_context.get_current_revision()
@@ -64,7 +81,9 @@ def check_alembic_revision(alembic_config, conn):
     return (db_revision, head_revision)
 
 
-def run_migrations_offline(context, config, target_metadata):
+def run_migrations_offline(
+    context: EnvironmentContext, config: Config, target_metadata: db.MetaData
+) -> None:
     """Run migrations in 'offline' mode.
 
     This configures the context with just a URL
@@ -103,7 +122,9 @@ def run_migrations_offline(context, config, target_metadata):
             raise
 
 
-def run_migrations_online(context, config, target_metadata):
+def run_migrations_online(
+    context: EnvironmentContext, config: Config, target_metadata: db.MetaData
+) -> None:
     """Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
@@ -145,7 +166,7 @@ MYSQL_FLOAT_PRECISION: int = 32
 
 # datetime issue fix from here: https://stackoverflow.com/questions/29711102/sqlalchemy-mysql-millisecond-or-microsecond-precision/29723278
 @compiles(db.DateTime, "mysql")
-def compile_datetime_and_add_precision_mysql(_element, _compiler, **_kw):
+def compile_datetime_and_add_precision_mysql(_element, _compiler, **_kw) -> str:
     return f"DATETIME({MYSQL_DATE_PRECISION})"
 
 
@@ -156,22 +177,22 @@ class get_current_timestamp(db.sql.expression.FunctionElement):  # pylint: disab
 
 
 @compiles(get_current_timestamp, "mysql")
-def compiles_get_current_timestamp_mysql(_element, _compiler, **_kw):
+def compiles_get_current_timestamp_mysql(_element, _compiler, **_kw) -> str:
     return f"CURRENT_TIMESTAMP({MYSQL_DATE_PRECISION})"
 
 
 @compiles(get_current_timestamp)
-def compiles_get_current_timestamp_default(_element, _compiler, **_kw):
+def compiles_get_current_timestamp_default(_element, _compiler, **_kw) -> str:
     return "CURRENT_TIMESTAMP"
 
 
 @compiles(db.types.TIMESTAMP, "mysql")
-def add_precision_to_mysql_timestamps(_element, _compiler, **_kw):
+def add_precision_to_mysql_timestamps(_element, _compiler, **_kw) -> str:
     return f"TIMESTAMP({MYSQL_DATE_PRECISION})"
 
 
 @compiles(db.types.Float, "mysql")
-def add_precision_to_mysql_floats(_element, _compiler, **_kw):
+def add_precision_to_mysql_floats(_element, _compiler, **_kw) -> str:
     """Forces floats to have minimum precision of 32, which converts the underlying type to be a
     double.  This is necessary because the default precision of floats is too low for some types,
     including unix timestamps, resulting in truncated values in MySQL.
@@ -180,7 +201,7 @@ def add_precision_to_mysql_floats(_element, _compiler, **_kw):
 
 
 @compiles(db.types.FLOAT, "mysql")
-def add_precision_to_mysql_FLOAT(_element, _compiler, **_kw):
+def add_precision_to_mysql_FLOAT(_element, _compiler, **_kw) -> str:
     """Forces floats to have minimum precision of 32, which converts the underlying type to be a
     double.  This is necessary because the default precision of floats is too low for some types,
     including unix timestamps, resulting in truncated values in MySQL.

--- a/python_modules/dagster/dagster/_core/storage/sqlite.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 import os
 import sqlite3
 

--- a/python_modules/dagster/dagster/_core/storage/sqlite.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite.py
@@ -1,10 +1,12 @@
+# pyright: strict
+
 import os
 import sqlite3
 
 import dagster._check as check
 
 
-def create_db_conn_string(base_dir, db_name):
+def create_db_conn_string(base_dir: str, db_name: str) -> str:
     check.str_param(base_dir, "base_dir")
     check.str_param(db_name, "db_name")
 
@@ -13,7 +15,7 @@ def create_db_conn_string(base_dir, db_name):
     return "sqlite:///{}".format("/".join(path_components + [db_file]))
 
 
-def create_in_memory_conn_string(db_name):
+def create_in_memory_conn_string(db_name: str) -> str:
     # Uses a named file-based URL for the in-memory connection (as opposed to the :memory: url) so
     # that multiple instances can share the same logical DB across connections, while maintaining
     # separate DBs for different db names.  The latter is required to have both the run / event_log
@@ -21,5 +23,5 @@ def create_in_memory_conn_string(db_name):
     return f"sqlite:///file:{db_name}?mode=memory&uri=true"
 
 
-def get_sqlite_version():
+def get_sqlite_version() -> str:
     return str(sqlite3.sqlite_version)

--- a/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
@@ -1,10 +1,12 @@
 import os
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import yaml
+from typing_extensions import Self, TypedDict
 
 from dagster import _check as check
 from dagster._config import StringSource
+from dagster._config.config_schema import UserConfigSchema
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import mkdir_p
 
@@ -16,16 +18,23 @@ from .runs.sqlite.sqlite_run_storage import SqliteRunStorage
 from .schedules.base import ScheduleStorage
 from .schedules.sqlite.sqlite_schedule_storage import SqliteScheduleStorage
 
+if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
 
-def _runs_directory(base):
+
+class SqliteStorageConfig(TypedDict):
+    base_dir: str
+
+
+def _runs_directory(base: str) -> str:
     return os.path.join(base, "history", "")
 
 
-def _event_logs_directory(base):
+def _event_logs_directory(base: str) -> str:
     return os.path.join(base, "history", "runs", "")
 
 
-def _schedule_directory(base):
+def _schedule_directory(base: str) -> str:
     return os.path.join(base, "schedules")
 
 
@@ -49,7 +58,7 @@ class DagsterSqliteStorage(DagsterStorage, ConfigurableClass):
 
     """
 
-    def __init__(self, base_dir, inst_data=None):
+    def __init__(self, base_dir: str, inst_data: Optional[ConfigurableClassData] = None):
         self.base_dir = check.str_param(base_dir, "base_dir")
         self._run_storage = SqliteRunStorage.from_local(_runs_directory(base_dir))
         self._event_log_storage = SqliteEventLogStorage(_event_logs_directory(base_dir))
@@ -58,29 +67,31 @@ class DagsterSqliteStorage(DagsterStorage, ConfigurableClass):
         super().__init__()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: ConfigurableClassData, config_value: SqliteStorageConfig
+    ) -> "DagsterSqliteStorage":
         return DagsterSqliteStorage.from_local(inst_data=inst_data, **config_value)
 
     @classmethod
-    def from_local(cls, base_dir, inst_data=None):
+    def from_local(cls, base_dir: str, inst_data: Optional[ConfigurableClassData] = None) -> Self:
         check.str_param(base_dir, "base_dir")
         mkdir_p(base_dir)
         return cls(base_dir, inst_data=inst_data)
 
-    def register_instance(self, instance):
-        if not self._run_storage._instance:  # pylint: disable=protected-access
+    def register_instance(self, instance: "DagsterInstance") -> None:
+        if not self._run_storage._instance:
             self._run_storage.register_instance(instance)
-        if not self._event_log_storage._instance:  # pylint: disable=protected-access
+        if not self._event_log_storage._instance:
             self._event_log_storage.register_instance(instance)
-        if not self._schedule_storage._instance:  # pylint: disable=protected-access
+        if not self._schedule_storage._instance:
             self._schedule_storage.register_instance(instance)
 
     @property
@@ -119,7 +130,7 @@ class DagsterSqliteStorage(DagsterStorage, ConfigurableClass):
             yaml.dump({"base_dir": _schedule_directory(self.base_dir)}, default_flow_style=False),
         )
 
-    def dispose(self):
+    def dispose(self) -> None:
         self.event_log_storage.dispose()
         self.run_storage.dispose()
         self.schedule_storage.dispose()

--- a/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
+++ b/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 from typing import NamedTuple, Optional, Sequence
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -3,13 +3,14 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Type
 
 import dagster._check as check
+from dagster._config.config_schema import UserConfigSchema
 from dagster._utils import convert_dagster_submodule_name
 from dagster._utils.yaml_utils import load_run_config_yaml
 
 from .serdes import DefaultNamedTupleSerializer, WhitelistMap, whitelist_for_serdes
 
 if TYPE_CHECKING:
-    from dagster._config.config_type import ConfigType
+    pass
 
 
 class ConfigurableClassDataSerializer(DefaultNamedTupleSerializer):
@@ -141,7 +142,7 @@ class ConfigurableClass(ABC):
 
     @classmethod
     @abstractmethod
-    def config_type(cls) -> "ConfigType":
+    def config_type(cls) -> "UserConfigSchema":
         """dagster.ConfigType: The config type against which to validate a config yaml fragment
         serialized in an instance of ``ConfigurableClassData``.
         """
@@ -149,7 +150,7 @@ class ConfigurableClass(ABC):
 
     @staticmethod
     @abstractmethod
-    def from_config_value(inst_data: Any, config_value: Mapping[str, Any]) -> object:
+    def from_config_value(inst_data: Any, config_value: Any) -> object:
         """New up an instance of the ConfigurableClass from a validated config value.
 
         Called by ConfigurableClassData.rehydrate.

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -1,6 +1,6 @@
 import importlib
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Type
+from typing import Any, Dict, Mapping, NamedTuple, Type
 
 import dagster._check as check
 from dagster._config.config_schema import UserConfigSchema
@@ -8,9 +8,6 @@ from dagster._utils import convert_dagster_submodule_name
 from dagster._utils.yaml_utils import load_run_config_yaml
 
 from .serdes import DefaultNamedTupleSerializer, WhitelistMap, whitelist_for_serdes
-
-if TYPE_CHECKING:
-    pass
 
 
 class ConfigurableClassDataSerializer(DefaultNamedTupleSerializer):

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -42,7 +42,7 @@ from typing import (
 )
 
 import packaging.version
-from typing_extensions import Literal
+from typing_extensions import Literal, TypeAlias
 
 import dagster._check as check
 import dagster._seven as seven
@@ -66,6 +66,8 @@ PICKLE_PROTOCOL = 4
 
 
 DEFAULT_WORKSPACE_YAML_FILENAME = "workspace.yaml"
+
+PrintFn: TypeAlias = Callable[[Any], None]
 
 
 # Use this to get the "library version" (pre-1.0 version) from the "core version" (post 1.0
@@ -473,7 +475,7 @@ def iterate_with_context(
         yield next_output
 
 
-def datetime_as_float(dt):
+def datetime_as_float(dt: datetime.datetime) -> float:
     check.inst_param(dt, "dt", datetime.datetime)
     return float((dt - EPOCH).total_seconds())
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -158,7 +158,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 conn.execute(
                     db_dialects.mysql.insert(AssetKeyTable)
                     .values(
-                        asset_key=event.dagster_event.asset_key.to_string(),  # type: ignore
+                        asset_key=event.dagster_event.asset_key.to_string(),  # type: ignore  # (possible none)
                         **values,
                     )
                     .on_duplicate_key_update(
@@ -169,7 +169,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 try:
                     conn.execute(
                         db_dialects.mysql.insert(AssetKeyTable).values(
-                            asset_key=event.dagster_event.asset_key.to_string(),  # type: ignore
+                            asset_key=event.dagster_event.asset_key.to_string(),  # type: ignore  # (possible none)
                         )
                     )
                 except db_exc.IntegrityError:
@@ -209,7 +209,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     @property
     def supports_intersect(self) -> bool:
-        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore
+        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore  # (possible none)
             MINIMUM_MYSQL_INTERSECT_VERSION
         )
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -1,6 +1,14 @@
+from typing import ContextManager, Optional
+
 import dagster._check as check
 import sqlalchemy as db
-from dagster._core.storage.config import mysql_config
+import sqlalchemy.dialects as db_dialects
+import sqlalchemy.exc as db_exc
+import sqlalchemy.pool as db_pool
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.event_api import EventHandlerFn
+from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.event_log import (
     AssetKeyTable,
     SqlEventLogStorage,
@@ -10,12 +18,14 @@ from dagster._core.storage.event_log import (
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
+from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_mysql_connection,
@@ -47,7 +57,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     """
 
-    def __init__(self, mysql_url, inst_data=None):
+    def __init__(self, mysql_url: str, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.mysql_url = check.str_param(mysql_url, "mysql_url")
         self._disposed = False
@@ -58,7 +68,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         self._engine = create_engine(
             self.mysql_url,
             isolation_level="AUTOCOMMIT",
-            poolclass=db.pool.NullPool,
+            poolclass=db_pool.NullPool,
         )
         self._secondary_index_cache = {}
 
@@ -75,13 +85,13 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         self._mysql_version = self.get_server_version()
         super().__init__()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
         with self._connect() as conn:
             with conn.begin():
                 SqlEventLogStorageMetadata.create_all(conn)
                 stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout, pool_recycle):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
@@ -91,39 +101,41 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             pool_recycle=pool_recycle,
         )
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         alembic_config = mysql_alembic_config(__file__)
         with self._connect() as conn:
             run_alembic_upgrade(alembic_config, conn)
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+    ) -> "MySQLEventLogStorage":
         return MySQLEventLogStorage(
             inst_data=inst_data, mysql_url=mysql_url_from_config(config_value)
         )
 
     @staticmethod
-    def wipe_storage(mysql_url):
-        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool)
+    def wipe_storage(mysql_url: str) -> None:
+        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool)
         try:
             SqlEventLogStorageMetadata.drop_all(engine)
         finally:
             engine.dispose()
 
     @staticmethod
-    def create_clean_storage(conn_string):
+    def create_clean_storage(conn_string: str) -> "MySQLEventLogStorage":
         MySQLEventLogStorage.wipe_storage(conn_string)
         return MySQLEventLogStorage(conn_string)
 
-    def get_server_version(self):
+    def get_server_version(self) -> Optional[str]:
         with self.index_connection() as conn:
             result_proxy = conn.execute("select version()")
             row = result_proxy.fetchone()
@@ -134,7 +146,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         return row[0]
 
-    def store_asset_event(self, event, event_id):
+    def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         # last_materialization_timestamp is updated upon observation, materialization, materialization_planned
         # See SqlEventLogStorage.store_asset_event method for more details
 
@@ -144,9 +156,9 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         with self.index_connection() as conn:
             if values:
                 conn.execute(
-                    db.dialects.mysql.insert(AssetKeyTable)
+                    db_dialects.mysql.insert(AssetKeyTable)
                     .values(
-                        asset_key=event.dagster_event.asset_key.to_string(),
+                        asset_key=event.dagster_event.asset_key.to_string(),  # type: ignore
                         **values,
                     )
                     .on_duplicate_key_update(
@@ -156,64 +168,64 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             else:
                 try:
                     conn.execute(
-                        db.dialects.mysql.insert(AssetKeyTable).values(
-                            asset_key=event.dagster_event.asset_key.to_string(),
+                        db_dialects.mysql.insert(AssetKeyTable).values(
+                            asset_key=event.dagster_event.asset_key.to_string(),  # type: ignore
                         )
                     )
-                except db.exc.IntegrityError:
+                except db_exc.IntegrityError:
                     pass
 
-    def _connect(self):
+    def _connect(self) -> ContextManager[Connection]:
         return create_mysql_connection(self._engine, __file__, "event log")
 
-    def run_connection(self, run_id=None):
+    def run_connection(self, run_id: Optional[str] = None) -> ContextManager[Connection]:
         return self._connect()
 
-    def index_connection(self):
+    def index_connection(self) -> ContextManager[Connection]:
         return self._connect()
 
     def has_table(self, table_name: str) -> bool:
         return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
 
-    def has_secondary_index(self, name):
+    def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:
             self._secondary_index_cache[name] = super(
                 MySQLEventLogStorage, self
             ).has_secondary_index(name)
         return self._secondary_index_cache[name]
 
-    def enable_secondary_index(self, name):
+    def enable_secondary_index(self, name: str) -> None:
         super(MySQLEventLogStorage, self).enable_secondary_index(name)
         if name in self._secondary_index_cache:
             del self._secondary_index_cache[name]
 
-    def watch(self, run_id, cursor, callback):
+    def watch(self, run_id: str, cursor: Optional[str], callback: EventHandlerFn) -> None:
         if cursor and EventLogCursor.parse(cursor).is_offset_cursor():
             check.failed("Cannot call `watch` with an offset cursor")
         self._event_watcher.watch_run(run_id, cursor, callback)
 
-    def end_watch(self, run_id, handler):
+    def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
         self._event_watcher.unwatch_run(run_id, handler)
 
     @property
-    def supports_intersect(self):
-        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(
+    def supports_intersect(self) -> bool:
+        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore
             MINIMUM_MYSQL_INTERSECT_VERSION
         )
 
     @property
-    def event_watcher(self):
+    def event_watcher(self) -> SqlPollingEventWatcher:
         return self._event_watcher
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.dispose()
 
-    def dispose(self):
+    def dispose(self) -> None:
         if not self._disposed:
             self._disposed = True
             self._event_watcher.close()
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = mysql_alembic_config(__file__)
         with self._connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -1,9 +1,11 @@
-from typing import Mapping
+from typing import ContextManager, Mapping, Optional
 
 import dagster._check as check
 import sqlalchemy as db
-import sqlalchemy.dialects.mysql as db_dialects_mysql
-from dagster._core.storage.config import mysql_config
+import sqlalchemy.dialects as db_dialects
+import sqlalchemy.pool as db_pool
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.runs import (
     DaemonHeartbeatsTable,
     InstanceInfo,
@@ -12,13 +14,16 @@ from dagster._core.storage.runs import (
 )
 from dagster._core.storage.runs.schema import KeyValueStoreTable
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
+from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
 from dagster._utils import utc_datetime_from_timestamp
+from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_mysql_connection,
@@ -51,7 +56,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
     :py:class:`~dagster.IntSource` and can be configured from environment variables.
     """
 
-    def __init__(self, mysql_url, inst_data=None):
+    def __init__(self, mysql_url: str, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.mysql_url = mysql_url
 
@@ -59,7 +64,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         self._engine = create_engine(
             self.mysql_url,
             isolation_level="AUTOCOMMIT",
-            poolclass=db.pool.NullPool,
+            poolclass=db_pool.NullPool,
         )
 
         self._index_migration_cache = {}
@@ -79,13 +84,13 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
 
         super().__init__()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
         with self.connect() as conn:
             with conn.begin():
                 RunStorageSqlMetadata.create_all(conn)
                 stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout, pool_recycle):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
@@ -96,14 +101,14 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         )
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
-    def get_server_version(self):
+    def get_server_version(self) -> Optional[str]:
         row = self.fetchone("select version()")
         if not row:
             return None
@@ -111,44 +116,46 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         return row[0]
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+    ) -> "MySQLRunStorage":
         return MySQLRunStorage(inst_data=inst_data, mysql_url=mysql_url_from_config(config_value))
 
     @staticmethod
-    def wipe_storage(mysql_url):
-        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool)
+    def wipe_storage(mysql_url: str) -> None:
+        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool)
         try:
             RunStorageSqlMetadata.drop_all(engine)
         finally:
             engine.dispose()
 
     @staticmethod
-    def create_clean_storage(mysql_url):
+    def create_clean_storage(mysql_url: str) -> "MySQLRunStorage":
         MySQLRunStorage.wipe_storage(mysql_url)
         return MySQLRunStorage(mysql_url)
 
-    def connect(self, run_id=None):  # pylint: disable=arguments-differ, unused-argument
+    def connect(self, run_id: Optional[str] = None) -> ContextManager[Connection]:
         return create_mysql_connection(self._engine, __file__, "run")
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         alembic_config = mysql_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_upgrade(alembic_config, conn)
 
-    def has_built_index(self, migration_name):
+    def has_built_index(self, migration_name: str) -> None:
         if migration_name not in self._index_migration_cache:
             self._index_migration_cache[migration_name] = super(
                 MySQLRunStorage, self
             ).has_built_index(migration_name)
         return self._index_migration_cache[migration_name]
 
-    def mark_index_built(self, migration_name):
+    def mark_index_built(self, migration_name: str) -> None:
         super(MySQLRunStorage, self).mark_index_built(migration_name)
         if migration_name in self._index_migration_cache:
             del self._index_migration_cache[migration_name]
 
     @property
-    def supports_bucket_queries(self):
+    def supports_bucket_queries(self) -> bool:
         if not super().supports_bucket_queries:
             return False
 
@@ -160,15 +167,15 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         )
 
     @property
-    def supports_intersect(self):
-        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(
+    def supports_intersect(self) -> bool:
+        return parse_mysql_version(self._mysql_version) >= parse_mysql_version(  # type: ignore
             MINIMUM_MYSQL_INTERSECT_VERSION
         )
 
-    def add_daemon_heartbeat(self, daemon_heartbeat):
+    def add_daemon_heartbeat(self, daemon_heartbeat: DaemonHeartbeat) -> None:
         with self.connect() as conn:
             conn.execute(
-                db_dialects_mysql.insert(DaemonHeartbeatsTable)
+                db_dialects.mysql.insert(DaemonHeartbeatsTable)
                 .values(
                     timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                     daemon_type=daemon_heartbeat.daemon_type,
@@ -187,14 +194,14 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
         db_values = [{"key": k, "value": v} for k, v in pairs.items()]
 
         with self.connect() as conn:
-            insert_stmt = db_dialects_mysql.insert(KeyValueStoreTable).values(db_values)
+            insert_stmt = db_dialects.mysql.insert(KeyValueStoreTable).values(db_values)
             conn.execute(
                 insert_stmt.on_duplicate_key_update(
                     value=insert_stmt.inserted.value,
                 )
             )
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = mysql_alembic_config(__file__)
         with self.connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -139,7 +139,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
     def upgrade(self) -> None:
         alembic_config = mysql_alembic_config(__file__)
-        run_alembic_upgrade(alembic_config, self._engine)  # type: ignore  # shouldn't this be a connection
+        run_alembic_upgrade(alembic_config, self._engine)  # type: ignore  # (should 2nd arg be a Connection instead of an Engine?)
 
     def _add_or_update_instigators_table(self, conn: Connection, state) -> None:
         selector_id = state.selector_id

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -1,16 +1,23 @@
+from typing import ContextManager, Optional
+
 import dagster._check as check
 import pendulum
 import sqlalchemy as db
-from dagster._core.storage.config import mysql_config
+import sqlalchemy.dialects as db_dialects
+import sqlalchemy.pool as db_pool
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
 from dagster._core.storage.schedules.schema import InstigatorsTable
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_mysql_connection,
@@ -41,7 +48,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     :py:class:`~dagster.IntSource` and can be configured from environment variables.
     """
 
-    def __init__(self, mysql_url, inst_data=None):
+    def __init__(self, mysql_url: str, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.mysql_url = mysql_url
 
@@ -49,7 +56,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self._engine = create_engine(
             self.mysql_url,
             isolation_level="AUTOCOMMIT",
-            poolclass=db.pool.NullPool,
+            poolclass=db_pool.NullPool,
         )
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
@@ -62,7 +69,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
         super().__init__()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
         with self.connect() as conn:
             with conn.begin():
                 ScheduleStorageSqlMetadata.create_all(conn)
@@ -72,7 +79,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_dagit(self, statement_timeout, pool_recycle):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
@@ -83,37 +90,39 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         )
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+    ) -> "MySQLScheduleStorage":
         return MySQLScheduleStorage(
             inst_data=inst_data, mysql_url=mysql_url_from_config(config_value)
         )
 
     @staticmethod
-    def wipe_storage(mysql_url):
-        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool)
+    def wipe_storage(mysql_url: str) -> None:
+        engine = create_engine(mysql_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool)
         try:
             ScheduleStorageSqlMetadata.drop_all(engine)
         finally:
             engine.dispose()
 
     @staticmethod
-    def create_clean_storage(mysql_url):
+    def create_clean_storage(mysql_url: str) -> "MySQLScheduleStorage":
         MySQLScheduleStorage.wipe_storage(mysql_url)
         return MySQLScheduleStorage(mysql_url)
 
-    def connect(self, run_id=None):  # pylint: disable=arguments-differ, unused-argument
+    def connect(self, run_id: Optional[str] = None) -> ContextManager[Connection]:
         return create_mysql_connection(self._engine, __file__, "schedule")
 
     @property
-    def supports_batch_queries(self):
+    def supports_batch_queries(self) -> bool:
         if not self._mysql_version:
             return False
 
@@ -121,21 +130,21 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             MINIMUM_MYSQL_BATCH_VERSION
         )
 
-    def get_server_version(self):
+    def get_server_version(self) -> Optional[str]:
         rows = self.execute("select version()")
         if not rows:
             return None
 
         return rows[0][0]
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         alembic_config = mysql_alembic_config(__file__)
-        run_alembic_upgrade(alembic_config, self._engine)
+        run_alembic_upgrade(alembic_config, self._engine)  # type: ignore  # shouldn't this be a connection
 
-    def _add_or_update_instigators_table(self, conn, state):
+    def _add_or_update_instigators_table(self, conn: Connection, state) -> None:
         selector_id = state.selector_id
         conn.execute(
-            db.dialects.mysql.insert(InstigatorsTable)
+            db_dialects.mysql.insert(InstigatorsTable)
             .values(
                 selector_id=selector_id,
                 repository_selector_id=state.repository_selector_id,
@@ -151,7 +160,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             )
         )
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = mysql_alembic_config(__file__)
         with self.connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/storage.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
 from dagster import _check as check
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.storage.base_storage import DagsterStorage
-from dagster._core.storage.config import mysql_config
+from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.event_log import EventLogStorage
 from dagster._core.storage.runs import RunStorage
 from dagster._core.storage.schedules import ScheduleStorage
@@ -41,15 +42,17 @@ class DagsterMySQLStorage(DagsterStorage, ConfigurableClass):
         super().__init__()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+    ) -> "DagsterMySQLStorage":
         return DagsterMySQLStorage(
             inst_data=inst_data,
             mysql_url=mysql_url_from_config(config_value),

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/utils.py
@@ -2,7 +2,7 @@ import logging
 import re
 import time
 from contextlib import contextmanager
-from typing import Callable, Optional, Union, cast
+from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union, cast
 from urllib.parse import (
     quote_plus as urlquote,
     urlparse,
@@ -14,9 +14,13 @@ import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from alembic.config import Config
 from dagster import _check as check
+from dagster._core.storage.config import MySqlStorageConfig
 from dagster._core.storage.sql import get_alembic_config
 from mysql.connector.pooling import PooledMySQLConnection
+from sqlalchemy.engine import Connection
 from typing_extensions import TypeAlias
+
+T = TypeVar("T")
 
 # Represents the output of mysql connection function
 MySQLConnectionUnion: TypeAlias = Union[
@@ -44,7 +48,7 @@ def get_conn(conn_string: str) -> MySQLConnectionUnion:
     return conn
 
 
-def mysql_url_from_config(config_value):
+def mysql_url_from_config(config_value: MySqlStorageConfig) -> str:
     if config_value.get("mysql_url"):
         return config_value["mysql_url"]
 
@@ -52,7 +56,7 @@ def mysql_url_from_config(config_value):
 
 
 def get_conn_string(
-    username: str, password: str, hostname: str, db_name: str, port: str = "3306"
+    username: str, password: str, hostname: str, db_name: str, port: Union[int, str] = "3306"
 ) -> str:
     return "mysql+mysqlconnector://{username}:{password}@{hostname}:{port}/{db_name}".format(
         username=username,
@@ -63,7 +67,7 @@ def get_conn_string(
     )
 
 
-def parse_mysql_version(version: str) -> tuple:
+def parse_mysql_version(version: str) -> Tuple[int, ...]:
     """Parse MySQL version into a tuple of ints.
 
     Args:
@@ -83,7 +87,9 @@ def parse_mysql_version(version: str) -> tuple:
     return tuple(parsed)
 
 
-def retry_mysql_creation_fn(fn, retry_limit: int = 5, retry_wait: float = 0.2):
+def retry_mysql_creation_fn(
+    fn: Callable[[], T], retry_limit: int = 5, retry_wait: float = 0.2
+) -> T:
     # Retry logic to recover from the case where two processes are creating
     # tables at the same time using sqlalchemy
 
@@ -118,10 +124,10 @@ def retry_mysql_creation_fn(fn, retry_limit: int = 5, retry_wait: float = 0.2):
 
 
 def retry_mysql_connection_fn(
-    fn: Callable[[], MySQLConnectionUnion],
+    fn: Callable[[], T],
     retry_limit: int = 5,
     retry_wait: float = 0.2,
-) -> MySQLConnectionUnion:
+) -> T:
     """Reusable retry logic for any MySQL connection functions that may fail.
     Intended to be used anywhere we connect to MySQL, to gracefully handle transient connection
     issues.
@@ -175,7 +181,7 @@ def mysql_alembic_config(dunder_file: str) -> Config:
 @contextmanager
 def create_mysql_connection(
     engine: db.engine.Engine, dunder_file: str, storage_type_desc: Optional[str] = None
-):
+) -> Iterator[Connection]:
     check.inst_param(engine, "engine", db.engine.Engine)
     check.str_param(dunder_file, "dunder_file")
     check.opt_str_param(storage_type_desc, "storage_type_desc", "")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -1,9 +1,12 @@
-from typing import Optional
+from typing import Any, ContextManager, Mapping, Optional
 
 import dagster._check as check
 import sqlalchemy as db
-import sqlalchemy.dialects.postgresql as db_dialects_postgresql
+import sqlalchemy.dialects as db_dialects
+import sqlalchemy.pool as db_pool
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.event_api import EventHandlerFn
 from dagster._core.events import ASSET_EVENTS
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.config import pg_config
@@ -16,12 +19,14 @@ from dagster._core.storage.event_log import (
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, deserialize_as
+from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_pg_connection,
@@ -65,7 +70,12 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     """
 
-    def __init__(self, postgres_url, should_autocreate_tables=True, inst_data=None):
+    def __init__(
+        self,
+        postgres_url: str,
+        should_autocreate_tables: bool = True,
+        inst_data: Optional[ConfigurableClassData] = None,
+    ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = check.str_param(postgres_url, "postgres_url")
         self.should_autocreate_tables = check.bool_param(
@@ -76,7 +86,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_engine(
-            self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool
+            self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
 
         # lazy init
@@ -95,13 +105,13 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         super().__init__()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
         with self._connect() as conn:
             with conn.begin():
                 SqlEventLogStorageMetadata.create_all(conn)
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout, pool_recycle):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)
@@ -117,21 +127,23 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             pool_recycle=pool_recycle,
         )
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         alembic_config = pg_alembic_config(__file__)
         with self._connect() as conn:
             run_alembic_upgrade(alembic_config, conn)
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, Any]
+    ) -> "PostgresEventLogStorage":
         return PostgresEventLogStorage(
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
@@ -139,9 +151,11 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         )
 
     @staticmethod
-    def create_clean_storage(conn_string, should_autocreate_tables=True):
+    def create_clean_storage(
+        conn_string: str, should_autocreate_tables: bool = True
+    ) -> "PostgresEventLogStorage":
         engine = create_engine(
-            conn_string, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool
+            conn_string, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
         try:
             SqlEventLogStorageMetadata.drop_all(engine)
@@ -150,7 +164,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         return PostgresEventLogStorage(conn_string, should_autocreate_tables)
 
-    def store_event(self, event):
+    def store_event(self, event: EventLogEntry) -> None:
         """Store an event corresponding to a pipeline run.
 
         Args:
@@ -168,14 +182,14 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             result.close()
             conn.execute(
                 """NOTIFY {channel}, %s; """.format(channel=CHANNEL_NAME),
-                (res[0] + "_" + str(res[1]),),
+                (res[0] + "_" + str(res[1]),),  # type: ignore
             )
-            event_id = res[1]
+            event_id = res[1]  # type: ignore
 
         if (
             event.is_dagster_event
             and event.dagster_event_type in ASSET_EVENTS
-            and event.dagster_event.asset_key
+            and event.dagster_event.asset_key  # type: ignore
         ):
             self.store_asset_event(event, event_id)
 
@@ -186,7 +200,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
             self.store_asset_event_tags(event, event_id)
 
-    def store_asset_event(self, event: EventLogEntry, event_id: int):
+    def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         check.inst_param(event, "event", EventLogEntry)
         if not (event.dagster_event and event.dagster_event.asset_key):
             return
@@ -225,7 +239,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             event, event_id, self.has_secondary_index(ASSET_KEY_INDEX_COLS)
         )
         with self.index_connection() as conn:
-            query = db_dialects_postgresql.insert(AssetKeyTable).values(
+            query = db_dialects.postgresql.insert(AssetKeyTable).values(
                 asset_key=event.dagster_event.asset_key.to_string(),
                 **values,
             )
@@ -238,31 +252,36 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 query = query.on_conflict_do_nothing()
             conn.execute(query)
 
-    def _connect(self):
+    def _connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)
 
-    def run_connection(self, run_id=None):
+    def run_connection(self, run_id: Optional[str] = None) -> ContextManager[Connection]:
         return self._connect()
 
-    def index_connection(self):
+    def index_connection(self) -> ContextManager[Connection]:
         return self._connect()
 
     def has_table(self, table_name: str) -> bool:
         return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
 
-    def has_secondary_index(self, name):
+    def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:
             self._secondary_index_cache[name] = super(
                 PostgresEventLogStorage, self
             ).has_secondary_index(name)
         return self._secondary_index_cache[name]
 
-    def enable_secondary_index(self, name):
+    def enable_secondary_index(self, name: str) -> None:
         super(PostgresEventLogStorage, self).enable_secondary_index(name)
         if name in self._secondary_index_cache:
             del self._secondary_index_cache[name]
 
-    def watch(self, run_id, cursor, callback):
+    def watch(
+        self,
+        run_id: str,
+        cursor: Optional[str],
+        callback: EventHandlerFn,
+    ) -> None:
         if cursor and EventLogCursor.parse(cursor).is_offset_cursor():
             check.failed("Cannot call `watch` with an offset cursor")
 
@@ -282,25 +301,25 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     SqlEventLogStorageTable.c.id == cursor
                 ),
             )
-            return deserialize_as(cursor_res.scalar(), EventLogEntry)
+            return deserialize_as(cursor_res.scalar(), EventLogEntry)  # type: ignore
 
-    def end_watch(self, run_id, handler):
+    def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
         if self._event_watcher is None:
             return
 
         self._event_watcher.unwatch_run(run_id, handler)
 
-    def __del__(self):
+    def __del__(self) -> None:
         # Keep the inherent limitations of __del__ in Python in mind!
         self.dispose()
 
-    def dispose(self):
+    def dispose(self) -> None:
         if not self._disposed:
             self._disposed = True
             if self._event_watcher:
                 self._event_watcher.close()
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = pg_alembic_config(__file__)
         with self._connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/pynotify.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/pynotify.py
@@ -40,7 +40,7 @@ from psycopg2.extensions import Notify
 from .utils import create_pg_connection
 
 
-def get_wakeup_fd():
+def get_wakeup_fd() -> int:
     pipe_r, pipe_w = os.pipe()
     if "win" not in sys.platform:
         import fcntl
@@ -56,7 +56,7 @@ def _empty_handler(_signal, _frame):
     pass
 
 
-def quote_table_name(name):
+def quote_table_name(name: str) -> str:
     return '"{}"'.format(name)
 
 
@@ -68,7 +68,7 @@ def start_listening(connection, channels):
         curs.execute(listens)
 
 
-def construct_signals(arg):
+def construct_signals(arg) -> signal.Signals:
     # function exists to consolidate and scope pylint directive
     return signal.Signals(arg)  # pylint: disable=no-member
 
@@ -108,7 +108,7 @@ def await_pg_notifications(
     )
 
     with create_pg_connection(engine) as conn:
-        connection = conn.connection.connection  # DBAPI connection
+        connection = conn.connection.connection  # DBAPI connection  # type: ignore
 
         if channels:
             start_listening(connection, channels)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -1,9 +1,11 @@
-from typing import Mapping
+from typing import ContextManager, Mapping, Optional
 
 import dagster._check as check
 import sqlalchemy as db
-import sqlalchemy.dialects.postgresql as db_dialects_postgresql
-from dagster._core.storage.config import pg_config
+import sqlalchemy.dialects as db_dialects
+import sqlalchemy.pool as db_pool
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.storage.config import PostgresStorageConfig, pg_config
 from dagster._core.storage.runs import (
     DaemonHeartbeatsTable,
     InstanceInfo,
@@ -12,13 +14,16 @@ from dagster._core.storage.runs import (
 )
 from dagster._core.storage.runs.schema import KeyValueStoreTable
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
+from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
 from dagster._utils import utc_datetime_from_timestamp
+from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_pg_connection,
@@ -58,7 +63,12 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
     :py:class:`~dagster.IntSource` and can be configured from environment variables.
     """
 
-    def __init__(self, postgres_url, should_autocreate_tables=True, inst_data=None):
+    def __init__(
+        self,
+        postgres_url: str,
+        should_autocreate_tables: bool = True,
+        inst_data: Optional[ConfigurableClassData] = None,
+    ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
@@ -69,7 +79,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         self._engine = create_engine(
             self.postgres_url,
             isolation_level="AUTOCOMMIT",
-            poolclass=db.pool.NullPool,
+            poolclass=db_pool.NullPool,
         )
 
         self._index_migration_cache = {}
@@ -87,14 +97,14 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
 
         super().__init__()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
         with self.connect() as conn:
             with conn.begin():
                 RunStorageSqlMetadata.create_all(conn)
                 # This revision may be shared by any other dagster storage classes using the same DB
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
-    def optimize_for_dagit(self, statement_timeout, pool_recycle):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold 1 open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)
@@ -111,15 +121,17 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         )
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
+    ):
         return PostgresRunStorage(
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
@@ -127,9 +139,11 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         )
 
     @staticmethod
-    def create_clean_storage(postgres_url, should_autocreate_tables=True):
+    def create_clean_storage(
+        postgres_url: str, should_autocreate_tables: bool = True
+    ) -> "PostgresRunStorage":
         engine = create_engine(
-            postgres_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool
+            postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
         try:
             RunStorageSqlMetadata.drop_all(engine)
@@ -137,30 +151,30 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             engine.dispose()
         return PostgresRunStorage(postgres_url, should_autocreate_tables)
 
-    def connect(self):
+    def connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         with self.connect() as conn:
             run_alembic_upgrade(pg_alembic_config(__file__), conn)
 
-    def has_built_index(self, migration_name):
+    def has_built_index(self, migration_name: str) -> bool:
         if migration_name not in self._index_migration_cache:
             self._index_migration_cache[migration_name] = super(
                 PostgresRunStorage, self
             ).has_built_index(migration_name)
         return self._index_migration_cache[migration_name]
 
-    def mark_index_built(self, migration_name):
+    def mark_index_built(self, migration_name: str) -> None:
         super(PostgresRunStorage, self).mark_index_built(migration_name)
         if migration_name in self._index_migration_cache:
             del self._index_migration_cache[migration_name]
 
-    def add_daemon_heartbeat(self, daemon_heartbeat):
+    def add_daemon_heartbeat(self, daemon_heartbeat: DaemonHeartbeat) -> None:
         with self.connect() as conn:
             # insert or update if already present, using postgres specific on_conflict
             conn.execute(
-                db_dialects_postgresql.insert(DaemonHeartbeatsTable)
+                db_dialects.postgresql.insert(DaemonHeartbeatsTable)
                 .values(  # pylint: disable=no-value-for-parameter
                     timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                     daemon_type=daemon_heartbeat.daemon_type,
@@ -181,7 +195,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         check.mapping_param(pairs, "pairs", key_type=str, value_type=str)
 
         # pg speciic on_conflict_do_update
-        insert_stmt = db_dialects_postgresql.insert(KeyValueStoreTable).values(
+        insert_stmt = db_dialects.postgresql.insert(KeyValueStoreTable).values(
             [{"key": k, "value": v} for k, v in pairs.items()]
         )
         upsert_stmt = insert_stmt.on_conflict_do_update(
@@ -194,7 +208,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         with self.connect() as conn:
             conn.execute(upsert_stmt)
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = pg_alembic_config(__file__)
         with self.connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -1,16 +1,24 @@
+from typing import ContextManager, Optional
+
 import dagster._check as check
 import pendulum
 import sqlalchemy as db
-from dagster._core.storage.config import pg_config
+import sqlalchemy.dialects as db_dialects
+import sqlalchemy.pool as db_pool
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.scheduler.instigation import InstigatorState
+from dagster._core.storage.config import PostgresStorageConfig, pg_config
 from dagster._core.storage.schedules import ScheduleStorageSqlMetadata, SqlScheduleStorage
 from dagster._core.storage.schedules.schema import InstigatorsTable
 from dagster._core.storage.sql import (
+    AlembicVersion,
     check_alembic_revision,
     create_engine,
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from sqlalchemy.engine import Connection
 
 from ..utils import (
     create_pg_connection,
@@ -50,7 +58,12 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     :py:class:`~dagster.IntSource` and can be configured from environment variables.
     """
 
-    def __init__(self, postgres_url, should_autocreate_tables=True, inst_data=None):
+    def __init__(
+        self,
+        postgres_url: str,
+        should_autocreate_tables: bool = True,
+        inst_data: Optional[ConfigurableClassData] = None,
+    ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
@@ -59,7 +72,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_engine(
-            self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool
+            self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
 
         table_names = retry_pg_connection_fn(lambda: db.inspect(self._engine).get_table_names())
@@ -72,7 +85,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
 
         super().__init__()
 
-    def _init_db(self):
+    def _init_db(self) -> None:
         with self.connect() as conn:
             with conn.begin():
                 ScheduleStorageSqlMetadata.create_all(conn)
@@ -82,7 +95,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.migrate()
         self.optimize()
 
-    def optimize_for_dagit(self, statement_timeout, pool_recycle):
+    def optimize_for_dagit(self, statement_timeout: int, pool_recycle: int) -> None:
         # When running in dagit, hold an open connection and set statement_timeout
         existing_options = self._engine.url.query.get("options")
         timeout_option = pg_statement_timeout(statement_timeout)
@@ -99,15 +112,17 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         )
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
+    ) -> "PostgresScheduleStorage":
         return PostgresScheduleStorage(
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
@@ -115,9 +130,11 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         )
 
     @staticmethod
-    def create_clean_storage(postgres_url, should_autocreate_tables=True):
+    def create_clean_storage(
+        postgres_url: str, should_autocreate_tables: bool = True
+    ) -> "PostgresScheduleStorage":
         engine = create_engine(
-            postgres_url, isolation_level="AUTOCOMMIT", poolclass=db.pool.NullPool
+            postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
         try:
             ScheduleStorageSqlMetadata.drop_all(engine)
@@ -125,18 +142,18 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             engine.dispose()
         return PostgresScheduleStorage(postgres_url, should_autocreate_tables)
 
-    def connect(self, run_id=None):  # pylint: disable=arguments-differ, unused-argument
+    def connect(self, run_id: Optional[str] = None) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         alembic_config = pg_alembic_config(__file__)
         with self.connect() as conn:
             run_alembic_upgrade(alembic_config, conn)
 
-    def _add_or_update_instigators_table(self, conn, state):
+    def _add_or_update_instigators_table(self, conn: Connection, state: InstigatorState) -> None:
         selector_id = state.selector_id
         conn.execute(
-            db.dialects.postgresql.insert(InstigatorsTable)
+            db_dialects.postgresql.insert(InstigatorsTable)
             .values(  # pylint: disable=no-value-for-parameter
                 selector_id=selector_id,
                 repository_selector_id=state.repository_selector_id,
@@ -155,7 +172,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             )
         )
 
-    def alembic_version(self):
+    def alembic_version(self) -> AlembicVersion:
         alembic_config = pg_alembic_config(__file__)
         with self.connect() as conn:
             return check_alembic_revision(alembic_config, conn)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
 from dagster import _check as check
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.storage.base_storage import DagsterStorage
-from dagster._core.storage.config import pg_config
+from dagster._core.storage.config import PostgresStorageConfig, pg_config
 from dagster._core.storage.event_log import EventLogStorage
 from dagster._core.storage.runs import RunStorage
 from dagster._core.storage.schedules import ScheduleStorage
@@ -45,15 +46,17 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
         super().__init__()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
     @staticmethod
-    def from_config_value(inst_data, config_value):
+    def from_config_value(
+        inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
+    ) -> "DagsterPostgresStorage":
         return DagsterPostgresStorage(
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -1,5 +1,3 @@
-# pyright: strict
-
 import logging
 import time
 from contextlib import contextmanager

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -1,31 +1,41 @@
+# pyright: strict
+
 import logging
 import time
 from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Mapping, Optional, TypeVar
 from urllib.parse import quote, urlencode
 
+import alembic.config
 import psycopg2
 import psycopg2.errorcodes
+import psycopg2.extensions
 import sqlalchemy
+import sqlalchemy.exc
 from dagster import _check as check
 from dagster._core.definitions.policy import Backoff, Jitter, calculate_delay
 
 # re-export
 from dagster._core.storage.config import pg_config as pg_config
+from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._core.storage.sql import get_alembic_config
+from sqlalchemy.engine import Connection
+
+T = TypeVar("T")
 
 
 class DagsterPostgresException(Exception):
     pass
 
 
-def get_conn(conn_string):
+def get_conn(conn_string: str) -> SqlDbConnection:
     """Get a connection directly without SQLAlchemy for tests."""
     conn = psycopg2.connect(conn_string)
     conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     return conn
 
 
-def pg_url_from_config(config_value):
+def pg_url_from_config(config_value: Mapping[str, Any]) -> str:
     if config_value.get("postgres_url"):
         check.invariant(
             "postgres_db" not in config_value,
@@ -42,8 +52,14 @@ def pg_url_from_config(config_value):
 
 
 def get_conn_string(
-    username, password, hostname, db_name, port="5432", params=None, scheme="postgresql"
-):
+    username: str,
+    password: str,
+    hostname: str,
+    db_name: str,
+    port: str = "5432",
+    params: Optional[Mapping[str, object]] = None,
+    scheme: str = "postgresql",
+) -> str:
     uri = f"{scheme}://{quote(username)}:{quote(password)}@{hostname}:{port}/{db_name}"
 
     if params:
@@ -53,7 +69,7 @@ def get_conn_string(
     return uri
 
 
-def retry_pg_creation_fn(fn, retry_limit=5, retry_wait=0.2):
+def retry_pg_creation_fn(fn: Callable[[], T], retry_limit: int = 5, retry_wait: float = 0.2) -> T:
     # Retry logic to recover from the case where two processes are creating
     # tables at the same time using sqlalchemy
 
@@ -89,7 +105,7 @@ def retry_pg_creation_fn(fn, retry_limit=5, retry_wait=0.2):
         retry_limit -= 1
 
 
-def retry_pg_connection_fn(fn, retry_limit=5, retry_wait=0.2):
+def retry_pg_connection_fn(fn: Callable[[], T], retry_limit: int = 5, retry_wait: float = 0.2) -> T:
     """
     Reusable retry logic for any psycopg2/sqlalchemy PG connection functions that may fail.
     Intended to be used anywhere we connect to PG, to gracefully handle transient connection issues.
@@ -125,7 +141,7 @@ def retry_pg_connection_fn(fn, retry_limit=5, retry_wait=0.2):
         )
 
 
-def wait_for_connection(conn_string, retry_limit=5, retry_wait=0.2):
+def wait_for_connection(conn_string: str, retry_limit: int = 5, retry_wait: float = 0.2) -> bool:
     """Get a connection with retries directly without SQLAlchemy for tests."""
     retry_pg_connection_fn(
         lambda: psycopg2.connect(conn_string), retry_limit=retry_limit, retry_wait=retry_wait
@@ -133,14 +149,18 @@ def wait_for_connection(conn_string, retry_limit=5, retry_wait=0.2):
     return True
 
 
-def pg_alembic_config(dunder_file, script_location=None):
+def pg_alembic_config(
+    dunder_file: str, script_location: Optional[str] = None
+) -> alembic.config.Config:
     return get_alembic_config(
         dunder_file, config_path="../alembic/alembic.ini", script_location=script_location
     )
 
 
 @contextmanager
-def create_pg_connection(engine):
+def create_pg_connection(
+    engine: sqlalchemy.engine.Engine,
+) -> Iterator[Connection]:
     check.inst_param(engine, "engine", sqlalchemy.engine.Engine)
     conn = None
     try:
@@ -152,6 +172,6 @@ def create_pg_connection(engine):
             conn.close()
 
 
-def pg_statement_timeout(millis):
+def pg_statement_timeout(millis: int) -> str:
     check.int_param(millis, "millis")
     return "-c statement_timeout={}".format(millis)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_pynotify.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_pynotify.py
@@ -7,7 +7,7 @@ import pytest
 from dagster_postgres.pynotify import await_pg_notifications
 
 
-def test_await_pg_notifications_failure(conn_string):
+def test_await_pg_notifications_failure(conn_string: str):
     expected_error_num = errno.ECONNREFUSED
     exceptions = [error(errno.EINTR, ""), error(expected_error_num, "")]
     with patch("dagster_postgres.pynotify.select") as mock_select:


### PR DESCRIPTION
### Summary & Motivation

Type annotations for storage layer. Annotations for many of the files in `dagster._core.storage`, `dagster-mysql` and `dagster-postgres`.

This is 99% a "pure typing PR". The only other change is some import changes (e.g. direct import `sqlalchemy.pool` and access as `db_pool` to avoid unloaded module access errors). **There are no changes to runtime type-checks**, which should make it much easier to review.

Added many type-ignores to suppress errors generated by the annotations. Fixed upstack.

### How I Tested These Changes

BK
