### PR TITLE
[refactor] Context `solid` renames

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -829,7 +829,7 @@ class DagsterEvent(
     def step_input_event(
         step_context: StepExecutionContext, step_input_data: "StepInputData"
     ) -> "DagsterEvent":
-        input_def = step_context.solid_def.input_def_named(step_input_data.input_name)
+        input_def = step_context.op_def.input_def_named(step_input_data.input_name)
 
         return DagsterEvent.from_step(
             event_type=DagsterEventType.STEP_INPUT,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -230,7 +230,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         :meta private:
         """
-        return self._step_execution_context.solid_handle
+        return self._step_execution_context.node_handle
 
     @property
     def op_handle(self) -> NodeHandle:

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Sequence,
     Union,
-    cast,
 )
 
 import dagster._check as check
@@ -83,7 +82,7 @@ class InputContext:
         *,
         name: Optional[str] = None,
         job_name: Optional[str] = None,
-        solid_def: Optional["OpDefinition"] = None,
+        op_def: Optional["OpDefinition"] = None,
         config: Optional[Any] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         upstream_output: Optional["OutputContext"] = None,
@@ -92,7 +91,6 @@ class InputContext:
         resource_config: Optional[Mapping[str, Any]] = None,
         resources: Optional[Union["Resources", Mapping[str, Any]]] = None,
         step_context: Optional["StepExecutionContext"] = None,
-        op_def: Optional["OpDefinition"] = None,
         asset_key: Optional[AssetKey] = None,
         partition_key: Optional[str] = None,
         asset_partitions_subset: Optional[PartitionsSubset] = None,
@@ -104,10 +102,7 @@ class InputContext:
 
         self._name = name
         self._job_name = job_name
-        check.invariant(
-            solid_def is None or op_def is None, "Can't provide both a solid_def and an op_def arg"
-        )
-        self._solid_def = solid_def or op_def
+        self._op_def = op_def
         self._config = config
         self._metadata = metadata
         self._upstream_output = upstream_output
@@ -194,28 +189,16 @@ class InputContext:
     def pipeline_name(self) -> str:
         return self.job_name
 
-    @property
-    def solid_def(self) -> "OpDefinition":
-        if self._solid_def is None:
-            raise DagsterInvariantViolationError(
-                "Attempting to access solid_def, "
-                "but it was not provided when constructing the InputContext"
-            )
-
-        return self._solid_def
-
     @public
     @property
     def op_def(self) -> "OpDefinition":
-        from dagster._core.definitions import OpDefinition
-
-        if self._solid_def is None:
+        if self._op_def is None:
             raise DagsterInvariantViolationError(
                 "Attempting to access op_def, "
                 "but it was not provided when constructing the InputContext"
             )
 
-        return cast(OpDefinition, self._solid_def)
+        return self._op_def
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -619,7 +619,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         return InputContext(
             job_name=self.pipeline_def.name,
             name=name,
-            solid_def=self.op_def,
+            op_def=self.op_def,
             config=config,
             metadata=metadata,
             upstream_output=upstream_output,

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -111,7 +111,7 @@ def _validate_event(event: Any, step_context: StepExecutionContext) -> OpOutputU
             ).format(
                 described_node=step_context.describe_op(),
                 type_=type(event),
-                node_type=step_context.solid_def.node_type_str,
+                node_type=step_context.op_def.node_type_str,
             )
         )
 
@@ -143,7 +143,7 @@ def _yield_compute_results(
                 "its results"
             ).format(
                 described_node=step_context.describe_op(),
-                node_type=step_context.solid_def.node_type_str,
+                node_type=step_context.op_def.node_type_str,
             )
         )
 
@@ -161,7 +161,7 @@ def _yield_compute_results(
             msg_fn=lambda: f"Error occurred while executing {op_label}:",
             step_context=step_context,
             step_key=step_context.step.key,
-            op_def_name=step_context.solid_def.name,
+            op_def_name=step_context.op_def.name,
             op_name=step_context.solid.name,
         ),
         user_event_generator,
@@ -196,6 +196,6 @@ def execute_core_compute(
     omitted_outputs = solid_output_names.difference(emitted_result_names)
     if omitted_outputs:
         step_context.log.info(
-            f"{step_context.solid_def.node_type_str} '{str(step.node_handle)}' did not fire "
+            f"{step_context.op_def.node_type_str} '{str(step.node_handle)}' did not fire "
             f"outputs {repr(omitted_outputs)}"
         )

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -160,7 +160,7 @@ def _trigger_hook(
     step_context: StepExecutionContext, step_event_list: Sequence[DagsterEvent]
 ) -> Iterator[DagsterEvent]:
     """Trigger hooks and record hook's operatonal events."""
-    hook_defs = step_context.pipeline_def.get_all_hooks_for_handle(step_context.solid_handle)
+    hook_defs = step_context.pipeline_def.get_all_hooks_for_handle(step_context.node_handle)
     # when the solid doesn't have a hook configured
     if hook_defs is None:
         return

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -302,7 +302,7 @@ class FromRootInputManager(
             ),
         )
 
-        input_def = step_context.solid_def.input_def_named(input_def.name)
+        input_def = step_context.op_def.input_def_named(input_def.name)
 
         solid_config = step_context.resolved_run_config.ops.get(str(self.solid_handle))
         config_data = solid_config.inputs.get(self.input_name) if solid_config else None

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -294,10 +294,10 @@ class FromRootInputManager(
         from dagster._core.events import DagsterEvent
 
         check.invariant(
-            step_context.solid_handle == self.solid_handle and input_def.name == self.input_name,
+            step_context.node_handle == self.solid_handle and input_def.name == self.input_name,
             (
                 "RootInputManager source must be op input and not one along composition mapping. "
-                f"Loading for op {step_context.solid_handle}.{input_def.name} "
+                f"Loading for op {step_context.node_handle}.{input_def.name} "
                 f"but source is {self.solid_handle}.{self.input_name}."
             ),
         )
@@ -464,7 +464,7 @@ class FromStepOutput(
         resource_config = step_context.resolved_run_config.resources[resolved_io_manager_key].config
         resources = build_resources_for_manager(resolved_io_manager_key, step_context)
 
-        solid_config = step_context.resolved_run_config.ops.get(str(step_context.solid_handle))
+        solid_config = step_context.resolved_run_config.ops.get(str(step_context.node_handle))
         config_data = solid_config.inputs.get(input_def.name) if solid_config else None
 
         return step_context.for_input_manager(

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -235,7 +235,7 @@ def _handle_events_from_notebook(
 
     output_nb = scrapbook.read_notebook(executed_notebook_path)
 
-    for output_name, _ in step_context.solid_def.output_dict.items():
+    for output_name, _ in step_context.op_def.output_dict.items():
         data_dict = output_nb.scraps.data_dict
         if output_name in data_dict:
             # read outputs that were passed out of process via io manager from `yield_result`

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -141,7 +141,7 @@ def get_papermill_parameters(
         "run_config": step_context.run_config,
     }
 
-    dm_node_handle_kwargs = step_context.solid_handle._asdict()
+    dm_node_handle_kwargs = step_context.node_handle._asdict()
     dm_step_key = step_context.step.key
 
     parameters = {}

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -409,7 +409,7 @@ class Manager:
             check.failed("Expected DagstermillRuntimeExecutionContext")
         step_context = dm_context.step_context  # pylint: disable=protected-access
         step_input = step_context.step.step_input_named(input_name)
-        input_def = step_context.solid_def.input_def_named(input_name)
+        input_def = step_context.op_def.input_def_named(input_name)
         for event_or_input_value in step_input.source.load_input_object(step_context, input_def):
             if isinstance(event_or_input_value, DagsterEvent):
                 continue


### PR DESCRIPTION
### Summary & Motivation

- `IStepContext.solid_handle` -> `node_handle`
- Delete StepExecutionContext.solid_def (update references to `op_def`)
- Delete `InputContext.solid_def` (update references to `op_def`)
 
### How I Tested These Changes

BK
