### PR TITLE
make setting the log level in grpc servers apply to all loggers, not just dagster/dagit

### DIFF
--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -262,23 +262,13 @@ def configure_loggers(handler="default", log_level="INFO"):
                 "class": "logging.NullHandler",
             },
         },
-        "loggers": {
-            "dagster": {
-                "handlers": [handler],
-                "level": "INFO",
-            },
-            "dagit": {
-                "handlers": [handler],
-                "level": "INFO",
-            },
-        },
+        "root": {"level": log_level, "handlers": [handler]},
     }
 
     logging.config.dictConfig(LOGGING_CONFIG)
 
     if handler == "default":
-        for name in ["dagster", "dagit"]:
-            logging.getLogger(name).handlers[0].formatter.formatTime = _mockable_formatTime
+        logging.getLogger("").handlers[0].formatter.formatTime = _mockable_formatTime
 
 
 def create_console_logger(name, level):


### PR DESCRIPTION
Summary:
There's a "--log-level" argument to 'dagster api grpc', but right now it only applies to a set of handpicked dagster loggers. This PR changes it so that it applies to all loggers, which I think is more in line with what somebody would expect when they set that flag.

Test Plan:
Load a repo that makes a logging.info() call
Before, it would do nothing even if you ran it with "dagster dev --code-server-log-level INFO" - now it does
Verify that dagster log messages are unchanged in dagit

### Summary & Motivation

### How I Tested These Changes
