### PR TITLE
[pythonic config] Add test showcasing use of Pydantic validators

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_validation.py
@@ -1,7 +1,7 @@
-from dagster import op, job
+import pytest
+from dagster import job, op
 from dagster._config.structured_config import Config
 from pydantic import ValidationError, validator
-import pytest
 
 
 def test_validators_basic() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_validation.py
@@ -1,0 +1,65 @@
+from dagster import op, job
+from dagster._config.structured_config import Config
+from pydantic import ValidationError, validator
+import pytest
+
+
+def test_validators_basic() -> None:
+    # showcase that Pydantic validators work as expected
+
+    class UserConfig(Config):
+        name: str
+        username: str
+
+        @validator("name")
+        def name_must_contain_space(cls, v):
+            if " " not in v:
+                raise ValueError("must contain a space")
+            return v.title()
+
+        @validator("username")
+        def username_alphanumeric(cls, v):
+            assert v.isalnum(), "must be alphanumeric"
+            return v
+
+    executed = {}
+
+    @op
+    def greet_user(config: UserConfig) -> None:
+        print(f"Hello {config.name}!")
+        executed["greet_user"] = True
+
+    @job
+    def greet_user_job() -> None:
+        greet_user()
+
+    # Ensure construction-time validation works
+    UserConfig(name="Arthur Miller", username="arthur")
+    with pytest.raises(ValidationError, match="must be alphanumeric"):
+        UserConfig(name="Arthur Miller", username="arthur invalid")
+    with pytest.raises(ValidationError, match="must contain a space"):
+        UserConfig(name="Arthur", username="arthur")
+
+    # Ensure execution-time validation works
+    assert greet_user_job.execute_in_process(
+        {"ops": {"greet_user": {"config": {"name": "Arthur Miller", "username": "arthur"}}}}
+    ).success
+    assert executed["greet_user"]
+
+    executed.clear()
+    with pytest.raises(ValidationError, match="must be alphanumeric"):
+        greet_user_job.execute_in_process(
+            {
+                "ops": {
+                    "greet_user": {
+                        "config": {"name": "Arthur Miller", "username": "arthur invalid"}
+                    }
+                }
+            }
+        )
+    assert not executed
+    with pytest.raises(ValidationError, match="must contain a space"):
+        greet_user_job.execute_in_process(
+            {"ops": {"greet_user": {"config": {"name": "Arthur", "username": "arthur"}}}}
+        )
+    assert not executed


### PR DESCRIPTION
## Summary

Introduces test coverage validating that Pydantic [validators](https://docs.pydantic.dev/usage/validators/) work as expected.


## Test Plan

Unit test. Tested manually in launchpad - the error here shows up when the run starts. Eventually, it would be good if this validation would show up in the launchpad itself.

![Screen Shot 2023-03-06 at 10 01 32 AM](https://user-images.githubusercontent.com/10215173/223193134-b8f91c36-4597-462a-9885-ecdc23506f24.png)
