### PR TITLE
add graphql fields for querying run tags

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2711,7 +2711,8 @@ type DagitQuery {
   pipelineRunOrError(runId: ID!): RunOrError!
   runsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
   runOrError(runId: ID!): RunOrError!
-  pipelineRunTags: [PipelineTagAndValues!]!
+  runTagKeys: [String!]!
+  runTags(tagKeys: [String!], valuePrefix: String, limit: Int): [PipelineTagAndValues!]!
   runGroupOrError(runId: ID!): RunGroupOrError!
   runGroupsOrError(filter: RunsFilter, cursor: String, limit: Int): RunGroupsOrError!
   isPipelineConfigValid(

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -575,7 +575,6 @@ export type DagitQuery = {
   permissions: Array<Permission>;
   pipelineOrError: PipelineOrError;
   pipelineRunOrError: RunOrError;
-  pipelineRunTags: Array<PipelineTagAndValues>;
   pipelineRunsOrError: RunsOrError;
   pipelineSnapshotOrError: PipelineSnapshotOrError;
   repositoriesOrError: RepositoriesOrError;
@@ -584,6 +583,8 @@ export type DagitQuery = {
   runGroupOrError: RunGroupOrError;
   runGroupsOrError: RunGroupsOrError;
   runOrError: RunOrError;
+  runTagKeys: Array<Scalars['String']>;
+  runTags: Array<PipelineTagAndValues>;
   runsOrError: RunsOrError;
   scheduleOrError: ScheduleOrError;
   scheduler: SchedulerOrError;
@@ -731,6 +732,12 @@ export type DagitQueryRunGroupsOrErrorArgs = {
 
 export type DagitQueryRunOrErrorArgs = {
   runId: Scalars['ID'];
+};
+
+export type DagitQueryRunTagsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  tagKeys?: InputMaybe<Array<Scalars['String']>>;
+  valuePrefix?: InputMaybe<Scalars['String']>;
 };
 
 export type DagitQueryRunsOrErrorArgs = {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -56,13 +56,28 @@ def get_run_by_id(
         return GrapheneRun(record)
 
 
-def get_run_tags(graphene_info: "ResolveInfo") -> List["GraphenePipelineTagAndValues"]:
+def get_run_tag_keys(graphene_info: "ResolveInfo") -> List[str]:
+    return [
+        tag_key
+        for tag_key in graphene_info.context.instance.get_run_tag_keys()
+        if get_tag_type(tag_key) != TagType.HIDDEN
+    ]
+
+
+def get_run_tags(
+    graphene_info: "ResolveInfo",
+    tag_keys: Optional[List[str]] = None,
+    value_prefix: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> List["GraphenePipelineTagAndValues"]:
     from ..schema.tags import GraphenePipelineTagAndValues
 
     instance = graphene_info.context.instance
     return [
         GraphenePipelineTagAndValues(key=key, values=values)
-        for key, values in instance.get_run_tags()
+        for key, values in instance.get_run_tags(
+            tag_keys=tag_keys, value_prefix=value_prefix, limit=limit
+        )
         if get_tag_type(key) != TagType.HIDDEN
     ]
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -316,8 +316,10 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
         assert len(runs) == 2
 
         all_tag_keys_result = execute_dagster_graphql(read_context, ALL_TAG_KEYS_QUERY)
-        tag_keys = all_tag_keys_result.data["runTagKeys"]
-        assert set(tag_keys) == {"fruit", "veggie"}
+        tag_keys = set(all_tag_keys_result.data["runTagKeys"])
+        # check presence rather than set equality since we might have extra tags in cloud
+        assert "fruit" in tag_keys
+        assert "veggie" in tag_keys
 
         all_tags_result = execute_dagster_graphql(read_context, ALL_TAGS_QUERY)
         tags = all_tags_result.data["runTags"]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -80,7 +80,7 @@ mutation DeleteRun($runId: String!) {
 
 ALL_TAGS_QUERY = """
 {
-  pipelineRunTags {
+  runTags {
     ... on PipelineTagAndValues {
       key
       values
@@ -88,6 +88,22 @@ ALL_TAGS_QUERY = """
   }
 }
 """
+
+ALL_TAG_KEYS_QUERY = """
+{
+  runTagKeys
+}
+"""
+
+FILTERED_TAGS_QUERY = """
+query FilteredRunTagsQuery($tagKeys: [String!]!) {
+  runTags(tagKeys: $tagKeys) {
+    key
+    values
+  }
+}
+"""
+
 
 ALL_RUNS_QUERY = """
 {
@@ -299,13 +315,23 @@ class TestGetRuns(ExecutingGraphQLContextTestMatrix):
         runs = result.data["pipelineOrError"]["runs"]
         assert len(runs) == 2
 
+        all_tag_keys_result = execute_dagster_graphql(read_context, ALL_TAG_KEYS_QUERY)
+        tag_keys = all_tag_keys_result.data["runTagKeys"]
+        assert set(tag_keys) == {"fruit", "veggie"}
+
         all_tags_result = execute_dagster_graphql(read_context, ALL_TAGS_QUERY)
-        tags = all_tags_result.data["pipelineRunTags"]
-
+        tags = all_tags_result.data["runTags"]
         tags_dict = {item["key"]: item["values"] for item in tags}
-
         assert tags_dict["fruit"] == ["apple"]
         assert tags_dict["veggie"] == ["carrot"]
+
+        filtered_tags_result = execute_dagster_graphql(
+            read_context, FILTERED_TAGS_QUERY, variables={"tagKeys": ["fruit"]}
+        )
+        tags = filtered_tags_result.data["runTags"]
+        tags_dict = {item["key"]: item["values"] for item in tags}
+        assert len(tags_dict) == 1
+        assert tags_dict["fruit"] == ["apple"]
 
         # delete the second run
         result = execute_dagster_graphql(


### PR DESCRIPTION
### Summary & Motivation
We want separate graphql endpoints to query run tag keys and filtered run tag values.

### How I Tested These Changes
Added new graphql tests