### PR TITLE
[refactor] simplify dependency dict typing

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -30,6 +30,7 @@ from dagster._core.errors import (
 from .config import ConfigMapping
 from .dependency import (
     DependencyDefinition,
+    DependencyMapping,
     DynamicCollectDependencyDefinition,
     IDependencyDefinition,
     MultiDependencyDefinition,
@@ -280,7 +281,7 @@ class CompleteCompositionContext(NamedTuple):
 
     name: str
     solid_defs: Sequence[NodeDefinition]
-    dependencies: Mapping[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]]
+    dependencies: DependencyMapping[NodeInvocation]
     input_mappings: Sequence[InputMapping]
     output_mapping_dict: Mapping[str, OutputMapping]
     node_input_source_assets: Mapping[str, Mapping[str, "SourceAsset"]]
@@ -292,10 +293,10 @@ class CompleteCompositionContext(NamedTuple):
         invocations: Mapping[str, "InvokedNode"],
         output_mapping_dict: Mapping[str, OutputMapping],
         pending_invocations: Mapping[str, "PendingNodeInvocation"],
-    ):
+    ) -> "CompleteCompositionContext":
         from .source_asset import SourceAsset
 
-        dep_dict: Dict[Union[str, NodeInvocation], Dict[str, IDependencyDefinition]] = {}
+        dep_dict: Dict[NodeInvocation, Dict[str, IDependencyDefinition]] = {}
         node_def_dict: Dict[str, NodeDefinition] = {}
         input_mappings = []
         node_input_source_assets: Dict[str, Dict[str, "SourceAsset"]] = defaultdict(dict)
@@ -983,7 +984,7 @@ def do_composition(
 ) -> Tuple[
     Sequence[InputMapping],
     Sequence[OutputMapping],
-    Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]],
+    DependencyMapping[NodeInvocation],
     Sequence[NodeDefinition],
     Optional[ConfigMapping],
     Sequence[str],

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -21,7 +21,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypeVar
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
@@ -45,6 +45,9 @@ if TYPE_CHECKING:
     from .graph_definition import GraphDefinition
     from .node_definition import NodeDefinition
     from .resource_requirement import ResourceRequirement
+
+T_DependencyKey = TypeVar("T_DependencyKey", str, "NodeInvocation")
+DependencyMapping: TypeAlias = Mapping[T_DependencyKey, Mapping[str, "IDependencyDefinition"]]
 
 
 class NodeInvocation(
@@ -780,7 +783,7 @@ InputToOutputMap: TypeAlias = Dict[NodeInput, DepTypeAndOutputs]
 
 def _create_handle_dict(
     node_dict: Mapping[str, Node],
-    dep_dict: Mapping[str, Mapping[str, IDependencyDefinition]],
+    dep_dict: DependencyMapping[str],
 ) -> InputToOutputMap:
     from .composition import MappedInputPlaceholder
 
@@ -827,7 +830,9 @@ def _create_handle_dict(
 
 class DependencyStructure:
     @staticmethod
-    def from_definitions(nodes: Mapping[str, Node], dep_dict: Mapping[str, Any]):
+    def from_definitions(
+        nodes: Mapping[str, Node], dep_dict: DependencyMapping[str]
+    ) -> "DependencyStructure":
         return DependencyStructure(list(dep_dict.keys()), _create_handle_dict(nodes, dep_dict))
 
     _node_input_index: DefaultDict[str, Dict[NodeInput, List[NodeOutput]]]

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -18,12 +18,12 @@ from typing import (
 )
 
 from toposort import CircularDependencyError, toposort_flatten
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
-from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -35,9 +35,9 @@ from dagster._core.types.dagster_type import (
 )
 
 from .dependency import (
+    DependencyMapping,
     DependencyStructure,
     GraphNode,
-    IDependencyDefinition,
     Node,
     NodeHandle,
     NodeInput,
@@ -47,8 +47,8 @@ from .dependency import (
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .logger_definition import LoggerDefinition
-from .metadata import RawMetadataValue
-from .node_container import create_execution_structure, validate_dependency_dict
+from .metadata import MetadataEntry, RawMetadataValue
+from .node_container import create_execution_structure, normalize_dependency_dict
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
 from .resource_requirement import ResourceRequirement
@@ -178,7 +178,7 @@ class GraphDefinition(NodeDefinition):
 
     _node_defs: Sequence[NodeDefinition]
     _dagster_type_dict: Mapping[str, DagsterType]
-    _dependencies: Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
+    _dependencies: DependencyMapping[NodeInvocation]
     _dependency_structure: DependencyStructure
     _node_dict: Mapping[str, Node]
     _input_mappings: Sequence[InputMapping]
@@ -199,7 +199,7 @@ class GraphDefinition(NodeDefinition):
         description: Optional[str] = None,
         node_defs: Optional[Sequence[NodeDefinition]] = None,
         dependencies: Optional[
-            Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
+            Union[DependencyMapping[str], DependencyMapping[NodeInvocation]]
         ] = None,
         input_mappings: Optional[Sequence[InputMapping]] = None,
         output_mappings: Optional[Sequence[OutputMapping]] = None,
@@ -209,7 +209,10 @@ class GraphDefinition(NodeDefinition):
         **kwargs: object,
     ):
         self._node_defs = _check_node_defs_arg(name, node_defs)
-        self._dependencies = validate_dependency_dict(dependencies)
+
+        # `dependencies` will be converted to `dependency_structure` and `node_dict`, which may
+        # alternatively be passed directly (useful when copying)
+        self._dependencies = normalize_dependency_dict(dependencies)
         self._dependency_structure, self._node_dict = create_execution_structure(
             self._node_defs, self._dependencies, graph_definition=self
         )
@@ -470,9 +473,7 @@ class GraphDefinition(NodeDefinition):
         return mapped_node.definition.input_has_default(mapping.maps_to.input_name)
 
     @property
-    def dependencies(
-        self,
-    ) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
+    def dependencies(self) -> DependencyMapping[NodeInvocation]:
         return self._dependencies
 
     @property
@@ -498,6 +499,28 @@ class GraphDefinition(NodeDefinition):
             mapping.maps_to.input_name
         )
 
+    def copy(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        input_mappings: Optional[Sequence[InputMapping]] = None,
+        output_mappings: Optional[Sequence[OutputMapping]] = None,
+        config: Optional[ConfigMapping] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        node_input_source_assets: Optional[Mapping[str, Mapping[str, "SourceAsset"]]] = None,
+    ) -> Self:
+        return GraphDefinition(
+            node_defs=self.node_defs,
+            dependencies=self.dependencies,
+            name=name or self.name,
+            description=description or self.description,
+            input_mappings=input_mappings or self._input_mappings,
+            output_mappings=output_mappings or self._output_mappings,
+            config=config or self.config_mapping,
+            tags=tags or self.tags,
+            node_input_source_assets=node_input_source_assets or self.node_input_source_assets,
+        )
+
     def copy_for_configured(
         self,
         name: str,
@@ -511,13 +534,9 @@ class GraphDefinition(NodeDefinition):
                 "configured.".format(graph_name=self.name)
             )
         config_mapping = cast(ConfigMapping, self.config_mapping)
-        return GraphDefinition(
+        return self.copy(
             name=name,
             description=check.opt_str_param(description, "description", default=self.description),
-            node_defs=self._node_defs,
-            dependencies=self._dependencies,
-            input_mappings=self._input_mappings,
-            output_mappings=self._output_mappings,
             config=ConfigMapping(
                 config_mapping.config_fn,
                 config_schema=config_schema,
@@ -797,7 +816,10 @@ class SubselectedGraphDefinition(GraphDefinition):
         parent_graph_def: GraphDefinition,
         node_defs: Optional[Sequence[NodeDefinition]],
         dependencies: Optional[
-            Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
+            Union[
+                DependencyMapping[str],
+                DependencyMapping[NodeInvocation],
+            ]
         ],
         input_mappings: Optional[Sequence[InputMapping]],
         output_mappings: Optional[Sequence[OutputMapping]],

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -824,7 +824,7 @@ def get_subselected_graph_definition(
     parent_handle: Optional[NodeHandle] = None,
 ) -> SubselectedGraphDefinition:
     deps: Dict[
-        Union[str, NodeInvocation],
+        NodeInvocation,
         Dict[str, IDependencyDefinition],
     ] = {}
 

--- a/python_modules/dagster/dagster/_core/definitions/node_container.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_container.py
@@ -9,6 +9,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypeVar,
     Union,
 )
 
@@ -17,6 +18,7 @@ from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 from .dependency import (
+    DependencyMapping,
     DependencyStructure,
     GraphNode,
     IDependencyDefinition,
@@ -29,15 +31,15 @@ if TYPE_CHECKING:
     from .graph_definition import GraphDefinition
     from .node_definition import NodeDefinition
 
+T_DependencyKey = TypeVar("T_DependencyKey", str, "NodeInvocation")
 
-def validate_dependency_dict(
-    dependencies: Optional[
-        Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
-    ],
-) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
+
+def normalize_dependency_dict(
+    dependencies: Optional[Union[DependencyMapping[str], DependencyMapping[NodeInvocation]]]
+) -> DependencyMapping[NodeInvocation]:
     prelude = (
-        'The expected type for "dependencies" is Dict[Union[str, NodeInvocation], Dict[str, '
-        "DependencyDefinition]]. "
+        'The expected type for "dependencies" is Union[Mapping[str, Mapping[str, '
+        "DependencyDefinition]], Mapping[NodeInvocation, Mapping[str, DependencyDefinition]]]. "
     )
 
     if dependencies is None:
@@ -48,13 +50,8 @@ def validate_dependency_dict(
             prelude + "Received value {dependencies} of type {type(dependencies)} at the top level."
         )
 
+    normalized_dependencies: Dict[NodeInvocation, Mapping[str, IDependencyDefinition]] = {}
     for key, dep_dict in dependencies.items():
-        if not isinstance(key, (str, NodeInvocation)):
-            raise DagsterInvalidDefinitionError(
-                prelude
-                + "Expected str or NodeInvocation key in the top level dict. "
-                "Received value {key} of type {type(key)}"
-            )
         if not isinstance(dep_dict, dict):
             if isinstance(dep_dict, IDependencyDefinition):
                 raise DagsterInvalidDefinitionError(
@@ -84,12 +81,23 @@ def validate_dependency_dict(
                     f"Received value {dep} of type {type(dep)}."
                 )
 
-    return dependencies
+        if isinstance(key, str):
+            normalized_dependencies[NodeInvocation(key)] = dep_dict
+        elif isinstance(key, NodeInvocation):
+            normalized_dependencies[key] = dep_dict
+        else:
+            raise DagsterInvalidDefinitionError(
+                prelude
+                + "Expected str or NodeInvocation key in the top level dict. "
+                "Received value {key} of type {type(key)}"
+            )
+
+    return normalized_dependencies
 
 
 def create_execution_structure(
     node_defs: Sequence["NodeDefinition"],
-    dependencies_dict: Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]],
+    dependencies_dict: DependencyMapping[NodeInvocation],
     graph_definition: "GraphDefinition",
 ) -> Tuple[DependencyStructure, Mapping[str, Node]]:
     """This builder takes the dependencies dictionary specified during creation of the
@@ -148,27 +156,24 @@ def create_execution_structure(
     # Same as dep_dict but with NodeInvocation replaced by alias string
     aliased_dependencies_dict: Dict[str, Mapping[str, IDependencyDefinition]] = {}
 
-    # Keep track of solid name -> all aliases used and alias -> name
+    # Keep track of node name -> all aliases used and alias -> name
     name_to_aliases: DefaultDict[str, Set[str]] = defaultdict(set)
-    alias_to_solid_instance: Dict[str, NodeInvocation] = {}
+    alias_to_node_invocation: Dict[str, NodeInvocation] = {}
     alias_to_name: Dict[str, str] = {}
 
-    for solid_key, input_dep_dict in dependencies_dict.items():
+    for node_invocation, input_dep_dict in dependencies_dict.items():
         # We allow deps of the form dependencies={'foo': DependencyDefinition('bar')}
         # Here, we replace 'foo' with NodeInvocation('foo')
 
-        solid_key_invoc = (
-            NodeInvocation(solid_key) if not isinstance(solid_key, NodeInvocation) else solid_key
-        )
-        alias = solid_key_invoc.alias or solid_key_invoc.name
+        alias = node_invocation.alias or node_invocation.name
 
-        name_to_aliases[solid_key_invoc.name].add(alias)
-        alias_to_solid_instance[alias] = solid_key_invoc
-        alias_to_name[alias] = solid_key_invoc.name
+        name_to_aliases[node_invocation.name].add(alias)
+        alias_to_node_invocation[alias] = node_invocation
+        alias_to_name[alias] = node_invocation.name
         aliased_dependencies_dict[alias] = input_dep_dict
 
     node_dict = _build_graph_node_dict(
-        node_defs, name_to_aliases, alias_to_solid_instance, graph_definition
+        node_defs, name_to_aliases, alias_to_node_invocation, graph_definition
     )
 
     _validate_dependencies(aliased_dependencies_dict, node_dict, alias_to_name)
@@ -225,7 +230,7 @@ def _build_graph_node_dict(
 
 
 def _validate_dependencies(
-    dependencies: Mapping[str, Mapping[str, IDependencyDefinition]],
+    dependencies: DependencyMapping[str],
     node_dict: Mapping[str, Node],
     alias_to_name: Mapping[str, str],
 ) -> None:

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -33,6 +33,7 @@ from dagster._utils.merger import merge_dicts
 from .asset_layer import AssetLayer
 from .dependency import (
     DependencyDefinition,
+    DependencyMapping,
     DependencyStructure,
     DynamicCollectDependencyDefinition,
     GraphNode,
@@ -177,7 +178,7 @@ class PipelineDefinition:
         name: Optional[str] = None,
         description: Optional[str] = None,
         dependencies: Optional[
-            Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]
+            Union[DependencyMapping[str], DependencyMapping[NodeInvocation]]
         ] = None,
         mode_defs: Optional[Sequence[ModeDefinition]] = None,
         preset_defs: Optional[Sequence[PresetDefinition]] = None,
@@ -375,9 +376,7 @@ class PipelineDefinition:
         return self._graph_def.dependency_structure
 
     @property
-    def dependencies(
-        self,
-    ) -> Mapping[Union[str, NodeInvocation], Mapping[str, IDependencyDefinition]]:
+    def dependencies(self) -> DependencyMapping[NodeInvocation]:
         return self._graph_def.dependencies
 
     def get_run_config_schema(self, mode: Optional[str] = None) -> "RunConfigSchema":
@@ -731,7 +730,7 @@ def _get_pipeline_subset_def(
     )
 
     deps: Dict[
-        Union[str, NodeInvocation],
+        NodeInvocation,
         Dict[str, IDependencyDefinition],
     ] = {_dep_key_of(solid): {} for solid in solids}
 

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -384,7 +384,7 @@ def execute_solid(
         PipelineDefinition(
             name="ephemeral_{}_solid_pipeline".format(solid_def.name),
             solid_defs=solid_defs,
-            dependencies=dependencies,  # type: ignore
+            dependencies=dependencies,
             mode_defs=[mode_def] if mode_def else None,
         ),
         run_config=run_config,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -36,7 +36,7 @@ from dagster._core.definitions import AssetGroup, AssetIn, SourceAsset, asset, b
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets_job import get_base_asset_jobs
-from dagster._core.definitions.dependency import NodeHandle
+from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.execution.api import execute_pipeline, execute_run_iterator
@@ -103,8 +103,8 @@ def test_two_asset_pipeline():
     job = build_assets_job("a", [asset1, asset2])
     assert job.graph.node_defs == [asset1.op, asset2.op]
     assert job.dependencies == {
-        "asset1": {},
-        "asset2": {"asset1": DependencyDefinition("asset1", "result")},
+        NodeInvocation("asset1"): {},
+        NodeInvocation("asset2"): {"asset1": DependencyDefinition("asset1", "result")},
     }
     assert job.execute_in_process().success
 
@@ -137,9 +137,9 @@ def test_fork():
     job = build_assets_job("a", [asset1, asset2, asset3])
     assert job.graph.node_defs == [asset1.op, asset2.op, asset3.op]
     assert job.dependencies == {
-        "asset1": {},
-        "asset2": {"asset1": DependencyDefinition("asset1", "result")},
-        "asset3": {"asset1": DependencyDefinition("asset1", "result")},
+        NodeInvocation("asset1"): {},
+        NodeInvocation("asset2"): {"asset1": DependencyDefinition("asset1", "result")},
+        NodeInvocation("asset3"): {"asset1": DependencyDefinition("asset1", "result")},
     }
     assert job.execute_in_process().success
 
@@ -161,9 +161,9 @@ def test_join():
     job = build_assets_job("a", [asset1, asset2, asset3])
     assert job.graph.node_defs == [asset1.op, asset2.op, asset3.op]
     assert job.dependencies == {
-        "asset1": {},
-        "asset2": {},
-        "asset3": {
+        NodeInvocation("asset1"): {},
+        NodeInvocation("asset2"): {},
+        NodeInvocation("asset3"): {
             "asset1": DependencyDefinition("asset1", "result"),
             "asset2": DependencyDefinition("asset2", "result"),
         },

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
@@ -140,7 +140,7 @@ def test_malformed_dependencies():
 def test_list_dependencies():
     with pytest.raises(
         DagsterInvalidDefinitionError,
-        match='The expected type for "dependencies" is Dict',
+        match=r'The expected type for "dependencies" is Union\[Mapping\[',
     ):
         GraphDefinition(node_defs=solid_a_b_list(), name="test", dependencies=[])
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -160,10 +160,7 @@ def load_assets_from_airflow_dag(
         dag, graph, mutated_task_ids_by_asset_key, upstream_dependencies_by_asset_key
     )
 
-    new_graph = GraphDefinition(
-        name=graph.name,
-        node_defs=graph.node_defs,
-        dependencies=graph.dependencies,
+    new_graph = graph.copy(
         output_mappings=list(output_mappings),
     )
 


### PR DESCRIPTION
### Summary & Motivation

Simplifies the typing for dependency dictionaries. Previously, these were typed `Mapping[Union[str, NodeInvocation], Mapping[str,
IDependencyDefinition]`. This doesn't work well because `Mapping` is invariant in its key type, so e.g. a `Mapping[NodeInvocation, Mapping[str, IDependencyDefinition]]` will not match this type.

This PR adds a type alias and does a light refactor of normalization of dependency dicts so that they are converted to the `NodeInvocation` form during `GraphDefinition` initialization.

### How I Tested These Changes

BK
