### PR TITLE
Add shortcuts for '--dagit-host' and '--dagit-port' to dagster dev

### DIFF
--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -53,8 +53,8 @@ def dev_command_options(f):
         ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
     ),
 )
-@click.option("--dagit-port", help="Port to use for the Dagit UI.", required=False)
-@click.option("--dagit-host", help="Host to use for the Dagit UI.", required=False)
+@click.option("--dagit-port", "-p", help="Port to use for the Dagit UI.", required=False)
+@click.option("--dagit-host", "-h", help="Host to use for the Dagit UI.", required=False)
 def dev_command(code_server_log_level, dagit_port, dagit_host, **kwargs):
     # check if dagit installed, crash if not
     try:


### PR DESCRIPTION
Summary:
This better matches the dagit command for people moving over

Test Plan:
```
(dagster-3.8.9) dgibson@Daniels-MacBook-Pro dagster % dagster dev --help
Usage: dagster dev [OPTIONS]

  Start a local deployment of Dagster, including dagit running on localhost and the dagster-daemon running in the
  background

Options:
  -d, --working-directory TEXT    Specify working directory to use when loading the repository or job
  -m, --module-name TEXT          Specify module or modules (flag can be used multiple times) where dagster
                                  definitions reside as top-level symbols/variables and load each module as a code
                                  location in the current python environment.
  -f, --python-file PATH          Specify python file or files (flag can be used multiple times) where dagster
                                  definitions reside as top-level symbols/variables and load each file as a code
                                  location in the current python environment.
  -w, --workspace PATH            Path to workspace file. Argument can be provided multiple times.
  --code-server-log-level [critical|error|warning|info|debug|trace]
                                  Set the log level for code servers spun up by dagster services.  [default: warning]
  -p, --dagit-port TEXT           Port to use for the Dagit UI.
  -h, --dagit-host TEXT           Host to use for the Dagit UI.
  --help                          Show this message and exit.
```

### Summary & Motivation

### How I Tested These Changes
