### PR TITLE
Add task_role_arn and execution_role_arn to EcsContainerContext

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -93,6 +93,23 @@ ECS_CONTAINER_CONTEXT_SCHEMA = {
             }
         )
     ),
+    "task_role_arn": Field(
+        StringSource,
+        is_required=False,
+        description=(
+            "ARN of the IAM role for launched tasks. See"
+            " https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html. "
+        ),
+    ),
+    "execution_role_arn": Field(
+        StringSource,
+        is_required=False,
+        description=(
+            "ARN of the task execution role for the ECS container and Fargate agent to make AWS API"
+            " calls on your behalf. See"
+            " https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html. "
+        ),
+    ),
     **SHARED_ECS_SCHEMA,
 }
 
@@ -108,6 +125,8 @@ class EcsContainerContext(
             ("container_name", Optional[str]),
             ("server_resources", Mapping[str, str]),
             ("run_resources", Mapping[str, str]),
+            ("task_role_arn", Optional[str]),
+            ("execution_role_arn", Optional[str]),
         ],
     )
 ):
@@ -122,6 +141,8 @@ class EcsContainerContext(
         container_name: Optional[str] = None,
         server_resources: Optional[Mapping[str, str]] = None,
         run_resources: Optional[Mapping[str, str]] = None,
+        task_role_arn: Optional[str] = None,
+        execution_role_arn: Optional[str] = None,
     ):
         return super(EcsContainerContext, cls).__new__(
             cls,
@@ -132,6 +153,8 @@ class EcsContainerContext(
             container_name=check.opt_str_param(container_name, "container_name"),
             server_resources=check.opt_mapping_param(server_resources, "server_resources"),
             run_resources=check.opt_mapping_param(run_resources, "run_resources"),
+            task_role_arn=check.opt_str_param(task_role_arn, "task_role_arn"),
+            execution_role_arn=check.opt_str_param(execution_role_arn, "execution_role_arn"),
         )
 
     def merge(self, other: "EcsContainerContext") -> "EcsContainerContext":
@@ -143,6 +166,8 @@ class EcsContainerContext(
             container_name=other.container_name or self.container_name,
             server_resources={**self.server_resources, **other.server_resources},
             run_resources={**self.run_resources, **other.run_resources},
+            task_role_arn=other.task_role_arn or self.task_role_arn,
+            execution_role_arn=other.execution_role_arn or self.execution_role_arn,
         )
 
     def get_secrets_dict(self, secrets_manager) -> Mapping[str, str]:
@@ -166,6 +191,8 @@ class EcsContainerContext(
                     env_vars=run_launcher.env_vars,
                     task_definition_arn=run_launcher.task_definition,  # run launcher converts this from short name to ARN in constructor
                     run_resources=run_launcher.run_resources,
+                    task_role_arn=run_launcher.task_role_arn,
+                    execution_role_arn=run_launcher.execution_role_arn,
                 )
             )
 
@@ -218,5 +245,7 @@ class EcsContainerContext(
                 container_name=processed_context_value.get("container_name"),
                 server_resources=processed_context_value.get("server_resources"),
                 run_resources=processed_context_value.get("run_resources"),
+                task_role_arn=processed_context_value.get("task_role_arn"),
+                execution_role_arn=processed_context_value.get("execution_role_arn"),
             )
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -170,6 +170,18 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
     def inst_data(self):
         return self._inst_data
 
+    @property
+    def task_role_arn(self) -> Optional[str]:
+        if not self.task_definition_dict:
+            return None
+        return self.task_definition_dict.get("task_role_arn")
+
+    @property
+    def execution_role_arn(self) -> Optional[str]:
+        if not self.task_definition_dict:
+            return None
+        return self.task_definition_dict.get("execution_role_arn")
+
     @classmethod
     def config_type(cls):
         return {
@@ -491,8 +503,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     ),
                     secrets=secrets if secrets else [],
                     environment=environment,
-                    execution_role_arn=self.task_definition_dict.get("execution_role_arn"),
-                    task_role_arn=self.task_definition_dict.get("task_role_arn"),
+                    execution_role_arn=container_context.execution_role_arn,
+                    task_role_arn=container_context.task_role_arn,
                     sidecars=self.task_definition_dict.get("sidecar_containers"),
                     requires_compatibilities=self.task_definition_dict.get(
                         "requires_compatibilities", []
@@ -509,6 +521,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     environment=environment,
                     secrets=secrets if secrets else {},
                     include_sidecars=self.include_sidecars,
+                    task_role_arn=container_context.task_role_arn,
+                    execution_role_arn=container_context.execution_role_arn,
                 )
 
                 task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -159,6 +159,8 @@ def get_task_definition_dict_from_current_task(
     command=None,
     secrets=None,
     include_sidecars=False,
+    task_role_arn=None,
+    execution_role_arn=None,
 ):
     current_container_name = current_ecs_container_name()
 
@@ -223,6 +225,8 @@ def get_task_definition_dict_from_current_task(
         **task_definition,
         "family": family,
         "containerDefinitions": container_definitions,
+        **({"taskRoleArn": task_role_arn} if task_role_arn else {}),
+        **({"executionRoleArn": execution_role_arn} if execution_role_arn else {}),
     }
 
     return task_definition

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -101,9 +101,6 @@ def task(ecs, subnet, security_group, task_definition, assign_public_ip):
 
 @pytest.fixture
 def stub_aws(ecs, ec2, secrets_manager, cloudwatch_client, monkeypatch):
-    print("ECS:" + str(ecs))
-    print("SECRETS MANAGER: " + str(secrets_manager))
-
     def mock_client(*args, **kwargs):
         if "ecs" in args:
             return ecs
@@ -388,6 +385,8 @@ def container_context_config(configured_secret):
                 "cpu": "1024",
                 "memory": "2048",
             },
+            "task_role_arn": "fake-task-role",
+            "execution_role_arn": "fake-execution-role",
         },
     }
 
@@ -413,6 +412,8 @@ def other_container_context_config(other_configured_secret):
                 "cpu": "2048",
                 "memory": "4096",
             },
+            "task_role_arn": "other-task-role",
+            "execution_role_arn": "other-fake-execution-role",
         },
     }
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
@@ -93,6 +93,9 @@ def test_merge(
         "memory": "4096",
     }
 
+    assert merged.task_role_arn == "other-task-role"
+    assert merged.execution_role_arn == "other-fake-execution-role"
+
     with pytest.raises(
         Exception, match="Tried to load environment variable OTHER_FOO_ENV_VAR, but it was not set"
     ):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -689,7 +689,7 @@ def test_launcher_run_resources(
     assert task.get("overrides").get("cpu") == "1024"
 
 
-def test_container_context_run_resources(
+def test_launch_run_with_container_context(
     ecs,
     instance,
     launch_run_with_container_context,
@@ -709,6 +709,17 @@ def test_container_context_run_resources(
     )
     assert (
         task.get("overrides").get("cpu") == container_context_config["ecs"]["run_resources"]["cpu"]
+    )
+
+    task_definition_arn = task["taskDefinitionArn"]
+
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)[
+        "taskDefinition"
+    ]
+
+    assert task_definition["taskRoleArn"] == container_context_config["ecs"]["task_role_arn"]
+    assert (
+        task_definition["executionRoleArn"] == container_context_config["ecs"]["execution_role_arn"]
     )
 
 


### PR DESCRIPTION
Summary:
This provides a way for code locations to vary the IAM roles used by each task.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
