### PR TITLE
[typing/runtime] Standardize StepInputSource.load_input_object

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -64,7 +64,7 @@ from dagster._core.execution.plan.outputs import StepOutputData, StepOutputHandl
 from dagster._core.execution.resolve_versions import resolve_step_output_versions
 from dagster._core.storage.tags import BACKFILL_ID_TAG, MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
-from dagster._utils import ensure_gen, iterate_with_context
+from dagster._utils import iterate_with_context
 from dagster._utils.backcompat import ExperimentalWarning, experimental_functionality_warning
 from dagster._utils.timing import time_execution_scope
 
@@ -339,9 +339,7 @@ def core_dagster_event_sequence_for_step(
         if dagster_type.is_nothing:
             continue
 
-        for event_or_input_value in ensure_gen(
-            step_input.source.load_input_object(step_context, input_def)
-        ):
+        for event_or_input_value in step_input.source.load_input_object(step_context, input_def):
             if isinstance(event_or_input_value, DagsterEvent):
                 yield event_or_input_value
             else:

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -39,7 +39,7 @@ from dagster._core.utils import make_new_run_id
 from dagster._legacy import Materialization, ModeDefinition, PipelineDefinition
 from dagster._loggers import colored_console_logger
 from dagster._serdes import unpack_value
-from dagster._utils import EventGenerationManager, ensure_gen
+from dagster._utils import EventGenerationManager
 from dagster._utils.backcompat import canonicalize_backcompat_args, deprecation_warning
 
 from .context import DagstermillExecutionContext, DagstermillRuntimeExecutionContext
@@ -415,9 +415,7 @@ class Manager:
         step_context = dm_context.step_context  # pylint: disable=protected-access
         step_input = step_context.step.step_input_named(input_name)
         input_def = step_context.solid_def.input_def_named(input_name)
-        for event_or_input_value in ensure_gen(
-            step_input.source.load_input_object(step_context, input_def)
-        ):
+        for event_or_input_value in step_input.source.load_input_object(step_context, input_def):
             if isinstance(event_or_input_value, DagsterEvent):
                 continue
             else:


### PR DESCRIPTION
### Summary & Motivation

Standardizes `StepInputSource.load_input_object`. Downstream of this function, and in the ABC, an `Iterator[object]` is expected but some implementations just return a value instead of yielding. This PR:

- Makes all implementations yield
- Removes the "ensure generator" check downstream, since it's no longer needed
- Fixes type errors as a result of above

### How I Tested These Changes

BK
