### PR TITLE
pare down multi-partition runtime type checking in upath IO manager

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
@@ -2,8 +2,13 @@ import datetime
 from typing import Any, Dict
 
 import pytest
-from dagster import DailyPartitionsDefinition, HourlyPartitionsDefinition, asset, materialize
-from dagster._check import CheckError
+from dagster import (
+    DagsterTypeCheckDidNotPass,
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+    asset,
+    materialize,
+)
 from pytest import fixture
 
 
@@ -73,13 +78,5 @@ def test_partitioned_io_manager_single_partition_dependency_errors_with_wrong_ty
     def daily_asset(upstream_asset: Dict[str, Any]):
         return upstream_asset
 
-    with pytest.raises(
-        CheckError,
-        match=r".*If you are loading a single partition, "
-        r"the upstream asset type annotation "
-        r"should not be a typing.Dict, but a single partition type.",
-    ):
-        materialize(
-            [upstream_asset, daily_asset],
-            partition_key="2022-01-01",
-        )
+    with pytest.raises(DagsterTypeCheckDidNotPass):
+        materialize([upstream_asset, daily_asset], partition_key="2022-01-01")

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -312,15 +312,13 @@ def test_user_forgot_dict_type_annotation_for_multiple_partitions(
     def upstream_asset(context: OpExecutionContext) -> str:
         return context.partition_key
 
-    @asset(
-        partitions_def=daily,
-    )
+    @asset(partitions_def=daily)
     def downstream_asset(upstream_asset: str) -> str:
         return upstream_asset
 
     with pytest.raises(
         CheckError,
-        match=r".* but the input has multiple partitions. .* should be used in this case.",
+        match="the type annotation on the op input is not a dict",
     ):
         materialize(
             [*upstream_asset.to_source_assets(), downstream_asset],


### PR DESCRIPTION
### Summary & Motivation

The `UPathIOManager` includes some type-checking to help users catch situations where they're mishandling the types for input partitions.  This type-checking is currently pretty aggressive and can lead to false positives, e.g. in the situation outlined here: https://github.com/dagster-io/dagster/issues/12426.

It's better to be too lax than too aggressive, because users have no workaround for the false positives.

This PR pares down this type-checking to only check a single situation, for what I believe is the most common error: handling unexpected cases of multiple input partitions.

### How I Tested These Changes

updated test