### PR TITLE
add another todo to create_dagster_package

### DIFF
--- a/scripts/templates_create_dagster_package/api-docs.rst.tmpl
+++ b/scripts/templates_create_dagster_package/api-docs.rst.tmpl
@@ -10,5 +10,6 @@
 
 .. TODO add your package name to the following files:
 .. docs/content/_navigation.json
+.. docs/content/_apidocs.mdx
 .. docs/sphinx/conf.py
 .. docs/sphinx/index.rst

--- a/scripts/templates_create_dagster_package/setup.py.tmpl
+++ b/scripts/templates_create_dagster_package/setup.py.tmpl
@@ -11,6 +11,7 @@ def get_version() -> str:
 
     return version["__version__"]
 
+# TODO - add your package to scripts/install_dev_python_modules.py
 
 ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues


### PR DESCRIPTION
### Summary & Motivation
Adds a TODO to add the newly created package to install_dev_python_modules.py 

There's not an obviously best place to put this reminder, so i put it in setup.py since there are already other TODOs to complete in the file

### How I Tested These Changes
