### PR TITLE
use opt_nullable_mapping for dagster library versions

### DIFF
--- a/python_modules/dagster/dagster/_check/__init__.py
+++ b/python_modules/dagster/dagster/_check/__init__.py
@@ -1043,7 +1043,7 @@ def opt_nullable_mapping_param(
     additional_message: Optional[str] = None,
 ) -> Optional[Mapping[T, U]]:
     if obj is None:
-        return dict()
+        return None
     else:
         return mapping_param(obj, param_name, key_type, value_type, additional_message)
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -329,7 +329,7 @@ class ListRepositoriesResponse(
                 if container_context is not None
                 else None
             ),
-            dagster_library_versions=check.opt_mapping_param(
+            dagster_library_versions=check.opt_nullable_mapping_param(
                 dagster_library_versions, "dagster_library_versions"
             ),
         )

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -992,6 +992,7 @@ def test_opt_mapping_param():
 
     with pytest.raises(CheckError):
         check.opt_mapping_param("foo", param_name="name")
+    assert check.opt_nullable_mapping_param(None, "name") is None
 
 
 # ########################


### PR DESCRIPTION
* use nullable variant where i meant to originally
* fix opt_nullable_mapping impl

### How I Tested These Changes

load dagit against an older code server and see entry omitted for library versions