### PR TITLE
[refactor] assorted Dagstermill renames

### DIFF
--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -27,8 +27,8 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         pipeline_context: PlanExecutionContext,
         pipeline_def: PipelineDefinition,
         resource_keys_to_init: AbstractSet[str],
-        solid_name: str,
-        solid_handle: NodeHandle,
+        op_name: str,
+        node_handle: NodeHandle,
         op_config: Any = None,
     ):
         self._pipeline_context = check.inst_param(
@@ -38,8 +38,8 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         self._resource_keys_to_init = check.set_param(
             resource_keys_to_init, "resource_keys_to_init", of_type=str
         )
-        self.solid_name = check.str_param(solid_name, "solid_name")
-        self.solid_handle = check.inst_param(solid_handle, "solid_handle", NodeHandle)
+        self.op_name = check.str_param(op_name, "op_name")
+        self.node_handle = check.inst_param(node_handle, "node_handle", NodeHandle)
         self._op_config = op_config
 
     def has_tag(self, key: str) -> bool:
@@ -172,35 +172,21 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         In interactive contexts, this may be a dagstermill-specific shim, depending whether an
         op definition was passed to ``dagstermill.get_context``.
         """
-        return cast(OpDefinition, self._pipeline_def.solid_def_named(self.solid_name))
+        return cast(OpDefinition, self._pipeline_def.solid_def_named(self.op_name))
 
     @property
-    def solid_def(self) -> OpDefinition:
-        """:class:`dagster.SolidDefinition`: The solid definition for the context.
-
-        In interactive contexts, this may be a dagstermill-specific shim, depending whether a
-        solid definition was passed to ``dagstermill.get_context``.
-        """
-        deprecation_warning(
-            "DagstermillExecutionContext.solid_def",
-            "0.17.0",
-            "use the 'op_def' property instead.",
-        )
-        return cast(OpDefinition, self._pipeline_def.solid_def_named(self.solid_name))
-
-    @property
-    def solid(self) -> Node:
+    def node(self) -> Node:
         """:class:`dagster.Node`: The solid for the context.
 
-        In interactive contexts, this may be a dagstermill-specific shim, depending whether a
-        solid definition was passed to ``dagstermill.get_context``.
+        In interactive contexts, this may be a dagstermill-specific shim, depending whether an
+        op definition was passed to ``dagstermill.get_context``.
         """
         deprecation_warning(
             "DagstermillExecutionContext.solid_def",
             "0.17.0",
             "use the 'op_def' property instead.",
         )
-        return self.pipeline_def.get_solid(self.solid_handle)
+        return self.pipeline_def.get_solid(self.node_handle)
 
     @public
     @property
@@ -211,7 +197,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
         if self._op_config:
             return self._op_config
 
-        op_config = self.resolved_run_config.ops.get(self.solid_name)
+        op_config = self.resolved_run_config.ops.get(self.op_name)
         return op_config.config if op_config else None
 
 
@@ -221,9 +207,9 @@ class DagstermillRuntimeExecutionContext(DagstermillExecutionContext):
         pipeline_context: PlanExecutionContext,
         pipeline_def: PipelineDefinition,
         resource_keys_to_init: AbstractSet[str],
-        solid_name: str,
+        op_name: str,
         step_context: StepExecutionContext,
-        solid_handle: NodeHandle,
+        node_handle: NodeHandle,
         op_config: Any = None,
     ):
         self._step_context = check.inst_param(step_context, "step_context", StepExecutionContext)
@@ -231,8 +217,8 @@ class DagstermillRuntimeExecutionContext(DagstermillExecutionContext):
             pipeline_context,
             pipeline_def,
             resource_keys_to_init,
-            solid_name,
-            solid_handle,
+            op_name,
+            node_handle,
             op_config,
         )
 

--- a/python_modules/libraries/dagstermill/dagstermill/context.py
+++ b/python_modules/libraries/dagstermill/dagstermill/context.py
@@ -176,7 +176,7 @@ class DagstermillExecutionContext(AbstractComputeExecutionContext):
 
     @property
     def node(self) -> Node:
-        """:class:`dagster.Node`: The solid for the context.
+        """:class:`dagster.Node`: The node for the context.
 
         In interactive contexts, this may be a dagstermill-specific shim, depending whether an
         op definition was passed to ``dagstermill.get_context``.

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -141,7 +141,7 @@ def get_papermill_parameters(
         "run_config": step_context.run_config,
     }
 
-    dm_solid_handle_kwargs = step_context.solid_handle._asdict()
+    dm_node_handle_kwargs = step_context.solid_handle._asdict()
     dm_step_key = step_context.step.key
 
     parameters = {}
@@ -149,7 +149,7 @@ def get_papermill_parameters(
     parameters["__dm_context"] = dm_context_dict
     parameters["__dm_executable_dict"] = dm_executable_dict
     parameters["__dm_pipeline_run_dict"] = pack_value(step_context.pipeline_run)
-    parameters["__dm_solid_handle_kwargs"] = dm_solid_handle_kwargs
+    parameters["__dm_node_handle_kwargs"] = dm_node_handle_kwargs
     parameters["__dm_instance_ref_dict"] = pack_value(step_context.instance.get_ref())
     parameters["__dm_step_key"] = dm_step_key
     parameters["__dm_input_names"] = list(inputs.keys())

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -181,13 +181,13 @@ class Manager:
             self.context = DagstermillRuntimeExecutionContext(
                 pipeline_context=pipeline_context,
                 pipeline_def=pipeline_def,
-                op_config=run_config.get("ops", {}).get(solid.name, {}).get("config"),
+                node_handle=run_config.get("ops", {}).get(solid.name, {}).get("config"),
                 resource_keys_to_init=get_required_resource_keys_to_init(
                     execution_plan,
                     pipeline_def,
                     resolved_run_config,
                 ),
-                solid_name=solid.name,
+                op_name=solid.name,
                 solid_handle=solid_handle,
                 step_context=cast(
                     StepExecutionContext,
@@ -317,8 +317,8 @@ class Manager:
                     pipeline_def,
                     resolved_run_config,
                 ),
-                solid_name=solid_def.name,
-                solid_handle=NodeHandle(solid_def.name, parent=None),
+                op_name=solid_def.name,
+                node_handle=NodeHandle(solid_def.name, parent=None),
             )
 
         return self.context

--- a/python_modules/libraries/dagstermill/dagstermill/translator.py
+++ b/python_modules/libraries/dagstermill/dagstermill/translator.py
@@ -8,7 +8,7 @@ RESERVED_INPUT_NAMES = [
     "__dm_executable_dict",
     "__dm_json",
     "__dm_pipeline_run_dict",
-    "__dm_solid_handle_kwargs",
+    "__dm_node_handle_kwargs",
     "__dm_instance_ref_dict",
     "__dm_step_key",
     "__dm_input_names",
@@ -35,7 +35,7 @@ class DagsterTranslator(papermill.translators.PythonTranslator):
         assert "__dm_context" in parameters
         assert "__dm_executable_dict" in parameters
         assert "__dm_pipeline_run_dict" in parameters
-        assert "__dm_solid_handle_kwargs" in parameters
+        assert "__dm_node_handle_kwargs" in parameters
         assert "__dm_instance_ref_dict" in parameters
         assert "__dm_step_key" in parameters
         assert "__dm_input_names" in parameters
@@ -44,7 +44,7 @@ class DagsterTranslator(papermill.translators.PythonTranslator):
         pipeline_context_args = dict(
             executable_dict=parameters["__dm_executable_dict"],
             pipeline_run_dict=parameters["__dm_pipeline_run_dict"],
-            solid_handle_kwargs=parameters["__dm_solid_handle_kwargs"],
+            node_handle_kwargs=parameters["__dm_node_handle_kwargs"],
             instance_ref_dict=parameters["__dm_instance_ref_dict"],
             step_key=parameters["__dm_step_key"],
             **context_args,

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
@@ -44,11 +44,11 @@ def test_resources():
 
 
 def test_solid_def():
-    assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.solid_def, OpDefinition)
+    assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.op_def, OpDefinition)
 
 
 def test_solid():
-    assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.solid, Node)
+    assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.node, Node)
 
 
 def test_log(capsys):

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
@@ -36,18 +36,18 @@ def test_environment_config():
 def test_pipeline_def():
     assert BARE_OUT_OF_PIPELINE_CONTEXT.pipeline_def.name == "ephemeral_dagstermill_pipeline"
     assert len(BARE_OUT_OF_PIPELINE_CONTEXT.pipeline_def.solids) == 1
-    assert BARE_OUT_OF_PIPELINE_CONTEXT.pipeline_def.solids[0].name == "this_solid"
+    assert BARE_OUT_OF_PIPELINE_CONTEXT.pipeline_def.solids[0].name == "this_op"
 
 
 def test_resources():
     assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.resources, tuple)
 
 
-def test_solid_def():
+def test_op_def():
     assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.op_def, OpDefinition)
 
 
-def test_solid():
+def test_node():
     assert isinstance(BARE_OUT_OF_PIPELINE_CONTEXT.node, Node)
 
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -58,7 +58,7 @@ def in_job_manager(
             with safe_tempfile_path() as output_log_file_path:
                 context_dict = {
                     "pipeline_run_dict": pipeline_run_dict,
-                    "solid_handle_kwargs": node_handle._asdict(),
+                    "node_handle_kwargs": node_handle._asdict(),
                     "executable_dict": executable_dict,
                     "marshal_dir": marshal_dir,
                     "run_config": {},
@@ -123,7 +123,7 @@ def test_yield_unserializable_result():
             manager.yield_result(threading.Lock())
 
 
-def test_in_job_manager_bad_solid():
+def test_in_job_manager_bad_op():
     with pytest.raises(
         check.CheckError,
         match="hello_world_job has no op named foobar",
@@ -152,7 +152,7 @@ def test_in_job_manager_resources():
         assert len(manager.context.resources._asdict()) == 1
 
 
-def test_in_job_manager_solid_config():
+def test_in_job_manager_op_config():
     with in_job_manager() as manager:
         assert manager.context.op_config is None
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -26,7 +26,7 @@ from dagstermill.manager import Manager
 @contextlib.contextmanager
 def in_job_manager(
     pipeline_name="hello_world_job",
-    solid_handle=NodeHandle("hello_world", None),
+    node_handle=NodeHandle("hello_world", None),
     step_key="hello_world",
     executable_dict=None,
     mode=None,
@@ -58,7 +58,7 @@ def in_job_manager(
             with safe_tempfile_path() as output_log_file_path:
                 context_dict = {
                     "pipeline_run_dict": pipeline_run_dict,
-                    "solid_handle_kwargs": solid_handle._asdict(),
+                    "solid_handle_kwargs": node_handle._asdict(),
                     "executable_dict": executable_dict,
                     "marshal_dir": marshal_dir,
                     "run_config": {},
@@ -112,7 +112,7 @@ def test_yield_unserializable_result():
 
     with in_job_manager(
         pipeline_name="hello_world_output_job",
-        solid_handle=NodeHandle("hello_world_output", None),
+        node_handle=NodeHandle("hello_world_output", None),
         executable_dict=ReconstructablePipeline.for_module(
             "dagstermill.examples.repository",
             "hello_world_output_job",
@@ -128,7 +128,7 @@ def test_in_job_manager_bad_solid():
         check.CheckError,
         match="hello_world_job has no op named foobar",
     ):
-        with in_job_manager(solid_handle=NodeHandle("foobar", None)) as _manager:
+        with in_job_manager(node_handle=NodeHandle("foobar", None)) as _manager:
             pass
 
 
@@ -158,7 +158,7 @@ def test_in_job_manager_solid_config():
 
     with in_job_manager(
         pipeline_name="hello_world_config_job",
-        solid_handle=NodeHandle("hello_world_config", None),
+        node_handle=NodeHandle("hello_world_config", None),
         executable_dict=ReconstructablePipeline.for_module(
             "dagstermill.examples.repository",
             "hello_world_config_job",
@@ -169,7 +169,7 @@ def test_in_job_manager_solid_config():
 
     with in_job_manager(
         pipeline_name="hello_world_config_job",
-        solid_handle=NodeHandle("hello_world_config", None),
+        node_handle=NodeHandle("hello_world_config", None),
         run_config={
             "ops": {
                 "hello_world_config": {"config": {"greeting": "bonjour"}},
@@ -186,7 +186,7 @@ def test_in_job_manager_solid_config():
 
     with in_job_manager(
         pipeline_name="hello_world_config_job",
-        solid_handle=NodeHandle("goodbye_config", None),
+        node_handle=NodeHandle("goodbye_config", None),
         run_config={
             "ops": {
                 "hello_world_config": {
@@ -215,7 +215,7 @@ def test_in_job_manager_with_resources():
                 "dagstermill.examples.repository",
                 "resource_job",
             ).to_dict(),
-            solid_handle=NodeHandle("hello_world_resource", None),
+            node_handle=NodeHandle("hello_world_resource", None),
             run_config={"resources": {"list": {"config": path}}},
             step_key="hello_world_resource",
         ) as manager:


### PR DESCRIPTION
### Summary & Motivation

Eliminate all remaining `solid` references from `dagstermill` APIs/locals:

- `DagstermillExecutionContext`
    - `solid_handle` → `node_handle`
    - `solid_name` → `op_name`
    - `solid_def` (rm, update refs to `op_def`)
    - `solid` → `node`
- `Manager`
    - `solid_def` → `op_def`
- `solid_handle_kwargs` → `node_handle_kwargs`
- various locals

### How I Tested These Changes

BK
