### PR TITLE
dynamic partitions toy

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/dynamic_asset_partitions.py
+++ b/python_modules/dagster-test/dagster_test/toys/dynamic_asset_partitions.py
@@ -1,0 +1,30 @@
+from dagster import (
+    AssetSelection,
+    Definitions,
+    DynamicPartitionsDefinition,
+    asset,
+    define_asset_job,
+    load_assets_from_current_module,
+)
+
+customers_partitions_def = DynamicPartitionsDefinition(name="customers")
+
+
+@asset(partitions_def=customers_partitions_def, group_name="dynamic_asset_partitions")
+def dynamic_partitions_asset1():
+    ...
+
+
+@asset(partitions_def=customers_partitions_def, group_name="dynamic_asset_partitions")
+def dynamic_partitions_asset2(dynamic_partitions_asset1):
+    ...
+
+
+dynamic_partitions_job = define_asset_job(
+    "dynamic_partitions_job",
+    selection=AssetSelection.groups("dynamic_asset_partitions"),
+    partitions_def=customers_partitions_def,
+)
+
+
+defs = Definitions(assets=load_assets_from_current_module(), jobs=[dynamic_partitions_job])

--- a/python_modules/dagster-test/dagster_test_tests/test_dynamic_asset_partitions.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_dynamic_asset_partitions.py
@@ -1,0 +1,24 @@
+from dagster import DagsterInstance, load_assets_from_modules, materialize_to_memory
+from dagster_test.toys import dynamic_asset_partitions
+from dagster_test.toys.dynamic_asset_partitions import (
+    customers_partitions_def,
+    defs,
+)
+
+
+def test_assets():
+    assets = load_assets_from_modules([dynamic_asset_partitions])
+
+    with DagsterInstance.ephemeral() as instance:
+        customers_partitions_def.add_partitions(["pepsi", "coca_cola"], instance=instance)
+        assert materialize_to_memory(assets, partition_key="pepsi", instance=instance).success
+
+
+def test_job():
+    with DagsterInstance.ephemeral() as instance:
+        customers_partitions_def.add_partitions(["pepsi", "coca_cola"], instance=instance)
+        assert (
+            defs.get_job_def("dynamic_partitions_job")
+            .execute_in_process(partition_key="pepsi", instance=instance)
+            .success
+        )


### PR DESCRIPTION
### Summary & Motivation

You can run this with
```
dagit -f python_modules/dagster-test/dagster_test/toys/dynamic_asset_partitions.py
```

from the repo root

### How I Tested These Changes

Did the above ^