### PR TITLE
[refactor] make ResolvedRunConfig.to_dict use "ops"

### DIFF
--- a/python_modules/dagster/dagster/_core/system_config/objects.py
+++ b/python_modules/dagster/dagster/_core/system_config/objects.py
@@ -214,7 +214,6 @@ class ResolvedRunConfig(
             pipeline_def, config_value.get(node_key, {}), mode_def.resource_defs
         )
         input_configs = config_value.get("inputs", {})
-
         return ResolvedRunConfig(
             ops=solid_config_dict,
             execution=ExecutionConfig.from_dict(config_mapped_execution_configs),
@@ -228,15 +227,15 @@ class ResolvedRunConfig(
     def to_dict(self) -> Mapping[str, Mapping[str, object]]:
         env_dict: Dict[str, Mapping[str, object]] = {}
 
-        solid_configs: Dict[str, object] = {}
-        for solid_name, solid_config in self.ops.items():
-            solid_configs[solid_name] = {
-                "config": solid_config.config,
-                "inputs": solid_config.inputs,
-                "outputs": solid_config.outputs.config,
+        op_configs: Dict[str, object] = {}
+        for op_name, op_config in self.ops.items():
+            op_configs[op_name] = {
+                "config": op_config.config,
+                "inputs": op_config.inputs,
+                "outputs": op_config.outputs.config,
             }
 
-        env_dict["solids"] = solid_configs
+        env_dict["ops"] = op_configs
 
         env_dict["execution"] = (
             {self.execution.execution_engine_name: self.execution.execution_engine_config}

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -350,11 +350,11 @@ def test_validate_run_config():
         requires_config()
 
     result = validate_run_config(
-        pipeline_requires_config, {"solids": {"requires_config": {"config": {"foo": "bar"}}}}
+        pipeline_requires_config, {"ops": {"requires_config": {"config": {"foo": "bar"}}}}
     )
 
     assert result == {
-        "solids": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
+        "ops": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
         "execution": {"in_process": {"retries": {"enabled": {}}}},
         "resources": {"io_manager": {"config": None}},
         "loggers": {},
@@ -372,11 +372,11 @@ def test_validate_run_config():
 
     result_with_storage = validate_run_config(
         pipeline_requires_config,
-        {"solids": {"requires_config": {"config": {"foo": "bar"}}}},
+        {"ops": {"requires_config": {"config": {"foo": "bar"}}}},
     )
 
     assert result_with_storage == {
-        "solids": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
+        "ops": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
         "execution": {"in_process": {"retries": {"enabled": {}}}},
         "resources": {"io_manager": {"config": None}},
         "loggers": {},

--- a/python_modules/dagster/dagster_tests/core_tests/test_validate_run_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_validate_run_config.py
@@ -25,11 +25,11 @@ def test_validate_run_config():
         requires_config()
 
     result = validate_run_config(
-        pipeline_requires_config, {"solids": {"requires_config": {"config": {"foo": "bar"}}}}
+        pipeline_requires_config, {"ops": {"requires_config": {"config": {"foo": "bar"}}}}
     )
 
     assert result == {
-        "solids": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
+        "ops": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
         "execution": {"in_process": {"retries": {"enabled": {}}}},
         "resources": {"io_manager": {"config": None}},
         "loggers": {},
@@ -37,11 +37,11 @@ def test_validate_run_config():
 
     result_with_storage = validate_run_config(
         pipeline_requires_config,
-        {"solids": {"requires_config": {"config": {"foo": "bar"}}}},
+        {"ops": {"requires_config": {"config": {"foo": "bar"}}}},
     )
 
     assert result_with_storage == {
-        "solids": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
+        "ops": {"requires_config": {"config": {"foo": "bar"}, "inputs": {}, "outputs": None}},
         "execution": {"in_process": {"retries": {"enabled": {}}}},
         "resources": {"io_manager": {"config": None}},
         "loggers": {},


### PR DESCRIPTION
### Summary & Motivation

Make `ResolvedRunConfig.to_dict` return the key `ops` instead of `solids`.

### How I Tested These Changes

BK