### PR TITLE
[asset-reconciliation][perf] Do not get/set known_used_data in asset reconciliation loop

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -428,7 +428,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         # in the future, we can share this same CachingInstanceQueryer across all
         # GrapheneMaterializationEvent which share an external repository for improved performance
         data_time_queryer = CachingInstanceQueryer(
-            instance=graphene_info.context.instance, use_known_used_data=True
+            instance=graphene_info.context.instance, cache_known_used_data=True
         )
         event_records = instance.get_event_records(
             EventRecordsFilter(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -427,7 +427,9 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         # in the future, we can share this same CachingInstanceQueryer across all
         # GrapheneMaterializationEvent which share an external repository for improved performance
-        data_time_queryer = CachingInstanceQueryer(instance=graphene_info.context.instance)
+        data_time_queryer = CachingInstanceQueryer(
+            instance=graphene_info.context.instance, use_known_used_data=True
+        )
         event_records = instance.get_event_records(
             EventRecordsFilter(
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -47,11 +47,19 @@ USED_DATA_TAG = ".dagster/used_data"
 class CachingInstanceQueryer(DynamicPartitionsStore):
     """Provides utility functions for querying for asset-materialization related data from the
     instance which will attempt to limit redundant expensive calls.
+
+    Args:
+        instance (DagsterInstance): The instance to query.
+        cache_known_used_data (bool): If True, will attempt to read a cached value for the used
+            data for a given record, rather than calculating it from scratch. If cached information
+            is not available, then the used data will be calculated and then cached. If this queryer
+            will be used to query for used data for a large number of records, it is recommended to
+            keep this set to False, as it will result in a large number of queries to the instance.
     """
 
-    def __init__(self, instance: "DagsterInstance", use_known_used_data: bool = False):
+    def __init__(self, instance: "DagsterInstance", cache_known_used_data: bool = False):
         self._instance = instance
-        self._use_known_used_data = use_known_used_data
+        self._cache_known_used_data = cache_known_used_data
 
         self._latest_materialization_record_cache: Dict[AssetKeyPartitionKey, EventLogRecord] = {}
         # if we try to fetch the latest materialization record after a given cursor and don't find
@@ -564,7 +572,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
 
         # grab the existing upstream data times already calculated for this record (if any)
         if (
-            self._use_known_used_data
+            self._cache_known_used_data
             and asset_graph.freshness_policies_by_key.get(asset_key) is not None
         ):
             known_data = self.get_known_used_data(asset_key, record_id)
@@ -677,7 +685,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             record_tags=frozendict(record.asset_materialization.tags or {}),
         )
         if (
-            self._use_known_used_data
+            self._cache_known_used_data
             and asset_graph.freshness_policies_by_key.get(record.asset_key) is not None
             and not asset_graph.is_partitioned(record.asset_key)
         ):

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -563,7 +563,10 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             return {asset_key: (record_id, record_timestamp)}
 
         # grab the existing upstream data times already calculated for this record (if any)
-        if asset_graph.freshness_policies_by_key.get(asset_key) is not None:
+        if (
+            self._use_known_used_data
+            and asset_graph.freshness_policies_by_key.get(asset_key) is not None
+        ):
             known_data = self.get_known_used_data(asset_key, record_id)
             if known_data:
                 return known_data

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -232,7 +232,7 @@ class PerfScenario(NamedTuple):
                 )
                 end = time.time()
                 execution_time_seconds = end - start
-                assert execution_time_seconds < 0, self.max_execution_time_seconds
+                assert execution_time_seconds < self.max_execution_time_seconds
 
 
 # ==============================================
@@ -328,7 +328,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=giant_unpartitioned_assets_2_random_runs,
         n_freshness_policies=0,
-        max_execution_time_seconds=20,
+        max_execution_time_seconds=10,
     ),
     PerfScenario(
         snapshot=giant_unpartitioned_assets_2_random_runs,
@@ -343,7 +343,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=large_unpartitioned_assets_2_random_runs,
         n_freshness_policies=100,
-        max_execution_time_seconds=15,
+        max_execution_time_seconds=10,
     ),
     PerfScenario(
         snapshot=large_all_partitioned_assets_2_partition_keys,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -323,12 +323,12 @@ perf_scenarios = [
     PerfScenario(
         snapshot=giant_unpartitioned_assets_1_run,
         n_freshness_policies=100,
-        max_execution_time_seconds=30,
+        max_execution_time_seconds=25,
     ),
     PerfScenario(
         snapshot=giant_unpartitioned_assets_2_random_runs,
         n_freshness_policies=0,
-        max_execution_time_seconds=25,
+        max_execution_time_seconds=20,
     ),
     PerfScenario(
         snapshot=giant_unpartitioned_assets_2_random_runs,
@@ -348,7 +348,7 @@ perf_scenarios = [
     PerfScenario(
         snapshot=large_all_partitioned_assets_2_partition_keys,
         n_freshness_policies=100,
-        max_execution_time_seconds=30,
+        max_execution_time_seconds=15,
     ),
     PerfScenario(
         snapshot=medium_all_partitioned_assets_2_partition_keys,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -232,7 +232,7 @@ class PerfScenario(NamedTuple):
                 )
                 end = time.time()
                 execution_time_seconds = end - start
-                assert execution_time_seconds < self.max_execution_time_seconds
+                assert execution_time_seconds < 0, self.max_execution_time_seconds
 
 
 # ==============================================


### PR DESCRIPTION
### Summary & Motivation

Even though it seems like this would save time, the per-query overhead is a lot. If you have many freshness policies, reading / writing the asset_event_tags table a bunch of times is not really all that efficient, you'd rather just do the query from scratch.

It's still nice to do this in the frontend codepath, as that's evaluated one node at a time.

### How I Tested These Changes
