### PR TITLE
[pythonic resources] Last set of class renames

### DIFF
--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/common_bucket_s3_pickle_io_manager.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/common_bucket_s3_pickle_io_manager.py
@@ -1,12 +1,12 @@
 from typing import Any
 
 from dagster import build_init_resource_context
-from dagster._config.structured_config import ConfigurableIOManagerInjector, ResourceDependency
+from dagster._config.structured_config import ConfigurableIOManagerFactory, ResourceDependency
 from dagster._core.storage.io_manager import IOManager
 from dagster_aws.s3 import s3_pickle_io_manager
 
 
-class CommonBucketS3PickleIOManager(ConfigurableIOManagerInjector):
+class CommonBucketS3PickleIOManager(ConfigurableIOManagerFactory):
     """
     A version of the s3_pickle_io_manager that gets its bucket from another resource.
     """
@@ -14,7 +14,7 @@ class CommonBucketS3PickleIOManager(ConfigurableIOManagerInjector):
     s3_bucket: str
     s3: ResourceDependency[Any]
 
-    def create_io_manager_to_inject(self, context) -> IOManager:
+    def create_io_manager(self, context) -> IOManager:
         return s3_pickle_io_manager(
             build_init_resource_context(
                 config={"s3_bucket": self.s3_bucket},

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -502,9 +502,9 @@ class ConfigurableResource(
         return with_env_vars._create_object_fn(context)
 
     def _create_object_fn(self, context: InitResourceContext) -> TResValue:
-        return self.create_resource_to_inject(context)
+        return self.create_resource(context)
 
-    def create_resource_to_inject(
+    def create_resource(
         self, context: InitResourceContext
     ) -> TResValue:  # pylint: disable=unused-argument
         """
@@ -624,7 +624,7 @@ class ConfigurableResourceAdapter(ConfigurableResource, ABC):
         return self.wrapped_resource(*args, **kwargs)
 
 
-class ConfigurableIOManagerInjector(ConfigurableResource[TIOManagerValue], IOManagerDefinition):
+class ConfigurableIOManagerFactory(ConfigurableResource[TIOManagerValue], IOManagerDefinition):
     """
     Base class for Dagster IO managers that utilize structured config. This base class
     is useful for cases in which the returned IO manager is not the same as the class itself
@@ -645,10 +645,10 @@ class ConfigurableIOManagerInjector(ConfigurableResource[TIOManagerValue], IOMan
         )
 
     def _create_object_fn(self, context: InitResourceContext) -> TIOManagerValue:
-        return self.create_io_manager_to_inject(context)
+        return self.create_io_manager(context)
 
     @abstractmethod
-    def create_io_manager_to_inject(self, context) -> TIOManagerValue:
+    def create_io_manager(self, context) -> TIOManagerValue:
         """Implement as one would implement a @io_manager decorator function"""
         raise NotImplementedError()
 
@@ -672,7 +672,7 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue], IOManager
         )
 
 
-class ConfigurableIOManager(ConfigurableIOManagerInjector, IOManager):
+class ConfigurableIOManager(ConfigurableIOManagerFactory, IOManager):
     """
     Base class for Dagster IO managers that utilize structured config.
 
@@ -681,7 +681,7 @@ class ConfigurableIOManager(ConfigurableIOManagerInjector, IOManager):
     :py:meth:`handle_output` and :py:meth:`load_input` methods.
     """
 
-    def create_io_manager_to_inject(self, context) -> IOManager:
+    def create_io_manager(self, context) -> IOManager:
         return self
 
 
@@ -786,13 +786,41 @@ def _is_pydantic_field_required(pydantic_field: ModelField) -> bool:
     )
 
 
-class StructuredIOManagerAdapter(ConfigurableIOManagerInjector):
+class ConfigurableIOManagerAdapter(ConfigurableIOManagerFactory):
+    """
+    Adapter base class for wrapping a decorated, function-style I/O manager
+    with structured config.
+
+    To use this class, subclass it, define config schema fields using Pydantic,
+    and implement the ``wrapped_io_manager`` method.
+
+    Example:
+    .. code-block:: python
+
+        class OldIOManager(IOManager):
+            def __init__(self, base_path: str):
+                ...
+
+        @io_manager(config_schema={"base_path": str})
+        def old_io_manager(context):
+            base_path = context.resource_config["base_path"]
+
+            return OldIOManager(base_path)
+
+        class MyIOManager(ConfigurableIOManagerAdapter):
+            base_path: str
+
+            @property
+            def wrapped_io_manager(self) -> IOManagerDefinition:
+                return old_io_manager
+    """
+
     @property
     @abstractmethod
     def wrapped_io_manager(self) -> IOManagerDefinition:
         raise NotImplementedError()
 
-    def create_io_manager_to_inject(self, context) -> IOManager:
+    def create_io_manager(self, context) -> IOManager:
         raise NotImplementedError(
             "Because we override resource_fn in the adapter, this is never called."
         )

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -583,7 +583,7 @@ class ResourceDependency(Generic[V]):
         setattr(obj, self._name, value)
 
 
-class ConfigurableResourceAdapter(ConfigurableResource, ABC):
+class ConfigurableLegacyResourceAdapter(ConfigurableResource, ABC):
     """
     Adapter base class for wrapping a decorated, function-style resource
     with structured config.
@@ -603,7 +603,7 @@ class ConfigurableResourceAdapter(ConfigurableResource, ABC):
 
             return output
 
-        class WriterResource(ConfigurableResourceAdapter):
+        class WriterResource(ConfigurableLegacyResourceAdapter):
             prefix: str
 
             @property
@@ -786,7 +786,7 @@ def _is_pydantic_field_required(pydantic_field: ModelField) -> bool:
     )
 
 
-class ConfigurableIOManagerAdapter(ConfigurableIOManagerFactory):
+class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
     """
     Adapter base class for wrapping a decorated, function-style I/O manager
     with structured config.
@@ -807,7 +807,7 @@ class ConfigurableIOManagerAdapter(ConfigurableIOManagerFactory):
 
             return OldIOManager(base_path)
 
-        class MyIOManager(ConfigurableIOManagerAdapter):
+        class MyIOManager(ConfigurableLegacyIOManagerAdapter):
             base_path: str
 
             @property

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -14,10 +14,10 @@ from dagster._config.field import Field
 from dagster._config.field_utils import EnvVar
 from dagster._config.structured_config import (
     Config,
-    ConfigurableIOManagerAdapter,
     ConfigurableIOManagerFactory,
+    ConfigurableLegacyIOManagerAdapter,
+    ConfigurableLegacyResourceAdapter,
     ConfigurableResource,
-    ConfigurableResourceAdapter,
     ResourceDependency,
 )
 from dagster._core.definitions.assets_job import build_assets_job
@@ -235,7 +235,7 @@ def test_wrapping_function_resource():
 
         return output
 
-    class WriterResource(ConfigurableResourceAdapter):
+    class WriterResource(ConfigurableLegacyResourceAdapter):
         prefix: str
 
         @property
@@ -279,7 +279,7 @@ def test_io_manager_adapter():
     def an_io_manager(context: InitResourceContext) -> AnIOManagerImplementation:
         return AnIOManagerImplementation(context.resource_config["a_config_value"])
 
-    class AdapterForIOManager(ConfigurableIOManagerAdapter):
+    class AdapterForIOManager(ConfigurableLegacyIOManagerAdapter):
         a_config_value: str
 
         @property

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -14,11 +14,11 @@ from dagster._config.field import Field
 from dagster._config.field_utils import EnvVar
 from dagster._config.structured_config import (
     Config,
-    ConfigurableIOManagerInjector,
+    ConfigurableIOManagerAdapter,
+    ConfigurableIOManagerFactory,
     ConfigurableResource,
     ConfigurableResourceAdapter,
     ResourceDependency,
-    StructuredIOManagerAdapter,
 )
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.definitions_class import Definitions
@@ -196,7 +196,7 @@ def test_yield_in_resource_function():
     class ResourceWithCleanup(ConfigurableResource):
         idx: int
 
-        def create_resource_to_inject(self, context):
+        def create_resource(self, context):
             called.append(f"creation_{self.idx}")
             yield True
             called.append(f"cleanup_{self.idx}")
@@ -279,7 +279,7 @@ def test_io_manager_adapter():
     def an_io_manager(context: InitResourceContext) -> AnIOManagerImplementation:
         return AnIOManagerImplementation(context.resource_config["a_config_value"])
 
-    class AdapterForIOManager(StructuredIOManagerAdapter):
+    class AdapterForIOManager(ConfigurableIOManagerAdapter):
         a_config_value: str
 
         @property
@@ -304,10 +304,10 @@ def test_io_manager_adapter():
 
 def test_io_manager_factory_class():
     # now test without the adapter
-    class AnIOManagerFactory(ConfigurableIOManagerInjector):
+    class AnIOManagerFactory(ConfigurableIOManagerFactory):
         a_config_value: str
 
-        def create_io_manager_to_inject(self, _) -> IOManager:
+        def create_io_manager(self, _) -> IOManager:
             """Implement as one would implement a @io_manager decorator function"""
             return AnIOManagerImplementation(self.a_config_value)
 
@@ -620,7 +620,7 @@ def test_resources_which_return():
     class StringResource(ConfigurableResource[str]):
         a_string: str
 
-        def create_resource_to_inject(self, context) -> str:
+        def create_resource(self, context) -> str:
             return self.a_string
 
     class MyResource(ConfigurableResource):
@@ -689,7 +689,7 @@ def test_nested_function_resource():
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
-        def create_resource_to_inject(self, context) -> Callable[[str], None]:
+        def create_resource(self, context) -> Callable[[str], None]:
             def output(text: str):
                 self.writer(f"{text}{self.postfix}")
 
@@ -727,7 +727,7 @@ def test_nested_function_resource_configured():
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
-        def create_resource_to_inject(self, context) -> Callable[[str], None]:
+        def create_resource(self, context) -> Callable[[str], None]:
             def output(text: str):
                 self.writer(f"{text}{self.postfix}")
 
@@ -779,7 +779,7 @@ def test_nested_function_resource_runtime_config():
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
-        def create_resource_to_inject(self, context) -> Callable[[str], None]:
+        def create_resource(self, context) -> Callable[[str], None]:
             def output(text: str):
                 self.writer(f"{text}{self.postfix}")
 


### PR DESCRIPTION
## Summary

Renames `ConfigurableIOManagerInjector` to `ConfigurableIOManagerFactory`, renames the `create_xyz_to_inject` methods to `create_xyz` and fixes `StructuredConfigIOManagerAdapter` to `ConfigurableIOManagerAdapter`.
