### PR TITLE
[bugfix] Make assets downstream of partitions never stale in dagit

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -581,7 +581,9 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_projectedLogicalVersion(self, _graphene_info: ResolveInfo) -> Optional[str]:
         if (
             self.external_asset_node.is_source
-            or self.external_asset_node.partitions_def_data is not None
+            or self.stale_status_loader.is_partitioned_or_downstream(
+                self.external_asset_node.asset_key
+            )
         ):
             return None
         else:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
@@ -131,7 +131,7 @@ def test_partitioned_self_dep():
             assert result
             assert result.data
             assert _get_asset_node("a", result)["projectedLogicalVersion"] is None
-            assert _get_asset_node("b", result)["projectedLogicalVersion"] == "UNKNOWN"
+            assert _get_asset_node("b", result)["projectedLogicalVersion"] is None
 
 
 def _materialize_assets(


### PR DESCRIPTION
### Summary & Motivation

Adjusts GQL resolver to return `None` for the projected logical version of any asset downstream of a partitioned asset. This will cause the asset to never be marked stale in dagit (the correct stale status is currently undefined for this case).

Also removes a chunk of leftover unreachable code.

### How I Tested These Changes

Modified unit test
