### PR TITLE
change storage signature for run tags

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -883,8 +883,19 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._event_storage.get_step_stats_for_run(run_id, step_keys)
 
     @traced
-    def get_run_tags(self) -> Sequence[Tuple[str, Set[str]]]:
-        return self._run_storage.get_run_tags()
+    def get_run_tags(
+        self,
+        tag_keys: Optional[Sequence[str]] = None,
+        value_prefix: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Tuple[str, Set[str]]]:
+        return self._run_storage.get_run_tags(
+            tag_keys=tag_keys, value_prefix=value_prefix, limit=limit
+        )
+
+    @traced
+    def get_run_tag_keys(self) -> Sequence[str]:
+        return self._run_storage.get_run_tag_keys()
 
     @traced
     def get_run_group(self, run_id: str) -> Optional[Tuple[str, Iterable[DagsterRun]]]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -232,8 +232,16 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
             filters, limit, order_by, ascending, cursor, bucket_by
         )
 
-    def get_run_tags(self) -> Sequence[Tuple[str, Set[str]]]:
-        return self._storage.run_storage.get_run_tags()
+    def get_run_tags(
+        self,
+        tag_keys: Optional[Sequence[str]] = None,
+        value_prefix: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Tuple[str, Set[str]]]:
+        return self._storage.run_storage.get_run_tags(tag_keys, value_prefix, limit)
+
+    def get_run_tag_keys(self) -> Sequence[str]:
+        return self._storage.run_storage.get_run_tag_keys()
 
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]):
         return self._storage.run_storage.add_run_tags(run_id, new_tags)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -173,11 +173,27 @@ class RunStorage(ABC, MayHaveInstanceWeakref):
         """
 
     @abstractmethod
-    def get_run_tags(self) -> Sequence[Tuple[str, Set[str]]]:
+    def get_run_tags(
+        self,
+        tag_keys: Optional[Sequence[str]] = None,
+        value_prefix: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Tuple[str, Set[str]]]:
         """Get a list of tag keys and the values that have been associated with them.
+
+        Args:
+            tag_keys (Optional[Sequence[str]]): tag keys to filter by.
 
         Returns:
             List[Tuple[str, Set[str]]]
+        """
+
+    @abstractmethod
+    def get_run_tag_keys(self) -> Sequence[str]:
+        """Get a list of tag keys.
+
+        Returns:
+            List[str]
         """
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -526,15 +526,37 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             for row in rows
         ]
 
-    def get_run_tags(self) -> Sequence[Tuple[str, Set[str]]]:
+    def get_run_tags(
+        self,
+        tag_keys: Optional[Sequence[str]] = None,
+        value_prefix: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Tuple[str, Set[str]]]:
         result = defaultdict(set)
-        query = db.select([RunTagsTable.c.key, RunTagsTable.c.value]).distinct(
-            RunTagsTable.c.key, RunTagsTable.c.value
+        query = (
+            db.select([RunTagsTable.c.key, RunTagsTable.c.value])
+            .distinct(RunTagsTable.c.key, RunTagsTable.c.value)
+            .order_by(RunTagsTable.c.key, RunTagsTable.c.value)
         )
+        if tag_keys:
+            query = query.where(RunTagsTable.c.key.in_(tag_keys))
+        if value_prefix:
+            query = query.where(RunTagsTable.c.value.startswith(value_prefix))
+        if limit:
+            query = query.limit(limit)
         rows = self.fetchall(query)
         for r in rows:
             result[r[0]].add(r[1])
         return sorted(list([(k, v) for k, v in result.items()]), key=lambda x: x[0])
+
+    def get_run_tag_keys(self) -> Sequence[str]:
+        query = (
+            db.select([RunTagsTable.c.key])
+            .distinct(RunTagsTable.c.key)
+            .order_by(RunTagsTable.c.key)
+        )
+        rows = self.fetchall(query)
+        return sorted([r[0] for r in rows])
 
     def add_run_tags(self, run_id: str, new_tags: Mapping[str, str]) -> None:
         check.str_param(run_id, "run_id")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -338,6 +338,48 @@ class TestRunStorage:
             "tag4": "val4",
         }
 
+    def test_get_run_tags(self, storage):
+        one = make_new_run_id()
+        two = make_new_run_id()
+        storage.add_run(TestRunStorage.build_run(run_id=one, pipeline_name="foo"))
+        storage.add_run(TestRunStorage.build_run(run_id=two, pipeline_name="foo"))
+        storage.add_run_tags(
+            one,
+            {
+                "tag1": "val1",
+                "tag2": "val2",
+                "tag3": "val3",
+                "tag4": "val4",
+                "x_1": "x_1",
+                "x_2": "x_2",
+            },
+        )
+        storage.add_run_tags(two, {"tag1": "val3"})
+
+        # test getting run tag keys
+        assert storage.get_run_tag_keys() == ["tag1", "tag2", "tag3", "tag4", "x_1", "x_2"]
+
+        # test getting run tags with key filter
+        assert storage.get_run_tags(tag_keys=["tag1"]) == [
+            ("tag1", {"val1", "val3"}),
+        ]
+        assert storage.get_run_tags(tag_keys=["tag1", "tag2"]) == [
+            ("tag1", {"val1", "val3"}),
+            ("tag2", {"val2"}),
+        ]
+
+        # test getting run tags with prefix
+        assert storage.get_run_tags(value_prefix="x_") == [
+            ("x_1", {"x_1"}),
+            ("x_2", {"x_2"}),
+        ]
+
+        # test getting run tags with limit
+        assert storage.get_run_tags(limit=3) == [
+            ("tag1", {"val1", "val3"}),
+            ("tag2", {"val2"}),
+        ]
+
     def test_fetch_by_filter(self, storage):
         assert storage
         one = make_new_run_id()


### PR DESCRIPTION
### Summary & Motivation
We want to enable some version of the tag autocomplete search on the runs page again.

Instead of fetching all key/value pairs of tags to power the search, I think we can do something where we first fetch all the possible keys, select a key (from a list) and then fetch all the values for the selected key.

For high cardinality keys, we can further do filtering by prefix and apply a limit.

### How I Tested These Changes
BK