### PR TITLE
Guard against OSerror in NUX state check

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from dagster_graphql.test.utils import (
     execute_dagster_graphql,
 )
@@ -28,3 +30,11 @@ def test_stores_nux_seen_state(graphql_context):
     assert not result.errors
     assert result.data
     assert result.data["shouldShowNux"] is False
+
+
+def test_filesystem_failure(graphql_context):
+    with mock.patch("dagster._core.nux.nux_seen_filepath", side_effect=OSError()):
+        result = execute_dagster_graphql(graphql_context, GET_SHOULD_SHOW_NUX_QUERY)
+        assert not result.errors
+        assert result.data
+        assert result.data["shouldShowNux"] is False

--- a/python_modules/dagster/dagster/_core/nux.py
+++ b/python_modules/dagster/dagster/_core/nux.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import yaml
 
@@ -24,5 +25,12 @@ def set_nux_seen():
 
 # Gets whether we've shown the Nux to any user on this instance
 def get_has_seen_nux():
-    # We only care about the existence of the file
-    return os.path.exists(nux_seen_filepath())
+    try:
+        # We only care about the existence of the file
+        return os.path.exists(nux_seen_filepath())
+    except OSError as e:
+        warnings.warn(
+            "Failed to check filesystem for NUX state, treating the NUX as though it has been"
+            f" viewed: {e}"
+        )
+        return True


### PR DESCRIPTION
Summary:
Several users with read-only filesystems have reported problems checking this state. Add a guard and fail the nux closed if dagit is running on read-only filesystem.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
