### PR TITLE
[dagit] Remove unnecessary usage of <TestProvider>

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.test.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.test.tsx
@@ -1,7 +1,6 @@
 import {render, screen, waitFor} from '@testing-library/react';
 import * as React from 'react';
-
-import {TestProvider} from '../testing/TestProvider';
+import {MemoryRouter} from 'react-router-dom';
 
 import {AssetNode} from './AssetNode';
 import {
@@ -21,13 +20,13 @@ describe('AssetNode', () => {
   Scenarios.forEach((scenario) =>
     it(`renders ${scenario.expectedText.join(',')} when ${scenario.title}`, async () => {
       render(
-        <TestProvider>
+        <MemoryRouter>
           <AssetNode
             definition={scenario.definition}
             liveData={scenario.liveData}
             selected={false}
           />
-        </TestProvider>,
+        </MemoryRouter>,
       );
 
       await waitFor(() => {

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.test.tsx
@@ -1,9 +1,9 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {render, screen, waitFor} from '@testing-library/react';
 import * as React from 'react';
+import {MemoryRouter} from 'react-router-dom';
 
 import * as Alerting from '../app/CustomAlertProvider';
-import {TestProvider} from '../testing/TestProvider';
 
 import {BackfillTable} from './BackfillTable';
 import {
@@ -19,12 +19,12 @@ describe('BackfillTable', () => {
     jest.spyOn(Alerting, 'showCustomAlert');
 
     render(
-      <TestProvider>
+      <MemoryRouter>
         <Alerting.CustomAlertProvider />
         <MockedProvider mocks={[BackfillTableFragmentFailedErrorStatus]}>
           <BackfillTable backfills={[BackfillTableFragmentFailedError]} refetch={() => {}} />
         </MockedProvider>
-      </TestProvider>,
+      </MemoryRouter>,
     );
 
     await waitFor(() => {

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
@@ -1,16 +1,16 @@
 import {render, screen, waitFor} from '@testing-library/react';
 import * as React from 'react';
+import {MemoryRouter} from 'react-router-dom';
 
-import {TestProvider} from '../testing/TestProvider';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 import {PipelineReference, Props as PipelineReferenceProps} from './PipelineReference';
 
 describe('PipelineReference', () => {
   const Test = (props: PipelineReferenceProps) => (
-    <TestProvider>
+    <MemoryRouter>
       <PipelineReference {...props} />
-    </TestProvider>
+    </MemoryRouter>
   );
 
   describe('Job name truncation', () => {

--- a/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/AssetKeyTagCollection.test.tsx
@@ -1,8 +1,7 @@
 import {act, render, screen} from '@testing-library/react';
 import faker from 'faker';
 import * as React from 'react';
-
-import {TestProvider} from '../testing/TestProvider';
+import {MemoryRouter} from 'react-router-dom';
 
 import {AssetKeyTagCollection} from './AssetKeyTagCollection';
 
@@ -16,9 +15,9 @@ describe('AssetKeyTagCollection', () => {
   it('renders individual tags if <= 3', async () => {
     await act(async () => {
       render(
-        <TestProvider>
+        <MemoryRouter>
           <AssetKeyTagCollection assetKeys={makeKeys(3)} clickableTags />
-        </TestProvider>,
+        </MemoryRouter>,
       );
     });
 
@@ -31,9 +30,9 @@ describe('AssetKeyTagCollection', () => {
   it('renders single tag if > 3', async () => {
     await act(async () => {
       render(
-        <TestProvider>
+        <MemoryRouter>
           <AssetKeyTagCollection assetKeys={makeKeys(5)} clickableTags />
-        </TestProvider>,
+        </MemoryRouter>,
       );
     });
 

--- a/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useRepoExpansionState.test.tsx
@@ -2,7 +2,6 @@ import {act, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import {TestProvider} from '../testing/TestProvider';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 
 import {buildStorageKey, useRepoExpansionState} from './useRepoExpansionState';
@@ -18,27 +17,25 @@ describe('useRepoExpansionState', () => {
     );
 
     return (
-      <TestProvider>
-        <div>
-          {ALL_REPO_KEYS.map((key) => (
-            <div key={key}>
-              <div>{`${key} ${expandedKeys.includes(key) ? 'expanded' : 'collapsed'}`}</div>
-              <button
-                onClick={() => {
-                  const repoAddress = repoAddressFromPath(key);
-                  if (repoAddress) {
-                    onToggle(repoAddress);
-                  }
-                }}
-              >
-                {`toggle ${key}`}
-              </button>
-            </div>
-          ))}
-          <button onClick={() => onToggleAll(true)}>expand all</button>
-          <button onClick={() => onToggleAll(false)}>collapse all</button>
-        </div>
-      </TestProvider>
+      <div>
+        {ALL_REPO_KEYS.map((key) => (
+          <div key={key}>
+            <div>{`${key} ${expandedKeys.includes(key) ? 'expanded' : 'collapsed'}`}</div>
+            <button
+              onClick={() => {
+                const repoAddress = repoAddressFromPath(key);
+                if (repoAddress) {
+                  onToggle(repoAddress);
+                }
+              }}
+            >
+              {`toggle ${key}`}
+            </button>
+          </div>
+        ))}
+        <button onClick={() => onToggleAll(true)}>expand all</button>
+        <button onClick={() => onToggleAll(false)}>collapse all</button>
+      </div>
     );
   };
 


### PR DESCRIPTION
### Summary & Motivation

I went through the tests that used `<TestProvider>` and refactored or removed it in places where it seemed straightforward. It's still in use in 15 files, but those pass mocks or other props and probably need more careful removal.

### How I Tested These Changes

Tests still pass! I also altered the ReexcutionDialog test "failure" case to be a bit more interesting since we have more control over the mocks with the MockedProvider.