### PR TITLE
[draft][pythonic config][docs] Introduce intro to Config doc utilizing Pythonic config

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -742,6 +742,10 @@
             "path": "/guides/dagster/asset-versioning-and-caching"
           },
           {
+            "title": "Pythonic config",
+            "path": "/guides/dagster/pythonic-config"
+          },
+          {
             "title": "Pythonic resources",
             "path": "/guides/dagster/pythonic-resources"
           }

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -44,6 +44,7 @@ Learn to apply [Dagster concepts](/concepts) to your work, explore experimental 
 
 ## Experimental features
 
+- [Pythonic config](/guides/dagster/pythonic-config) - Get started using the new Pythonic config APIs, a more ergonomic way to define op and asset config
 - [Pythonic resources](/guides/dagster/pythonic-resources) - Get started using the new Pythonic resource APIs, a more ergonomic way to define and use resources
 - [Using Custom Run Coordinators to perform run attribution](/guides/dagster/run-attribution) - A look at using a Custom Run Coordinator to perform run attribution
 - [Asset versioning and caching](/guides/dagster/asset-versioning-and-caching) - Memoize assets using Dagster's logical versioning system

--- a/docs/content/guides/dagster/pythonic-config.mdx
+++ b/docs/content/guides/dagster/pythonic-config.mdx
@@ -86,6 +86,8 @@ To execute a job or materialize an asset which specifies config, you'll need to 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_execute_with_config endbefore=end_execute_with_config dedent=4
 from dagster import job, materialize, op
 
+from dagster._core.definitions.run_config import RunConfig
+
 @job
 def greeting_job():
     print_greeting()
@@ -96,7 +98,7 @@ job_result = greeting_job.execute_in_process(
 
 asset_result = materialize(
     [greeting],
-    run_config=RunConfig(assets={"greeting": MyAssetConfig(person_name="Alice")}),
+    run_config=RunConfig(ops={"greeting": MyAssetConfig(person_name="Alice")}),
 )
 ```
 
@@ -137,6 +139,8 @@ from dagster._config.structured_config import Config
 from typing import List, Dict
 from dagster import materialize, asset
 
+from dagster._core.definitions.run_config import RunConfig
+
 class MyDataStructuresConfig(Config):
     user_names: List[str]
     user_scores: Dict[str, int]
@@ -148,7 +152,7 @@ def scoreboard(config: MyDataStructuresConfig):
 result = materialize(
     [scoreboard],
     run_config=RunConfig(
-        assets={
+        ops={
             "scoreboard": MyDataStructuresConfig(
                 user_names=["Alice", "Bob"],
                 user_scores={"Alice": 10, "Bob": 20},
@@ -165,8 +169,10 @@ Schemas can be nested in one another, or in basic Python data structures.
 Here, we define a schema which contains a mapping of user names to complex user data objects.
 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_nested_schema_config endbefore=end_nested_schema_config dedent=4
-from dagster._config.structured_config import Config
 from dagster import asset, materialize
+from dagster._config.structured_config import Config
+from dagster._core.definitions.run_config import RunConfig
+from typing import Dict
 
 class UserData(Config):
     age: int
@@ -183,7 +189,7 @@ def average_age(config: MyNestedConfig):
 result = materialize(
     [average_age],
     run_config=RunConfig(
-        assets={
+        ops={
             "average_age": MyNestedConfig(
                 user_data={
                     "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
@@ -202,11 +208,12 @@ Union types are supported using Pydantic [discriminated unions](https://docs.pyd
 Here, we define a config schema which takes in a `pet` field, which can be either a `Cat` or a `Dog`, as indicated by the `pet_type` field.
 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_union_schema_config endbefore=end_union_schema_config dedent=4
-from typing import Union
-from pydantic import Field
-from typing_extensions import Literal
-from dagster._config.structured_config import Config
 from dagster import asset, materialize
+from dagster._config.structured_config import Config
+from dagster._core.definitions.run_config import RunConfig
+from pydantic import Field
+from typing import Union
+from typing_extensions import Literal
 
 class Cat(Config):
     pet_type: Literal["cat"]
@@ -229,7 +236,7 @@ def pet_stats(config: ConfigWithUnion):
 result = materialize(
     [pet_stats],
     run_config=RunConfig(
-        assets={
+        ops={
             "pet_stats": ConfigWithUnion(
                 pet=Cat(pet_type="cat", meows=10),
             )

--- a/docs/content/guides/dagster/pythonic-config.mdx
+++ b/docs/content/guides/dagster/pythonic-config.mdx
@@ -11,7 +11,9 @@ description: Pythonic run configuration is an experimental new feature that make
 
 This guide acts as an introduction to providing parameters to assets and jobs using the experimental Pythonic configuration APIs, which makes defining and passing this [configuration](/concepts/configuration/config-schema) more lightweight.
 
-## It's often useful to provide user-chosen values to Dagster jobs or software-defined assets at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
+It's often useful to provide user-chosen values to Dagster jobs or software-defined assets at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
+
+---
 
 ## Using Pythonic configuration
 
@@ -19,7 +21,7 @@ This guide acts as an introduction to providing parameters to assets and jobs us
 
 Configurable parameters accepted by an op or asset are specified by defining a config model subclass of <PyObject object="Config"/> and a `config` parameter to the corresponding op or asset function. Under the hood, these config models utilize [Pydantic](https://docs.pydantic.dev/), a popular Python library for data validation and serialization.
 
-During execution, the specified config is accessed within the body of the op or asset using the `config` parameter.
+During execution, the specified config is accessed within the body of the op or asset using the `config` parameter, which is reserved specifically for this purpose.
 
 <TabGroup persistentKey="assetsorops">
 <TabItem name="Using software-defined-assets">
@@ -81,7 +83,7 @@ For more information on using resources, see [the Pythonic resources guide](/gui
 
 ### Specifying runtime configuration in code
 
-To execute a job or materialize an asset which specifies config, you'll need to provide values for its parameters. When specifying config from the Python API, we can use the `run_config` argument for <PyObject object="JobDefinition" method="execute_in_process"/> or <PyObject object="materialize"/>. This takes a `RunConfig` object, within which we can supply config on a per-op or per-asset basis. The config is specified as a dictionary, with the keys corresponding to the op/asset names and the values corresponding to the config values.
+To execute a job or materialize an asset that specifies config, you'll need to provide values for its parameters. When specifying config from the Python API, we can use the `run_config` argument for <PyObject object="JobDefinition" method="execute_in_process"/> or <PyObject object="materialize"/>. This takes a `RunConfig` object, within which we can supply config on a per-op or per-asset basis. The config is specified as a dictionary, with the keys corresponding to the op/asset names and the values corresponding to the config values.
 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_execute_with_config endbefore=end_execute_with_config dedent=4
 from dagster import job, materialize, op
@@ -93,12 +95,12 @@ def greeting_job():
     print_greeting()
 
 job_result = greeting_job.execute_in_process(
-    run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})
+    run_config=RunConfig({"print_greeting": MyOpConfig(person_name="Alice")})
 )
 
 asset_result = materialize(
     [greeting],
-    run_config=RunConfig(ops={"greeting": MyAssetConfig(person_name="Alice")}),
+    run_config=RunConfig({"greeting": MyAssetConfig(person_name="Alice")}),
 )
 ```
 
@@ -119,6 +121,7 @@ from dagster._config.structured_config import Config
 from pydantic import Field
 
 class MyMetadataConfig(Config):
+    # Here, the ellipses `...` indicates that the field is required and has no default value.
     person_name: str = Field(..., description="The name of the person to greet")
     age: int = Field(
         ..., gt=0, lt=100, description="The age of the person to greet"
@@ -152,7 +155,7 @@ def scoreboard(config: MyDataStructuresConfig):
 result = materialize(
     [scoreboard],
     run_config=RunConfig(
-        ops={
+        {
             "scoreboard": MyDataStructuresConfig(
                 user_names=["Alice", "Bob"],
                 user_scores={"Alice": 10, "Bob": 20},
@@ -189,7 +192,7 @@ def average_age(config: MyNestedConfig):
 result = materialize(
     [average_age],
     run_config=RunConfig(
-        ops={
+        {
             "average_age": MyNestedConfig(
                 user_data={
                     "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
@@ -216,14 +219,15 @@ from typing import Union
 from typing_extensions import Literal
 
 class Cat(Config):
-    pet_type: Literal["cat"]
+    pet_type: Literal["cat"] = "cat"
     meows: int
 
 class Dog(Config):
-    pet_type: Literal["dog"]
+    pet_type: Literal["dog"] = "dog"
     barks: float
 
 class ConfigWithUnion(Config):
+    # Here, the ellipses `...` indicates that the field is required and has no default value.
     pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
 
 @asset
@@ -236,9 +240,9 @@ def pet_stats(config: ConfigWithUnion):
 result = materialize(
     [pet_stats],
     run_config=RunConfig(
-        ops={
+        {
             "pet_stats": ConfigWithUnion(
-                pet=Cat(pet_type="cat", meows=10),
+                pet=Cat(meows=10),
             )
         }
     ),

--- a/docs/content/guides/dagster/pythonic-config.mdx
+++ b/docs/content/guides/dagster/pythonic-config.mdx
@@ -11,11 +11,11 @@ description: Pythonic run configuration is an experimental new feature that make
 
 This guide acts as an introduction to providing parameters to assets and jobs using the experimental Pythonic configuration APIs, which makes defining and passing this [configuration](/concepts/configuration/config-schema) more lightweight.
 
-It's often useful to provide user-chosen values to Dagster jobs or software-defined assets at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
+## It's often useful to provide user-chosen values to Dagster jobs or software-defined assets at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
 
-## Usinig Pythonic configuration
+## Using Pythonic configuration
 
-### Defining Pythonic configuration on ops and assets
+### Defining Pythonic configuration on assets and ops
 
 Configurable parameters accepted by an op or asset are specified by defining a config model subclass of <PyObject object="Config"/> and a `config` parameter to the corresponding op or asset function. Under the hood, these config models utilize [Pydantic](https://docs.pydantic.dev/), a popular Python library for data validation and serialization.
 
@@ -28,10 +28,12 @@ During execution, the specified config is accessed within the body of the op or 
 
 Here, we define a subclass of <PyObject object="Config"/> holding a single string value representing the name of a user. We can access the config through the `config` parameter in the asset body.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_asset_config endbefore=end_basic_asset_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_asset_config endbefore=end_basic_asset_config dedent=4
+from dagster import asset
+from dagster._config.structured_config import Config
+
 class MyAssetConfig(Config):
     person_name: str
-
 
 @asset
 def greeting(config: MyAssetConfig) -> str:
@@ -45,10 +47,12 @@ def greeting(config: MyAssetConfig) -> str:
 
 Here, we define a subclass of <PyObject object="Config"/> holding a single string value representing the name of a user. We can access the config through the `config` parameter in the op body.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_op_config endbefore=end_basic_op_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_op_config endbefore=end_basic_op_config dedent=4
+from dagster import op
+from dagster._config.structured_config import Config
+
 class MyOpConfig(Config):
     person_name: str
-
 
 @op
 def print_greeting(config: MyOpConfig):
@@ -58,33 +62,33 @@ def print_greeting(config: MyOpConfig):
 </TabItem>
 </TabGroup>
 
----
-
-### Defining and accessing configuration for a resource
+### Defining and accessing Pythonic configuration for a resource
 
 Configurable parameters for a resource are defined by specifying attributes for a resource class, which subclasses <PyObject object="ConfigurableResource"/>. The below resource defines a configurable connection URL, which can be accessed in any methods defined on the resource.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_resource_config endbefore=end_basic_resource_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_resource_config endbefore=end_basic_resource_config dedent=4
+from dagster import op
+from dagster._config.structured_config import ConfigurableResource
+
 class MyDatabaseResource(ConfigurableResource):
     connection_url: str
 
-    def query(self, query: str) -> Response:
+    def query(self, query: str):
         return get_engine(self.connection_url).execute(query)
 ```
 
 For more information on using resources, see [the Pythonic resources guide](/guides/dagster/pythonic-resources).
 
----
-
-### Specifying runtime configuration in Python
+### Specifying runtime configuration in code
 
 To execute a job or materialize an asset which specifies config, you'll need to provide values for its parameters. When specifying config from the Python API, we can use the `run_config` argument for <PyObject object="JobDefinition" method="execute_in_process"/> or <PyObject object="materialize"/>. This takes a `RunConfig` object, within which we can supply config on a per-op or per-asset basis. The config is specified as a dictionary, with the keys corresponding to the op/asset names and the values corresponding to the config values.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_execute_with_config endbefore=end_execute_with_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_execute_with_config endbefore=end_execute_with_config dedent=4
+from dagster import job, materialize, op
+
 @job
 def greeting_job():
     print_greeting()
-
 
 job_result = greeting_job.execute_in_process(
     run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})
@@ -96,6 +100,8 @@ asset_result = materialize(
 )
 ```
 
+\--
+
 ## Defining complex config schemas
 
 In some cases, you may want to define a more complex config schema. For example, you may want to define a config schema that takes in a list of files or complex data. Below we'll walk through some common patterns for defining more complex config schemas.
@@ -106,11 +112,15 @@ Config fields can be annotated with metadata, which can be used to provide addit
 
 For example, we can annotate a config field with a description, which will be displayed in the documentation for the config field. We can add a value range to a field, which will be validated when config is specified.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_metadata_config endbefore=end_metadata_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_metadata_config endbefore=end_metadata_config dedent=4
+from dagster._config.structured_config import Config
+from pydantic import Field
+
 class MyMetadataConfig(Config):
     person_name: str = Field(..., description="The name of the person to greet")
-    age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
-
+    age: int = Field(
+        ..., gt=0, lt=100, description="The age of the person to greet"
+    )
 
 # errors!
 MyMetadataConfig(person_name="Alice", age=200)
@@ -122,16 +132,18 @@ Many basic Python data structures can be used in your config schemas, including 
 
 For example, we can define a config schema that takes in a list of user names and a mapping of user names to user scores.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_data_structures_config endbefore=end_basic_data_structures_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_data_structures_config endbefore=end_basic_data_structures_config dedent=4
+from dagster._config.structured_config import Config
+from typing import List, Dict
+from dagster import materialize, asset
+
 class MyDataStructuresConfig(Config):
     user_names: List[str]
     user_scores: Dict[str, int]
 
-
 @asset
 def scoreboard(config: MyDataStructuresConfig):
     ...
-
 
 result = materialize(
     [scoreboard],
@@ -152,21 +164,21 @@ Schemas can be nested in one another, or in basic Python data structures.
 
 Here, we define a schema which contains a mapping of user names to complex user data objects.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_nested_schema_config endbefore=end_nested_schema_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_nested_schema_config endbefore=end_nested_schema_config dedent=4
+from dagster._config.structured_config import Config
+from dagster import asset, materialize
+
 class UserData(Config):
     age: int
     email: str
     profile_picture_url: str
 
-
 class MyNestedConfig(Config):
     user_data: Dict[str, UserData]
-
 
 @asset
 def average_age(config: MyNestedConfig):
     ...
-
 
 result = materialize(
     [average_age],
@@ -189,20 +201,23 @@ Union types are supported using Pydantic [discriminated unions](https://docs.pyd
 
 Here, we define a config schema which takes in a `pet` field, which can be either a `Cat` or a `Dog`, as indicated by the `pet_type` field.
 
-```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_union_schema_config endbefore=end_union_schema_config
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_union_schema_config endbefore=end_union_schema_config dedent=4
+from typing import Union
+from pydantic import Field
+from typing_extensions import Literal
+from dagster._config.structured_config import Config
+from dagster import asset, materialize
+
 class Cat(Config):
     pet_type: Literal["cat"]
     meows: int
-
 
 class Dog(Config):
     pet_type: Literal["dog"]
     barks: float
 
-
 class ConfigWithUnion(Config):
     pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
-
 
 @asset
 def pet_stats(config: ConfigWithUnion):
@@ -210,7 +225,6 @@ def pet_stats(config: ConfigWithUnion):
         return f"Cat meows {config.pet.meows} times"
     else:
         return f"Dog barks {config.pet.barks} times"
-
 
 result = materialize(
     [pet_stats],

--- a/docs/content/guides/dagster/pythonic-config.mdx
+++ b/docs/content/guides/dagster/pythonic-config.mdx
@@ -1,0 +1,225 @@
+---
+title: Pythonic run configuration | Dagster
+description: Pythonic run configuration is an experimental new feature that makes Dagster config easier to use.
+---
+
+# Pythonic run configuration
+
+<Note>
+  This feature is considered <strong>experimental</strong>.
+</Note>
+
+This guide acts as an introduction to providing parameters to assets and jobs using the experimental Pythonic configuration APIs, which makes defining and passing this [configuration](/concepts/configuration/config-schema) more lightweight.
+
+It's often useful to provide user-chosen values to Dagster jobs or software-defined assets at runtime. For example, you might want to choose what dataset an op runs against, or provide a connection URL for a database resource. Dagster exposes this functionality through a configuration API.
+
+## Usinig Pythonic configuration
+
+### Defining Pythonic configuration on ops and assets
+
+Configurable parameters accepted by an op or asset are specified by defining a config model subclass of <PyObject object="Config"/> and a `config` parameter to the corresponding op or asset function. Under the hood, these config models utilize [Pydantic](https://docs.pydantic.dev/), a popular Python library for data validation and serialization.
+
+During execution, the specified config is accessed within the body of the op or asset using the `config` parameter.
+
+<TabGroup persistentKey="assetsorops">
+<TabItem name="Using software-defined-assets">
+
+#### Using software-defined assets
+
+Here, we define a subclass of <PyObject object="Config"/> holding a single string value representing the name of a user. We can access the config through the `config` parameter in the asset body.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_asset_config endbefore=end_basic_asset_config
+class MyAssetConfig(Config):
+    person_name: str
+
+
+@asset
+def greeting(config: MyAssetConfig) -> str:
+    return f"hello {config.person_name}"
+```
+
+</TabItem>
+<TabItem name="Using ops and jobs">
+
+#### Using ops
+
+Here, we define a subclass of <PyObject object="Config"/> holding a single string value representing the name of a user. We can access the config through the `config` parameter in the op body.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_op_config endbefore=end_basic_op_config
+class MyOpConfig(Config):
+    person_name: str
+
+
+@op
+def print_greeting(config: MyOpConfig):
+    print(f"hello {config.person_name}")
+```
+
+</TabItem>
+</TabGroup>
+
+---
+
+### Defining and accessing configuration for a resource
+
+Configurable parameters for a resource are defined by specifying attributes for a resource class, which subclasses <PyObject object="ConfigurableResource"/>. The below resource defines a configurable connection URL, which can be accessed in any methods defined on the resource.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_resource_config endbefore=end_basic_resource_config
+class MyDatabaseResource(ConfigurableResource):
+    connection_url: str
+
+    def query(self, query: str) -> Response:
+        return get_engine(self.connection_url).execute(query)
+```
+
+For more information on using resources, see [the Pythonic resources guide](/guides/dagster/pythonic-resources).
+
+---
+
+### Specifying runtime configuration in Python
+
+To execute a job or materialize an asset which specifies config, you'll need to provide values for its parameters. When specifying config from the Python API, we can use the `run_config` argument for <PyObject object="JobDefinition" method="execute_in_process"/> or <PyObject object="materialize"/>. This takes a `RunConfig` object, within which we can supply config on a per-op or per-asset basis. The config is specified as a dictionary, with the keys corresponding to the op/asset names and the values corresponding to the config values.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_execute_with_config endbefore=end_execute_with_config
+@job
+def greeting_job():
+    print_greeting()
+
+
+job_result = greeting_job.execute_in_process(
+    run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})
+)
+
+asset_result = materialize(
+    [greeting],
+    run_config=RunConfig(assets={"greeting": MyAssetConfig(person_name="Alice")}),
+)
+```
+
+## Defining complex config schemas
+
+In some cases, you may want to define a more complex config schema. For example, you may want to define a config schema that takes in a list of files or complex data. Below we'll walk through some common patterns for defining more complex config schemas.
+
+### Attaching metadata to config fields
+
+Config fields can be annotated with metadata, which can be used to provide additional information about the field, using the Pydantic <PyObject object="Field"/> class.
+
+For example, we can annotate a config field with a description, which will be displayed in the documentation for the config field. We can add a value range to a field, which will be validated when config is specified.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_metadata_config endbefore=end_metadata_config
+class MyMetadataConfig(Config):
+    person_name: str = Field(..., description="The name of the person to greet")
+    age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
+
+
+# errors!
+MyMetadataConfig(person_name="Alice", age=200)
+```
+
+### Basic data structures
+
+Many basic Python data structures can be used in your config schemas, including lists and mappings.
+
+For example, we can define a config schema that takes in a list of user names and a mapping of user names to user scores.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_data_structures_config endbefore=end_basic_data_structures_config
+class MyDataStructuresConfig(Config):
+    user_names: List[str]
+    user_scores: Dict[str, int]
+
+
+@asset
+def scoreboard(config: MyDataStructuresConfig):
+    ...
+
+
+result = materialize(
+    [scoreboard],
+    run_config=RunConfig(
+        assets={
+            "scoreboard": MyDataStructuresConfig(
+                user_names=["Alice", "Bob"],
+                user_scores={"Alice": 10, "Bob": 20},
+            )
+        }
+    ),
+)
+```
+
+### Nested schemas
+
+Schemas can be nested in one another, or in basic Python data structures.
+
+Here, we define a schema which contains a mapping of user names to complex user data objects.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_nested_schema_config endbefore=end_nested_schema_config
+class UserData(Config):
+    age: int
+    email: str
+    profile_picture_url: str
+
+
+class MyNestedConfig(Config):
+    user_data: Dict[str, UserData]
+
+
+@asset
+def average_age(config: MyNestedConfig):
+    ...
+
+
+result = materialize(
+    [average_age],
+    run_config=RunConfig(
+        assets={
+            "average_age": MyNestedConfig(
+                user_data={
+                    "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
+                    "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),
+                }
+            )
+        }
+    ),
+)
+```
+
+### Union types
+
+Union types are supported using Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions). Each union type must be a subclass of <PyObject object="Config"/>. The `discriminator` argument to <PyObject object="Field"/> specifies the field that will be used to determine which union type to use.
+
+Here, we define a config schema which takes in a `pet` field, which can be either a `Cat` or a `Dog`, as indicated by the `pet_type` field.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_union_schema_config endbefore=end_union_schema_config
+class Cat(Config):
+    pet_type: Literal["cat"]
+    meows: int
+
+
+class Dog(Config):
+    pet_type: Literal["dog"]
+    barks: float
+
+
+class ConfigWithUnion(Config):
+    pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+
+
+@asset
+def pet_stats(config: ConfigWithUnion):
+    if isinstance(config.pet, Cat):
+        return f"Cat meows {config.pet.meows} times"
+    else:
+        return f"Dog barks {config.pet.barks} times"
+
+
+result = materialize(
+    [pet_stats],
+    run_config=RunConfig(
+        assets={
+            "pet_stats": ConfigWithUnion(
+                pet=Cat(pet_type="cat", meows=10),
+            )
+        }
+    ),
+)
+```

--- a/docs/content/guides/dagster/pythonic-resources.mdx
+++ b/docs/content/guides/dagster/pythonic-resources.mdx
@@ -171,6 +171,7 @@ Then, configuration for the resource can be provided at runtime in the launchpad
 
 ```python file=/guides/dagster/pythonic_resources/pythonic_resources.py startafter=start_new_resource_runtime_launch endbefore=end_new_resource_runtime_launch dedent=4
 from dagster import sensor, define_asset_job, RunRequest
+from dagster._core.definitions.run_config import RunConfig
 
 update_data_job = define_asset_job(
     name="update_data_job", selection=[data_from_database]

--- a/docs/content/guides/experimental-features.mdx
+++ b/docs/content/guides/experimental-features.mdx
@@ -4,6 +4,7 @@ title: Experimental Feature Guides | Dagster Docs
 
 # Experimental feature guides
 
+- [Pythonic config](/guides/dagster/pythonic-config) - Get started using the new Pythonic config APIs, a more ergonomic way to define op and asset config
 - [Pythonic resources](/guides/dagster/pythonic-resources) - Get started using the new Pythonic resource APIs, a more ergonomic way to define and use resources
 - [Using Custom Run Coordinators to perform run attribution](/guides/dagster/run-attribution) - A look at using a Custom Run Coordinator to perform run attribution
 - [Asset versioning and caching](/guides/dagster/asset-versioning-and-caching) - Memoize assets using Dagster's logical versioning system

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -65,12 +65,12 @@ def execute_with_config() -> None:
         print_greeting()
 
     job_result = greeting_job.execute_in_process(
-        run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})  # type: ignore
+        run_config=RunConfig({"print_greeting": MyOpConfig(person_name="Alice")})  # type: ignore
     )
 
     asset_result = materialize(
         [greeting],
-        run_config=RunConfig(ops={"greeting": MyAssetConfig(person_name="Alice")}),
+        run_config=RunConfig({"greeting": MyAssetConfig(person_name="Alice")}),
     )
 
     # end_execute_with_config
@@ -95,7 +95,7 @@ def basic_data_structures_config() -> None:
     result = materialize(
         [scoreboard],
         run_config=RunConfig(
-            ops={
+            {
                 "scoreboard": MyDataStructuresConfig(
                     user_names=["Alice", "Bob"],
                     user_scores={"Alice": 10, "Bob": 20},
@@ -129,7 +129,7 @@ def nested_schema_config() -> None:
     result = materialize(
         [average_age],
         run_config=RunConfig(
-            ops={
+            {
                 "average_age": MyNestedConfig(
                     user_data={
                         "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),  # type: ignore
@@ -154,14 +154,15 @@ def union_schema_config() -> None:
     from typing_extensions import Literal
 
     class Cat(Config):
-        pet_type: Literal["cat"]
+        pet_type: Literal["cat"] = "cat"
         meows: int
 
     class Dog(Config):
-        pet_type: Literal["dog"]
+        pet_type: Literal["dog"] = "dog"
         barks: float
 
     class ConfigWithUnion(Config):
+        # Here, the ellipses `...` indicates that the field is required and has no default value.
         pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
 
     @asset
@@ -174,9 +175,9 @@ def union_schema_config() -> None:
     result = materialize(
         [pet_stats],
         run_config=RunConfig(
-            ops={
+            {
                 "pet_stats": ConfigWithUnion(
-                    pet=Cat(pet_type="cat", meows=10),
+                    pet=Cat(meows=10),
                 )
             }
         ),
@@ -190,6 +191,7 @@ def metadata_config() -> None:
     from pydantic import Field
 
     class MyMetadataConfig(Config):
+        # Here, the ellipses `...` indicates that the field is required and has no default value.
         person_name: str = Field(..., description="The name of the person to greet")
         age: int = Field(
             ..., gt=0, lt=100, description="The age of the person to greet"

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -1,64 +1,8 @@
 # isort: skip_file
 # pylint: disable=unused-argument,reimported,unnecessary-ellipsis
-from dagster import ResourceDefinition, graph, job, Definitions, resource, op, asset
-import requests
-from requests import Response
-from typing import Generic, List, TypeVar
-from dagster._config.structured_config import Config, ConfigurableResource
 
 
-# start_basic_op_config
-
-
-class MyOpConfig(Config):
-    person_name: str
-
-
-@op
-def print_greeting(config: MyOpConfig):
-    print(f"hello {config.person_name}")
-
-
-# end_basic_op_config
-
-# start_basic_asset_config
-
-
-class MyAssetConfig(Config):
-    person_name: str
-
-
-@asset
-def greeting(config: MyAssetConfig) -> str:
-    return f"hello {config.person_name}"
-
-
-# end_basic_asset_config
-
-
-class Engine:
-    def execute(self, query: str):
-        ...
-
-
-def get_engine(connection_url: str) -> Engine:
-    return Engine()
-
-
-# start_basic_resource_config
-
-
-class MyDatabaseResource(ConfigurableResource):
-    connection_url: str
-
-    def query(self, query: str) -> Response:
-        return get_engine(self.connection_url).execute(query)
-
-
-# end_basic_resource_config
-
-from typing import NamedTuple, Dict, Any, Mapping, Optional
-from dagster import materialize
+from typing import Dict, Any, Optional
 
 
 class RunConfig(Dict[str, Any]):
@@ -71,141 +15,193 @@ class RunConfig(Dict[str, Any]):
         super().__init__({**(ops or {}), **(assets or {}), **(resources or {})})
 
 
-# start_execute_with_config
+class Engine:
+    def execute(self, query: str):
+        ...
 
 
-@job
-def greeting_job():
-    print_greeting()
+def get_engine(connection_url: str) -> Engine:
+    return Engine()
 
 
-job_result = greeting_job.execute_in_process(
-    run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})
-)
+def basic_resource_config() -> None:
+    # start_basic_resource_config
 
-asset_result = materialize(
-    [greeting],
-    run_config=RunConfig(assets={"greeting": MyAssetConfig(person_name="Alice")}),
-)
+    from dagster import op
+    from dagster._config.structured_config import ConfigurableResource
 
-# end_execute_with_config
+    class MyDatabaseResource(ConfigurableResource):
+        connection_url: str
 
+        def query(self, query: str):
+            return get_engine(self.connection_url).execute(query)
 
-# start_basic_data_structures_config
-
-
-class MyDataStructuresConfig(Config):
-    user_names: List[str]
-    user_scores: Dict[str, int]
+    # end_basic_resource_config
 
 
-@asset
-def scoreboard(config: MyDataStructuresConfig):
-    ...
+def execute_with_config() -> None:
+    # start_basic_op_config
+
+    from dagster import op
+    from dagster._config.structured_config import Config
+
+    class MyOpConfig(Config):
+        person_name: str
+
+    @op
+    def print_greeting(config: MyOpConfig):
+        print(f"hello {config.person_name}")
+
+    # end_basic_op_config
+
+    # start_basic_asset_config
+
+    from dagster import asset
+    from dagster._config.structured_config import Config
+
+    class MyAssetConfig(Config):
+        person_name: str
+
+    @asset
+    def greeting(config: MyAssetConfig) -> str:
+        return f"hello {config.person_name}"
+
+    # end_basic_asset_config
+
+    # start_execute_with_config
+    from dagster import job, materialize, op
+
+    @job
+    def greeting_job():
+        print_greeting()
+
+    job_result = greeting_job.execute_in_process(
+        run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})
+    )
+
+    asset_result = materialize(
+        [greeting],
+        run_config=RunConfig(assets={"greeting": MyAssetConfig(person_name="Alice")}),
+    )
+
+    # end_execute_with_config
 
 
-result = materialize(
-    [scoreboard],
-    run_config=RunConfig(
-        assets={
-            "scoreboard": MyDataStructuresConfig(
-                user_names=["Alice", "Bob"],
-                user_scores={"Alice": 10, "Bob": 20},
-            )
-        }
-    ),
-)
+def basic_data_structures_config() -> None:
+    # start_basic_data_structures_config
+    from dagster._config.structured_config import Config
+    from typing import List, Dict
+    from dagster import materialize, asset
+
+    class MyDataStructuresConfig(Config):
+        user_names: List[str]
+        user_scores: Dict[str, int]
+
+    @asset
+    def scoreboard(config: MyDataStructuresConfig):
+        ...
+
+    result = materialize(
+        [scoreboard],
+        run_config=RunConfig(
+            assets={
+                "scoreboard": MyDataStructuresConfig(
+                    user_names=["Alice", "Bob"],
+                    user_scores={"Alice": 10, "Bob": 20},
+                )
+            }
+        ),
+    )
+
+    # end_basic_data_structures_config
 
 
-# end_basic_data_structures_config
+def nested_schema_config() -> None:
+    # start_nested_schema_config
+    from dagster._config.structured_config import Config
+    from dagster import asset, materialize
+
+    class UserData(Config):
+        age: int
+        email: str
+        profile_picture_url: str
+
+    class MyNestedConfig(Config):
+        user_data: Dict[str, UserData]
+
+    @asset
+    def average_age(config: MyNestedConfig):
+        ...
+
+    result = materialize(
+        [average_age],
+        run_config=RunConfig(
+            assets={
+                "average_age": MyNestedConfig(
+                    user_data={
+                        "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),  # type: ignore
+                        "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),  # type: ignore
+                    }
+                )
+            }
+        ),
+    )
+
+    # end_nested_schema_config
 
 
-# start_nested_schema_config
+def union_schema_config() -> None:
+    # start_union_schema_config
+
+    from typing import Union
+    from pydantic import Field
+    from typing_extensions import Literal
+    from dagster._config.structured_config import Config
+    from dagster import asset, materialize
+
+    class Cat(Config):
+        pet_type: Literal["cat"]
+        meows: int
+
+    class Dog(Config):
+        pet_type: Literal["dog"]
+        barks: float
+
+    class ConfigWithUnion(Config):
+        pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+
+    @asset
+    def pet_stats(config: ConfigWithUnion):
+        if isinstance(config.pet, Cat):
+            return f"Cat meows {config.pet.meows} times"
+        else:
+            return f"Dog barks {config.pet.barks} times"
+
+    result = materialize(
+        [pet_stats],
+        run_config=RunConfig(
+            assets={
+                "pet_stats": ConfigWithUnion(
+                    pet=Cat(pet_type="cat", meows=10),
+                )
+            }
+        ),
+    )
+    # end_union_schema_config
 
 
-class UserData(Config):
-    age: int
-    email: str
-    profile_picture_url: str
+def metadata_config() -> None:
+    #  start_metadata_config
+    from dagster._config.structured_config import Config
+    from pydantic import Field
 
+    class MyMetadataConfig(Config):
+        person_name: str = Field(..., description="The name of the person to greet")
+        age: int = Field(
+            ..., gt=0, lt=100, description="The age of the person to greet"
+        )
 
-class MyNestedConfig(Config):
-    user_data: Dict[str, UserData]
+    # errors!
+    MyMetadataConfig(person_name="Alice", age=200)
 
-
-@asset
-def average_age(config: MyNestedConfig):
-    ...
-
-
-result = materialize(
-    [average_age],
-    run_config=RunConfig(
-        assets={
-            "average_age": MyNestedConfig(
-                user_data={
-                    "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
-                    "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),
-                }
-            )
-        }
-    ),
-)
-
-
-# end_nested_schema_config
-
-from typing import Union
-from pydantic import Field
-from typing_extensions import Literal
-
-# start_union_schema_config
-
-
-class Cat(Config):
-    pet_type: Literal["cat"]
-    meows: int
-
-
-class Dog(Config):
-    pet_type: Literal["dog"]
-    barks: float
-
-
-class ConfigWithUnion(Config):
-    pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
-
-
-@asset
-def pet_stats(config: ConfigWithUnion):
-    if isinstance(config.pet, Cat):
-        return f"Cat meows {config.pet.meows} times"
-    else:
-        return f"Dog barks {config.pet.barks} times"
-
-
-result = materialize(
-    [pet_stats],
-    run_config=RunConfig(
-        assets={
-            "pet_stats": ConfigWithUnion(
-                pet=Cat(pet_type="cat", meows=10),
-            )
-        }
-    ),
-)
-# end_union_schema_config
-
-
-#  start_metadata_config
-
-
-class MyMetadataConfig(Config):
-    person_name: str = Field(..., description="The name of the person to greet")
-    age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
-
-
-# errors!
-MyMetadataConfig(person_name="Alice", age=200)
-
-# end_metadata_config
+    # end_metadata_config

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -1,0 +1,211 @@
+# isort: skip_file
+# pylint: disable=unused-argument,reimported,unnecessary-ellipsis
+from dagster import ResourceDefinition, graph, job, Definitions, resource, op, asset
+import requests
+from requests import Response
+from typing import Generic, List, TypeVar
+from dagster._config.structured_config import Config, ConfigurableResource
+
+
+# start_basic_op_config
+
+
+class MyOpConfig(Config):
+    person_name: str
+
+
+@op
+def print_greeting(config: MyOpConfig):
+    print(f"hello {config.person_name}")
+
+
+# end_basic_op_config
+
+# start_basic_asset_config
+
+
+class MyAssetConfig(Config):
+    person_name: str
+
+
+@asset
+def greeting(config: MyAssetConfig) -> str:
+    return f"hello {config.person_name}"
+
+
+# end_basic_asset_config
+
+
+class Engine:
+    def execute(self, query: str):
+        ...
+
+
+def get_engine(connection_url: str) -> Engine:
+    return Engine()
+
+
+# start_basic_resource_config
+
+
+class MyDatabaseResource(ConfigurableResource):
+    connection_url: str
+
+    def query(self, query: str) -> Response:
+        return get_engine(self.connection_url).execute(query)
+
+
+# end_basic_resource_config
+
+from typing import NamedTuple, Dict, Any, Mapping, Optional
+from dagster import materialize
+
+
+class RunConfig(Dict[str, Any]):
+    def __init__(
+        self,
+        ops: Optional[Dict[str, Any]] = None,
+        assets: Optional[Dict[str, Any]] = None,
+        resources: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__({**(ops or {}), **(assets or {}), **(resources or {})})
+
+
+# start_execute_with_config
+
+
+@job
+def greeting_job():
+    print_greeting()
+
+
+job_result = greeting_job.execute_in_process(
+    run_config=RunConfig(ops={"print_greeting": MyOpConfig(person_name="Alice")})
+)
+
+asset_result = materialize(
+    [greeting],
+    run_config=RunConfig(assets={"greeting": MyAssetConfig(person_name="Alice")}),
+)
+
+# end_execute_with_config
+
+
+# start_basic_data_structures_config
+
+
+class MyDataStructuresConfig(Config):
+    user_names: List[str]
+    user_scores: Dict[str, int]
+
+
+@asset
+def scoreboard(config: MyDataStructuresConfig):
+    ...
+
+
+result = materialize(
+    [scoreboard],
+    run_config=RunConfig(
+        assets={
+            "scoreboard": MyDataStructuresConfig(
+                user_names=["Alice", "Bob"],
+                user_scores={"Alice": 10, "Bob": 20},
+            )
+        }
+    ),
+)
+
+
+# end_basic_data_structures_config
+
+
+# start_nested_schema_config
+
+
+class UserData(Config):
+    age: int
+    email: str
+    profile_picture_url: str
+
+
+class MyNestedConfig(Config):
+    user_data: Dict[str, UserData]
+
+
+@asset
+def average_age(config: MyNestedConfig):
+    ...
+
+
+result = materialize(
+    [average_age],
+    run_config=RunConfig(
+        assets={
+            "average_age": MyNestedConfig(
+                user_data={
+                    "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
+                    "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),
+                }
+            )
+        }
+    ),
+)
+
+
+# end_nested_schema_config
+
+from typing import Union
+from pydantic import Field
+from typing_extensions import Literal
+
+# start_union_schema_config
+
+
+class Cat(Config):
+    pet_type: Literal["cat"]
+    meows: int
+
+
+class Dog(Config):
+    pet_type: Literal["dog"]
+    barks: float
+
+
+class ConfigWithUnion(Config):
+    pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+
+
+@asset
+def pet_stats(config: ConfigWithUnion):
+    if isinstance(config.pet, Cat):
+        return f"Cat meows {config.pet.meows} times"
+    else:
+        return f"Dog barks {config.pet.barks} times"
+
+
+result = materialize(
+    [pet_stats],
+    run_config=RunConfig(
+        assets={
+            "pet_stats": ConfigWithUnion(
+                pet=Cat(pet_type="cat", meows=10),
+            )
+        }
+    ),
+)
+# end_union_schema_config
+
+
+#  start_metadata_config
+
+
+class MyMetadataConfig(Config):
+    person_name: str = Field(..., description="The name of the person to greet")
+    age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
+
+
+# errors!
+MyMetadataConfig(person_name="Alice", age=200)
+
+# end_metadata_config

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
@@ -173,18 +173,9 @@ def new_resource_runtime() -> None:
 
     # end_new_resource_runtime
 
-    from typing import Optional
-
-    class RunConfig(Dict[str, Any]):
-        def __init__(
-            self,
-            ops: Optional[Dict[str, Any]] = None,
-            resources: Optional[Dict[str, Any]] = None,
-        ):
-            super().__init__({**(ops or {}), **(resources or {})})
-
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest
+    from dagster._core.definitions.run_config import RunConfig
 
     update_data_job = define_asset_job(
         name="update_data_job", selection=[data_from_database]


### PR DESCRIPTION
## Summary

Introduces a new experimental guide, aiming to introduce the new Pythonic config APIs.

Also see #12260 for the corresponding resources guide.

## Test Plan

https://dagster-git-benpankow-update-config-schema-docs-acca2b-elementl.vercel.app/guides/dagster/pythonic-config