### PR TITLE
[refactor] Delete build_solid_context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/solid_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/solid_invocation.py
@@ -33,7 +33,7 @@ def op_invocation_result(
     **kwargs,
 ) -> Any:
     from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
-    from dagster._core.execution.context.invocation import build_solid_context
+    from dagster._core.execution.context.invocation import build_op_context
 
     from .composition import PendingNodeInvocation
 
@@ -45,7 +45,7 @@ def op_invocation_result(
 
     _check_invocation_requirements(op_def, context)
 
-    bound_context = (context or build_solid_context()).bind(op_def_or_invocation)
+    bound_context = (context or build_op_context()).bind(op_def_or_invocation)
 
     input_dict = _resolve_inputs(op_def, args, kwargs, bound_context)
 

--- a/python_modules/dagster/dagster/_legacy/__init__.py
+++ b/python_modules/dagster/dagster/_legacy/__init__.py
@@ -24,7 +24,6 @@ from dagster._core.execution.api import (
     reexecute_pipeline as reexecute_pipeline,
 )
 from dagster._core.execution.context.compute import OpExecutionContext as OpExecutionContext
-from dagster._core.execution.context.invocation import build_solid_context as build_solid_context
 from dagster._core.execution.results import (
     CompositeSolidExecutionResult as CompositeSolidExecutionResult,
     OpExecutionResult as OpExecutionResult,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_resources.py
@@ -1,7 +1,7 @@
 import json
 
 from dagster._core.definitions.decorators import op
-from dagster._legacy import build_solid_context
+from dagster._core.execution.context.invocation import build_op_context
 from dagster_dbt import dbt_cli_resource
 
 
@@ -17,7 +17,7 @@ def get_dbt_resource(project_dir, profiles_dir, **kwargs):
 
 
 def get_dbt_solid_context(project_dir, profiles_dir, **kwargs):
-    return build_solid_context(
+    return build_op_context(
         resources={"dbt": get_dbt_resource(project_dir, profiles_dir, **kwargs)}
     )
 
@@ -29,7 +29,7 @@ def test_unconfigured(
     def my_dbt_solid(context):
         return context.resources.dbt.run(project_dir=test_project_dir, profiles_dir=dbt_config_dir)
 
-    context = build_solid_context(resources={"dbt": dbt_cli_resource})
+    context = build_op_context(resources={"dbt": dbt_cli_resource})
     dbt_result = my_dbt_solid(context)
 
     assert len(dbt_result.result["results"]) == 4


### PR DESCRIPTION
### Summary & Motivation

- Delete `build_solid_context` and update all references to `build_op_context` (which already existed)

### How I Tested These Changes

BK
