### PR TITLE
[refactor] Remove symbols deprecated until 1.2

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -673,29 +673,14 @@ class DependencyDefinition(
             passed between the two nodes originates.
         output (Optional[str]): The name of the output that is depended on. (default: "result")
         description (Optional[str]): Human-readable description of this dependency.
-        solid (str): (legacy) The name of the solid that is depended on, that is, from which the value
-            passed between the two nodes originates.
     """
 
     def __new__(
         cls,
-        node: Optional[str] = None,
+        node: str,
         output: str = DEFAULT_OUTPUT,
         description: Optional[str] = None,
-        solid: Optional[str] = None,
     ):
-        if solid and node:
-            raise DagsterInvalidDefinitionError(
-                "Both ``node`` and legacy ``solid`` arguments provided to DependencyDefinition."
-                " Please use one or the other."
-            )
-
-        if not solid and not node:
-            raise DagsterInvalidDefinitionError(
-                "Expected node parameter to be str for DependencyDefinition"
-            )
-
-        node = node or solid
         return super(DependencyDefinition, cls).__new__(
             cls,
             check.str_param(node, "node"),

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -45,7 +45,6 @@ def build_resources(
     resource_config: Optional[Mapping[str, Any]] = None,
     dagster_run: Optional[DagsterRun] = None,
     log_manager: Optional[DagsterLogManager] = None,
-    pipeline_run: Optional[DagsterRun] = None,
 ) -> Generator[Resources, None, None]:
     """Context manager that yields resources using provided resource definitions and run config.
 
@@ -83,7 +82,6 @@ def build_resources(
                 assert resources.from_val == "bar"
 
     """
-    dagster_run = dagster_run or pipeline_run
     resources = check.mapping_param(resources, "resource_defs", key_type=str)
     instance = check.opt_inst_param(instance, "instance", DagsterInstance)
     resource_config = check.opt_mapping_param(resource_config, "resource_config", key_type=str)

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -721,10 +721,6 @@ class RunRecord(
             end_time=check.opt_float_param(end_time, "end_time"),
         )
 
-    @property
-    def pipeline_run(self) -> DagsterRun:
-        return self.dagster_run
-
 
 @whitelist_for_serdes
 class RunPartitionData(


### PR DESCRIPTION
### Summary & Motivation

This PR removes a collection of symbols deprecated up to 1.2:

- `DependencyDefinition.solid` (background: https://github.com/dagster-io/dagster/pull/12338#discussion_r1107593259)
- `RunRecord.pipeline_run`
- `build_resources(..., pipeline_run, ...)`
- `pipeline_name` on `@{hourly,daily,monthly,weekly}_schedule` decorators

### How I Tested These Changes

BK
