### PR TITLE
[dagster-snowflake-pyspark] fix bug loading partitions

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -287,7 +287,7 @@ def test_time_window_partitioned_asset():
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in daily_partitioned
-            assert df.count() == 3
+            assert len(df.index) == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
@@ -375,7 +375,7 @@ def test_static_partitioned_asset():
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in static_partitioned
-            assert df.count() == 3
+            assert len(df.index) == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
@@ -467,7 +467,7 @@ def test_multi_partitioned_asset():
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in multi_partitioned
-            assert df.count() == 3
+            assert len(df.index) == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
@@ -566,7 +566,7 @@ def test_dynamic_partitions():
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in dynamic_partitioned
-            assert df.count() == 3
+            assert len(df.index) == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -22,6 +22,7 @@ from dagster import (
     asset,
     build_input_context,
     build_output_context,
+    fs_io_manager,
     instance_for_test,
     job,
     materialize,
@@ -282,6 +283,7 @@ def test_time_window_partitioned_asset():
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in daily_partitioned
@@ -299,7 +301,7 @@ def test_time_window_partitioned_asset():
         )
 
         snowflake_io_manager = snowflake_pandas_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
 
         materialize(
             [daily_partitioned, downstream_partitioned],
@@ -369,6 +371,7 @@ def test_static_partitioned_asset():
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in static_partitioned
@@ -386,7 +389,7 @@ def test_static_partitioned_asset():
         )
 
         snowflake_io_manager = snowflake_pandas_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
         materialize(
             [static_partitioned, downstream_partitioned],
             partition_key="red",
@@ -460,6 +463,7 @@ def test_multi_partitioned_asset():
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in multi_partitioned
@@ -477,7 +481,7 @@ def test_multi_partitioned_asset():
         )
 
         snowflake_io_manager = snowflake_pandas_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
 
         materialize(
             [multi_partitioned, downstream_partitioned],
@@ -558,6 +562,7 @@ def test_dynamic_partitions():
             partitions_def=dynamic_fruits,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in dynamic_partitioned
@@ -575,7 +580,7 @@ def test_dynamic_partitions():
         )
 
         snowflake_io_manager = snowflake_pandas_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
 
         with instance_for_test() as instance:
             dynamic_fruits.add_partitions(["apple"], instance)

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -24,7 +24,6 @@ def _get_snowflake_options(config, table_slice: TableSlice) -> Mapping[str, str]
         "sfDatabase": config["database"],
         "sfSchema": table_slice.schema,
         "sfWarehouse": config["warehouse"],
-        "dbtable": table_slice.table,
     }
 
     return conf
@@ -70,9 +69,9 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
 
         with_uppercase_cols = obj.toDF(*[c.upper() for c in obj.columns])
 
-        with_uppercase_cols.write.format(SNOWFLAKE_CONNECTOR).options(**options).mode(
-            "append"
-        ).save()
+        with_uppercase_cols.write.format(SNOWFLAKE_CONNECTOR).options(**options).option(
+            "dbtable", table_slice.table
+        ).mode("append").save()
 
         return {
             "dataframe_columns": MetadataValue.table_schema(

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -21,6 +21,7 @@ from dagster import (
     asset,
     build_input_context,
     build_output_context,
+    fs_io_manager,
     instance_for_test,
     job,
     materialize,
@@ -234,6 +235,7 @@ def test_time_window_partitioned_asset():
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in daily_partitioned
@@ -251,7 +253,7 @@ def test_time_window_partitioned_asset():
         )
 
         snowflake_io_manager = snowflake_pyspark_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
 
         materialize(
             [daily_partitioned, downstream_partitioned],
@@ -330,6 +332,7 @@ def test_static_partitioned_asset():
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in static_partitioned
@@ -347,7 +350,7 @@ def test_static_partitioned_asset():
         )
 
         snowflake_io_manager = snowflake_pyspark_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
         materialize(
             [static_partitioned, downstream_partitioned],
             partition_key="red",
@@ -436,6 +439,7 @@ def test_multi_partitioned_asset():
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in multi_partitioned
@@ -453,7 +457,7 @@ def test_multi_partitioned_asset():
         )
 
         snowflake_io_manager = snowflake_pyspark_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
 
         materialize(
             [multi_partitioned, downstream_partitioned],
@@ -547,6 +551,7 @@ def test_dynamic_partitions():
             partitions_def=dynamic_fruits,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
             ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
+            io_manager_key="fs_io",
         )
         def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in dynamic_partitioned
@@ -564,7 +569,7 @@ def test_dynamic_partitions():
         )
 
         snowflake_io_manager = snowflake_pyspark_io_manager.configured(snowflake_config)
-        resource_defs = {"io_manager": snowflake_io_manager}
+        resource_defs = {"io_manager": snowflake_io_manager, "fs_io": fs_io_manager}
 
         with instance_for_test() as instance:
             dynamic_fruits.add_partitions(["apple"], instance)

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from dagster import (
+    AssetIn,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     IOManagerDefinition,
@@ -232,10 +233,11 @@ def test_time_window_partitioned_asset():
         @asset(
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
+            ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
         )
-        def downstream_partitioned(daily_partitioned) -> None:
+        def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in daily_partitioned
-            assert daily_partitioned.count() == 3
+            assert df.count() == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
@@ -288,7 +290,7 @@ def test_time_window_partitioned_asset():
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
 
 
-@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_static_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
@@ -327,10 +329,11 @@ def test_static_partitioned_asset():
         @asset(
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
+            ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
         )
-        def downstream_partitioned(static_partitioned) -> None:
+        def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in static_partitioned
-            assert static_partitioned.count() == 3
+            assert df.count() == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
@@ -432,10 +435,11 @@ def test_multi_partitioned_asset():
         @asset(
             partitions_def=partitions_def,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
+            ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
         )
-        def downstream_partitioned(multi_partitioned) -> None:
+        def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in multi_partitioned
-            assert multi_partitioned.count() == 3
+            assert df.count() == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"
@@ -500,7 +504,7 @@ def test_multi_partitioned_asset():
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
 
 
-@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 def test_dynamic_partitions():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
@@ -542,10 +546,11 @@ def test_dynamic_partitions():
         @asset(
             partitions_def=dynamic_fruits,
             key_prefix="SNOWFLAKE_IO_MANAGER_SCHEMA",
+            ins={"df": AssetIn(["SNOWFLAKE_IO_MANAGER_SCHEMA", table_name])},
         )
-        def downstream_partitioned(dynamic_partitioned) -> None:
+        def downstream_partitioned(df) -> None:
             # assert that we only get the columns created in dynamic_partitioned
-            assert dynamic_partitioned.count() == 3
+            assert df.count() == 3
 
         asset_full_name = f"SNOWFLAKE_IO_MANAGER_SCHEMA__{table_name}"
         snowflake_table_path = f"SNOWFLAKE_IO_MANAGER_SCHEMA.{table_name}"


### PR DESCRIPTION
### Summary & Motivation
Found a bug where the Pyspark type handler wasn't loading inputs correctly. added a downstream asset to each test so that `load_input` has test coverage
### How I Tested These Changes
new unit tests
