### PR TITLE
Bump typing-extensions dep to >=4.4.0

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -88,7 +88,7 @@ setup(
         "tabulate",
         "tomli",
         "tqdm",
-        "typing_extensions>=4.0.1",
+        "typing_extensions>=4.4.0",
         "sqlalchemy>=1.0,<2.0.0",
         "toposort>=1.0",
         "watchdog>=0.8.3",


### PR DESCRIPTION
### Summary & Motivation

This allows for use of `TypeVar` defaults.

### How I Tested These Changes

BK
