### PR TITLE
[refactor] MayHaveInstanceWeakRef error on access non-existent _instance

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -214,6 +214,9 @@ class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
     def __init__(self):
         self._instance_weakref = None
 
+    def _has_instance(self) -> bool:
+        return hasattr(self, "_instance_weakref") and self._instance_weakref is not None
+
     @property
     def _instance(self) -> T_DagsterInstance:
         instance = (
@@ -223,7 +226,12 @@ class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
             if (hasattr(self, "_instance_weakref") and self._instance_weakref is not None)
             else None
         )
-        return cast(T_DagsterInstance, instance)
+        if instance is None:
+            raise DagsterInvariantViolationError(
+                "Attempted to resolve undefined DagsterInstance weakref."
+            )
+        else:
+            return instance
 
     def register_instance(self, instance: T_DagsterInstance):
         check.invariant(


### PR DESCRIPTION
### Summary & Motivation

Currently the `MayHaveInstanceWeakref` class can return `None` when
attempting to access the associated instance if no `_instance_weakref`
is defined. This is the source of many type errors, as most (all?) callsites
assume a `DagsterInstance` return value.

This PR:

- updates `MayHaveInstanceWeakRef._instance` to always return a `DagsterInstance`, and error where previously it would return `None`.
- Adds a `_has_instance` predicate method to check if the instance weakref is defined.

### How I Tested These Changes

BK
