### PR TITLE
[typing/static] Fix @repository decorator typing

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -38,7 +38,7 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 ASSET_BASE_JOB_PREFIX = "__ASSET_JOB"
 
 
-def is_base_asset_job_name(name) -> bool:
+def is_base_asset_job_name(name: str) -> bool:
     return name.startswith(ASSET_BASE_JOB_PREFIX)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -242,7 +242,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         )
 
         super().__init__(
-            unique_id=f"{wrapped._unique_id}_prefix_or_group_{self._get_hash()}",  # noqa: SLF001
+            unique_id=f"{wrapped.unique_id}_prefix_or_group_{self._get_hash()}",
             wrapped=wrapped,
         )
 
@@ -331,7 +331,7 @@ class ResourceWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefinition)
         self._resource_defs = resource_defs
 
         super().__init__(
-            unique_id=f"{wrapped._unique_id}_resources_{self._get_hash()}",  # noqa: SLF001
+            unique_id=f"{wrapped.unique_id}_resources_{self._get_hash()}",
             wrapped=wrapped,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -28,8 +28,10 @@ from ..repository_definition import (
     VALID_REPOSITORY_DATA_DICT_KEYS,
     CachingRepositoryData,
     PendingRepositoryDefinition,
+    PendingRepositoryListDefinition,
     RepositoryData,
     RepositoryDefinition,
+    RepositoryListDefinition,
 )
 from ..schedule_definition import ScheduleDefinition
 from ..sensor_definition import SensorDefinition
@@ -68,8 +70,20 @@ class _Repository:
             top_level_resources, "top_level_resources", key_type=str, value_type=ResourceDefinition
         )
 
+    @overload
     def __call__(
-        self, fn: Callable[[], Sequence[Any]]
+        self, fn: Callable[[], Sequence[PendingRepositoryListDefinition]]
+    ) -> PendingRepositoryDefinition:
+        ...
+
+    @overload
+    def __call__(
+        self, fn: Callable[[], Sequence[RepositoryListDefinition]]
+    ) -> RepositoryDefinition:
+        ...
+
+    def __call__(
+        self, fn: Callable[[], Sequence[PendingRepositoryListDefinition]]
     ) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
         from dagster._core.definitions import AssetGroup, AssetsDefinition, SourceAsset
         from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
@@ -180,7 +194,16 @@ class _Repository:
 
 
 @overload
-def repository(definitions_fn: Callable[..., Sequence[Any]]) -> RepositoryDefinition:
+def repository(
+    definitions_fn: Callable[..., Sequence[RepositoryListDefinition]]
+) -> RepositoryDefinition:
+    ...
+
+
+@overload
+def repository(
+    definitions_fn: Callable[..., Sequence[PendingRepositoryListDefinition]]
+) -> PendingRepositoryDefinition:
     ...
 
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/__init__.py
@@ -9,4 +9,6 @@ from .repository_definition import (
 from .valid_definitions import (
     SINGLETON_REPOSITORY_NAME as SINGLETON_REPOSITORY_NAME,
     VALID_REPOSITORY_DATA_DICT_KEYS as VALID_REPOSITORY_DATA_DICT_KEYS,
+    PendingRepositoryListDefinition as PendingRepositoryListDefinition,
+    RepositoryListDefinition as RepositoryListDefinition,
 )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
@@ -13,20 +13,20 @@ from typing import (
 import dagster._check as check
 from dagster._core.errors import DagsterInvariantViolationError
 
-from .valid_definitions import RepositoryLevelDefinition
+from .valid_definitions import T_RepositoryLevelDefinition
 
 
-class CacheingDefinitionIndex(Generic[RepositoryLevelDefinition]):
+class CacheingDefinitionIndex(Generic[T_RepositoryLevelDefinition]):
     def __init__(
         self,
-        definition_class: Type[RepositoryLevelDefinition],
+        definition_class: Type[T_RepositoryLevelDefinition],
         definition_class_name: str,
         definition_kind: str,
         definitions: Mapping[
-            str, Union[RepositoryLevelDefinition, Callable[[], RepositoryLevelDefinition]]
+            str, Union[T_RepositoryLevelDefinition, Callable[[], T_RepositoryLevelDefinition]]
         ],
-        validation_fn: Callable[[RepositoryLevelDefinition], RepositoryLevelDefinition],
-        lazy_definitions_fn: Optional[Callable[[], Sequence[RepositoryLevelDefinition]]] = None,
+        validation_fn: Callable[[T_RepositoryLevelDefinition], T_RepositoryLevelDefinition],
+        lazy_definitions_fn: Optional[Callable[[], Sequence[T_RepositoryLevelDefinition]]] = None,
     ):
         """Args:
         definitions: A dictionary of definition names to definitions or functions that load
@@ -47,27 +47,27 @@ class CacheingDefinitionIndex(Generic[RepositoryLevelDefinition]):
                 ),
             )
 
-        self._definition_class: Type[RepositoryLevelDefinition] = definition_class
+        self._definition_class: Type[T_RepositoryLevelDefinition] = definition_class
         self._definition_class_name = definition_class_name
         self._definition_kind = definition_kind
         self._validation_fn: Callable[
-            [RepositoryLevelDefinition], RepositoryLevelDefinition
+            [T_RepositoryLevelDefinition], T_RepositoryLevelDefinition
         ] = validation_fn
 
         self._definitions: Mapping[
-            str, Union[RepositoryLevelDefinition, Callable[[], RepositoryLevelDefinition]]
+            str, Union[T_RepositoryLevelDefinition, Callable[[], T_RepositoryLevelDefinition]]
         ] = definitions
-        self._definition_cache: Dict[str, RepositoryLevelDefinition] = {}
+        self._definition_cache: Dict[str, T_RepositoryLevelDefinition] = {}
         self._definition_names: Optional[Sequence[str]] = None
 
         self._lazy_definitions_fn: Callable[
-            [], Sequence[RepositoryLevelDefinition]
+            [], Sequence[T_RepositoryLevelDefinition]
         ] = lazy_definitions_fn or (lambda: [])
-        self._lazy_definitions: Optional[Sequence[RepositoryLevelDefinition]] = None
+        self._lazy_definitions: Optional[Sequence[T_RepositoryLevelDefinition]] = None
 
-        self._all_definitions: Optional[Sequence[RepositoryLevelDefinition]] = None
+        self._all_definitions: Optional[Sequence[T_RepositoryLevelDefinition]] = None
 
-    def _get_lazy_definitions(self) -> Sequence[RepositoryLevelDefinition]:
+    def _get_lazy_definitions(self) -> Sequence[T_RepositoryLevelDefinition]:
         if self._lazy_definitions is None:
             self._lazy_definitions = self._lazy_definitions_fn()
             for definition in self._lazy_definitions:
@@ -98,7 +98,7 @@ class CacheingDefinitionIndex(Generic[RepositoryLevelDefinition]):
 
         return definition_name in self.get_definition_names()
 
-    def get_all_definitions(self) -> Sequence[RepositoryLevelDefinition]:
+    def get_all_definitions(self) -> Sequence[T_RepositoryLevelDefinition]:
         if self._all_definitions is not None:
             return self._all_definitions
 
@@ -110,7 +110,7 @@ class CacheingDefinitionIndex(Generic[RepositoryLevelDefinition]):
         )
         return self._all_definitions
 
-    def get_definition(self, definition_name: str) -> RepositoryLevelDefinition:
+    def get_definition(self, definition_name: str) -> T_RepositoryLevelDefinition:
         check.str_param(definition_name, "definition_name")
 
         if not self.has_definition(definition_name):
@@ -142,7 +142,7 @@ class CacheingDefinitionIndex(Generic[RepositoryLevelDefinition]):
             return definition
 
     def _validate_and_cache_definition(
-        self, definition: RepositoryLevelDefinition, definition_dict_key: str
+        self, definition: T_RepositoryLevelDefinition, definition_dict_key: str
     ):
         check.invariant(
             isinstance(definition, self._definition_class),

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -40,7 +40,8 @@ from .repository_data import CachingRepositoryData, RepositoryData
 from .valid_definitions import (
     SINGLETON_REPOSITORY_NAME as SINGLETON_REPOSITORY_NAME,
     VALID_REPOSITORY_DATA_DICT_KEYS as VALID_REPOSITORY_DATA_DICT_KEYS,
-    RepositoryListDefinition,
+    PendingRepositoryListDefinition as PendingRepositoryListDefinition,
+    RepositoryListDefinition as RepositoryListDefinition,
 )
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/valid_definitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/valid_definitions.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, TypeVar, Union
 
+from typing_extensions import TypeAlias
+
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.partition import PartitionSetDefinition
@@ -11,6 +13,7 @@ from dagster._core.definitions.unresolved_asset_job_definition import Unresolved
 
 if TYPE_CHECKING:
     from dagster._core.definitions import AssetGroup, AssetsDefinition
+    from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
     from dagster._core.definitions.partitioned_schedule import (
         UnresolvedPartitionedAssetScheduleDefinition,
     )
@@ -25,8 +28,8 @@ VALID_REPOSITORY_DATA_DICT_KEYS = {
     "jobs",
 }
 
-RepositoryLevelDefinition = TypeVar(
-    "RepositoryLevelDefinition",
+T_RepositoryLevelDefinition = TypeVar(
+    "T_RepositoryLevelDefinition",
     PipelineDefinition,
     JobDefinition,
     PartitionSetDefinition,
@@ -34,7 +37,7 @@ RepositoryLevelDefinition = TypeVar(
     SensorDefinition,
 )
 
-RepositoryListDefinition = Union[
+RepositoryListDefinition: TypeAlias = Union[
     "AssetsDefinition",
     "AssetGroup",
     GraphDefinition,
@@ -45,4 +48,9 @@ RepositoryListDefinition = Union[
     SourceAsset,
     UnresolvedAssetJobDefinition,
     "UnresolvedPartitionedAssetScheduleDefinition",
+]
+
+PendingRepositoryListDefinition: TypeAlias = Union[
+    RepositoryListDefinition,
+    "CacheableAssetsDefinition",
 ]

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import re
+from typing import Sequence
 
 import pytest
 from dagster import (
@@ -25,6 +26,9 @@ from dagster._core.definitions.input import In
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.pipeline_base import InMemoryPipeline
 from dagster._core.definitions.reconstruct import ReconstructablePipeline, ReconstructableRepository
+from dagster._core.definitions.repository_definition.valid_definitions import (
+    PendingRepositoryListDefinition,
+)
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.instance import DagsterInstance
@@ -362,5 +366,5 @@ def bar(foo):
 
 
 @repository
-def pending_repo():
+def pending_repo() -> Sequence[PendingRepositoryListDefinition]:
     return [bar, MyCacheableAssetsDefinition("xyz"), define_asset_job("all_asset_job")]


### PR DESCRIPTION
### Summary & Motivation

Minor cleanup of typing and other issues around repositories.

- Overload `@repository` decorator so annotations reflect ability to return `PendingRepositoryDefinition`
- Delete zombie file `repository_definition.py` (this was empty and converted to a package `repository_definition/__init__.py` in the past
- Rename `RepositoryLevelDefinition` to `T_RepositoryLevelDefinition` for consistency with other type vars
- Add a few other annotations

Fix `@repository` decorator typing so that it correctly returns `PendingRepositoryDefinition`.

### How I Tested These Changes

BK
