### PR TITLE
fix

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
@@ -32,12 +32,9 @@ def test_stores_nux_seen_state(graphql_context):
 
 
 def test_does_not_show_nux_if_read_only_filesystem(graphql_context):
-    def mock_seen_filepath():
-        fn = mock.Mock()
-        fn.side_effect = OSError("Read-only filesystem")
-        return fn
-
-    with mock.patch("dagster._core.nux.nux_seen_filepath", new_callable=mock_seen_filepath):
+    with mock.patch(
+        "dagster._core.nux.nux_seen_filepath", side_effect=OSError("Read-only filesystem")
+    ):
         result = execute_dagster_graphql(graphql_context, GET_SHOULD_SHOW_NUX_QUERY)
         assert not result.errors
         assert result.data

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
@@ -1,3 +1,4 @@
+import mock
 from dagster_graphql.test.utils import (
     execute_dagster_graphql,
 )
@@ -28,3 +29,16 @@ def test_stores_nux_seen_state(graphql_context):
     assert not result.errors
     assert result.data
     assert result.data["shouldShowNux"] is False
+
+
+def test_does_not_show_nux_if_read_only_filesystem(graphql_context):
+    def mock_seen_filepath():
+        fn = mock.Mock()
+        fn.side_effect = OSError("Read-only filesystem")
+        return fn
+
+    with mock.patch("dagster._core.nux.nux_seen_filepath", new_callable=mock_seen_filepath):
+        result = execute_dagster_graphql(graphql_context, GET_SHOULD_SHOW_NUX_QUERY)
+        assert not result.errors
+        assert result.data
+        assert result.data["shouldShowNux"] is False

--- a/python_modules/dagster/dagster/_core/nux.py
+++ b/python_modules/dagster/dagster/_core/nux.py
@@ -24,5 +24,8 @@ def set_nux_seen():
 
 # Gets whether we've shown the Nux to any user on this instance
 def get_has_seen_nux():
-    # We only care about the existence of the file
-    return os.path.exists(nux_seen_filepath())
+    try:
+        # We only care about the existence of the file
+        return os.path.exists(nux_seen_filepath())
+    except:
+        return True

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_file_in_directory/hello_world_repository.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/hello_world_file_in_directory/hello_world_repository.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 from dagster import repository
+
 from src.pipelines import hello_world_pipeline
 
 


### PR DESCRIPTION
### Summary & Motivation

Add a try/catch around `nux_seen_filepath` which tries to create a temp directory if one doesn't exist. This causes an exception on read only file systems.


### How I Tested These Changes

pytest