### PR TITLE
docs: update scaffold to use dagster dev

### DIFF
--- a/docs/content/getting-started/create-new-project.mdx
+++ b/docs/content/getting-started/create-new-project.mdx
@@ -190,7 +190,7 @@ pip install -e ".[dev]"
   so that as you develop, local code changes will automatically apply.
 </Note>
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```bash
 dagster dev

--- a/examples/assets_dbt_python/README.md
+++ b/examples/assets_dbt_python/README.md
@@ -20,10 +20,10 @@ To install this example and its Python dependencies, run:
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -60,33 +60,6 @@ Environment variables, which are key-value pairs configured outside your source 
 Using environment variables, you can define various configuration options for your Dagster application and securely set up secrets. For example, instead of hard-coding database credentials - which is bad practice and cumbersome for development - you can use environment variables to supply user details. This allows you to parameterize your pipeline without modifying code or insecurely storing sensitive data.
 
 Check out [Using environment variables and secrets](https://docs.dagster.io/guides/dagster/using-environment-variables-and-secrets) for more info and examples.
-
-### Running daemon locally
-
-If you're running Dagster locally and trying to set up schedules, you will see a warning that your daemon isn’t running.
-
-<details><summary>👈 Expand to learn how to set up a local daemon</summary>
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/yuhan/11-11-quickstart_1/_add_quickstart_basic_etl_as_the_very_basic_template/docs/next/public/images/quickstarts/basic/step-3-3-daemon-warning.png?raw=true" />
-</p>
-
-If you want to enable Dagster [Schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) for your jobs, start the [Dagster Daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within /tmp may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-In this case, go to the project root directory and run:
-```bash
-dagster-daemon run
-```
-
-Once your Dagster Daemon is running, the schedules that are turned on will start running.
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-4-daemon-on.png?raw=true" />
-</p>
-
-</details>
 
 ### Adding new Python dependencies
 

--- a/examples/assets_modern_data_stack/README.md
+++ b/examples/assets_modern_data_stack/README.md
@@ -57,10 +57,10 @@ To install this example and its Python dependencies, run:
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -133,33 +133,6 @@ Or from the left nav or on each job page:
 
 <p align="center">
     <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/more-reload-left-nav.png" />
-</p>
-
-</details>
-
-### Running daemon locally
-
-If you're running Dagster locally and trying to set up schedules, you will see a warning that your daemon isn’t running.
-
-<details><summary>👈 Expand to learn how to set up a local daemon</summary>
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/yuhan/11-11-quickstart_1/_add_quickstart_basic_etl_as_the_very_basic_template/docs/next/public/images/quickstarts/basic/step-3-3-daemon-warning.png?raw=true" />
-</p>
-
-If you want to enable Dagster [Schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) for your jobs, start the [Dagster Daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within /tmp may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-In this case, go to the project root directory and run:
-```bash
-dagster-daemon run
-```
-
-Once your Dagster Daemon is running, the schedules that are turned on will start running.
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-4-daemon-on.png?raw=true" />
 </p>
 
 </details>

--- a/examples/quickstart_aws/README.md
+++ b/examples/quickstart_aws/README.md
@@ -15,7 +15,6 @@ This guide covers:
   - [Step 1: Materializing assets](#step-1-materializing-assets)
   - [Step 2: Viewing and monitoring assets](#step-2-viewing-and-monitoring-assets)
   - [Step 3: Scheduling a daily job](#step-3-scheduling-a-daily-job)
-    - [(Optional) Running daemon locally](#optional-running-daemon-locally)
   - [Learning more](#learning-more)
     - [Changing the code locally](#changing-the-code-locally)
     - [Writing a custom I/O manager](#writing-a-custom-io-manager)
@@ -90,10 +89,10 @@ First, install your Dagster repository as a Python package. By using the `--edit
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```bash
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -201,33 +200,6 @@ You can now turn on the schedule switch to set up the daily job we defined in [q
 <p align="center">
     <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-2-schedule-on.png" />
 </p>
-
-### (Optional) Running daemon locally
-
-If you're running Dagster locally, you will see a warning that your daemon isn’t running.
-
-<p align="center">
-    <img height="300" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-3-daemon-warning.png" />
-</p>
-
-<details><summary>👈 Expand to learn how to set up a local daemon</summary>
-
-If you want to enable Dagster [schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) for your jobs, start the [Dagster daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within `/tmp` may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-In this case, go to the project root directory and run:
-```bash
-dagster-daemon run
-```
-
-Once your Dagster daemon is running, the schedules that are turned on will start running.
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-4-daemon-on.png" />
-</p>
-
-</details>
 
 <br />
 <br />

--- a/examples/quickstart_etl/README.md
+++ b/examples/quickstart_etl/README.md
@@ -13,7 +13,6 @@ This guide covers:
   - [Step 1: Materializing assets](#step-1-materializing-assets)
   - [Step 2: Viewing and monitoring assets](#step-2-viewing-and-monitoring-assets)
   - [Step 3: Scheduling a daily job](#step-3-scheduling-a-daily-job)
-    - [(Optional) Running daemon locally](#optional-running-daemon-locally)
   - [Learning more](#learning-more)
     - [Changing the code locally](#changing-the-code-locally)
     - [Using environment variables and secrets](#using-environment-variables-and-secrets)
@@ -64,10 +63,10 @@ First, install your Dagster code as a Python package. By using the `--editable` 
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```bash
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -175,33 +174,6 @@ You can now turn on the schedule switch to set up the daily job we defined in [q
 <p align="center">
     <img height="500" src="../../docs/next/public/images/quickstarts/basic/step-3-2-schedule-on.png" />
 </p>
-
-### (Optional) Running daemon locally
-
-If you're running Dagster locally, you will see a warning that your daemon isn’t running.
-
-<p align="center">
-    <img height="300" src="../../docs/next/public/images/quickstarts/basic/step-3-3-daemon-warning.png" />
-</p>
-
-<details><summary>👈 Expand to learn how to set up a local daemon</summary>
-
-If you want to enable Dagster [schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) for your jobs, start the [Dagster daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within `/tmp` may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-In this case, go to the project root directory and run:
-```bash
-dagster-daemon run
-```
-
-Once your Dagster daemon is running, the schedules that are turned on will start running.
-
-<p align="center">
-    <img height="500" src="../../docs/next/public/images/quickstarts/basic/step-3-4-daemon-on.png" />
-</p>
-
-</details>
 
 <br />
 <br />

--- a/examples/quickstart_gcp/README.md
+++ b/examples/quickstart_gcp/README.md
@@ -15,7 +15,6 @@ This guide covers:
   - [Step 1: Materializing assets](#step-1-materializing-assets)
   - [Step 2: Viewing and monitoring assets](#step-2-viewing-and-monitoring-assets)
   - [Step 3: Scheduling a daily job](#step-3-scheduling-a-daily-job)
-    - [(Optional) Running daemon locally](#optional-running-daemon-locally)
   - [Learning more](#learning-more)
     - [Changing the code locally](#changing-the-code-locally)
     - [Writing a custom I/O manager](#writing-a-custom-io-manager)
@@ -88,10 +87,10 @@ First, install your Dagster repository as a Python package. By using the `--edit
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```bash
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -199,33 +198,6 @@ You can now turn on the schedule switch to set up the daily job we defined in [q
 <p align="center">
     <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-2-schedule-on.png" />
 </p>
-
-### (Optional) Running daemon locally
-
-If you're running Dagster locally, you will see a warning that your daemon isn’t running.
-
-<p align="center">
-    <img height="300" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-3-daemon-warning.png" />
-</p>
-
-<details><summary>👈 Expand to learn how to set up a local daemon</summary>
-
-If you want to enable Dagster [schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) for your jobs, start the [Dagster daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within `/tmp` may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-In this case, go to the project root directory and run:
-```bash
-dagster-daemon run
-```
-
-Once your Dagster daemon is running, the schedules that are turned on will start running.
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-4-daemon-on.png" />
-</p>
-
-</details>
 
 <br />
 <br />

--- a/examples/quickstart_snowflake/README.md
+++ b/examples/quickstart_snowflake/README.md
@@ -15,7 +15,6 @@ This guide covers:
   - [Step 1: Materializing assets](#step-1-materializing-assets)
   - [Step 2: Viewing and monitoring assets](#step-2-viewing-and-monitoring-assets)
   - [Step 3: Scheduling a daily job](#step-3-scheduling-a-daily-job)
-    - [(Optional) Running daemon locally](#optional-running-daemon-locally)
   - [Learning more](#learning-more)
     - [Changing the code locally](#changing-the-code-locally)
     - [Adding new Python dependencies](#adding-new-python-dependencies)
@@ -88,10 +87,10 @@ First, install your Dagster repository as a Python package. By using the `--edit
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```bash
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -199,33 +198,6 @@ You can now turn on the schedule switch to set up the daily job we defined in [q
 <p align="center">
     <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-2-schedule-on.png" />
 </p>
-
-### (Optional) Running daemon locally
-
-If you're running Dagster locally, you will see a warning that your daemon isn’t running.
-
-<p align="center">
-    <img height="300" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-3-daemon-warning.png" />
-</p>
-
-<details><summary>👈 Expand to learn how to set up a local daemon</summary>
-
-If you want to enable Dagster [schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) for your jobs, start the [Dagster daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within `/tmp` may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-In this case, go to the project root directory and run:
-```bash
-dagster-daemon run
-```
-
-Once your Dagster daemon is running, the schedules that are turned on will start running.
-
-<p align="center">
-    <img height="500" src="https://raw.githubusercontent.com/dagster-io/dagster/master/docs/next/public/images/quickstarts/basic/step-3-4-daemon-on.png" />
-</p>
-
-</details>
 
 <br />
 <br />

--- a/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/README.md
+++ b/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/README.md
@@ -10,10 +10,10 @@ First, install your Dagster code location as a Python package. By using the --ed
 pip install -e ".[dev]"
 ```
 
-Then, start the Dagit web server:
+Then, start the Dagster UI web server:
 
 ```bash
-dagit
+dagster dev
 ```
 
 Open http://localhost:3000 with your browser to see the project.
@@ -37,13 +37,7 @@ pytest {{ repo_name }}_tests
 
 ### Schedules and sensors
 
-If you want to enable Dagster [Schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) or [Sensors](https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors) for your jobs, start the [Dagster Daemon](https://docs.dagster.io/deployment/dagster-daemon) process in the same folder as your `workspace.yaml` file, but in a different shell or terminal.
-
-The `$DAGSTER_HOME` environment variable must be set to a directory for the daemon to work. Note: using directories within /tmp may cause issues. See [Dagster Instance default local behavior](https://docs.dagster.io/deployment/dagster-instance#default-local-behavior) for more details.
-
-```bash
-dagster-daemon run
-```
+If you want to enable Dagster [Schedules](https://docs.dagster.io/concepts/partitions-schedules-sensors/schedules) or [Sensors](https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors) for your jobs, the [Dagster Daemon](https://docs.dagster.io/deployment/dagster-daemon) process must be running. This is done automatically when you run `dagster dev`.
 
 Once your Dagster Daemon is running, you can start turning on schedules and sensors for your jobs.
 


### PR DESCRIPTION
### Summary & Motivation
As the title. Can fix the existing copy if the new copy on the template makes sense.

- scrub references to Dagit
- scrub references to running the Dagster Daemon as a standalone command: `dagster dev` should make you not need to worry about this.

### How I Tested These Changes
local
