### PR TITLE
fix: resolve correct legacy arguments for emr pyspark step launcher

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -169,7 +169,7 @@ def emr_pyspark_step_launcher(context):
     ) or context.resource_config.get("local_pipeline_package_path")
 
     if context.resource_config.get("deploy_local_job_package") and context.resource_config.get(
-        "deploy_local_job_package"
+        "deploy_local_pipeline_package"
     ):
         raise DagsterInvariantViolationError(
             "Provided both ``deploy_local_job_package`` and legacy version "


### PR DESCRIPTION
### Summary & Motivation
Compare `deploy_local_job_package` with `deploy_local_pipeline_package`, as intended.

### How I Tested These Changes
pytest
