### PR TITLE
Add text to timestamp dropdown

### DIFF
--- a/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
@@ -117,6 +117,7 @@ const EvaluateSchedule: React.FC<Props> = ({repoAddress, name, onClose, jobName}
     selectedTimestampRef.current = _selectedTimestamp || timestamps[0];
     return (
       <SelectWrapper>
+        <ScheduleDescriptor>Select a mock evaluation time</ScheduleDescriptor>
         <Popover
           isOpen={isTickSelectionOpen}
           position="bottom-left"
@@ -403,4 +404,8 @@ const Grid = styled.div`
   button {
     margin-top: 4px;
   }
+`;
+
+const ScheduleDescriptor = styled.div`
+  padding-bottom: 2px;
 `;


### PR DESCRIPTION
Adds some text to the timestamp dropdown of the schedule testing button to just provide a little more context.
![Screen Shot 2023-02-15 at 3 16 52 PM](https://user-images.githubusercontent.com/17576880/219214371-5a6aaac0-8d5f-42df-91c4-ee9bd015ab2a.png)
