### PR TITLE
Include partition in asset materialization planned event

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/mode.py
+++ b/python_modules/dagster/dagster/_core/definitions/mode.py
@@ -48,7 +48,7 @@ class ModeDefinition(
             executors (:py:data:`~dagster.default_executors`).
         description (Optional[str]): A human-readable description of the mode.
         _config_mapping (Optional[ConfigMapping]): Only for internal use.
-        _partitions (Optional[PartitionedConfig]): Only for internal use.
+        _partitioned_config (Optional[PartitionedConfig]): Only for internal use.
     """
 
     def __new__(

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -652,6 +652,8 @@ class DagsterEvent(
             return self.step_materialization_data.materialization.partition
         elif self.event_type == DagsterEventType.ASSET_OBSERVATION:
             return self.asset_observation_data.asset_observation.partition
+        elif self.event_type == DagsterEventType.ASSET_MATERIALIZATION_PLANNED:
+            return self.asset_materialization_planned_data.partition
         else:
             return None
 
@@ -1451,11 +1453,16 @@ class StepMaterializationData(
 
 @whitelist_for_serdes
 class AssetMaterializationPlannedData(
-    NamedTuple("_AssetMaterializationPlannedData", [("asset_key", AssetKey)])
+    NamedTuple(
+        "_AssetMaterializationPlannedData",
+        [("asset_key", AssetKey), ("partition", Optional[str])],
+    )
 ):
-    def __new__(cls, asset_key: AssetKey):
+    def __new__(cls, asset_key: AssetKey, partition: Optional[str] = None):
         return super(AssetMaterializationPlannedData, cls).__new__(
-            cls, asset_key=check.inst_param(asset_key, "asset_key", AssetKey)
+            cls,
+            asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
+            partition=check.opt_str_param(partition, "partition"),
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -79,6 +79,7 @@ def create_step_outputs(
                     is_asset=asset_info is not None,
                     should_materialize=output_def.name in config_output_names,
                     asset_key=asset_info.key if asset_info and asset_info.is_required else None,
+                    is_asset_partitioned=bool(asset_info.partitions_def) if asset_info else False,
                 ),
             )
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -24,6 +24,7 @@ class StepOutputProperties(
             ("is_asset", bool),
             ("should_materialize", bool),
             ("asset_key", Optional[AssetKey]),
+            ("is_asset_partitioned", bool),
         ],
     )
 ):
@@ -34,6 +35,7 @@ class StepOutputProperties(
         is_asset: bool,
         should_materialize: bool,
         asset_key: Optional[AssetKey] = None,
+        is_asset_partitioned: bool = False,
     ):
         return super(StepOutputProperties, cls).__new__(
             cls,
@@ -42,6 +44,7 @@ class StepOutputProperties(
             check.bool_param(is_asset, "is_asset"),
             check.bool_param(should_materialize, "should_materialize"),
             check.opt_inst_param(asset_key, "asset_key", AssetKey),
+            check.bool_param(is_asset_partitioned, "is_asset_partitioned"),
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_execution_plan.py
@@ -47,6 +47,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -117,6 +118,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -182,6 +184,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -258,6 +261,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -389,6 +393,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -459,6 +464,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -507,6 +513,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -585,6 +592,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false
@@ -633,6 +641,7 @@ snapshots[
             "__class__": "StepOutputProperties",
             "asset_key": null,
             "is_asset": false,
+            "is_asset_partitioned": false,
             "is_dynamic": false,
             "is_required": true,
             "should_materialize": false

--- a/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_asset_events.py
@@ -6,9 +6,11 @@ from dagster import (
     Output,
     asset,
     job,
+    materialize_to_memory,
     multi_asset,
     op,
 )
+from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import build_assets_job
 
@@ -87,3 +89,31 @@ def test_multi_asset_asset_materialization_planned_events():
 
         assert instance.run_ids_for_asset_key(AssetKey("my_asset_name")) == [run_id]
         assert instance.run_ids_for_asset_key(AssetKey("my_other_asset")) == [run_id]
+
+
+def test_asset_partition_materialization_planned_events():
+    @asset(partitions_def=StaticPartitionsDefinition(["a", "b"]))
+    def my_asset():
+        return 0
+
+    @asset()
+    def my_other_asset(my_asset):
+        pass
+
+    with instance_for_test() as instance:
+        materialize_to_memory([my_asset, my_other_asset], instance=instance, partition_key="b")
+        [record] = instance.get_event_records(
+            EventRecordsFilter(
+                DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                AssetKey("my_asset"),
+            )
+        )
+        assert record.event_log_entry.dagster_event.event_specific_data.partition == "b"
+
+        [record] = instance.get_event_records(
+            EventRecordsFilter(
+                DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+                AssetKey("my_other_asset"),
+            )
+        )
+        assert record.event_log_entry.dagster_event.event_specific_data.partition is None


### PR DESCRIPTION
Record which partition of an asset a run plans to materialize, so we can use it to say a materialization attempt failed.

Leaving out asset partition ranges for now. These will require resolving the range to actual partitions inside a host process.