### PR TITLE
[dagit] Support backfills on partition-mapped asset selections

### DIFF
--- a/js_modules/dagit/packages/core/src/app/CustomAlertProvider.tsx
+++ b/js_modules/dagit/packages/core/src/app/CustomAlertProvider.tsx
@@ -2,6 +2,8 @@ import {Button, Dialog, DialogBody, DialogFooter, FontFamily} from '@dagster-io/
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {testId} from '../testing/testId';
+
 import {copyValue} from './DomUtils';
 
 const CURRENT_ALERT_CHANGED = 'alert-changed';
@@ -74,7 +76,7 @@ export const CustomAlertProvider = () => {
       isOpen={!!alert}
     >
       {alert ? (
-        <DialogBody>
+        <DialogBody data-testid={testId('alert-body')}>
           <Body ref={body}>{alert.body}</Body>
         </DialogBody>
       ) : null}

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -225,3 +225,8 @@ export function tokenForAssetKey(key: {path: string[]}) {
 export function displayNameForAssetKey(key: {path: string[]}) {
   return key.path.join(' / ');
 }
+
+export const itemWithAssetKey = (key: {path: string[]}) => {
+  const token = tokenForAssetKey(key);
+  return (asset: {assetKey: {path: string[]}}) => tokenForAssetKey(asset.assetKey) === token;
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.test.tsx
@@ -75,12 +75,15 @@ describe('AssetPartitions', () => {
       // Verify that the counts update to reflect the subrange
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('150 Partitions');
     });
-    expect(screen.getByText('Missing (135)')).toBeVisible();
-    expect(screen.getByText('Completed (15)')).toBeVisible();
-
-    // Verify that the items shown on the left update to reflect the subrange
-    expect(screen.queryByText('2022-06-01-01:00')).toBeNull();
-    expect(screen.queryByText('2022-11-28-20:00')).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByText('Missing (135)')).toBeVisible();
+      expect(screen.getByText('Completed (15)')).toBeVisible();
+    });
+    await waitFor(() => {
+      // Verify that the items shown on the left update to reflect the subrange
+      expect(screen.queryByText('2022-06-01-01:00')).toBeNull();
+      expect(screen.queryByText('2022-11-28-20:00')).toBeVisible();
+    });
   });
 
   it('should sync time range selection to the URL', async () => {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -206,6 +206,10 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     launchWithRangesAsTags && setMissingOnly(false);
   }, [launchWithRangesAsTags]);
 
+  React.useEffect(() => {
+    displayType === 'anchor-asset' && setMissingOnly(false);
+  }, [displayType]);
+
   const onLaunch = async () => {
     setLaunching(true);
 
@@ -378,11 +382,8 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
             <Alert
               intent="info"
               title="Dagster will materialize all dependent asset partitions downstream of the anchor asset
-            selection."
-            >
-              If partitions in your selection have unrelated partition spaces, this backfill may
-              fail.
-            </Alert>
+            selection, using separate runs as needed."
+            />
           ) : (
             <Box flex={{justifyContent: 'space-between'}}>
               <Checkbox
@@ -511,7 +512,11 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
         </Button>
         {launchAsBackfill && !canLaunchPartitionBackfill.enabled ? (
           <Tooltip content={canLaunchPartitionBackfill.disabledReason}>
-            <Button disabled>{`Launch ${keysFiltered.length}-Run Backfill`}</Button>
+            <Button disabled>
+              {displayType === 'merged'
+                ? `Launch ${keysFiltered.length}-Run Backfill`
+                : 'Launch Backfill'}
+            </Button>
           </Tooltip>
         ) : (
           <Button
@@ -523,7 +528,9 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
             {launching
               ? 'Launching...'
               : launchAsBackfill
-              ? `Launch ${keysFiltered.length}-Run Backfill`
+              ? displayType === 'merged'
+                ? `Launch ${keysFiltered.length}-Run Backfill`
+                : 'Launch Backfill'
               : `Launch 1 Run`}
           </Button>
         )}

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -51,6 +51,7 @@ import {DimensionRangeWizard} from '../partitions/DimensionRangeWizard';
 import {PartitionState} from '../partitions/PartitionStatus';
 import {assembleIntoSpans, stringForSpan} from '../partitions/SpanRepresentation';
 import {DagsterTag} from '../runs/RunTag';
+import {testId} from '../testing/testId';
 import {RepoAddress} from '../workspace/types';
 
 import {executionParamsForAssetJob} from './LaunchAssetExecutionButton';
@@ -344,10 +345,10 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
 
   return (
     <>
-      <DialogBody>
+      <DialogBody data-testid={testId('choose-partitions-dialog')}>
         <Box flex={{direction: 'column', gap: 8}}>
           {displayType === 'anchor-asset' && (
-            <Box flex={{gap: 8}}>
+            <Box flex={{gap: 8}} data-testid={testId('anchor-asset-label')}>
               <Icon name="asset" size={20} />
               <Subheading>{displayNameForAssetKey(anchorAsset.assetKey)}</Subheading>
             </Box>
@@ -387,6 +388,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           ) : (
             <Box flex={{justifyContent: 'space-between'}}>
               <Checkbox
+                data-testid={testId('missing-only-checkbox')}
                 label="Missing partitions only"
                 checked={missingOnly}
                 disabled={launchWithRangesAsTags}
@@ -394,6 +396,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
               />
 
               <Checkbox
+                data-testid={testId('ranges-as-tags-checkbox')}
                 label={
                   <Box flex={{alignItems: 'center', gap: 4}}>
                     Pass partition ranges to single run
@@ -520,6 +523,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           </Tooltip>
         ) : (
           <Button
+            data-testid={testId('launch-button')}
             intent="primary"
             onClick={onLaunch}
             disabled={keysFiltered.length === 0}
@@ -604,7 +608,7 @@ const UpstreamUnavailableWarning: React.FC<{
   );
 };
 
-const LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY = gql`
+export const LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY = gql`
   query LaunchAssetChoosePartitionsQuery {
     instance {
       ...DaemonNotRunningAlertInstanceFragment

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -22,7 +22,7 @@ import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {usePermissionsForLocation} from '../app/Permissions';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {displayNameForAssetKey, itemWithAssetKey, tokenForAssetKey} from '../asset-graph/Utils';
+import {displayNameForAssetKey, itemWithAssetKey} from '../asset-graph/Utils';
 import {AssetKey} from '../assets/types';
 import {LaunchBackfillParams} from '../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/BackfillUtils';
@@ -378,8 +378,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           {target.type === 'pureAssetBackfill' ? (
             <Alert
               intent="info"
-              title="Dagster will materialize all dependent asset partitions downstream of the anchor asset
-            selection, using separate runs as needed."
+              title="Dagster will materialize all partitions downstream of the selected partitions for the selected assets, using separate runs as needed."
             />
           ) : (
             <Box flex={{justifyContent: 'space-between'}}>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.mocks.ts
@@ -87,6 +87,16 @@ export const ASSET_WEEKLY: AssetNodeForGraphQueryFragment = {
   },
 };
 
+export const ASSET_WEEKLY_ROOT: AssetNodeForGraphQueryFragment = {
+  ...ASSET_WEEKLY,
+  id: 'test.py.repo.["asset_weekly_root"]',
+  dependencyKeys: [],
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['asset_weekly_root'],
+  },
+};
+
 export const LaunchAssetChoosePartitionsMock: MockedResponse<LaunchAssetChoosePartitionsQuery> = {
   request: {
     query: LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY,
@@ -211,6 +221,41 @@ export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery
   },
 };
 
+export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQuery> = {
+  request: {
+    query: PARTITION_HEALTH_QUERY,
+    variables: {
+      assetKey: {
+        path: ['asset_weekly_root'],
+      },
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        id: 'test.py.repo.["asset_weekly_root"]',
+        partitionKeysByDimension: [
+          {
+            name: 'default',
+            __typename: 'DimensionPartitionKeys',
+            partitionKeys: generateDailyTimePartitions(
+              new Date('2020-01-01'),
+              new Date('2023-02-22'),
+              7,
+            ),
+          },
+        ],
+        materializedPartitions: {
+          ranges: [],
+          __typename: 'TimePartitions',
+        },
+        __typename: 'AssetNode',
+      },
+    },
+  },
+};
+
 export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLoaderQuery> = {
   request: {
     query: LAUNCH_ASSET_LOADER_QUERY,
@@ -248,6 +293,102 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
         },
         {
           ...ASSET_WEEKLY,
+          requiredResources: [],
+          partitionDefinition: {
+            description: 'Weekly, starting 2020-01-01 UTC.',
+            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            __typename: 'PartitionDefinition',
+          },
+          configField: {
+            name: 'config',
+            isRequired: false,
+            configType: {
+              __typename: 'RegularConfigType',
+              givenName: 'Any',
+              key: 'Any',
+              description: null,
+              isSelector: false,
+              typeParamKeys: [],
+              recursiveConfigTypes: [],
+            },
+            __typename: 'ConfigTypeField',
+          },
+          __typename: 'AssetNode',
+        },
+      ],
+      assetNodeDefinitionCollisions: [],
+    },
+  },
+};
+
+export const LaunchAssetLoaderAssetDailyWeeklyRootsDifferentPartitioningMock: MockedResponse<LaunchAssetLoaderQuery> = {
+  request: {
+    query: LAUNCH_ASSET_LOADER_QUERY,
+    variables: {
+      assetKeys: [{path: ['asset_daily']}, {path: ['asset_weekly']}, {path: ['asset_weekly_root']}],
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodes: [
+        {
+          ...ASSET_DAILY,
+          requiredResources: [],
+          partitionDefinition: {
+            description: 'Daily, starting 2020-01-01 UTC.',
+            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            __typename: 'PartitionDefinition',
+          },
+          configField: {
+            name: 'config',
+            isRequired: false,
+            configType: {
+              __typename: 'RegularConfigType',
+              givenName: 'Any',
+              key: 'Any',
+              description: null,
+              isSelector: false,
+              typeParamKeys: [],
+              recursiveConfigTypes: [],
+            },
+            __typename: 'ConfigTypeField',
+          },
+          __typename: 'AssetNode',
+        },
+        {
+          ...ASSET_WEEKLY,
+          requiredResources: [],
+          partitionDefinition: {
+            description: 'Weekly, starting 2020-01-01 UTC.',
+            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            __typename: 'PartitionDefinition',
+          },
+
+          dependencyKeys: [
+            {
+              __typename: 'AssetKey',
+              path: ['asset_daily', 'asset_weekly_root'],
+            },
+          ],
+          configField: {
+            name: 'config',
+            isRequired: false,
+            configType: {
+              __typename: 'RegularConfigType',
+              givenName: 'Any',
+              key: 'Any',
+              description: null,
+              isSelector: false,
+              typeParamKeys: [],
+              recursiveConfigTypes: [],
+            },
+            __typename: 'ConfigTypeField',
+          },
+          __typename: 'AssetNode',
+        },
+        {
+          ...ASSET_WEEKLY_ROOT,
           requiredResources: [],
           partitionDefinition: {
             description: 'Weekly, starting 2020-01-01 UTC.',

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.mocks.ts
@@ -1,0 +1,277 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
+
+import {LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY} from './LaunchAssetChoosePartitionsDialog';
+import {LAUNCH_ASSET_LOADER_QUERY} from './LaunchAssetExecutionButton';
+import {generateDailyTimePartitions} from './PartitionHealthSummary.mocks';
+import {LaunchAssetChoosePartitionsQuery} from './types/LaunchAssetChoosePartitionsDialog.types';
+import {LaunchAssetLoaderQuery} from './types/LaunchAssetExecutionButton.types';
+import {PartitionHealthQuery} from './types/usePartitionHealthData.types';
+import {PARTITION_HEALTH_QUERY} from './usePartitionHealthData';
+
+export const ASSET_DAILY_PARTITION_KEYS = generateDailyTimePartitions(
+  new Date('2020-01-01'),
+  new Date('2023-02-22'),
+);
+
+export const ASSET_DAILY: AssetNodeForGraphQueryFragment = {
+  __typename: 'AssetNode',
+  id: 'test.py.repo.["asset_daily"]',
+  groupName: 'mapped',
+  repository: {
+    __typename: 'Repository',
+    id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+    name: 'repo',
+    location: {
+      __typename: 'RepositoryLocation',
+      id: 'test.py',
+      name: 'test.py',
+    },
+  },
+  dependencyKeys: [],
+  dependedByKeys: [
+    {
+      __typename: 'AssetKey',
+      path: ['asset_weekly'],
+    },
+  ],
+  graphName: null,
+  jobNames: ['__ASSET_JOB_7'],
+  opNames: ['asset_daily'],
+  opVersion: null,
+  description: null,
+  computeKind: null,
+  isPartitioned: true,
+  isObservable: false,
+  isSource: false,
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['asset_daily'],
+  },
+};
+
+export const ASSET_WEEKLY: AssetNodeForGraphQueryFragment = {
+  __typename: 'AssetNode',
+  id: 'test.py.repo.["asset_weekly"]',
+  groupName: 'mapped',
+  repository: {
+    __typename: 'Repository',
+    id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+    name: 'repo',
+    location: {
+      __typename: 'RepositoryLocation',
+      id: 'test.py',
+      name: 'test.py',
+    },
+  },
+  dependencyKeys: [
+    {
+      __typename: 'AssetKey',
+      path: ['asset_daily'],
+    },
+  ],
+  dependedByKeys: [],
+  graphName: null,
+  jobNames: ['__ASSET_JOB_8'],
+  opNames: ['asset_weekly'],
+  opVersion: null,
+  description: null,
+  computeKind: null,
+  isPartitioned: true,
+  isObservable: false,
+  isSource: false,
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['asset_weekly'],
+  },
+};
+
+export const LaunchAssetChoosePartitionsMock: MockedResponse<LaunchAssetChoosePartitionsQuery> = {
+  request: {
+    query: LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY,
+    variables: {},
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      instance: {
+        daemonHealth: {
+          id: 'daemonHealth',
+          daemonStatus: {id: 'BACKFILL', healthy: false, __typename: 'DaemonStatus'},
+          __typename: 'DaemonHealth',
+        },
+        __typename: 'Instance',
+        runQueuingSupported: false,
+        runLauncher: {name: 'DefaultRunLauncher', __typename: 'RunLauncher'},
+      },
+    },
+  },
+};
+
+export const PartitionHealthAssetDailyMock: MockedResponse<PartitionHealthQuery> = {
+  request: {
+    query: PARTITION_HEALTH_QUERY,
+    variables: {
+      assetKey: {
+        path: ['asset_daily'],
+      },
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        id: 'test.py.repo.["asset_daily"]',
+        partitionKeysByDimension: [
+          {
+            name: 'default',
+            __typename: 'DimensionPartitionKeys',
+            partitionKeys: ASSET_DAILY_PARTITION_KEYS,
+          },
+        ],
+        materializedPartitions: {
+          ranges: [
+            {
+              startTime: 1662940800.0,
+              endTime: 1663027200.0,
+              startKey: '2022-09-12',
+              endKey: '2022-09-12',
+              __typename: 'TimePartitionRange',
+            },
+            {
+              startTime: 1663027200.0,
+              endTime: 1667088000.0,
+              startKey: '2022-09-13',
+              endKey: '2022-10-29',
+              __typename: 'TimePartitionRange',
+            },
+            {
+              startTime: 1668816000.0,
+              endTime: 1670803200.0,
+              startKey: '2022-11-19',
+              endKey: '2022-12-11',
+              __typename: 'TimePartitionRange',
+            },
+            {
+              startTime: 1671494400.0,
+              endTime: 1674086400.0,
+              startKey: '2022-12-20',
+              endKey: '2023-01-18',
+              __typename: 'TimePartitionRange',
+            },
+            {
+              startTime: 1676851200.0,
+              endTime: 1676937600.0,
+              startKey: '2023-02-20',
+              endKey: '2023-02-20',
+              __typename: 'TimePartitionRange',
+            },
+          ],
+          __typename: 'TimePartitions',
+        },
+        __typename: 'AssetNode',
+      },
+    },
+  },
+};
+
+export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery> = {
+  request: {
+    query: PARTITION_HEALTH_QUERY,
+    variables: {
+      assetKey: {
+        path: ['asset_weekly'],
+      },
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        id: 'test.py.repo.["asset_weekly"]',
+        partitionKeysByDimension: [
+          {
+            name: 'default',
+            __typename: 'DimensionPartitionKeys',
+            partitionKeys: generateDailyTimePartitions(
+              new Date('2020-01-01'),
+              new Date('2023-02-22'),
+              7,
+            ),
+          },
+        ],
+        materializedPartitions: {
+          ranges: [],
+          __typename: 'TimePartitions',
+        },
+        __typename: 'AssetNode',
+      },
+    },
+  },
+};
+
+export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLoaderQuery> = {
+  request: {
+    query: LAUNCH_ASSET_LOADER_QUERY,
+    variables: {
+      assetKeys: [{path: ['asset_daily']}, {path: ['asset_weekly']}],
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodes: [
+        {
+          ...ASSET_DAILY,
+          requiredResources: [],
+          partitionDefinition: {
+            description: 'Daily, starting 2020-01-01 UTC.',
+            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            __typename: 'PartitionDefinition',
+          },
+          configField: {
+            name: 'config',
+            isRequired: false,
+            configType: {
+              __typename: 'RegularConfigType',
+              givenName: 'Any',
+              key: 'Any',
+              description: null,
+              isSelector: false,
+              typeParamKeys: [],
+              recursiveConfigTypes: [],
+            },
+            __typename: 'ConfigTypeField',
+          },
+          __typename: 'AssetNode',
+        },
+        {
+          ...ASSET_WEEKLY,
+          requiredResources: [],
+          partitionDefinition: {
+            description: 'Weekly, starting 2020-01-01 UTC.',
+            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            __typename: 'PartitionDefinition',
+          },
+          configField: {
+            name: 'config',
+            isRequired: false,
+            configType: {
+              __typename: 'RegularConfigType',
+              givenName: 'Any',
+              key: 'Any',
+              description: null,
+              isSelector: false,
+              typeParamKeys: [],
+              recursiveConfigTypes: [],
+            },
+            __typename: 'ConfigTypeField',
+          },
+          __typename: 'AssetNode',
+        },
+      ],
+      assetNodeDefinitionCollisions: [],
+    },
+  },
+};

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.test.tsx
@@ -1,0 +1,93 @@
+import {MockedProvider, MockedResponse} from '@apollo/client/testing';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/BackfillUtils';
+import {LaunchPartitionBackfillMutation} from '../instance/types/BackfillUtils.types';
+import {TestProvider} from '../testing/TestProvider';
+
+import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+import {
+  ASSET_DAILY,
+  ASSET_DAILY_PARTITION_KEYS,
+  ASSET_WEEKLY,
+  LaunchAssetChoosePartitionsMock,
+  LaunchAssetLoaderAssetDailyWeeklyMock,
+  PartitionHealthAssetDailyMock,
+  PartitionHealthAssetWeeklyMock,
+} from './LaunchAssetExecutionButton.mocks';
+
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../graph/asyncGraphLayout', () => ({}));
+
+describe('LaunchAssetExecutionButton', () => {
+  it('should show the partition dialog with an anchor asset', async () => {
+    const LaunchMutationMock: MockedResponse<LaunchPartitionBackfillMutation> = {
+      request: {
+        query: LAUNCH_PARTITION_BACKFILL_MUTATION,
+        variables: {
+          backfillParams: {
+            selector: undefined,
+            assetSelection: [{path: ['asset_daily']}, {path: ['asset_weekly']}],
+            partitionNames: ASSET_DAILY_PARTITION_KEYS,
+            fromFailure: false,
+            tags: [],
+          },
+        },
+      },
+      result: jest.fn(() => ({
+        data: {
+          __typename: 'DagitMutation',
+          launchPartitionBackfill: {__typename: 'LaunchBackfillSuccess', backfillId: 'vlpmimsl'},
+        },
+      })),
+    };
+
+    await act(async () => {
+      render(
+        <TestProvider>
+          <MockedProvider
+            mocks={[
+              LaunchAssetChoosePartitionsMock,
+              LaunchAssetLoaderAssetDailyWeeklyMock,
+              PartitionHealthAssetDailyMock,
+              PartitionHealthAssetWeeklyMock,
+              LaunchMutationMock,
+            ]}
+          >
+            <LaunchAssetExecutionButton scope={{all: [ASSET_DAILY, ASSET_WEEKLY]}} />
+          </MockedProvider>
+        </TestProvider>,
+      );
+    });
+
+    // click Materialize
+    const materializeButton = await screen.findByTestId('materialize-button');
+    expect(materializeButton).toBeVisible();
+    materializeButton.click();
+
+    // expect the dialog to be displayed
+    await waitFor(async () => {
+      await screen.findByTestId('choose-partitions-dialog');
+    });
+
+    // expect the anchor asset label to be present, and the missing + tags options to be hidden
+    expect((await screen.findByTestId('anchor-asset-label')).textContent).toEqual('asset_daily');
+    expect(await screen.queryByTestId('missing-only-checkbox')).toBeNull();
+    expect(await screen.queryByTestId('ranges-as-tags-checkbox')).toBeNull();
+
+    const launchButton = await screen.findByTestId('launch-button');
+    expect(launchButton.textContent).toEqual('Launch Backfill');
+    await launchButton.click();
+
+    // expect that it triggers the mutation (variables checked by mock matching)
+    await waitFor(async () => {
+      expect(LaunchMutationMock.result).toHaveBeenCalled();
+    });
+
+    // expect the dialog to close
+    await waitFor(async () => {
+      expect(await screen.queryByTestId('choose-partitions-dialog')).toBeNull();
+    });
+  });
+});

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -18,6 +18,7 @@ import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {AssetLaunchpad} from '../launchpad/LaunchpadRoot';
 import {DagsterTag} from '../runs/RunTag';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
+import {testId} from '../testing/testId';
 import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
@@ -78,7 +79,10 @@ const isAnyPartitioned = (assets: Asset[]) =>
       ('isPartitioned' in a && a.isPartitioned),
   );
 
-function optionsForButton(scope: AssetsInScope, liveDataForStale?: LiveData): LaunchOption[] {
+export function optionsForButton(
+  scope: AssetsInScope,
+  liveDataForStale?: LiveData,
+): LaunchOption[] {
   // If you pass a set of selected assets, we always show just one option
   // to materialize that selection.
   if ('selected' in scope) {
@@ -128,6 +132,7 @@ export const LaunchAssetExecutionButton: React.FC<{
   const {onClick, loading, launchpadElement} = useMaterializationAction(preferredJobName);
   const [isOpen, setIsOpen] = React.useState(false);
 
+  console.log(scope);
   const options = optionsForButton(scope, liveDataForStale);
   const firstOption = options[0];
 
@@ -157,6 +162,7 @@ export const LaunchAssetExecutionButton: React.FC<{
         >
           <MaterializeButton
             intent={intent}
+            data-testid={testId('materialize-button')}
             onClick={(e) => onClick(firstOption.assetKeys, e)}
             style={
               options.length > 1

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -1,4 +1,3 @@
-import {PartitionDefinition} from '../graphql/types';
 import {PartitionState} from '../partitions/PartitionStatus';
 
 import {

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -1,3 +1,4 @@
+import {PartitionDefinition} from '../graphql/types';
 import {PartitionState} from '../partitions/PartitionStatus';
 
 import {
@@ -169,6 +170,16 @@ export function assembleRangesFromTransitions(
   }
 
   return result.filter((range) => range.value !== PartitionState.MISSING) as Range[];
+}
+
+export function partitionDefinitionsEqual(
+  a: {description: string; dimensionTypes: {name: string}[]},
+  b: {description: string; dimensionTypes: {name: string}[]},
+) {
+  return (
+    a.description === b.description &&
+    JSON.stringify(a.dimensionTypes) === JSON.stringify(b.dimensionTypes)
+  );
 }
 
 export function explodePartitionKeysInSelection(

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.mocks.ts
@@ -17,12 +17,13 @@ function generateHourlyTimePartitions(startDate: Date, endDate: Date) {
   return partitions;
 }
 
-// Generates hourly partitions in the format 2022-08-31-00:00
-function generateDailyTimePartitions(startDate: Date, endDate: Date) {
+// Generates daily partitions in the format 2022-08-31. Passing `step=7` allows you to
+// generate weekly partitions as well.
+export function generateDailyTimePartitions(startDate: Date, endDate: Date, step = 1) {
   const date = new Date(startDate);
   const partitions: string[] = [];
   while (date < endDate) {
-    date.setDate(date.getDate() + 1);
+    date.setDate(date.getDate() + step);
     const yyyymmdd = date.toISOString().split('T')[0];
     partitions.push(`${yyyymmdd}`);
   }

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -525,6 +525,7 @@ export const PARTITION_HEALTH_QUERY = gql`
     }
   }
 `;
+
 function warnUnlessTest(msg: string) {
   if (process.env.NODE_ENV !== 'test') {
     console.warn(msg);

--- a/js_modules/dagit/packages/core/src/assets/usePartitionNameForPipeline.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionNameForPipeline.tsx
@@ -14,6 +14,7 @@ export function usePartitionNameForPipeline(repoAddress: RepoAddress, pipelineNa
     AssetJobPartitionSetsQuery,
     AssetJobPartitionSetsQueryVariables
   >(ASSET_JOB_PARTITION_SETS_QUERY, {
+    skip: !pipelineName,
     variables: {
       repositoryLocationName: repoAddress.location,
       repositoryName: repoAddress.name,

--- a/js_modules/dagit/packages/ui/src/components/Dialog.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Dialog.tsx
@@ -54,10 +54,10 @@ export const DialogHeader: React.FC<HeaderProps> = (props) => {
   );
 };
 
-export const DialogBody: React.FC = (props) => {
+export const DialogBody: React.FC = ({children, ...rest}) => {
   return (
-    <Box padding={{vertical: 16, horizontal: 20}} background={Colors.White}>
-      {props.children}
+    <Box padding={{vertical: 16, horizontal: 20}} background={Colors.White} {...rest}>
+      {children}
     </Box>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

This PR:

- Replaces two Materialize button error states ("assets must be in the same partition space" and "assets must be in the same repo / job") with a new "pure asset backfill" version of the backfill modal.

- This version has some additional messaging indicating that it will auto-infer the runs + partitions needed to execute the backfill. It does not offer the ability to launch a single run, does not offer to filter to "Missing only", and does not show you a preview of how many runs will be launched.

### How I Tested These Changes

This PR adds a .test.tsx file for the LaunchAssetMaterialization button and all the related mocks for the first time! 🙌

- I added a test case covering the new behavior, which verifies that clicking Materialize shows the modal with the correct content (several options disabled), the Launch Backfill button has the right title, and clicking it fires the right mutation.

** The launch materialization button probably needs 15-20 tests to cover all of the available cases, and this PR only adds the tests for this new case we're adding. Will write another PR with more tests later this week! It might be a couple day adventure...

Before:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/1037212/220670724-04014745-6efc-430e-ad64-d1bcdeaadc33.png">


After:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/1037212/220670827-d2ad2e48-f33a-4bc0-8f2d-6765eefef992.png">
