### PR TITLE
[rename] LogicalVersion -> DataVersion in gql/dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventSystemTags.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventSystemTags.tsx
@@ -7,9 +7,13 @@ import {DagsterTag} from '../runs/RunTag';
 
 import {AssetEventGroup} from './groupByPartition';
 
-// There can be other keys in the event tags, but we want to show these two
+// There can be other keys in the event tags, but we want to show data and code version
 // at the top consistently regardless of their alphabetical / backend ordering.
-const ORDER = ['dagster/logical_version', 'dagster/code_version'];
+const ORDER = [
+  DagsterTag.AssetEventDataVersion.valueOf(),
+  DagsterTag.AssetEventDataVersionDeprecated.valueOf(),
+  DagsterTag.AssetEventCodeVersion.valueOf(),
+];
 
 export const AssetEventSystemTags: React.FC<{
   event: AssetEventGroup['latest'] | null;

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -652,7 +652,7 @@ type AssetNode {
   ): [ObservationEvent!]!
   computeKind: String
   configField: ConfigTypeField
-  currentLogicalVersion: String
+  currentDataVersion: String
   dependedBy: [AssetDependency!]!
   dependedByKeys: [AssetKey!]!
   dependencies: [AssetDependency!]!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -189,7 +189,7 @@ export type AssetNode = {
   assetPartitionStatuses: AssetPartitionStatuses;
   computeKind: Maybe<Scalars['String']>;
   configField: Maybe<ConfigTypeField>;
-  currentLogicalVersion: Maybe<Scalars['String']>;
+  currentDataVersion: Maybe<Scalars['String']>;
   dependedBy: Array<AssetDependency>;
   dependedByKeys: Array<AssetKey>;
   dependencies: Array<AssetDependency>;

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -18,7 +18,8 @@ export enum DagsterTag {
   SensorName = 'dagster/sensor_name',
   AssetPartitionRangeStart = 'dagster/asset_partition_range_start',
   AssetPartitionRangeEnd = 'dagster/asset_partition_range_end',
-  AssetEventDataVersion = 'dagster/logical_version',
+  AssetEventDataVersion = 'dagster/data_version',
+  AssetEventDataVersionDeprecated = 'dagster/logical_version',
   AssetEventCodeVersion = 'dagster/code_version',
 
   // Hidden tags (using ".dagster" HIDDEN_TAG_PREFIX)

--- a/js_modules/dagit/packages/core/src/runs/RunTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTag.tsx
@@ -18,7 +18,7 @@ export enum DagsterTag {
   SensorName = 'dagster/sensor_name',
   AssetPartitionRangeStart = 'dagster/asset_partition_range_start',
   AssetPartitionRangeEnd = 'dagster/asset_partition_range_end',
-  AssetEventLogicalVersion = 'dagster/logical_version',
+  AssetEventDataVersion = 'dagster/logical_version',
   AssetEventCodeVersion = 'dagster/code_version',
 
   // Hidden tags (using ".dagster" HIDDEN_TAG_PREFIX)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -192,7 +192,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     )
     computeKind = graphene.String()
     configField = graphene.Field(GrapheneConfigTypeField)
-    currentLogicalVersion = graphene.String()
+    currentDataVersion = graphene.String()
     dependedBy = non_null_list(GrapheneAssetDependency)
     dependedByKeys = non_null_list(GrapheneAssetKey)
     dependencies = non_null_list(GrapheneAssetDependency)
@@ -303,7 +303,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def stale_status_loader(self) -> StaleStatusLoader:
         loader = check.not_none(
             self._stale_status_loader,
-            "stale_status_loader must exist in order to logical versioning information",
+            "stale_status_loader must exist in order to access data versioning information",
         )
         return loader
 
@@ -578,7 +578,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             for cause in causes
         ]
 
-    def resolve_currentLogicalVersion(self, graphene_info: ResolveInfo) -> Optional[str]:
+    def resolve_currentDataVersion(self, graphene_info: ResolveInfo) -> Optional[str]:
         version = self.stale_status_loader.get_current_data_version(
             self._external_asset_node.asset_key
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -143,7 +143,7 @@ GET_ASSET_LATEST_RUN_STATS = """
     }
 """
 
-GET_ASSET_LOGICAL_VERSIONS = """
+GET_ASSET_DATA_VERSIONS = """
     query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
         assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {
             id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -151,7 +151,6 @@ GET_ASSET_DATA_VERSIONS = """
               path
             }
             currentDataVersion
-            projectedDataVersion
             staleStatus
             staleCauses {
                 key { path }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -150,7 +150,8 @@ GET_ASSET_DATA_VERSIONS = """
             assetKey {
               path
             }
-            currentLogicalVersion
+            currentDataVersion
+            projectedDataVersion
             staleStatus
             staleCauses {
                 key { path }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -69,7 +69,7 @@ def test_stale_status():
         with define_out_of_process_context(__file__, "get_repo_v1", instance) as context:
             result = _fetch_data_versions(context, repo)
             foo = _get_asset_node("foo", result)
-            assert foo["currentLogicalVersion"] is None
+            assert foo["currentDataVersion"] is None
             assert foo["staleStatus"] == "MISSING"
             assert foo["staleCauses"] == []
 
@@ -78,7 +78,7 @@ def test_stale_status():
 
             result = _fetch_data_versions(context, repo)
             foo = _get_asset_node("foo", result)
-            assert foo["currentLogicalVersion"] is not None
+            assert foo["currentDataVersion"] is not None
             assert foo["staleStatus"] == "FRESH"
             assert foo["staleCauses"] == []
 
@@ -92,7 +92,7 @@ def test_data_version_from_tags():
             result = _fetch_data_versions(context_v1, repo_v1)
             tags = result.data["assetNodes"][0]["assetMaterializations"][0]["tags"]
             dv_tag = next(tag for tag in tags if tag["key"] == DATA_VERSION_TAG)
-            assert dv_tag["value"] == result.data["assetNodes"][0]["currentLogicalVersion"]
+            assert dv_tag["value"] == result.data["assetNodes"][0]["currentDataVersion"]
 
 
 def get_repo_with_partitioned_self_dep_asset():


### PR DESCRIPTION
### Summary & Motivation

Converts GQL schema fields from `*LogicalVersion` -> `*DataVersion` and updates dagit to use the new names.

### How I Tested These Changes

BK, loading test repo in dagit
