### PR TITLE
[refactor] serdes pack/deserialize APIs

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -15,7 +15,7 @@ from dagster._core.instance import InstanceRef
 from dagster._core.telemetry import START_DAGIT_WEBSERVER, log_action
 from dagster._core.telemetry_upload import uploading_logging_thread
 from dagster._core.workspace.context import WorkspaceProcessContext
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, find_free_port, is_port_in_use
 from dagster._utils.log import configure_loggers
 
@@ -159,7 +159,7 @@ def dagit(
 
     with get_instance_for_service(
         "dagit",
-        instance_ref=deserialize_as(instance_ref, InstanceRef) if instance_ref else None,
+        instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
         logger_fn=logger.info,
     ) as instance:
         # Allow the instance components to change behavior in the context of a long running server process

--- a/python_modules/dagit/dagit/debug.py
+++ b/python_modules/dagit/dagit/debug.py
@@ -3,11 +3,10 @@ from gzip import GzipFile
 import click
 from dagster import (
     DagsterInstance,
-    _check as check,
 )
 from dagster._core.debug import DebugRunPayload
 from dagster._core.workspace.context import WorkspaceProcessContext
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._serdes.serdes import deserialize_value
 
 from .cli import (
     DEFAULT_DAGIT_HOST,
@@ -35,9 +34,7 @@ def dagit_debug_command(input_files, port):
         click.echo("Loading {} ...".format(input_file))
         with GzipFile(input_file, "rb") as file:
             blob = file.read().decode("utf-8")
-            debug_payload = deserialize_json_to_dagster_namedtuple(blob)
-
-            check.invariant(isinstance(debug_payload, DebugRunPayload))
+            debug_payload = deserialize_value(blob, DebugRunPayload)
 
             click.echo(
                 "\trun_id: {} \n\tdagster version: {}".format(

--- a/python_modules/dagster/dagster/_api/list_repositories.py
+++ b/python_modules/dagster/dagster/_api/list_repositories.py
@@ -4,7 +4,7 @@ import dagster._check as check
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.types import ListRepositoriesResponse
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ def sync_list_repositories_grpc(api_client: "DagsterGrpcClient") -> ListReposito
     from dagster._grpc.client import DagsterGrpcClient
 
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.list_repositories(),
         (ListRepositoriesResponse, SerializableErrorInfo),
     )

--- a/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
@@ -11,7 +11,7 @@ from dagster._core.snap.execution_plan_snapshot import (
     ExecutionPlanSnapshotErrorData,
 )
 from dagster._grpc.types import ExecutionPlanSnapshotArgs
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 if TYPE_CHECKING:
     from dagster._grpc.client import DagsterGrpcClient
@@ -44,7 +44,7 @@ def sync_get_external_execution_plan_grpc(
     check.opt_inst_param(known_state, "known_state", KnownExecutionState)
     check.opt_inst_param(instance, "instance", DagsterInstance)
 
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.execution_plan_snapshot(
             execution_plan_snapshot_args=ExecutionPlanSnapshotArgs(
                 pipeline_origin=pipeline_origin,

--- a/python_modules/dagster/dagster/_api/snapshot_partition.py
+++ b/python_modules/dagster/dagster/_api/snapshot_partition.py
@@ -12,7 +12,7 @@ from dagster._core.host_representation.external_data import (
 from dagster._core.host_representation.handle import RepositoryHandle
 from dagster._core.instance import DagsterInstance
 from dagster._grpc.types import PartitionArgs, PartitionNamesArgs, PartitionSetExecutionParamArgs
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 if TYPE_CHECKING:
     from dagster._grpc.client import DagsterGrpcClient
@@ -27,7 +27,7 @@ def sync_get_external_partition_names_grpc(
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(partition_set_name, "partition_set_name")
     repository_origin = repository_handle.get_external_origin()
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_partition_names(
             partition_names_args=PartitionNamesArgs(
                 repository_origin=repository_origin,
@@ -56,7 +56,7 @@ def sync_get_external_partition_config_grpc(
     check.str_param(partition_set_name, "partition_set_name")
     check.str_param(partition_name, "partition_name")
     repository_origin = repository_handle.get_external_origin()
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_partition_config(
             partition_args=PartitionArgs(
                 repository_origin=repository_origin,
@@ -88,7 +88,7 @@ def sync_get_external_partition_tags_grpc(
     check.str_param(partition_name, "partition_name")
 
     repository_origin = repository_handle.get_external_origin()
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_partition_tags(
             partition_args=PartitionArgs(
                 repository_origin=repository_origin,
@@ -121,7 +121,7 @@ def sync_get_external_partition_set_execution_param_data_grpc(
 
     repository_origin = repository_handle.get_external_origin()
 
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_partition_set_execution_params(
             partition_set_execution_param_args=PartitionSetExecutionParamArgs(
                 repository_origin=repository_origin,

--- a/python_modules/dagster/dagster/_api/snapshot_pipeline.py
+++ b/python_modules/dagster/dagster/_api/snapshot_pipeline.py
@@ -6,7 +6,7 @@ from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.host_representation.external_data import ExternalPipelineSubsetResult
 from dagster._core.host_representation.origin import ExternalPipelineOrigin
 from dagster._grpc.types import PipelineSubsetSnapshotArgs
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 if TYPE_CHECKING:
     from dagster._grpc.client import DagsterGrpcClient
@@ -25,7 +25,7 @@ def sync_get_external_pipeline_subset_grpc(
     solid_selection = check.opt_sequence_param(solid_selection, "solid_selection", of_type=str)
     asset_selection = check.opt_sequence_param(asset_selection, "asset_selection", of_type=AssetKey)
 
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_pipeline_subset(
             pipeline_subset_snapshot_args=PipelineSubsetSnapshotArgs(
                 pipeline_origin=pipeline_origin,

--- a/python_modules/dagster/dagster/_api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/_api/snapshot_repository.py
@@ -6,7 +6,7 @@ from dagster._core.host_representation.external_data import (
     ExternalRepositoryData,
     ExternalRepositoryErrorData,
 )
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 if TYPE_CHECKING:
     from dagster._core.host_representation import RepositoryLocation
@@ -31,7 +31,7 @@ def sync_get_streaming_external_repositories_data_grpc(
             )
         )
 
-        result = deserialize_as(
+        result = deserialize_value(
             "".join(
                 [
                     chunk["serialized_external_repository_chunk"]

--- a/python_modules/dagster/dagster/_api/snapshot_schedule.py
+++ b/python_modules/dagster/dagster/_api/snapshot_schedule.py
@@ -7,7 +7,7 @@ from dagster._core.host_representation.external_data import ExternalScheduleExec
 from dagster._core.host_representation.handle import RepositoryHandle
 from dagster._core.instance import DagsterInstance
 from dagster._grpc.types import ExternalScheduleExecutionArgs
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._seven.compat.pendulum import PendulumDateTime
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ def sync_get_external_schedule_execution_data_grpc(
     check.opt_inst_param(scheduled_execution_time, "scheduled_execution_time", PendulumDateTime)
 
     origin = repository_handle.get_external_origin()
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_schedule_execution(
             external_schedule_execution_args=ExternalScheduleExecutionArgs(
                 repository_origin=origin,

--- a/python_modules/dagster/dagster/_api/snapshot_sensor.py
+++ b/python_modules/dagster/dagster/_api/snapshot_sensor.py
@@ -7,7 +7,7 @@ from dagster._core.host_representation.external_data import ExternalSensorExecut
 from dagster._core.host_representation.handle import RepositoryHandle
 from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT
 from dagster._grpc.types import SensorExecutionArgs
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance
@@ -59,7 +59,7 @@ def sync_get_external_sensor_execution_data_grpc(
 
     origin = repository_handle.get_external_origin()
 
-    result = deserialize_as(
+    result = deserialize_value(
         api_client.external_sensor_execution(
             sensor_execution_args=SensorExecutionArgs(
                 repository_origin=origin,

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -33,7 +33,7 @@ from dagster._core.utils import coerce_valid_log_level
 from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer
 from dagster._grpc.impl import core_execute_run
 from dagster._grpc.types import ExecuteRunArgs, ExecuteStepArgs, ResumeRunArgs
-from dagster._serdes import deserialize_as, serialize_dagster_namedtuple
+from dagster._serdes import deserialize_value, serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_pipeline_from_origin
 from dagster._utils.interrupts import capture_interrupts
@@ -58,7 +58,7 @@ def api_cli():
 @click.argument("input_json", type=click.STRING)
 def execute_run_command(input_json):
     with capture_interrupts():
-        args = deserialize_as(input_json, ExecuteRunArgs)
+        args = deserialize_value(input_json, ExecuteRunArgs)
 
         with (
             DagsterInstance.from_ref(args.instance_ref)
@@ -68,7 +68,7 @@ def execute_run_command(input_json):
             buffer = []
 
             def send_to_buffer(event):
-                buffer.append(serialize_dagster_namedtuple(event))
+                buffer.append(serialize_value(event))
 
             return_code = _execute_run_command_body(
                 args.pipeline_run_id,
@@ -165,7 +165,7 @@ def _execute_run_command_body(
 @click.argument("input_json", type=click.STRING)
 def resume_run_command(input_json):
     with capture_interrupts():
-        args = deserialize_as(input_json, ResumeRunArgs)
+        args = deserialize_value(input_json, ResumeRunArgs)
 
         with (
             DagsterInstance.from_ref(args.instance_ref)
@@ -175,7 +175,7 @@ def resume_run_command(input_json):
             buffer = []
 
             def send_to_buffer(event):
-                buffer.append(serialize_dagster_namedtuple(event))
+                buffer.append(serialize_value(event))
 
             return_code = _resume_run_command_body(
                 args.pipeline_run_id,
@@ -343,7 +343,7 @@ def execute_step_command(input_json, compressed_input_json):
         if compressed_input_json:
             input_json = zlib.decompress(base64.b64decode(compressed_input_json.encode())).decode()
 
-        args = deserialize_as(input_json, ExecuteStepArgs)
+        args = deserialize_value(input_json, ExecuteStepArgs)
 
         with (
             DagsterInstance.from_ref(args.instance_ref)
@@ -359,7 +359,7 @@ def execute_step_command(input_json, compressed_input_json):
                 instance,
                 pipeline_run,
             ):
-                buff.append(serialize_dagster_namedtuple(event))
+                buff.append(serialize_value(event))
 
             for line in buff:
                 click.echo(line)
@@ -721,7 +721,7 @@ def grpc_command(
             if container_context is not None
             else None,
             inject_env_vars_from_instance=inject_env_vars_from_instance,
-            instance_ref=deserialize_as(instance_ref, InstanceRef) if instance_ref else None,
+            instance_ref=deserialize_value(instance_ref, InstanceRef) if instance_ref else None,
             location_name=location_name,
         )
 

--- a/python_modules/dagster/dagster/_cli/debug.py
+++ b/python_modules/dagster/dagster/_cli/debug.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from dagster import DagsterInstance
 from dagster._core.debug import DebugRunPayload
 from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 
 def _recent_failed_runs_text(instance):
@@ -71,7 +71,7 @@ def import_command(input_files: Tuple[str, ...]):
     for input_file in input_files:
         with GzipFile(input_file, "rb") as file:
             blob = file.read().decode("utf-8")
-            debug_payload = deserialize_as(blob, DebugRunPayload)
+            debug_payload = deserialize_value(blob, DebugRunPayload)
             debug_payloads.append(debug_payload)
 
     with DagsterInstance.get() as instance:

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 import dagster._check as check
-from dagster._serdes import serialize_dagster_namedtuple
+from dagster._serdes import serialize_value
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 from dagster._utils.log import configure_loggers
 
@@ -91,7 +91,7 @@ def dev_command(code_server_log_level, dagit_port, dagit_host, **kwargs):
 
         args = [
             "--instance-ref",
-            serialize_dagster_namedtuple(instance.get_ref()),
+            serialize_value(instance.get_ref()),
             "--code-server-log-level",
             code_server_log_level,
         ]

--- a/python_modules/dagster/dagster/_core/assets.py
+++ b/python_modules/dagster/dagster/_core/assets.py
@@ -1,7 +1,9 @@
 from typing import NamedTuple, Optional
 
 import dagster._check as check
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, whitelist_for_serdes
+from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.errors import DeserializationError
+from dagster._serdes.serdes import deserialize_value
 
 
 @whitelist_for_serdes
@@ -20,8 +22,9 @@ class AssetDetails(NamedTuple("_AssetDetails", [("last_wipe_timestamp", Optional
         if not db_string:
             return None
 
-        details = deserialize_json_to_dagster_namedtuple(db_string)
-        if not isinstance(details, AssetDetails):
+        try:
+            details = deserialize_value(db_string, AssetDetails)
+        except DeserializationError:
             return None
 
         return details

--- a/python_modules/dagster/dagster/_core/debug.py
+++ b/python_modules/dagster/dagster/_core/debug.py
@@ -4,7 +4,7 @@ import dagster._check as check
 from dagster._core.events.log import EventLogEntry
 from dagster._core.snap import ExecutionPlanSnapshot, PipelineSnapshot
 from dagster._core.storage.pipeline_run import DagsterRun
-from dagster._serdes import serialize_dagster_namedtuple, whitelist_for_serdes
+from dagster._serdes import serialize_value, whitelist_for_serdes
 
 
 @whitelist_for_serdes
@@ -56,4 +56,4 @@ class DebugRunPayload(
         )
 
     def write(self, output_file):
-        return output_file.write(serialize_dagster_namedtuple(self).encode("utf-8"))
+        return output_file.write(serialize_value(self).encode("utf-8"))

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -16,11 +16,11 @@ from dagster._core.errors import (
 )
 from dagster._core.instance import DagsterInstance
 from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
+    serialize_value,
     whitelist_for_serdes,
 )
 from dagster._serdes.errors import DeserializationError
+from dagster._serdes.serdes import deserialize_value
 from dagster._seven import JSONDecodeError
 
 from ..decorator_utils import get_function_params
@@ -55,8 +55,8 @@ class FreshnessPolicySensorCursor(
     @staticmethod
     def is_valid(json_str: str) -> bool:
         try:
-            obj = deserialize_json_to_dagster_namedtuple(json_str)
-            return isinstance(obj, FreshnessPolicySensorCursor)
+            deserialize_value(json_str, FreshnessPolicySensorCursor)
+            return True
         except (JSONDecodeError, DeserializationError):
             return False
 
@@ -73,11 +73,11 @@ class FreshnessPolicySensorCursor(
         return {AssetKey.from_user_string(k): v for k, v in self.minutes_late_by_key_str.items()}
 
     def to_json(self) -> str:
-        return serialize_dagster_namedtuple(cast(NamedTuple, self))
+        return serialize_value(cast(NamedTuple, self))
 
     @staticmethod
     def from_json(json_str: str) -> "FreshnessPolicySensorCursor":
-        return cast(FreshnessPolicySensorCursor, deserialize_json_to_dagster_namedtuple(json_str))
+        return deserialize_value(json_str, FreshnessPolicySensorCursor)
 
 
 class FreshnessPolicySensorContext(

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -340,8 +340,8 @@ class ReconstructablePipeline(
     def for_module(module: str, fn_name: str) -> ReconstructablePipeline:
         return bootstrap_standalone_recon_pipeline(ModuleCodePointer(module, fn_name, os.getcwd()))
 
-    def to_dict(self) -> Mapping[str, Any]:
-        return pack_value(self)  # type: ignore
+    def to_dict(self) -> Mapping[str, object]:
+        return pack_value(self)
 
     @staticmethod
     def from_dict(val: Mapping[str, Any]) -> ReconstructablePipeline:

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -29,12 +29,11 @@ from dagster._core.events import PIPELINE_RUN_STATUS_TO_EVENT_TYPE, DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
+    serialize_value,
     whitelist_for_serdes,
 )
 from dagster._serdes.errors import DeserializationError
-from dagster._serdes.serdes import register_serdes_tuple_fallbacks
+from dagster._serdes.serdes import deserialize_value, register_serdes_tuple_fallbacks
 from dagster._seven import JSONDecodeError
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.backcompat import deprecation_warning
@@ -91,17 +90,17 @@ class RunStatusSensorCursor(
     @staticmethod
     def is_valid(json_str: str) -> bool:
         try:
-            obj = deserialize_json_to_dagster_namedtuple(json_str)
+            obj = deserialize_value(json_str, RunStatusSensorCursor)
             return isinstance(obj, RunStatusSensorCursor)
         except (JSONDecodeError, DeserializationError):
             return False
 
     def to_json(self) -> str:
-        return serialize_dagster_namedtuple(cast(NamedTuple, self))
+        return serialize_value(cast(NamedTuple, self))
 
     @staticmethod
-    def from_json(json_str: str) -> tuple:
-        return deserialize_json_to_dagster_namedtuple(json_str)
+    def from_json(json_str: str) -> "RunStatusSensorCursor":
+        return deserialize_value(json_str, RunStatusSensorCursor)
 
 
 # handle backcompat

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -9,9 +9,9 @@ from dagster._core.utils import coerce_valid_log_level
 from dagster._serdes.serdes import (
     DefaultNamedTupleSerializer,
     WhitelistMap,
-    deserialize_json_to_dagster_namedtuple,
+    deserialize_value,
     register_serdes_tuple_fallbacks,
-    serialize_dagster_namedtuple,
+    serialize_value,
     whitelist_for_serdes,
 )
 from dagster._utils.error import SerializableErrorInfo
@@ -127,11 +127,11 @@ class EventLogEntry(
         return self.dagster_event
 
     def to_json(self):
-        return serialize_dagster_namedtuple(self)
+        return serialize_value(self)
 
     @staticmethod
-    def from_json(json_str):
-        return deserialize_json_to_dagster_namedtuple(json_str)
+    def from_json(json_str: str):
+        return deserialize_value(json_str, EventLogEntry)
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/events/utils.py
+++ b/python_modules/dagster/dagster/_core/events/utils.py
@@ -1,7 +1,8 @@
 from json import JSONDecodeError
 
 import dagster._check as check
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._core.events import DagsterEvent
+from dagster._serdes.serdes import deserialize_value
 
 
 def filter_dagster_events_from_cli_logs(log_lines):
@@ -38,7 +39,7 @@ def filter_dagster_events_from_cli_logs(log_lines):
     events = []
     for line in coalesced_lines:
         try:
-            events.append(deserialize_json_to_dagster_namedtuple(line))
+            events.append(deserialize_value(line, DagsterEvent))
         except JSONDecodeError:
             pass
         except check.CheckError:

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -29,7 +29,7 @@ from dagster._serdes import (
     register_serdes_tuple_fallbacks,
     whitelist_for_serdes,
 )
-from dagster._serdes.serdes import WhitelistMap, unpack_inner_value
+from dagster._serdes.serdes import WhitelistMap, unpack_value
 
 if TYPE_CHECKING:
     from dagster._core.host_representation.repository_location import (
@@ -435,7 +435,9 @@ class ExternalInstigatorOriginSerializer(DefaultNamedTupleSerializer):
         descent_path: str,
     ) -> NamedTuple:
         raw_dict = {
-            key: unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+            key: unpack_value(
+                value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+            )
             for key, value in storage_dict.items()
         }
         # the stored key for the instigator name should always be `job_name`, for backcompat

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -59,7 +59,7 @@ from dagster._grpc.impl import (
     get_partition_tags,
 )
 from dagster._grpc.types import GetCurrentImageResult, GetCurrentRunsResult
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._seven.compat.pendulum import PendulumDateTime
 from dagster._utils.merger import merge_dicts
 
@@ -694,13 +694,13 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         return self._use_ssl
 
     def _reload_current_image(self) -> Optional[str]:
-        return deserialize_as(
+        return deserialize_value(
             self.client.get_current_image(),
             GetCurrentImageResult,
         ).current_image
 
     def get_current_runs(self) -> Sequence[str]:
-        return deserialize_as(self.client.get_current_runs(), GetCurrentRunsResult).current_runs
+        return deserialize_value(self.client.get_current_runs(), GetCurrentRunsResult).current_runs
 
     def cleanup(self) -> None:
         if self._heartbeat_shutdown_event:

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -17,7 +17,7 @@ from dagster._serdes.serdes import (
     register_serdes_enum_fallbacks,
     register_serdes_tuple_fallbacks,
     replace_storage_keys,
-    unpack_inner_value,
+    unpack_value,
     whitelist_for_serdes,
 )
 from dagster._utils.error import SerializableErrorInfo
@@ -138,7 +138,9 @@ class InstigatorStateSerializer(DefaultNamedTupleSerializer):
     ) -> NamedTuple:
         klass_kwargs = {}
         for key, value in storage_dict.items():
-            unpacked = unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+            unpacked = unpack_value(
+                value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+            )
             if key in args_for_class:
                 klass_kwargs[key] = unpacked
             elif key == "job_type":
@@ -291,7 +293,9 @@ class TickSerializer(DefaultNamedTupleSerializer):
     ) -> NamedTuple:
         klass_kwargs = {}
         for key, value in storage_dict.items():
-            unpacked = unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+            unpacked = unpack_value(
+                value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+            )
             if key in args_for_class:
                 klass_kwargs[key] = unpacked
             elif key == "job_tick_data":
@@ -441,7 +445,9 @@ class TickDataSerializer(DefaultNamedTupleSerializer):
     ) -> NamedTuple:
         klass_kwargs = {}
         for key, value in storage_dict.items():
-            unpacked = unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+            unpacked = unpack_value(
+                value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+            )
             if key in args_for_class:
                 klass_kwargs[key] = unpacked
             elif key == "job_origin_id":

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -35,9 +35,9 @@ from dagster._serdes import (
     DefaultNamedTupleSerializer,
     create_snapshot_id,
     deserialize_value,
-    unpack_inner_value,
     whitelist_for_serdes,
 )
+from dagster._serdes.serdes import unpack_value
 
 from .config_types import build_config_schema_snapshot
 from .dagster_types import DagsterTypeNamespaceSnapshot, build_dagster_type_namespace_snapshot
@@ -75,7 +75,9 @@ class PipelineSnapshotSerializer(DefaultNamedTupleSerializer):
     ):
         # unpack all stored fields
         unpacked_dict = {
-            key: unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+            key: unpack_value(
+                value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+            )
             for key, value in storage_dict.items()
         }
         # called by the serdes layer, delegates to helper method with expanded kwargs

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -10,6 +10,7 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -38,9 +39,8 @@ from dagster._core.events import ASSET_EVENTS, MARKER_EVENTS, DagsterEventType
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, build_run_step_stats_from_events
 from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
 from dagster._serdes import (
-    deserialize_as,
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
+    deserialize_value,
+    serialize_value,
 )
 from dagster._serdes.errors import DeserializationError
 from dagster._utils import (
@@ -134,7 +134,7 @@ class SqlEventLogStorage(EventLogStorage):
         # https://stackoverflow.com/a/54386260/324449
         return SqlEventLogStorageTable.insert().values(  # pylint: disable=no-value-for-parameter
             run_id=event.run_id,
-            event=serialize_dagster_namedtuple(event),
+            event=serialize_value(event),
             dagster_event_type=dagster_event_type,
             # Postgres requires a datetime that is in UTC but has no timezone info set
             # in order to be stored correctly
@@ -208,7 +208,7 @@ class SqlEventLogStorage(EventLogStorage):
         if dagster_event.is_step_materialization:
             entry_values.update(
                 {
-                    "last_materialization": serialize_dagster_namedtuple(
+                    "last_materialization": serialize_value(
                         EventLogRecord(
                             storage_id=event_id,
                             event_log_entry=event,
@@ -452,7 +452,7 @@ class SqlEventLogStorage(EventLogStorage):
                 records.append(
                     EventLogRecord(
                         storage_id=record_id,
-                        event_log_entry=deserialize_as(json_str, EventLogEntry),
+                        event_log_entry=deserialize_value(json_str, EventLogEntry),
                     )
                 )
                 last_record_id = record_id
@@ -580,13 +580,8 @@ class SqlEventLogStorage(EventLogStorage):
             results = conn.execute(raw_event_query).fetchall()
 
         try:
-            records = [
-                check.inst_param(
-                    deserialize_json_to_dagster_namedtuple(json_str), "event", EventLogEntry
-                )
-                for (json_str,) in results
-            ]
-            return build_run_step_stats_from_events(run_id, records)  # type: ignore
+            records = [deserialize_value(json_str, EventLogEntry) for (json_str,) in results]
+            return build_run_step_stats_from_events(run_id, records)
         except (seven.JSONDecodeError, DeserializationError) as err:
             raise DagsterEventLogInvalidForRun(run_id=run_id) from err
 
@@ -711,7 +706,7 @@ class SqlEventLogStorage(EventLogStorage):
                 SqlEventLogStorageTable.update()  # pylint: disable=no-value-for-parameter
                 .where(SqlEventLogStorageTable.c.id == record_id)
                 .values(
-                    event=serialize_dagster_namedtuple(event),
+                    event=serialize_value(event),
                     dagster_event_type=dagster_event_type,
                     timestamp=datetime.utcfromtimestamp(event.timestamp),
                     step_key=event.step_key,
@@ -930,7 +925,7 @@ class SqlEventLogStorage(EventLogStorage):
         event_records = []
         for row_id, json_str in results:
             try:
-                event_record = deserialize_json_to_dagster_namedtuple(json_str)
+                event_record = deserialize_value(json_str, NamedTuple)
                 if not isinstance(event_record, EventLogEntry):
                     logging.warning(
                         "Could not resolve event record as EventLogEntry for id `%s`.", row_id
@@ -1011,8 +1006,8 @@ class SqlEventLogStorage(EventLogStorage):
                 record_id,
                 json_str,
             ) in results:
-                events[record_id] = deserialize_as(json_str, EventLogEntry)
-        except (seven.JSONDecodeError, check.CheckError):
+                events[record_id] = deserialize_value(json_str, EventLogEntry)
+        except (seven.JSONDecodeError, DeserializationError):
             logging.warning("Could not parse event record id `%s`.", record_id)
 
         return events
@@ -1059,9 +1054,7 @@ class SqlEventLogStorage(EventLogStorage):
             asset_key = AssetKey.from_db_string(row[1])
             if not asset_key:
                 continue
-            event_or_materialization = (
-                deserialize_json_to_dagster_namedtuple(row[2]) if row[2] else None
-            )
+            event_or_materialization = deserialize_value(row[2], NamedTuple) if row[2] else None
             if isinstance(event_or_materialization, EventLogRecord):
                 results[asset_key] = event_or_materialization
             else:
@@ -1108,10 +1101,7 @@ class SqlEventLogStorage(EventLogStorage):
             asset_key = AssetKey.from_db_string(row[0])
             if asset_key:
                 results[asset_key] = EventLogRecord(
-                    storage_id=row[1],
-                    event_log_entry=cast(
-                        EventLogEntry, deserialize_json_to_dagster_namedtuple(row[2])
-                    ),
+                    storage_id=row[1], event_log_entry=deserialize_value(row[2], EventLogEntry)
                 )
         return results
 
@@ -1272,7 +1262,7 @@ class SqlEventLogStorage(EventLogStorage):
                 row_by_asset_key[asset_key] = row
                 continue
             materialization_or_event_or_record = (
-                deserialize_json_to_dagster_namedtuple(row[2]) if row[2] else None
+                deserialize_value(row[2], NamedTuple) if row[2] else None
             )
             if isinstance(materialization_or_event_or_record, (EventLogRecord, EventLogEntry)):
                 if isinstance(materialization_or_event_or_record, EventLogRecord):
@@ -1317,7 +1307,7 @@ class SqlEventLogStorage(EventLogStorage):
                     .where(
                         AssetKeyTable.c.asset_key == asset_key.to_string(),
                     )
-                    .values(cached_status_data=serialize_dagster_namedtuple(cache_values))
+                    .values(cached_status_data=serialize_value(cache_values))
                 )
 
     def _fetch_backcompat_materialization_times(
@@ -1400,7 +1390,8 @@ class SqlEventLogStorage(EventLogStorage):
             ).fetchall()
 
             asset_key_to_details = {
-                row[0]: (deserialize_as(row[1], AssetDetails) if row[1] else None) for row in rows
+                row[0]: (deserialize_value(row[1], AssetDetails) if row[1] else None)
+                for row in rows
             }
 
             # returns a list of the corresponding asset_details to provided asset_keys
@@ -1592,7 +1583,7 @@ class SqlEventLogStorage(EventLogStorage):
         #
         # https://github.com/dagster-io/dagster/issues/3945
 
-        event_or_materialization = deserialize_json_to_dagster_namedtuple(json_str)
+        event_or_materialization = deserialize_value(json_str, NamedTuple)
         if isinstance(event_or_materialization, AssetMaterialization):
             return event_or_materialization
 
@@ -1608,9 +1599,7 @@ class SqlEventLogStorage(EventLogStorage):
     def _get_asset_key_values_on_wipe(self) -> Mapping[str, Any]:
         wipe_timestamp = pendulum.now("UTC").timestamp()
         values = {
-            "asset_details": serialize_dagster_namedtuple(
-                AssetDetails(last_wipe_timestamp=wipe_timestamp)
-            ),
+            "asset_details": serialize_value(AssetDetails(last_wipe_timestamp=wipe_timestamp)),
             "last_run_id": None,
         }
         if self.has_asset_key_index_cols():

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -31,7 +31,7 @@ from dagster._serdes.serdes import (
     register_serdes_enum_fallbacks,
     register_serdes_tuple_fallbacks,
     replace_storage_keys,
-    unpack_inner_value,
+    unpack_value,
     whitelist_for_serdes,
 )
 
@@ -182,7 +182,9 @@ class DagsterRunSerializer(DefaultNamedTupleSerializer):
     ):
         # unpack all stored fields
         unpacked_dict = {
-            key: unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+            key: unpack_value(
+                value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+            )
             for key, value in storage_dict.items()
         }
         # called by the serdes layer, delegates to helper method with expanded kwargs

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from typing_extensions import Final, TypeAlias
 
 import dagster._check as check
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 from ...execution.job_backfill import PartitionBackfill
 from ..pipeline_run import DagsterRun, DagsterRunStatus, RunRecord
@@ -196,7 +196,7 @@ def migrate_run_repo_tags(run_storage: RunStorage, print_fn: Optional[PrintFn] =
 
             has_more = len(rows) >= CHUNK_SIZE
             for row in rows:
-                run = deserialize_as(row[0], DagsterRun)
+                run = deserialize_value(row[0], DagsterRun)
                 cursor = row[1]
                 write_repo_tag(conn, run)
 
@@ -251,7 +251,7 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn: Optional[PrintFn] = 
 
             has_more = len(rows) >= CHUNK_SIZE
             for row in rows:
-                backfill = deserialize_as(row[0], PartitionBackfill)
+                backfill = deserialize_value(row[0], PartitionBackfill)
                 storage_id = row[1]
                 conn.execute(
                     BulkActionsTable.update()

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -52,10 +52,9 @@ from dagster._core.storage.tags import (
 )
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import (
-    deserialize_as,
-    serialize_dagster_namedtuple,
+    deserialize_value,
+    serialize_value,
 )
-from dagster._serdes.serdes import deserialize_json_to_dagster_namedtuple
 from dagster._seven import JSONDecodeError
 from dagster._utils import PrintFn, utc_datetime_from_timestamp
 from dagster._utils.merger import merge_dicts
@@ -142,7 +141,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             run_id=pipeline_run.run_id,
             pipeline_name=pipeline_run.pipeline_name,
             status=pipeline_run.status.value,
-            run_body=serialize_dagster_namedtuple(pipeline_run),
+            run_body=serialize_value(pipeline_run),
             snapshot_id=pipeline_run.pipeline_snapshot_id,
             partition=partition,
             partition_set=partition_set,
@@ -202,7 +201,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
                 RunsTable.update()  # pylint: disable=no-value-for-parameter
                 .where(RunsTable.c.run_id == run_id)
                 .values(
-                    run_body=serialize_dagster_namedtuple(run.with_status(new_pipeline_status)),
+                    run_body=serialize_value(run.with_status(new_pipeline_status)),
                     status=new_pipeline_status.value,
                     update_timestamp=now,
                     **kwargs,
@@ -210,7 +209,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             )
 
     def _row_to_run(self, row: SqlAlchemyRow) -> DagsterRun:
-        run = deserialize_as(row["run_body"], DagsterRun)
+        run = deserialize_value(row["run_body"], DagsterRun)
         status = DagsterRunStatus(row["status"])
         # NOTE: the status column is more trustworthy than the status in the run body, since concurrent
         # writes (e.g.  handle_run_event and add_tags) can cause the status in the body to be out of
@@ -578,9 +577,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
                 RunsTable.update()  # pylint: disable=no-value-for-parameter
                 .where(RunsTable.c.run_id == run_id)
                 .values(
-                    run_body=serialize_dagster_namedtuple(
-                        run.with_tags(merge_dicts(current_tags, new_tags))
-                    ),
+                    run_body=serialize_value(run.with_tags(merge_dicts(current_tags, new_tags))),
                     partition=partition,
                     partition_set=partition_set,
                     update_timestamp=pendulum.now("UTC"),
@@ -864,9 +861,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             snapshot_insert = (
                 SnapshotsTable.insert().values(  # pylint: disable=no-value-for-parameter
                     snapshot_id=snapshot_id,
-                    snapshot_body=zlib.compress(
-                        serialize_dagster_namedtuple(snapshot_obj).encode("utf-8")
-                    ),
+                    snapshot_body=zlib.compress(serialize_value(snapshot_obj).encode("utf-8")),
                     snapshot_type=snapshot_type.value,
                 )
             )
@@ -900,7 +895,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 
         row = self.fetchone(query)
 
-        return defensively_unpack_pipeline_snapshot_query(logging, row) if row else None  # type: ignore
+        return defensively_unpack_execution_plan_snapshot_query(logging, row) if row else None  # type: ignore
 
     def get_run_partition_data(self, runs_filter: RunsFilter) -> Sequence[RunPartitionData]:
         if self.has_built_index(RUN_PARTITIONS) and self.has_run_stats_index_cols():
@@ -1049,7 +1044,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
                         timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                         daemon_type=daemon_heartbeat.daemon_type,
                         daemon_id=daemon_heartbeat.daemon_id,
-                        body=serialize_dagster_namedtuple(daemon_heartbeat),
+                        body=serialize_value(daemon_heartbeat),
                     )
                 )
             except db_exc.IntegrityError:
@@ -1059,7 +1054,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
                     .values(  # pylint: disable=no-value-for-parameter
                         timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                         daemon_id=daemon_heartbeat.daemon_id,
-                        body=serialize_dagster_namedtuple(daemon_heartbeat),
+                        body=serialize_value(daemon_heartbeat),
                     )
                 )
 
@@ -1068,7 +1063,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             rows = conn.execute(db.select([DaemonHeartbeatsTable.c.body]))
             heartbeats = []
             for row in rows:
-                heartbeats.append(deserialize_as(row.body, DaemonHeartbeat))
+                heartbeats.append(deserialize_value(row.body, DaemonHeartbeat))
             return {heartbeat.daemon_type: heartbeat for heartbeat in heartbeats}
 
     def wipe(self) -> None:
@@ -1105,13 +1100,13 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())
         rows = self.fetchall(query)
-        return [deserialize_as(row[0], PartitionBackfill) for row in rows]
+        return [deserialize_value(row[0], PartitionBackfill) for row in rows]
 
     def get_backfill(self, backfill_id: str) -> Optional[PartitionBackfill]:
         check.str_param(backfill_id, "backfill_id")
         query = db.select([BulkActionsTable.c.body]).where(BulkActionsTable.c.key == backfill_id)
         row = self.fetchone(query)
-        return deserialize_as(row[0], PartitionBackfill) if row else None
+        return deserialize_value(row[0], PartitionBackfill) if row else None
 
     def add_backfill(self, partition_backfill: PartitionBackfill) -> None:
         check.inst_param(partition_backfill, "partition_backfill", PartitionBackfill)
@@ -1119,7 +1114,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
             key=partition_backfill.backfill_id,
             status=partition_backfill.status.value,
             timestamp=utc_datetime_from_timestamp(partition_backfill.backfill_timestamp),
-            body=serialize_dagster_namedtuple(cast(NamedTuple, partition_backfill)),
+            body=serialize_value(cast(NamedTuple, partition_backfill)),
         )
 
         if self.has_bulk_actions_selector_cols():
@@ -1144,7 +1139,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
                 .where(BulkActionsTable.c.key == backfill_id)
                 .values(
                     status=partition_backfill.status.value,
-                    body=serialize_dagster_namedtuple(partition_backfill),
+                    body=serialize_value(partition_backfill),
                 )
             )
 
@@ -1184,7 +1179,7 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
                 RunsTable.update()  # pylint: disable=no-value-for-parameter
                 .where(RunsTable.c.run_id == run.run_id)
                 .values(
-                    run_body=serialize_dagster_namedtuple(run.with_job_origin(job_origin)),
+                    run_body=serialize_value(run.with_job_origin(job_origin)),
                 )
             )
             conn.execute(
@@ -1198,9 +1193,9 @@ class SqlRunStorage(RunStorage):  # pylint: disable=no-init
 GET_PIPELINE_SNAPSHOT_QUERY_ID = "get-pipeline-snapshot"
 
 
-def defensively_unpack_pipeline_snapshot_query(
+def defensively_unpack_execution_plan_snapshot_query(
     logger: logging.Logger, row: SqlAlchemyRow
-) -> Optional[PipelineSnapshot]:
+) -> Optional[Union[ExecutionPlanSnapshot, PipelineSnapshot]]:
     # no checking here because sqlalchemy returns a special
     # row proxy and don't want to instance check on an internal
     # implementation detail
@@ -1225,7 +1220,7 @@ def defensively_unpack_pipeline_snapshot_query(
         return None
 
     try:
-        return deserialize_json_to_dagster_namedtuple(decoded_str)  # type: ignore
+        return deserialize_value(decoded_str, (ExecutionPlanSnapshot, PipelineSnapshot))
     except JSONDecodeError:
         _warn("Could not parse json in snapshot table.")
         return None

--- a/python_modules/dagster/dagster/_core/storage/schedules/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/migration.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 from dagster._core.scheduler.instigation import InstigatorState
 from dagster._core.storage.schedules.base import ScheduleStorage
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._utils import PrintFn
 
 from ..schedules.schema import InstigatorsTable, JobTable, JobTickTable
@@ -47,7 +47,7 @@ def add_selector_id_to_jobs_table(
         rows_progress = tqdm(rows) if print_fn else rows
 
         for row_id, state_str, create_timestamp, update_timestamp in rows_progress:
-            state = deserialize_as(state_str, InstigatorState)
+            state = deserialize_value(state_str, InstigatorState)
             selector_id = state.selector_id
 
             # insert the state into a new instigator table, which has a unique constraint on

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -16,7 +16,7 @@ from dagster._daemon.controller import (
     get_daemon_statuses,
 )
 from dagster._daemon.daemon import get_telemetry_daemon_session_id
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._utils.interrupts import capture_interrupts
 
 
@@ -51,7 +51,7 @@ def run_command(code_server_log_level, instance_ref, **kwargs):
     try:
         with capture_interrupts():
             with DagsterInstance.from_ref(
-                deserialize_as(instance_ref, InstanceRef)
+                deserialize_value(instance_ref, InstanceRef)
             ) if instance_ref else DagsterInstance.get() as instance:
                 _daemon_run_command(instance, code_server_log_level, kwargs)
     except KeyboardInterrupt:

--- a/python_modules/dagster/dagster/_daemon/types.py
+++ b/python_modules/dagster/dagster/_daemon/types.py
@@ -2,7 +2,8 @@ from enum import Enum
 from typing import NamedTuple, Optional, Sequence, cast
 
 import dagster._check as check
-from dagster._serdes import DefaultNamedTupleSerializer, unpack_inner_value, whitelist_for_serdes
+from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes.serdes import unpack_value
 from dagster._utils.error import SerializableErrorInfo
 
 
@@ -25,9 +26,9 @@ class DaemonBackcompat(DefaultNamedTupleSerializer):
         descent_path,
     ):
         # Handle case where daemon_type used to be an enum (e.g. DaemonType.SCHEDULER)
-        daemon_type = unpack_inner_value(
+        daemon_type = unpack_value(
             storage_dict.get("daemon_type"),
-            whitelist_map,
+            whitelist_map=whitelist_map,
             descent_path=f"{descent_path}.daemon_type",
         )
         return DaemonHeartbeat(
@@ -35,16 +36,16 @@ class DaemonBackcompat(DefaultNamedTupleSerializer):
             daemon_type=(daemon_type.value if isinstance(daemon_type, DaemonType) else daemon_type),
             daemon_id=cast(str, storage_dict.get("daemon_id")),
             errors=[
-                unpack_inner_value(
+                unpack_value(
                     storage_dict.get("error"),
-                    whitelist_map,
+                    whitelist_map=whitelist_map,
                     descent_path=f"{descent_path}.error",
                 )
             ]  # error was replaced with errors
             if storage_dict.get("error")
-            else unpack_inner_value(
+            else unpack_value(
                 storage_dict.get("errors"),
-                whitelist_map,
+                whitelist_map=whitelist_map,
                 descent_path=f"{descent_path}.errors",
             ),
         )

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -18,7 +18,7 @@ from dagster._core.events import EngineEventData
 from dagster._core.host_representation.origin import ExternalRepositoryOrigin
 from dagster._core.instance import DagsterInstance
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._serdes import serialize_dagster_namedtuple
+from dagster._serdes import serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from .__generated__ import DagsterApiStub, api_pb2
@@ -223,9 +223,7 @@ class DagsterGrpcClient:
         res = self._query(
             "ExecutionPlanSnapshot",
             api_pb2.ExecutionPlanSnapshotRequest,  # type: ignore
-            serialized_execution_plan_snapshot_args=serialize_dagster_namedtuple(
-                execution_plan_snapshot_args
-            ),
+            serialized_execution_plan_snapshot_args=serialize_value(execution_plan_snapshot_args),
         )
         return res.serialized_execution_plan_snapshot
 
@@ -239,7 +237,7 @@ class DagsterGrpcClient:
         res = self._query(
             "ExternalPartitionNames",
             api_pb2.ExternalPartitionNamesRequest,
-            serialized_partition_names_args=serialize_dagster_namedtuple(partition_names_args),
+            serialized_partition_names_args=serialize_value(partition_names_args),
         )
 
         return res.serialized_external_partition_names_or_external_partition_execution_error
@@ -250,7 +248,7 @@ class DagsterGrpcClient:
         res = self._query(
             "ExternalPartitionConfig",
             api_pb2.ExternalPartitionConfigRequest,
-            serialized_partition_args=serialize_dagster_namedtuple(partition_args),
+            serialized_partition_args=serialize_value(partition_args),
         )
 
         return res.serialized_external_partition_config_or_external_partition_execution_error
@@ -261,7 +259,7 @@ class DagsterGrpcClient:
         res = self._query(
             "ExternalPartitionTags",
             api_pb2.ExternalPartitionTagsRequest,
-            serialized_partition_args=serialize_dagster_namedtuple(partition_args),
+            serialized_partition_args=serialize_value(partition_args),
         )
 
         return res.serialized_external_partition_tags_or_external_partition_execution_error
@@ -277,7 +275,7 @@ class DagsterGrpcClient:
             self._streaming_query(
                 "ExternalPartitionSetExecutionParams",
                 api_pb2.ExternalPartitionSetExecutionParamsRequest,
-                serialized_partition_set_execution_param_args=serialize_dagster_namedtuple(
+                serialized_partition_set_execution_param_args=serialize_value(
                     partition_set_execution_param_args
                 ),
             )
@@ -295,9 +293,7 @@ class DagsterGrpcClient:
         res = self._query(
             "ExternalPipelineSubsetSnapshot",
             api_pb2.ExternalPipelineSubsetSnapshotRequest,
-            serialized_pipeline_subset_snapshot_args=serialize_dagster_namedtuple(
-                pipeline_subset_snapshot_args
-            ),
+            serialized_pipeline_subset_snapshot_args=serialize_value(pipeline_subset_snapshot_args),
         )
 
         return res.serialized_external_pipeline_subset_result
@@ -317,9 +313,7 @@ class DagsterGrpcClient:
             "ExternalRepository",
             api_pb2.ExternalRepositoryRequest,  # type: ignore
             # rename this param name
-            serialized_repository_python_origin=serialize_dagster_namedtuple(
-                external_repository_origin
-            ),
+            serialized_repository_python_origin=serialize_value(external_repository_origin),
             defer_snapshots=defer_snapshots,
         )
 
@@ -339,7 +333,7 @@ class DagsterGrpcClient:
         return self._query(
             "ExternalJob",
             api_pb2.ExternalJobRequest,  # type: ignore
-            serialized_repository_origin=serialize_dagster_namedtuple(external_repository_origin),
+            serialized_repository_origin=serialize_value(external_repository_origin),
             job_name=job_name,
         )
 
@@ -352,9 +346,7 @@ class DagsterGrpcClient:
             "StreamingExternalRepository",
             api_pb2.ExternalRepositoryRequest,  # type: ignore
             # Rename parameter
-            serialized_repository_python_origin=serialize_dagster_namedtuple(
-                external_repository_origin
-            ),
+            serialized_repository_python_origin=serialize_value(external_repository_origin),
             defer_snapshots=defer_snapshots,
         ):
             yield {
@@ -373,7 +365,7 @@ class DagsterGrpcClient:
             self._streaming_query(
                 "ExternalScheduleExecution",
                 api_pb2.ExternalScheduleExecutionRequest,
-                serialized_external_schedule_execution_args=serialize_dagster_namedtuple(
+                serialized_external_schedule_execution_args=serialize_value(
                     external_schedule_execution_args
                 ),
             )
@@ -400,9 +392,7 @@ class DagsterGrpcClient:
                 "ExternalSensorExecution",
                 api_pb2.ExternalSensorExecutionRequest,
                 timeout=timeout,
-                serialized_external_sensor_execution_args=serialize_dagster_namedtuple(
-                    sensor_execution_args
-                ),
+                serialized_external_sensor_execution_args=serialize_value(sensor_execution_args),
                 custom_timeout_message=custom_timeout_message,
             )
         )
@@ -432,9 +422,7 @@ class DagsterGrpcClient:
         res = self._query(
             "CancelExecution",
             api_pb2.CancelExecutionRequest,
-            serialized_cancel_execution_request=serialize_dagster_namedtuple(
-                cancel_execution_request
-            ),
+            serialized_cancel_execution_request=serialize_value(cancel_execution_request),
         )
 
         return res.serialized_cancel_execution_result
@@ -454,22 +442,20 @@ class DagsterGrpcClient:
             "CanCancelExecution",
             api_pb2.CanCancelExecutionRequest,  # type: ignore
             timeout=timeout,
-            serialized_can_cancel_execution_request=serialize_dagster_namedtuple(
-                can_cancel_execution_request
-            ),
+            serialized_can_cancel_execution_request=serialize_value(can_cancel_execution_request),
         )
 
         return res.serialized_can_cancel_execution_result
 
-    def start_run(self, execute_run_args) -> ExecuteExternalPipelineArgs:
+    def start_run(self, execute_run_args: ExecuteExternalPipelineArgs):
         check.inst_param(execute_run_args, "execute_run_args", ExecuteExternalPipelineArgs)
 
-        with DagsterInstance.from_ref(execute_run_args.instance_ref) as instance:
+        with DagsterInstance.from_ref(execute_run_args.instance_ref) as instance:  # type: ignore  # (possible none)
             try:
                 res = self._query(
                     "StartRun",
                     api_pb2.StartRunRequest,  # type: ignore
-                    serialized_execute_run_args=serialize_dagster_namedtuple(execute_run_args),
+                    serialized_execute_run_args=serialize_value(execute_run_args),
                 )
                 return res.serialized_start_run_result
 

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -43,7 +43,7 @@ from dagster._core.snap.execution_plan_snapshot import (
 )
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._grpc.types import ExecutionPlanSnapshotArgs
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 from dagster._serdes.ipc import IPCErrorMessage
 from dagster._seven import nullcontext
 from dagster._utils import start_termination_thread
@@ -159,7 +159,9 @@ def _run_in_subprocess(
 ):
     start_termination_thread(termination_event)
     try:
-        execute_run_args = deserialize_as(serialized_execute_run_args, ExecuteExternalPipelineArgs)
+        execute_run_args = deserialize_value(
+            serialized_execute_run_args, ExecuteExternalPipelineArgs
+        )
 
         with (
             DagsterInstance.from_ref(execute_run_args.instance_ref)

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -14,7 +14,7 @@ from dagster._core.host_representation.origin import (
 )
 from dagster._core.instance.ref import InstanceRef
 from dagster._core.origin import PipelinePythonOrigin, get_python_environment_entry_point
-from dagster._serdes import serialize_dagster_namedtuple, whitelist_for_serdes
+from dagster._serdes import serialize_value, whitelist_for_serdes
 from dagster._utils import frozenlist
 from dagster._utils.error import SerializableErrorInfo
 
@@ -119,7 +119,7 @@ class ExecuteRunArgs(
         return _get_entry_point(self.pipeline_origin) + [
             "api",
             "execute_run",
-            serialize_dagster_namedtuple(self),
+            serialize_value(self),
         ]
 
 
@@ -164,7 +164,7 @@ class ResumeRunArgs(
         return _get_entry_point(self.pipeline_origin) + [
             "api",
             "resume_run",
-            serialize_dagster_namedtuple(self),
+            serialize_value(self),
         ]
 
 
@@ -242,7 +242,7 @@ class ExecuteStepArgs(
 
     def _get_compressed_args(self) -> str:
         # Compress, then base64 encode so we can pass it around as a str
-        return base64.b64encode(zlib.compress(serialize_dagster_namedtuple(self).encode())).decode()
+        return base64.b64encode(zlib.compress(serialize_value(self).encode())).decode()
 
     def get_command_args(self, skip_serialized_namedtuple: bool = False) -> Sequence[str]:
         """

--- a/python_modules/dagster/dagster/_serdes/__init__.py
+++ b/python_modules/dagster/dagster/_serdes/__init__.py
@@ -6,15 +6,10 @@ from .config_class import (
 from .serdes import (
     DefaultNamedTupleSerializer as DefaultNamedTupleSerializer,
     WhitelistMap as WhitelistMap,
-    deserialize_as as deserialize_as,
-    deserialize_json_to_dagster_namedtuple as deserialize_json_to_dagster_namedtuple,
     deserialize_value as deserialize_value,
-    pack_inner_value as pack_inner_value,
     pack_value as pack_value,
     register_serdes_tuple_fallbacks as register_serdes_tuple_fallbacks,
-    serialize_dagster_namedtuple as serialize_dagster_namedtuple,
     serialize_value as serialize_value,
-    unpack_inner_value as unpack_inner_value,
     unpack_value as unpack_value,
     whitelist_for_serdes as whitelist_for_serdes,
 )

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -13,8 +13,8 @@ from typing import Iterator, NamedTuple, Optional, Sequence, Tuple
 import dagster._check as check
 from dagster._core.errors import DagsterError
 from dagster._serdes.serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
+    deserialize_value,
+    serialize_value,
     whitelist_for_serdes,
 )
 from dagster._utils.error import (
@@ -28,13 +28,13 @@ def write_unary_input(input_file: str, obj: NamedTuple) -> None:
     check.str_param(input_file, "input_file")
     check.not_none_param(obj, "obj")
     with open(os.path.abspath(input_file), "w", encoding="utf8") as fp:
-        fp.write(serialize_dagster_namedtuple(obj))
+        fp.write(serialize_value(obj))
 
 
 def read_unary_input(input_file: str) -> Tuple[object, ...]:
     check.str_param(input_file, "input_file")
     with open(os.path.abspath(input_file), "r", encoding="utf8") as fp:
-        return deserialize_json_to_dagster_namedtuple(fp.read())
+        return deserialize_value(fp.read(), NamedTuple)
 
 
 def ipc_write_unary_response(output_file: str, obj: NamedTuple) -> None:
@@ -111,7 +111,7 @@ class FileBasedWriteStream:
 
 def _send(file_path: str, obj: NamedTuple) -> None:
     with open(os.path.abspath(file_path), "a+", encoding="utf8") as fp:
-        fp.write(serialize_dagster_namedtuple(obj) + "\n")
+        fp.write(serialize_value(obj) + "\n")
 
 
 def _send_error(file_path: str, exc_info: ExceptionInfo, message: Optional[str]) -> None:
@@ -139,7 +139,7 @@ def _process_line(file_pointer: TextIOWrapper, sleep_interval: float = 0.1) -> O
     while True:
         line = file_pointer.readline()
         if line:
-            return deserialize_json_to_dagster_namedtuple(line.rstrip())
+            return deserialize_value(line.rstrip(), NamedTuple)
         sleep(sleep_interval)
 
 

--- a/python_modules/dagster/dagster/_serdes/utils.py
+++ b/python_modules/dagster/dagster/_serdes/utils.py
@@ -1,11 +1,11 @@
 import hashlib
 from typing import NamedTuple
 
-from .serdes import serialize_dagster_namedtuple
+from .serdes import serialize_value
 
 
 def create_snapshot_id(snapshot: NamedTuple) -> str:
-    json_rep = serialize_dagster_namedtuple(snapshot)
+    json_rep = serialize_value(snapshot)
     return hash_str(json_rep)
 
 
@@ -17,4 +17,4 @@ def hash_str(in_str: str) -> str:
 
 def serialize_pp(value: NamedTuple) -> str:
     """Serialize and pretty print."""
-    return serialize_dagster_namedtuple(value, indent=2, separators=(",", ": "))
+    return serialize_value(value, indent=2, separators=(",", ": "))

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -7,7 +7,8 @@ from dagster._core.test_utils import (
     poll_for_finished_run,
 )
 from dagster._grpc.server import ExecuteExternalPipelineArgs
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._grpc.types import StartRunResult
+from dagster._serdes.serdes import deserialize_value
 
 from .utils import get_bar_repo_repository_location
 
@@ -35,7 +36,7 @@ def test_launch_run_with_unloadable_pipeline_grpc():
             original_origin = job_handle.get_external_origin()
 
             # point the api to a pipeline that cannot be loaded
-            res = deserialize_json_to_dagster_namedtuple(
+            res = deserialize_value(
                 api_client.start_run(
                     ExecuteExternalPipelineArgs(
                         pipeline_origin=original_origin._replace(
@@ -44,7 +45,8 @@ def test_launch_run_with_unloadable_pipeline_grpc():
                         pipeline_run_id=run_id,
                         instance_ref=instance.get_ref(),
                     )
-                )
+                ),
+                StartRunResult,
             )
 
             assert res.success
@@ -81,14 +83,15 @@ def test_launch_run_grpc():
             run = create_run_for_test(instance, "foo")
             run_id = run.run_id
 
-            res = deserialize_json_to_dagster_namedtuple(
+            res = deserialize_value(
                 api_client.start_run(
                     ExecuteExternalPipelineArgs(
                         pipeline_origin=job_handle.get_external_origin(),
                         pipeline_run_id=run_id,
                         instance_ref=instance.get_ref(),
                     )
-                )
+                ),
+                StartRunResult,
             )
 
             assert res.success
@@ -126,14 +129,15 @@ def test_launch_unloadable_run_grpc():
             run_id = run.run_id
 
             with instance_for_test() as other_instance:
-                res = deserialize_json_to_dagster_namedtuple(
+                res = deserialize_value(
                     api_client.start_run(
                         ExecuteExternalPipelineArgs(
                             pipeline_origin=job_handle.get_external_origin(),
                             pipeline_run_id=run_id,
                             instance_ref=other_instance.get_ref(),
                         )
-                    )
+                    ),
+                    StartRunResult,
                 )
 
                 assert not res.success

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -17,7 +17,7 @@ from dagster._core.host_representation.origin import ExternalRepositoryOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._legacy import pipeline
-from dagster._serdes.serdes import deserialize_as
+from dagster._serdes.serdes import deserialize_value
 
 from .utils import get_bar_repo_repository_location
 
@@ -122,9 +122,9 @@ def test_defer_snapshots(instance):
                 repo_origin,
                 ref.name,
             )
-            return deserialize_as(reply.serialized_job_data, ExternalPipelineData)
+            return deserialize_value(reply.serialized_job_data, ExternalPipelineData)
 
-        external_repository_data = deserialize_as(ser_repo_data, ExternalRepositoryData)
+        external_repository_data = deserialize_value(ser_repo_data, ExternalRepositoryData)
 
         assert len(external_repository_data.external_job_refs) == 5
         assert external_repository_data.external_pipeline_datas is None

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -2,8 +2,8 @@ import pytest
 from dagster import StaticPartitionMapping, StaticPartitionsDefinition
 from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._serdes.serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
+    deserialize_value,
+    serialize_value,
 )
 
 
@@ -79,6 +79,6 @@ def test_static_partition_mapping_serdes():
     mapping = StaticPartitionMapping(
         {"p1": "p", "p2": "p", "p3": "p", "q": ["q1", "q2"], "r1": "r"}
     )
-    ser = serialize_dagster_namedtuple(mapping)
-    deser = deserialize_json_to_dagster_namedtuple(ser)
+    ser = serialize_value(mapping)
+    deser = deserialize_value(ser, StaticPartitionMapping)
     assert mapping == deser

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -11,7 +11,7 @@ from dagster._core.execution.retries import RetryState
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot
 from dagster._core.host_representation import JobHandle
 from dagster._core.test_utils import create_run_for_test, environ, instance_for_test
-from dagster._serdes import serialize_dagster_namedtuple
+from dagster._serdes import serialize_value
 
 from dagster_tests.api_tests.utils import get_bar_repo_handle, get_foo_job_handle
 
@@ -56,7 +56,7 @@ def test_execute_run():
                 pipeline_code_origin=job_handle.get_python_origin(),
             )
 
-            input_json = serialize_dagster_namedtuple(
+            input_json = serialize_value(
                 ExecuteRunArgs(
                     pipeline_origin=job_handle.get_python_origin(),
                     pipeline_run_id=run.run_id,
@@ -115,7 +115,7 @@ def test_execute_run_with_secrets_loader():
                 pipeline_code_origin=recon_job.get_python_origin(),
             )
 
-            input_json = serialize_dagster_namedtuple(
+            input_json = serialize_value(
                 ExecuteRunArgs(
                     pipeline_origin=recon_job.get_python_origin(),
                     pipeline_run_id=run.run_id,
@@ -146,7 +146,7 @@ def test_execute_run_with_secrets_loader():
             pipeline_code_origin=recon_job.get_python_origin(),
         )
 
-        input_json = serialize_dagster_namedtuple(
+        input_json = serialize_value(
             ExecuteRunArgs(
                 pipeline_origin=recon_job.get_python_origin(),
                 pipeline_run_id=run.run_id,
@@ -184,7 +184,7 @@ def test_execute_run_fail_pipeline():
                 pipeline_code_origin=job_handle.get_python_origin(),
             )
 
-            input_json = serialize_dagster_namedtuple(
+            input_json = serialize_value(
                 ExecuteRunArgs(
                     pipeline_origin=job_handle.get_python_origin(),
                     pipeline_run_id=run.run_id,
@@ -207,7 +207,7 @@ def test_execute_run_fail_pipeline():
                 pipeline_code_origin=job_handle.get_python_origin(),
             )
 
-            input_json_raise_on_failure = serialize_dagster_namedtuple(
+            input_json_raise_on_failure = serialize_value(
                 ExecuteRunArgs(
                     pipeline_origin=job_handle.get_python_origin(),
                     pipeline_run_id=run.run_id,
@@ -231,7 +231,7 @@ def test_execute_run_fail_pipeline():
                     instance, pipeline_name="foo", run_id="new_run_framework_error"
                 )
 
-                input_json_raise_on_failure = serialize_dagster_namedtuple(
+                input_json_raise_on_failure = serialize_value(
                     ExecuteRunArgs(
                         pipeline_origin=job_handle.get_python_origin(),
                         pipeline_run_id=run.run_id,
@@ -257,7 +257,7 @@ def test_execute_run_cannot_load():
         with get_foo_job_handle(instance) as job_handle:
             runner = CliRunner()
 
-            input_json = serialize_dagster_namedtuple(
+            input_json = serialize_value(
                 ExecuteRunArgs(
                     pipeline_origin=job_handle.get_python_origin(),
                     pipeline_run_id="FOOBAR",
@@ -454,7 +454,7 @@ def test_execute_step_non_compressed():
                 instance_ref=instance.get_ref(),
             )
 
-            result = runner_execute_step(runner, [serialize_dagster_namedtuple(args)])
+            result = runner_execute_step(runner, [serialize_value(args)])
 
         assert "STEP_SUCCESS" in result.stdout
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -34,7 +34,7 @@ from dagster._core.host_representation.external_data import (
     external_multi_partitions_definition_from_def,
     external_time_window_partitions_definition_from_def,
 )
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._serdes.serdes import deserialize_value
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
 
@@ -928,7 +928,7 @@ def test_back_compat_external_sensor():
         '{"__class__": "ExternalSensorData", "description": null, "min_interval": null, "mode":'
         ' "default", "name": "my_sensor", "pipeline_name": "my_pipeline", "solid_selection": null}'
     )
-    external_sensor_data = deserialize_json_to_dagster_namedtuple(SERIALIZED_0_12_10_SENSOR)
+    external_sensor_data = deserialize_value(SERIALIZED_0_12_10_SENSOR, ExternalSensorData)
     assert isinstance(external_sensor_data, ExternalSensorData)
     assert len(external_sensor_data.target_dict) == 1
     assert "my_pipeline" in external_sensor_data.target_dict

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
@@ -4,7 +4,8 @@ from dagster._core.snap import (
     DependencyStructureIndex,
     build_composite_solid_def_snap,
 )
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._serdes import serialize_value
+from dagster._serdes.serdes import deserialize_value
 
 
 def test_noop_comp_solid_definition():
@@ -20,7 +21,7 @@ def test_noop_comp_solid_definition():
 
     assert isinstance(comp_solid_meta, CompositeSolidDefSnap)
     assert (
-        deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(comp_solid_meta))
+        deserialize_value(serialize_value(comp_solid_meta), CompositeSolidDefSnap)
         == comp_solid_meta
     )
 
@@ -42,7 +43,7 @@ def test_basic_comp_solid_definition():
 
     assert isinstance(comp_solid_meta, CompositeSolidDefSnap)
     assert (
-        deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(comp_solid_meta))
+        deserialize_value(serialize_value(comp_solid_meta), CompositeSolidDefSnap)
         == comp_solid_meta
     )
 
@@ -70,7 +71,7 @@ def test_complex_comp_solid_definition():
 
     assert isinstance(comp_solid_meta, CompositeSolidDefSnap)
     assert (
-        deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(comp_solid_meta))
+        deserialize_value(serialize_value(comp_solid_meta), CompositeSolidDefSnap)
         == comp_solid_meta
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_mode_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_mode_def_snap.py
@@ -1,7 +1,9 @@
 from dagster import logger, resource
 from dagster._core.snap import PipelineSnapshot
+from dagster._core.snap.mode import ModeDefSnap
 from dagster._legacy import ModeDefinition, pipeline
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._serdes import serialize_value
+from dagster._serdes.serdes import deserialize_value
 
 
 def test_mode_snap(snapshot):
@@ -44,8 +46,6 @@ def test_mode_snap(snapshot):
     assert len(pipeline_snapshot.mode_def_snaps) == 1
     mode_def_snap = pipeline_snapshot.mode_def_snaps[0]
 
-    snapshot.assert_match(serialize_dagster_namedtuple(mode_def_snap))
+    snapshot.assert_match(serialize_value(mode_def_snap))
 
-    assert mode_def_snap == deserialize_json_to_dagster_namedtuple(
-        serialize_dagster_namedtuple(mode_def_snap)
-    )
+    assert mode_def_snap == deserialize_value(serialize_value(mode_def_snap), ModeDefSnap)

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_old_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_old_execution_plan_snapshot.py
@@ -4,7 +4,8 @@ import pytest
 from dagster import job
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.plan.plan import ExecutionPlan
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
+from dagster._serdes.serdes import deserialize_value
 
 OLD_EXECUTION_PLAN_SNAPSHOT = """{
   "__class__": "ExecutionPlanSnapshot",
@@ -132,7 +133,7 @@ def noop_job():
 
 
 def test_cant_load_old_snapshot():
-    snapshot = deserialize_json_to_dagster_namedtuple(OLD_EXECUTION_PLAN_SNAPSHOT)
+    snapshot = deserialize_value(OLD_EXECUTION_PLAN_SNAPSHOT, ExecutionPlanSnapshot)
     with pytest.raises(
         DagsterInvariantViolationError,
         match=(
@@ -197,5 +198,5 @@ PRE_CACHE_EXECUTION_PLAN_SNAPSHOT = """{
 
 
 def test_rebuild_pre_cached_key_execution_plan_snapshot():
-    snapshot = deserialize_json_to_dagster_namedtuple(PRE_CACHE_EXECUTION_PLAN_SNAPSHOT)
+    snapshot = deserialize_value(PRE_CACHE_EXECUTION_PLAN_SNAPSHOT, ExecutionPlanSnapshot)
     ExecutionPlan.rebuild_from_snapshot("noop_job", snapshot)

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -11,20 +11,21 @@ from dagster._core.snap import (
     snap_from_config_type,
 )
 from dagster._core.snap.dep_snapshot import (
+    DependencyStructureSnapshot,
     InputHandle,
     OutputHandleSnap,
     build_dep_structure_snapshot_from_icontains_solids,
 )
 from dagster._legacy import pipeline
 from dagster._serdes import (
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
     serialize_pp,
+    serialize_value,
 )
+from dagster._serdes.serdes import deserialize_value
 
 
-def serialize_rt(value):
-    return deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(value))
+def serialize_rt(value: PipelineSnapshot) -> PipelineSnapshot:
+    return deserialize_value(serialize_value(value), PipelineSnapshot)
 
 
 def get_noop_pipeline():
@@ -177,7 +178,7 @@ def test_basic_dep_fan_out(snapshot):
     )
 
     assert (
-        deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(dep_structure_snapshot))
+        deserialize_value(serialize_value(dep_structure_snapshot), DependencyStructureSnapshot)
         == dep_structure_snapshot
     )
 
@@ -218,7 +219,7 @@ def test_basic_fan_in(snapshot):
     ]
 
     assert (
-        deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(dep_structure_snapshot))
+        deserialize_value(serialize_value(dep_structure_snapshot), DependencyStructureSnapshot)
         == dep_structure_snapshot
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
@@ -1,6 +1,7 @@
 from dagster import In, Out, op
-from dagster._core.snap.solid import build_core_solid_def_snap
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._core.snap.solid import SolidDefSnap, build_core_solid_def_snap
+from dagster._serdes import serialize_value
+from dagster._serdes.serdes import deserialize_value
 
 
 def test_basic_solid_definition():
@@ -11,10 +12,7 @@ def test_basic_solid_definition():
     solid_snap = build_core_solid_def_snap(noop_op)
 
     assert solid_snap
-    assert (
-        deserialize_json_to_dagster_namedtuple(serialize_dagster_namedtuple(solid_snap))
-        == solid_snap
-    )
+    assert deserialize_value(serialize_value(solid_snap), SolidDefSnap) == solid_snap
 
 
 def test_solid_definition_kitchen_sink():
@@ -75,8 +73,6 @@ def test_solid_definition_kitchen_sink():
     assert kitchen_sink_op.positional_inputs == ["arg_two", "arg_one"]
 
     assert (
-        deserialize_json_to_dagster_namedtuple(
-            serialize_dagster_namedtuple(kitchen_sink_solid_snap)
-        )
+        deserialize_value(serialize_value(kitchen_sink_solid_snap), SolidDefSnap)
         == kitchen_sink_solid_snap
     )

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
@@ -7,7 +7,7 @@ from dagster._core.events import DagsterEventType
 from dagster._core.events.log import EventLogEntry, construct_event_logger
 from dagster._legacy import ModeDefinition, PipelineDefinition, execute_pipeline, pipeline
 from dagster._loggers import colored_console_logger
-from dagster._serdes import deserialize_as
+from dagster._serdes import deserialize_value
 
 
 def mode_def(event_callback):
@@ -162,7 +162,9 @@ SERIALIZED_EVENT_FROM_THE_FUTURE_WITHOUT_EVENT_SPECIFIC_DATA = (
 
 
 def test_event_forward_compat_with_event_specific_data():
-    result = deserialize_as(SERIALIZED_EVENT_FROM_THE_FUTURE_WITH_EVENT_SPECIFIC_DATA, DagsterEvent)
+    result = deserialize_value(
+        SERIALIZED_EVENT_FROM_THE_FUTURE_WITH_EVENT_SPECIFIC_DATA, DagsterEvent
+    )
 
     assert (
         result.message
@@ -179,7 +181,7 @@ def test_event_forward_compat_with_event_specific_data():
 
 
 def test_event_forward_compat_without_event_specific_data():
-    result = deserialize_as(
+    result = deserialize_value(
         SERIALIZED_EVENT_FROM_THE_FUTURE_WITHOUT_EVENT_SPECIFIC_DATA, DagsterEvent
     )
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_types.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.run_status_sensor_definition import RunStatusSensorCursor
 from dagster._daemon.types import DaemonHeartbeat
-from dagster._serdes import deserialize_as, deserialize_json_to_dagster_namedtuple
+from dagster._serdes import deserialize_value
 from dagster._utils.error import SerializableErrorInfo
 
 
@@ -10,7 +10,7 @@ def test_error_backcompat():
         ' "DaemonType.SENSOR"}, "error": {"__class__": "SerializableErrorInfo", "cause": null,'
         ' "cls_name": null, "message": "fizbuz", "stack": []}, "timestamp": 0.0}'
     )
-    heartbeat = deserialize_as(old_heartbeat, DaemonHeartbeat)
+    heartbeat = deserialize_value(old_heartbeat, DaemonHeartbeat)
     assert heartbeat.daemon_id == "foobar"
     assert heartbeat.daemon_type == "SENSOR"
     assert heartbeat.timestamp == 0.0
@@ -23,7 +23,7 @@ def test_heartbeat_backcompat():
         ' "daemon_type": {"__enum__": "DaemonType.SCHEDULER"}, "errors": [], "timestamp":'
         " 1612453213.775866}"
     )
-    heartbeat = deserialize_as(old_heartbeat, DaemonHeartbeat)
+    heartbeat = deserialize_value(old_heartbeat, DaemonHeartbeat)
     assert heartbeat.daemon_id == "05f24887-fb6a-4821-807b-fbd772a921e3"
     assert heartbeat.daemon_type == "SCHEDULER"
     assert heartbeat.errors == []
@@ -36,6 +36,5 @@ def test_run_status_sensor_cursor_backcompat():
         ' "2021-07-22T00:22:29.914776+00:00"}'
     )
     assert RunStatusSensorCursor.is_valid(old_cursor)
-    cursor = deserialize_json_to_dagster_namedtuple(old_cursor)
-    assert isinstance(cursor, RunStatusSensorCursor)
+    cursor = deserialize_value(old_cursor, RunStatusSensorCursor)
     assert cursor.record_id == 20585

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -32,7 +32,7 @@ from dagster._core.definitions.metadata.table import (
 )
 from dagster._core.execution.results import OpExecutionResult, PipelineExecutionResult
 from dagster._legacy import execute_pipeline, pipeline
-from dagster._serdes.serdes import deserialize_as, serialize_dagster_namedtuple
+from dagster._serdes.serdes import deserialize_value, serialize_value
 from dagster._utils import frozendict
 
 
@@ -366,8 +366,8 @@ def test_table_serialization():
             ],
         ),
     )
-    serialized = serialize_dagster_namedtuple(entry)
-    assert deserialize_as(serialized, MetadataEntry) == entry
+    serialized = serialize_value(entry)
+    assert deserialize_value(serialized, MetadataEntry) == entry
 
 
 def test_bool_metadata_value():

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -37,10 +37,8 @@ from dagster._legacy import execute_pipeline, pipeline
 from dagster._serdes import DefaultNamedTupleSerializer, create_snapshot_id
 from dagster._serdes.serdes import (
     WhitelistMap,
-    _deserialize_json,
     _whitelist_for_serdes,
-    deserialize_json_to_dagster_namedtuple,
-    serialize_dagster_namedtuple,
+    deserialize_value,
     serialize_value,
 )
 from dagster._utils.error import SerializableErrorInfo
@@ -271,9 +269,7 @@ def instance_from_debug_payloads(payload_files):
     for input_file in payload_files:
         with GzipFile(input_file, "rb") as file:
             blob = file.read().decode("utf-8")
-            debug_payload = deserialize_json_to_dagster_namedtuple(blob)
-
-            check.invariant(isinstance(debug_payload, DebugRunPayload))
+            debug_payload = deserialize_value(blob, DebugRunPayload)
 
             debug_payloads.append(debug_payload)
 
@@ -453,8 +449,7 @@ def test_0_11_0_add_asset_columns():
 
 def test_rename_event_log_entry():
     old_event_record = """{"__class__":"EventRecord","dagster_event":{"__class__":"DagsterEvent","event_specific_data":null,"event_type_value":"PIPELINE_SUCCESS","logging_tags":{},"message":"Finished execution of pipeline.","pid":71356,"pipeline_name":"error_monster","solid_handle":null,"step_handle":null,"step_key":null,"step_kind_value":null},"error_info":null,"level":10,"message":"error_monster - 4be295b5-fcf2-47cc-8e90-cb14d3cf3ac7 - 71356 - PIPELINE_SUCCESS - Finished execution of pipeline.","pipeline_name":"error_monster","run_id":"4be295b5-fcf2-47cc-8e90-cb14d3cf3ac7","step_key":null,"timestamp":1622659924.037028,"user_message":"Finished execution of pipeline."}"""
-    event_log_entry = deserialize_json_to_dagster_namedtuple(old_event_record)
-    assert isinstance(event_log_entry, EventLogEntry)
+    event_log_entry = deserialize_value(old_event_record, EventLogEntry)
     dagster_event = event_log_entry.dagster_event
     assert isinstance(dagster_event, DagsterEvent)
     assert dagster_event.event_type_value == "PIPELINE_SUCCESS"
@@ -528,7 +523,7 @@ def test_0_12_0_extract_asset_index_cols():
 def test_solid_handle_node_handle():
     # serialize in current code
     test_handle = NodeHandle("test", None)
-    test_str = serialize_dagster_namedtuple(test_handle)
+    test_str = serialize_value(test_handle)
 
     # deserialize in "legacy" code
     legacy_env = WhitelistMap.create()
@@ -537,7 +532,7 @@ def test_solid_handle_node_handle():
     class SolidHandle(namedtuple("_SolidHandle", "name parent")):
         pass
 
-    result = _deserialize_json(test_str, legacy_env)
+    result = deserialize_value(test_str, whitelist_map=legacy_env)
     assert isinstance(result, SolidHandle)
     assert result.name == test_handle.name
 
@@ -545,7 +540,7 @@ def test_solid_handle_node_handle():
 def test_pipeline_run_dagster_run():
     # serialize in current code
     test_run = DagsterRun(pipeline_name="test")
-    test_str = serialize_dagster_namedtuple(test_run)
+    test_str = serialize_value(test_run)
 
     # deserialize in "legacy" code
     legacy_env = WhitelistMap.create()
@@ -569,7 +564,7 @@ def test_pipeline_run_dagster_run():
         QUEUED = "QUEUED"
         NOT_STARTED = "NOT_STARTED"
 
-    result = _deserialize_json(test_str, legacy_env)
+    result = deserialize_value(test_str, whitelist_map=legacy_env)
     assert isinstance(result, PipelineRun)
     assert result.pipeline_name == test_run.pipeline_name
 
@@ -586,7 +581,7 @@ def test_pipeline_run_status_dagster_run_status():
     class PipelineRunStatus(Enum):
         QUEUED = "QUEUED"
 
-    result = _deserialize_json(test_str, legacy_env)
+    result = deserialize_value(test_str, whitelist_map=legacy_env)
     assert isinstance(result, PipelineRunStatus)
     assert result.value == test_status.value
 
@@ -687,8 +682,8 @@ def test_external_job_origin_instigator_origin():
         ),
         instigator_name="simple_schedule",
     )
-    instigator_origin_str = serialize_dagster_namedtuple(instigator_origin)
-    instigator_to_job = _deserialize_json(instigator_origin_str, legacy_env)
+    instigator_origin_str = serialize_value(instigator_origin)
+    instigator_to_job = deserialize_value(instigator_origin_str, whitelist_map=legacy_env)
     assert isinstance(instigator_to_job, klass)
     # ensure that the origin id is stable
     assert instigator_to_job.get_id() == instigator_origin.get_id()
@@ -705,8 +700,7 @@ def test_external_job_origin_instigator_origin():
     )
     job_origin_str = serialize_value(job_origin, legacy_env)
 
-    job_to_instigator = deserialize_json_to_dagster_namedtuple(job_origin_str)
-    assert isinstance(job_to_instigator, ExternalInstigatorOrigin)
+    job_to_instigator = deserialize_value(job_origin_str, ExternalInstigatorOrigin)
     # ensure that the origin id is stable
     assert job_to_instigator.get_id() == job_origin.get_id()
 
@@ -791,9 +785,9 @@ def test_legacy_event_log_load():
         timestamp=time.time(),
     )
 
-    storage_str = serialize_dagster_namedtuple(new_event)
+    storage_str = serialize_value(new_event)
 
-    result = _deserialize_json(storage_str, legacy_env)
+    result = deserialize_value(storage_str, OldEventLogEntry, whitelist_map=legacy_env)
     assert result.message is not None
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_dead_events.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_dead_events.py
@@ -1,7 +1,8 @@
 from os import path
 
 from dagster._core.events import DagsterEvent, DagsterEventType
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, deserialize_value
+from dagster._core.events.log import EventLogEntry
+from dagster._serdes import deserialize_value
 
 
 def test_dead_events():
@@ -18,7 +19,7 @@ def test_dead_events():
 
 def test_dead_pipeline_init_failure_event():
     old_pipeline_init_failure_event = """{"__class__":"EventRecord","dagster_event":{"__class__":"DagsterEvent","event_specific_data":{"__class__":"PipelineFailureData","error":{"__class__":"SerializableErrorInfo","cause":null,"cls_name":"DagsterError","message":"","stack":[]}},"event_type_value":"PIPELINE_FAILURE","logging_tags":{},"message":"Pipeline failure during initialization for pipeline.","pid":16977,"pipeline_name":"error_monster","solid_handle":null,"step_handle":null,"step_key":null,"step_kind_value":null},"error_info":null,"level":40,"message":"error_monster - a52c3489-60ca-4801-bf8d-43d3ebcbf81f - 16977 - PIPELINE_INIT_FAILURE - Pipeline failure during initialization for pipeline.","pipeline_name":"error_monster","run_id":"a52c3489-60ca-4801-bf8d-43d3ebcbf81f","step_key":null,"timestamp":1622868716.203709,"user_message":"Pipeline failure during initialization for pipeline. This may be due to a failure in initializing the executor or one of the loggers."}"""
-    event_record = deserialize_json_to_dagster_namedtuple(old_pipeline_init_failure_event)
+    event_record = deserialize_value(old_pipeline_init_failure_event, EventLogEntry)
     old_event = event_record.dagster_event
     assert old_event
     new_event = DagsterEvent(

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -30,8 +30,9 @@ from dagster._grpc.server import (
     open_server_process,
     wait_for_grpc_server,
 )
-from dagster._grpc.types import ListRepositoriesResponse, SensorExecutionArgs
-from dagster._serdes import deserialize_json_to_dagster_namedtuple, serialize_dagster_namedtuple
+from dagster._grpc.types import ListRepositoriesResponse, SensorExecutionArgs, StartRunResult
+from dagster._serdes import serialize_value
+from dagster._serdes.serdes import deserialize_value
 from dagster._seven import get_system_temp_directory
 from dagster._utils import file_relative_path, find_free_port
 from dagster._utils.error import SerializableErrorInfo
@@ -507,10 +508,9 @@ def test_lazy_load_with_error():
         wait_for_grpc_server(
             process, DagsterGrpcClient(port=port, host="localhost"), subprocess_args
         )
-        list_repositories_response = deserialize_json_to_dagster_namedtuple(
-            DagsterGrpcClient(port=port).list_repositories()
+        list_repositories_response = deserialize_value(
+            DagsterGrpcClient(port=port).list_repositories(), SerializableErrorInfo
         )
-        assert isinstance(list_repositories_response, SerializableErrorInfo)
         assert "Dagster recognizes standard cron expressions" in list_repositories_response.message
     finally:
         process.terminate()
@@ -541,10 +541,9 @@ def test_lazy_load_via_env_var():
             wait_for_grpc_server(
                 process, DagsterGrpcClient(port=port, host="localhost"), subprocess_args
             )
-            list_repositories_response = deserialize_json_to_dagster_namedtuple(
-                DagsterGrpcClient(port=port).list_repositories()
+            list_repositories_response = deserialize_value(
+                DagsterGrpcClient(port=port).list_repositories(), SerializableErrorInfo
             )
-            assert isinstance(list_repositories_response, SerializableErrorInfo)
             assert (
                 "Dagster recognizes standard cron expressions" in list_repositories_response.message
             )
@@ -572,10 +571,9 @@ def test_load_with_missing_env_var():
     process = subprocess.Popen(subprocess_args, stdout=subprocess.PIPE)
     try:
         wait_for_grpc_server(process, client, subprocess_args)
-        list_repositories_response = deserialize_json_to_dagster_namedtuple(
-            client.list_repositories()
+        list_repositories_response = deserialize_value(
+            client.list_repositories(), SerializableErrorInfo
         )
-        assert isinstance(list_repositories_response, SerializableErrorInfo)
         assert "Missing env var" in list_repositories_response.message
     finally:
         client.shutdown_server()
@@ -608,18 +606,14 @@ def test_load_with_secrets_loader_instance_ref():
                 + [
                     "--inject-env-vars-from-instance",
                     "--instance-ref",
-                    serialize_dagster_namedtuple(instance.get_ref()),
+                    serialize_value(instance.get_ref()),
                 ],
                 cwd=os.path.dirname(__file__),
             )
             try:
                 wait_for_grpc_server(process, client, subprocess_args)
 
-                list_repositories_response = deserialize_json_to_dagster_namedtuple(
-                    client.list_repositories()
-                )
-
-                assert isinstance(list_repositories_response, ListRepositoriesResponse)
+                deserialize_value(client.list_repositories(), ListRepositoriesResponse)
 
                 # Launch a run and verify that it finishes
 
@@ -636,14 +630,15 @@ def test_load_with_secrets_loader_instance_ref():
                     ),
                 )
 
-                res = deserialize_json_to_dagster_namedtuple(
+                res = deserialize_value(
                     client.start_run(
                         ExecuteExternalPipelineArgs(
                             pipeline_origin=pipeline_origin,
                             pipeline_run_id=run.run_id,
                             instance_ref=instance.get_ref(),
                         )
-                    )
+                    ),
+                    StartRunResult,
                 )
 
                 assert res.success
@@ -687,11 +682,9 @@ def test_load_with_secrets_loader_no_instance_ref():
 
             try:
                 wait_for_grpc_server(process, client, subprocess_args)
-                list_repositories_response = deserialize_json_to_dagster_namedtuple(
-                    DagsterGrpcClient(port=port).list_repositories()
+                deserialize_value(
+                    DagsterGrpcClient(port=port).list_repositories(), ListRepositoriesResponse
                 )
-
-                assert isinstance(list_repositories_response, ListRepositoriesResponse)
 
             finally:
                 client.shutdown_server()

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -13,16 +13,13 @@ from dagster._serdes.serdes import (
     DefaultNamedTupleSerializer,
     EnumSerializer,
     WhitelistMap,
-    _deserialize_json,
-    _serialize_dagster_namedtuple,
     _whitelist_for_serdes,
-    deserialize_json_to_dagster_namedtuple,
     deserialize_value,
-    pack_inner_value,
+    pack_value,
     register_serdes_enum_fallbacks,
     register_serdes_tuple_fallbacks,
     serialize_value,
-    unpack_inner_value,
+    unpack_value,
 )
 from dagster._serdes.utils import hash_str
 
@@ -35,13 +32,13 @@ def test_deserialize_value_ok():
 
 def test_deserialize_json_non_namedtuple():
     with pytest.raises(DeserializationError, match="was not expected type"):
-        deserialize_json_to_dagster_namedtuple('{"foo": "bar"}')
+        deserialize_value('{"foo": "bar"}', NamedTuple)
 
 
 @pytest.mark.parametrize("bad_obj", [1, None, False])
 def test_deserialize_json_invalid_types(bad_obj):
     with pytest.raises(ParameterCheckError):
-        deserialize_json_to_dagster_namedtuple(bad_obj)
+        deserialize_value(bad_obj)
 
 
 def test_deserialize_empty_set():
@@ -64,12 +61,10 @@ def test_descent_path():
         buzz: int
 
     # Arg is not actually a namedtuple but the function still works on it
-    ser = _serialize_dagster_namedtuple(
-        {"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map
-    )
+    ser = serialize_value({"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map)
 
     with pytest.raises(DeserializationError, match=re.escape("Descent path: <root:dict>.a.b[2].c")):
-        _deserialize_json(ser, whitelist_map=blank_map)
+        deserialize_value(ser, whitelist_map=blank_map)
 
 
 def test_forward_compat_serdes_new_field_with_default():
@@ -86,7 +81,7 @@ def test_forward_compat_serdes_new_field_with_default():
 
     quux = Quux("zip", "zow")
 
-    serialized = _serialize_dagster_namedtuple(quux, whitelist_map=test_map)
+    serialized = serialize_value(quux, whitelist_map=test_map)
 
     @_whitelist_for_serdes(whitelist_map=test_map)
     class Quux(namedtuple("_Quux", "foo bar baz")):
@@ -97,7 +92,7 @@ def test_forward_compat_serdes_new_field_with_default():
     klass, _, _ = test_map.get_tuple_entry("Quux")
     assert klass is Quux
 
-    deserialized = _deserialize_json(serialized, whitelist_map=test_map)
+    deserialized = deserialize_value(serialized, whitelist_map=test_map)
 
     assert deserialized != quux
     assert deserialized.foo == quux.foo
@@ -117,7 +112,7 @@ def test_forward_compat_serdes_new_enum_field():
 
     corge = Corge.FOO
 
-    packed = pack_inner_value(corge, whitelist_map=test_map, descent_path="")
+    packed = pack_value(corge, whitelist_map=test_map, descent_path="")
 
     # pylint: disable=function-redefined
     @_whitelist_for_serdes(whitelist_map=test_map)
@@ -126,7 +121,7 @@ def test_forward_compat_serdes_new_enum_field():
         BAR = 2
         BAZ = 3
 
-    unpacked = unpack_inner_value(packed, whitelist_map=test_map, descent_path="")
+    unpacked = unpack_value(packed, whitelist_map=test_map, descent_path="")
 
     assert unpacked != corge
     assert unpacked.name == corge.name
@@ -145,7 +140,7 @@ def test_serdes_enum_backcompat():
 
     corge = Corge.FOO
 
-    packed = pack_inner_value(corge, whitelist_map=test_map, descent_path="")
+    packed = pack_value(corge, whitelist_map=test_map, descent_path="")
 
     class CorgeBackCompatSerializer(DefaultEnumSerializer):
         @classmethod
@@ -164,7 +159,7 @@ def test_serdes_enum_backcompat():
         BAZ = 3
         FOO_FOO = 4
 
-    unpacked = unpack_inner_value(packed, whitelist_map=test_map, descent_path="")
+    unpacked = unpack_value(packed, whitelist_map=test_map, descent_path="")
 
     assert unpacked != corge
     assert unpacked == Corge.FOO_FOO
@@ -180,7 +175,7 @@ def test_backward_compat_serdes():
 
     quux = Quux("zip", "zow", "whoopie")
 
-    serialized = _serialize_dagster_namedtuple(quux, whitelist_map=test_map)
+    serialized = serialize_value(quux, whitelist_map=test_map)
 
     # pylint: disable=function-redefined
     @_whitelist_for_serdes(whitelist_map=test_map)
@@ -188,7 +183,7 @@ def test_backward_compat_serdes():
         def __new__(cls, foo, bar):
             return super(Quux, cls).__new__(cls, foo, bar)
 
-    deserialized = _deserialize_json(serialized, whitelist_map=test_map)
+    deserialized = deserialize_value(serialized, whitelist_map=test_map)
 
     assert deserialized != quux
     assert deserialized.foo == quux.foo
@@ -221,10 +216,10 @@ def test_forward_compat():
     new_quux = Quux(foo=Foo("wow"), bar="bar", baz="baz")
 
     # write from new
-    serialized = _serialize_dagster_namedtuple(new_quux, whitelist_map=new_map)
+    serialized = serialize_value(new_quux, whitelist_map=new_map)
 
     # read from old, foo ignored
-    deserialized = _deserialize_json(serialized, whitelist_map=old_map)
+    deserialized = deserialize_value(serialized, whitelist_map=old_map)
     assert deserialized.bar == "bar"
     assert deserialized.baz == "baz"
 
@@ -365,19 +360,19 @@ def test_set():
 
     foo = HasSets({1, 2, 3, "3"}, frozenset([4, 5, 6, "6"]))
 
-    serialized = _serialize_dagster_namedtuple(foo, whitelist_map=test_map)
-    foo_2 = _deserialize_json(serialized, whitelist_map=test_map)
+    serialized = serialize_value(foo, whitelist_map=test_map)
+    foo_2 = deserialize_value(serialized, whitelist_map=test_map)
     assert foo == foo_2
 
     # verify that set elements are serialized in a consistent order so that
     # equal objects always have a consistent serialization / snapshot ID
     big_foo = HasSets(set(string.ascii_lowercase), frozenset(string.ascii_lowercase))
 
-    snap_id = hash_str(_serialize_dagster_namedtuple(big_foo, whitelist_map=test_map))
+    snap_id = hash_str(serialize_value(big_foo, whitelist_map=test_map))
     roundtrip_snap_id = hash_str(
-        _serialize_dagster_namedtuple(
-            _deserialize_json(
-                _serialize_dagster_namedtuple(big_foo, whitelist_map=test_map),
+        serialize_value(
+            deserialize_value(
+                serialize_value(big_foo, whitelist_map=test_map),
                 whitelist_map=test_map,
             ),
             whitelist_map=test_map,
@@ -395,8 +390,8 @@ def test_persistent_tuple():
             return super(Alphabet, cls).__new__(cls, a, b, c)
 
     foo = Alphabet(a="A", b="B", c="C")
-    serialized = _serialize_dagster_namedtuple(foo, whitelist_map=test_map)
-    foo_2 = _deserialize_json(serialized, whitelist_map=test_map)
+    serialized = serialize_value(foo, whitelist_map=test_map)
+    foo_2 = deserialize_value(serialized, whitelist_map=test_map)
     assert foo == foo_2
 
 
@@ -408,7 +403,7 @@ def test_from_storage_dict():
     class MyThing(NamedTuple):  # type: ignore
         orig_name: str
 
-    serialized_old = _serialize_dagster_namedtuple(MyThing("old"), whitelist_map=old_map)
+    serialized_old = serialize_value(MyThing("old"), whitelist_map=old_map)
 
     class CompatSerializer(DefaultNamedTupleSerializer):
         @classmethod
@@ -424,12 +419,12 @@ def test_from_storage_dict():
     class MyThing(NamedTuple):
         new_name: str
 
-    deser_old_val = _deserialize_json(serialized_old, whitelist_map=new_map)
+    deser_old_val = deserialize_value(serialized_old, whitelist_map=new_map)
 
     assert deser_old_val.new_name == "old"
 
-    serialized_new = _serialize_dagster_namedtuple(MyThing("new"), whitelist_map=new_map)
-    deser_new_val = _deserialize_json(serialized_new, whitelist_map=new_map)
+    serialized_new = serialize_value(MyThing("new"), whitelist_map=new_map)
+    deser_new_val = deserialize_value(serialized_new, whitelist_map=new_map)
     assert deser_new_val.new_name == "new"
 
 
@@ -458,7 +453,7 @@ def test_from_unpacked():
 
     serialized = '{"__class__": "DeprecatedAlphabet", "a": "A", "b": "B", "c": "C"}'
 
-    nt = _deserialize_json(serialized, whitelist_map=test_map)
+    nt = deserialize_value(serialized, whitelist_map=test_map)
     assert isinstance(nt, DeprecatedAlphabet)
 
 
@@ -472,7 +467,7 @@ def test_skip_when_empty():
             return super(SameSnapshotTuple, cls).__new__(cls, foo)
 
     old_tuple = SameSnapshotTuple(foo="A")
-    old_serialized = _serialize_dagster_namedtuple(old_tuple, whitelist_map=test_map)
+    old_serialized = serialize_value(old_tuple, whitelist_map=test_map)
     old_snapshot = hash_str(old_serialized)
 
     # Without setting skip_when_empty, the ID changes
@@ -486,7 +481,7 @@ def test_skip_when_empty():
 
     new_tuple_without_serializer = SameSnapshotTuple(foo="A")
     new_snapshot_without_serializer = hash_str(
-        _serialize_dagster_namedtuple(new_tuple_without_serializer, whitelist_map=test_map)
+        serialize_value(new_tuple_without_serializer, whitelist_map=test_map)
     )
 
     assert new_snapshot_without_serializer != old_snapshot
@@ -508,11 +503,13 @@ def test_skip_when_empty():
 
     for bar_val in [None, [], {}, set()]:
         new_tuple = SameSnapshotTuple(foo="A", bar=bar_val)
-        new_snapshot = hash_str(_serialize_dagster_namedtuple(new_tuple, whitelist_map=test_map))
+        new_snapshot = hash_str(serialize_value(new_tuple, whitelist_map=test_map))
 
         assert old_snapshot == new_snapshot
 
-        rehydrated_tuple = _deserialize_json(old_serialized, whitelist_map=test_map)
+        rehydrated_tuple = deserialize_value(
+            old_serialized, SameSnapshotTuple, whitelist_map=test_map
+        )
         assert rehydrated_tuple.foo == "A"
         assert rehydrated_tuple.bar is None
 
@@ -545,8 +542,8 @@ def test_to_storage_value():
 
     nested = DeprecatedAlphabet(None, None, "_C")
     deprecated = DeprecatedAlphabet("A", "B", nested)
-    serialized = _serialize_dagster_namedtuple(deprecated, whitelist_map=test_map)
-    alphabet = _deserialize_json(serialized, whitelist_map=test_map)
+    serialized = serialize_value(deprecated, whitelist_map=test_map)
+    alphabet = deserialize_value(serialized, SubstituteAlphabet, whitelist_map=test_map)
     assert not isinstance(alphabet, DeprecatedAlphabet)
     assert isinstance(alphabet, SubstituteAlphabet)
     assert not isinstance(alphabet.c, DeprecatedAlphabet)
@@ -561,8 +558,8 @@ def test_long_int():
         num: int
 
     x = NumHolder(98765432109876543210)
-    ser_x = _serialize_dagster_namedtuple(x, test_map)
-    roundtrip_x = _deserialize_json(ser_x, test_map)
+    ser_x = serialize_value(x, test_map)
+    roundtrip_x = deserialize_value(ser_x, whitelist_map=test_map)
     assert x.num == roundtrip_x.num
 
 
@@ -593,7 +590,7 @@ def test_enum_backcompat():
 
     my_enum = MyEnum("color.red")
     enum_json = serialize_value(my_enum, whitelist_map=test_env)
-    result = _deserialize_json(enum_json, test_env)
+    result = deserialize_value(enum_json, whitelist_map=test_env)
     assert result == my_enum
 
     # ensure that "legacy" environment can correctly interpret enum stored under legacy name.
@@ -604,7 +601,7 @@ def test_enum_backcompat():
         RED = "color.red"
         BLUE = "color.blue"
 
-    result = _deserialize_json(enum_json, legacy_env)
+    result = deserialize_value(enum_json, whitelist_map=legacy_env)
     old_enum = OldEnum("color.red")
     assert old_enum == result
 
@@ -617,13 +614,13 @@ def test_namedtuple_backcompat():
         old_name: str
 
         def get_id(self):
-            json_rep = _serialize_dagster_namedtuple(self, whitelist_map=old_map)
+            json_rep = serialize_value(self, whitelist_map=old_map)
             return hash_str(json_rep)
 
     # create the old things
     old_thing = OldThing("thing")
     old_thing_id = old_thing.get_id()
-    old_thing_serialized = _serialize_dagster_namedtuple(old_thing, old_map)
+    old_thing_serialized = serialize_value(old_thing, old_map)
 
     new_map = WhitelistMap.create()
 
@@ -633,7 +630,9 @@ def test_namedtuple_backcompat():
             cls, storage_dict, klass, args_for_class, whitelist_map, descent_path
         ):
             raw_dict = {
-                key: unpack_inner_value(value, whitelist_map, f"{descent_path}.{key}")
+                key: unpack_value(
+                    value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+                )
                 for key, value in storage_dict.items()
             }
             # typical pattern is to use the same serialization format from an old field and passing
@@ -665,7 +664,7 @@ def test_namedtuple_backcompat():
         new_name: str
 
         def get_id(self):
-            json_rep = _serialize_dagster_namedtuple(self, whitelist_map=new_map)
+            json_rep = serialize_value(self, whitelist_map=new_map)
             return hash_str(json_rep)
 
     # exercising the old serialization format
@@ -673,18 +672,18 @@ def test_namedtuple_backcompat():
 
     new_thing = NewThing("thing")
     new_thing_id = new_thing.get_id()
-    new_thing_serialized = _serialize_dagster_namedtuple(new_thing, new_map)
+    new_thing_serialized = serialize_value(new_thing, new_map)
 
     assert new_thing_id == old_thing_id
     assert new_thing_serialized == old_thing_serialized
 
     # ensure that the new serializer can correctly interpret old serialized data
-    old_thing_deserialized = _deserialize_json(old_thing_serialized, new_map)
+    old_thing_deserialized = deserialize_value(old_thing_serialized, whitelist_map=new_map)
     assert isinstance(old_thing_deserialized, NewThing)
     assert old_thing_deserialized.get_id() == new_thing_id
 
     # ensure that the new things serialized can still be read by old code
-    new_thing_deserialized = _deserialize_json(new_thing_serialized, old_map)
+    new_thing_deserialized = deserialize_value(new_thing_serialized, whitelist_map=old_map)
     assert isinstance(new_thing_deserialized, OldThing)
     assert new_thing_deserialized.get_id() == old_thing_id
 
@@ -699,14 +698,14 @@ def test_namedtuple_name_map():
     wmap.register_serialized_name("Thing", "SerializedThing")
     thing = Thing("foo")
 
-    thing_serialized = _serialize_dagster_namedtuple(thing, wmap)
+    thing_serialized = serialize_value(thing, wmap)
     assert _seven.json.loads(thing_serialized)["__class__"] == "SerializedThing"
 
     with pytest.raises(DeserializationError):
-        _deserialize_json(thing_serialized, wmap)
+        deserialize_value(thing_serialized, whitelist_map=wmap)
 
     wmap.register_deserialized_name("SerializedThing", "Thing")
-    assert _deserialize_json(thing_serialized, wmap) == thing
+    assert deserialize_value(thing_serialized, whitelist_map=wmap) == thing
 
 
 def test_whitelist_storage_name():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_defensive_row_unpack.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_defensive_row_unpack.py
@@ -3,14 +3,16 @@ import zlib
 from unittest import mock
 
 from dagster import job, op
-from dagster._core.storage.runs.sql_run_storage import defensively_unpack_pipeline_snapshot_query
-from dagster._serdes import serialize_dagster_namedtuple
+from dagster._core.storage.runs.sql_run_storage import (
+    defensively_unpack_execution_plan_snapshot_query,
+)
+from dagster._serdes import serialize_value
 
 
 def test_defensive_pipeline_not_a_string():
     mock_logger = mock.MagicMock()
 
-    assert defensively_unpack_pipeline_snapshot_query(mock_logger, [234]) is None
+    assert defensively_unpack_execution_plan_snapshot_query(mock_logger, [234]) is None
     assert mock_logger.warning.call_count == 1
 
     mock_logger.warning.assert_called_with(
@@ -21,7 +23,7 @@ def test_defensive_pipeline_not_a_string():
 def test_defensive_pipeline_not_bytes():
     mock_logger = mock.MagicMock()
 
-    assert defensively_unpack_pipeline_snapshot_query(mock_logger, ["notbytes"]) is None
+    assert defensively_unpack_execution_plan_snapshot_query(mock_logger, ["notbytes"]) is None
     assert mock_logger.warning.call_count == 1
 
     if sys.version_info.major == 2:
@@ -39,7 +41,7 @@ def test_defensive_pipeline_not_bytes():
 def test_defensive_pipelines_cannot_decompress():
     mock_logger = mock.MagicMock()
 
-    assert defensively_unpack_pipeline_snapshot_query(mock_logger, [b"notbytes"]) is None
+    assert defensively_unpack_execution_plan_snapshot_query(mock_logger, [b"notbytes"]) is None
     assert mock_logger.warning.call_count == 1
     mock_logger.warning.assert_called_with(
         "get-pipeline-snapshot: Could not decompress bytes stored in snapshot table."
@@ -51,7 +53,7 @@ def test_defensive_pipelines_cannot_decode_post_decompress():
 
     # guarantee that we cannot decode by double compressing bytes.
     assert (
-        defensively_unpack_pipeline_snapshot_query(
+        defensively_unpack_execution_plan_snapshot_query(
             mock_logger, [zlib.compress(zlib.compress(b"notbytes"))]
         )
         is None
@@ -67,7 +69,8 @@ def test_defensive_pipelines_cannot_parse_json():
     mock_logger = mock.MagicMock()
 
     assert (
-        defensively_unpack_pipeline_snapshot_query(mock_logger, [zlib.compress(b"notjson")]) is None
+        defensively_unpack_execution_plan_snapshot_query(mock_logger, [zlib.compress(b"notjson")])
+        is None
     )
     assert mock_logger.warning.call_count == 1
     mock_logger.warning.assert_called_with(
@@ -88,9 +91,9 @@ def test_correctly_fetch_decompress_parse_snapshot():
 
     mock_logger = mock.MagicMock()
     assert (
-        defensively_unpack_pipeline_snapshot_query(
+        defensively_unpack_execution_plan_snapshot_query(
             mock_logger,
-            [zlib.compress(serialize_dagster_namedtuple(noop_pipeline_snapshot).encode("utf-8"))],
+            [zlib.compress(serialize_value(noop_pipeline_snapshot).encode("utf-8"))],
         )
         == noop_pipeline_snapshot
     )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
@@ -22,7 +22,7 @@ from dagster._core.storage.pipeline_run import (
     RunsFilter,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._serdes import deserialize_as, serialize_dagster_namedtuple
+from dagster._serdes import deserialize_value, serialize_value
 
 
 def test_queued_pipeline_origin_check():
@@ -86,4 +86,4 @@ def test_runs_filter_supports_nonempty_run_ids():
 
 
 def test_serialize_runs_filter():
-    deserialize_as(serialize_dagster_namedtuple(RunsFilter()), RunsFilter)
+    deserialize_value(serialize_value(RunsFilter()), RunsFilter)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_pipeline_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_pipeline_run.py
@@ -22,7 +22,7 @@ from dagster._core.storage.pipeline_run import (
     RunsFilter,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._serdes import deserialize_as, serialize_dagster_namedtuple
+from dagster._serdes import deserialize_value, serialize_value
 
 
 def test_queued_pipeline_origin_check():
@@ -86,4 +86,4 @@ def test_runs_filter_supports_nonempty_run_ids():
 
 
 def test_serialize_runs_filter():
-    deserialize_as(serialize_dagster_namedtuple(RunsFilter()), RunsFilter)
+    deserialize_value(serialize_value(RunsFilter()), RunsFilter)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -68,7 +68,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
 from dagster._legacy import AssetGroup, build_assets_job
 from dagster._loggers import colored_console_logger
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._serdes.serdes import deserialize_value
 from dagster._utils import datetime_as_float
 
 TEST_TIMEOUT = 5
@@ -659,7 +659,7 @@ class TestEventLogStorage:
 
         rows = _fetch_all_events(storage, run_id=test_run_id)
 
-        out_events = list(map(lambda r: deserialize_json_to_dagster_namedtuple(r[0]), rows))
+        out_events = list(map(lambda r: deserialize_value(r[0], EventLogEntry), rows))
 
         # messages can come out of order
         event_type_counts = CollectionsCounter(_event_types(out_events))
@@ -1001,14 +1001,14 @@ class TestEventLogStorage:
                 # for generic sql-based event log storage
                 stack.enter_context(
                     mock.patch(
-                        "dagster._core.storage.event_log.sql_event_log.deserialize_json_to_dagster_namedtuple",
+                        "dagster._core.storage.event_log.sql_event_log.deserialize_value",
                         return_value="not_an_event_record",
                     )
                 )
                 # for sqlite event log storage, which overrides the record fetching implementation
                 stack.enter_context(
                     mock.patch(
-                        "dagster._core.storage.event_log.sqlite.sqlite_event_log.deserialize_json_to_dagster_namedtuple",
+                        "dagster._core.storage.event_log.sqlite.sqlite_event_log.deserialize_value",
                         return_value="not_an_event_record",
                     )
                 )
@@ -1035,14 +1035,14 @@ class TestEventLogStorage:
                 # for generic sql-based event log storage
                 stack.enter_context(
                     mock.patch(
-                        "dagster._core.storage.event_log.sql_event_log.deserialize_json_to_dagster_namedtuple",
+                        "dagster._core.storage.event_log.sql_event_log.deserialize_value",
                         side_effect=seven.JSONDecodeError("error", "", 0),
                     )
                 )
                 # for sqlite event log storage, which overrides the record fetching implementation
                 stack.enter_context(
                     mock.patch(
-                        "dagster._core.storage.event_log.sqlite.sqlite_event_log.deserialize_json_to_dagster_namedtuple",
+                        "dagster._core.storage.event_log.sqlite.sqlite_event_log.deserialize_value",
                         side_effect=seven.JSONDecodeError("error", "", 0),
                     )
                 )

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -17,7 +17,7 @@ from dagster._core.events import EngineEventData
 from dagster._core.events.utils import filter_dagster_events_from_cli_logs
 from dagster._core.execution.retries import RetryMode
 from dagster._core.storage.pipeline_run import DagsterRun
-from dagster._serdes import pack_value, serialize_dagster_namedtuple, unpack_value
+from dagster._serdes import pack_value, serialize_value, unpack_value
 from dagster._utils.merger import merge_dicts
 from dagster_celery.config import DEFAULT_CONFIG, dict_wrapper
 from dagster_celery.core_execution_loop import DELEGATE_MARKER, core_celery_execution_loop
@@ -273,7 +273,7 @@ def create_docker_task(celery_app, **task_kwargs):
             step_key=execute_step_args.step_keys_to_execute[0],
         )
 
-        serialized_events = [serialize_dagster_namedtuple(engine_event)]
+        serialized_events = [serialize_value(engine_event)]
 
         docker_env = {}
         if docker_config.get("env_vars"):
@@ -327,7 +327,7 @@ def create_docker_task(celery_app, **task_kwargs):
                 raise Exception("No response from execute_step in CeleryDockerExecutor")
 
             events = filter_dagster_events_from_cli_logs(res.split("\n"))
-            serialized_events += [serialize_dagster_namedtuple(event) for event in events]
+            serialized_events += [serialize_value(event) for event in events]
 
         return serialized_events
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -22,7 +22,7 @@ from dagster._core.events.utils import filter_dagster_events_from_cli_logs
 from dagster._core.execution.plan.objects import StepFailureData, UserFailureData
 from dagster._core.execution.retries import RetryMode
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
-from dagster._serdes import pack_value, serialize_dagster_namedtuple, unpack_value
+from dagster._serdes import pack_value, serialize_value, unpack_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster_celery.config import DEFAULT_CONFIG, dict_wrapper
 from dagster_celery.core_execution_loop import DELEGATE_MARKER
@@ -549,7 +549,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 )
 
         events += filter_dagster_events_from_cli_logs(logs)
-        serialized_events = [serialize_dagster_namedtuple(event) for event in events]
+        serialized_events = [serialize_value(event) for event in events]
         return serialized_events
 
     return _execute_step_k8s_job

--- a/python_modules/libraries/dagster-celery/dagster_celery/cli.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/cli.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import uuid
+from typing import Any, Mapping, Optional
 
 import click
 import dagster._check as check
@@ -23,15 +24,16 @@ def create_worker_cli_group():
     return group
 
 
-def get_config_value_from_yaml(yaml_path):
+def get_config_value_from_yaml(yaml_path: Optional[str]) -> Mapping[str, Any]:
     if yaml_path is None:
         return {}
     parsed_yaml = load_yaml_from_path(yaml_path) or {}
+    assert isinstance(parsed_yaml, dict)
     # Would be better not to hardcode this path
     return parsed_yaml.get("execution", {}).get("celery", {}) or {}
 
 
-def get_app(config_yaml=None):
+def get_app(config_yaml: Optional[str] = None) -> CeleryExecutor:
     return make_app(
         CeleryExecutor.for_cli(**get_config_value_from_yaml(config_yaml)).app_args()
         if config_yaml
@@ -39,7 +41,7 @@ def get_app(config_yaml=None):
     )
 
 
-def get_worker_name(name=None):
+def get_worker_name(name: Optional[str] = None) -> str:
     return (
         name + "@%h"
         if name is not None
@@ -47,7 +49,7 @@ def get_worker_name(name=None):
     )
 
 
-def get_validated_config(config_yaml=None):
+def get_validated_config(config_yaml: Optional[str] = None) -> Any:
     config_type = celery_executor.config_schema.config_type
     config_value = get_config_value_from_yaml(config_yaml)
     config = validate_config(config_type, config_value)
@@ -57,7 +59,7 @@ def get_validated_config(config_yaml=None):
             config.errors,
             config_value,
         )
-    return post_process_config(config_type, config_value).value
+    return post_process_config(config_type, config_value).value  # type: ignore  # (possible none)
 
 
 def get_config_dir(config_yaml=None):

--- a/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
@@ -8,7 +8,7 @@ from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.context.system import PlanOrchestrationContext
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.storage.tags import PRIORITY_TAG
-from dagster._serdes import deserialize_json_to_dagster_namedtuple
+from dagster._serdes.serdes import deserialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from .defaults import task_default_priority, task_default_queue
@@ -100,7 +100,7 @@ def core_celery_execution_loop(pipeline_context, execution_plan, step_execution_
                             sys.exc_info()
                         )
                     for step_event in step_events:
-                        event = deserialize_json_to_dagster_namedtuple(step_event)
+                        event = deserialize_value(step_event, DagsterEvent)
                         yield event
                         active_execution.handle_event(event)
 

--- a/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.events import EngineEventData
 from dagster._core.execution.api import create_execution_plan, execute_plan_iterator
 from dagster._grpc.types import ExecuteStepArgs
-from dagster._serdes import serialize_dagster_namedtuple, unpack_value
+from dagster._serdes import serialize_value, unpack_value
 
 from .core_execution_loop import DELEGATE_MARKER
 from .executor import CeleryExecutor
@@ -71,7 +71,7 @@ def create_task(celery_app, **task_kwargs):
         ):
             events.append(step_event)
 
-        serialized_events = [serialize_dagster_namedtuple(event) for event in events]
+        serialized_events = [serialize_value(event) for event in events]
         return serialized_events
 
     return _execute_plan

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -21,7 +21,7 @@ from dagster._core.storage.sql import (
     stamp_alembic_rev,
 )
 from dagster._daemon.types import DaemonHeartbeat
-from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
 from dagster._utils import utc_datetime_from_timestamp
 from sqlalchemy.engine import Connection
 
@@ -180,12 +180,12 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
                     timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                     daemon_type=daemon_heartbeat.daemon_type,
                     daemon_id=daemon_heartbeat.daemon_id,
-                    body=serialize_dagster_namedtuple(daemon_heartbeat),
+                    body=serialize_value(daemon_heartbeat),
                 )
                 .on_duplicate_key_update(
                     timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                     daemon_id=daemon_heartbeat.daemon_id,
-                    body=serialize_dagster_namedtuple(daemon_heartbeat),
+                    body=serialize_value(daemon_heartbeat),
                 )
             )
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -16,7 +16,7 @@ from dagster._core.storage.sql import (
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
-from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
 from sqlalchemy.engine import Connection
 
 from ..utils import (
@@ -150,12 +150,12 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                 repository_selector_id=state.repository_selector_id,
                 status=state.status.value,
                 instigator_type=state.instigator_type.value,
-                instigator_body=serialize_dagster_namedtuple(state),
+                instigator_body=serialize_value(state),
             )
             .on_duplicate_key_update(
                 status=state.status.value,
                 instigator_type=state.instigator_type.value,
-                instigator_body=serialize_dagster_namedtuple(state),
+                instigator_body=serialize_value(state),
                 update_timestamp=pendulum.now("UTC"),
             )
         )

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -25,7 +25,7 @@ from dagster._core.storage.sql import (
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
-from dagster._serdes import ConfigurableClass, ConfigurableClassData, deserialize_as
+from dagster._serdes import ConfigurableClass, ConfigurableClassData, deserialize_value
 from sqlalchemy.engine import Connection
 
 from ..utils import (
@@ -301,7 +301,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     SqlEventLogStorageTable.c.id == cursor
                 ),
             )
-            return deserialize_as(cursor_res.scalar(), EventLogEntry)  # type: ignore
+            return deserialize_value(cursor_res.scalar(), EventLogEntry)  # type: ignore
 
     def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:
         if self._event_watcher is None:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -21,7 +21,7 @@ from dagster._core.storage.sql import (
     stamp_alembic_rev,
 )
 from dagster._daemon.types import DaemonHeartbeat
-from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
 from dagster._utils import utc_datetime_from_timestamp
 from sqlalchemy.engine import Connection
 
@@ -179,14 +179,14 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                     timestamp=utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                     daemon_type=daemon_heartbeat.daemon_type,
                     daemon_id=daemon_heartbeat.daemon_id,
-                    body=serialize_dagster_namedtuple(daemon_heartbeat),
+                    body=serialize_value(daemon_heartbeat),
                 )
                 .on_conflict_do_update(
                     index_elements=[DaemonHeartbeatsTable.c.daemon_type],
                     set_={
                         "timestamp": utc_datetime_from_timestamp(daemon_heartbeat.timestamp),
                         "daemon_id": daemon_heartbeat.daemon_id,
-                        "body": serialize_dagster_namedtuple(daemon_heartbeat),
+                        "body": serialize_value(daemon_heartbeat),
                     },
                 )
             )

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -17,7 +17,7 @@ from dagster._core.storage.sql import (
     run_alembic_upgrade,
     stamp_alembic_rev,
 )
-from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_dagster_namedtuple
+from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
 from sqlalchemy.engine import Connection
 
 from ..utils import (
@@ -159,14 +159,14 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                 repository_selector_id=state.repository_selector_id,
                 status=state.status.value,
                 instigator_type=state.instigator_type.value,
-                instigator_body=serialize_dagster_namedtuple(state),
+                instigator_body=serialize_value(state),
             )
             .on_conflict_do_update(
                 index_elements=[InstigatorsTable.c.selector_id],
                 set_={
                     "status": state.status.value,
                     "instigator_type": state.instigator_type.value,
-                    "instigator_body": serialize_dagster_namedtuple(state),
+                    "instigator_body": serialize_value(state),
                     "update_timestamp": pendulum.now("UTC"),
                 },
             )

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -141,14 +141,14 @@ class Manager:
         pipeline_def = pipeline.get_definition()
 
         try:
-            instance_ref = cast(InstanceRef, unpack_value(instance_ref_dict))
+            instance_ref = unpack_value(instance_ref_dict, InstanceRef)
             instance = DagsterInstance.from_ref(instance_ref)
         except Exception as err:
             raise DagstermillError(
                 "Error when attempting to resolve DagsterInstance from serialized InstanceRef"
             ) from err
 
-        pipeline_run = cast(DagsterRun, unpack_value(pipeline_run_dict))
+        dagster_run = unpack_value(pipeline_run_dict, DagsterRun)
 
         node_handle = NodeHandle.from_dict(node_handle_kwargs)
         op = pipeline_def.get_solid(node_handle)
@@ -160,20 +160,20 @@ class Manager:
         self.pipeline = pipeline
 
         resolved_run_config = ResolvedRunConfig.build(
-            pipeline_def, run_config, mode=pipeline_run.mode
+            pipeline_def, run_config, mode=dagster_run.mode
         )
 
         execution_plan = ExecutionPlan.build(
             self.pipeline,
             resolved_run_config,
-            step_keys_to_execute=pipeline_run.step_keys_to_execute,
+            step_keys_to_execute=dagster_run.step_keys_to_execute,
         )
 
         with scoped_pipeline_context(
             execution_plan,
             pipeline,
             run_config,
-            pipeline_run,
+            dagster_run,
             instance,
             scoped_resources_builder_cm=self._setup_resources,
             # Set this flag even though we're not in test for clearer error reporting


### PR DESCRIPTION
### Summary & Motivation

Consolidate APIs of `dagster._serdes` and update all callsites to use the new (typed) APIs.

Major change is the consolidation of the various `deserialize/serialize/pack/unpack` functions used throughout the codebase into just 4 module-public functions, which incorporate typing:

- `deserialize_value`
- `serialize_value`
- `unpack_value`
- `pack_value`

`*_value` was used as opposed to bare e.g. `deserialize` because `serialize_value` and `deserialize_value` are part of our public API. This PR does not break the existing contract of those functions but does add some optional args to them.

There is a significant companion PR for internal here: https://github.com/dagster-io/internal/pull/4974

### How I Tested These Changes

BK
