### PR TITLE
[refactor] Update pipeline_name -> job_name for schedule decs

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/preset_helper.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/preset_helper.py
@@ -14,7 +14,7 @@ def daily_schedule_definition_from_pipeline_preset(pipeline, preset_name, start_
 
     @daily_schedule(
         start_date=start_date,
-        pipeline_name=pipeline.name,
+        job_name=pipeline.name,
         solid_selection=preset.solid_selection,
         mode=preset.mode,
         tags_fn_for_date=lambda _: preset.tags,

--- a/python_modules/dagit/dagit_tests/pipeline.py
+++ b/python_modules/dagit/dagit_tests/pipeline.py
@@ -20,7 +20,7 @@ def math():
 
 
 @daily_schedule(
-    pipeline_name="math",
+    job_name="math",
     start_date=today_at_midnight(),
 )
 def my_schedule(_):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1085,7 +1085,7 @@ def define_schedules():
     )
 
     @daily_schedule(
-        pipeline_name="no_config_pipeline",
+        job_name="no_config_pipeline",
         start_date=today_at_midnight().subtract(days=1),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=2)).time(),
     )
@@ -1093,7 +1093,7 @@ def define_schedules():
         return {}
 
     @daily_schedule(
-        pipeline_name="no_config_pipeline",
+        job_name="no_config_pipeline",
         start_date=today_at_midnight().subtract(days=1),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=2)).time(),
         default_status=DefaultScheduleStatus.RUNNING,
@@ -1102,7 +1102,7 @@ def define_schedules():
         return {}
 
     @daily_schedule(
-        pipeline_name="multi_mode_with_loggers",
+        job_name="multi_mode_with_loggers",
         start_date=today_at_midnight().subtract(days=1),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=2)).time(),
         mode="foo_mode",
@@ -1111,7 +1111,7 @@ def define_schedules():
         return {}
 
     @hourly_schedule(
-        pipeline_name="no_config_chain_pipeline",
+        job_name="no_config_chain_pipeline",
         start_date=today_at_midnight().subtract(days=1),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=2)).time(),
         solid_selection=["return_foo"],
@@ -1120,7 +1120,7 @@ def define_schedules():
         return {}
 
     @daily_schedule(
-        pipeline_name="no_config_chain_pipeline",
+        job_name="no_config_chain_pipeline",
         start_date=today_at_midnight().subtract(days=2),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=3)).time(),
         solid_selection=["return_foo"],
@@ -1129,7 +1129,7 @@ def define_schedules():
         return {}
 
     @monthly_schedule(
-        pipeline_name="no_config_chain_pipeline",
+        job_name="no_config_chain_pipeline",
         start_date=(today_at_midnight().subtract(days=100)).replace(day=1),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=4)).time(),
         solid_selection=["return_foo"],
@@ -1138,7 +1138,7 @@ def define_schedules():
         return {}
 
     @weekly_schedule(
-        pipeline_name="no_config_chain_pipeline",
+        job_name="no_config_chain_pipeline",
         start_date=today_at_midnight().subtract(days=50),
         execution_time=(datetime.datetime.now() + datetime.timedelta(hours=5)).time(),
         solid_selection=["return_foo"],
@@ -1148,7 +1148,7 @@ def define_schedules():
 
     # Schedules for testing the user error boundary
     @daily_schedule(
-        pipeline_name="no_config_pipeline",
+        job_name="no_config_pipeline",
         start_date=today_at_midnight().subtract(days=1),
         should_execute=lambda _: asdf,  # noqa: F821
     )
@@ -1156,7 +1156,7 @@ def define_schedules():
         return {}
 
     @daily_schedule(
-        pipeline_name="no_config_pipeline",
+        job_name="no_config_pipeline",
         start_date=today_at_midnight().subtract(days=1),
         tags_fn_for_date=lambda _: asdf,  # noqa: F821
     )
@@ -1164,14 +1164,14 @@ def define_schedules():
         return {}
 
     @daily_schedule(
-        pipeline_name="no_config_pipeline",
+        job_name="no_config_pipeline",
         start_date=today_at_midnight().subtract(days=1),
     )
     def run_config_error_schedule(_date):
         return asdf  # noqa: F821
 
     @daily_schedule(
-        pipeline_name="no_config_pipeline",
+        job_name="no_config_pipeline",
         start_date=today_at_midnight("US/Central") - datetime.timedelta(days=1),
         execution_timezone="US/Central",
     )

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -464,7 +464,7 @@ def define_resources_limit_pipeline():
 def define_schedules():
     @daily_schedule(
         name="daily_optional_outputs",
-        pipeline_name=optional_outputs.name,
+        job_name=optional_outputs.name,
         start_date=datetime.datetime(2020, 1, 1),
     )
     def daily_optional_outputs(_date):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -28,6 +28,7 @@ from dagster._core.errors import (
     user_code_error_boundary,
 )
 from dagster._utils import ensure_gen
+from dagster._utils.backcompat import canonicalize_backcompat_args
 from dagster._utils.partitions import (
     DEFAULT_DATE_FORMAT,
     DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE,
@@ -200,7 +201,7 @@ def schedule(
 
 
 def monthly_schedule(
-    pipeline_name: Optional[str],
+    job_name: Optional[str] = None,
     *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -216,6 +217,7 @@ def monthly_schedule(
     partition_months_offset: Optional[int] = 1,
     description: Optional[str] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
+    pipeline_name: Optional[str] = None,
 ) -> Callable[[Callable[[datetime.datetime], Mapping[str, Any]]], PartitionScheduleDefinition]:
     """Create a partitioned schedule that runs monthly.
 
@@ -228,7 +230,7 @@ def monthly_schedule(
     The decorator produces a :py:class:`~dagster.PartitionScheduleDefinition`.
 
     Args:
-        pipeline_name (str): The name of the pipeline to execute when the schedule runs.
+        job_name (str): The name of the job to execute when the schedule runs.
         start_date (datetime.datetime): The date from which to run the schedule.
         name (Optional[str]): The name of the schedule to create.
         execution_day_of_month (int): The day of the month on which to run the schedule (must be
@@ -260,6 +262,10 @@ def monthly_schedule(
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
     """
+    job_name = check.not_none(
+        canonicalize_backcompat_args(job_name, "job_name", pipeline_name, "pipeline_name", "1.2.0")
+    )
+
     check.opt_str_param(name, "name")
     check.inst_param(start_date, "start_date", datetime.datetime)
     check.opt_inst_param(end_date, "end_date", datetime.datetime)
@@ -268,7 +274,7 @@ def monthly_schedule(
     mode = check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME)
     check.opt_callable_param(should_execute, "should_execute")
     check.opt_mapping_param(environment_vars, "environment_vars", key_type=str, value_type=str)
-    check.opt_str_param(pipeline_name, "pipeline_name")
+    check.opt_str_param(job_name, "job_name")
     check.int_param(execution_day_of_month, "execution_day")
     check.inst_param(execution_time, "execution_time", datetime.time)
     check.opt_str_param(execution_timezone, "execution_timezone")
@@ -333,7 +339,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,
+            pipeline_name=job_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,
@@ -362,7 +368,7 @@ def my_schedule_definition(_):
 
 
 def weekly_schedule(
-    pipeline_name: Optional[str],
+    job_name: Optional[str] = None,
     *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -378,6 +384,7 @@ def weekly_schedule(
     partition_weeks_offset: Optional[int] = 1,
     description: Optional[str] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
+    pipeline_name: Optional[str] = None,
 ) -> Callable[[Callable[[datetime.datetime], Mapping[str, Any]]], PartitionScheduleDefinition]:
     """Create a partitioned schedule that runs daily.
 
@@ -390,7 +397,7 @@ def weekly_schedule(
     The decorator produces a :py:class:`~dagster.PartitionScheduleDefinition`.
 
     Args:
-        pipeline_name (str): The name of the pipeline to execute when the schedule runs.
+        job_name (str): The name of the job to execute when the schedule runs.
         start_date (datetime.datetime): The date from which to run the schedule.
         name (Optional[str]): The name of the schedule to create.
         execution_day_of_week (int): The day of the week on which to run the schedule. Must be
@@ -422,6 +429,10 @@ def weekly_schedule(
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
     """
+    job_name = check.not_none(
+        canonicalize_backcompat_args(job_name, "job_name", pipeline_name, "pipeline_name", "1.2.0")
+    )
+
     check.opt_str_param(name, "name")
     check.inst_param(start_date, "start_date", datetime.datetime)
     check.opt_inst_param(end_date, "end_date", datetime.datetime)
@@ -430,7 +441,7 @@ def weekly_schedule(
     mode = check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME)
     check.opt_callable_param(should_execute, "should_execute")
     check.opt_mapping_param(environment_vars, "environment_vars", key_type=str, value_type=str)
-    check.opt_str_param(pipeline_name, "pipeline_name")
+    check.opt_str_param(job_name, "job_name")
     check.int_param(execution_day_of_week, "execution_day_of_week")
     check.inst_param(execution_time, "execution_time", datetime.time)
     check.opt_str_param(execution_timezone, "execution_timezone")
@@ -490,7 +501,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,
+            pipeline_name=job_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,
@@ -519,7 +530,7 @@ def my_schedule_definition(_):
 
 
 def daily_schedule(
-    pipeline_name: Optional[str],
+    job_name: Optional[str] = None,
     *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -534,6 +545,7 @@ def daily_schedule(
     partition_days_offset: Optional[int] = 1,
     description: Optional[str] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
+    pipeline_name: Optional[str] = None,
 ) -> Callable[[Callable[[datetime.datetime], Mapping[str, Any]]], PartitionScheduleDefinition]:
     """Create a partitioned schedule that runs daily.
 
@@ -546,7 +558,7 @@ def daily_schedule(
     The decorator produces a :py:class:`~dagster.PartitionScheduleDefinition`.
 
     Args:
-        pipeline_name (str): The name of the pipeline to execute when the schedule runs.
+        job_name (str): The name of the job to execute when the schedule runs.
         start_date (datetime.datetime): The date from which to run the schedule.
         name (Optional[str]): The name of the schedule to create.
         execution_time (datetime.time): The time at which to execute the schedule.
@@ -576,7 +588,11 @@ def daily_schedule(
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
     """
-    check.opt_str_param(pipeline_name, "pipeline_name")
+    job_name = check.not_none(
+        canonicalize_backcompat_args(job_name, "job_name", pipeline_name, "pipeline_name", "1.2.0")
+    )
+
+    check.opt_str_param(job_name, "job_name")
     check.inst_param(start_date, "start_date", datetime.datetime)
     check.opt_str_param(name, "name")
     check.inst_param(execution_time, "execution_time", datetime.time)
@@ -635,7 +651,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,
+            pipeline_name=job_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,
@@ -663,7 +679,7 @@ def my_schedule_definition(_):
 
 
 def hourly_schedule(
-    pipeline_name: Optional[str],
+    job_name: Optional[str] = None,
     *,
     start_date: datetime.datetime,
     name: Optional[str] = None,
@@ -678,6 +694,7 @@ def hourly_schedule(
     partition_hours_offset: Optional[int] = 1,
     description: Optional[str] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
+    pipeline_name: Optional[str] = None,
 ) -> Callable[[Callable[[datetime.datetime], Mapping[str, Any]]], PartitionScheduleDefinition]:
     """Create a partitioned schedule that runs hourly.
 
@@ -690,7 +707,7 @@ def hourly_schedule(
     The decorator produces a :py:class:`~dagster.PartitionScheduleDefinition`.
 
     Args:
-        pipeline_name (str): The name of the pipeline to execute when the schedule runs.
+        job_name (str): The name of the job to execute when the schedule runs.
         start_date (datetime.datetime): The date from which to run the schedule.
         name (Optional[str]): The name of the schedule to create. By default, this will be the name
             of the decorated function.
@@ -722,6 +739,10 @@ def hourly_schedule(
         default_status (DefaultScheduleStatus): Whether the schedule starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.
     """
+    job_name = check.not_none(
+        canonicalize_backcompat_args(job_name, "job_name", pipeline_name, "pipeline_name", "1.2.0")
+    )
+
     check.opt_str_param(name, "name")
     check.inst_param(start_date, "start_date", datetime.datetime)
     check.opt_inst_param(end_date, "end_date", datetime.datetime)
@@ -730,7 +751,7 @@ def hourly_schedule(
     mode = check.opt_str_param(mode, "mode", DEFAULT_MODE_NAME)
     check.opt_callable_param(should_execute, "should_execute")
     check.opt_mapping_param(environment_vars, "environment_vars", key_type=str, value_type=str)
-    check.opt_str_param(pipeline_name, "pipeline_name")
+    check.opt_str_param(job_name, "job_name")
     check.inst_param(execution_time, "execution_time", datetime.time)
     check.opt_str_param(execution_timezone, "execution_timezone")
     check.opt_int_param(partition_hours_offset, "partition_hours_offset")
@@ -795,7 +816,7 @@ def my_schedule_definition(_):
 
         partition_set = PartitionSetDefinition(
             name="{}_partitions".format(schedule_name),
-            pipeline_name=pipeline_name,
+            pipeline_name=job_name,
             run_config_fn_for_partition=lambda partition: fn(partition.value),
             solid_selection=solid_selection,
             tags_fn_for_partition=tags_fn_for_partition_value,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -41,7 +41,7 @@ def a_pipeline():
 
 
 @daily_schedule(  # type: ignore
-    pipeline_name="a_pipeline",
+    job_name="a_pipeline",
     start_date=datetime(year=2019, month=1, day=1),
     end_date=datetime(year=2019, month=2, day=1),
     execution_timezone="US/Central",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -62,7 +62,7 @@ def test_incorrect_cron_schedule_invocation():
 
 def partition_schedule_factory():
     @daily_schedule(
-        pipeline_name="test_pipeline",
+        job_name="test_pipeline",
         start_date=datetime.datetime(2020, 1, 1),
     )
     def my_partition_schedule(date):

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -137,18 +137,18 @@ def _solid_config(date):
     }
 
 
-@daily_schedule(pipeline_name="the_job", start_date=_COUPLE_DAYS_AGO, execution_timezone="UTC")
+@daily_schedule(job_name="the_job", start_date=_COUPLE_DAYS_AGO, execution_timezone="UTC")
 def simple_schedule(date):
     return _solid_config(date)
 
 
-@daily_schedule(pipeline_name="the_job", start_date=_COUPLE_DAYS_AGO)
+@daily_schedule(job_name="the_job", start_date=_COUPLE_DAYS_AGO)
 def daily_schedule_without_timezone(date):
     return _solid_config(date)
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="US/Central",
 )
@@ -176,7 +176,7 @@ def union_schedule(context):
 
 # Schedule that runs on a different day in Central Time vs UTC
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_time=datetime.time(hour=23, minute=0),
     execution_timezone="US/Central",
@@ -186,7 +186,7 @@ def daily_late_schedule(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_time=datetime.time(hour=2, minute=30),
     execution_timezone="US/Central",
@@ -196,7 +196,7 @@ def daily_dst_transition_schedule_skipped_time(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_time=datetime.time(hour=1, minute=30),
     execution_timezone="US/Central",
@@ -206,7 +206,7 @@ def daily_dst_transition_schedule_doubled_time(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="US/Eastern",
 )
@@ -215,7 +215,7 @@ def daily_eastern_time_schedule(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     end_date=datetime.datetime(year=2019, month=3, day=1),
     execution_timezone="UTC",
@@ -226,7 +226,7 @@ def simple_temporary_schedule(date):
 
 # forgot date arg
 @daily_schedule(  # type: ignore
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="UTC",
 )
@@ -239,7 +239,7 @@ NUM_CALLS = {"sync": 0, "async": 0}
 
 def get_passes_on_retry_schedule(key):
     @daily_schedule(
-        pipeline_name="the_job",
+        job_name="the_job",
         start_date=_COUPLE_DAYS_AGO,
         execution_timezone="UTC",
         name=f"passes_on_retry_schedule_{key}",
@@ -254,7 +254,7 @@ def get_passes_on_retry_schedule(key):
 
 
 @hourly_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="UTC",
 )
@@ -263,7 +263,7 @@ def simple_hourly_schedule(date):
 
 
 @hourly_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="US/Central",
 )
@@ -272,7 +272,7 @@ def hourly_central_time_schedule(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     should_execute=_throw,
     execution_timezone="UTC",
@@ -282,7 +282,7 @@ def bad_should_execute_schedule(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     should_execute=_throw_on_odd_day,
     execution_timezone="UTC",
@@ -292,7 +292,7 @@ def bad_should_execute_schedule_on_odd_days(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     should_execute=_never,
     execution_timezone="UTC",
@@ -302,7 +302,7 @@ def skip_schedule(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="UTC",
 )
@@ -393,7 +393,7 @@ def config_job():
 
 
 @daily_schedule(
-    pipeline_name="config_job",
+    job_name="config_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="UTC",
 )
@@ -511,7 +511,7 @@ def the_repo():
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="UTC",
     default_status=DefaultScheduleStatus.RUNNING,
@@ -521,7 +521,7 @@ def always_running_schedule(date):
 
 
 @daily_schedule(
-    pipeline_name="the_job",
+    job_name="the_job",
     start_date=_COUPLE_DAYS_AGO,
     execution_timezone="UTC",
     default_status=DefaultScheduleStatus.STOPPED,


### PR DESCRIPTION
### Summary & Motivation

All of the special case schedule decorators (e.g. `@daily_schedule`) still had `pipeline_name` as their first arg. This PR updates it to `job_name` while retaining a deprecated `pipeline_name` option (for removal in 1.2.0).

### How I Tested These Changes

BK