### PR TITLE
[typing/runtime] serdes

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -86,7 +86,7 @@ class LocalExternalStepLauncher(StepLauncher):
             # write each pickled event from the external instance to the local instance
             step_context.instance.handle_new_event(event)
             if event.is_dagster_event:
-                yield event.dagster_event  # type: ignore  # (possible none)
+                yield event.get_dagster_event()
 
 
 def _module_in_package_dir(file_path: str, package_dir: str) -> str:

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -30,6 +30,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Sequence,
     Sized,
@@ -42,7 +43,7 @@ from typing import (
 )
 
 import packaging.version
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Literal, TypeAlias, TypeGuard
 
 import dagster._check as check
 import dagster._seven as seven
@@ -742,3 +743,11 @@ def iter_to_list(iterable: Iterable[T]) -> List[T]:
 
 def last_file_comp(path: str) -> str:
     return os.path.basename(os.path.normpath(path))
+
+
+def is_named_tuple_instance(obj: object) -> TypeGuard[NamedTuple]:
+    return isinstance(obj, tuple) and hasattr(obj, "_fields")
+
+
+def is_named_tuple_subclass(klass: Type[object]) -> TypeGuard[Type[NamedTuple]]:
+    return isinstance(klass, type) and issubclass(klass, tuple) and hasattr(klass, "_fields")

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -21,7 +21,6 @@ from dagster._core.definitions.decorators import op
 from dagster._core.definitions.metadata import (
     DagsterInvalidMetadata,
     MetadataEntry,
-    TableMetadataValue,
     normalize_metadata,
 )
 from dagster._core.definitions.metadata.table import (
@@ -359,13 +358,16 @@ def test_table_schema_from_name_type_dict():
 
 
 def test_table_serialization():
-    entry = MetadataValue.table(
-        records=[
-            TableRecord(dict(foo=1, bar=2)),
-        ],
+    entry = MetadataEntry(
+        "foo",
+        value=MetadataValue.table(
+            records=[
+                TableRecord(dict(foo=1, bar=2)),
+            ],
+        ),
     )
     serialized = serialize_dagster_namedtuple(entry)
-    assert deserialize_as(serialized, TableMetadataValue) == entry
+    assert deserialize_as(serialized, MetadataEntry) == entry
 
 
 def test_bool_metadata_value():


### PR DESCRIPTION
### Summary & Motivation

Fix some type errors requiring runtime alterations in `dagster._serdes` and some light refactors. Adds and uses `TypeGuard` for checking if a class is a `NamedTuple` descendant (`isinstance(x, NamedTuple)` does not work).

### How I Tested These Changes

BK
