### PR TITLE
[dagster-gcp-pandas] API docs fix

### DIFF
--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -85,8 +85,7 @@ Examples:
 
     .. code-block:: python
 
-        from dagster_gcp import build_bigquery_io_manager
-        from dagster_bigquery_pandas import BigQueryPandasTypeHandler
+        from dagster_bigquery_pandas import bigquery_pandas_io_manager
         from dagster import Definitions
 
         @asset(
@@ -95,12 +94,10 @@ Examples:
         def my_table() -> pd.DataFrame:  # the name of the asset will be the table name
             ...
 
-        bigquery_io_manager = build_bigquery_io_manager([BigQueryPandasTypeHandler()])
-
         defs = Definitions(
             assets=[my_table],
             resources={
-                "io_manager": bigquery_io_manager.configured({
+                "io_manager": bigquery_pandas_io_manager.configured({
                     "project" : {"env": "GCP_PROJECT"}
                 })
             }

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -138,6 +138,6 @@ Examples:
     store this key in a temporary file and set GOOGLE_APPLICATION_CREDENTIALS to point to the file.
     After the run completes, the file will be deleted, and GOOGLE_APPLICATION_CREDENTIALS will be
     unset. The key must be base64 encoded to avoid issues with newlines in the keys. You can retrieve
-    the base64 encoded with this shell command: cat $GOOGLE_AUTH_CREDENTIALS | base64
+    the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
 
 """

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -95,7 +95,7 @@ def build_bigquery_io_manager(
         store this key in a temporary file and set GOOGLE_APPLICATION_CREDENTIALS to point to the file.
         After the run completes, the file will be deleted, and GOOGLE_APPLICATION_CREDENTIALS will be
         unset. The key must be base64 encoded to avoid issues with newlines in the keys. You can retrieve
-        the base64 encoded with this shell command: cat $GOOGLE_AUTH_CREDENTIALS | base64
+        the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
     """
 
     @io_manager(

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -59,6 +59,7 @@ def main(
         "-e python_modules/libraries/dagster-dbt",
         "-e python_modules/libraries/dagster-docker",
         "-e python_modules/libraries/dagster-gcp",
+        "-e python_modules/libraries/dagster-gcp-pandas",
         "-e python_modules/libraries/dagster-fivetran",
         "-e python_modules/libraries/dagster-k8s",
         "-e python_modules/libraries/dagster-celery-k8s",


### PR DESCRIPTION
### Summary & Motivation
* found a spot in the api docs where i used the build_bigquery_io_manager method instead of the bigquery_pandas_io_manager helper
* had the wrong env var in the docs as well
* and forgot to add the package to the dev install script

### How I Tested These Changes
