### PR TITLE
[refactor] Delete NodeInput.solid_name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -113,7 +113,7 @@ def _resolve_output_to_destinations(
         for input_handle in downstream_input_handles:
             all_destinations.append(
                 NodeInputHandle(
-                    NodeHandle(input_handle.solid_name, parent=handle), input_handle.input_name
+                    NodeHandle(input_handle.node_name, parent=handle), input_handle.input_name
                 )
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -571,10 +571,6 @@ class NodeInput(NamedTuple("_NodeInput", [("node", Node), ("input_def", InputDef
         return self.node.name
 
     @property
-    def solid_name(self) -> str:
-        return self.node.name
-
-    @property
     def input_name(self) -> str:
         return self.input_def.name
 
@@ -600,10 +596,10 @@ class NodeOutput(NamedTuple("_NodeOutput", [("node", Node), ("output_def", Outpu
     def __repr__(self):
         return self._inner_str()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.node.name, self.output_def.name))
 
-    def __eq__(self, other: Any):
+    def __eq__(self, other: Any) -> bool:
         return self.node.name == other.node.name and self.output_def.name == other.output_def.name
 
     def describe(self) -> str:

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -174,7 +174,7 @@ def generate_dep_graph(pipeline_def: "PipelineDefinition") -> DependencyGraph[st
         downstream_dep = dependency_structure.output_to_downstream_inputs_for_node(item_name)
         for downstreams in downstream_dep.values():
             for down in downstreams:
-                graph["downstream"][item_name].add(down.solid_name)
+                graph["downstream"][item_name].add(down.node_name)
 
     return graph
 


### PR DESCRIPTION
### Summary & Motivation

- Delete `NodeInput.solid_name`, update references to existing `NodeInput.node_name`

### How I Tested These Changes

BK
