### PR TITLE
Update Contributing doc with instructions for ruff/pyright

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -62,11 +62,11 @@ We love to see our community members get involved! If you are planning to contri
 
 Some notes on developing in Dagster:
 
-- **Black/Pylint**: We use [black](https://github.com/python/black) to enforce a consistent code style, along with [pylint](https://www.pylint.org/). We test these in our CI/CD pipeline.
-  - You can run `make black` from the repo root to automatically format your files.
+- **Black/Ruff/Pyright**: We use [black](https://github.com/python/black) to enforce a consistent code style, [ruff](https://github.com/charliermarsh/ruff) for linting and import sorting, and [pyright](https://github.com/microsoft/pyright) for static type-checking. We test these in our CI/CD pipeline.
+  - Run `make black` from the repo root to automatically format your files.
+  - Run `make ruff` from the repo root to sort imports and autofix some lint errors. It will also print out errors that need to be manually fixed.
+  - Run `make pyright` from the repo root to analyze the whole repo for type-correctness. Note that the first time you run this, it will take several minutes because a new virtualenv will be constructed.
 - **Line Width**: We use a line width of 100.
-- **Import ordering**: We use [isort](https://github.com/PyCQA/isort) to standardize the order of imports.
-  - You can run "make isort" from the repo root to automatically isort your files.
 - **IDE**: We recommend setting up your IDE to format with black on save and check pylint, but you can always run `make black` and `make pylint` in the root Dagster directory before submitting a pull request. If you're also using VS Code, you can see what we're using for our `settings.json` [here](https://gist.github.com/natekupp/7a17a9df8d2064e5389cc84aa118a896).
 - **Docker**: Some tests require [Docker Desktop](https://www.docker.com/products/docker-desktop) to be able to run them locally.
 


### PR DESCRIPTION
### Summary & Motivation

Updates contributing doc to remove references to `pylint`/`isort` and add references to `ruff`/`pyright`.

### How I Tested These Changes

BK
