### PR TITLE
[RFC] Add an is_test_evaluation property for sensor contexts

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -230,6 +230,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                     cursor=self._cursor,
                     last_completion_time=None,
                     last_run_key=None,
+                    is_test_evaluation=True,
                 )
             except Exception:
                 sensor_data = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1297,7 +1297,9 @@ def define_partitions():
 
 def define_sensors():
     @sensor(job_name="no_config_pipeline")
-    def always_no_config_sensor(_):
+    def always_no_config_sensor(context):
+        if context.is_test_evaluation:
+            context.instance.run_storage.kvs_set({"always_no_config_sensor": "in_test_eval"})
         return RunRequest(
             run_key=None,
             tags={"test": "1234"},

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -410,6 +410,9 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
         assert evaluation_result["skipReason"] is None
         assert evaluation_result["error"] is None
 
+        # The definition of always_no_config_sensor writes to kvs if within test evaluation - ensure that occurred.
+        assert graphql_context.instance.run_storage.kvs_get({"always_no_config_sensor"})["always_no_config_sensor"] == "in_test_eval"
+
     def test_dry_run_failure(self, graphql_context):
         instigator_selector = infer_sensor_selector(graphql_context, "always_error_sensor")
         result = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/_api/snapshot_sensor.py
@@ -50,12 +50,14 @@ def sync_get_external_sensor_execution_data_grpc(
     last_run_key: Optional[str],
     cursor: Optional[str],
     timeout: Optional[int] = DEFAULT_GRPC_TIMEOUT,
+    is_test_evaluation: bool = False,
 ) -> SensorExecutionData:
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(sensor_name, "sensor_name")
     check.opt_float_param(last_completion_time, "last_completion_time")
     check.opt_str_param(last_run_key, "last_run_key")
     check.opt_str_param(cursor, "cursor")
+    check.bool_param(is_test_evaluation, "is_test_evaluation")
 
     origin = repository_handle.get_external_origin()
 
@@ -68,6 +70,7 @@ def sync_get_external_sensor_execution_data_grpc(
                 last_completion_time=last_completion_time,
                 last_run_key=last_run_key,
                 cursor=cursor,
+                is_test_evaluation=is_test_evaluation,
             ),
             timeout=timeout,
         ),

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -293,6 +293,7 @@ def execute_preview_command(
                         since,
                         last_run_key,
                         cursor,
+                        is_test_evaluation=True,
                     )
                 except Exception:
                     error_info = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -217,6 +217,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         repository_def: "RepositoryDefinition",
         monitored_assets: Union[Sequence[AssetKey], AssetSelection],
         instance: Optional[DagsterInstance] = None,
+        is_test_evaluation: Optional[bool] = False,
     ):
         from dagster._core.storage.event_log.base import EventLogRecord
 
@@ -264,6 +265,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             repository_name=repository_name,
             instance=instance,
             repository_def=repository_def,
+            is_test_evaluation=is_test_evaluation,
         )
 
     def _cache_initial_unconsumed_events(self) -> None:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -102,6 +102,7 @@ class SensorEvaluationContext:
         repository_def: Optional["RepositoryDefinition"] = None,
         instance: Optional[DagsterInstance] = None,
         sensor_name: Optional[str] = None,
+        is_test_evaluation: bool = False,
     ):
         self._exit_stack = ExitStack()
         self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
@@ -124,6 +125,7 @@ class SensorEvaluationContext:
             else None
         )
         self._logger: Optional[InstigationLogger] = None
+        self._is_test_evaluation = is_test_evaluation
 
     def __enter__(self):
         return self
@@ -156,6 +158,15 @@ class SensorEvaluationContext:
     @property
     def last_completion_time(self) -> Optional[float]:
         return self._last_completion_time
+
+    @public
+    @property
+    def is_test_evaluation(self) -> bool:
+        """Returns True if this evaluation was kicked off from a dagster testing utility.
+
+        The dagster sensor testing utilities are direct invocation of a sensor via python, the dagster sensor preview CLI, and the Test sensor button in dagit.
+        """
+        return self._is_test_evaluation
 
     @public
     @property
@@ -650,6 +661,7 @@ def build_sensor_context(
         instance=instance,
         repository_def=repository_def,
         sensor_name=sensor_name,
+        is_test_evaluation=True,
     )
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -211,6 +211,7 @@ class RepositoryLocation(AbstractContextManager):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        is_test_evaluation: bool
     ) -> "SensorExecutionData":
         pass
 
@@ -500,6 +501,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        is_test_evaluation: bool = False
     ) -> "SensorExecutionData":
         result = get_external_sensor_execution(
             self._get_repo_def(repository_handle.repository_name),
@@ -508,6 +510,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             last_completion_time,
             last_run_key,
             cursor,
+            is_test_evaluation,
         )
         if isinstance(result, ExternalSensorExecutionErrorData):
             raise DagsterUserCodeProcessError.from_error_info(result.error)
@@ -847,6 +850,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        is_test_evaluation: bool,
     ) -> "SensorExecutionData":
         from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_grpc
 
@@ -858,6 +862,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
             last_completion_time,
             last_run_key,
             cursor,
+            is_test_evaluation=is_test_evaluation,
         )
 
     def get_external_partition_set_execution_param_data(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -556,6 +556,7 @@ def _evaluate_sensor(
         instigator_data.last_tick_timestamp if instigator_data else None,
         instigator_data.last_run_key if instigator_data else None,
         instigator_data.cursor if instigator_data else None,
+        is_test_evaluation=False,
     )
 
     yield

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -302,6 +302,7 @@ def get_external_sensor_execution(
     last_completion_timestamp: Optional[float],
     last_run_key: Optional[str],
     cursor: Optional[str],
+    is_test_evaluation: bool
 ):
     sensor_def = repo_def.get_sensor_def(sensor_name)
 
@@ -315,6 +316,7 @@ def get_external_sensor_execution(
                 repository_name=repo_def.name,
                 repository_def=repo_def,
                 sensor_name=sensor_name,
+                is_test_evaluation=is_test_evaluation
             )
         )
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -629,6 +629,7 @@ class DagsterApiServer(DagsterApiServicer):
                 args.last_completion_time,
                 args.last_run_key,
                 args.cursor,
+                args.is_test_evaluation,
             )
         )
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -536,6 +536,7 @@ class SensorExecutionArgs(
             ("last_completion_time", Optional[float]),
             ("last_run_key", Optional[str]),
             ("cursor", Optional[str]),
+            ("is_test_evaluation", bool)
         ],
     )
 ):
@@ -547,6 +548,7 @@ class SensorExecutionArgs(
         last_completion_time: Optional[float],
         last_run_key: Optional[str],
         cursor: Optional[str],
+        is_test_evaluation: bool,
     ):
         return super(SensorExecutionArgs, cls).__new__(
             cls,
@@ -560,6 +562,7 @@ class SensorExecutionArgs(
             ),
             last_run_key=check.opt_str_param(last_run_key, "last_run_key"),
             cursor=check.opt_str_param(cursor, "cursor"),
+            is_test_evaluation=check.bool_param(is_test_evaluation, "is_test_evaluation")
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -104,6 +104,13 @@ def test_sensor_invocation_args():
             context, _arbitrary_context=None
         )
 
+def test_basic_sensor_test_evaluation():
+    @sensor(job_name="irrelevant")
+    def the_sensor(context):
+        assert context.is_test_evaluation
+
+    the_sensor(None)
+    the_sensor(build_sensor_context())
 
 def test_instance_access_built_sensor():
     with pytest.raises(
@@ -145,6 +152,7 @@ def test_sensor_w_no_job():
 def test_run_status_sensor():
     @run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
     def status_sensor(context):
+        assert context.is_test_evaluation
         assert context.dagster_event.event_type_value == "PIPELINE_SUCCESS"
 
     @op
@@ -174,6 +182,7 @@ def test_run_status_sensor():
 def test_run_failure_sensor():
     @run_failure_sensor
     def failure_sensor(context):
+        assert context.is_test_evaluation
         assert context.dagster_event.event_type_value == "PIPELINE_FAILURE"
 
     @op
@@ -278,6 +287,7 @@ def test_run_failure_w_run_request():
 def test_freshness_policy_sensor():
     @freshness_policy_sensor(asset_selection=AssetSelection.all())
     def freshness_sensor(context):
+        assert context.is_test_evaluation
         assert context.minutes_late == 10
         assert context.previous_minutes_late is None
 
@@ -331,6 +341,7 @@ def test_multi_asset_sensor():
 
     @multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
     def a_and_b_sensor(context):
+        assert context.is_test_evaluation
         asset_events = context.latest_materialization_records_by_key()
         if all(asset_events.values()):
             context.advance_all_cursors()

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -772,6 +772,7 @@ def test_sensor_timeout():
                         last_completion_time=None,
                         last_run_key=None,
                         cursor=None,
+                        is_test_evaluation=False,
                     ),
                     timeout=2,
                 )
@@ -787,6 +788,7 @@ def test_sensor_timeout():
                     last_completion_time=None,
                     last_run_key=None,
                     cursor=None,
+                    is_test_evaluation=False,
                 ),
             )
     finally:


### PR DESCRIPTION
When evaluating a sensor, there's currently no way to avoid side effects. Adding this property would allow users to gate side effect behavior to not occur during test runs (namely test sensor / schedule button, direct invocation, sensor preview).

This is somewhat similar to just including mocked resources, but I think that there's a distinct set of scenarios where you might want to test run things on real data / real infrastructure, but not actually risk messing up anything in prod. 

Curious what folks think of this pattern. Could imagine including something similar for jobs / assets when using the launchpad for example, but some folks use the launchpad for prod use cases, and arguably config can serve the same purpose.