### PR TITLE
Support requiring resources in sensors, experimentally

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -1,7 +1,7 @@
 import collections.abc
 import inspect
 from functools import update_wrapper
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
@@ -35,6 +35,7 @@ def sensor(
     jobs: Optional[Sequence[ExecutableDefinition]] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     asset_selection: Optional[AssetSelection] = None,
+    required_resource_keys: Optional[Set[str]] = None,
 ) -> Callable[[RawSensorEvaluationFunction], SensorDefinition]:
     """
     Creates a sensor where the decorated function is used as the sensor's evaluation function.  The
@@ -78,6 +79,7 @@ def sensor(
             jobs=jobs,
             default_status=default_status,
             asset_selection=asset_selection,
+            required_resource_keys=required_resource_keys,
         )
 
         update_wrapper(sensor_def, wrapped=fn)

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -4,6 +4,7 @@ import pendulum
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
+from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey
@@ -30,7 +31,6 @@ from .sensor_definition import (
     SensorEvaluationContext,
     SensorType,
     SkipReason,
-    has_at_least_one_parameter,
 )
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -19,6 +19,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import experimental, public
+from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -38,7 +39,6 @@ from .sensor_definition import (
     SensorDefinition,
     SensorEvaluationContext,
     SensorType,
-    has_at_least_one_parameter,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -18,6 +18,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -51,7 +52,6 @@ from .sensor_definition import (
     SensorEvaluationContext,
     SensorType,
     SkipReason,
-    has_at_least_one_parameter,
 )
 from .target import ExecutableDefinition
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -36,7 +36,9 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._serdes import whitelist_for_serdes
 
-from ..decorator_utils import get_function_params
+from ..decorator_utils import (
+    get_function_params,  # pylint: disable=unused-import
+)
 from .asset_selection import AssetSelection
 from .graph_definition import GraphDefinition
 from .mode import DEFAULT_MODE_NAME

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -24,10 +24,10 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.instigation_logger import InstigationLogger
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import (
     Resources,
 )
-from dagster._core.definitions.resource_output import get_resource_args
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -140,11 +140,11 @@ class SensorEvaluationContext:
         
         For example:
         
-        my_sensor(build_sensor_context(resource_defs={"my_resource": my_non_cm_resource})
+        my_sensor(build_sensor_context(resources={"my_resource": my_non_cm_resource})
         
         will work ok, but for a CM resource we must do
 
-        with build_sensor_context(resource_defs={"my_resource": my_cm_resource}) as context:
+        with build_sensor_context(resources={"my_resource": my_cm_resource}) as context:
             my_sensor(context)
         """
 
@@ -736,7 +736,7 @@ def build_sensor_context(
     repository_name: Optional[str] = None,
     repository_def: Optional["RepositoryDefinition"] = None,
     sensor_name: Optional[str] = None,
-    resource_defs: Optional[Mapping[str, "ResourceDefinition"]] = None,
+    resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
 ) -> SensorEvaluationContext:
     """Builds sensor execution context using the provided parameters.
 
@@ -750,7 +750,7 @@ def build_sensor_context(
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
         repository_def (Optional[RepositoryDefinition]): The repository that the sensor belongs to.
             If needed by the sensor top-level resource definitions will be pulled from this repository.
-        resource_defs (Optional[Mapping[str, ResourceDefinition]]): A set of resource definitions
+        resources (Optional[Mapping[str, ResourceDefinition]]): A set of resource definitions
             to provide to the sensor. If passed, these will override any resource definitions
             provided by the repository.
 
@@ -767,14 +767,14 @@ def build_sensor_context(
 
     # Determine the set of resources to pass by
     # 1. Trying to pull the required resource keys from the repository, if available
-    # 2. Using the resource_defs explicitly passed in
+    # 2. Using the resources explicitly passed in
     required_resource_keys = None
     if repository_def and sensor_name:
         sensor_def = repository_def.get_sensor_def(sensor_name)
         required_resource_keys = sensor_def.required_resource_keys
 
     top_level_resources = repository_def.get_top_level_resources() if repository_def else {}
-    all_resources = {**top_level_resources, **(resource_defs or {})}
+    all_resources = {**top_level_resources, **(resources or {})}
 
     resources_to_build = (
         {k: v for k, v in all_resources.items() if k in required_resource_keys}

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -322,6 +322,13 @@ def _validate_and_get_resource_dict(
 def get_or_create_sensor_context(
     fn: Callable, *args: Any, **kwargs: Any
 ) -> SensorEvaluationContext:
+    """
+    Based on the passed resource function and the arguments passed to it, returns the
+    user-passed SensorEvaluationContext or creates one if it is not passed.
+
+    Raises an exception if the user passes more than one argument or if the user-provided
+    function requires a context parameter but none is passed.
+    """
     context_param_name = context_param_name_if_present(fn)
 
     if len(args) + len(kwargs) > 1:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -711,7 +711,6 @@ def build_sensor_context(
     check.opt_str_param(cursor, "cursor")
     check.opt_str_param(repository_name, "repository_name")
 
-
     required_resource_keys = None
     if repository_def and sensor_name:
         sensor_def = repository_def.get_sensor_def(sensor_name)

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -308,7 +308,6 @@ def get_external_sensor_execution(
     sensor_def = repo_def.get_sensor_def(sensor_name)
 
     with ExitStack() as stack:
-
         resources_to_build = {
             k: v
             for k, v in repo_def.get_top_level_resources().items()

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -308,26 +308,24 @@ def get_external_sensor_execution(
     sensor_def = repo_def.get_sensor_def(sensor_name)
 
     with ExitStack() as stack:
-        from dagster._core.execution.build_resources import build_resources
 
         resources_to_build = {
             k: v
             for k, v in repo_def.get_top_level_resources().items()
             if k in sensor_def.required_resource_keys
         }
-        with build_resources(resources_to_build) as resources:
-            sensor_context = stack.enter_context(
-                SensorEvaluationContext(
-                    instance_ref,
-                    last_completion_time=last_completion_timestamp,
-                    last_run_key=last_run_key,
-                    cursor=cursor,
-                    repository_name=repo_def.name,
-                    repository_def=repo_def,
-                    sensor_name=sensor_name,
-                    resources=resources,
-                )
+        sensor_context = stack.enter_context(
+            SensorEvaluationContext(
+                instance_ref,
+                last_completion_time=last_completion_timestamp,
+                last_run_key=last_run_key,
+                cursor=cursor,
+                repository_name=repo_def.name,
+                repository_def=repo_def,
+                sensor_name=sensor_name,
+                resource_defs=resources_to_build,
             )
+        )
 
         try:
             with user_code_error_boundary(

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -322,7 +322,7 @@ def get_external_sensor_execution(
                 repository_name=repo_def.name,
                 repository_def=repo_def,
                 sensor_name=sensor_name,
-                resource_defs=resources_to_build,
+                resources=resources_to_build,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
@@ -1,0 +1,156 @@
+import os
+import sys
+from typing import Optional
+
+import pendulum
+import pytest
+from dagster import (
+    SensorEvaluationContext,
+    job,
+    op,
+    sensor,
+)
+from dagster._config.structured_config import ConfigurableResource
+from dagster._core.definitions.decorators.sensor_decorator import sensor
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.repository_definition.valid_definitions import (
+    SINGLETON_REPOSITORY_NAME,
+)
+from dagster._core.definitions.run_request import InstigatorType
+from dagster._core.definitions.sensor_definition import RunRequest
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.test_utils import (
+    create_test_daemon_workspace_context,
+)
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.load_target import ModuleTarget
+from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+
+from .test_sensor_run import evaluate_sensors, validate_tick, wait_for_all_runs_to_start
+
+
+@op
+def the_op(_):
+    return 1
+
+
+@job
+def the_job():
+    the_op()
+
+
+@sensor(job_name="the_job", required_resource_keys={"my_resource"})
+def sensor_from_context(context: SensorEvaluationContext):
+    return RunRequest(context.resources.my_resource.a_str, run_config={}, tags={})
+
+
+class MyResource(ConfigurableResource):
+    a_str: str
+
+
+@sensor(job_name="the_job")
+def sensor_from_fn_arg(context: SensorEvaluationContext, my_resource: MyResource):
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+the_repo = Definitions(
+    jobs=[the_job],
+    sensors=[sensor_from_context, sensor_from_fn_arg],
+    resources={"my_resource": MyResource(a_str="foo")},
+)
+
+
+def create_workspace_load_target(attribute: Optional[str] = SINGLETON_REPOSITORY_NAME):
+    return ModuleTarget(
+        module_name="dagster_tests.daemon_sensor_tests.test_struct_resources",
+        attribute=None,
+        working_directory=os.path.dirname(__file__),
+        location_name="test_location",
+    )
+
+
+@pytest.fixture(name="workspace_context_struct_resources", scope="module")
+def workspace_fixture(instance_module_scoped):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=create_workspace_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace:
+        yield workspace
+
+
+@pytest.fixture(name="external_repo_struct_resources", scope="module")
+def external_repo_fixture(workspace_context_struct_resources: WorkspaceProcessContext):
+    repo_loc = next(
+        iter(
+            workspace_context_struct_resources.create_request_context()
+            .get_workspace_snapshot()
+            .values()
+        )
+    ).repository_location
+    assert repo_loc
+    return repo_loc.get_repository(SINGLETON_REPOSITORY_NAME)
+
+
+def loadable_target_origin() -> LoadableTargetOrigin:
+    return LoadableTargetOrigin(
+        executable_path=sys.executable,
+        module_name="dagster_tests.daemon_sensor_tests.test_struct_resources",
+        working_directory=os.getcwd(),
+        attribute=None,
+    )
+
+
+@pytest.mark.parametrize("sensor_name", ["sensor_from_context", "sensor_from_fn_arg"])
+def test_resources(
+    caplog,
+    instance,
+    workspace_context_struct_resources,
+    external_repo_struct_resources,
+    sensor_name,
+):
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 0
+
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+
+        assert instance.get_runs_count() == 1
+        run = instance.get_runs()[0]
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 1
+        assert ticks[0].run_keys == ["foo"]
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+            expected_run_ids=[run.run_id],
+        )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
-from dagster._core.definitions.resource_output import Resource
+from dagster._core.definitions.resource_annotation import Resource
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from contextlib import contextmanager
 from typing import Iterator, Optional
 
 import pendulum
@@ -8,6 +9,7 @@ from dagster import (
     SensorEvaluationContext,
     job,
     op,
+    resource,
     sensor,
 )
 from dagster._check import ParameterCheckError
@@ -16,6 +18,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
+from dagster._core.definitions.resource_output import Resource
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
@@ -28,10 +31,6 @@ from dagster._core.workspace.load_target import ModuleTarget
 from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 
 from .test_sensor_run import evaluate_sensors, validate_tick, wait_for_all_runs_to_start
-
-from dagster import resource
-from contextlib import contextmanager
-from dagster._core.definitions.resource_output import Resource
 
 
 @op

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -41,11 +41,10 @@ from dagster import (
     run_status_sensor,
     sensor,
 )
-from dagster._check import CheckError
 from dagster._config.structured_config import ConfigurableResource
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.resource_output import Resource
-from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.test_utils import instance_for_test
 
 
@@ -119,7 +118,13 @@ def test_sensor_invocation_resources() -> None:
     def basic_sensor_resource_req(my_resource: MyResource):
         return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
 
-    with pytest.raises(CheckError, match="Sensor missing required resources: my_resource"):
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by sensor 'basic_sensor_resource_req' was not"
+            " provided."
+        ),
+    ):
         basic_sensor_resource_req()
 
     # Just need to pass context, which splats out into resource parameters

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -43,7 +43,7 @@ from dagster import (
 )
 from dagster._config.structured_config import ConfigurableResource
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
-from dagster._core.definitions.resource_output import Resource
+from dagster._core.definitions.resource_annotation import Resource
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.test_utils import instance_for_test
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -131,7 +131,7 @@ def test_sensor_invocation_resources() -> None:
     assert cast(
         RunRequest,
         basic_sensor_resource_req(
-            build_sensor_context(resource_defs={"my_resource": MyResource(a_str="foo")})
+            build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
     ).run_config == {"foo": "foo"}
 
@@ -151,10 +151,10 @@ def test_sensor_invocation_resources_context_manager() -> None:
         DagsterInvariantViolationError, match="At least one provided resource is a generator"
     ):
         basic_sensor_str_resource_req(
-            build_sensor_context(resource_defs={"my_resource": my_cm_resource})
+            build_sensor_context(resources={"my_resource": my_cm_resource})
         )
 
-    with build_sensor_context(resource_defs={"my_resource": my_cm_resource}) as context:
+    with build_sensor_context(resources={"my_resource": my_cm_resource}) as context:
         assert cast(RunRequest, basic_sensor_str_resource_req(context)).run_config == {"foo": "foo"}
 
 


### PR DESCRIPTION
## Summary

Implements very basic resource support for sensors. Effectively just calls `build_resouces` and passes the results to user code, so we don't get any new observability from this implementation, this would be separately addressed by work that increases sensor observability in general.

Resources can be specified through `required_resource_keys` or through annoated params on the sensor fn. They can be accessed through context or through these params:

```python

class MyResource(ConfigurableResource):
    a_str: str
    
@sensor(job_name="the_job", required_resource_keys={"my_resource"})
def sensor_from_context(context: SensorEvaluationContext):
    return RunRequest(context.resources.my_resource.a_str, run_config={}, tags={})


@sensor(job_name="the_job")
def sensor_from_fn_arg(context: SensorEvaluationContext, my_resource: MyResource):
    return RunRequest(my_resource.a_str, run_config={}, tags={})

```


Directly invoking sensors requires that a user only provide the context (for simplicity's sake - alternatively, we could have users directly pass in `my_resource` here if that's preferred).

```python
# Here, `resource_defs` is exploded into the various resource args which `sensor_from_fn_arg` expects 
sensor_from_fn_arg(
    build_sensor_context(
        resource_defs={"my_resource": MyResource(a_str="foo")}
    )
)
```

This PR doesn't handle any of the fancy sensor types (e.g. `multi_asset_sensor`), bumped to a stacked diff so as to keep this diff fairly clean.

## Test Plan

unit test