### PR TITLE
Auto infer multipartition <-> single dimension mapping

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -253,6 +253,7 @@ from dagster._core.definitions.partition_mapping import (
     LastPartitionMapping as LastPartitionMapping,
     PartitionMapping as PartitionMapping,
     StaticPartitionMapping as StaticPartitionMapping,
+    SingleDimensionDependencyMapping as SingleDimensionDependencyMapping,
 )
 from dagster._core.definitions.partitioned_schedule import (
     build_schedule_from_partitioned_job as build_schedule_from_partitioned_job,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -251,6 +251,7 @@ from dagster._core.definitions.partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
+    MultiToSingleDimensionMapping as MultiToSingleDimensionMapping,
     PartitionMapping as PartitionMapping,
     StaticPartitionMapping as StaticPartitionMapping,
 )

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -253,7 +253,6 @@ from dagster._core.definitions.partition_mapping import (
     LastPartitionMapping as LastPartitionMapping,
     PartitionMapping as PartitionMapping,
     StaticPartitionMapping as StaticPartitionMapping,
-    SingleDimensionDependencyMapping as SingleDimensionDependencyMapping,
 )
 from dagster._core.definitions.partitioned_schedule import (
     build_schedule_from_partitioned_job as build_schedule_from_partitioned_job,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -251,7 +251,7 @@ from dagster._core.definitions.partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
-    MultiToSingleDimensionMapping as MultiToSingleDimensionMapping,
+    MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
     StaticPartitionMapping as StaticPartitionMapping,
 )

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -170,6 +170,7 @@ from .partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
+    MultiToSingleDimensionMapping as MultiToSingleDimensionMapping,
     PartitionMapping as PartitionMapping,
 )
 from .partitioned_schedule import (

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -170,7 +170,7 @@ from .partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
-    MultiToSingleDimensionMapping as MultiToSingleDimensionMapping,
+    MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
 )
 from .partitioned_schedule import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -134,9 +134,12 @@ class AssetGraph:
     def get_partition_mapping(
         self, asset_key: AssetKey, in_asset_key: AssetKey
     ) -> PartitionMapping:
-        partitions_def = self.get_partitions_def(asset_key)
         partition_mappings = self._partition_mappings_by_key.get(asset_key) or {}
-        return infer_partition_mapping(partition_mappings.get(in_asset_key), partitions_def)
+        return infer_partition_mapping(
+            partition_mappings.get(in_asset_key),
+            self.get_partitions_def(asset_key),
+            self.get_partitions_def(in_asset_key),
+        )
 
     def is_partitioned(self, asset_key: AssetKey) -> bool:
         return self.get_partitions_def(asset_key) is not None

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -615,12 +615,16 @@ class AssetsDefinition(ResourceAddable):
     def get_partition_mapping_for_input(self, input_name: str) -> Optional[PartitionMapping]:
         return self._partition_mappings.get(self._keys_by_input_name[input_name])
 
-    def infer_partition_mapping(self, in_asset_key: AssetKey) -> PartitionMapping:
+    def infer_partition_mapping(
+        self, upstream_asset_key: AssetKey, upstream_partitions_def: Optional[PartitionsDefinition]
+    ) -> PartitionMapping:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
-            partition_mapping = self._partition_mappings.get(in_asset_key)
-            return infer_partition_mapping(partition_mapping, self._partitions_def)
+            partition_mapping = self._partition_mappings.get(upstream_asset_key)
+            return infer_partition_mapping(
+                partition_mapping, self._partitions_def, upstream_partitions_def
+            )
 
     def get_output_name_for_asset_key(self, key: AssetKey) -> str:
         for output_name, asset_key in self.keys_by_output_name.items():

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -779,7 +779,7 @@ class MultiDependencyDefinition(
                 if key in seen:
                     raise DagsterInvalidDefinitionError(
                         f'Duplicate dependencies on node "{dep.node}" output "{dep.output}" '
-                        'used in the same MultiDependencyDefinition.'
+                        "used in the same MultiDependencyDefinition."
                     )
                 seen[key] = True
             elif dep is MappedInputPlaceholder:
@@ -911,14 +911,14 @@ class DependencyStructure:
                         raise DagsterInvalidDefinitionError(
                             "Currently, items in a fan-in dependency cannot be downstream of"
                             " dynamic outputs. Problematic dependency on dynamic output"
-                            f" \"{node_output.describe()}\"."
+                            f' "{node_output.describe()}".'
                         )
                     if self._dynamic_fan_out_index.get(node_output.node_name):
                         raise DagsterInvalidDefinitionError(
                             "Currently, items in a fan-in dependency cannot be downstream of"
                             " dynamic outputs. Problematic dependency on output"
-                            f" \"{node_output.describe()}\", downstream of"
-                            f" \"{self._dynamic_fan_out_index[node_output.node_name].describe()}\"."
+                            f' "{node_output.describe()}", downstream of'
+                            f' "{self._dynamic_fan_out_index[node_output.node_name].describe()}".'
                         )
 
                     node_output_list.append(node_output)
@@ -963,7 +963,7 @@ class DependencyStructure:
         if not node_input.node.definition.input_supports_dynamic_output_dep(node_input.input_name):
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be downstream of dynamic output"
-                f" \"{node_output.describe()}\" since input \"{node_input.input_name}\" maps to a"
+                f' "{node_output.describe()}" since input "{node_input.input_name}" maps to a'
                 " node that is already downstream of another dynamic output. Nodes cannot be"
                 " downstream of more than one dynamic output"
             )
@@ -982,8 +982,8 @@ class DependencyStructure:
         if self._dynamic_fan_out_index[node_input.node_name] != node_output:
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be downstream of more than one dynamic"
-                f" output. It is downstream of both \"{node_output.describe()}\" and"
-                f" \"{self._dynamic_fan_out_index[node_input.node_name].describe()}\""
+                f' output. It is downstream of both "{node_output.describe()}" and'
+                f' "{self._dynamic_fan_out_index[node_input.node_name].describe()}"'
             )
 
     def _validate_and_set_collect(
@@ -1004,8 +1004,8 @@ class DependencyStructure:
         if self._dynamic_fan_out_index.get(node_output.node_name):
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be downstream of more than one dynamic"
-                f" output. It is downstream of both \"{node_output.describe()}\" and"
-                f" \"{self._dynamic_fan_out_index[node_output.node_name].describe()}\""
+                f' output. It is downstream of both "{node_output.describe()}" and'
+                f' "{self._dynamic_fan_out_index[node_output.node_name].describe()}"'
             )
 
     def all_upstream_outputs_from_node(self, node_name: str) -> Sequence[NodeOutput]:

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -779,7 +779,7 @@ class MultiDependencyDefinition(
                 if key in seen:
                     raise DagsterInvalidDefinitionError(
                         f'Duplicate dependencies on node "{dep.node}" output "{dep.output}" '
-                        "used in the same MultiDependencyDefinition."
+                        'used in the same MultiDependencyDefinition.'
                     )
                 seen[key] = True
             elif dep is MappedInputPlaceholder:
@@ -911,14 +911,14 @@ class DependencyStructure:
                         raise DagsterInvalidDefinitionError(
                             "Currently, items in a fan-in dependency cannot be downstream of"
                             " dynamic outputs. Problematic dependency on dynamic output"
-                            f' "{node_output.describe()}".'
+                            f" \"{node_output.describe()}\"."
                         )
                     if self._dynamic_fan_out_index.get(node_output.node_name):
                         raise DagsterInvalidDefinitionError(
                             "Currently, items in a fan-in dependency cannot be downstream of"
                             " dynamic outputs. Problematic dependency on output"
-                            f' "{node_output.describe()}", downstream of'
-                            f' "{self._dynamic_fan_out_index[node_output.node_name].describe()}".'
+                            f" \"{node_output.describe()}\", downstream of"
+                            f" \"{self._dynamic_fan_out_index[node_output.node_name].describe()}\"."
                         )
 
                     node_output_list.append(node_output)
@@ -963,9 +963,9 @@ class DependencyStructure:
         if not node_input.node.definition.input_supports_dynamic_output_dep(node_input.input_name):
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be downstream of dynamic output"
-                f' "{node_output.describe()}" since input "{node_input.input_name}" maps to a node'
-                " that is already downstream of another dynamic output. Nodes cannot be downstream"
-                " of more than one dynamic output"
+                f" \"{node_output.describe()}\" since input \"{node_input.input_name}\" maps to a"
+                " node that is already downstream of another dynamic output. Nodes cannot be"
+                " downstream of more than one dynamic output"
             )
 
         if self._collect_index.get(node_input.node_name):
@@ -982,8 +982,8 @@ class DependencyStructure:
         if self._dynamic_fan_out_index[node_input.node_name] != node_output:
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be downstream of more than one dynamic"
-                f' output. It is downstream of both "{node_output.describe()}" and'
-                f' "{self._dynamic_fan_out_index[node_input.node_name].describe()}"'
+                f" output. It is downstream of both \"{node_output.describe()}\" and"
+                f" \"{self._dynamic_fan_out_index[node_input.node_name].describe()}\""
             )
 
     def _validate_and_set_collect(
@@ -1004,8 +1004,8 @@ class DependencyStructure:
         if self._dynamic_fan_out_index.get(node_output.node_name):
             raise DagsterInvalidDefinitionError(
                 f"{node_input.node.describe_node()} cannot be downstream of more than one dynamic"
-                f' output. It is downstream of both "{node_output.describe()}" and'
-                f' "{self._dynamic_fan_out_index[node_output.node_name].describe()}"'
+                f" output. It is downstream of both \"{node_output.describe()}\" and"
+                f" \"{self._dynamic_fan_out_index[node_output.node_name].describe()}\""
             )
 
     def all_upstream_outputs_from_node(self, node_name: str) -> Sequence[NodeOutput]:

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -708,7 +708,9 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 f"Asset key {from_asset_key} is not partitioned. Cannot get partition keys."
             )
 
-        partition_mapping = to_asset.infer_partition_mapping(from_asset_key)
+        partition_mapping = to_asset.infer_partition_mapping(
+            from_asset_key, from_asset.partitions_def
+        )
         downstream_partition_key_subset = (
             partition_mapping.get_downstream_partitions_for_partitions(
                 from_asset.partitions_def.empty_subset().with_partition_keys([partition_key]),

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -278,11 +278,6 @@ class PartitionsDefinition(ABC, Generic[T]):
         else:
             return None
 
-    def get_default_partition_mapping(self):
-        from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
-
-        return IdentityPartitionMapping()
-
     def get_partition_keys_in_range(
         self,
         partition_key_range: PartitionKeyRange,

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -267,7 +267,11 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
 
 
 @experimental
-class SingleDimensionDependencyMapping(PartitionMapping):
+@whitelist_for_serdes
+class SingleDimensionDependencyMapping(
+    PartitionMapping,
+    NamedTuple("_SingleDimensionDependencyMapping", [("partition_dimension_name", str)]),
+):
     """
     Defines a correspondence between an upstream single-dimensional partitions definition
     and a downstream MultiPartitionsDefinition. The upstream partitions definition must be
@@ -281,8 +285,13 @@ class SingleDimensionDependencyMapping(PartitionMapping):
             MultiPartitionsDefinition that matches the upstream partitions definition.
     """
 
-    def __init__(self, partition_dimension_name: str):
-        self.partition_dimension_name = partition_dimension_name
+    def __new__(cls, partition_dimension_name: str):
+        return super(SingleDimensionDependencyMapping, cls).__new__(
+            cls,
+            partition_dimension_name=check.str_param(
+                partition_dimension_name, "partition_dimension_name"
+            ),
+        )
 
     def _check_upstream_partitions_def_equals_selected_dimension(
         self,
@@ -524,4 +533,5 @@ def get_builtin_partition_mapping_types() -> Tuple[Type[PartitionMapping], ...]:
         LastPartitionMapping,
         StaticPartitionMapping,
         TimeWindowPartitionMapping,
+        SingleDimensionDependencyMapping,
     )

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -430,13 +430,6 @@ class TimeWindowPartitionsDefinition(
     def end_time_for_partition_key(self, partition_key: str) -> datetime:
         return self.time_window_for_partition_key(partition_key).end
 
-    def get_default_partition_mapping(self):
-        from dagster._core.definitions.time_window_partition_mapping import (
-            TimeWindowPartitionMapping,
-        )
-
-        return TimeWindowPartitionMapping()
-
     def get_partition_keys_in_time_window(self, time_window: TimeWindow) -> Sequence[str]:
         result: List[str] = []
         for partition_time_window in self._iterate_time_windows(time_window.start):

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -443,9 +443,10 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         """Returns a list of the partition keys of the upstream asset corresponding to the
         given input.
         """
-        return self.asset_partitions_def_for_input(input_name).get_partition_keys_in_range(
-            self._step_execution_context.asset_partition_key_range_for_input(input_name),
-            dynamic_partitions_store=self.instance,
+        return list(
+            self._step_execution_context.asset_partitions_subset_for_input(
+                input_name
+            ).get_partition_keys()
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -934,6 +934,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                         self.node_handle, upstream_asset_key
                     ),
                     partitions_def,
+                    upstream_asset_partitions_def,
                 )
                 return partition_mapping.get_upstream_partitions_for_partitions(
                     partitions_subset,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -9,19 +9,25 @@ from dagster import (
     AssetOut,
     AssetsDefinition,
     DailyPartitionsDefinition,
+    IdentityPartitionMapping,
     IOManager,
     IOManagerDefinition,
     LastPartitionMapping,
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
+    MultiToSingleDimensionMapping,
     Output,
     PartitionsDefinition,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
     WeeklyPartitionsDefinition,
+    define_asset_job,
     graph,
     materialize,
     op,
 )
 from dagster._core.definitions import asset, build_assets_job, multi_asset
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import (
@@ -586,3 +592,147 @@ def test_exported_partition_mappings_whitelisted():
     } - {PartitionMapping}
 
     assert set(get_builtin_partition_mapping_types()) == exported_partition_mapping_classes
+
+
+def test_multipartitions_def_partition_mapping_infer_identity():
+    composite = MultiPartitionsDefinition(
+        {
+            "abc": StaticPartitionsDefinition(["a", "b", "c"]),
+            "123": StaticPartitionsDefinition(["1", "2", "3"]),
+        }
+    )
+
+    @asset(partitions_def=composite)
+    def upstream(context):
+        return 1
+
+    @asset(partitions_def=composite)
+    def downstream(context, upstream):
+        assert (
+            context.asset_partition_keys_for_input("upstream")
+            == context.asset_partition_keys_for_output()
+        )
+        return 1
+
+    assets_job = define_asset_job("foo", [upstream, downstream]).resolve([upstream, downstream], [])
+    asset_graph = AssetGraph.from_assets([upstream, downstream])
+
+    assert (
+        asset_graph.get_partition_mapping(upstream.key, downstream.key)
+        == IdentityPartitionMapping()
+    )
+    assert assets_job.execute_in_process(
+        partition_key=MultiPartitionKey({"abc": "a", "123": "1"})
+    ).success
+
+
+def test_multipartitions_def_partition_mapping_infer_single_dim_to_multi():
+    abc_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    composite = MultiPartitionsDefinition(
+        {
+            "abc": abc_def,
+            "123": StaticPartitionsDefinition(["1", "2", "3"]),
+        }
+    )
+
+    @asset(partitions_def=abc_def)
+    def upstream(context):
+        assert context.asset_partition_keys_for_output("result") == ["a"]
+        return 1
+
+    @asset(partitions_def=composite)
+    def downstream(context, upstream):
+        assert context.asset_partition_keys_for_input("upstream") == ["a"]
+        assert context.asset_partition_keys_for_output("result") == [
+            MultiPartitionKey({"abc": "a", "123": "1"})
+        ]
+        return 1
+
+    asset_graph = AssetGraph.from_assets([upstream, downstream])
+
+    assert (
+        asset_graph.get_partition_mapping(upstream.key, downstream.key)
+        == MultiToSingleDimensionMapping()
+    )
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):  # pylint: disable=unused-argument
+            if context.asset_key == AssetKey("upstream"):
+                assert context.has_asset_partitions
+                assert context.asset_partition_keys == ["a"]
+
+        def load_input(self, context):
+            assert context.has_asset_partitions
+            assert context.asset_partition_keys == ["a"]
+
+    upstream_job = build_assets_job(
+        "upstream_job",
+        assets=[upstream],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    upstream_job.execute_in_process(partition_key="a")
+
+    downstream_job = build_assets_job(
+        "downstream_job",
+        assets=[downstream],
+        source_assets=[upstream],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    downstream_job.execute_in_process(partition_key=MultiPartitionKey({"abc": "a", "123": "1"}))
+
+
+def test_multipartitions_def_partition_mapping_infer_multi_to_single_dim():
+    abc_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    composite = MultiPartitionsDefinition(
+        {
+            "abc": abc_def,
+            "123": StaticPartitionsDefinition(["1", "2", "3"]),
+        }
+    )
+
+    a_multipartition_keys = {
+        MultiPartitionKey(kv)
+        for kv in [{"abc": "a", "123": "1"}, {"abc": "a", "123": "2"}, {"abc": "a", "123": "3"}]
+    }
+
+    @asset(partitions_def=composite)
+    def upstream(context):
+        return 1
+
+    @asset(partitions_def=abc_def)
+    def downstream(context, upstream):
+        assert set(context.asset_partition_keys_for_input("upstream")) == a_multipartition_keys
+        assert context.asset_partition_keys_for_output("result") == ["a"]
+        return 1
+
+    asset_graph = AssetGraph.from_assets([upstream, downstream])
+
+    assert (
+        asset_graph.get_partition_mapping(upstream.key, downstream.key)
+        == MultiToSingleDimensionMapping()
+    )
+
+    class MyIOManager(IOManager):
+        def handle_output(self, context, obj):  # pylint: disable=unused-argument
+            pass
+
+        def load_input(self, context):
+            assert set(context.asset_partition_keys) == a_multipartition_keys
+
+    upstream_job = build_assets_job(
+        "upstream_job",
+        assets=[upstream],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    for pk in a_multipartition_keys:
+        upstream_job.execute_in_process(partition_key=pk)
+
+    downstream_job = build_assets_job(
+        "downstream_job",
+        assets=[downstream],
+        source_assets=[upstream],
+        resource_defs={"io_manager": IOManagerDefinition.hardcoded_io_manager(MyIOManager())},
+    )
+    downstream_job.execute_in_process(partition_key="a")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -15,7 +15,7 @@ from dagster import (
     LastPartitionMapping,
     MultiPartitionKey,
     MultiPartitionsDefinition,
-    MultiToSingleDimensionMapping,
+    MultiToSingleDimensionPartitionMapping,
     Output,
     PartitionsDefinition,
     StaticPartitionsDefinition,
@@ -653,7 +653,7 @@ def test_multipartitions_def_partition_mapping_infer_single_dim_to_multi():
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)
-        == MultiToSingleDimensionMapping()
+        == MultiToSingleDimensionPartitionMapping()
     )
 
     class MyIOManager(IOManager):
@@ -711,7 +711,7 @@ def test_multipartitions_def_partition_mapping_infer_multi_to_single_dim():
 
     assert (
         asset_graph.get_partition_mapping(upstream.key, downstream.key)
-        == MultiToSingleDimensionMapping()
+        == MultiToSingleDimensionPartitionMapping()
     )
 
     class MyIOManager(IOManager):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -3,7 +3,7 @@ from dagster import MultiPartitionKey, MultiPartitionsDefinition, StaticPartitio
 from dagster._check import CheckError
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partition_mapping import MultiToSingleDimensionMapping
+from dagster._core.definitions.partition_mapping import MultiToSingleDimensionPartitionMapping
 
 
 def test_get_downstream_partitions_single_key_in_range():
@@ -15,7 +15,7 @@ def test_get_downstream_partitions_single_key_in_range():
     single_dimension_subset = single_dimension_def.empty_subset().with_partition_key_range(
         PartitionKeyRange("a", "a")
     )
-    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_subset,
         downstream_partitions_def=multipartitions_def,
     )
@@ -28,7 +28,7 @@ def test_get_downstream_partitions_single_key_in_range():
     )
     assert result == multipartitions_subset
 
-    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=multipartitions_subset,
         downstream_partitions_def=single_dimension_def,
     )
@@ -38,7 +38,7 @@ def test_get_downstream_partitions_single_key_in_range():
         {"abc": single_dimension_def, "xyz": StaticPartitionsDefinition(["x", "y", "z"])}
     )
 
-    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_def.empty_subset().with_partition_key_range(
             PartitionKeyRange("b", "b")
         ),
@@ -73,13 +73,13 @@ def test_get_downstream_partitions_multiple_keys_in_range():
         },
     )
 
-    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_subset,
         downstream_partitions_def=multipartitions_def,
     )
     assert result == multipartitions_subset
 
-    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=multipartitions_subset,
         downstream_partitions_def=single_dimension_def,
     )
@@ -148,7 +148,7 @@ def test_get_upstream_single_dimension_to_multi_partition_mapping(
     downstream_partitions_subset,
 ):
     assert (
-        MultiToSingleDimensionMapping().get_upstream_partitions_for_partitions(
+        MultiToSingleDimensionPartitionMapping().get_upstream_partitions_for_partitions(
             downstream_partitions_subset,
             upstream_partitions_def,
         )
@@ -167,7 +167,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
     single_dimension_def = StaticPartitionsDefinition(["1", "2", "3"])
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionMapping().get_upstream_partitions_for_partitions(
+        MultiToSingleDimensionPartitionMapping().get_upstream_partitions_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange(
                     MultiPartitionKey({"a": "1", "b": "1"}),
@@ -178,7 +178,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+        MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange(
                     MultiPartitionKey({"a": "1", "b": "1"}),
@@ -189,7 +189,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionMapping().get_upstream_partitions_for_partitions(
+        MultiToSingleDimensionPartitionMapping().get_upstream_partitions_for_partitions(
             single_dimension_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange("1", "1")
             ),
@@ -197,7 +197,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
+        MultiToSingleDimensionPartitionMapping().get_downstream_partitions_for_partitions(
             single_dimension_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange("1", "1")
             ),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -1,46 +1,51 @@
 from dagster import MultiPartitionKey, MultiPartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partition_mapping import SingleDimensionDependencyMapping
+from dagster._core.definitions.partition_mapping import MultiToSingleDimensionDependencyMapping
+import pytest
+from dagster._check import CheckError
 
 
 def test_get_downstream_partitions_single_key_in_range():
-    upstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
-    downstream_partitions_def = MultiPartitionsDefinition(
-        {"abc": upstream_partitions_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
+    single_dimension_def = StaticPartitionsDefinition(["a", "b", "c"])
+    multipartitions_def = MultiPartitionsDefinition(
+        {"abc": single_dimension_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
     )
 
-    result = SingleDimensionDependencyMapping(
-        partition_dimension_name="abc"
-    ).get_downstream_partitions_for_partitions(
-        upstream_partitions_subset=upstream_partitions_def.empty_subset().with_partition_key_range(
-            PartitionKeyRange("a", "a")
-        ),
-        downstream_partitions_def=downstream_partitions_def,
+    single_dimension_subset = single_dimension_def.empty_subset().with_partition_key_range(
+        PartitionKeyRange("a", "a")
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
+    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=single_dimension_subset,
+        downstream_partitions_def=multipartitions_def,
+    )
+    multipartitions_subset = multipartitions_def.empty_subset().with_partition_keys(
         {
             MultiPartitionKey({"abc": "a", "123": "1"}),
             MultiPartitionKey({"abc": "a", "123": "2"}),
             MultiPartitionKey({"abc": "a", "123": "3"}),
         },
     )
+    assert result == multipartitions_subset
 
-    downstream_partitions_def = MultiPartitionsDefinition(
-        {"abc": upstream_partitions_def, "xyz": StaticPartitionsDefinition(["x", "y", "z"])}
+    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=multipartitions_subset,
+        downstream_partitions_def=single_dimension_def,
+    )
+    assert result == single_dimension_subset
+
+    multipartitions_def = MultiPartitionsDefinition(
+        {"abc": single_dimension_def, "xyz": StaticPartitionsDefinition(["x", "y", "z"])}
     )
 
-    result = SingleDimensionDependencyMapping(
-        partition_dimension_name="abc"
-    ).get_downstream_partitions_for_partitions(
-        upstream_partitions_subset=upstream_partitions_def.empty_subset().with_partition_key_range(
+    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=single_dimension_def.empty_subset().with_partition_key_range(
             PartitionKeyRange("b", "b")
         ),
-        downstream_partitions_def=downstream_partitions_def,
+        downstream_partitions_def=multipartitions_def,
     )
     assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
+        multipartitions_def,
         {
             MultiPartitionKey({"abc": "b", "xyz": "x"}),
             MultiPartitionKey({"abc": "b", "xyz": "y"}),
@@ -50,21 +55,14 @@ def test_get_downstream_partitions_single_key_in_range():
 
 
 def test_get_downstream_partitions_multiple_keys_in_range():
-    upstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
-    downstream_partitions_def = MultiPartitionsDefinition(
-        {"abc": upstream_partitions_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
+    single_dimension_def = StaticPartitionsDefinition(["a", "b", "c"])
+    multipartitions_def = MultiPartitionsDefinition(
+        {"abc": single_dimension_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
     )
-
-    result = SingleDimensionDependencyMapping(
-        partition_dimension_name="abc"
-    ).get_downstream_partitions_for_partitions(
-        upstream_partitions_subset=upstream_partitions_def.empty_subset().with_partition_key_range(
-            PartitionKeyRange("a", "b")
-        ),
-        downstream_partitions_def=downstream_partitions_def,
+    single_dimension_subset = single_dimension_def.empty_subset().with_partition_key_range(
+        PartitionKeyRange("a", "b")
     )
-    assert result == DefaultPartitionsSubset(
-        downstream_partitions_def,
+    multipartitions_subset = multipartitions_def.empty_subset().with_partition_keys(
         {
             MultiPartitionKey({"abc": "a", "123": "1"}),
             MultiPartitionKey({"abc": "a", "123": "2"}),
@@ -75,36 +73,133 @@ def test_get_downstream_partitions_multiple_keys_in_range():
         },
     )
 
-
-def test_get_upstream_single_dimension_to_multi_partition_mapping():
-    upstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
-    downstream_partitions_def = MultiPartitionsDefinition(
-        {"abc": upstream_partitions_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
+    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=single_dimension_subset,
+        downstream_partitions_def=multipartitions_def,
     )
+    assert result == multipartitions_subset
 
-    result = SingleDimensionDependencyMapping(
-        partition_dimension_name="abc"
-    ).get_upstream_partitions_for_partitions(
-        downstream_partitions_def.empty_subset().with_partition_key_range(
-            PartitionKeyRange(
-                MultiPartitionKey({"abc": "a", "123": "1"}),
-                MultiPartitionKey({"abc": "a", "123": "1"}),
-            )
+    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        upstream_partitions_subset=multipartitions_subset,
+        downstream_partitions_def=single_dimension_def,
+    )
+    assert result == single_dimension_subset
+
+
+single_dimension_def = StaticPartitionsDefinition(["a", "b", "c"])
+multipartitions_def = MultiPartitionsDefinition(
+    {"abc": single_dimension_def, "123": StaticPartitionsDefinition(["1", "2", "3"])}
+)
+
+
+@pytest.mark.parametrize(
+    "upstream_partitions_def,upstream_partitions_subset,downstream_partitions_subset",
+    [
+        (
+            single_dimension_def,
+            single_dimension_def.empty_subset().with_partition_keys({"a"}),
+            multipartitions_def.empty_subset().with_partition_key_range(
+                PartitionKeyRange(
+                    MultiPartitionKey({"abc": "a", "123": "1"}),
+                    MultiPartitionKey({"abc": "a", "123": "1"}),
+                )
+            ),
         ),
-        upstream_partitions_def,
-    )
-    assert result == DefaultPartitionsSubset(upstream_partitions_def, {"a"})
-
-    result = SingleDimensionDependencyMapping(
-        partition_dimension_name="abc"
-    ).get_upstream_partitions_for_partitions(
-        DefaultPartitionsSubset(
-            downstream_partitions_def,
-            {
-                MultiPartitionKey({"abc": "b", "123": "2"}),
-                MultiPartitionKey({"abc": "a", "123": "2"}),
-            },
+        (
+            single_dimension_def,
+            single_dimension_def.empty_subset().with_partition_keys({"a", "b"}),
+            multipartitions_def.empty_subset().with_partition_keys(
+                {
+                    MultiPartitionKey({"abc": "b", "123": "2"}),
+                    MultiPartitionKey({"abc": "a", "123": "2"}),
+                }
+            ),
         ),
-        upstream_partitions_def,
+        (
+            multipartitions_def,
+            multipartitions_def.empty_subset().with_partition_keys(
+                {
+                    MultiPartitionKey({"abc": "a", "123": "1"}),
+                    MultiPartitionKey({"abc": "a", "123": "2"}),
+                    MultiPartitionKey({"abc": "a", "123": "3"}),
+                }
+            ),
+            single_dimension_def.empty_subset().with_partition_keys({"a"}),
+        ),
+        (
+            multipartitions_def,
+            multipartitions_def.empty_subset().with_partition_keys(
+                {
+                    MultiPartitionKey({"abc": "a", "123": "1"}),
+                    MultiPartitionKey({"abc": "a", "123": "2"}),
+                    MultiPartitionKey({"abc": "a", "123": "3"}),
+                    MultiPartitionKey({"abc": "b", "123": "1"}),
+                    MultiPartitionKey({"abc": "b", "123": "2"}),
+                    MultiPartitionKey({"abc": "b", "123": "3"}),
+                }
+            ),
+            single_dimension_def.empty_subset().with_partition_keys({"a", "b"}),
+        ),
+    ],
+)
+def test_get_upstream_single_dimension_to_multi_partition_mapping(
+    upstream_partitions_def,
+    upstream_partitions_subset,
+    downstream_partitions_subset,
+):
+    assert (
+        MultiToSingleDimensionDependencyMapping().get_upstream_partitions_for_partitions(
+            downstream_partitions_subset,
+            upstream_partitions_def,
+        )
+        == upstream_partitions_subset
     )
-    assert result == DefaultPartitionsSubset(upstream_partitions_def, {"a", "b"})
+
+
+def test_error_thrown_when_no_partition_dimension_name_provided():
+    multipartitions_def = MultiPartitionsDefinition(
+        {
+            "a": StaticPartitionsDefinition(["1", "2", "3"]),
+            "b": StaticPartitionsDefinition(["1", "2", "3"]),
+        }
+    )
+
+    single_dimension_def = StaticPartitionsDefinition(["1", "2", "3"])
+
+    with pytest.raises(CheckError, match="dimension name must be specified"):
+        MultiToSingleDimensionDependencyMapping().get_upstream_partitions_for_partitions(
+            multipartitions_def.empty_subset().with_partition_key_range(
+                PartitionKeyRange(
+                    MultiPartitionKey({"a": "1", "b": "1"}),
+                    MultiPartitionKey({"a": "1", "b": "1"}),
+                )
+            ),
+            single_dimension_def,
+        )
+
+    with pytest.raises(CheckError, match="dimension name must be specified"):
+        MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+            multipartitions_def.empty_subset().with_partition_key_range(
+                PartitionKeyRange(
+                    MultiPartitionKey({"a": "1", "b": "1"}),
+                    MultiPartitionKey({"a": "1", "b": "1"}),
+                )
+            ),
+            single_dimension_def,
+        )
+
+    with pytest.raises(CheckError, match="dimension name must be specified"):
+        MultiToSingleDimensionDependencyMapping().get_upstream_partitions_for_partitions(
+            single_dimension_def.empty_subset().with_partition_key_range(
+                PartitionKeyRange("1", "1")
+            ),
+            multipartitions_def,
+        )
+
+    with pytest.raises(CheckError, match="dimension name must be specified"):
+        MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+            single_dimension_def.empty_subset().with_partition_key_range(
+                PartitionKeyRange("1", "1")
+            ),
+            multipartitions_def,
+        )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -1,9 +1,9 @@
+import pytest
 from dagster import MultiPartitionKey, MultiPartitionsDefinition, StaticPartitionsDefinition
+from dagster._check import CheckError
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partition_mapping import MultiToSingleDimensionDependencyMapping
-import pytest
-from dagster._check import CheckError
+from dagster._core.definitions.partition_mapping import MultiToSingleDimensionMapping
 
 
 def test_get_downstream_partitions_single_key_in_range():
@@ -15,7 +15,7 @@ def test_get_downstream_partitions_single_key_in_range():
     single_dimension_subset = single_dimension_def.empty_subset().with_partition_key_range(
         PartitionKeyRange("a", "a")
     )
-    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_subset,
         downstream_partitions_def=multipartitions_def,
     )
@@ -28,7 +28,7 @@ def test_get_downstream_partitions_single_key_in_range():
     )
     assert result == multipartitions_subset
 
-    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=multipartitions_subset,
         downstream_partitions_def=single_dimension_def,
     )
@@ -38,7 +38,7 @@ def test_get_downstream_partitions_single_key_in_range():
         {"abc": single_dimension_def, "xyz": StaticPartitionsDefinition(["x", "y", "z"])}
     )
 
-    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_def.empty_subset().with_partition_key_range(
             PartitionKeyRange("b", "b")
         ),
@@ -73,13 +73,13 @@ def test_get_downstream_partitions_multiple_keys_in_range():
         },
     )
 
-    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=single_dimension_subset,
         downstream_partitions_def=multipartitions_def,
     )
     assert result == multipartitions_subset
 
-    result = MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+    result = MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
         upstream_partitions_subset=multipartitions_subset,
         downstream_partitions_def=single_dimension_def,
     )
@@ -148,7 +148,7 @@ def test_get_upstream_single_dimension_to_multi_partition_mapping(
     downstream_partitions_subset,
 ):
     assert (
-        MultiToSingleDimensionDependencyMapping().get_upstream_partitions_for_partitions(
+        MultiToSingleDimensionMapping().get_upstream_partitions_for_partitions(
             downstream_partitions_subset,
             upstream_partitions_def,
         )
@@ -167,7 +167,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
     single_dimension_def = StaticPartitionsDefinition(["1", "2", "3"])
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionDependencyMapping().get_upstream_partitions_for_partitions(
+        MultiToSingleDimensionMapping().get_upstream_partitions_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange(
                     MultiPartitionKey({"a": "1", "b": "1"}),
@@ -178,7 +178,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
             multipartitions_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange(
                     MultiPartitionKey({"a": "1", "b": "1"}),
@@ -189,7 +189,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionDependencyMapping().get_upstream_partitions_for_partitions(
+        MultiToSingleDimensionMapping().get_upstream_partitions_for_partitions(
             single_dimension_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange("1", "1")
             ),
@@ -197,7 +197,7 @@ def test_error_thrown_when_no_partition_dimension_name_provided():
         )
 
     with pytest.raises(CheckError, match="dimension name must be specified"):
-        MultiToSingleDimensionDependencyMapping().get_downstream_partitions_for_partitions(
+        MultiToSingleDimensionMapping().get_downstream_partitions_for_partitions(
             single_dimension_def.empty_subset().with_partition_key_range(
                 PartitionKeyRange("1", "1")
             ),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -62,7 +62,9 @@ def get_upstream_partitions_for_partition_range(
     if upstream_partitions_def is None:
         check.failed("upstream asset is not partitioned")
 
-    downstream_partition_mapping = downstream_assets_def.infer_partition_mapping(upstream_asset_key)
+    downstream_partition_mapping = downstream_assets_def.infer_partition_mapping(
+        upstream_asset_key, upstream_partitions_def
+    )
     downstream_partitions_def = downstream_assets_def.partitions_def
     downstream_partitions_subset = (
         downstream_partitions_def.empty_subset().with_partition_keys(
@@ -94,7 +96,9 @@ def get_downstream_partitions_for_partition_range(
     if upstream_assets_def.partitions_def is None:
         check.failed("upstream asset is not partitioned")
 
-    downstream_partition_mapping = downstream_assets_def.infer_partition_mapping(upstream_asset_key)
+    downstream_partition_mapping = downstream_assets_def.infer_partition_mapping(
+        upstream_asset_key, upstream_assets_def.partitions_def
+    )
     upstream_partitions_def = upstream_assets_def.partitions_def
     upstream_partitions_subset = upstream_partitions_def.empty_subset().with_partition_keys(
         upstream_partitions_def.get_partition_keys_in_range(upstream_partition_key_range)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -179,11 +179,18 @@ def make_backfill_data(
 def get_asset_graph(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]]
 ) -> ExternalAssetGraph:
+    assets_defs_by_key = {
+        assets_def.key: assets_def
+        for assets in assets_by_repo_name.values()
+        for assets_def in assets
+    }
     with patch(
         "dagster._core.host_representation.external_data.get_builtin_partition_mapping_types"
     ) as get_builtin_partition_mapping_types:
         get_builtin_partition_mapping_types.return_value = tuple(
-            assets_def.infer_partition_mapping(dep_key).__class__
+            assets_def.infer_partition_mapping(
+                dep_key, assets_defs_by_key[dep_key].partitions_def
+            ).__class__
             for assets in assets_by_repo_name.values()
             for assets_def in assets
             for dep_key in assets_def.dependency_keys


### PR DESCRIPTION
The existing `SingleDimensionDependencyMapping` class handles the upstream single-dimension -> downstream multipartitioned dependency relationship. This PR refactors this class to also handle the opposite relationship (upstream multipartition -> downstream single dimension), renaming to `MultiToSingleDimensionMapping`.

This class previously required a `partition_dimension_name` argument, which this PR makes optional. This argument is required when the multipartitions definition has dimension partition defs that are equivalent, in which case the class throws an error.

The final change is that we can now auto-infer when we should use this partition mapping--when a single dimension partitions def matches a dimension of a multipartitions def, and the two assets have a dependency relationship. This PR adds tests to ensure that we choose this partition mapping in those cases, otherwise relying on the `IdentityPartitionMapping` or `AllPartitionMapping`.