### PR TITLE
[dagit] Use range-based asset health for asset partitions / job partitions pages

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -8,15 +8,16 @@ import {Inner} from '../ui/VirtualizedTable';
 import {AssetListRow, AssetListContainer} from './AssetEventList';
 
 export const AssetPartitionList: React.FC<{
-  partitions: {dimensionKey: string; state: PartitionState}[];
+  partitions: string[];
+  stateForPartition: (dimensionKey: string) => PartitionState;
   focusedDimensionKey?: string;
   setFocusedDimensionKey?: (dimensionKey: string | undefined) => void;
-}> = ({focusedDimensionKey, setFocusedDimensionKey, partitions}) => {
+}> = ({focusedDimensionKey, setFocusedDimensionKey, partitions, stateForPartition}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 
   const rowVirtualizer = useVirtualizer({
     count: partitions.length,
-    getItemKey: (idx) => partitions[idx].dimensionKey,
+    getItemKey: (idx) => partitions[idx],
     getScrollElement: () => parentRef.current,
     estimateSize: () => 36,
     overscan: 10,
@@ -26,10 +27,10 @@ export const AssetPartitionList: React.FC<{
 
   React.useEffect(() => {
     if (focusedDimensionKey) {
-      rowVirtualizer.scrollToIndex(
-        partitions.findIndex((p) => p.dimensionKey === focusedDimensionKey),
-        {smoothScroll: false, align: 'auto'},
-      );
+      rowVirtualizer.scrollToIndex(partitions.indexOf(focusedDimensionKey), {
+        smoothScroll: false,
+        align: 'auto',
+      });
     }
   }, [focusedDimensionKey, rowVirtualizer, partitions]);
 
@@ -42,18 +43,18 @@ export const AssetPartitionList: React.FC<{
         if (!setFocusedDimensionKey || !shift || !focusedDimensionKey || e.isDefaultPrevented()) {
           return;
         }
-        const nextIdx = partitions.findIndex((p) => p.dimensionKey === focusedDimensionKey) + shift;
+        const nextIdx = partitions.indexOf(focusedDimensionKey) + shift;
         const next = partitions[nextIdx];
         if (next) {
           e.preventDefault();
-          setFocusedDimensionKey(next.dimensionKey);
+          setFocusedDimensionKey(next);
         }
       }}
     >
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
-          const {dimensionKey, state} = partitions[index];
-
+          const dimensionKey = partitions[index];
+          const state = stateForPartition(dimensionKey);
           return (
             <AssetListRow
               key={key}

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -7,12 +7,18 @@ import {Inner} from '../ui/VirtualizedTable';
 
 import {AssetListRow, AssetListContainer} from './AssetEventList';
 
-export const AssetPartitionList: React.FC<{
+export interface AssetPartitionListProps {
   partitions: string[];
   stateForPartition: (dimensionKey: string) => PartitionState;
   focusedDimensionKey?: string;
   setFocusedDimensionKey?: (dimensionKey: string | undefined) => void;
-}> = ({focusedDimensionKey, setFocusedDimensionKey, partitions, stateForPartition}) => {
+}
+export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
+  focusedDimensionKey,
+  setFocusedDimensionKey,
+  partitions,
+  stateForPartition,
+}) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 
   const rowVirtualizer = useVirtualizer({

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.stories.tsx
@@ -1,0 +1,112 @@
+import {MockedProvider} from '@apollo/client/testing';
+import React from 'react';
+
+import {StorybookProvider} from '../testing/StorybookProvider';
+
+import {AssetPartitions} from './AssetPartitions';
+import {AssetViewParams} from './AssetView';
+import {
+  MultiDimensionStaticPartitionHealthQuery,
+  MultiDimensionTimeFirstPartitionHealthQuery,
+  MultiDimensionTimeSecondPartitionHealthQuery,
+  SingleDimensionStaticPartitionHealthQuery,
+  SingleDimensionTimePartitionHealthQuery,
+} from './PartitionHealthSummary.mocks';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: AssetPartitions};
+
+export const SingleDimensionStaticAsset = () => {
+  const [params, setParams] = React.useState<AssetViewParams>({});
+
+  return (
+    <StorybookProvider>
+      <MockedProvider mocks={[SingleDimensionStaticPartitionHealthQuery]}>
+        <AssetPartitions
+          assetKey={{path: ['single_dimension_static']}}
+          params={params}
+          setParams={setParams}
+          paramsTimeWindowOnly={false}
+          assetPartitionDimensions={['default']}
+          assetLastMaterializedAt={undefined}
+        />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};
+
+export const SingleDimensionTimeAsset = () => {
+  const [params, setParams] = React.useState<AssetViewParams>({});
+
+  return (
+    <StorybookProvider>
+      <MockedProvider mocks={[SingleDimensionTimePartitionHealthQuery]}>
+        <AssetPartitions
+          assetKey={{path: ['single_dimension_time']}}
+          params={params}
+          setParams={setParams}
+          paramsTimeWindowOnly={false}
+          assetPartitionDimensions={['default']}
+          assetLastMaterializedAt={undefined}
+        />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};
+
+export const MultiDimensionStaticAsset = () => {
+  const [params, setParams] = React.useState<AssetViewParams>({});
+
+  return (
+    <StorybookProvider>
+      <MockedProvider mocks={[MultiDimensionStaticPartitionHealthQuery]}>
+        <AssetPartitions
+          assetKey={{path: ['multi_dimension_static']}}
+          params={params}
+          setParams={setParams}
+          paramsTimeWindowOnly={false}
+          assetPartitionDimensions={['month', 'state']}
+          assetLastMaterializedAt={undefined}
+        />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};
+
+export const MultiDimensionTimeFirstAsset = () => {
+  const [params, setParams] = React.useState<AssetViewParams>({});
+
+  return (
+    <StorybookProvider>
+      <MockedProvider mocks={[MultiDimensionTimeFirstPartitionHealthQuery]}>
+        <AssetPartitions
+          assetKey={{path: ['multi_dimension_time_first']}}
+          params={params}
+          setParams={setParams}
+          paramsTimeWindowOnly={false}
+          assetPartitionDimensions={['date', 'zstate']}
+          assetLastMaterializedAt={undefined}
+        />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};
+
+export const MultiDimensionTimeSecondAsset = () => {
+  const [params, setParams] = React.useState<AssetViewParams>({});
+
+  return (
+    <StorybookProvider>
+      <MockedProvider mocks={[MultiDimensionTimeSecondPartitionHealthQuery]}>
+        <AssetPartitions
+          assetKey={{path: ['multi_dimension_time_second']}}
+          params={params}
+          setParams={setParams}
+          paramsTimeWindowOnly={false}
+          assetPartitionDimensions={['astate', 'date']}
+          assetLastMaterializedAt={undefined}
+        />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
@@ -1,0 +1,158 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent, {specialChars} from '@testing-library/user-event';
+import React from 'react';
+import {Route} from 'react-router-dom';
+
+import {AssetKeyInput} from '../graphql/types';
+import {TestProvider} from '../testing/TestProvider';
+
+import {AssetPartitionListProps} from './AssetPartitionList';
+import {AssetPartitions} from './AssetPartitions';
+import {AssetViewParams} from './AssetView';
+import {
+  SingleDimensionStaticPartitionHealthQuery,
+  SingleDimensionTimePartitionHealthQuery,
+} from './PartitionHealthSummary.mocks';
+
+// This file must be mocked because useVirtualizer tries to create a ResizeObserver,
+// and the component tree fails to mount. We still want to test whether certain partitions
+// are shown, so we print the keys in a simple "list".
+jest.mock('./AssetPartitionList', () => ({
+  AssetPartitionList: (props: AssetPartitionListProps) => (
+    <div>
+      <div data-testid="focused-partition">{props.focusedDimensionKey}</div>
+      {props.partitions.slice(0, 50).map((p) => (
+        <div key={p} onClick={() => props.setFocusedDimensionKey?.(p)}>
+          {p}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+const SingleDimensionAssetPartitions: React.FC<{assetKey: AssetKeyInput}> = ({assetKey}) => {
+  const [params, setParams] = React.useState<AssetViewParams>({});
+  return (
+    <TestProvider>
+      <MockedProvider
+        mocks={[SingleDimensionTimePartitionHealthQuery, SingleDimensionStaticPartitionHealthQuery]}
+      >
+        <div style={{height: 1000}}>
+          <AssetPartitions
+            assetKey={assetKey}
+            params={params}
+            setParams={setParams}
+            paramsTimeWindowOnly={false}
+            assetPartitionDimensions={['default']}
+            assetLastMaterializedAt={undefined}
+          />
+        </div>
+      </MockedProvider>
+      <Route
+        path="*"
+        render={({location}) => <div data-testid="router-search">{location.search}</div>}
+      />
+    </TestProvider>
+  );
+};
+
+describe('AssetPartitions', () => {
+  it('should support filtering a time-partitioned asset to a time range using the top bar', async () => {
+    await act(async () => {
+      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('6,000 Partitions');
+      expect(screen.queryByText('2022-06-01-01:00')).toBeVisible();
+    });
+
+    await waitFor(async () => {
+      const partitionInput = screen.getByTestId('dimension-range-input');
+      await userEvent.type(partitionInput, specialChars.selectAll);
+      await userEvent.type(partitionInput, specialChars.backspace);
+      await userEvent.type(partitionInput, '[2022-11-28-20:00...2022-12-05-01:00]', {delay: 1});
+      await userEvent.tab();
+    });
+    await waitFor(() => {
+      // Verify that the counts update to reflect the subrange
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('150 Partitions');
+      expect(screen.getByText('Missing (135)')).toBeVisible();
+      expect(screen.getByText('Completed (15)')).toBeVisible();
+
+      // Verify that the items shown on the left update to reflect the subrange
+      expect(screen.queryByText('2022-06-01-01:00')).toBeNull();
+      expect(screen.queryByText('2022-11-28-20:00')).toBeVisible();
+    });
+  });
+
+  it('should sync time range selection to the URL', async () => {
+    await act(async () => {
+      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
+    });
+
+    await waitFor(async () => {
+      const partitionInput = screen.getByTestId('dimension-range-input');
+      await userEvent.type(partitionInput, specialChars.selectAll);
+      await userEvent.type(partitionInput, specialChars.backspace);
+      await userEvent.type(partitionInput, '[2022-11-28-20:00...2022-12-05-01:00]', {delay: 1});
+      await userEvent.tab();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('router-search')).toHaveTextContent(
+        'default_range=%5B2022-11-28-20%3A00...2022-12-05-01%3A00%5D',
+      );
+    });
+  });
+
+  it('should support filtering by partition status and sync state to the URL', async () => {
+    await act(async () => {
+      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_time']}} />);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('6,000 Partitions');
+    });
+
+    const successCheck = screen.getByTestId('partition-state-success-checkbox');
+    await userEvent.click(successCheck);
+    expect(screen.getByTestId('partitions-selected')).toHaveTextContent('5,288 Partitions');
+    expect(screen.getByTestId('router-search')).toHaveTextContent('states=missing');
+
+    const missingCheck = screen.getByTestId('partition-state-missing-checkbox');
+    await userEvent.click(missingCheck);
+    expect(screen.getByTestId('partitions-selected')).toHaveTextContent('0 Partitions Selected');
+    expect(screen.getByTestId('router-search')).toHaveTextContent('states=');
+
+    await userEvent.click(successCheck);
+    expect(screen.getByTestId('partitions-selected')).toHaveTextContent('712 Partitions Selected');
+    expect(screen.getByTestId('router-search')).toHaveTextContent('states=success');
+
+    // verify that filtering by state updates the left sidebar
+    expect(screen.queryByText('2022-08-31-00:00')).toBeVisible();
+  });
+
+  it('should set the focused partition when you click a list element', async () => {
+    await act(async () => {
+      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_static']}} />);
+    });
+    await waitFor(async () => {
+      const listItem = screen.getByText('NC');
+      await userEvent.click(listItem);
+    });
+    await waitFor(async () => {
+      expect(screen.getByTestId('focused-partition')).toHaveTextContent('NC');
+    });
+  });
+
+  it('should not render a top bar with a partition input for statically partitioned assets', async () => {
+    await act(async () => {
+      render(<SingleDimensionAssetPartitions assetKey={{path: ['single_dimension_static']}} />);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('partitions-selected')).toHaveTextContent('11 Partitions Selected');
+      expect(screen.queryByTestId('dimension-range-input')).toBeNull();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
@@ -2,10 +2,9 @@ import {MockedProvider} from '@apollo/client/testing';
 import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent, {specialChars} from '@testing-library/user-event';
 import React from 'react';
-import {Route} from 'react-router-dom';
+import {MemoryRouter, Route} from 'react-router-dom';
 
 import {AssetKeyInput} from '../graphql/types';
-import {TestProvider} from '../testing/TestProvider';
 
 import {AssetPartitionListProps} from './AssetPartitionList';
 import {AssetPartitions} from './AssetPartitions';
@@ -34,7 +33,7 @@ jest.mock('./AssetPartitionList', () => ({
 const SingleDimensionAssetPartitions: React.FC<{assetKey: AssetKeyInput}> = ({assetKey}) => {
   const [params, setParams] = React.useState<AssetViewParams>({});
   return (
-    <TestProvider>
+    <MemoryRouter>
       <MockedProvider
         mocks={[SingleDimensionTimePartitionHealthQuery, SingleDimensionStaticPartitionHealthQuery]}
       >
@@ -51,7 +50,7 @@ const SingleDimensionAssetPartitions: React.FC<{assetKey: AssetKeyInput}> = ({as
         path="*"
         render={({location}) => <div data-testid="router-search">{location.search}</div>}
       />
-    </TestProvider>
+    </MemoryRouter>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
@@ -38,16 +38,14 @@ const SingleDimensionAssetPartitions: React.FC<{assetKey: AssetKeyInput}> = ({as
       <MockedProvider
         mocks={[SingleDimensionTimePartitionHealthQuery, SingleDimensionStaticPartitionHealthQuery]}
       >
-        <div style={{height: 1000}}>
-          <AssetPartitions
-            assetKey={assetKey}
-            params={params}
-            setParams={setParams}
-            paramsTimeWindowOnly={false}
-            assetPartitionDimensions={['default']}
-            assetLastMaterializedAt={undefined}
-          />
-        </div>
+        <AssetPartitions
+          assetKey={assetKey}
+          params={params}
+          setParams={setParams}
+          paramsTimeWindowOnly={false}
+          assetPartitionDimensions={['default']}
+          assetLastMaterializedAt={undefined}
+        />
       </MockedProvider>
       <Route
         path="*"
@@ -68,23 +66,22 @@ describe('AssetPartitions', () => {
       expect(screen.queryByText('2022-06-01-01:00')).toBeVisible();
     });
 
-    await waitFor(async () => {
-      const partitionInput = screen.getByTestId('dimension-range-input');
-      await userEvent.type(partitionInput, specialChars.selectAll);
-      await userEvent.type(partitionInput, specialChars.backspace);
-      await userEvent.type(partitionInput, '[2022-11-28-20:00...2022-12-05-01:00]', {delay: 1});
-      await userEvent.tab();
-    });
+    const partitionInput = screen.getByTestId('dimension-range-input');
+    await userEvent.type(partitionInput, specialChars.selectAll);
+    await userEvent.type(partitionInput, specialChars.backspace);
+    await userEvent.type(partitionInput, '[2022-11-28-20:00...2022-12-05-01:00]');
+    await userEvent.tab();
+
     await waitFor(() => {
       // Verify that the counts update to reflect the subrange
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('150 Partitions');
-      expect(screen.getByText('Missing (135)')).toBeVisible();
-      expect(screen.getByText('Completed (15)')).toBeVisible();
-
-      // Verify that the items shown on the left update to reflect the subrange
-      expect(screen.queryByText('2022-06-01-01:00')).toBeNull();
-      expect(screen.queryByText('2022-11-28-20:00')).toBeVisible();
     });
+    expect(screen.getByText('Missing (135)')).toBeVisible();
+    expect(screen.getByText('Completed (15)')).toBeVisible();
+
+    // Verify that the items shown on the left update to reflect the subrange
+    expect(screen.queryByText('2022-06-01-01:00')).toBeNull();
+    expect(screen.queryByText('2022-11-28-20:00')).toBeVisible();
   });
 
   it('should sync time range selection to the URL', async () => {

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -33,7 +33,7 @@ the asset health bar you see is a flattened representation of the health of all 
 */
 export function mergedAssetHealth(
   assetHealth: PartitionHealthData[],
-): Omit<PartitionHealthData, 'assetKey'> {
+): Omit<PartitionHealthData, 'assetKey' | 'ranges' | 'rangesPrimaryDimension'> {
   if (!assetHealth.length) {
     return {
       dimensions: [],

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -38,7 +38,6 @@ export function mergedAssetHealth(
     return {
       dimensions: [],
       stateForKey: () => PartitionState.MISSING,
-      stateForSingleDimension: () => PartitionState.MISSING,
       rangesForSingleDimension: () => [],
     };
   }
@@ -68,16 +67,6 @@ export function mergedAssetHealth(
     })),
     stateForKey: (dimensionKeys: string[]) =>
       mergedStates(assetHealth.map((health) => health.stateForKey(dimensionKeys))),
-    stateForSingleDimension: (
-      dimensionIdx: number,
-      dimensionKey: string,
-      otherDimensionSelectedKeys?: string[],
-    ) =>
-      mergedStates(
-        assetHealth.map((health) =>
-          health.stateForSingleDimension(dimensionIdx, dimensionKey, otherDimensionSelectedKeys),
-        ),
-      ),
     rangesForSingleDimension: (dimensionIdx, otherDimensionSelectedRanges?) =>
       mergedRanges(
         dimensions[dimensionIdx].partitionKeys,

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -33,7 +33,7 @@ the asset health bar you see is a flattened representation of the health of all 
 */
 export function mergedAssetHealth(
   assetHealth: PartitionHealthData[],
-): Omit<PartitionHealthData, 'assetKey' | 'ranges' | 'rangesPrimaryDimension'> {
+): Omit<PartitionHealthData, 'assetKey' | 'ranges'> {
   if (!assetHealth.length) {
     return {
       dimensions: [],

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
@@ -12,6 +12,8 @@ import {
   keyCountByStateInSelection,
   PartitionHealthDimension,
   PartitionDimensionSelection,
+  keyCountInRanges,
+  keyCountInSelection,
 } from './usePartitionHealthData';
 
 const {SUCCESS, MISSING} = PartitionState;
@@ -544,9 +546,31 @@ describe('usePartitionHealthData utilities', () => {
     });
   });
 
+  describe('keyCountInRanges', () => {
+    it('should return 0 if passed no ranges', () => {
+      expect(keyCountInRanges([])).toEqual(0);
+    });
+    it('should return the sum of the lengths of the ranges', () => {
+      expect(keyCountInRanges([A_C, G_I])).toEqual(6);
+    });
+  });
+
+  describe('keyCountInSelection', () => {
+    it('should return 0 if passed no selections', () => {
+      expect(keyCountInSelection([])).toEqual(0);
+    });
+    it('should return the sum of the lengths of the selections', () => {
+      expect(keyCountInSelection([SEL_A_C, SEL_E_G])).toEqual(6);
+    });
+  });
+
   describe('rangesForKeys', () => {
     it('should return a complete range given all dimension keys', () => {
       expect(rangesForKeys(KEYS, KEYS)).toEqual([A_I]);
+    });
+    it('should return an empty range if all dimension keys is an empty array', () => {
+      expect(rangesForKeys([], [])).toEqual([]);
+      expect(rangesForKeys(KEYS, [])).toEqual([]);
     });
     it('should return the correct result if `keys` is unsorted', () => {
       expect(rangesForKeys(['A', 'C', 'B', 'D', 'F', 'G', 'I', 'H', 'E'], KEYS)).toEqual([A_I]);
@@ -589,6 +613,11 @@ describe('usePartitionHealthData utilities', () => {
   });
 
   describe('keyCountByStateInSelection', () => {
+    it('should return nothing when passed an empty selection array (invalid use)', () => {
+      const one = buildPartitionHealthData(ONE_DIMENSIONAL_ASSET, {path: ['asset']});
+      expect(keyCountByStateInSelection(one, [])).toEqual({missing: 0, success: 0});
+    });
+
     it('should return correct counts in the one dimensional case', () => {
       const one = buildPartitionHealthData(ONE_DIMENSIONAL_ASSET, {path: ['asset']});
 

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.test.tsx
@@ -10,7 +10,7 @@ import {
   rangesForKeys,
 } from './usePartitionHealthData';
 
-const {SUCCESS_MISSING, SUCCESS, MISSING} = PartitionState;
+const {SUCCESS, MISSING} = PartitionState;
 
 const DIMENSION_ONE_KEYS = [
   '2022-01-01',
@@ -221,9 +221,6 @@ describe('usePartitionHealthData', () => {
       expect(assetHealth.stateForKey(['2022-01-01'])).toEqual(MISSING);
       expect(assetHealth.stateForKey(['2022-01-04'])).toEqual(SUCCESS);
 
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-01')).toEqual(MISSING);
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-04')).toEqual(SUCCESS);
-
       expect(assetHealth.rangesForSingleDimension(0)).toEqual([
         {
           start: {idx: 3, key: '2022-01-04'},
@@ -254,17 +251,6 @@ describe('usePartitionHealthData', () => {
       // Ask for the state of a full key (cell)
       expect(assetHealth.stateForKey(['2022-01-01', 'TN'])).toEqual(MISSING);
       expect(assetHealth.stateForKey(['2022-01-04', 'NY'])).toEqual(SUCCESS);
-
-      // Ask for the state of a row
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-03')).toEqual(SUCCESS_MISSING);
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-04')).toEqual(SUCCESS);
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-01')).toEqual(SUCCESS_MISSING);
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-01', ['MN', 'NY'])).toEqual(SUCCESS);
-
-      // Ask for the state of a column
-      expect(assetHealth.stateForSingleDimension(1, 'TN')).toEqual(SUCCESS_MISSING);
-      expect(assetHealth.stateForSingleDimension(1, 'MN')).toEqual(SUCCESS);
-      expect(assetHealth.stateForSingleDimension(1, 'TN', ['2022-01-04'])).toEqual(SUCCESS);
 
       // Ask for the ranges of a row
       expect(assetHealth.rangesForSingleDimension(0)).toEqual([
@@ -369,9 +355,6 @@ describe('usePartitionHealthData', () => {
       expect(assetHealth.stateForKey(['2022-01-01', 'TN'])).toEqual(MISSING);
       expect(assetHealth.stateForKey(['2022-01-04', 'NY'])).toEqual(MISSING);
 
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-03')).toEqual(MISSING);
-      expect(assetHealth.stateForSingleDimension(1, 'TN')).toEqual(MISSING);
-
       expect(assetHealth.rangesForSingleDimension(0)).toEqual([]);
       expect(
         assetHealth.rangesForSingleDimension(0, [
@@ -400,12 +383,6 @@ describe('usePartitionHealthData', () => {
       expect(assetHealth.assetKey).toEqual({path: ['asset']});
       expect(assetHealth.stateForKey(['TN', 'TN'])).toEqual(SUCCESS);
       expect(assetHealth.stateForKey(['CA', 'NY'])).toEqual(MISSING);
-      expect(assetHealth.stateForSingleDimension(0, 'CA')).toEqual(SUCCESS_MISSING);
-      expect(assetHealth.stateForSingleDimension(0, 'CA', ['TN', 'CA'])).toEqual(SUCCESS);
-      expect(assetHealth.stateForSingleDimension(0, 'CA', ['NY', 'MN'])).toEqual(MISSING);
-      expect(assetHealth.stateForSingleDimension(1, 'TN')).toEqual(SUCCESS_MISSING);
-      expect(assetHealth.stateForSingleDimension(1, 'TN', ['TN', 'CA'])).toEqual(SUCCESS);
-      expect(assetHealth.stateForSingleDimension(1, 'CA')).toEqual(SUCCESS);
     });
 
     it('should return correct (empty) data if the asset is not partitioned at all', async () => {
@@ -415,7 +392,6 @@ describe('usePartitionHealthData', () => {
 
       // These should safely no-op
       expect(assetHealth.stateForKey(['2022-01-01'])).toEqual(MISSING);
-      expect(assetHealth.stateForSingleDimension(0, '2022-01-01')).toEqual(MISSING);
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -32,7 +32,6 @@ export interface PartitionHealthData {
 
   stateForKey: (dimensionKeys: string[]) => PartitionState;
 
-  rangesPrimaryDimension: PartitionHealthDimension;
   ranges: Range[];
   rangesForSingleDimension: (
     dimensionIdx: number,
@@ -181,7 +180,6 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
     stateForKey,
 
     ranges,
-    rangesPrimaryDimension: dimensions[0],
     rangesForSingleDimension,
   };
 
@@ -298,13 +296,16 @@ export function keyCountByStateInSelection(
     assetHealth?.ranges || [],
     selections[0].selectedRanges,
   );
+  const secondDimensionKeyCount =
+    selections.length > 1 ? keyCountInSelection(selections[1].selectedRanges) : 1;
+
   const success = rangesInSelection.reduce(
     (a, b) =>
       a +
       (b.end.idx - b.start.idx + 1) *
         (b.subranges
-          ? keyCountInRanges(b.subranges)
-          : keyCountInSelection(selections[1].selectedRanges)),
+          ? keyCountInRanges(rangesClippedToSelection(b.subranges, selections[1].selectedRanges))
+          : secondDimensionKeyCount),
     0,
   );
 

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -260,7 +260,10 @@ export function partitionStatusGivenRanges(ranges: Range[], totalKeyCount: numbe
  * Given a set of ranges that specify materialized regions and a selection of interest, returns the
  * ranges required to represent the ranges clipped to the selection (within the selected area only.)
  */
-function rangesClippedToSelection(ranges: Range[], selection: PartitionDimensionSelectionRange[]) {
+export function rangesClippedToSelection(
+  ranges: Range[],
+  selection: PartitionDimensionSelectionRange[],
+) {
   return ranges.flatMap((range) => rangeClippedToSelection(range, selection));
 }
 
@@ -308,14 +311,14 @@ function removeSubrangesAndJoin(ranges: Range[]): Range[] {
 
 // In a follow-up, maybe we make these two data structures share a signature
 
-function keyCountInRanges(ranges: Range[]) {
+export function keyCountInRanges(ranges: Range[]) {
   let count = 0;
   for (const range of ranges) {
     count += range.end.idx - range.start.idx + 1;
   }
   return count;
 }
-function keyCountInSelection(ranges: PartitionDimensionSelectionRange[]) {
+export function keyCountInSelection(ranges: PartitionDimensionSelectionRange[]) {
   let count = 0;
   for (const range of ranges) {
     count += range[1].idx - range[0].idx + 1;

--- a/js_modules/dagit/packages/core/src/assets/usePartitionKeyInParams.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionKeyInParams.test.tsx
@@ -1,0 +1,126 @@
+import {render, waitFor, screen} from '@testing-library/react';
+import React from 'react';
+
+import {usePartitionKeyInParams} from './usePartitionKeyInParams';
+
+describe('usePartitionKeyInParams', () => {
+  it('should parse and set a one-dimensional partition key', async () => {
+    const HookUse: React.FC = () => {
+      const setParams = jest.fn();
+      const [focusedDimensionKeys, setFocusedDimensionKey] = usePartitionKeyInParams({
+        params: {partition: 'VA'},
+        setParams,
+        dimensionCount: 1,
+        defaultKeyInDimension: () => 'TN',
+      });
+
+      expect(focusedDimensionKeys).toEqual(['VA']);
+      setFocusedDimensionKey(0, 'CA');
+      expect(setParams).toHaveBeenCalledWith({partition: 'CA'});
+      return <span>Done</span>;
+    };
+
+    render(<HookUse />);
+    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+  });
+
+  it('should default to no value for a one-dimensional partition key', async () => {
+    const HookUse: React.FC = () => {
+      const [focusedDimensionKeys] = usePartitionKeyInParams({
+        params: {},
+        setParams: jest.fn(),
+        dimensionCount: 1,
+        defaultKeyInDimension: () => 'TN',
+      });
+      expect(focusedDimensionKeys).toEqual([]);
+      return <span>Done</span>;
+    };
+
+    render(<HookUse />);
+    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+  });
+
+  it('should parse and set a two-dimensional partition key', async () => {
+    const HookUse: React.FC = () => {
+      const setParams = jest.fn();
+      const [focusedDimensionKeys, setFocusedDimensionKey] = usePartitionKeyInParams({
+        params: {partition: '2022-05-01|VA'},
+        setParams,
+        dimensionCount: 2,
+        defaultKeyInDimension: (idx: number) => (idx === 0 ? '2022-01-01' : 'TN'),
+      });
+
+      expect(focusedDimensionKeys).toEqual(['2022-05-01', 'VA']);
+
+      // Note: both tests run from the params.partition initial state above
+
+      // Changing the dimension 1 value clears the dimension 2 value
+      setFocusedDimensionKey(0, '2022-05-02');
+      expect(setParams).toHaveBeenCalledWith({partition: '2022-05-02'});
+
+      // Changing the dimension 2 value does not change dimension 1 value
+      setFocusedDimensionKey(1, 'CA');
+      expect(setParams).toHaveBeenCalledWith({partition: '2022-05-01|CA'});
+      return <span>Done</span>;
+    };
+
+    render(<HookUse />);
+    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+  });
+
+  it('should allow a partial selection of just the first partition key', async () => {
+    const HookUse: React.FC = () => {
+      const setParams = jest.fn();
+      const [, setFocusedDimensionKey] = usePartitionKeyInParams({
+        params: {partition: ''},
+        setParams,
+        dimensionCount: 2,
+        defaultKeyInDimension: (idx: number) => (idx === 0 ? '2022-01-01' : 'TN'),
+      });
+
+      setFocusedDimensionKey(0, '2022-05-02');
+      expect(setParams).toHaveBeenCalledWith({partition: '2022-05-02'});
+      return <span>Done</span>;
+    };
+
+    render(<HookUse />);
+    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+  });
+
+  it('should default to no values for a two-dimensional partition key', async () => {
+    const HookUse: React.FC = () => {
+      const [focusedDimensionKeys] = usePartitionKeyInParams({
+        params: {},
+        setParams: jest.fn(),
+        dimensionCount: 2,
+        defaultKeyInDimension: (idx: number) => (idx === 0 ? '2022-01-01' : 'TN'),
+      });
+
+      expect(focusedDimensionKeys).toEqual([]);
+      return <span>Done</span>;
+    };
+
+    render(<HookUse />);
+    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+  });
+
+  it('should default to the 1st key of dimension 1 if dimension 2 is selected first', async () => {
+    const HookUse: React.FC = () => {
+      const setParams = jest.fn();
+      const [focusedDimensionKeys, setFocusedDimensionKey] = usePartitionKeyInParams({
+        params: {},
+        setParams,
+        dimensionCount: 2,
+        defaultKeyInDimension: (idx: number) => (idx === 0 ? '2022-01-01' : 'TN'),
+      });
+
+      expect(focusedDimensionKeys).toEqual([]);
+      setFocusedDimensionKey(1, 'CA');
+      expect(setParams).toHaveBeenCalledWith({partition: '2022-01-01|CA'});
+      return <span>Done</span>;
+    };
+
+    render(<HookUse />);
+    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+  });
+});

--- a/js_modules/dagit/packages/core/src/assets/usePartitionKeyInParams.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionKeyInParams.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {AssetViewParams} from './AssetView';
+
+export function usePartitionKeyInParams({
+  params,
+  setParams,
+  dimensionCount,
+  defaultKeyInDimension,
+}: {
+  params: AssetViewParams;
+  setParams: (params: AssetViewParams) => void;
+  dimensionCount: number;
+  defaultKeyInDimension: (idx: number) => string;
+}) {
+  const focusedDimensionKeys = React.useMemo(
+    () =>
+      params.partition
+        ? dimensionCount > 1
+          ? params.partition.split('|').filter(Boolean) // 2D partition keys
+          : [params.partition] // "|" character is allowed in 1D partition keys for historical reasons
+        : [],
+    [dimensionCount, params.partition],
+  );
+
+  const setFocusedDimensionKey = (dimensionIdx: number, dimensionKey: string | undefined) => {
+    // Automatically make a selection in column 0 if the user
+    // clicked in column 1 and there is no column 0 selection.
+    const nextFocusedDimensionKeys: string[] = [];
+    for (let ii = 0; ii < dimensionIdx; ii++) {
+      nextFocusedDimensionKeys.push(focusedDimensionKeys[ii] || defaultKeyInDimension(ii));
+    }
+    if (dimensionKey) {
+      nextFocusedDimensionKeys.push(dimensionKey);
+    }
+    setParams({
+      ...params,
+      partition: nextFocusedDimensionKeys.join('|'),
+    });
+  };
+
+  return [focusedDimensionKeys, setFocusedDimensionKey] as const;
+}

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -258,7 +258,7 @@ const BackfillRunStatus = ({
     () => ({
       partitionStateForKey: (key: string) =>
         statuses
-          ? runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0].runStatus)
+          ? runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0]?.runStatus)
           : PartitionState.MISSING,
     }),
     [statuses],

--- a/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
@@ -41,7 +41,7 @@ import {
   USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT,
 } from './BackfillMessaging';
 import {DimensionRangeWizard} from './DimensionRangeWizard';
-import {PartitionStateCheckboxes} from './PartitionStateCheckboxes';
+import {countsByState, PartitionStateCheckboxes} from './PartitionStateCheckboxes';
 import {PartitionState} from './PartitionStatus';
 import {
   BackfillSelectorQuery,
@@ -166,6 +166,13 @@ export const BackfillPartitionSelector: React.FC<{
     }
   };
 
+  const counts = countsByState(
+    range.map((key) => ({
+      partitionKey: key,
+      state: partitionData[key],
+    })),
+  );
+
   return (
     <>
       <DialogBody>
@@ -184,10 +191,7 @@ export const BackfillPartitionSelector: React.FC<{
 
             <PartitionStateCheckboxes
               value={stateFilters}
-              partitionKeysForCounts={range.map((key) => ({
-                partitionKey: key,
-                state: partitionData[key],
-              }))}
+              counts={counts}
               allowed={
                 options.fromFailure
                   ? [PartitionState.FAILURE]

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeInput.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeInput.tsx
@@ -2,6 +2,7 @@ import {Icon, TextInput} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
+import {testId} from '../testing/testId';
 import {ClearButton} from '../ui/ClearButton';
 
 import {partitionsToText, spanTextToSelections} from './SpanRepresentation';
@@ -43,6 +44,7 @@ export const DimensionRangeInput: React.FC<{
 
   return (
     <TextInput
+      data-testid={testId('dimension-range-input')}
       placeholder={placeholder}
       value={valueString}
       style={{display: 'flex', width: '100%', flex: 1, flexGrow: 1}}

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStateCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStateCheckboxes.tsx
@@ -3,28 +3,30 @@ import * as React from 'react';
 
 import {PartitionState, partitionStatusToText} from './PartitionStatus';
 
+export function countsByState(
+  partitionKeysForCounts: {partitionKey: string; state: PartitionState}[],
+) {
+  const result: {[state: string]: number} = {
+    [PartitionState.SUCCESS]: 0,
+    [PartitionState.SUCCESS_MISSING]: 0,
+    [PartitionState.MISSING]: 0,
+    [PartitionState.FAILURE]: 0,
+    [PartitionState.QUEUED]: 0,
+    [PartitionState.STARTED]: 0,
+  };
+  for (const key of partitionKeysForCounts) {
+    result[key.state] = (result[key.state] || 0) + 1;
+  }
+  return result;
+}
+
 export const PartitionStateCheckboxes: React.FC<{
-  partitionKeysForCounts: {partitionKey: string; state: PartitionState}[];
+  counts: {[state: string]: number};
   value: PartitionState[];
   allowed: PartitionState[];
   onChange: (selected: PartitionState[]) => void;
   disabled?: boolean;
-}> = ({partitionKeysForCounts, value, onChange, allowed, disabled}) => {
-  const byState = React.useMemo(() => {
-    const result: {[state: string]: number} = {
-      [PartitionState.SUCCESS]: 0,
-      [PartitionState.SUCCESS_MISSING]: 0,
-      [PartitionState.MISSING]: 0,
-      [PartitionState.FAILURE]: 0,
-      [PartitionState.QUEUED]: 0,
-      [PartitionState.STARTED]: 0,
-    };
-    for (const key of partitionKeysForCounts) {
-      result[key.state] = (result[key.state] || 0) + 1;
-    }
-    return result;
-  }, [partitionKeysForCounts]);
-
+}> = ({counts, value, onChange, allowed, disabled}) => {
   return (
     <Box flex={{direction: 'row', alignItems: 'center', gap: 12}} style={{overflow: 'hidden'}}>
       {allowed.map((state) => (
@@ -33,7 +35,7 @@ export const PartitionStateCheckboxes: React.FC<{
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
           checked={value.includes(state) && !disabled}
-          label={`${partitionStatusToText(state)} (${byState[state]})`}
+          label={`${partitionStatusToText(state)} (${counts[state]})`}
           onChange={() =>
             onChange(value.includes(state) ? value.filter((v) => v !== state) : [...value, state])
           }

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStateCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStateCheckboxes.tsx
@@ -1,6 +1,8 @@
 import {Box, Checkbox} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {testId} from '../testing/testId';
+
 import {PartitionState, partitionStatusToText} from './PartitionStatus';
 
 export function countsByState(
@@ -32,6 +34,7 @@ export const PartitionStateCheckboxes: React.FC<{
       {allowed.map((state) => (
         <Checkbox
           key={state}
+          data-testid={testId(`partition-state-${state}-checkbox`)}
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
           checked={value.includes(state) && !disabled}


### PR DESCRIPTION
### Summary & Motivation

This PR moves the remaining bits of Dagit to use range-based asset health data in the most direct form possible.

This is likely to be a big performance win, especially for the asset job partitions page which loaded and very-inefficiently-queried the health data of all the assets in the job.  ( It was using a translation layer of sorts mapping the ranges to a structure that was then queried per-partition to count partitions, etc. )

One caveat of this move to range-based health is that we had to assemble a utility library for slicing / subsetting ranges, counting keys in a set of ranges with a given status, etc. This PR adds a few more (hopefully the last of them), and I'm writing exhaustive test coverage for them because the logic can be complex.

I think the range-based implementation is much more efficient, but it's harder to grok two dimensional ranges windowed to a two dimensional selection than it was to understand + visualize a 2D matrix of booleans.  I think there's a chance this could get /real/ complicated if/when we layer "stale" into asset health, but at least we'll have strong test coverage.

### How I Tested These Changes

15 new tests and a bunch of updated ones! The tests and storybooks share mocks. This PR adds:

- Storybooks for AssetPartitions

- Basic tests that the AssetPartitions page renders and interactions work:
   + Slicing the partition space via the top text input when a time partition is present
   + Filtering the partitions based on status and seeing the counts / list change
   + Clicking partitions to set focus

- Exhaustive tests for the new utility methods
