### PR TITLE
[dagit] add dagster libraries menu to code location row

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1893,6 +1893,12 @@ type RepositoryLocation {
   environmentPath: String
   repositories: [Repository!]!
   serverId: String
+  dagsterLibraryVersions: [DagsterLibraryVersion!]
+}
+
+type DagsterLibraryVersion {
+  name: String!
+  version: String!
 }
 
 union RepositoryOrError = PythonError | Repository | RepositoryNotFoundError

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -836,6 +836,12 @@ export enum DagsterEventType {
   STEP_WORKER_STARTING = 'STEP_WORKER_STARTING',
 }
 
+export type DagsterLibraryVersion = {
+  __typename: 'DagsterLibraryVersion';
+  name: Scalars['String'];
+  version: Scalars['String'];
+};
+
 export type DagsterRunEvent =
   | AlertFailureEvent
   | AlertStartEvent
@@ -2686,6 +2692,7 @@ export type RepositoryConnection = {
 
 export type RepositoryLocation = {
   __typename: 'RepositoryLocation';
+  dagsterLibraryVersions: Maybe<Array<DagsterLibraryVersion>>;
   environmentPath: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   isReloadSupported: Scalars['Boolean'];

--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationMenu.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationMenu.tsx
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Popover,
   StyledReadOnlyCodeMirror,
+  Table,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import * as yaml from 'yaml';
@@ -16,14 +17,35 @@ import {WorkspaceRepositoryLocationNode} from './WorkspaceContext';
 export const CodeLocationMenu: React.FC<{locationNode: WorkspaceRepositoryLocationNode}> = ({
   locationNode,
 }) => {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [configIsOpen, setConfigIsOpen] = React.useState(false);
+  const [libsIsOpen, setLibsIsOpen] = React.useState(false);
+
+  let libsMenuItem = null;
+  let libsDialog = null;
+  if (
+    locationNode.locationOrLoadError?.__typename === 'RepositoryLocation' &&
+    locationNode.locationOrLoadError.dagsterLibraryVersions !== null
+  ) {
+    libsMenuItem = (
+      <MenuItem icon="info" text="View Dagster libraries" onClick={() => setLibsIsOpen(true)} />
+    );
+    libsDialog = (
+      <DagsterLibrariesDialog
+        libraries={locationNode.locationOrLoadError.dagsterLibraryVersions}
+        isOpen={libsIsOpen}
+        setIsOpen={setLibsIsOpen}
+      />
+    );
+  }
+
   return (
     <>
       <Popover
         position="bottom-left"
         content={
           <Menu>
-            <MenuItem icon="info" text="View configuration" onClick={() => setIsOpen(true)} />
+            <MenuItem icon="info" text="View configuration" onClick={() => setConfigIsOpen(true)} />
+            {libsMenuItem}
           </Menu>
         }
       >
@@ -31,9 +53,10 @@ export const CodeLocationMenu: React.FC<{locationNode: WorkspaceRepositoryLocati
       </Popover>
       <CodeLocationConfigDialog
         metadata={locationNode.displayMetadata}
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
+        isOpen={configIsOpen}
+        setIsOpen={setConfigIsOpen}
       />
+      {libsDialog}
     </>
   );
 };
@@ -52,6 +75,44 @@ export const CodeLocationConfigDialog: React.FC<{
       style={{width: '600px'}}
     >
       <CodeLocationConfig displayMetadata={metadata} />
+      <DialogFooter topBorder>
+        <Button onClick={() => setIsOpen(false)} intent="primary">
+          Done
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+export const DagsterLibrariesDialog: React.FC<{
+  isOpen: boolean;
+  setIsOpen: (next: boolean) => void;
+  libraries: {name: string; version: string}[];
+}> = ({isOpen, setIsOpen, libraries}) => {
+  return (
+    <Dialog
+      title="Dagster library versions"
+      icon="info"
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      style={{width: '600px'}}
+    >
+      <Table>
+        <thead>
+          <tr>
+            <th>Libray</th>
+            <th>Version</th>
+          </tr>
+        </thead>
+        <tbody>
+          {libraries.map((library) => (
+            <tr key={library.name}>
+              <td>{library.name}</td>
+              <td>{library.version}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
       <DialogFooter topBorder>
         <Button onClick={() => setIsOpen(false)} intent="primary">
           Done

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -90,6 +90,10 @@ const ROOT_WORKSPACE_QUERY = gql`
     isReloadSupported
     serverId
     name
+    dagsterLibraryVersions {
+      name
+      version
+    }
     repositories {
       id
       ...WorkspaceRepository

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
@@ -43,6 +43,11 @@ export type RootWorkspaceQuery = {
                 isReloadSupported: boolean;
                 serverId: string | null;
                 name: string;
+                dagsterLibraryVersions: Array<{
+                  __typename: 'DagsterLibraryVersion';
+                  name: string;
+                  version: string;
+                }> | null;
                 repositories: Array<{
                   __typename: 'Repository';
                   id: string;
@@ -132,6 +137,11 @@ export type WorkspaceLocationNodeFragment = {
         isReloadSupported: boolean;
         serverId: string | null;
         name: string;
+        dagsterLibraryVersions: Array<{
+          __typename: 'DagsterLibraryVersion';
+          name: string;
+          version: string;
+        }> | null;
         repositories: Array<{
           __typename: 'Repository';
           id: string;
@@ -199,6 +209,11 @@ export type WorkspaceLocationFragment = {
   isReloadSupported: boolean;
   serverId: string | null;
   name: string;
+  dagsterLibraryVersions: Array<{
+    __typename: 'DagsterLibraryVersion';
+    name: string;
+    version: string;
+  }> | null;
   repositories: Array<{
     __typename: 'Repository';
     id: string;

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -32,6 +32,7 @@ from dagster._core.host_representation.external_data import (
 )
 from dagster._core.host_representation.origin import ExternalRepositoryOrigin
 from dagster._core.instance import DagsterInstance, InstanceRef
+from dagster._core.libraries import DagsterLibraryRegistry
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.autodiscovery import LoadableTarget
@@ -416,6 +417,7 @@ class DagsterApiServer(DagsterApiServicer):
             entry_point=self._entry_point,
             container_image=self._container_image,
             container_context=self._container_context,
+            dagster_library_versions=DagsterLibraryRegistry.get(),
         )
 
         return api_pb2.ListRepositoriesReply(

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -292,17 +292,19 @@ class ListRepositoriesResponse(
             ("entry_point", Optional[Sequence[str]]),
             ("container_image", Optional[str]),
             ("container_context", Optional[Mapping[str, Any]]),
+            ("dagster_library_versions", Optional[Mapping[str, str]]),
         ],
     )
 ):
     def __new__(
         cls,
-        repository_symbols,
-        executable_path=None,
-        repository_code_pointer_dict=None,
-        entry_point=None,
-        container_image=None,
-        container_context=None,
+        repository_symbols: Sequence[LoadableRepositorySymbol],
+        executable_path: Optional[str] = None,
+        repository_code_pointer_dict: Optional[Mapping[str, CodePointer]] = None,
+        entry_point: Optional[Sequence[str]] = None,
+        container_image: Optional[str] = None,
+        container_context: Optional[Mapping] = None,
+        dagster_library_versions: Optional[Mapping[str, str]] = None,
     ):
         return super(ListRepositoriesResponse, cls).__new__(
             cls,
@@ -310,7 +312,7 @@ class ListRepositoriesResponse(
                 repository_symbols, "repository_symbols", of_type=LoadableRepositorySymbol
             ),
             executable_path=check.opt_str_param(executable_path, "executable_path"),
-            repository_code_pointer_dict=check.opt_dict_param(
+            repository_code_pointer_dict=check.opt_mapping_param(
                 repository_code_pointer_dict,
                 "repository_code_pointer_dict",
                 key_type=str,
@@ -326,6 +328,9 @@ class ListRepositoriesResponse(
                 check.dict_param(container_context, "container_context")
                 if container_context is not None
                 else None
+            ),
+            dagster_library_versions=check.opt_mapping_param(
+                dagster_library_versions, "dagster_library_versions"
             ),
         )
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -35,6 +35,7 @@ from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_da
 from dagster._seven import get_system_temp_directory
 from dagster._utils import file_relative_path, find_free_port
 from dagster._utils.error import SerializableErrorInfo
+from dagster.version import __version__ as dagster_version
 
 
 def _get_ipc_output_file():
@@ -829,6 +830,7 @@ def test_load_with_container_context(capfd):
         assert list_repositories_response.entry_point == ["dagster"]
         assert list_repositories_response.executable_path == sys.executable
         assert list_repositories_response.container_context == container_context
+        assert list_repositories_response.dagster_library_versions == {"dagster": dagster_version}
 
     finally:
         process.terminate()


### PR DESCRIPTION
Add a simple menu for now that allows you to view the libraries that were used when loading the definitions for a code location.

### How I Tested These Changes
![Screen Shot 2023-02-13 at 3 47 55 PM](https://user-images.githubusercontent.com/202219/218582974-56967ed1-822c-40cb-a782-e6a2cd287e81.png)
![Screen Shot 2023-02-13 at 3 47 43 PM](https://user-images.githubusercontent.com/202219/218582975-d8decd2f-4b67-496a-bfa7-7d8adc3c06cb.png)

