### PR TITLE
Improve multipartition performance for `get_partition`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -33,7 +33,6 @@ from .partition import (
     PartitionsDefinition,
     PartitionsSubset,
     StaticPartitionsDefinition,
-    Partition,
 )
 from .time_window_partitions import TimeWindowPartitionsDefinition
 
@@ -219,7 +218,8 @@ class MultiPartitionsDefinition(PartitionsDefinition):
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Partition:
         if not isinstance(partition_key, MultiPartitionKey):
-            check.failed("get_partition can only be called with a MultiPartitionKey")
+            partition_key = self.get_partition_key_from_str(partition_key)
+        partition_key = cast(MultiPartitionKey, partition_key)
 
         if partition_key.keys_by_dimension.keys() != set(self.partition_dimension_names):
             raise DagsterUnknownPartitionError(
@@ -236,8 +236,8 @@ class MultiPartitionsDefinition(PartitionsDefinition):
             )
             if not partition:
                 check.failed(
-                    "Invalid partition key {partition_key}. The partition key does not exist in the"
-                    " partitions definition."
+                    f"Invalid partition key {partition_key}. The partition key does not exist in"
+                    " the partitions definition."
                 )
             partitions_by_dimension[dimension.name] = partition
 


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/12441

User with 90K partitions in a multipartitions definition was attempting to yield 50 multipartitioned run requests within a schedule, causing timeouts in sensor evaluation.
![slow_schedule_eval](https://user-images.githubusercontent.com/29110579/219793179-449f82ab-3da4-4132-8b55-a80a803c2706.svg)

Within `run_request_for_partition`, calling `partition_set.get_partition` invokes `get_partitions` to fetch the matching partition. Calling `get_partitions` this many times on a multipartitions definition becomes expensive with 90K partitions and causes the timeout in the flamegraph above.

This PR adds a performance improvement for this by adding a `get_partition` method on `PartitionsDefinition`, with `MultiPartitionsDefinition` subclassing this method and fetching the partition by dimension to avoid fetching all partitions.