### PR TITLE
refactor(databricks): use databricks_cli's raw api client

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -24,6 +24,7 @@ from dagster._core.execution.plan.external_step import (
 from dagster._serdes import deserialize_value
 from dagster._utils.backoff import backoff
 from dagster_pyspark.utils import build_pyspark_zip
+from databricks_cli.sdk import JobsService
 from requests import HTTPError
 
 from dagster_databricks import databricks_step_main
@@ -366,7 +367,9 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         # Retrieve run info
         cluster_id = None
         for i in range(1, request_retries + 1):
-            run_info = self.databricks_runner.client.get_run(databricks_run_id)
+            run_info = JobsService(self.databricks_runner.client.api_client).get_run(
+                databricks_run_id
+            )
             # if a new job cluster is created, the cluster_instance key may not be immediately present in the run response
             try:
                 cluster_id = run_info["cluster_instance"]["cluster_id"]

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -7,8 +7,9 @@ from dagster import (
     _check as check,
     op,
 )
+from databricks_cli.sdk import JobsService
 
-from .databricks import wait_for_run_to_complete
+from .databricks import DatabricksClient, wait_for_run_to_complete
 
 _START = "start"
 
@@ -100,8 +101,9 @@ def create_databricks_job_op(
     )
     def databricks_fn(context):
         job_config = context.op_config["job"]
-        databricks_client = context.resources.databricks_client
-        run_id = databricks_client.submit_run(**job_config)
+        databricks_client: DatabricksClient = context.resources.databricks_client
+
+        run_id = JobsService(databricks_client.api_client).submit_run(**job_config)["run_id"]
 
         context.log.info(
             "Launched databricks job with run id {run_id}. UI: {url}. Waiting to run to"

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -16,7 +16,7 @@ HOST = "https://uksouth.azuredatabricks.net"
 TOKEN = "super-secret-token"
 
 
-@mock.patch("dagster_databricks.databricks.DatabricksClient.submit_run")
+@mock.patch("databricks_cli.sdk.JobsService.submit_run")
 def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_config):
     mock_submit_run.return_value = {"run_id": 1}
 
@@ -46,7 +46,7 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
     )
 
 
-@mock.patch("dagster_databricks.databricks.DatabricksClient.submit_run")
+@mock.patch("databricks_cli.sdk.JobsService.submit_run")
 def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_config):
     mock_submit_run.return_value = {"run_id": 1}
 
@@ -79,9 +79,9 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
     )
 
 
-@mock.patch("dagster_databricks.databricks.DatabricksClient.submit_run")
+@mock.patch("databricks_cli.sdk.JobsService.submit_run")
 def test_databricks_wait_for_run(mock_submit_run, databricks_run_config):
-    mock_submit_run.return_value = 1
+    mock_submit_run.return_value = {"run_id": 1}
 
     context = create_test_pipeline_execution_context()
     runner = DatabricksJobRunner(HOST, TOKEN, poll_interval_sec=0.01)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
@@ -13,7 +13,7 @@ from dagster_databricks.types import (
 
 @pytest.mark.parametrize("job_creator", [create_databricks_job_op])
 @mock.patch("dagster_databricks.databricks.DatabricksClient.get_run_state")
-@mock.patch("dagster_databricks.databricks.DatabricksClient.submit_run")
+@mock.patch("databricks_cli.sdk.JobsService.submit_run")
 def test_run_create_databricks_job_op(
     mock_submit_run, mock_get_run_state, databricks_run_config, job_creator
 ):
@@ -28,7 +28,7 @@ def test_run_create_databricks_job_op(
         )()
 
     RUN_ID = 1
-    mock_submit_run.return_value = RUN_ID
+    mock_submit_run.return_value = {"run_id": RUN_ID}
     mock_get_run_state.return_value = DatabricksRunState(
         state_message="",
         result_state=DatabricksRunResultState.SUCCESS,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -167,11 +167,11 @@ def test_local():
     assert result.success
 
 
-@mock.patch("dagster_databricks.databricks.DatabricksClient.submit_run")
+@mock.patch("databricks_cli.sdk.JobsService.submit_run")
 @mock.patch("dagster_databricks.databricks.DatabricksClient.read_file")
 @mock.patch("dagster_databricks.databricks.DatabricksClient.put_file")
 @mock.patch("dagster_databricks.DatabricksPySparkStepLauncher.get_step_events")
-@mock.patch("dagster_databricks.databricks.DatabricksClient.get_run")
+@mock.patch("databricks_cli.sdk.JobsService.get_run")
 @mock.patch("dagster_databricks.databricks.DatabricksClient.get_run_state")
 @mock.patch("databricks_cli.sdk.api_client.ApiClient.perform_query")
 def test_pyspark_databricks(
@@ -183,7 +183,7 @@ def test_pyspark_databricks(
     mock_read_file,
     mock_submit_run,
 ):
-    mock_submit_run.return_value = 12345
+    mock_submit_run.return_value = {"run_id": 12345}
     mock_read_file.return_value = "somefilecontents".encode()
 
     running_state = DatabricksRunState(DatabricksRunLifeCycleState.RUNNING, None, "")


### PR DESCRIPTION
### Summary & Motivation
Use `XXXService` when possible to start removing the trivial uses of `DatabricksApi`. Also, remove unnecessary indrection in `DatabricksClient`.

### How I Tested These Changes
pytest
