### PR TITLE
[typing/runtime] Make AssetKey.to_string always return AssetKey

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -110,12 +110,10 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
                 return False
         return True
 
-    def to_string(self, legacy: Optional[bool] = False) -> Optional[str]:
+    def to_string(self, legacy: Optional[bool] = False) -> str:
         """
         E.g. '["first_component", "second_component"]'.
         """
-        if not self.path:
-            return None
         if legacy:
             return ASSET_KEY_LEGACY_DELIMITER.join(self.path)
         return seven.json.dumps(self.path)


### PR DESCRIPTION
### Summary & Motivation

Unclear why `AssetKey.to_string` ever returns `None`. Also most callsites assume a string.

### How I Tested These Changes

BK
