### PR TITLE
Add asset provenance access to OpExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -191,7 +191,10 @@ from dagster._core.definitions.logger_definition import (
     build_init_logger_context as build_init_logger_context,
     logger as logger,
 )
-from dagster._core.definitions.logical_version import LogicalVersion as LogicalVersion
+from dagster._core.definitions.logical_version import (
+    LogicalVersion as LogicalVersion,
+    LogicalVersionProvenance as LogicalVersionProvenance,
+)
 from dagster._core.definitions.materialize import (
     materialize as materialize,
     materialize_to_memory as materialize_to_memory,

--- a/python_modules/dagster/dagster/_core/definitions/logical_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/logical_version.py
@@ -68,6 +68,14 @@ class LogicalVersionProvenance(
         ],
     )
 ):
+    """(Experimental) Provenance information for an asset materialization.
+
+    Args:
+        code_version (str): The code version of the op that generated a materialization.
+        input_logical_versions (Mapping[AssetKey, LogicalVersion]): The logical versions of the
+            inputs used for the materialization.
+    """
+
     def __new__(
         cls,
         code_version: str,

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -4,7 +4,7 @@ from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Se
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import public
+from dagster._annotations import experimental, public
 from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.definitions.events import (
     AssetKey,
@@ -15,6 +15,10 @@ from dagster._core.definitions.events import (
     UserEvent,
 )
 from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.logical_version import (
+    LogicalVersionProvenance,
+    extract_logical_version_provenance_from_entry,
+)
 from dagster._core.definitions.mode import ModeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -594,6 +598,28 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         Which mapping_key this execution is for if downstream of a DynamicOutput, otherwise None.
         """
         return self._step_execution_context.step.get_mapping_key()
+
+    @public
+    @experimental
+    def get_asset_provenance(self, asset_key: AssetKey) -> Optional[LogicalVersionProvenance]:
+        """
+        Return the provenance information for the most recent materialization of an asset.
+
+        Args:
+            asset_key (AssetKey): Key of the asset for which to retrieve provenance.
+
+        Returns:
+            Optional[LogicalVersionProvenance]: Provenance information for the most recent
+                materialization of the asset. Returns `None` if the asset was never materialized or
+                the materialization record is too old to contain provenance information.
+        """
+        record = self.instance.get_latest_logical_version_record(asset_key)
+
+        return (
+            None
+            if record is None
+            else extract_logical_version_provenance_from_entry(record.event_log_entry)
+        )
 
 
 SourceAssetObserveContext: TypeAlias = OpExecutionContext


### PR DESCRIPTION
### Summary & Motivation

Adds a `get_asset_provenance` method to `OpExecutionContext`. This can be used to fetch the latest provenance for an arbitrary asset-- this can be used for userland memoization logic.

### How I Tested These Changes

New unit test
