### PR TITLE
updates tests to handle new kubernetes resources field

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_k8s_config_tag.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_k8s_config_tag.py
@@ -17,8 +17,11 @@ def test_k8s_tag_job():
     job = construct_dagster_k8s_job(
         cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
     )
-
-    assert job.to_dict()["spec"]["template"]["spec"]["containers"][0]["resources"] == {
+    resolved_resources = job.to_dict()["spec"]["template"]["spec"]["containers"][0][
+        "resources"
+    ]
+    resolved_resources.pop("claims", None)
+    assert resolved_resources == {
         "requests": {"cpu": "250m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "2560Mi"},
     }
@@ -36,8 +39,11 @@ def test_k8s_tag_op():
     job = construct_dagster_k8s_job(
         cfg, [], "job123", user_defined_k8s_config=user_defined_cfg
     )
-
-    assert job.to_dict()["spec"]["template"]["spec"]["containers"][0]["resources"] == {
+    resolved_resources = job.to_dict()["spec"]["template"]["spec"]["containers"][0][
+        "resources"
+    ]
+    resolved_resources.pop("claims", None)
+    assert resolved_resources == {
         "requests": {"cpu": "200m", "memory": "32Mi"},
         "limits": None,
     }

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -374,7 +374,9 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             container = kwargs["body"].spec.template.spec.containers[0]
 
             job_resources = container.resources
-            assert job_resources.to_dict() == expected_resources
+            resolved_resources = job_resources.to_dict()
+            resolved_resources.pop("claims", None)  # remove claims if returned
+            assert resolved_resources == expected_resources
 
             labels = kwargs["body"].spec.template.metadata.labels
             assert labels["foo_label_key"] == "bar_label_value"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -393,8 +393,9 @@ def test_step_handler_user_defined_config(kubeconfig_file, k8s_instance):
         method_name, _args, kwargs = mock_method_calls[0]
         assert method_name == "create_namespaced_job"
         assert kwargs["body"].spec.template.spec.containers[0].image == "bizbuz"
-        job_resources = kwargs["body"].spec.template.spec.containers[0].resources
-        assert job_resources.to_dict() == RESOURCE_TAGS
+        job_resources = kwargs["body"].spec.template.spec.containers[0].resources.to_dict()
+        job_resources.pop("claims", None)
+        assert job_resources == RESOURCE_TAGS
 
         env_vars = {
             env.name: env.value for env in kwargs["body"].spec.template.spec.containers[0].env

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -147,8 +147,9 @@ def test_launcher_with_container_context(kubeconfig_file):
 
         container = kwargs["body"].spec.template.spec.containers[0]
 
-        resources = container.resources
-        assert resources.to_dict() == {
+        resources = container.resources.to_dict()
+        resources.pop("claims", None)
+        assert resources == {
             "limits": {"memory": "64Mi", "cpu": "250m"},
             "requests": {"memory": "32Mi", "cpu": "125m"},
         }
@@ -349,7 +350,10 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
         container = kwargs["body"].spec.template.spec.containers[0]
 
         job_resources = container.resources
-        assert job_resources.to_dict() == expected_resources
+        resolved_resources = job_resources.to_dict()
+        resolved_resources.pop("claims", None)  # remove claims if returned
+        assert resolved_resources == expected_resources
+
         assert DAGSTER_PG_PASSWORD_ENV_VAR in [env.name for env in container.env]
         assert "DAGSTER_RUN_JOB_NAME" in [env.name for env in container.env]
 


### PR DESCRIPTION
kubernetes 26.1.0 has started returning a "claims" section for resources for a new alpha feature 
https://github.com/kubernetes-client/python/blame/master/kubernetes/docs/V1ResourceRequirements.md#L7

this PR just pops the key out for existing comparisons with expected requests & limits  

### How I Tested These Changes

bk
