### PR TITLE
add cloud to scaffold

### DIFF
--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/setup.py.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/setup.py.tmpl
@@ -5,6 +5,7 @@ setup(
     packages=find_packages(exclude=["{{ code_location_name }}_tests"]),
     install_requires=[
         "dagster",
+        "dagster-cloud"
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/setup.py.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/setup.py.tmpl
@@ -5,6 +5,7 @@ setup(
     packages=find_packages(exclude=["{{ repo_name }}_tests"]),
     install_requires=[
         "dagster",
+        "dagster-cloud"
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )


### PR DESCRIPTION
### Summary & Motivation

dagster cloud users who start with the project scaffold are often surprised/confused/frustrated that deploying to dagster cloud fails due to a missing dependency

### How I Tested These Changes
