### PR TITLE
[op] error on multiple values for argument

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -561,6 +561,13 @@ class PendingNodeInvocation:
     def _process_argument_node(self, node_name, output_node, input_name, input_bindings, arg_desc):
         from .source_asset import SourceAsset
 
+        # already set - conflict between kwargs and args
+        if input_bindings.get(input_name):
+            raise DagsterInvalidInvocationError(
+                f"{self.node_def.node_type_str} {node_name} got multiple values for"
+                f" argument '{input_name}'"
+            )
+
         if isinstance(
             output_node, (InvokedNodeOutputHandle, InputMappingNode, DynamicFanIn, SourceAsset)
         ):
@@ -576,7 +583,7 @@ class PendingNodeInvocation:
                         "In {source} {name}, received a list containing an invalid type "
                         'at index {idx} for input "{input_name}" {arg_desc} in '
                         "{node_type} invocation {node_name}. Lists can only contain the "
-                        "output from previous solid invocations or input mappings, "
+                        "output from previous op invocations or input mappings, "
                         "received {type}".format(
                             source=current_context().source,
                             name=current_context().name,

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     Generator,
     Iterator,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -97,12 +98,12 @@ async def _coerce_async_solid_to_async_gen(awaitable, context, output_defs):
 def invoke_compute_fn(
     fn: Callable,
     context: OpExecutionContext,
-    kwargs: Dict[str, Any],
+    kwargs: Mapping[str, Any],
     context_arg_provided: bool,
     config_arg_cls: Optional[Type[Config]],
     resource_args: Optional[Dict[str, str]] = None,
 ) -> Any:
-    args_to_pass = kwargs
+    args_to_pass = {**kwargs}
     if config_arg_cls:
         # config_arg_cls is either a Config class or a primitive type
         if issubclass(config_arg_cls, Config):

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
@@ -215,7 +215,7 @@ def test_source_assets_list_input_value():
     # not yet supported
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Lists can only contain the output from previous solid invocations or input mappings",
+        match="Lists can only contain the output from previous op invocations or input mappings",
     ):
 
         @graph

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -384,7 +384,7 @@ def test_solid_with_inputs():
     with pytest.raises(
         DagsterInvalidInvocationError, match='No value provided for required input "y".'
     ):
-        solid_with_inputs(5, x=5)
+        solid_with_inputs(5)
 
 
 def test_failing_solid():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
@@ -887,7 +887,7 @@ def test_fan_in_scalars_fails():
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match="Lists can only contain the output from previous solid invocations or input mappings",
+        match="Lists can only contain the output from previous op invocations or input mappings",
     ):
 
         @job


### PR DESCRIPTION
Via debugging a user report we didnt catch this correctly.
In normal python we get
```
def foo(x, y):
    print(x, y)


bar = partial(foo, x=4)
bar(5)

====
TypeError: foo() got multiple values for argument 'x'
```

so emulate that error message

### How I Tested These Changes

added test