### PR TITLE
Add support for loading multiple modules from pyproject.toml

### DIFF
--- a/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
+++ b/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
@@ -60,6 +60,13 @@ Instead of this:
 dagster dev -m your_module_name
 ```
 
+You can also include multiple modules at a time using the `pyproject.toml` file, where each module will be loaded as a code location:
+
+```toml
+[tool.dagster]
+module_name = ["your_module_name", "you_second_module_name"]  ## names of project's Python modules
+```
+
 ---
 
 </TabItem>

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/multiple_modules.toml
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/multiple_modules.toml
@@ -1,0 +1,3 @@
+[tool.dagster]
+
+module_name = ["baaz", "foo"]

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -2,6 +2,13 @@ from dagster._core.workspace.load_target import get_origins_from_toml
 from dagster._utils import file_relative_path
 
 
+def test_load_multiple_python_modules_from_toml():
+    origins = get_origins_from_toml(file_relative_path(__file__, "multiple_modules.toml"))
+    assert len(origins) == 2
+    assert origins[0].loadable_target_origin.module_name == "baaz"
+    assert origins[1].loadable_target_origin.module_name == "foo"
+
+
 def test_load_python_module_from_toml():
     origins = get_origins_from_toml(file_relative_path(__file__, "single_module.toml"))
     assert len(origins) == 1


### PR DESCRIPTION
### Summary & Motivation
It would be nice to load multiple modules using `pyproject.toml` so users don't have to type out all the modules they want to load using the CLI command. See issue #11439 and discussion #11167.

### How I Tested These Changes
I added a new unit test in `dagster_tests/cli_tests/test_toml_loading.py`
