### PR TITLE
[CustomConfirmationDialog] Allow overriding the button text

### DIFF
--- a/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
@@ -7,7 +7,7 @@ interface ConfirmationOptions {
   description?: React.ReactNode;
   icon?: ConfirmationDialogProps['icon'];
   intent?: ConfirmationDialogProps['intent'];
-  buttonText?: string;
+  buttonText?: React.ReactNode;
 }
 
 interface ConfirmationDialogProps extends ConfirmationOptions {

--- a/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomConfirmationProvider.tsx
@@ -7,6 +7,7 @@ interface ConfirmationOptions {
   description?: React.ReactNode;
   icon?: ConfirmationDialogProps['icon'];
   intent?: ConfirmationDialogProps['intent'];
+  buttonText?: string;
 }
 
 interface ConfirmationDialogProps extends ConfirmationOptions {
@@ -22,6 +23,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   icon,
   title,
   intent = 'danger',
+  buttonText = 'Confirm',
   description,
   onSubmit,
   onClose,
@@ -32,7 +34,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
       <DialogFooter>
         <Button onClick={onClose}>Cancel</Button>
         <Button onClick={onSubmit} intent={intent}>
-          Confirm
+          {buttonText}
         </Button>
       </DialogFooter>
     </Dialog>

--- a/js_modules/dagit/packages/ui/src/components/TextInput.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TextInput.tsx
@@ -24,7 +24,7 @@ export const TextInput = React.forwardRef(
     } = props;
 
     return (
-      <Container $disabled={!!disabled}>
+      <TextInputContainer $disabled={!!disabled}>
         {icon ? <Icon name={icon} color={Colors.Gray900} /> : null}
         <StyledInput
           {...rest}
@@ -36,7 +36,7 @@ export const TextInput = React.forwardRef(
           type={type}
         />
         {rightElement ? <RightContainer>{rightElement}</RightContainer> : null}
-      </Container>
+      </TextInputContainer>
     );
   },
 );
@@ -56,7 +56,7 @@ export const TextInputContainerStyles = css`
   position: relative;
 `;
 
-const Container = styled.div<{$disabled: boolean}>`
+export const TextInputContainer = styled.div<{$disabled: boolean}>`
   ${TextInputContainerStyles}
 
   > ${IconWrapper}:first-child {


### PR DESCRIPTION
### Summary & Motivation

I'd like to override the button text for my usecase.

### How I Tested These Changes

used the feature:
<img width="665" alt="Screen Shot 2023-02-21 at 12 24 45 PM" src="https://user-images.githubusercontent.com/2286579/220425423-651391c6-689e-415c-abd8-26bcd520eac5.png">
