### PR TITLE
[refactor] execute_step renames

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -40,7 +40,7 @@ from .utils import op_execution_error_boundary
 
 T = TypeVar("T")
 
-SolidOutputUnion: TypeAlias = Union[
+OpOutputUnion: TypeAlias = Union[
     DynamicOutput[Any],
     Output[Any],
     AssetMaterialization,
@@ -85,7 +85,7 @@ def create_step_outputs(
     return step_outputs
 
 
-def _validate_event(event: Any, step_context: StepExecutionContext) -> SolidOutputUnion:
+def _validate_event(event: Any, step_context: StepExecutionContext) -> OpOutputUnion:
     if not isinstance(
         event,
         (
@@ -129,7 +129,7 @@ def gen_from_async_gen(async_gen: AsyncIterator[T]) -> Iterator[T]:
 
 def _yield_compute_results(
     step_context: StepExecutionContext, inputs: Mapping[str, Any], compute_fn: Callable
-) -> Iterator[SolidOutputUnion]:
+) -> Iterator[OpOutputUnion]:
     check.inst_param(step_context, "step_context", StepExecutionContext)
 
     context = OpExecutionContext(step_context)
@@ -176,9 +176,9 @@ def _yield_compute_results(
 
 def execute_core_compute(
     step_context: StepExecutionContext, inputs: Mapping[str, Any], compute_fn: OpComputeFunction
-) -> Iterator[SolidOutputUnion]:
+) -> Iterator[OpOutputUnion]:
     """
-    Execute the user-specified compute for the solid. Wrap in an error boundary and do
+    Execute the user-specified compute for the op. Wrap in an error boundary and do
     all relevant logging and metrics tracking.
     """
     check.inst_param(step_context, "step_context", StepExecutionContext)

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -38,11 +38,11 @@ class NoAnnotationSentinel:
     pass
 
 
-def create_solid_compute_wrapper(solid_def: OpDefinition):
-    compute_fn = cast(DecoratedOpFunction, solid_def.compute_fn)
+def create_op_compute_wrapper(op_def: OpDefinition):
+    compute_fn = cast(DecoratedOpFunction, op_def.compute_fn)
     fn = compute_fn.decorated_fn
-    input_defs = solid_def.input_defs
-    output_defs = solid_def.output_defs
+    input_defs = op_def.input_defs
+    output_defs = op_def.output_defs
     context_arg_provided = compute_fn.has_context_arg()
     config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
     resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -68,14 +68,14 @@ from dagster._utils import ensure_gen, iterate_with_context
 from dagster._utils.backcompat import ExperimentalWarning, experimental_functionality_warning
 from dagster._utils.timing import time_execution_scope
 
-from .compute import SolidOutputUnion
-from .compute_generator import create_solid_compute_wrapper
+from .compute import OpOutputUnion
+from .compute_generator import create_op_compute_wrapper
 from .utils import op_execution_error_boundary
 
 
 def _step_output_error_checked_user_event_sequence(
-    step_context: StepExecutionContext, user_event_sequence: Iterator[SolidOutputUnion]
-) -> Iterator[SolidOutputUnion]:
+    step_context: StepExecutionContext, user_event_sequence: Iterator[OpOutputUnion]
+) -> Iterator[OpOutputUnion]:
     """
     Process the event sequence to check for invariant violations in the event
     sequence related to Output events emitted from the compute_fn.
@@ -360,7 +360,7 @@ def core_dagster_event_sequence_for_step(
     # into this format. If the solid definition was created directly, then it is expected that the
     # compute_fn is already in this format.
     if isinstance(step_context.solid_def.compute_fn, DecoratedOpFunction):
-        core_gen = create_solid_compute_wrapper(step_context.solid_def)
+        core_gen = create_op_compute_wrapper(step_context.solid_def)
     else:
         core_gen = step_context.solid_def.compute_fn
 


### PR DESCRIPTION
### Summary & Motivation

Two renames in `execute_step`

- `SolidOutputUnion` -> `OpOutputUnion`
- `create_solid_compute_wrapper` -> `create_op_compute_wrapper`

### How I Tested These Changes

BK
