### PR TITLE
Fix intermittent dynamic partitions table SQLite concurrency error

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -184,6 +184,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     or "table event_logs already exists" in err_msg
                     or "table asset_event_tags already exists" in err_msg
                     or "table alembic_version already exists" in err_msg
+                    or "table dynamic_partitions already exists" in err_msg
                     or "database is locked" in err_msg
                     or "UNIQUE constraint failed: alembic_version.version_num" in err_msg
                 ):

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -1,6 +1,7 @@
 import glob
 import logging
 import os
+import re
 import sqlite3
 import threading
 import time
@@ -179,12 +180,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 err_msg = str(exc)
 
                 if not (
-                    "table asset_keys already exists" in err_msg
-                    or "table secondary_indexes already exists" in err_msg
-                    or "table event_logs already exists" in err_msg
-                    or "table asset_event_tags already exists" in err_msg
-                    or "table alembic_version already exists" in err_msg
-                    or "table dynamic_partitions already exists" in err_msg
+                    re.search(r"table [A-Za-z_]* already exists", err_msg)
                     or "database is locked" in err_msg
                     or "UNIQUE constraint failed: alembic_version.version_num" in err_msg
                 ):


### PR DESCRIPTION
[BK fails intermittently](https://buildkite.com/dagster/dagster/builds/49143#018656f4-c887-4210-99a8-0f4835e83021/253-1210) when different processes contend to create tables.

This PR adds the dynamic partitions table to the error list to prevent this test from failing spuriously.