### PR TITLE
refactor(databricks): consolidate types

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -18,11 +18,6 @@ from .databricks_pyspark_step_launcher import (
 )
 from .ops import create_databricks_job_op
 from .resources import databricks_client
-from .types import (
-    DATABRICKS_RUN_TERMINATED_STATES,
-    DatabricksRunLifeCycleState,
-    DatabricksRunResultState,
-)
 from .version import __version__
 
 DagsterLibraryRegistry.register("dagster-databricks", __version__)
@@ -36,7 +31,4 @@ __all__ = [
     "DatabricksJobRunner",
     "DatabricksPySparkStepLauncher",
     "databricks_pyspark_step_launcher",
-    "DATABRICKS_RUN_TERMINATED_STATES",
-    "DatabricksRunLifeCycleState",
-    "DatabricksRunResultState",
 ]

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
@@ -7,10 +7,13 @@ class DatabricksRunResultState(str, Enum):
     See https://docs.databricks.com/dev-tools/api/2.0/jobs.html#runresultstate.
     """
 
-    Success = "SUCCESS"
-    Failed = "FAILED"
-    TimedOut = "TIMEDOUT"
-    Canceled = "CANCELED"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    TIMEDOUT = "TIMEDOUT"
+    CANCELED = "CANCELED"
+
+    def is_successful(self) -> bool:
+        return self == DatabricksRunResultState.SUCCESS
 
 
 class DatabricksRunLifeCycleState(str, Enum):
@@ -18,19 +21,19 @@ class DatabricksRunLifeCycleState(str, Enum):
     See https://docs.databricks.com/dev-tools/api/2.0/jobs.html#jobsrunlifecyclestate.
     """
 
-    Pending = "PENDING"
-    Running = "RUNNING"
-    Terminating = "TERMINATING"
-    Terminated = "TERMINATED"
-    Skipped = "SKIPPED"
-    InternalError = "INTERNAL_ERROR"
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    TERMINATING = "TERMINATING"
+    TERMINATED = "TERMINATED"
+    SKIPPED = "SKIPPED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
 
-
-DATABRICKS_RUN_TERMINATED_STATES = [
-    DatabricksRunLifeCycleState.Terminating,
-    DatabricksRunLifeCycleState.Terminated,
-    DatabricksRunLifeCycleState.InternalError,
-]
+    def has_terminated(self) -> bool:
+        return self in [
+            DatabricksRunLifeCycleState.TERMINATING,
+            DatabricksRunLifeCycleState.TERMINATED,
+            DatabricksRunLifeCycleState.INTERNAL_ERROR,
+        ]
 
 
 class DatabricksRunState(NamedTuple):
@@ -42,8 +45,8 @@ class DatabricksRunState(NamedTuple):
 
     def has_terminated(self) -> bool:
         """Has the job terminated?"""
-        return self.life_cycle_state in DATABRICKS_RUN_TERMINATED_STATES
+        return self.life_cycle_state.has_terminated()
 
     def is_successful(self) -> bool:
         """Was the job successful?"""
-        return self.result_state == DatabricksRunResultState.Success
+        return bool(self.result_state and self.result_state.is_successful())

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -91,8 +91,8 @@ def test_databricks_wait_for_run(mock_submit_run, databricks_run_config):
     calls = {
         "num_calls": 0,
         "final_state": DatabricksRunState(
-            DatabricksRunLifeCycleState.Terminated,
-            DatabricksRunResultState.Success,
+            DatabricksRunLifeCycleState.TERMINATED,
+            DatabricksRunResultState.SUCCESS,
             "Finished",
         ),
     }
@@ -102,15 +102,15 @@ def test_databricks_wait_for_run(mock_submit_run, databricks_run_config):
 
         if calls["num_calls"] == 1:
             return DatabricksRunState(
-                DatabricksRunLifeCycleState.Pending,
+                DatabricksRunLifeCycleState.PENDING,
                 None,
-                None,
+                "",
             )
         elif calls["num_calls"] == 2:
             return DatabricksRunState(
-                DatabricksRunLifeCycleState.Running,
+                DatabricksRunLifeCycleState.RUNNING,
                 None,
-                None,
+                "",
             )
         else:
             return calls["final_state"]
@@ -120,8 +120,8 @@ def test_databricks_wait_for_run(mock_submit_run, databricks_run_config):
 
     calls["num_calls"] = 0
     calls["final_state"] = DatabricksRunState(
-        DatabricksRunLifeCycleState.Terminated,
-        DatabricksRunResultState.Failed,
+        DatabricksRunLifeCycleState.TERMINATED,
+        DatabricksRunResultState.FAILED,
         "Failed",
     )
     with pytest.raises(DatabricksError) as exc_info:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
@@ -31,8 +31,8 @@ def test_run_create_databricks_job_op(
     mock_submit_run.return_value = RUN_ID
     mock_get_run_state.return_value = DatabricksRunState(
         state_message="",
-        result_state=DatabricksRunResultState.Success,
-        life_cycle_state=DatabricksRunLifeCycleState.Terminated,
+        result_state=DatabricksRunResultState.SUCCESS,
+        life_cycle_state=DatabricksRunLifeCycleState.TERMINATED,
     )
 
     result = test_job.execute_in_process()

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -10,11 +10,13 @@ from dagster._utils.merger import deep_merge_dicts
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 from dagster_azure.adls2 import adls2_pickle_io_manager, adls2_resource
 from dagster_databricks import (
-    DatabricksRunLifeCycleState,
-    DatabricksRunResultState,
     databricks_pyspark_step_launcher,
 )
-from dagster_databricks.types import DatabricksRunState
+from dagster_databricks.types import (
+    DatabricksRunLifeCycleState,
+    DatabricksRunResultState,
+    DatabricksRunState,
+)
 from dagster_pyspark import DataFrame, pyspark_resource
 from pyspark.sql import Row
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
@@ -184,9 +186,9 @@ def test_pyspark_databricks(
     mock_submit_run.return_value = 12345
     mock_read_file.return_value = "somefilecontents".encode()
 
-    running_state = DatabricksRunState(DatabricksRunLifeCycleState.Running, None, "")
+    running_state = DatabricksRunState(DatabricksRunLifeCycleState.RUNNING, None, "")
     final_state = DatabricksRunState(
-        DatabricksRunLifeCycleState.Terminated, DatabricksRunResultState.Success, ""
+        DatabricksRunLifeCycleState.TERMINATED, DatabricksRunResultState.SUCCESS, ""
     )
     mock_get_run_state.side_effect = [running_state] * 5 + [final_state]
 


### PR DESCRIPTION
### Summary & Motivation
We shouldn't need to export our internal representations about the Databricks API.

### How I Tested These Changes
pytest
