### PR TITLE
[fix][dagster-fivetran][dagster-airbyte] Correctly type ingestion outs as Nothing for I/O managers

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -25,6 +25,7 @@ from dagster import (
     AssetKey,
     AssetOut,
     FreshnessPolicy,
+    Nothing,
     Output,
     ResourceDefinition,
     _check as check,
@@ -154,6 +155,7 @@ def _build_airbyte_assets_from_metadata(
                 freshness_policy=assets_defn_meta.freshness_policies_by_output_name.get(k)
                 if assets_defn_meta.freshness_policies_by_output_name
                 else None,
+                dagster_type=Nothing,
             )
             for k, v in (assets_defn_meta.keys_by_output_name or {}).items()
         },

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -1,9 +1,13 @@
+from typing import Any
+
 import pytest
 import responses
 from dagster import (
     AssetKey,
     FreshnessPolicy,
+    InputContext,
     IOManager,
+    OutputContext,
     asset,
     build_init_resource_context,
     io_manager,
@@ -46,12 +50,13 @@ def test_load_from_instance(
     load_calls = []
 
     @io_manager
-    def test_io_manager(_context):
+    def test_io_manager(_context) -> IOManager:
         class TestIOManager(IOManager):
-            def handle_output(self, context, obj):
+            def handle_output(self, context: OutputContext, obj) -> None:
+                assert context.dagster_type.is_nothing
                 return
 
-            def load_input(self, context):
+            def load_input(self, context: InputContext) -> Any:
                 load_calls.append(context.asset_key)
                 return None
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -8,6 +8,7 @@ from dagster import (
     AssetKey,
     AssetOut,
     AssetsDefinition,
+    Nothing,
     Output,
     _check as check,
     multi_asset,
@@ -63,6 +64,7 @@ def _build_fivetran_assets(
                 io_manager_key=io_manager_key,
                 key=user_facing_asset_keys[table],
                 metadata=_metadata_by_table_name.get(table),
+                dagster_type=Nothing,
             )
             for table, key in tracked_asset_keys.items()
         },

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -9,6 +9,7 @@ from dagster import (
     AssetOut,
     AssetsDefinition,
     Nothing,
+    OpExecutionContext,
     Output,
     _check as check,
     multi_asset,
@@ -20,8 +21,9 @@ from dagster._core.definitions.cacheable_assets import (
 )
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.load_assets_from_modules import with_group
-from dagster._core.definitions.metadata import MetadataUserInput
+from dagster._core.definitions.metadata import MetadataEntry, MetadataUserInput
 from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.errors import DagsterStepOutputNotFoundError
 from dagster._core.execution.context.init import build_init_resource_context
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
@@ -74,7 +76,7 @@ def _build_fivetran_assets(
         group_name=group_name,
         op_tags=op_tags,
     )
-    def _assets(context):
+    def _assets(context: OpExecutionContext) -> Any:
         fivetran_output = context.resources.fivetran.sync_and_poll(
             connector_id=connector_id,
             poll_interval=poll_interval,
@@ -92,7 +94,8 @@ def _build_fivetran_assets(
                     value=None,
                     output_name="_".join(materialization.asset_key.path),
                     metadata={
-                        entry.label: entry.entry_data for entry in materialization.metadata_entries
+                        cast(MetadataEntry, entry).label: cast(MetadataEntry, entry).entry_data
+                        for entry in materialization.metadata_entries
                     },
                 )
                 materialized_asset_keys.add(materialization.asset_key)
@@ -101,11 +104,24 @@ def _build_fivetran_assets(
                 yield materialization
 
         unmaterialized_asset_keys = set(tracked_asset_keys.values()) - materialized_asset_keys
-        if unmaterialized_asset_keys and infer_missing_tables:
+        if infer_missing_tables:
             for asset_key in unmaterialized_asset_keys:
                 yield Output(
                     value=None,
                     output_name="_".join(asset_key.path),
+                )
+
+        else:
+            if unmaterialized_asset_keys:
+                asset_key = list(unmaterialized_asset_keys)[0]
+                output_name = "_".join(asset_key.path)
+                raise DagsterStepOutputNotFoundError(
+                    (
+                        f"Core compute for {context.op_def.name} did not return an output for"
+                        f' non-optional output "{output_name}".'
+                    ),
+                    step_key=context.get_step_execution_context().step.key,
+                    output_name=output_name,
                 )
 
     return [_assets]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
@@ -1,6 +1,17 @@
+from typing import Any
+
 import pytest
 import responses
-from dagster import AssetIn, AssetKey, IOManager, asset, build_init_resource_context, io_manager
+from dagster import (
+    AssetIn,
+    AssetKey,
+    InputContext,
+    IOManager,
+    OutputContext,
+    asset,
+    build_init_resource_context,
+    io_manager,
+)
 from dagster._core.definitions.assets_job import build_assets_job
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
@@ -36,12 +47,13 @@ def test_load_from_instance(connector_to_group_fn, filter_connector, connector_t
     load_calls = []
 
     @io_manager
-    def test_io_manager(_context):
+    def test_io_manager(_context) -> IOManager:
         class TestIOManager(IOManager):
-            def handle_output(self, context, obj):
+            def handle_output(self, context: OutputContext, obj) -> None:
+                assert context.dagster_type.is_nothing
                 return
 
-            def load_input(self, context):
+            def load_input(self, context: InputContext) -> Any:
                 load_calls.append(context.asset_key)
                 return None
 


### PR DESCRIPTION
## Summary

Attach `Nothing` types to the outputs of `dagster-fivetran` and `dagster-airbyte` sync ops, to ensure that our I/O managers handle them properly. Currently, these outputs are untyped, which leads to e.g. the DB I/O managers complaining that `None` is output.

See this user report: https://dagster.slack.com/archives/C01U954MEER/p1677338017299429


## Test Plan

Update tests to assert that output types are `None` as expected.