### PR TITLE
[graphql] empty numPartitions and partitionNames for cross-partitioning backfills

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2332,9 +2332,9 @@ type PartitionRun {
 type PartitionBackfill {
   backfillId: String!
   status: BulkActionStatus!
-  partitionNames: [String!]!
+  partitionNames: [String!]
   isValidSerialization: Boolean!
-  numPartitions: Int!
+  numPartitions: Int
   numCancelable: Int!
   fromFailure: Boolean!
   reexecutionSteps: [String!]

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2156,8 +2156,8 @@ export type PartitionBackfill = {
   hasCancelPermission: Scalars['Boolean'];
   isValidSerialization: Scalars['Boolean'];
   numCancelable: Scalars['Int'];
-  numPartitions: Scalars['Int'];
-  partitionNames: Array<Scalars['String']>;
+  numPartitions: Maybe<Scalars['Int']>;
+  partitionNames: Maybe<Array<Scalars['String']>>;
   partitionSet: Maybe<PartitionSet>;
   partitionSetName: Maybe<Scalars['String']>;
   partitionStatusCounts: Array<PartitionStatusCounts>;

--- a/js_modules/dagit/packages/core/src/instance/BackfillPartitionsRequestedDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillPartitionsRequestedDialog.tsx
@@ -22,9 +22,9 @@ export const BackfillPartitionsRequestedDialog = ({backfill, onClose}: Props) =>
       onClose={onClose}
     >
       <DialogBody>
-        {backfill ? (
+        {backfill && backfill.partitionNames ? (
           <Box flex={{direction: 'column', gap: 8}} style={{maxHeight: '80vh', overflowY: 'auto'}}>
-            {backfill.partitionNames.map((partitionName: string) => (
+            {backfill.partitionNames.map((partitionName) => (
               <div key={partitionName}>{partitionName}</div>
             ))}
           </Box>

--- a/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export const BackfillStepStatusDialog = ({backfill, onClose}: Props) => {
   const content = () => {
-    if (!backfill?.partitionSet) {
+    if (!backfill?.partitionSet || backfill.partitionNames === null) {
       return null;
     }
 
@@ -34,6 +34,7 @@ export const BackfillStepStatusDialog = ({backfill, onClose}: Props) => {
       <BackfillStepStatusDialogContent
         backfill={backfill}
         partitionSet={backfill.partitionSet}
+        partitionNames={backfill.partitionNames}
         repoAddress={repoAddress}
         onClose={onClose}
       />
@@ -58,6 +59,7 @@ export const BackfillStepStatusDialog = ({backfill, onClose}: Props) => {
 interface ContentProps {
   backfill: BackfillTableFragment;
   partitionSet: PartitionSetForBackfillTableFragment;
+  partitionNames: string[];
   repoAddress: RepoAddress;
   onClose: () => void;
 }
@@ -65,6 +67,7 @@ interface ContentProps {
 export const BackfillStepStatusDialogContent = ({
   backfill,
   partitionSet,
+  partitionNames,
   repoAddress,
 }: ContentProps) => {
   const [pageSize, setPageSize] = React.useState(60);
@@ -78,7 +81,7 @@ export const BackfillStepStatusDialogContent = ({
   const partitions = usePartitionStepQuery({
     partitionSetName: partitionSet.name,
     partitionTagName: DagsterTag.Partition,
-    partitionNames: backfill.partitionNames,
+    partitionNames,
     pageSize,
     runsFilter,
     repositorySelector: repoAddressToSelector(repoAddress),
@@ -89,7 +92,7 @@ export const BackfillStepStatusDialogContent = ({
 
   return (
     <PartitionPerOpStatus
-      partitionNames={backfill.partitionNames}
+      partitionNames={partitionNames}
       partitions={partitions}
       pipelineName={partitionSet?.pipelineName}
       repoAddress={repoAddress}

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.mocks.ts
@@ -142,16 +142,7 @@ export const BackfillTableFragmentFailedError: BackfillTableFragment = {
     __typename: 'PythonError',
     message:
       'dagster._core.errors.DagsterLaunchFailedError: Tried to start a run on a server after telling it to shut down\n',
-    stack: [
-      '  File "/dagster/python_modules/dagster/dagster/_daemon/backfill.py", line 34, in execute_backfill_iteration\n    yield from execute_asset_backfill_iteration(backfill, workspace, instance)\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/execution/asset_backfill.py", line 193, in execute_asset_backfill_iteration\n    submit_run_request(\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/execution/asset_backfill.py", line 265, in submit_run_request\n    instance.submit_run(run.run_id, workspace)\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 1926, in submit_run\n    submitted_run = self._run_coordinator.submit_run(\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py", line 34, in submit_run\n    self._instance.launch_run(pipeline_run.run_id, context.workspace)\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 1979, in launch_run\n    self.run_launcher.launch_run(LaunchRunContext(pipeline_run=run, workspace=workspace))\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py", line 121, in launch_run\n    DefaultRunLauncher.launch_run_from_grpc_client(\n',
-      '  File "/dagster/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py", line 89, in launch_run_from_grpc_client\n    raise (\n',
-    ],
+    stack: ['OMITTED FROM MOCKS'],
     errorChain: [],
   },
   numCancelable: 0,
@@ -178,7 +169,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
       partitionBackfillOrError: {
         backfillId: 'sjqzcfhe',
         partitionStatuses: {
-          results: BackfillTableFragmentFailedError.partitionNames.map((n) => ({
+          results: BackfillTableFragmentFailedError.partitionNames!.map((n) => ({
             id: `__NO_PARTITION_SET__:${n}:ccpbwdbq`,
             partitionName: n,
             runId: null,
@@ -439,6 +430,77 @@ export const BackfillTableFragmentInvalidPartitionSet: BackfillTableFragment = {
   __typename: 'PartitionBackfill',
 };
 
+export const BackfillTablePureAssetCountsOnly: BackfillTableFragment = {
+  backfillId: 'likqkgna',
+  status: BulkActionStatus.FAILED,
+  isValidSerialization: true,
+  numPartitions: 30,
+  timestamp: 1677023094.435064,
+  partitionSetName: null,
+  partitionSet: null,
+  error: {
+    __typename: 'PythonError',
+    message:
+      'dagster._core.errors.DagsterUserCodeUnreachableError: Could not reach user code server. gRPC Error code: UNAVAILABLE\n',
+    stack: ['OMITTED FROM MOCKS'],
+    errorChain: [
+      {
+        isExplicitLink: true,
+        error: {
+          message:
+            'grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAVAILABLE\n\tdetails = "failed to connect to all addresses"\n\tdebug_error_string = "{"created":"@1677105084.883333000","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":3261,"referenced_errors":[{"created":"@1677105084.883332000","description":"failed to connect to all addresses","file":"src/core/lib/transport/error_utils.cc","file_line":167,"grpc_status":14}]}"\n>\n',
+          stack: ['OMITTED FROM MOCKS'],
+          __typename: 'PythonError',
+        },
+        __typename: 'ErrorChainLink',
+      },
+    ],
+  },
+  numCancelable: 0,
+  partitionNames: null,
+  assetSelection: [
+    {
+      path: ['asset_daily'],
+      __typename: 'AssetKey',
+    },
+    {
+      path: ['asset_weekly'],
+      __typename: 'AssetKey',
+    },
+  ],
+  __typename: 'PartitionBackfill',
+};
+
+const BackfillTablePureAssetNoCountsOrPartitionNames: BackfillTableFragment = {
+  backfillId: 'vlpmimsl',
+  status: BulkActionStatus.COMPLETED,
+  isValidSerialization: true,
+  numPartitions: null,
+  timestamp: 1677078839.707758,
+  partitionSetName: null,
+  partitionSet: null,
+  error: {
+    __typename: 'PythonError',
+    message:
+      'dagster._core.errors.DagsterLaunchFailedError: Tried to start a run on a server after telling it to shut down\n',
+    stack: ['OMITTED FROM MOCKS'],
+    errorChain: [],
+  },
+  numCancelable: 0,
+  partitionNames: null,
+  assetSelection: [
+    {
+      path: ['asset_daily'],
+      __typename: 'AssetKey',
+    },
+    {
+      path: ['asset_weekly'],
+      __typename: 'AssetKey',
+    },
+  ],
+  __typename: 'PartitionBackfill',
+};
+
 export const BackfillTableFragments: BackfillTableFragment[] = [
   BackfillTableFragmentRequested2000AssetsPure,
   BackfillTableFragmentCancelledAssetsPartitionSet,
@@ -446,4 +508,6 @@ export const BackfillTableFragments: BackfillTableFragment[] = [
   BackfillTableFragmentCompletedAssetJob,
   BackfillTableFragmentCompletedOpJob,
   BackfillTableFragmentInvalidPartitionSet,
+  BackfillTablePureAssetCountsOnly,
+  BackfillTablePureAssetNoCountsOrPartitionNames,
 ];

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTable.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTable.types.ts
@@ -7,9 +7,9 @@ export type BackfillTableFragment = {
   backfillId: string;
   status: Types.BulkActionStatus;
   numCancelable: number;
-  partitionNames: Array<string>;
+  partitionNames: Array<string> | null;
   isValidSerialization: boolean;
-  numPartitions: number;
+  numPartitions: number | null;
   timestamp: number;
   partitionSetName: string | null;
   partitionSet: {

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
@@ -49,11 +49,11 @@ export type InstanceBackfillsQuery = {
           backfillId: string;
           status: Types.BulkActionStatus;
           isValidSerialization: boolean;
-          numPartitions: number;
+          numPartitions: number | null;
           timestamp: number;
           partitionSetName: string | null;
           numCancelable: number;
-          partitionNames: Array<string>;
+          partitionNames: Array<string> | null;
           partitionSet: {
             __typename: 'PartitionSet';
             id: string;

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
@@ -21,9 +21,9 @@ export type JobBackfillsQuery = {
           backfillId: string;
           status: Types.BulkActionStatus;
           numCancelable: number;
-          partitionNames: Array<string>;
+          partitionNames: Array<string> | null;
           isValidSerialization: boolean;
-          numPartitions: number;
+          numPartitions: number | null;
           timestamp: number;
           partitionSetName: string | null;
           partitionSet: {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -1,3 +1,5 @@
+from typing import Optional, Sequence
+
 import dagster._check as check
 import graphene
 from dagster._core.execution.backfill import PartitionBackfill
@@ -95,9 +97,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
     backfillId = graphene.NonNull(graphene.String)
     status = graphene.NonNull(GrapheneBulkActionStatus)
-    partitionNames = non_null_list(graphene.String)
+    partitionNames = graphene.List(graphene.NonNull(graphene.String))
     isValidSerialization = graphene.NonNull(graphene.Boolean)
-    numPartitions = graphene.NonNull(graphene.Int)
+    numPartitions = graphene.Field(graphene.Int)
     numCancelable = graphene.NonNull(graphene.Int)
     fromFailure = graphene.NonNull(graphene.Boolean)
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
@@ -200,10 +202,10 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     def resolve_isValidSerialization(self, _graphene_info: ResolveInfo):
         return self._backfill_job.is_valid_serialization(_graphene_info.context)
 
-    def resolve_partitionNames(self, _graphene_info: ResolveInfo):
+    def resolve_partitionNames(self, _graphene_info: ResolveInfo) -> Optional[Sequence[str]]:
         return self._backfill_job.get_partition_names(_graphene_info.context)
 
-    def resolve_numPartitions(self, _graphene_info: ResolveInfo):
+    def resolve_numPartitions(self, _graphene_info: ResolveInfo) -> Optional[int]:
         return self._backfill_job.get_num_partitions(_graphene_info.context)
 
     def resolve_numCancelable(self, _graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -299,6 +299,20 @@ def test_launch_asset_backfill_with_upstream_anchor_asset():
                 },
             )
 
+            # on PartitionBackfills
+            get_backfills_result = execute_dagster_graphql(
+                context, GET_PARTITION_BACKFILLS_QUERY, variables={}
+            )
+            assert not get_backfills_result.errors
+            assert get_backfills_result.data
+            backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
+            assert len(backfill_results) == 1
+            assert backfill_results[0]["numPartitions"] is None
+            assert backfill_results[0]["backfillId"] == backfill_id
+            assert backfill_results[0]["partitionSet"] is None
+            assert backfill_results[0]["partitionSetName"] is None
+            assert backfill_results[0]["partitionNames"] is None
+
 
 def get_daily_two_hourly_repo():
     @asset(partitions_def=HourlyPartitionsDefinition(start_date="2020-01-01-00:00"))

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -67,11 +67,11 @@ class AssetBackfillData(NamedTuple):
             self.target_subset.filter_asset_keys(root_asset_keys).iterate_asset_partitions()
         )
 
-    def get_num_partitions(self) -> int:
+    def get_num_partitions(self) -> Optional[int]:
         """
         Only valid when the same number of partitions are targeted in every asset.
 
-        When not valid, raises an error.
+        When not valid, returns None.
         """
         asset_partition_nums = {
             len(subset) for subset in self.target_subset.partitions_subsets_by_asset_key.values()
@@ -81,27 +81,21 @@ class AssetBackfillData(NamedTuple):
         elif len(asset_partition_nums) == 1:
             return next(iter(asset_partition_nums))
         else:
-            check.failed(
-                "Can't compute number of partitions for asset backfill because different assets "
-                "have different numbers of partitions"
-            )
+            return None
 
-    def get_partition_names(self) -> Sequence[str]:
+    def get_partition_names(self) -> Optional[Sequence[str]]:
         """
         Only valid when the same number of partitions are targeted in every asset.
 
-        When not valid, raises an error.
+        When not valid, returns None.
         """
         subsets = self.target_subset.partitions_subsets_by_asset_key.values()
         if len(subsets) == 0:
             return []
 
         first_subset = next(iter(subsets))
-        if any(subset != subset for subset in subsets):
-            check.failed(
-                "Can't find partition names for asset backfill because different assets "
-                "have different partitions"
-            )
+        if any(subset != first_subset for subset in subsets):
+            return None
 
         return list(first_subset.get_partition_keys())
 

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -126,7 +126,7 @@ class PartitionBackfill(
         else:
             return True
 
-    def get_num_partitions(self, workspace: IWorkspace) -> int:
+    def get_num_partitions(self, workspace: IWorkspace) -> Optional[int]:
         if not self.is_valid_serialization(workspace):
             return 0
 
@@ -146,7 +146,7 @@ class PartitionBackfill(
 
             return len(self.partition_names)
 
-    def get_partition_names(self, workspace: IWorkspace) -> Sequence[str]:
+    def get_partition_names(self, workspace: IWorkspace) -> Optional[Sequence[str]]:
         if not self.is_valid_serialization(workspace):
             return []
 
@@ -157,7 +157,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                 )
             except DagsterDefinitionChangedDeserializationError:
-                return []
+                return None
 
             return asset_backfill_data.get_partition_names()
         else:


### PR DESCRIPTION
### Summary & Motivation

This PR makes a handful of backfill fields optional, because things like `numPartitions` and `partitionNames` are not always available for pure asset backfills with partition mapping. The number of partitions is /usually/ available (unless we were unable to determine the relationships between the partition mappings), but the partition names are never available.

@bengotow UI Changes: On the front-end this required making a few things in the UI optional - most notably you cannot click the partition count badge to see the partitions requested, and the run status column is blank. 

### How I Tested These Changes

To make sure this functionality doesn't get broken in the future and ensure we preview what these cases look like when changing the backfill table, I added two new cases to the storybook. (Bottom two in screenshot!)

<img width="1726" alt="image" src="https://user-images.githubusercontent.com/1037212/220788087-87db5dc5-4792-4053-bcce-b96205c8840d.png">
