### PR TITLE
[db io managers] add default_load_type

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -168,7 +168,6 @@ class DbIOManager(IOManager):
         with self._db_client.connect(context, table_slice) as conn:
             return self._handlers_by_type[load_type].load_input(context, table_slice, conn)
 
-
     def _get_partition_value(
         self, partition_def: PartitionsDefinition, partition_key: str
     ) -> Union[TimeWindow, str]:

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import (
@@ -28,7 +27,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
 from dagster._core.storage.io_manager import IOManager
@@ -158,14 +157,6 @@ class DbIOManager(IOManager):
     def load_input(self, context: InputContext) -> object:
         obj_type = context.dagster_type.typing_type
         if obj_type is Any and self._default_load_type is not None:
-            msg = (
-                f"Input {context.name} does not have a type hint, loading as default type"
-                f" {self._default_load_type}"
-            )
-            try:
-                context.log.warning(msg)
-            except DagsterInvariantViolationError:
-                warnings.warn(msg)
             load_type = self._default_load_type
         else:
             load_type = obj_type

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -2,7 +2,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from dagster import AssetKey, InputContext, OutputContext, build_output_context
+from dagster import AssetKey, InputContext, OutputContext, asset, build_output_context
 from dagster._check import CheckError
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition, TimeWindow
@@ -436,3 +436,66 @@ def test_non_supported_type():
         CheckError, match="DbIOManager does not have a handler for type '<class 'str'>'"
     ):
         manager.handle_output(output_context, "a_string")
+
+
+def test_default_load_type():
+    handler = IntHandler()
+    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+    manager = DbIOManager(
+        type_handlers=[handler],
+        database=resource_config["database"],
+        db_client=db_client,
+        default_load_type=int,
+    )
+    asset_key = AssetKey(["schema1", "table1"])
+    output_context = build_output_context(asset_key=asset_key, resource_config=resource_config)
+
+    @asset
+    def asset1():
+        ...
+
+    input_context = MagicMock(
+        upstream_output=output_context,
+        resource_config=resource_config,
+        dagster_type=asset1.op.outs["result"].dagster_type,
+        asset_key=asset_key,
+        has_asset_partitions=False,
+        metadata=None,
+    )
+
+    manager.handle_output(output_context, 1)
+    assert len(handler.handle_output_calls) == 1
+
+    assert manager.load_input(input_context) == 7
+
+    assert len(handler.handle_input_calls) == 1
+
+    assert handler.handle_input_calls[0][1] == TableSlice(
+        database="database_abc", schema="schema1", table="table1", partition_dimensions=[]
+    )
+
+
+def test_default_load_type_determination():
+    int_handler = IntHandler()
+    string_handler = StringHandler()
+    db_client = MagicMock(spec=DbClient, get_select_statement=MagicMock(return_value=""))
+
+    manager = DbIOManager(
+        type_handlers=[int_handler], database=resource_config["database"], db_client=db_client
+    )
+    assert manager._default_load_type == int
+
+    manager = DbIOManager(
+        type_handlers=[int_handler, string_handler],
+        database=resource_config["database"],
+        db_client=db_client,
+    )
+    assert manager._default_load_type is None
+
+    manager = DbIOManager(
+        type_handlers=[int_handler, string_handler],
+        database=resource_config["database"],
+        db_client=db_client,
+        default_load_type=int,
+    )
+    assert manager._default_load_type == int

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -69,7 +69,9 @@ class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         return [pd.DataFrame]
 
 
-duckdb_pandas_io_manager = build_duckdb_io_manager([DuckDBPandasTypeHandler()])
+duckdb_pandas_io_manager = build_duckdb_io_manager(
+    [DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
+)
 duckdb_pandas_io_manager.__doc__ = """
 An IO manager definition that reads inputs from and writes pandas dataframes to DuckDB.
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -73,7 +73,9 @@ duckdb_pandas_io_manager = build_duckdb_io_manager(
     [DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
 )
 duckdb_pandas_io_manager.__doc__ = """
-An IO manager definition that reads inputs from and writes pandas dataframes to DuckDB.
+An IO manager definition that reads inputs from and writes Pandas DataFrames to DuckDB. When
+using the duckdb_pandas_io_manager, any inputs and outputs without type annotations will be loaded
+as Pandas DataFrames.
 
 Returns:
     IOManagerDefinition

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -82,7 +82,9 @@ duckdb_pyspark_io_manager = build_duckdb_io_manager(
     [DuckDBPySparkTypeHandler()], default_load_type=pyspark.sql.DataFrame
 )
 duckdb_pyspark_io_manager.__doc__ = """
-An IO manager definition that reads inputs from and writes PySpark DataFrames to DuckDB.
+An IO manager definition that reads inputs from and writes PySpark DataFrames to DuckDB. When
+using the duckdb_pyspark_io_manager, any inputs and outputs without type annotations will be loaded
+as PySpark DataFrames.
 
 Returns:
     IOManagerDefinition

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -78,7 +78,9 @@ class DuckDBPySparkTypeHandler(DbTypeHandler[pyspark.sql.DataFrame]):
         return [pyspark.sql.DataFrame]
 
 
-duckdb_pyspark_io_manager = build_duckdb_io_manager([DuckDBPySparkTypeHandler()])
+duckdb_pyspark_io_manager = build_duckdb_io_manager(
+    [DuckDBPySparkTypeHandler()], default_load_type=pyspark.sql.DataFrame
+)
 duckdb_pyspark_io_manager.__doc__ = """
 An IO manager definition that reads inputs from and writes PySpark DataFrames to DuckDB.
 

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
-from typing import Sequence, cast
-
+from typing import Optional, Sequence, Type, cast
 import duckdb
 from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -16,13 +15,16 @@ from dagster._utils.backoff import backoff
 DUCKDB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-def build_duckdb_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOManagerDefinition:
+def build_duckdb_io_manager(
+    type_handlers: Sequence[DbTypeHandler], default_load_type: Optional[Type] = None
+) -> IOManagerDefinition:
     """
     Builds an IO manager definition that reads inputs from and writes outputs to DuckDB.
 
     Args:
         type_handlers (Sequence[DbTypeHandler]): Each handler defines how to translate between
             DuckDB tables and an in-memory type - e.g. a Pandas DataFrame.
+        default_load_type (Type): When an input has no type annotation, load it as this type.
 
     Returns:
         IOManagerDefinition
@@ -97,6 +99,7 @@ def build_duckdb_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOManager
             io_manager_name="DuckDBIOManager",
             database=init_context.resource_config["database"],
             schema=init_context.resource_config.get("schema"),
+            default_load_type=default_load_type,
         )
 
     return duckdb_io_manager

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -23,7 +23,8 @@ def build_duckdb_io_manager(
 
     Args:
         type_handlers (Sequence[DbTypeHandler]): Each handler defines how to translate between
-            DuckDB tables and an in-memory type - e.g. a Pandas DataFrame.
+            DuckDB tables and an in-memory type - e.g. a Pandas DataFrame. If only
+            one DbTypeHandler is provided, it will be used as teh default_load_type.
         default_load_type (Type): When an input has no type annotation, load it as this type.
 
     Returns:

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from typing import Optional, Sequence, Type, cast
+
 import duckdb
 from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
 from dagster._core.definitions.time_window_partitions import TimeWindow

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -102,7 +102,10 @@ snowflake_pandas_io_manager = build_snowflake_io_manager(
     [SnowflakePandasTypeHandler()], default_load_type=pd.DataFrame
 )
 snowflake_pandas_io_manager.__doc__ = """
-An IO manager definition that reads inputs from and writes pandas dataframes to Snowflake.
+An IO manager definition that reads inputs from and writes Pandas DataFrames to Snowflake. When
+using the snowflake_pandas_io_manager, any inputs and outputs without type annotations will be loaded
+as Pandas DataFrames.
+
 
 Returns:
     IOManagerDefinition

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -98,7 +98,9 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         return [pd.DataFrame]
 
 
-snowflake_pandas_io_manager = build_snowflake_io_manager([SnowflakePandasTypeHandler()])
+snowflake_pandas_io_manager = build_snowflake_io_manager(
+    [SnowflakePandasTypeHandler()], default_load_type=pd.DataFrame
+)
 snowflake_pandas_io_manager.__doc__ = """
 An IO manager definition that reads inputs from and writes pandas dataframes to Snowflake.
 

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -97,7 +97,9 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
         return [DataFrame]
 
 
-snowflake_pyspark_io_manager = build_snowflake_io_manager([SnowflakePySparkTypeHandler()])
+snowflake_pyspark_io_manager = build_snowflake_io_manager(
+    [SnowflakePySparkTypeHandler()], default_load_type=DataFrame
+)
 snowflake_pyspark_io_manager.__doc__ = """
 An IO manager definition that reads inputs from and writes PySpark DataFrames to Snowflake.
 

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -101,7 +101,9 @@ snowflake_pyspark_io_manager = build_snowflake_io_manager(
     [SnowflakePySparkTypeHandler()], default_load_type=DataFrame
 )
 snowflake_pyspark_io_manager.__doc__ = """
-An IO manager definition that reads inputs from and writes PySpark DataFrames to Snowflake.
+An IO manager definition that reads inputs from and writes PySpark DataFrames to Snowflake. When
+using the snowflake_pyspark_io_manager, any inputs and outputs without type annotations will be loaded
+as PySpark DataFrames.
 
 Returns:
     IOManagerDefinition

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -24,7 +24,8 @@ def build_snowflake_io_manager(
 
     Args:
         type_handlers (Sequence[DbTypeHandler]): Each handler defines how to translate between
-            slices of Snowflake tables and an in-memory type - e.g. a Pandas DataFrame.
+            slices of Snowflake tables and an in-memory type - e.g. a Pandas DataFrame. If only
+            one DbTypeHandler is provided, it will be used as teh default_load_type.
         default_load_type (Type): When an input has no type annotation, load it as this type.
 
     Returns:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
-from typing import Mapping, Sequence, cast
-
+from typing import Mapping, Sequence, cast, Type
 from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
@@ -17,13 +16,16 @@ from .resources import SnowflakeConnection
 SNOWFLAKE_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-def build_snowflake_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOManagerDefinition:
+def build_snowflake_io_manager(
+    type_handlers: Sequence[DbTypeHandler], default_load_type: Optional[Type] = None
+) -> IOManagerDefinition:
     """
     Builds an IO manager definition that reads inputs from and writes outputs to Snowflake.
 
     Args:
         type_handlers (Sequence[DbTypeHandler]): Each handler defines how to translate between
             slices of Snowflake tables and an in-memory type - e.g. a Pandas DataFrame.
+        default_load_type (Type): When an input has no type annotation, load it as this type.
 
     Returns:
         IOManagerDefinition
@@ -134,6 +136,7 @@ def build_snowflake_io_manager(type_handlers: Sequence[DbTypeHandler]) -> IOMana
             io_manager_name="SnowflakeIOManager",
             database=init_context.resource_config["database"],
             schema=init_context.resource_config.get("schema"),
+            default_load_type=default_load_type,
         )
 
     return snowflake_io_manager

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
-from typing import Mapping, Sequence, cast, Type
+from typing import Mapping, Optional, Sequence, Type, cast
+
 from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (


### PR DESCRIPTION
### Summary & Motivation
Adds `default_load_type` to DBIOManager so that they can load Any types as `default_load_type`

fixes #12328

replaces #9373 which did the same thing (but wasn't merged and now the merge conflicts are bad)

### How I Tested These Changes
