### PR TITLE
Booleans that check permissions for specific objects and automatically incorporate per-location checks

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1217,6 +1217,9 @@ type Run implements PipelineRun {
   startTime: Float
   endTime: Float
   updateTime: Float
+  hasReExecutePermission: Boolean!
+  hasTerminatePermission: Boolean!
+  hasDeletePermission: Boolean!
 }
 
 type SelectorTypeConfigError implements PipelineConfigValidationError {
@@ -2117,6 +2120,8 @@ type InstigationState {
   ): [InstigationTick!]!
   nextTick: DryRunInstigationTick
   runningCount: Int!
+  hasStartPermission: Boolean!
+  hasStopPermission: Boolean!
 }
 
 enum InstigationType {
@@ -2342,6 +2347,7 @@ type PartitionBackfill {
   error: PythonError
   partitionStatuses: PartitionStatuses!
   partitionStatusCounts: [PartitionStatusCounts!]!
+  hasCancelPermission: Boolean!
 }
 
 enum BulkActionStatus {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1496,6 +1496,8 @@ export type InstigationSelector = {
 
 export type InstigationState = {
   __typename: 'InstigationState';
+  hasStartPermission: Scalars['Boolean'];
+  hasStopPermission: Scalars['Boolean'];
   id: Scalars['ID'];
   instigationType: InstigationType;
   name: Scalars['String'];
@@ -2151,6 +2153,7 @@ export type PartitionBackfill = {
   backfillId: Scalars['String'];
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean'];
+  hasCancelPermission: Scalars['Boolean'];
   isValidSerialization: Scalars['Boolean'];
   numCancelable: Scalars['Int'];
   numPartitions: Scalars['Int'];
@@ -2868,6 +2871,9 @@ export type Run = PipelineRun & {
   endTime: Maybe<Scalars['Float']>;
   eventConnection: EventConnection;
   executionPlan: Maybe<ExecutionPlan>;
+  hasDeletePermission: Scalars['Boolean'];
+  hasReExecutePermission: Scalars['Boolean'];
+  hasTerminatePermission: Scalars['Boolean'];
   id: Scalars['ID'];
   jobName: Scalars['String'];
   mode: Scalars['String'];

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -114,6 +114,8 @@ query getScheduleState($scheduleSelector: ScheduleSelector!) {
         id
         selectorId
         status
+        hasStartPermission
+        hasStopPermission
       }
     }
   }
@@ -801,6 +803,9 @@ def test_start_schedule_with_default_status(graphql_context):
 
     assert result.data["scheduleOrError"]["scheduleState"]["status"] == "RUNNING"
 
+    assert result.data["scheduleOrError"]["scheduleState"]["hasStartPermission"] is True
+    assert result.data["scheduleOrError"]["scheduleState"]["hasStopPermission"] is True
+
     # Start a single schedule
     start_result = execute_dagster_graphql(
         graphql_context,
@@ -868,6 +873,9 @@ class TestSchedulePermissions(ReadonlyGraphQLContextTestMatrix):
             GET_SCHEDULE_STATE_QUERY,
             variables={"scheduleSelector": schedule_selector},
         )
+
+        assert result.data["scheduleOrError"]["scheduleState"]["hasStartPermission"] is False
+        assert result.data["scheduleOrError"]["scheduleState"]["hasStopPermission"] is False
 
         schedule_origin_id = result.data["scheduleOrError"]["scheduleState"]["id"]
         schedule_selector_id = result.data["scheduleOrError"]["scheduleState"]["selectorId"]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -137,6 +137,8 @@ query SensorStateQuery($sensorSelector: SensorSelector!) {
         id
         status
         selectorId
+        hasStartPermission
+        hasStopPermission
       }
     }
   }
@@ -540,6 +542,10 @@ class TestReadonlySensorPermissions(ReadonlyGraphQLContextTestMatrix):
             GET_SENSOR_STATUS_QUERY,
             variables={"sensorSelector": sensor_selector},
         )
+
+        assert result.data["sensorOrError"]["sensorState"]["hasStartPermission"] is False
+        assert result.data["sensorOrError"]["sensorState"]["hasStopPermission"] is False
+
         sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
         sensor_selector_id = result.data["sensorOrError"]["sensorState"]["selectorId"]
 
@@ -651,6 +657,9 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         assert result.data["sensorOrError"]["sensorState"]["status"] == "RUNNING"
         sensor_origin_id = result.data["sensorOrError"]["sensorState"]["id"]
         sensor_selector_id = result.data["sensorOrError"]["sensorState"]["selectorId"]
+
+        assert result.data["sensorOrError"]["sensorState"]["hasStartPermission"] is True
+        assert result.data["sensorOrError"]["sensorState"]["hasStopPermission"] is True
 
         start_result = execute_dagster_graphql(
             graphql_context,


### PR DESCRIPTION
These help the frontend validate per-location permissions for objects that might no longer be associated with a specific code location.