### PR TITLE
[refactor] GraphDefinition method renames

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -94,7 +94,7 @@ def _resolve_output_to_destinations(
         if mapping.graph_output_name != output_name:
             continue
         output_pointer = mapping.maps_from
-        output_node = node_def.solid_named(output_pointer.solid_name)
+        output_node = node_def.node_named(output_pointer.solid_name)
 
         all_destinations.extend(
             _resolve_output_to_destinations(

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1098,7 +1098,7 @@ def _validate_graph_def(graph_def: "GraphDefinition", prefix: Optional[Sequence[
             _validate_graph_def(inner_node_def, prefix=[*prefix, graph_def.name])
 
     # leaf nodes have no downstream nodes
-    forward_edges, _ = create_adjacency_lists(graph_def.solids, graph_def.dependency_structure)
+    forward_edges, _ = create_adjacency_lists(graph_def.nodes, graph_def.dependency_structure)
     leaf_nodes = {
         node_name for node_name, downstream_nodes in forward_edges.items() if not downstream_nodes
     }

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -308,7 +308,7 @@ class GraphDefinition(NodeDefinition):
         return self._node_defs
 
     @property
-    def solids_in_topological_order(self) -> Sequence[Node]:
+    def nodes_in_topological_order(self) -> Sequence[Node]:
         return self._nodes_in_topological_order
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -252,7 +252,7 @@ class GraphDefinition(NodeDefinition):
 
     def _get_nodes_in_topological_order(self) -> Sequence[Node]:
         _forward_edges, backward_edges = create_adjacency_lists(
-            self.solids, self.dependency_structure
+            self.nodes, self.dependency_structure
         )
 
         try:
@@ -294,10 +294,6 @@ class GraphDefinition(NodeDefinition):
     @property
     def is_graph_job_op_node(self) -> bool:
         return True
-
-    @property
-    def solids(self) -> Sequence[Node]:
-        return list(set(self._node_dict.values()))
 
     @property
     def nodes(self) -> Sequence[Node]:
@@ -826,7 +822,7 @@ class SubselectedGraphDefinition(GraphDefinition):
 
     def get_top_level_omitted_nodes(self) -> Sequence[Node]:
         return [
-            solid for solid in self.parent_graph_def.solids if not self.has_node_named(solid.name)
+            solid for solid in self.parent_graph_def.nodes if not self.has_node_named(solid.name)
         ]
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -319,7 +319,7 @@ class GraphDefinition(NodeDefinition):
     def node_input_source_assets(self) -> Mapping[str, Mapping[str, "SourceAsset"]]:
         return self._node_input_source_assets
 
-    def has_solid_named(self, name: str) -> bool:
+    def has_node_named(self, name: str) -> bool:
         check.str_param(name, "name")
         return name in self._node_dict
 
@@ -826,7 +826,7 @@ class SubselectedGraphDefinition(GraphDefinition):
 
     def get_top_level_omitted_nodes(self) -> Sequence[Node]:
         return [
-            solid for solid in self.parent_graph_def.solids if not self.has_solid_named(solid.name)
+            solid for solid in self.parent_graph_def.solids if not self.has_node_named(solid.name)
         ]
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -768,7 +768,7 @@ def get_subselected_graph_definition(
 
     selected_nodes: List[Tuple[str, NodeDefinition]] = []
 
-    for node in graph.solids_in_topological_order:
+    for node in graph.nodes_in_topological_order:
         node_handle = NodeHandle(node.name, parent=parent_handle)
         # skip if the node isn't selected
         if node.name not in resolved_op_selection_dict:

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -469,7 +469,7 @@ class PipelineDefinition:
 
     @property
     def solids(self) -> Sequence[Node]:
-        return self._graph_def.solids
+        return self._graph_def.nodes
 
     @property
     def solids_in_topological_order(self) -> Sequence[Node]:
@@ -818,7 +818,7 @@ def _create_run_config_schema(
 
             ignored_solids = [
                 solid
-                for solid in parent_job.graph.solids
+                for solid in parent_job.graph.nodes
                 if not pipeline_def.has_solid_named(solid.name)
             ]
     elif pipeline_def.is_subset_pipeline:
@@ -827,7 +827,7 @@ def _create_run_config_schema(
 
         ignored_solids = [
             solid
-            for solid in pipeline_def.parent_pipeline_def.graph.solids
+            for solid in pipeline_def.parent_pipeline_def.graph.nodes
             if not pipeline_def.has_solid_named(solid.name)
         ]
     else:
@@ -836,7 +836,7 @@ def _create_run_config_schema(
     run_config_schema_type = define_run_config_schema_type(
         RunConfigSchemaCreationData(
             pipeline_name=pipeline_def.name,
-            solids=pipeline_def.graph.solids,
+            solids=pipeline_def.graph.nodes,
             graph_def=pipeline_def.graph,
             dependency_structure=pipeline_def.graph.dependency_structure,
             mode_definition=mode_definition,

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -462,7 +462,7 @@ class PipelineDefinition:
         return self._graph_def.get_solid(handle)
 
     def has_solid_named(self, name: str) -> bool:
-        return self._graph_def.has_solid_named(name)
+        return self._graph_def.has_node_named(name)
 
     def solid_named(self, name: str) -> Node:
         return self._graph_def.solid_named(name)
@@ -691,7 +691,7 @@ def _get_pipeline_subset_def(
     check.set_param(solids_to_execute, "solids_to_execute", of_type=str)
     graph = pipeline_def.graph
     for solid_name in solids_to_execute:
-        if not graph.has_solid_named(solid_name):
+        if not graph.has_node_named(solid_name):
             raise DagsterInvalidSubsetError(
                 "{target_type} {pipeline_name} has no {node_type} named {name}.".format(
                     target_type=pipeline_def.target_type,

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -465,7 +465,7 @@ class PipelineDefinition:
         return self._graph_def.has_node_named(name)
 
     def solid_named(self, name: str) -> Node:
-        return self._graph_def.solid_named(name)
+        return self._graph_def.node_named(name)
 
     @property
     def solids(self) -> Sequence[Node]:
@@ -575,7 +575,7 @@ class PipelineDefinition:
 
         # hooks on top-level solid
         name = lineage.pop()
-        solid = self._graph_def.solid_named(name)
+        solid = self._graph_def.node_named(name)
         hook_defs = hook_defs.union(solid.hook_defs)
 
         # hooks on non-top-level solids
@@ -583,7 +583,7 @@ class PipelineDefinition:
             name = lineage.pop()
             # While lineage is non-empty, definition is guaranteed to be a graph
             definition = cast(GraphDefinition, solid.definition)
-            solid = definition.solid_named(name)
+            solid = definition.node_named(name)
             hook_defs = hook_defs.union(solid.hook_defs)
 
         # hooks applied to a pipeline definition will run on every solid

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -473,7 +473,7 @@ class PipelineDefinition:
 
     @property
     def solids_in_topological_order(self) -> Sequence[Node]:
-        return self._graph_def.solids_in_topological_order
+        return self._graph_def.nodes_in_topological_order
 
     def all_dagster_types(self) -> Iterable[DagsterType]:
         return self._graph_def.all_dagster_types()
@@ -703,7 +703,7 @@ def _get_pipeline_subset_def(
 
     # go in topo order to ensure deps dict is ordered
     solids = list(
-        filter(lambda solid: solid.name in solids_to_execute, graph.solids_in_topological_order)
+        filter(lambda solid: solid.name in solids_to_execute, graph.nodes_in_topological_order)
     )
 
     deps: Dict[

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -529,7 +529,7 @@ def define_isolid_field(
         }
         nodes_field = Field(
             define_solid_dictionary_cls(
-                solids=graph_def.solids,
+                solids=graph_def.nodes,
                 ignored_solids=None,
                 dependency_structure=graph_def.dependency_structure,
                 parent_handle=handle,
@@ -619,7 +619,7 @@ def iterate_node_def_config_types(node_def: NodeDefinition) -> Iterator[ConfigTy
         if node_def.has_config_field:
             yield from node_def.get_config_field().config_type.type_iterator()
     elif isinstance(node_def, GraphDefinition):
-        for solid in node_def.solids:
+        for solid in node_def.nodes:
             yield from iterate_node_def_config_types(solid.definition)
 
     else:

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -209,7 +209,7 @@ class UnboundHookContext(HookContext):
             def temp_graph():
                 op()
 
-            self._op = temp_graph.solids[0]
+            self._op = temp_graph.nodes[0]
 
         # Open resource context manager
         self._resource_defs = wrap_resources_for_execution(resources)

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process.py
@@ -87,7 +87,7 @@ def core_execute_in_process(
 
 def _check_top_level_inputs(job_def: JobDefinition) -> None:
     for input_mapping in job_def.graph.input_mappings:
-        node = job_def.graph.solid_named(input_mapping.maps_to.solid_name)
+        node = job_def.graph.node_named(input_mapping.maps_to.solid_name)
         top_level_input_name = input_mapping.graph_input_name
         input_name = input_mapping.maps_to.input_name
         _check_top_level_inputs_for_node(
@@ -111,7 +111,7 @@ def _check_top_level_inputs_for_node(
     if isinstance(node.definition, GraphDefinition):
         graph_def = cast(GraphDefinition, node.definition)
         for input_mapping in graph_def.input_mappings:
-            next_node = graph_def.solid_named(input_mapping.maps_to.solid_name)
+            next_node = graph_def.node_named(input_mapping.maps_to.solid_name)
             input_name = input_mapping.maps_to.input_name
             _check_top_level_inputs_for_node(
                 next_node,

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -85,7 +85,7 @@ class ExecutionResult(ABC):
             )
         # Resolve the first layer of mapping
         output_mapping = graph_def.get_output_mapping(output_name)
-        mapped_node = graph_def.solid_named(output_mapping.maps_from.solid_name)
+        mapped_node = graph_def.node_named(output_mapping.maps_from.solid_name)
         origin_output_def, origin_handle = mapped_node.definition.resolve_output_to_origin(
             output_mapping.maps_from.output_name,
             NodeHandle(mapped_node.name, None),

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -389,7 +389,7 @@ class _PlanBuilder:
             # Recurse over the solids contained in an instance of GraphDefinition
             elif isinstance(solid.definition, GraphDefinition):
                 self._build_from_sorted_solids(
-                    solid.definition.solids_in_topological_order,
+                    solid.definition.nodes_in_topological_order,
                     solid.definition.dependency_structure,
                     parent_handle=handle,
                     parent_step_inputs=step_inputs,

--- a/python_modules/dagster/dagster/_core/execution/results.py
+++ b/python_modules/dagster/dagster/_core/execution/results.py
@@ -103,7 +103,7 @@ class GraphExecutionResult:
             Union[CompositeSolidExecutionResult, SolidExecutionResult]: The result of the solid
             execution within the pipeline.
         """
-        if not self.container.has_solid_named(name):
+        if not self.container.has_node_named(name):
             raise DagsterInvariantViolationError(
                 "Tried to get result for solid '{name}' in '{container}'. No such top level "
                 "solid.".format(name=name, container=self.container.name)

--- a/python_modules/dagster/dagster/_core/execution/results.py
+++ b/python_modules/dagster/dagster/_core/execution/results.py
@@ -292,7 +292,7 @@ class CompositeSolidExecutionResult(GraphExecutionResult):
             output_mapping = self.node.definition.get_output_mapping(output_name)
 
             inner_solid_values = self._result_for_handle(
-                self.node.definition.solid_named(output_mapping.maps_from.solid_name),
+                self.node.definition.node_named(output_mapping.maps_from.solid_name),
                 NodeHandle(output_mapping.maps_from.solid_name, None),
             ).output_values
 
@@ -323,7 +323,7 @@ class CompositeSolidExecutionResult(GraphExecutionResult):
         output_mapping = self.node.definition.get_output_mapping(output_name)
 
         return self._result_for_handle(
-            self.node.definition.solid_named(output_mapping.maps_from.solid_name),
+            self.node.definition.node_named(output_mapping.maps_from.solid_name),
             NodeHandle(output_mapping.maps_from.solid_name, None),
         ).output_value(output_mapping.maps_from.output_name)
 

--- a/python_modules/dagster/dagster/_core/execution/results.py
+++ b/python_modules/dagster/dagster/_core/execution/results.py
@@ -132,7 +132,7 @@ class GraphExecutionResult:
         """List[Union[CompositeSolidExecutionResult, SolidExecutionResult]]: The results for each
         top level solid.
         """
-        return [self.result_for_node(node.name) for node in self.container.solids]
+        return [self.result_for_node(node.name) for node in self.container.nodes]
 
     def _result_for_handle(
         self, node: Node, handle: NodeHandle

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -47,8 +47,7 @@ def build_dep_structure_snapshot_from_icontains_solids(
     check.inst_param(icontains_solids, "icontains_solids", GraphDefinition)
     return DependencyStructureSnapshot(
         solid_invocation_snaps=[
-            build_solid_invocation_snap(icontains_solids, solid)
-            for solid in icontains_solids.solids
+            build_solid_invocation_snap(icontains_solids, solid) for solid in icontains_solids.nodes
         ]
     )
 

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -115,7 +115,7 @@ def _composite_descent(
 
     This process unrolls recursively as you descend down the tree.
     """
-    for solid in parent_stack.current_container.solids:
+    for solid in parent_stack.current_container.nodes:
         current_stack = parent_stack.descend(solid)
         current_handle = current_stack.handle
 
@@ -204,7 +204,7 @@ def _apply_top_level_config_mapping(
         # be evaluated against
 
         type_to_evaluate_against = define_solid_dictionary_cls(
-            solids=graph_def.solids,
+            solids=graph_def.nodes,
             ignored_solids=None,
             dependency_structure=graph_def.dependency_structure,
             resource_defs=resource_defs,
@@ -268,7 +268,7 @@ def _get_mapped_solids_dict(
     ignored_solids = graph_def.get_top_level_omitted_nodes() if graph_def.is_subselected else None
 
     type_to_evaluate_against = define_solid_dictionary_cls(
-        solids=graph_def.solids,
+        solids=graph_def.nodes,
         ignored_solids=ignored_solids,
         dependency_structure=graph_def.dependency_structure,
         parent_handle=current_stack.handle,

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
@@ -214,7 +214,7 @@ def test_hook_invocation_with_solid():
     @success_hook
     def basic_hook(context):
         assert context.op.name == "foo"
-        assert len(context.op.graph_definition.solids) == 1
+        assert len(context.op.graph_definition.nodes) == 1
 
     @op
     def foo():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
@@ -47,7 +47,7 @@ def test_solid_def():
         dependencies={"op_one": {"input_one": DependencyDefinition("produce_string")}},
     )
 
-    assert len(list(pipeline_def.solids[0].outputs())) == 1
+    assert len(list(pipeline_def.nodes[0].outputs())) == 1
 
     assert isinstance(pipeline_def.node_named("op_one"), Node)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
@@ -49,9 +49,9 @@ def test_solid_def():
 
     assert len(list(pipeline_def.solids[0].outputs())) == 1
 
-    assert isinstance(pipeline_def.solid_named("op_one"), Node)
+    assert isinstance(pipeline_def.node_named("op_one"), Node)
 
-    solid_one_solid = pipeline_def.solid_named("op_one")
+    solid_one_solid = pipeline_def.node_named("op_one")
 
     assert solid_one_solid.has_input("input_one")
 


### PR DESCRIPTION
### Summary & Motivation

- Rename GraphDefinition.has_solid_named -> has_node_named
- Rename GraphDefinition.solid_named -> node_named
- Rename GraphDefinition.solids_in_topological_order -> nodes_in_topological_order
- Delete GraphDefinition.solids (update references to use existing `nodes`)

### How I Tested These Changes

BK
