### PR TITLE
Modify `get_first_partition_window` to account for offset

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -652,3 +652,77 @@ def test_time_window_partition_len():
         partitions_def.get_partition_keys_between_indexes(50, 53, current_time=current_time)
         == partitions_def.get_partition_keys(current_time=current_time)[50:53]
     )
+
+
+def test_get_first_partition_window():
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-01"
+    ).get_first_partition_window() == time_window("2023-01-01", "2023-01-02")
+
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-01", end_offset=1
+    ).get_first_partition_window(
+        current_time=datetime.strptime("2023-01-01", "%Y-%m-%d")
+    ) == time_window(
+        "2023-01-01", "2023-01-02"
+    )
+
+    assert (
+        DailyPartitionsDefinition(start_date="2023-02-15", end_offset=1).get_first_partition_window(current_time=datetime.strptime("2023-02-14", "%Y-%m-%d")) is None
+    )
+
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-01", end_offset=2
+    ).get_first_partition_window(
+        current_time=datetime.strptime("2023-01-02", "%Y-%m-%d")
+    ) == time_window(
+        "2023-01-01", "2023-01-02"
+    )
+
+    assert MonthlyPartitionsDefinition(
+        start_date="2023-01-01", end_offset=1
+    ).get_first_partition_window(
+        current_time=datetime.strptime("2023-01-15", "%Y-%m-%d")
+    ) == time_window(
+        "2023-01-01", "2023-02-01"
+    )
+
+    assert (
+        DailyPartitionsDefinition(start_date="2023-01-15", end_offset=-1).get_first_partition_window(current_time=datetime.strptime("2023-01-16", "%Y-%m-%d")) is None
+    )
+
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-15", end_offset=-1
+    ).get_first_partition_window(
+        current_time=datetime.strptime("2023-01-17", "%Y-%m-%d")
+    ) == time_window(
+        "2023-01-15", "2023-01-16"
+    )
+
+    assert (
+        DailyPartitionsDefinition(start_date="2023-01-15", end_offset=-2).get_first_partition_window(current_time=datetime.strptime("2023-01-17", "%Y-%m-%d")) is None
+    )
+
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-15", end_offset=-2
+    ).get_first_partition_window(
+        current_time=datetime.strptime("2023-01-18", "%Y-%m-%d")
+    ) == time_window(
+        "2023-01-15", "2023-01-16"
+    )
+
+    assert (
+        MonthlyPartitionsDefinition(start_date="2023-01-01", end_offset=-1).get_first_partition_window(current_time=datetime.strptime("2023-01-15", "%Y-%m-%d")) is None
+    )
+
+    assert (
+        MonthlyPartitionsDefinition(start_date="2023-01-01", end_offset=-1).get_first_partition_window(current_time=datetime.strptime("2023-02-01", "%Y-%m-%d")) is None
+    )
+
+    assert MonthlyPartitionsDefinition(
+        start_date="2023-01-01", end_offset=-1
+    ).get_first_partition_window(
+        current_time=datetime.strptime("2023-03-01", "%Y-%m-%d")
+    ) == time_window(
+        "2023-01-01", "2023-02-01"
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -668,7 +668,10 @@ def test_get_first_partition_window():
     )
 
     assert (
-        DailyPartitionsDefinition(start_date="2023-02-15", end_offset=1).get_first_partition_window(current_time=datetime.strptime("2023-02-14", "%Y-%m-%d")) is None
+        DailyPartitionsDefinition(start_date="2023-02-15", end_offset=1).get_first_partition_window(
+            current_time=datetime.strptime("2023-02-14", "%Y-%m-%d")
+        )
+        is None
     )
 
     assert DailyPartitionsDefinition(
@@ -688,7 +691,10 @@ def test_get_first_partition_window():
     )
 
     assert (
-        DailyPartitionsDefinition(start_date="2023-01-15", end_offset=-1).get_first_partition_window(current_time=datetime.strptime("2023-01-16", "%Y-%m-%d")) is None
+        DailyPartitionsDefinition(
+            start_date="2023-01-15", end_offset=-1
+        ).get_first_partition_window(current_time=datetime.strptime("2023-01-16", "%Y-%m-%d"))
+        is None
     )
 
     assert DailyPartitionsDefinition(
@@ -700,7 +706,10 @@ def test_get_first_partition_window():
     )
 
     assert (
-        DailyPartitionsDefinition(start_date="2023-01-15", end_offset=-2).get_first_partition_window(current_time=datetime.strptime("2023-01-17", "%Y-%m-%d")) is None
+        DailyPartitionsDefinition(
+            start_date="2023-01-15", end_offset=-2
+        ).get_first_partition_window(current_time=datetime.strptime("2023-01-17", "%Y-%m-%d"))
+        is None
     )
 
     assert DailyPartitionsDefinition(
@@ -712,11 +721,54 @@ def test_get_first_partition_window():
     )
 
     assert (
-        MonthlyPartitionsDefinition(start_date="2023-01-01", end_offset=-1).get_first_partition_window(current_time=datetime.strptime("2023-01-15", "%Y-%m-%d")) is None
+        MonthlyPartitionsDefinition(
+            start_date="2023-01-01", end_offset=-1
+        ).get_first_partition_window(current_time=datetime.strptime("2023-01-15", "%Y-%m-%d"))
+        is None
     )
 
     assert (
-        MonthlyPartitionsDefinition(start_date="2023-01-01", end_offset=-1).get_first_partition_window(current_time=datetime.strptime("2023-02-01", "%Y-%m-%d")) is None
+        DailyPartitionsDefinition(start_date="2023-01-15", end_offset=1).get_first_partition_window(
+            current_time=datetime.strptime("2023-01-14", "%Y-%m-%d")
+        )
+        is None
+    )
+
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-15", end_offset=1
+    ).get_first_partition_window(
+        current_time=datetime(year=2023, month=1, day=15, hour=12, minute=0, second=0)
+    ) == time_window(
+        "2023-01-15", "2023-01-16"
+    )
+
+    assert DailyPartitionsDefinition(
+        start_date="2023-01-15", end_offset=1
+    ).get_first_partition_window(
+        current_time=datetime(year=2023, month=1, day=14, hour=12, minute=0, second=0)
+    ) == time_window(
+        "2023-01-15", "2023-01-16"
+    )
+
+    assert (
+        DailyPartitionsDefinition(start_date="2023-01-15", end_offset=1).get_first_partition_window(
+            current_time=datetime(year=2023, month=1, day=13, hour=12, minute=0, second=0)
+        )
+        is None
+    )
+
+    assert (
+        MonthlyPartitionsDefinition(
+            start_date="2023-01-01", end_offset=-1
+        ).get_first_partition_window(current_time=datetime.strptime("2023-01-15", "%Y-%m-%d"))
+        is None
+    )
+
+    assert (
+        MonthlyPartitionsDefinition(
+            start_date="2023-01-01", end_offset=-1
+        ).get_first_partition_window(current_time=datetime.strptime("2023-02-01", "%Y-%m-%d"))
+        is None
     )
 
     assert MonthlyPartitionsDefinition(


### PR DESCRIPTION
Causes a graphQL error reported by a user here: https://dagster.slack.com/archives/C01U954MEER/p1677064207587029

Previously, `get_first_partition_window` did not account for the end offset.

This led to errors such as `get_first_partition_window` returning `None` when the start time window is the current time window and offset > 0.

