### PR TITLE
[bugfix] fix projected logical version resolution for asset downstream of self-dep

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -147,6 +147,9 @@ GET_ASSET_LOGICAL_VERSIONS = """
     query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
         assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {
             id
+            assetKey {
+              path
+            }
             currentLogicalVersion
             projectedLogicalVersion
             assetMaterializations {

--- a/python_modules/dagster/dagster/_core/definitions/logical_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/logical_version.py
@@ -271,7 +271,9 @@ class CachingStaleStatusResolver:
 
     @cached_method
     def _get_projected_logical_version(self, *, key: AssetKey) -> LogicalVersion:
-        if self.asset_graph.is_source(key):
+        if self.asset_graph.get_partitions_def(key):
+            return UNKNOWN_LOGICAL_VERSION
+        elif self.asset_graph.is_source(key):
             event = self._instance.get_latest_logical_version_record(key, True)
             if event:
                 version = (


### PR DESCRIPTION
### Summary & Motivation

Makes the projected logical version of assets downstream of partitioned assets "UNKNOWN". Previously being downstream of a self-dep asset caused a bug during PLV computation.

Fixes #11600

### How I Tested These Changes

- Modified existing unit test
- Manually confirmed error reported in #11600 no longer present
