### PR TITLE
[1.2] Remove legacy asset key format from queries

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 
 ASSET_KEY_SPLIT_REGEX = re.compile("[^a-zA-Z0-9_]")
 ASSET_KEY_DELIMITER = "/"
-ASSET_KEY_LEGACY_DELIMITER = "."
 
 
 def parse_asset_key_string(s: str) -> Sequence[str]:
@@ -112,12 +111,10 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
                 return False
         return True
 
-    def to_string(self, legacy: Optional[bool] = False) -> str:
+    def to_string(self) -> str:
         """
         E.g. '["first_component", "second_component"]'.
         """
-        if legacy:
-            return ASSET_KEY_LEGACY_DELIMITER.join(self.path)
         return seven.json.dumps(self.path)
 
     def to_user_string(self) -> str:
@@ -156,10 +153,8 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
         return AssetKey(path)
 
     @staticmethod
-    def get_db_prefix(path: Sequence[str], legacy: Optional[bool] = False):
+    def get_db_prefix(path: Sequence[str]):
         check.sequence_param(path, "path", of_type=str)
-        if legacy:
-            return ASSET_KEY_LEGACY_DELIMITER.join(path)
         return seven.json.dumps(path)[:-2]  # strip trailing '"]' from json string
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/migration.py
@@ -121,10 +121,7 @@ def migrate_asset_keys_index_columns(event_log_storage, print_fn=None):
                 materialization_query = (
                     db.select([SqlEventLogStorageTable.c.event])
                     .where(
-                        db.or_(
-                            SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
-                            SqlEventLogStorageTable.c.asset_key == asset_key.to_string(legacy=True),
-                        )
+                        SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
                     )
                     .order_by(SqlEventLogStorageTable.c.timestamp.desc())
                     .limit(1)

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1704,10 +1704,7 @@ class SqlEventLogStorage(EventLogStorage):
             )
             .where(
                 db.and_(
-                    db.or_(
-                        SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
-                        SqlEventLogStorageTable.c.asset_key == asset_key.to_string(legacy=True),
-                    ),
+                    SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
                     SqlEventLogStorageTable.c.partition != None,  # noqa: E711
                 )
             )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -387,10 +387,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         with self.index_connection() as conn:
             conn.execute(
                 SqlEventLogStorageTable.delete().where(  # pylint: disable=no-value-for-parameter
-                    db.or_(
-                        SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
-                        SqlEventLogStorageTable.c.asset_key == asset_key.to_string(legacy=True),
-                    )
+                    SqlEventLogStorageTable.c.asset_key == asset_key.to_string(),
                 )
             )
 


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/10240

This PR removes support for the legacy asset key serialization (path joined by `'.'`). Users who were using assets prior to `0.10.0` may be affected. For these users, we'll direct them to reach out to us for a data migration.

