### PR TITLE
[dagit] Expose range-based asset health, use it for partition status rendering

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -128,7 +128,7 @@ export const AssetPartitions: React.FC<Props> = ({
         >
           <DimensionRangeWizard
             partitionKeys={timeRange.dimension.partitionKeys}
-            ranges={assetHealth.rangesForSingleDimension(timeRangeIdx)}
+            health={{ranges: assetHealth.rangesForSingleDimension(timeRangeIdx)}}
             selected={timeRange.selectedKeys}
             setSelected={(selectedKeys) =>
               setRanges(ranges.map((r) => (r === timeRange ? {...r, selectedKeys} : r)))

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -128,9 +128,7 @@ export const AssetPartitions: React.FC<Props> = ({
         >
           <DimensionRangeWizard
             partitionKeys={timeRange.dimension.partitionKeys}
-            partitionStateForKey={(dimensionKey) =>
-              assetHealth.stateForSingleDimension(timeRangeIdx, dimensionKey)
-            }
+            ranges={assetHealth.rangesForSingleDimension(timeRangeIdx)}
             selected={timeRange.selectedKeys}
             setSelected={(selectedKeys) =>
               setRanges(ranges.map((r) => (r === timeRange ? {...r, selectedKeys} : r)))

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -329,13 +329,10 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
             <DimensionRangeWizard
               key={range.dimension.name}
               partitionKeys={range.dimension.partitionKeys}
-              partitionStateForKey={(dimensionKey) =>
-                mergedHealth.stateForSingleDimension(
-                  idx,
-                  dimensionKey,
-                  selections.length === 2 ? selections[1 - idx].selectedKeys : undefined,
-                )
-              }
+              ranges={mergedHealth.rangesForSingleDimension(
+                idx,
+                selections.length === 2 ? selections[1 - idx].selectedRanges : undefined,
+              )}
               selected={range.selectedKeys}
               setSelected={(selectedKeys) =>
                 setSelections(

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -329,10 +329,12 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
             <DimensionRangeWizard
               key={range.dimension.name}
               partitionKeys={range.dimension.partitionKeys}
-              ranges={mergedHealth.rangesForSingleDimension(
-                idx,
-                selections.length === 2 ? selections[1 - idx].selectedRanges : undefined,
-              )}
+              health={{
+                ranges: mergedHealth.rangesForSingleDimension(
+                  idx,
+                  selections.length === 2 ? selections[1 - idx].selectedRanges : undefined,
+                ),
+              }}
               selected={range.selectedKeys}
               setSelected={(selectedKeys) =>
                 setSelections(

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.test.tsx
@@ -1,0 +1,134 @@
+import {PartitionState} from '../partitions/PartitionStatus';
+
+import {mergedRanges, mergedStates} from './MultipartitioningSupport';
+import {Range} from './usePartitionHealthData';
+
+describe('multipartitioning support', () => {
+  describe('mergedStates', () => {
+    it('returns SUCCESS_MISSING if SUCCESS and MISSING are both present', () => {
+      expect(
+        mergedStates([PartitionState.SUCCESS, PartitionState.MISSING, PartitionState.MISSING]),
+      ).toEqual(PartitionState.SUCCESS_MISSING);
+    });
+
+    it('returns SUCCESS_MISSING if SUCCESS_MISSING is present', () => {
+      expect(
+        mergedStates([
+          PartitionState.SUCCESS_MISSING,
+          PartitionState.MISSING,
+          PartitionState.MISSING,
+        ]),
+      ).toEqual(PartitionState.SUCCESS_MISSING);
+    });
+
+    it('returns SUCCESS if all states are success', () => {
+      expect(
+        mergedStates([PartitionState.SUCCESS, PartitionState.SUCCESS, PartitionState.SUCCESS]),
+      ).toEqual(PartitionState.SUCCESS);
+    });
+
+    it('returns MISSING if all states are missing', () => {
+      expect(
+        mergedStates([PartitionState.MISSING, PartitionState.MISSING, PartitionState.MISSING]),
+      ).toEqual(PartitionState.MISSING);
+    });
+    it('should not modify the input data', () => {
+      const input = [
+        PartitionState.SUCCESS_MISSING,
+        PartitionState.MISSING,
+        PartitionState.MISSING,
+      ];
+      const before = JSON.stringify({input});
+      mergedStates(input);
+      expect(JSON.stringify({input})).toEqual(before);
+    });
+  });
+
+  describe('mergedRanges', () => {
+    const KEYS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
+    const A_I: Range = {
+      start: {idx: 0, key: 'A'},
+      end: {idx: 8, key: 'I'},
+      value: PartitionState.SUCCESS,
+    };
+    const A_I_Partial: Range = {
+      ...A_I,
+      value: PartitionState.SUCCESS_MISSING,
+    };
+    const B_E: Range = {
+      start: {idx: 1, key: 'B'},
+      end: {idx: 4, key: 'E'},
+      value: PartitionState.SUCCESS,
+    };
+    const G_I: Range = {
+      start: {idx: 6, key: 'G'},
+      end: {idx: 8, key: 'I'},
+      value: PartitionState.SUCCESS,
+    };
+    it('merges two [A...I] range set into one [A...I] range set', () => {
+      expect(mergedRanges(KEYS, [[A_I], [A_I]])).toEqual([A_I]);
+    });
+
+    it('merges two [A...I] partial range sets into one [A...I] partial range set', () => {
+      expect(mergedRanges(KEYS, [[A_I_Partial], [A_I_Partial]])).toEqual([A_I_Partial]);
+    });
+
+    it('makes no modifications to a single range set', () => {
+      expect(mergedRanges(KEYS, [[A_I_Partial]])).toEqual([A_I_Partial]);
+      expect(mergedRanges(KEYS, [[A_I]])).toEqual([A_I]);
+      expect(mergedRanges(KEYS, [[B_E, G_I]])).toEqual([B_E, G_I]);
+    });
+
+    it('merges range sets which overlap', () => {
+      expect(mergedRanges(KEYS, [[A_I], [B_E]])).toEqual([
+        {
+          start: {idx: 0, key: 'A'},
+          end: {idx: 0, key: 'A'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+        {
+          start: {idx: 1, key: 'B'},
+          end: {idx: 4, key: 'E'},
+          value: PartitionState.SUCCESS,
+        },
+        {
+          start: {idx: 5, key: 'F'},
+          end: {idx: 8, key: 'I'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+      ]);
+    });
+
+    it('merges range sets with a one-partition "hole"', () => {
+      expect(mergedRanges(KEYS, [[A_I], [B_E, G_I]])).toEqual([
+        {
+          start: {idx: 0, key: 'A'},
+          end: {idx: 0, key: 'A'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+        {
+          start: {idx: 1, key: 'B'},
+          end: {idx: 4, key: 'E'},
+          value: PartitionState.SUCCESS,
+        },
+        {
+          start: {idx: 5, key: 'F'},
+          end: {idx: 5, key: 'F'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+        {
+          start: {idx: 6, key: 'G'},
+          end: {idx: 8, key: 'I'},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
+    });
+
+    it('should not modify the input data', () => {
+      const rangeSets = [[A_I], [B_E, G_I]];
+      const before = JSON.stringify({KEYS, rangeSets});
+      mergedRanges(KEYS, rangeSets);
+      expect(JSON.stringify({KEYS, rangeSets})).toEqual(before);
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.test.tsx
@@ -65,12 +65,17 @@ describe('multipartitioning support', () => {
       end: {idx: 8, key: 'I'},
       value: PartitionState.SUCCESS,
     };
+
     it('merges two [A...I] range set into one [A...I] range set', () => {
       expect(mergedRanges(KEYS, [[A_I], [A_I]])).toEqual([A_I]);
     });
 
     it('merges two [A...I] partial range sets into one [A...I] partial range set', () => {
       expect(mergedRanges(KEYS, [[A_I_Partial], [A_I_Partial]])).toEqual([A_I_Partial]);
+    });
+
+    it('does not throw errors if an empty set is passed', () => {
+      expect(mergedRanges(KEYS, [])).toEqual([]);
     });
 
     it('makes no modifications to a single range set', () => {

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -4,6 +4,7 @@ import {
   PartitionHealthData,
   PartitionHealthDimension,
   PartitionDimensionSelection,
+  Range,
 } from './usePartitionHealthData';
 
 export function isTimeseriesDimension(dimension: PartitionHealthDimension) {
@@ -15,20 +16,13 @@ export function isTimeseriesPartition(aPartitionKey = '') {
 
 export function mergedAssetHealth(
   assetHealth: PartitionHealthData[],
-): {
-  dimensions: PartitionHealthDimension[];
-  stateForKey: (dimensionKeys: string[]) => PartitionState;
-  stateForSingleDimension: (
-    dimensionIdx: number,
-    dimensionKey: string,
-    otherDimensionSelectedKeys?: string[],
-  ) => PartitionState;
-} {
+): Omit<PartitionHealthData, 'assetKey'> {
   if (!assetHealth.length) {
     return {
       dimensions: [],
       stateForKey: () => PartitionState.MISSING,
       stateForSingleDimension: () => PartitionState.MISSING,
+      rangesForSingleDimension: () => [],
     };
   }
 
@@ -67,6 +61,12 @@ export function mergedAssetHealth(
           health.stateForSingleDimension(dimensionIdx, dimensionKey, otherDimensionSelectedKeys),
         ),
       ),
+    rangesForSingleDimension: (dimensionIdx, otherDimensionSelectedRanges?) =>
+      mergedRanges(
+        assetHealth.map((health) =>
+          health.rangesForSingleDimension(dimensionIdx, otherDimensionSelectedRanges),
+        ),
+      ),
   };
 }
 
@@ -76,6 +76,78 @@ export function mergedStates(states: PartitionState[]): PartitionState {
   } else {
     return states[0];
   }
+}
+
+/**
+ * This function takes the materialized ranges of several assets and returns a single set of ranges with the
+ * "success" / "partial" (SUCCESS_MISSING) states have been flattened together. This implementation is based
+ * on this solution: https://stackoverflow.com/questions/4542892 and involves placing all the start/end points
+ * into an ordered array.
+ *
+ * Why?: If you select multiple assets with the same partitioning in the asset graph and click Materialize,
+ * the asset health bar you see is a flattened representation of the health of all of all of them, with a
+ * "show per-asset health" button beneath.
+ *
+ * Note that this function does not populate subranges on the returned ranges -- if you want to filter the
+ * health data to a second-dimension partition key range, do that FIRST and then merge the results.
+ */
+export function mergedRanges(rangeSets: Range[][]): Range[] {
+  const transitions: {key: string; idx: number; delta: 1 | -1}[] = [];
+  for (const ranges of rangeSets) {
+    for (const range of ranges) {
+      transitions.push({key: range.start.key, idx: range.start.idx, delta: 1});
+      transitions.push({key: range.end.key, idx: range.end.idx, delta: -1});
+    }
+  }
+
+  // sort the array
+  transitions.sort((a, b) => a.idx - b.idx);
+
+  // walk the transitions array and apply the transitions to a counter, creating an array of just the changes
+  // in the number of currently-overlapping ranges. (eg: how many of the assets are materialized at this time).
+  //
+  // FROM: [{idx: 0, delta: 1}, {idx: 0, delta: 1}, {idx: 3, delta: 1}, {idx: 10, delta: -1}]
+  //   TO: [{idx: 0, depth: 2}, {idx: 3, depth: 3}, {idx: 10, depth: 2}]
+  //
+  const depths: {idx: number; key: string; depth: number}[] = [];
+  for (const transition of transitions) {
+    const last = depths[depths.length - 1];
+    if (last && last.idx === transition.idx) {
+      last.depth += transition.delta;
+    } else {
+      depths.push({
+        idx: transition.idx,
+        key: transition.key,
+        depth: (last?.depth || 0) + transition.delta,
+      });
+    }
+  }
+
+  // Ok! This array of depth values IS our SUCCESS vs. SUCCESS_MISSING range state. We just need to flatten it one
+  // more time. Anytime depth == rangeSets.length - 1, all the assets were materialzied within this band.
+  const result: Range[] = [];
+  for (const {idx, key, depth} of depths) {
+    const value =
+      depth === rangeSets.length - 1
+        ? PartitionState.SUCCESS
+        : depth > 0
+        ? PartitionState.SUCCESS_MISSING
+        : PartitionState.MISSING;
+
+    const last = result[result.length - 1];
+    if (last && last.value !== value) {
+      last.end = {idx, key};
+    }
+    if (value !== PartitionState.MISSING && last?.value !== value) {
+      result.push({
+        start: {idx, key},
+        end: {idx, key},
+        value,
+      });
+    }
+  }
+
+  return result;
 }
 
 export function explodePartitionKeysInSelection(

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -135,11 +135,11 @@ export function mergedRanges(allKeys: string[], rangeSets: Range[][]): Range[] {
 
 export function assembleRangesFromTransitions(
   allKeys: string[],
-  transitions: {idx: number; delta: number}[],
+  transitionsUnsorted: {idx: number; delta: number}[],
   maxOverlap: number,
 ) {
-  // sort the array
-  transitions.sort((a, b) => a.idx - b.idx);
+  // sort the input array, this algorithm does not work unless the transitions are in order
+  const transitions = [...transitionsUnsorted].sort((a, b) => a.idx - b.idx);
 
   // walk the transitions array and apply the transitions to a counter, creating an array of just the changes
   // in the number of currently-overlapping ranges. (eg: how many of the assets are materialized at this time).

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -54,10 +54,12 @@ export const PartitionHealthSummary: React.FC<{
             partitionNames={dimension.partitionKeys}
             splitPartitions={!isTimeseriesDimension(dimension)}
             selected={selections ? selections[dimensionIdx].selectedKeys : undefined}
-            ranges={assetData.rangesForSingleDimension(
-              dimensionIdx,
-              selections?.length === 2 ? selections[1 - dimensionIdx].selectedRanges : undefined,
-            )}
+            health={{
+              ranges: assetData.rangesForSingleDimension(
+                dimensionIdx,
+                selections?.length === 2 ? selections[1 - dimensionIdx].selectedRanges : undefined,
+              ),
+            }}
           />
         </Box>
       ))}

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -54,13 +54,10 @@ export const PartitionHealthSummary: React.FC<{
             partitionNames={dimension.partitionKeys}
             splitPartitions={!isTimeseriesDimension(dimension)}
             selected={selections ? selections[dimensionIdx].selectedKeys : undefined}
-            partitionStateForKey={(key) =>
-              assetData.stateForSingleDimension(
-                dimensionIdx,
-                key,
-                selections?.length === 2 ? selections[1 - dimensionIdx].selectedKeys : undefined,
-              )
-            }
+            ranges={assetData.rangesForSingleDimension(
+              dimensionIdx,
+              selections?.length === 2 ? selections[1 - dimensionIdx].selectedRanges : undefined,
+            )}
           />
         </Box>
       ))}

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -13,7 +13,7 @@ export const PartitionHealthSummary: React.FC<{
   showAssetKey?: boolean;
   data: PartitionHealthData[];
   selections?: PartitionDimensionSelection[];
-}> = ({showAssetKey, assetKey, data, selections}) => {
+}> = React.memo(({showAssetKey, assetKey, data, selections}) => {
   const assetData = data.find((d) => JSON.stringify(d.assetKey) === JSON.stringify(assetKey));
 
   if (!assetData) {
@@ -63,4 +63,4 @@ export const PartitionHealthSummary: React.FC<{
       ))}
     </Box>
   );
-};
+});

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
@@ -231,6 +231,10 @@ describe('usePartitionHealthData', () => {
           value: PartitionState.SUCCESS,
         },
       ]);
+
+      // should not crash if asked for an invalid dimension -- just return []
+      expect(assetHealth.rangesForSingleDimension(1)).toEqual([]);
+      expect(assetHealth.rangesForSingleDimension(2)).toEqual([]);
     });
 
     it('should return an object with accessors for 2D partition data', async () => {
@@ -353,6 +357,9 @@ describe('usePartitionHealthData', () => {
           value: PartitionState.SUCCESS,
         },
       ]);
+
+      // should not crash if asked for an invalid dimension -- just return []
+      expect(assetHealth.rangesForSingleDimension(2)).toEqual([]);
     });
 
     it('should return correct data in all-missing states', async () => {

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
@@ -1,7 +1,14 @@
 import {PartitionState} from '../partitions/PartitionStatus';
 
 import {PartitionHealthQuery} from './types/usePartitionHealthData.types';
-import {buildPartitionHealthData} from './usePartitionHealthData';
+import {
+  Range,
+  buildPartitionHealthData,
+  PartitionDimensionSelectionRange,
+  partitionStatusGivenRanges,
+  rangeClippedToSelection,
+  rangesForKeys,
+} from './usePartitionHealthData';
 
 const {SUCCESS_MISSING, SUCCESS, MISSING} = PartitionState;
 
@@ -216,6 +223,14 @@ describe('usePartitionHealthData', () => {
 
       expect(assetHealth.stateForSingleDimension(0, '2022-01-01')).toEqual(MISSING);
       expect(assetHealth.stateForSingleDimension(0, '2022-01-04')).toEqual(SUCCESS);
+
+      expect(assetHealth.rangesForSingleDimension(0)).toEqual([
+        {
+          start: {idx: 3, key: '2022-01-04'},
+          end: {idx: 4, key: '2022-01-05'},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
     });
 
     it('should return an object with accessors for 2D partition data', async () => {
@@ -246,15 +261,129 @@ describe('usePartitionHealthData', () => {
       expect(assetHealth.stateForSingleDimension(1, 'TN')).toEqual(SUCCESS_MISSING);
       expect(assetHealth.stateForSingleDimension(1, 'MN')).toEqual(SUCCESS);
       expect(assetHealth.stateForSingleDimension(1, 'TN', ['2022-01-04'])).toEqual(SUCCESS);
+
+      // Ask for the ranges of a row
+      expect(assetHealth.rangesForSingleDimension(0)).toEqual([
+        {
+          start: {idx: 0, key: '2022-01-01'},
+          end: {idx: 2, key: '2022-01-03'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+        {
+          start: {idx: 3, key: '2022-01-04'},
+          end: {idx: 3, key: '2022-01-04'},
+          value: PartitionState.SUCCESS,
+        },
+        {
+          start: {idx: 4, key: '2022-01-05'},
+          end: {idx: 5, key: '2022-01-06'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+      ]);
+
+      expect(
+        assetHealth.rangesForSingleDimension(0, [
+          [
+            {key: 'MN', idx: 4},
+            {key: 'MN', idx: 4},
+          ],
+        ]),
+      ).toEqual([
+        {
+          start: {idx: 0, key: '2022-01-01'},
+          end: {idx: 5, key: '2022-01-06'},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
+
+      expect(
+        assetHealth.rangesForSingleDimension(0, [
+          [
+            {key: 'NY', idx: 3},
+            {key: 'MN', idx: 4},
+          ],
+        ]),
+      ).toEqual([
+        {
+          start: {idx: 0, key: '2022-01-01'},
+          end: {idx: 0, key: '2022-01-01'},
+          value: PartitionState.SUCCESS,
+        },
+        {
+          start: {idx: 1, key: '2022-01-02'},
+          end: {idx: 2, key: '2022-01-03'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+        {
+          start: {idx: 3, key: '2022-01-04'},
+          end: {idx: 3, key: '2022-01-04'},
+          value: PartitionState.SUCCESS,
+        },
+        {
+          start: {idx: 4, key: '2022-01-05'},
+          end: {idx: 5, key: '2022-01-06'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+      ]);
+
+      expect(assetHealth.rangesForSingleDimension(1)).toEqual([
+        {
+          start: {idx: 0, key: 'TN'},
+          end: {idx: 3, key: 'NY'},
+          value: PartitionState.SUCCESS_MISSING,
+        },
+        {
+          start: {idx: 4, key: 'MN'},
+          end: {idx: 4, key: 'MN'},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
+
+      expect(
+        assetHealth.rangesForSingleDimension(1, [
+          [
+            {key: '2022-01-01', idx: 0},
+            {key: '2022-01-01', idx: 0},
+          ],
+        ]),
+      ).toEqual([
+        {
+          start: {idx: 3, key: 'NY'},
+          end: {idx: 4, key: 'MN'},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
     });
 
     it('should return correct data in all-missing states', async () => {
       const assetHealth = buildPartitionHealthData(TWO_DIMENSIONAL_ASSET_EMPTY, {path: ['asset']});
       expect(assetHealth.assetKey).toEqual({path: ['asset']});
+
       expect(assetHealth.stateForKey(['2022-01-01', 'TN'])).toEqual(MISSING);
       expect(assetHealth.stateForKey(['2022-01-04', 'NY'])).toEqual(MISSING);
+
       expect(assetHealth.stateForSingleDimension(0, '2022-01-03')).toEqual(MISSING);
       expect(assetHealth.stateForSingleDimension(1, 'TN')).toEqual(MISSING);
+
+      expect(assetHealth.rangesForSingleDimension(0)).toEqual([]);
+      expect(
+        assetHealth.rangesForSingleDimension(0, [
+          [
+            {key: 'NY', idx: 3},
+            {key: 'MN', idx: 4},
+          ],
+        ]),
+      ).toEqual([]);
+
+      expect(assetHealth.rangesForSingleDimension(1)).toEqual([]);
+      expect(
+        assetHealth.rangesForSingleDimension(1, [
+          [
+            {key: '2022-01-01', idx: 0},
+            {key: '2022-01-01', idx: 0},
+          ],
+        ]),
+      ).toEqual([]);
     });
 
     it('should return an object with accessors for 2D partition data where both are static', async () => {
@@ -280,6 +409,143 @@ describe('usePartitionHealthData', () => {
       // These should safely no-op
       expect(assetHealth.stateForKey(['2022-01-01'])).toEqual(MISSING);
       expect(assetHealth.stateForSingleDimension(0, '2022-01-01')).toEqual(MISSING);
+    });
+  });
+});
+
+const KEYS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
+
+const A_F: Range = {
+  start: {idx: 0, key: 'A'},
+  end: {idx: 5, key: 'F'},
+  value: PartitionState.SUCCESS,
+};
+const A_C: Range = {
+  start: {idx: 0, key: 'A'},
+  end: {key: 'C', idx: 2},
+  value: PartitionState.SUCCESS,
+};
+const A_I: Range = {
+  start: {idx: 0, key: 'A'},
+  end: {idx: 8, key: 'I'},
+  value: PartitionState.SUCCESS,
+};
+const B_E: Range = {
+  start: {idx: 1, key: 'B'},
+  end: {idx: 4, key: 'E'},
+  value: PartitionState.SUCCESS,
+};
+const G_I: Range = {
+  start: {idx: 6, key: 'G'},
+  end: {idx: 8, key: 'I'},
+  value: PartitionState.SUCCESS,
+};
+
+const SEL_A_C: PartitionDimensionSelectionRange = [
+  {key: 'A', idx: 0},
+  {key: 'C', idx: 2},
+];
+const SEL_A_D: PartitionDimensionSelectionRange = [
+  {key: 'A', idx: 0},
+  {key: 'D', idx: 3},
+];
+const SEL_C_D: PartitionDimensionSelectionRange = [
+  {key: 'C', idx: 2},
+  {key: 'D', idx: 3},
+];
+const SEL_E_G: PartitionDimensionSelectionRange = [
+  {key: 'E', idx: 4},
+  {key: 'G', idx: 6},
+];
+const SEL_G_G: PartitionDimensionSelectionRange = [
+  {key: 'G', idx: 6},
+  {key: 'G', idx: 6},
+];
+
+describe('usePartitionHealthData utilities', () => {
+  describe('partitionStatusGivenRanges', () => {
+    it('should return SUCCESS if the ranges span the total key count', () => {
+      expect(partitionStatusGivenRanges([A_I], KEYS.length)).toEqual(PartitionState.SUCCESS);
+      expect(partitionStatusGivenRanges([A_F, G_I], KEYS.length)).toEqual(PartitionState.SUCCESS);
+    });
+
+    it('should return SUCCESS_MISSING if the ranges are not empty', () => {
+      expect(partitionStatusGivenRanges([A_F], KEYS.length)).toEqual(
+        PartitionState.SUCCESS_MISSING,
+      );
+      expect(partitionStatusGivenRanges([G_I], KEYS.length)).toEqual(
+        PartitionState.SUCCESS_MISSING,
+      );
+    });
+
+    it('should return MISSING if the ranges are empty', () => {
+      expect(partitionStatusGivenRanges([], KEYS.length)).toEqual(PartitionState.MISSING);
+    });
+  });
+
+  describe('rangeClippedToSelection', () => {
+    it('should clip the range to a selection specifying one sub-section of it', () => {
+      expect(rangeClippedToSelection(B_E, [SEL_C_D])).toEqual([
+        {
+          start: {key: 'C', idx: 2},
+          end: {key: 'D', idx: 3},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
+    });
+
+    it('should clip the range to a selection specifying one end of it', () => {
+      expect(rangeClippedToSelection(B_E, [SEL_A_D])).toEqual([
+        {
+          start: {key: 'B', idx: 1},
+          end: {key: 'D', idx: 3},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
+    });
+
+    it('should clip the range to a selection specifying both ends but not the middle', () => {
+      expect(rangeClippedToSelection(B_E, [SEL_A_C, SEL_E_G])).toEqual([
+        {
+          start: {key: 'B', idx: 1},
+          end: {key: 'C', idx: 2},
+          value: PartitionState.SUCCESS,
+        },
+        {
+          start: {key: 'E', idx: 4},
+          end: {key: 'E', idx: 4},
+          value: PartitionState.SUCCESS,
+        },
+      ]);
+    });
+
+    it('should clip the range to a selection that does not overlap with the range at all', () => {
+      expect(rangeClippedToSelection(B_E, [SEL_G_G])).toEqual([]);
+    });
+
+    it('should not alter the input data', () => {
+      const before = JSON.stringify({B_E, SEL_A_D});
+      rangeClippedToSelection(B_E, [SEL_A_D]);
+      expect(JSON.stringify({B_E, SEL_A_D})).toEqual(before);
+    });
+  });
+
+  describe('rangesForKeys', () => {
+    it('should return a complete range given all dimension keys', () => {
+      expect(rangesForKeys(KEYS, KEYS)).toEqual([A_I]);
+    });
+    it('should return the correct result if `keys` is unsorted', () => {
+      expect(rangesForKeys(['A', 'C', 'B', 'D', 'F', 'G', 'I', 'H', 'E'], KEYS)).toEqual([A_I]);
+    });
+    it('should return several ranges if there are segments in `keys`', () => {
+      expect(rangesForKeys(['B', 'C', 'D', 'E'], KEYS)).toEqual([B_E]);
+      expect(rangesForKeys(['A', 'B', 'C', 'G', 'H', 'I'], KEYS)).toEqual([A_C, G_I]);
+      expect(rangesForKeys(['G'], KEYS)).toEqual([
+        {start: {idx: 6, key: 'G'}, end: {idx: 6, key: 'G'}, value: PartitionState.SUCCESS},
+      ]);
+    });
+    it('should return no ranges if no keys are provided', () => {
+      expect(rangesForKeys([], KEYS)).toEqual([]);
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -93,6 +93,10 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       console.warn('[stateForKey] called with incorrect number of dimensions');
       return PartitionState.MISSING;
     }
+    if (dimensionKeys.length === 0) {
+      console.warn('[stateForKey] called with zero dimension keys');
+      return PartitionState.MISSING;
+    }
 
     const dIndexes = dimensionKeys.map((key, idx) => dimensions[idx].partitionKeys.indexOf(key));
     const d0Range = ranges.find((r) => r.start.idx <= dIndexes[0] && r.end.idx >= dIndexes[0]);
@@ -100,7 +104,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
     if (!d0Range) {
       return PartitionState.MISSING;
     }
-    if (!d0Range.subranges) {
+    if (!d0Range.subranges || dIndexes.length === 1) {
       return PartitionState.SUCCESS; // 1D case
     }
     const d1Range = d0Range.subranges.find(
@@ -166,6 +170,10 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
     otherDimensionSelectedRanges?: PartitionDimensionSelectionRange[] | undefined,
   ): Range[] => {
     if (dimensions.length === 0) {
+      return [];
+    }
+    if (dimensionIdx >= dimensions.length) {
+      console.warn('[rangesForSingleDimension] called with invalid dimension index');
       return [];
     }
 

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -12,8 +12,8 @@ import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RunStatus, BulkActionStatus} from '../graphql/types';
 import {
+  PartitionRunStatus,
   PartitionState,
-  PartitionStatus,
   runStatusToPartitionState,
 } from '../partitions/PartitionStatus';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -255,7 +255,7 @@ const BackfillRunStatus = ({
   }, {});
 
   return statuses ? (
-    <PartitionStatus
+    <PartitionRunStatus
       partitionNames={backfill.partitionNames}
       partitionStateForKey={(key, _) =>
         runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0].runStatus)
@@ -376,7 +376,7 @@ const BackfillRequestedRange = ({
         </TagButton>
       </div>
       {allPartitions && (
-        <PartitionStatus
+        <PartitionRunStatus
           small
           hideStatusTooltip
           partitionNames={allPartitions}

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -12,8 +12,8 @@ import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RunStatus, BulkActionStatus} from '../graphql/types';
 import {
-  PartitionRunStatus,
   PartitionState,
+  PartitionStatus,
   runStatusToPartitionState,
 } from '../partitions/PartitionStatus';
 import {PipelineReference} from '../pipelines/PipelineReference';
@@ -254,13 +254,21 @@ const BackfillRunStatus = ({
     return partitionCounts;
   }, {});
 
+  const health = React.useMemo(
+    () => ({
+      partitionStateForKey: (key: string) =>
+        statuses
+          ? runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0].runStatus)
+          : PartitionState.MISSING,
+    }),
+    [statuses],
+  );
+
   return statuses ? (
-    <PartitionRunStatus
+    <PartitionStatus
       partitionNames={backfill.partitionNames}
-      partitionStateForKey={(key, _) =>
-        runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0].runStatus)
-      }
-      splitPartitions={true}
+      health={health}
+      splitPartitions
       onClick={(partitionName) => {
         const entry = statuses.find((r) => r.partitionName === partitionName);
         if (entry?.runId) {
@@ -366,6 +374,14 @@ const BackfillRequestedRange = ({
   allPartitions?: string[];
   onExpand: () => void;
 }) => {
+  const health = React.useMemo(
+    () => ({
+      partitionStateForKey: (key: string) =>
+        backfill.partitionNames.includes(key) ? PartitionState.QUEUED : PartitionState.MISSING,
+    }),
+    [backfill.partitionNames],
+  );
+
   return (
     <Box flex={{direction: 'column', gap: 8}}>
       <div>
@@ -376,14 +392,7 @@ const BackfillRequestedRange = ({
         </TagButton>
       </div>
       {allPartitions && (
-        <PartitionRunStatus
-          small
-          hideStatusTooltip
-          partitionNames={allPartitions}
-          partitionStateForKey={(key) =>
-            backfill.partitionNames.includes(key) ? PartitionState.QUEUED : PartitionState.MISSING
-          }
-        />
+        <PartitionStatus small hideStatusTooltip partitionNames={allPartitions} health={health} />
       )}
     </Box>
   );

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -115,7 +115,7 @@ export const AssetJobPartitionsView: React.FC<{
           <PartitionStatus
             partitionNames={dimensionKeys}
             splitPartitions={dimension ? !isTimeseriesDimension(dimension) : false}
-            ranges={merged.rangesForSingleDimension(dimensionIdx)}
+            health={{ranges: merged.rangesForSingleDimension(dimensionIdx)}}
             selected={selectedDimensionKeys}
             selectionWindowSize={pageSize}
             tooltipMessage="Click to view per-asset status"

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -115,7 +115,7 @@ export const AssetJobPartitionsView: React.FC<{
           <PartitionStatus
             partitionNames={dimensionKeys}
             splitPartitions={dimension ? !isTimeseriesDimension(dimension) : false}
-            partitionStateForKey={(key) => merged.stateForSingleDimension(dimensionIdx, key)}
+            ranges={merged.rangesForSingleDimension(dimensionIdx)}
             selected={selectedDimensionKeys}
             selectionWindowSize={pageSize}
             tooltipMessage="Click to view per-asset status"

--- a/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
@@ -178,7 +178,7 @@ export const BackfillPartitionSelector: React.FC<{
             <DimensionRangeWizard
               selected={range}
               setSelected={setRange}
-              partitionStateForKey={(name) => partitionData[name]}
+              health={{partitionStateForKey: (key) => partitionData[key]}}
               partitionKeys={partitionNames}
             />
 

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -2,16 +2,17 @@ import {Box, Button} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {isTimeseriesPartition} from '../assets/MultipartitioningSupport';
+import {Range} from '../assets/usePartitionHealthData';
 
 import {DimensionRangeInput} from './DimensionRangeInput';
-import {PartitionState, PartitionStatus} from './PartitionStatus';
+import {PartitionStatus} from './PartitionStatus';
 
 export const DimensionRangeWizard: React.FC<{
   selected: string[];
   setSelected: (selected: string[]) => void;
   partitionKeys: string[];
-  partitionStateForKey: (partitionKey: string, partitionIdx: number) => PartitionState;
-}> = ({selected, setSelected, partitionKeys, partitionStateForKey}) => {
+  ranges: Range[];
+}> = ({selected, setSelected, partitionKeys, ranges}) => {
   const isTimeseries = isTimeseriesPartition(partitionKeys[0]);
 
   return (
@@ -37,7 +38,7 @@ export const DimensionRangeWizard: React.FC<{
       <Box margin={{bottom: 8}}>
         <PartitionStatus
           partitionNames={partitionKeys}
-          partitionStateForKey={partitionStateForKey}
+          ranges={ranges}
           splitPartitions={!isTimeseries}
           selected={selected}
           onSelect={setSelected}

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -5,14 +5,14 @@ import {isTimeseriesPartition} from '../assets/MultipartitioningSupport';
 import {Range} from '../assets/usePartitionHealthData';
 
 import {DimensionRangeInput} from './DimensionRangeInput';
-import {PartitionStatus} from './PartitionStatus';
+import {PartitionRunStatus, PartitionState, PartitionStatus} from './PartitionStatus';
 
 export const DimensionRangeWizard: React.FC<{
   selected: string[];
   setSelected: (selected: string[]) => void;
   partitionKeys: string[];
-  ranges: Range[];
-}> = ({selected, setSelected, partitionKeys, ranges}) => {
+  health: {ranges: Range[]} | {partitionStateForKey: (key: string) => PartitionState};
+}> = ({selected, setSelected, partitionKeys, health}) => {
   const isTimeseries = isTimeseriesPartition(partitionKeys[0]);
 
   return (
@@ -36,13 +36,23 @@ export const DimensionRangeWizard: React.FC<{
         </Button>
       </Box>
       <Box margin={{bottom: 8}}>
-        <PartitionStatus
-          partitionNames={partitionKeys}
-          ranges={ranges}
-          splitPartitions={!isTimeseries}
-          selected={selected}
-          onSelect={setSelected}
-        />
+        {'partitionStateForKey' in health ? (
+          <PartitionRunStatus
+            partitionNames={partitionKeys}
+            partitionStateForKey={health.partitionStateForKey}
+            splitPartitions={!isTimeseries}
+            selected={selected}
+            onSelect={setSelected}
+          />
+        ) : (
+          <PartitionStatus
+            partitionNames={partitionKeys}
+            ranges={health.ranges}
+            splitPartitions={!isTimeseries}
+            selected={selected}
+            onSelect={setSelected}
+          />
+        )}
       </Box>
     </>
   );

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -2,16 +2,15 @@ import {Box, Button} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {isTimeseriesPartition} from '../assets/MultipartitioningSupport';
-import {Range} from '../assets/usePartitionHealthData';
 
 import {DimensionRangeInput} from './DimensionRangeInput';
-import {PartitionRunStatus, PartitionState, PartitionStatus} from './PartitionStatus';
+import {PartitionStatusHealthSource, PartitionStatus} from './PartitionStatus';
 
 export const DimensionRangeWizard: React.FC<{
   selected: string[];
   setSelected: (selected: string[]) => void;
   partitionKeys: string[];
-  health: {ranges: Range[]} | {partitionStateForKey: (key: string) => PartitionState};
+  health: PartitionStatusHealthSource;
 }> = ({selected, setSelected, partitionKeys, health}) => {
   const isTimeseries = isTimeseriesPartition(partitionKeys[0]);
 
@@ -36,23 +35,13 @@ export const DimensionRangeWizard: React.FC<{
         </Button>
       </Box>
       <Box margin={{bottom: 8}}>
-        {'partitionStateForKey' in health ? (
-          <PartitionRunStatus
-            partitionNames={partitionKeys}
-            partitionStateForKey={health.partitionStateForKey}
-            splitPartitions={!isTimeseries}
-            selected={selected}
-            onSelect={setSelected}
-          />
-        ) : (
-          <PartitionStatus
-            partitionNames={partitionKeys}
-            ranges={health.ranges}
-            splitPartitions={!isTimeseries}
-            selected={selected}
-            onSelect={setSelected}
-          />
-        )}
+        <PartitionStatus
+          partitionNames={partitionKeys}
+          health={health}
+          splitPartitions={!isTimeseries}
+          selected={selected}
+          onSelect={setSelected}
+        />
       </Box>
     </>
   );

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -13,7 +13,12 @@ import {RepoAddress} from '../workspace/types';
 import {BackfillPartitionSelector} from './BackfillSelector';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {PartitionGraph} from './PartitionGraph';
-import {PartitionState, PartitionStatus, runStatusToPartitionState} from './PartitionStatus';
+import {
+  PartitionRunStatus,
+  PartitionState,
+  PartitionStatus,
+  runStatusToPartitionState,
+} from './PartitionStatus';
 import {getVisibleItemCount, PartitionPerOpStatus} from './PartitionStepStatus';
 import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
 import {
@@ -225,7 +230,7 @@ const OpJobPartitionsViewContent: React.FC<{
       </Box>
       <Box padding={{vertical: 16, horizontal: 24}}>
         <div {...containerProps}>
-          <PartitionStatus
+          <PartitionRunStatus
             partitionNames={partitionNames}
             partitionStateForKey={(name) => statusData[name]}
             selected={showSteps ? selectedPartitions : undefined}

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -358,7 +358,7 @@ function useRenderableRanges(
       ? buildRangesFromStateFn(partitionNames, splitPartitions, _stateForKey)
       : _ranges && splitPartitions
       ? convertToSingleKeyRanges(partitionNames, _ranges)
-      : joinRangesSharingValue(_ranges!);
+      : _ranges!;
   }, [splitPartitions, partitionNames, _ranges, _stateForKey]);
 }
 
@@ -377,27 +377,6 @@ function convertToSingleKeyRanges(
         end: {idx, key: partitionNames[idx]},
         value: range.value,
       });
-    }
-  }
-  return result;
-}
-
-// If you provide the primary dimension ranges of a multi-partitioned asset, there can be tons of
-// small ranges which differ only in their subranges, which can lead to tiny "A-B", "C-D", "E"
-// ranges rendering when one "A-E" would suffice. This is noticeable because we use a striped pattern
-// for partial ranges and the pattern resets.
-//
-// This function walks the ranges and merges them if their top level status is the same so they
-// can be rendered with the minimal number of divs.
-//
-function joinRangesSharingValue(ranges: PartitionStatusRange[]): PartitionStatusRange[] {
-  const result: PartitionStatusRange[] = [];
-  for (const range of ranges) {
-    const last = result[result.length - 1];
-    if (last && last.end.idx === range.start.idx - 1 && last.value === range.value) {
-      last.end = range.end;
-    } else {
-      result.push({...range});
     }
   }
   return result;


### PR DESCRIPTION
### Summary & Motivation

Earlier this month we started sending asset partition health to Dagit as "ranges" of partition keys. The goal of this was to more concisely express the typical case, in which large bands of a potentially enormous range are all in the same state.

This PR updates the partition health bars in Dagit to take advantage of this format, which more directly maps onto what we render (green / gray bars). This PR finally de-couples the performance of the partition health bars from the number of keys in the asset partition space.

This code is complicated because Dagit allows you to:

1) view partition health on both dimensions of a multi-partitioned asset, even though the data sent to Dagit is always ranges on one dimension with subranges on the other. This requires that dagit can effectively "pivot" ranges onto the other axis.

2) view partition health filtered to a selection of keys. ("Eg: If I look at just "Prod" on dimension 2, do I have all of 2022?" on dimension 1?) This is a super cool interaction in the backfill modal but requires that Dagit can slice and subset range-based data.

3) view the aggregate health of several assets at once, flattening their individual health ranges into a single bar that shows "partial" where some of the assets are unmaterialized. (in the backfill modal if you have multiple assets selected). This requires that we can "union" overlapping ranges and generate a new summary set. 


Next Steps:

### How I Tested These Changes

- New tests covering all the utility methods with cases written to exercise all the branches in the logic.

- New tests covering the output of the range accessor on the health data object. I wrote these tests directly from the example data and then verified the output against the function (which I think is important because it'd be easy to copy-paste the output into the toEqual and not catch a bug in this...)

- I screenshotted the storybook coverage of PartitionHealthSummary and verified the rendering is the same for a variety of health bars. This was super useful in catching a bunch of bugs as I was writing the code.

### Follow-ups:

- There are only two callsites still using `stateForSingleDimension`. Most importantly, the AssetPartitions page uses this and introduces an O(length of partitions array) to implement the status dots next to the partition rows and the filtering for "Success / Missing" on that page. It'd be great to get rid of `stateForSingleDimension`, because it's largely just a way-less-performant version of `rangesForSingleDimension`.

- The PartitionState enum should really be called PartitionStatus to match RunStatus. Will fix this on a quiet Friday at some point soon.