### PR TITLE
Fix resolution error with input manager key and custom dagster type

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -288,6 +288,7 @@ class OpDefinition(NodeDefinition):
                 and not input_def.dagster_type.kind == DagsterTypeKind.NOTHING
                 and not input_def.root_manager_key
                 and not input_def.has_default_value
+                and not input_def.input_manager_key
             ):
                 input_asset_key = asset_layer.asset_key_for_input(handle, input_def.name)
                 # If input_asset_key is present, this input can be resolved

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -3,7 +3,6 @@ import json
 from datetime import datetime
 from typing import Any, List, Optional
 
-import pandas as pd
 import pendulum
 import pytest
 from dagster import (
@@ -1408,11 +1407,15 @@ def test_infer_graph_input_type_from_inner_input_mixed_fan_in():
 
 
 def test_input_manager_key_and_custom_dagster_type_resolved():
+    class CustomType:
+        def __init__(self, value):
+            self.value = value
+
     @input_manager
     def data_input_manager():
-        return pd.DataFrame([])
+        return CustomType(5)
 
-    @op(ins={"df_train": In(pd.DataFrame, input_manager_key="data_input_manager")})
+    @op(ins={"df_train": In(CustomType, input_manager_key="data_input_manager")})
     def target_extractor_op(df_train):
         return 1
 


### PR DESCRIPTION
Reported by a user: https://dagster.slack.com/archives/C01U954MEER/p1676752453296759

Our input resolution logic misses an edge case that occurs when a custom dagster type is used with an input manager key. This results in the following error in graph resolution:
```
dagster._core.errors.DagsterInvalidDefinitionError: Input 'df_train' of op 'target_extractor_op' has no way of being resolved. Must provide a resolution to this input via another op/graph, or via a direct input value mapped from the top-level graph. To learn more, see the docs for unconnected inputs: https://docs.dagster.io/concepts/io-management/unconnected-inputs#unconnected-inputs.
```
This PR fixes this error.