### PR TITLE
Include instance-level / code-location-level runK8sConfig in step pods

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -141,7 +141,9 @@ class K8sContainerContext(
 
     @staticmethod
     def create_for_run(
-        pipeline_run: DagsterRun, run_launcher: Optional["K8sRunLauncher"]
+        pipeline_run: DagsterRun,
+        run_launcher: Optional["K8sRunLauncher"],
+        include_run_tags: bool,
     ) -> "K8sContainerContext":
         context = K8sContainerContext()
 
@@ -175,11 +177,12 @@ class K8sContainerContext(
                     K8sContainerContext.create_from_config(run_container_context)
                 )
 
-        user_defined_k8s_config = get_user_defined_k8s_config(frozentags(pipeline_run.tags))
+        if include_run_tags:
+            user_defined_k8s_config = get_user_defined_k8s_config(frozentags(pipeline_run.tags))
 
-        context = context.merge(
-            K8sContainerContext(run_k8s_config=user_defined_k8s_config.to_dict())
-        )
+            context = context.merge(
+                K8sContainerContext(run_k8s_config=user_defined_k8s_config.to_dict())
+            )
 
         return context
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -35,25 +35,27 @@ from .job import (
     get_user_defined_k8s_config,
 )
 
+_K8S_EXECUTOR_CONFIG_SCHEMA = merge_dicts(
+    DagsterK8sJobConfig.config_type_job(),
+    {
+        "job_namespace": Field(StringSource, is_required=False),
+        "retries": get_retries_config(),
+        "max_concurrent": Field(
+            IntSource,
+            is_required=False,
+            description=(
+                "Limit on the number of pods that will run concurrently within the scope "
+                "of a Dagster run. Note that this limit is per run, not global."
+            ),
+        ),
+        "tag_concurrency_limits": get_tag_concurrency_limits_config(),
+    },
+)
+
 
 @executor(
     name="k8s",
-    config_schema=merge_dicts(
-        DagsterK8sJobConfig.config_type_job(),
-        {
-            "job_namespace": Field(StringSource, is_required=False),
-            "retries": get_retries_config(),
-            "max_concurrent": Field(
-                IntSource,
-                is_required=False,
-                description=(
-                    "Limit on the number of pods that will run concurrently within the scope "
-                    "of a Dagster run. Note that this limit is per run, not global."
-                ),
-            ),
-            "tag_concurrency_limits": get_tag_concurrency_limits_config(),
-        },
-    ),
+    config_schema=_K8S_EXECUTOR_CONFIG_SCHEMA,
     requirements=multiple_process_executor_requirements(),
 )
 def k8s_job_executor(init_context: InitExecutorContext) -> Executor:
@@ -167,21 +169,30 @@ class K8sStepHandler(StepHandler):
             batch_api_override=k8s_client_batch_api
         )
 
+    def _get_step_key(self, step_handler_context: StepHandlerContext) -> str:
+        step_keys_to_execute = cast(
+            List[str], step_handler_context.execute_step_args.step_keys_to_execute
+        )
+        assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
+        return step_keys_to_execute[0]
+
     def _get_container_context(self, step_handler_context: StepHandlerContext):
-        run_target = K8sContainerContext.create_for_run(
+        step_key = self._get_step_key(step_handler_context)
+
+        context = K8sContainerContext.create_for_run(
             step_handler_context.pipeline_run,
             cast(K8sRunLauncher, step_handler_context.instance.run_launcher),
+            include_run_tags=False,  # For now don't include job-level dagster-k8s/config tags in step pods
         )
-        return run_target.merge(self._executor_container_context)
+        context = context.merge(self._executor_container_context)
+
+        user_defined_k8s_config = get_user_defined_k8s_config(
+            frozentags(step_handler_context.step_tags[step_key])
+        )
+        return context.merge(K8sContainerContext(run_k8s_config=user_defined_k8s_config.to_dict()))
 
     def _get_k8s_step_job_name(self, step_handler_context: StepHandlerContext):
-        if (
-            step_handler_context.execute_step_args.step_keys_to_execute is None
-            or len(step_handler_context.execute_step_args.step_keys_to_execute) != 1
-        ):
-            check.failed("Expected step_keys_to_execute to contain single entry")
-
-        step_key = next(iter(step_handler_context.execute_step_args.step_keys_to_execute))
+        step_key = self._get_step_key(step_handler_context)
 
         name_key = get_k8s_job_name(
             step_handler_context.execute_step_args.pipeline_run_id,
@@ -196,11 +207,7 @@ class K8sStepHandler(StepHandler):
         return "dagster-step-%s" % (name_key)
 
     def launch_step(self, step_handler_context: StepHandlerContext) -> Iterator[DagsterEvent]:
-        step_keys_to_execute = cast(
-            List[str], step_handler_context.execute_step_args.step_keys_to_execute
-        )
-        assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
-        step_key = step_keys_to_execute[0]
+        step_key = self._get_step_key(step_handler_context)
 
         job_name = self._get_k8s_step_job_name(step_handler_context)
         pod_name = job_name
@@ -223,17 +230,13 @@ class K8sStepHandler(StepHandler):
         if not job_config.job_image:
             raise Exception("No image included in either executor config or the job")
 
-        user_defined_k8s_config = get_user_defined_k8s_config(
-            frozentags(step_handler_context.step_tags[step_key])
-        )
-
         job = construct_dagster_k8s_job(
             job_config=job_config,
             args=args,
             job_name=job_name,
             pod_name=pod_name,
             component="step_worker",
-            user_defined_k8s_config=user_defined_k8s_config,
+            user_defined_k8s_config=container_context.get_run_user_defined_k8s_config(),
             labels={
                 "dagster/job": step_handler_context.pipeline_run.pipeline_name,
                 "dagster/op": step_key,
@@ -262,11 +265,7 @@ class K8sStepHandler(StepHandler):
         )
 
     def check_step_health(self, step_handler_context: StepHandlerContext) -> CheckStepHealthResult:
-        step_keys_to_execute = cast(
-            List[str], step_handler_context.execute_step_args.step_keys_to_execute
-        )
-        assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
-        step_key = step_keys_to_execute[0]
+        step_key = self._get_step_key(step_handler_context)
 
         job_name = self._get_k8s_step_job_name(step_handler_context)
 
@@ -284,11 +283,7 @@ class K8sStepHandler(StepHandler):
         return CheckStepHealthResult.healthy()
 
     def terminate_step(self, step_handler_context: StepHandlerContext) -> Iterator[DagsterEvent]:
-        step_keys_to_execute = cast(
-            List[str], step_handler_context.execute_step_args.step_keys_to_execute
-        )
-        assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
-        step_key = step_keys_to_execute[0]
+        step_key = self._get_step_key(step_handler_context)
 
         job_name = self._get_k8s_step_job_name(step_handler_context)
         container_context = self._get_container_context(step_handler_context)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -204,7 +204,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         return self._inst_data
 
     def get_container_context_for_run(self, pipeline_run: DagsterRun) -> K8sContainerContext:
-        return K8sContainerContext.create_for_run(pipeline_run, self)
+        return K8sContainerContext.create_for_run(pipeline_run, self, include_run_tags=True)
 
     def _launch_k8s_job_with_args(self, job_name, args, run):
         container_context = self.get_container_context_for_run(run)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -202,6 +202,7 @@ def execute_k8s_job(
         context.instance.run_launcher
         if isinstance(context.instance.run_launcher, K8sRunLauncher)
         else None,
+        include_run_tags=True,
     )
 
     container_config = container_config.copy() if container_config else {}

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from dagster import execute_job, job, op
+from dagster._config import process_config, resolve_to_config_type
 from dagster._core.definitions.reconstruct import reconstructable
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
 from dagster._core.execution.api import create_execution_plan
@@ -16,7 +17,7 @@ from dagster._core.storage.fs_io_manager import fs_io_manager
 from dagster._core.test_utils import create_run_for_test, environ, instance_for_test
 from dagster._grpc.types import ExecuteStepArgs
 from dagster_k8s.container_context import K8sContainerContext
-from dagster_k8s.executor import K8sStepHandler, k8s_job_executor
+from dagster_k8s.executor import _K8S_EXECUTOR_CONFIG_SCHEMA, K8sStepHandler, k8s_job_executor
 from dagster_k8s.job import UserDefinedDagsterK8sConfig
 
 
@@ -37,6 +38,16 @@ RESOURCE_TAGS = {
     "requests": {"cpu": "250m", "memory": "64Mi"},
 }
 
+OTHER_RESOURCE_TAGS = {
+    "limits": {"cpu": "1000m", "memory": "1280Mi"},
+    "requests": {"cpu": "500m", "memory": "128Mi"},
+}
+
+
+VOLUME_MOUNTS_TAGS = [{"name": "volume1", "mount_path": "foo/bar", "sub_path": "file.txt"}]
+
+OTHER_VOLUME_MOUNTS_TAGS = [{"name": "volume2", "mount_path": "baz/quux", "sub_path": "voom.txt"}]
+
 
 @job(
     executor_def=k8s_job_executor,
@@ -52,6 +63,32 @@ def bar_with_resources():
     )
 
     @op(tags={"dagster-k8s/config": user_defined_k8s_config_with_resources_json})
+    def foo():
+        return 1
+
+    foo()
+
+
+@job(
+    executor_def=k8s_job_executor,
+    resource_defs={"io_manager": fs_io_manager},
+    tags={
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": RESOURCE_TAGS,
+                "volume_mounts": VOLUME_MOUNTS_TAGS,
+            }
+        }
+    },
+)
+def bar_with_tags_in_job_and_op():
+    expected_resources = RESOURCE_TAGS
+    user_defined_k8s_config_with_resources = UserDefinedDagsterK8sConfig(
+        container_config={"resources": expected_resources},
+    )
+    json.dumps(user_defined_k8s_config_with_resources.to_dict())
+
+    @op(tags={"dagster-k8s/config": {"container_config": {"resources": OTHER_RESOURCE_TAGS}}})
     def foo():
         return 1
 
@@ -109,11 +146,17 @@ def test_requires_k8s_launcher_fail():
 
 
 def _get_executor(instance, pipeline, executor_config=None):
+    process_result = process_config(
+        resolve_to_config_type(_K8S_EXECUTOR_CONFIG_SCHEMA),
+        executor_config or {},
+    )
+    assert process_result.success, str(process_result.errors)
+
     return k8s_job_executor.executor_creation_fn(
         InitExecutorContext(
             job=pipeline,
             executor_def=k8s_job_executor,
-            executor_config=executor_config or {"retries": {}},
+            executor_config=process_result.value,
             instance=instance,
         )
     )
@@ -160,7 +203,6 @@ def test_executor_init(k8s_run_launcher_instance):
         reconstructable(bar),
         {
             "env_vars": ["FOO_TEST"],
-            "retries": {},
             "resources": resources,
             "scheduler_name": "my-scheduler",
         },
@@ -206,7 +248,7 @@ def test_executor_init_container_context(
     executor = _get_executor(
         k8s_run_launcher_instance,
         reconstructable(bar),
-        {"env_vars": ["FOO_TEST"], "retries": {}, "max_concurrent": 4},
+        {"env_vars": ["FOO_TEST"], "max_concurrent": 4},
     )
 
     run = create_run_for_test(
@@ -444,3 +486,49 @@ def test_step_handler_with_container_context(
 
         assert envs["FOO_TEST"] == "bar"
         assert envs["BAZ_TEST"] == "blergh"
+
+
+def test_step_raw_k8s_config_inheritance(
+    k8s_run_launcher_instance, python_origin_with_container_context
+):
+    container_context_config = {
+        "k8s": {
+            "run_k8s_config": {"container_config": {"volume_mounts": OTHER_VOLUME_MOUNTS_TAGS}},
+        }
+    }
+
+    python_origin = reconstructable(bar_with_tags_in_job_and_op).get_python_origin()
+
+    python_origin_with_container_context = python_origin._replace(
+        repository_origin=python_origin.repository_origin._replace(
+            container_context=container_context_config
+        )
+    )
+
+    # Verifies that raw k8s config for step pods is pulled from the container context and
+    # dagster-k8s/config tags on the op, but *not* from tags on the job
+    executor = _get_executor(
+        k8s_run_launcher_instance,
+        reconstructable(bar_with_tags_in_job_and_op),
+        {},
+    )
+
+    run = create_run_for_test(
+        k8s_run_launcher_instance,
+        pipeline_name="bar_with_tags_in_job_and_op",
+        pipeline_code_origin=python_origin_with_container_context,
+    )
+
+    step_handler_context = _step_handler_context(
+        pipeline=reconstructable(bar_with_tags_in_job_and_op),
+        pipeline_run=run,
+        instance=k8s_run_launcher_instance,
+        executor=executor,
+    )
+
+    container_context = executor._step_handler._get_container_context(step_handler_context)
+
+    raw_k8s_config = container_context.get_run_user_defined_k8s_config()
+
+    assert raw_k8s_config.container_config["resources"] == OTHER_RESOURCE_TAGS
+    assert raw_k8s_config.container_config["volume_mounts"] == OTHER_VOLUME_MOUNTS_TAGS


### PR DESCRIPTION
Summary:
This makes it so that setting runK8sConfig or code-location runK8sConfig is automatically passed through to steps when using the k8s-job-executor. @job tags are not automatically passed through - seemed like a toss-up and would be a breaking change since those tags have been around for a while.
