### PR TITLE
Bind top-level resources to jobs at Definitions-time

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -152,6 +152,7 @@ from dagster._core.definitions.decorators.source_asset_decorator import (
     observable_source_asset as observable_source_asset,
 )
 from dagster._core.definitions.definitions_class import (
+    BindResourcesToJobs as BindResourcesToJobs,
     Definitions as Definitions,
     create_repository_using_definitions_args as create_repository_using_definitions_args,
 )

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -101,7 +101,7 @@ class _AttachedObjects(NamedTuple):
     sensors: Iterable[SensorDefinition]
 
 
-def _attach_resources_to_jobs(
+def _attach_resources_to_jobs_and_instigators(
     jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]],
     schedules: Optional[
         Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]
@@ -210,7 +210,7 @@ def _create_repository_using_definitions_args(
         jobs_with_resources,
         schedules_with_resources,
         sensors_with_resources,
-    ) = _attach_resources_to_jobs(jobs, schedules, sensors, resource_defs)
+    ) = _attach_resources_to_jobs_and_instigators(jobs, schedules, sensors, resource_defs)
 
     @repository(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -133,6 +133,16 @@ def _create_repository_using_definitions_args(
 
     check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
 
+    jobs_with_resources = (
+        [
+            job.with_top_level_resources(resource_defs)
+            for job in jobs
+            if isinstance(job, JobDefinition)
+        ]
+        if jobs
+        else []
+    )
+
     @repository(
         name=name,
         default_executor_def=executor_def,
@@ -144,7 +154,7 @@ def _create_repository_using_definitions_args(
             *with_resources(assets or [], resource_defs),
             *(schedules or []),
             *(sensors or []),
-            *(jobs or []),
+            *(jobs_with_resources),
         ]
 
     return created_repo

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -140,13 +140,17 @@ def _attach_resources_to_jobs(
     # Update all schedules and sensors to use the resource bound version
     updated_schedules = [
         schedule.with_updated_job(unsatisfied_job_to_resource_bound_job[id(schedule.job)])
-        if (isinstance(schedule, ScheduleDefinition) and schedule.job in unsatisfied_jobs)
+        if (
+            isinstance(schedule, ScheduleDefinition)
+            and schedule.has_loadable_target()
+            and schedule.job in unsatisfied_jobs
+        )
         else schedule
         for schedule in schedules
     ]
     updated_sensors = [
         sensor.with_updated_job(unsatisfied_job_to_resource_bound_job[id(sensor.job)])
-        if sensor.job in unsatisfied_jobs
+        if sensor.has_loadable_targets() and sensor.job in unsatisfied_jobs
         else sensor
         for sensor in sensors
     ]

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -135,9 +135,8 @@ def _create_repository_using_definitions_args(
 
     jobs_with_resources = (
         [
-            job.with_top_level_resources(resource_defs)
+            job.with_top_level_resources(resource_defs) if isinstance(job, JobDefinition) else job
             for job in jobs
-            if isinstance(job, JobDefinition)
         ]
         if jobs
         else []

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,7 +1,9 @@
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
+    List,
     Mapping,
     NamedTuple,
     Optional,
@@ -112,7 +114,24 @@ def _io_manager_needs_replacement(job: JobDefinition, resource_defs: Mapping[str
     )
 
 
-def _attach_resources_to_jobs_and_instigators(
+def _jobs_which_will_have_io_manager_replaced(
+    jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]],
+    resource_defs: Mapping[str, Any],
+) -> List[Union[JobDefinition, UnresolvedAssetJobDefinition]]:
+    """
+    Returns whether any jobs will have their I/O manager replaced by an `io_manager` override from
+    the top-level `resource_defs` provided to `Definitions` in 1.3. We will warn users if this is
+    the case.
+    """
+    jobs = jobs or []
+    return [
+        job
+        for job in jobs
+        if isinstance(job, JobDefinition) and _io_manager_needs_replacement(job, resource_defs)
+    ]
+
+
+def _attach_resources_to_jobs_and_instigator_jobs(
     jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]],
     schedules: Optional[
         Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]
@@ -220,11 +239,40 @@ def _create_repository_using_definitions_args(
 
     check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
 
-    (
-        jobs_with_resources,
-        schedules_with_resources,
-        sensors_with_resources,
-    ) = _attach_resources_to_jobs_and_instigators(jobs, schedules, sensors, resource_defs)
+    if isinstance(jobs, BindResourcesToJobs):
+        # Binds top-level resources to jobs and any jobs attached to schedules or sensors
+        (
+            jobs_with_resources,
+            schedules_with_resources,
+            sensors_with_resources,
+        ) = _attach_resources_to_jobs_and_instigator_jobs(jobs, schedules, sensors, resource_defs)
+    else:
+        jobs_to_warn = _jobs_which_will_have_io_manager_replaced(jobs, resource_defs)
+        if jobs_to_warn:
+            jobs_text = ", ".join([f"`{job.name}`" for job in jobs_to_warn[:10]])
+            if len(jobs_to_warn) > 10:
+                jobs_text += f", and {len(jobs_to_warn) - 10} others"
+            warnings.warn(
+                f"""You have overridden the default `io_manager` on `Definitions`. One or more jobs utilize the default filesystem I/O manager. In the future, these jobs will use the `Definitions`-level override instead. To silence this warning, explicitly set the `io_manager` on the jobs in question:
+
+@job(resource_defs={{'io_manager': fs_io_manager}})
+def my_job():
+    ...
+    
+Alternatively, wrap the jobs input to `Definitions` with `BindResourceToJobs`:
+
+defs = Definitions(
+    jobs=BindResourcesToJobs([my_job, my_other_job, ...])
+)
+
+In later releases, this will be the default behavior, and `BindResourcesToJobs` will not be required.
+
+The following jobs are affected: {jobs_text}
+                """
+            )
+        jobs_with_resources = jobs or []
+        schedules_with_resources = schedules or []
+        sensors_with_resources = sensors or []
 
     @repository(
         name=name,
@@ -241,6 +289,10 @@ def _create_repository_using_definitions_args(
         ]
 
     return created_repo
+
+
+class BindResourcesToJobs(list):
+    pass
 
 
 class Definitions:

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -705,9 +705,6 @@ class JobDefinition(PipelineDefinition):
         ):
             merged_resource_defs["io_manager"] = resource_defs["io_manager"]
 
-        print("MERGING")
-        print(merged_resource_defs.keys())
-
         job_def = JobDefinition(
             name=self._name,
             graph_def=self._graph_def,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -111,7 +111,6 @@ class JobDefinition(PipelineDefinition):
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
-        _definitions_resources_bound: bool = False,
     ):
         from dagster._core.definitions.run_config import RunConfig, convert_config_input
         from dagster._loggers import default_loggers
@@ -242,9 +241,6 @@ class JobDefinition(PipelineDefinition):
                     f" '{input_name}', but job has no top-level input with that name."
                 )
 
-        should_validate_resource_requirements = (
-            _definitions_resources_bound or did_user_provide_resources
-        )
         super(JobDefinition, self).__init__(
             name=name,
             description=description,
@@ -258,7 +254,7 @@ class JobDefinition(PipelineDefinition):
             graph_def=graph_def,
             version_strategy=version_strategy,
             asset_layer=asset_layer or _infer_asset_layer_from_source_asset_deps(graph_def),
-            _should_validate_resource_requirements=should_validate_resource_requirements,
+            _should_validate_resource_requirements=did_user_provide_resources,
         )
 
     @property
@@ -708,7 +704,6 @@ class JobDefinition(PipelineDefinition):
             _executor_def_specified=self._executor_def_specified,
             _logger_defs_specified=self._logger_defs_specified,
             _preset_defs=self._preset_defs,
-            _definitions_resources_bound=False,
         )
 
         update_wrapper(job_def, self, updated=())

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -692,13 +692,26 @@ class JobDefinition(PipelineDefinition):
         """Apply a set of resources to all op instances within the job."""
         resource_defs = check.dict_param(resource_defs, "resource_defs", key_type=str)
 
+        merged_resource_defs = {
+            **resource_defs,
+            **self.resource_defs,
+        }
+
+        # If we are using the default io_manager, we want to replace it with the one
+        # provided at the top level
+        if (
+            "io_manager" in resource_defs
+            and self.resource_defs.get("io_manager") == default_job_io_manager
+        ):
+            merged_resource_defs["io_manager"] = resource_defs["io_manager"]
+
+        print("MERGING")
+        print(merged_resource_defs.keys())
+
         job_def = JobDefinition(
             name=self._name,
             graph_def=self._graph_def,
-            resource_defs={
-                **resource_defs,
-                **self.resource_defs,
-            },
+            resource_defs=merged_resource_defs,
             logger_defs=dict(self.loggers),
             executor_def=self.executor_def,
             config=self.partitioned_config or self.config_mapping,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -689,7 +689,7 @@ class JobDefinition(PipelineDefinition):
         resource_defs = check.dict_param(resource_defs, "resource_defs", key_type=str)
 
         job_def = JobDefinition(
-            name=self.name,
+            name=self._name,
             graph_def=self._graph_def,
             resource_defs={
                 **resource_defs,
@@ -698,12 +698,13 @@ class JobDefinition(PipelineDefinition):
             logger_defs=dict(self.loggers),
             executor_def=self.executor_def,
             config=self.partitioned_config or self.config_mapping,
-            tags=self.tags,
-            hook_defs=self.hook_defs,
             description=self._description,
-            op_retry_policy=self._solid_retry_policy,
-            asset_layer=self.asset_layer,
+            tags=self._tags,
+            hook_defs=self._hook_defs,
+            version_strategy=self.version_strategy,
             _subset_selection_data=self._subset_selection_data,
+            asset_layer=self._asset_layer,
+            _metadata_entries=self._metadata_entries,
             _executor_def_specified=self._executor_def_specified,
             _logger_defs_specified=self._logger_defs_specified,
             _preset_defs=self._preset_defs,

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -332,6 +332,14 @@ class PipelineDefinition:
             requirements = self._get_mode_requirements(mode_def)
             ensure_requirements_satisfied(mode_def.resource_defs, requirements, mode_def.name)
 
+    def is_missing_required_resources(self) -> bool:
+        for mode_def in self._mode_definitions:
+            requirements = self._get_mode_requirements(mode_def)
+            for requirement in requirements:
+                if not requirement.resources_contain_key(mode_def.resource_defs):
+                    return True
+        return False
+
     @property
     def name(self) -> str:
         return self._name

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -1,4 +1,4 @@
-from functools import update_wrapper
+`from functools import update_wrapper
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -51,7 +51,7 @@ from .mode import ModeDefinition
 from .node_definition import NodeDefinition
 from .op_definition import OpDefinition
 from .preset import PresetDefinition
-from .resource_requirement import ensure_requirements_satisfied
+from .resource_requirement import ResourceRequirement, ensure_requirements_satisfied
 from .utils import validate_tags
 from .version_strategy import VersionStrategy
 
@@ -193,6 +193,7 @@ class PipelineDefinition:
         version_strategy: Optional[VersionStrategy] = None,
         asset_layer: Optional[AssetLayer] = None,
         metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+        _should_validate_resource_requirements: bool = True,
     ):
         # If a graph is specified directly use it
         if isinstance(graph_def, GraphDefinition):
@@ -278,7 +279,7 @@ class PipelineDefinition:
         resource_requirements = {}
         for mode_def in self._mode_definitions:
             resource_requirements[mode_def.name] = self._get_resource_requirements_for_mode(
-                mode_def
+                mode_def, _should_validate_resource_requirements
             )
         self._resource_requirements = resource_requirements
 
@@ -299,9 +300,24 @@ class PipelineDefinition:
 
         self._graph_def.get_inputs_must_be_resolved_top_level(self._asset_layer)
 
-    def _get_resource_requirements_for_mode(self, mode_def: ModeDefinition) -> Set[str]:
+    def _get_resource_requirements_for_mode(
+        self, mode_def: ModeDefinition, validate_requirements: bool = False
+    ) -> Set[str]:
         from ..execution.resources_init import get_transitive_required_resource_keys
 
+        requirements = self._get_mode_requirements(mode_def)
+        if validate_requirements:
+            ensure_requirements_satisfied(mode_def.resource_defs, requirements, mode_def.name)
+        required_keys = {requirement.key for requirement in requirements}
+
+        if validate_requirements:
+            return required_keys.union(
+                get_transitive_required_resource_keys(required_keys, mode_def.resource_defs)
+            )
+        else:
+            return required_keys
+
+    def _get_mode_requirements(self, mode_def: ModeDefinition) -> Sequence[ResourceRequirement]:
         requirements = list(self._graph_def.get_resource_requirements(self.asset_layer))
         for hook_def in self._hook_defs:
             requirements += list(
@@ -309,11 +325,12 @@ class PipelineDefinition:
                     outer_context=f"{self.target_type} '{self._name}'"
                 )
             )
-        ensure_requirements_satisfied(mode_def.resource_defs, requirements, mode_def.name)
-        required_keys = {requirement.key for requirement in requirements}
-        return required_keys.union(
-            get_transitive_required_resource_keys(required_keys, mode_def.resource_defs)
-        )
+        return requirements
+
+    def validate_resource_requirements_satisfied(self) -> None:
+        for mode_def in self._mode_definitions:
+            requirements = self._get_mode_requirements(mode_def)
+            ensure_requirements_satisfied(mode_def.resource_defs, requirements, mode_def.name)
 
     @property
     def name(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -1,4 +1,4 @@
-`from functools import update_wrapper
+from functools import update_wrapper
 from typing import (
     TYPE_CHECKING,
     AbstractSet,

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -370,6 +370,8 @@ def build_caching_repository_data_from_dict(
                 f"Object mapped to {key} is not an instance of JobDefinition or GraphDefinition."
             )
 
+    # Late validate all jobs' resource requirements are satisfied, since
+    # they may not be applied until now
     for pipeline_or_job in repository_definitions["jobs"].values():
         if isinstance(pipeline_or_job, PipelineDefinition):
             pipeline_or_job.validate_resource_requirements_satisfied()

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -273,6 +273,9 @@ def build_caching_repository_data_from_list(
             )
             pipelines_or_jobs[name] = resolved_job
 
+    for pipeline_or_job in pipelines_or_jobs.values():
+        pipeline_or_job.validate_resource_requirements_satisfied()
+
     pipelines: Dict[str, PipelineDefinition] = {}
     jobs: Dict[str, JobDefinition] = {}
     for name, pipeline_or_job in pipelines_or_jobs.items():
@@ -345,6 +348,10 @@ def build_caching_repository_data_from_dict(
             "Duplicate definitions between schedules and sensors found for keys:"
             f" {', '.join(duplicate_keys)}"
         )
+
+    for pipeline_or_job in repository_definitions["jobs"].values():
+        if isinstance(pipeline_or_job, PipelineDefinition):
+            pipeline_or_job.validate_resource_requirements_satisfied()
 
     # merge jobs in to pipelines while they are just implemented as pipelines
     for key, job in repository_definitions["jobs"].items():

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -349,10 +349,6 @@ def build_caching_repository_data_from_dict(
             f" {', '.join(duplicate_keys)}"
         )
 
-    for pipeline_or_job in repository_definitions["jobs"].values():
-        if isinstance(pipeline_or_job, PipelineDefinition):
-            pipeline_or_job.validate_resource_requirements_satisfied()
-
     # merge jobs in to pipelines while they are just implemented as pipelines
     for key, job in repository_definitions["jobs"].items():
         if key in repository_definitions["pipelines"]:
@@ -373,6 +369,10 @@ def build_caching_repository_data_from_dict(
             raise DagsterInvalidDefinitionError(
                 f"Object mapped to {key} is not an instance of JobDefinition or GraphDefinition."
             )
+
+    for pipeline_or_job in repository_definitions["jobs"].values():
+        if isinstance(pipeline_or_job, PipelineDefinition):
+            pipeline_or_job.validate_resource_requirements_satisfied()
 
     return CachingRepositoryData(
         **repository_definitions,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -429,6 +429,25 @@ class ScheduleDefinition:
         required_resource_keys (Optional[Set[str]]): The set of resource keys required by the schedule.
     """
 
+    def with_updated_job(self, new_job: ExecutableDefinition) -> "ScheduleDefinition":
+        """Returns a copy of this schedule with the job replaced.
+
+        Args:
+            job (Union[GraphDefinition, JobDefinition]): The job that should execute when this
+                schedule runs.
+        """
+        return ScheduleDefinition(
+            name=self.name,
+            cron_schedule=self._cron_schedule,
+            job_name=self.job_name,
+            environment_vars=self.environment_vars,
+            execution_timezone=self.execution_timezone,
+            execution_fn=self._execution_fn,
+            description=self.description,
+            job=new_job,
+            default_status=self.default_status,
+        )
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -479,6 +498,7 @@ class ScheduleDefinition:
         self._environment_vars = check.opt_mapping_param(
             environment_vars, "environment_vars", key_type=str, value_type=str
         )
+
         self._execution_timezone = check.opt_str_param(execution_timezone, "execution_timezone")
 
         if execution_fn and (run_config_fn or tags_fn or should_execute or tags or run_config):
@@ -522,6 +542,8 @@ class ScheduleDefinition:
                 tags_fn = check.opt_callable_param(
                     tags_fn, "tags_fn", default=lambda _context: cast(Mapping[str, str], {})
                 )
+            self._tags_fn = tags_fn
+            self._tags = tags
 
             _should_execute: ScheduleShouldExecuteFunction = check.opt_callable_param(
                 should_execute, "should_execute", default=lambda _context: True

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -433,7 +433,7 @@ class ScheduleDefinition:
         """Returns a copy of this schedule with the job replaced.
 
         Args:
-            job (Union[GraphDefinition, JobDefinition]): The job that should execute when this
+            job (ExecutableDefinition): The job that should execute when this
                 schedule runs.
         """
         return ScheduleDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -380,6 +380,23 @@ class SensorDefinition:
             the sensor condition is met. This can be provided instead of specifying a job.
     """
 
+    def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":
+        """Returns a copy of this schedule with the job replaced.
+
+        Args:
+            job (Union[GraphDefinition, JobDefinition]): The job that should execute when this
+                schedule runs.
+        """
+        return SensorDefinition(
+            name=self.name,
+            evaluation_fn=self._evaluation_fn,
+            minimum_interval_seconds=self.minimum_interval_seconds,
+            description=self.description,
+            job=new_job,
+            default_status=self.default_status,
+            asset_selection=self.asset_selection,
+        )
+
     def __init__(
         self,
         name: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -384,7 +384,7 @@ class SensorDefinition:
         """Returns a copy of this schedule with the job replaced.
 
         Args:
-            job (Union[GraphDefinition, JobDefinition]): The job that should execute when this
+            job (ExecutableDefinition): The job that should execute when this
                 schedule runs.
         """
         return SensorDefinition(

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -10,6 +10,7 @@ from dagster import (
     graph,
     job,
     op,
+    repository,
     resource,
     usable_as_dagster_type,
 )
@@ -448,6 +449,10 @@ def test_type_missing_resource_fails():
         def _type_check_job():
             custom_type_op()
 
+        @repository
+        def _repo():
+            return [_type_check_job]
+
 
 def test_loader_missing_resource_fails():
     @dagster_type_loader(String, required_resource_keys={"a"})
@@ -471,6 +476,42 @@ def test_loader_missing_resource_fails():
         @job
         def _type_check_job():
             custom_type_op()
+
+        @repository
+        def _repo():
+            return [_type_check_job]
+
+
+def test_materialize_missing_resource_fails():
+    @dagster_type_materializer(String, required_resource_keys={"a"})
+    def materialize(context, *_args, **_kwargs):
+        assert context.resources.a == "A"
+        return AssetMaterialization("hello")
+
+    CustomType = create_any_type(name="CustomType", materializer=materialize)
+
+    @op(
+        out={
+            "custom_type": Out(
+                CustomType,
+            )
+        }
+    )
+    def custom_type_op(_):
+        return "A"
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="required by the materializer on type 'CustomType'",
+    ):
+
+        @job
+        def _type_check_job():
+            custom_type_op()
+
+        @repository
+        def _repo():
+            return [_type_check_job]
 
 
 def test_extra_resources():
@@ -564,6 +605,10 @@ def test_root_input_manager_missing_fails():
         def _invalid():
             requires_missing_root_input_manager()
 
+        @repository
+        def _repo():
+            return [_invalid]
+
 
 def test_io_manager_missing_fails():
     @op(out={"result": Out(int, io_manager_key="missing_io_manager")})
@@ -581,3 +626,7 @@ def test_io_manager_missing_fails():
         @job
         def _invalid():
             requires_missing_io_manager()
+
+        @repository
+        def _repo():
+            return [_invalid]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -449,10 +449,6 @@ def test_type_missing_resource_fails():
         def _type_check_job():
             custom_type_op()
 
-        @repository
-        def _repo():
-            return [_type_check_job]
-
 
 def test_loader_missing_resource_fails():
     @dagster_type_loader(String, required_resource_keys={"a"})
@@ -471,38 +467,6 @@ def test_loader_missing_resource_fails():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="required by the loader on type 'CustomType'",
-    ):
-
-        @job
-        def _type_check_job():
-            custom_type_op()
-
-        @repository
-        def _repo():
-            return [_type_check_job]
-
-
-def test_materialize_missing_resource_fails():
-    @dagster_type_materializer(String, required_resource_keys={"a"})
-    def materialize(context, *_args, **_kwargs):
-        assert context.resources.a == "A"
-        return AssetMaterialization("hello")
-
-    CustomType = create_any_type(name="CustomType", materializer=materialize)
-
-    @op(
-        out={
-            "custom_type": Out(
-                CustomType,
-            )
-        }
-    )
-    def custom_type_op(_):
-        return "A"
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="required by the materializer on type 'CustomType'",
     ):
 
         @job
@@ -605,10 +569,6 @@ def test_root_input_manager_missing_fails():
         def _invalid():
             requires_missing_root_input_manager()
 
-        @repository
-        def _repo():
-            return [_invalid]
-
 
 def test_io_manager_missing_fails():
     @op(out={"result": Out(int, io_manager_key="missing_io_manager")})
@@ -626,7 +586,3 @@ def test_io_manager_missing_fails():
         @job
         def _invalid():
             requires_missing_io_manager()
-
-        @repository
-        def _repo():
-            return [_invalid]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -473,33 +473,6 @@ def test_loader_missing_resource_fails():
             custom_type_op()
 
 
-def test_extra_resources():
-    @resource
-    def resource_a(_):
-        return "a"
-
-    @resource(config_schema=int)
-    def resource_b(_):
-        return "b"
-
-    @op(required_resource_keys={"A"})
-    def echo(context):
-        return context.resources.A
-
-    @job(
-        resource_defs={
-            "A": resource_a,
-            "B": resource_b,
-            "BB": resource_b,
-        }
-    )
-    def extra():
-        echo()
-
-    # should work since B & BB's resources are not needed so missing config should be fine
-    assert extra.execute_in_process().success
-
-
 def test_extra_configured_resources():
     @resource
     def resource_a(_):

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -448,6 +448,10 @@ def test_type_missing_resource_fails():
         def _type_check_job():
             custom_type_op()
 
+        @repository
+        def _repo():
+            return [_type_check_job]
+
 
 def test_loader_missing_resource_fails():
     @dagster_type_loader(String, required_resource_keys={"a"})
@@ -471,6 +475,10 @@ def test_loader_missing_resource_fails():
         @job
         def _type_check_job():
             custom_type_op()
+
+        @repository
+        def _repo():
+            return [_type_check_job]
 
 
 def test_extra_configured_resources():
@@ -537,6 +545,10 @@ def test_root_input_manager_missing_fails():
         def _invalid():
             requires_missing_root_input_manager()
 
+        @repository
+        def _repo():
+            return [_invalid]
+
 
 def test_io_manager_missing_fails():
     @op(out={"result": Out(int, io_manager_key="missing_io_manager")})
@@ -554,3 +566,7 @@ def test_io_manager_missing_fails():
         @job
         def _invalid():
             requires_missing_io_manager()
+
+        @repository
+        def _repo():
+            return [_invalid]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -10,6 +10,7 @@ from dagster import (
     graph,
     job,
     op,
+    repository,
     resource,
     usable_as_dagster_type,
 )
@@ -479,6 +480,33 @@ def test_loader_missing_resource_fails():
         @repository
         def _repo():
             return [_type_check_job]
+
+
+def test_extra_resources():
+    @resource
+    def resource_a(_):
+        return "a"
+
+    @resource(config_schema=int)
+    def resource_b(_):
+        return "b"
+
+    @op(required_resource_keys={"A"})
+    def echo(context):
+        return context.resources.A
+
+    @job(
+        resource_defs={
+            "A": resource_a,
+            "B": resource_b,
+            "BB": resource_b,
+        }
+    )
+    def extra():
+        echo()
+
+    # should work since B & BB's resources are not needed so missing config should be fine
+    assert extra.execute_in_process().success
 
 
 def test_extra_configured_resources():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -10,7 +10,6 @@ from dagster import (
     graph,
     job,
     op,
-    repository,
     resource,
     usable_as_dagster_type,
 )
@@ -472,10 +471,6 @@ def test_loader_missing_resource_fails():
         @job
         def _type_check_job():
             custom_type_op()
-
-        @repository
-        def _repo():
-            return [_type_check_job]
 
 
 def test_extra_resources():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -5,8 +5,7 @@ import subprocess
 import sys
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, Mapping
-from typing import Any, Callable, List, cast
+from typing import Any, Callable, List, Mapping, cast
 
 import pytest
 from dagster import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -376,7 +376,10 @@ def test_bare_graph_with_resources():
     def bare():
         needy()
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Failed attempting to coerce Graph"):
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'stuff' required by op 'needy' was not provided",
+    ):
 
         @repository
         def _test():
@@ -661,7 +664,10 @@ def test_bad_coerce():
     def bar():
         foo()
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Failed attempting to coerce Graph"):
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'x' required by op 'foo' was not provided",
+    ):
 
         @repository
         def _fails():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
@@ -21,6 +21,7 @@ from dagster import (
     job,
     materialize,
     op,
+    repository,
     resource,
     root_input_manager,
 )
@@ -779,6 +780,10 @@ def test_resource_not_input_manager():
         def basic():
             op_requires_manager()
 
+        @repository
+        def _my_repo():
+            return [basic]
+
 
 def test_mode_missing_input_manager():
     @op(ins={"a": In(root_manager_key="missing_root_manager")})
@@ -790,6 +795,10 @@ def test_mode_missing_input_manager():
         @job
         def _my_job():
             my_op()
+
+        @repository
+        def _my_repo():
+            return [_my_job]
 
 
 def test_missing_input_manager():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
@@ -21,7 +21,6 @@ from dagster import (
     job,
     materialize,
     op,
-    repository,
     resource,
     root_input_manager,
 )
@@ -780,10 +779,6 @@ def test_resource_not_input_manager():
         def basic():
             op_requires_manager()
 
-        @repository
-        def _my_repo():
-            return [basic]
-
 
 def test_mode_missing_input_manager():
     @op(ins={"a": In(root_manager_key="missing_root_manager")})
@@ -795,10 +790,6 @@ def test_mode_missing_input_manager():
         @job
         def _my_job():
             my_op()
-
-        @repository
-        def _my_repo():
-            return [_my_job]
 
 
 def test_missing_input_manager():

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from dagster import job
+from dagster import job, repository
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagstermill.examples.repository import hello_world
 
@@ -14,6 +14,10 @@ def test_yes_output_notebook_no_file_manager():
         @job
         def _job():
             hello_world()
+
+        @repository
+        def _repo():
+            return [_job]
 
 
 @pytest.mark.notebook_test

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from dagster import job, repository
+from dagster import job
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagstermill.examples.repository import hello_world
 
@@ -14,10 +14,6 @@ def test_yes_output_notebook_no_file_manager():
         @job
         def _job():
             hello_world()
-
-        @repository
-        def _repo():
-            return [_job]
 
 
 @pytest.mark.notebook_test


### PR DESCRIPTION
## Summary

Enables users to specify resources for jobs at the top-level in a `Definitions` object. Defers validation of a job's resources until repo initialization time. This is a pretty naive first-pass at doing so, there may be demons that this approach doesn't acknowledge.

Users may continue to specify resources at the job level. If they do so, they are validated immediately, as before.

```python
class WriterResource(ConfigurableResource):
    prefix: str

    def output(self, text: str) -> None:
        out_txt.append(f"{self.prefix}{text}")

@op
def hello_world_op(writer: WriterResource):
    writer.output("hello, world!")

# No resource binding needed here - if resource is not provided at `Definitions` time, error thrown
@job
def hello_world_job():
    hello_world_op()

defs = Definitions(
    jobs=[hello_world_job],
    resources={
        "writer": WriterResource(prefix="message: "),
    },
)
```

### How I Tested These Changes

New unit tests & existing tests.