### PR TITLE
[Runs Table] Open link in new tab 

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -279,6 +279,7 @@ const RunRow: React.FC<{
                       })
                     : workspacePipelinePathGuessRepo(run.pipelineName)
                 }
+                target="_blank"
               >
                 <Icon name="open_in_new" color={Colors.Blue500} />
               </Link>


### PR DESCRIPTION
### Summary & Motivation

This link has the "open_in_new" icon next to it indicating it opens in a new tab. 
So this pr adds the missing `target="_blank"` to open in a new tab

### How I Tested These Changes

Click the link and watch it open in a new tab