### PR TITLE
[fix] Correctly resolve asset jobs with empty selections

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_group.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_group.py
@@ -351,7 +351,7 @@ class AssetGroup:
 
     def materialize(
         self,
-        selection: Optional[Union[str, Sequence[str]]] = None,
+        selection: Optional[Union[str, Sequence[str]]] = "*",
         run_config: Optional[Any] = None,
     ) -> "ExecuteInProcessResult":
         """

--- a/python_modules/dagster/dagster/_core/definitions/asset_group.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_group.py
@@ -139,7 +139,7 @@ class AssetGroup:
     def build_job(
         self,
         name: str,
-        selection: Optional[Union[str, Sequence[str]]] = None,
+        selection: Optional[Union[str, Sequence[str]]] = "*",
         executor_def: Optional[ExecutorDefinition] = None,
         tags: Optional[Mapping[str, Any]] = None,
         description: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -759,7 +759,7 @@ def build_asset_selection_job(
         build_source_asset_observation_job,
     )
 
-    if asset_selection:
+    if asset_selection is not None:
         (included_assets, excluded_assets) = _subset_assets_defs(assets, asset_selection)
         included_source_assets = _subset_source_assets(source_assets, asset_selection)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
@@ -407,7 +407,7 @@ def test_asset_group_build_subset_job_errors(job_selection, use_multi, expected_
 @pytest.mark.parametrize(
     "job_selection,expected_assets",
     [
-        (None, "a,b,c"),
+        ("*", "a,b,c"),
         ("a+", "a,b"),
         ("+c", "b,c"),
         (["a", "c"], "a,c"),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -122,6 +122,17 @@ def test_asset_selection_subtraction(all_assets):
     assert sel.resolve(all_assets) == _asset_keys_of({bob})
 
 
+def test_asset_selection_nothing(all_assets):
+    sel = AssetSelection.keys()
+    assert sel.resolve(all_assets) == set()
+
+    sel = AssetSelection.groups("ladies") - AssetSelection.groups("ladies")
+    assert sel.resolve(all_assets) == set()
+
+    sel = AssetSelection.keys("alice", "bob") - AssetSelection.keys("alice", "bob")
+    assert sel.resolve(all_assets) == set()
+
+
 def test_asset_selection_sinks(all_assets):
     sel = AssetSelection.keys("alice", "bob").sinks()
     assert sel.resolve(all_assets) == _asset_keys_of({bob})

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1,6 +1,5 @@
 import os
 import warnings
-from dagster._core.definitions.asset_selection import AssetSelection
 
 import pytest
 from dagster import (
@@ -34,6 +33,7 @@ from dagster import (
 )
 from dagster._config import StringSource
 from dagster._core.definitions import AssetGroup, AssetIn, SourceAsset, asset, build_assets_job
+from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets_job import get_base_asset_jobs
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.executor_definition import in_process_executor


### PR DESCRIPTION
### Summary & Motivation

Previously, when an AssetSelection that resolved to an empty set was passed into define_asset_job, the generated job would select all assets, rather than none of them. Classic case of checking for `if foo` instead of `if foo is None`.

### How I Tested These Changes

The test added to test_assets_job.py failed before, and passes now.
