### PR TITLE
Tag Selector Component

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
@@ -15,16 +15,21 @@ export default {
   component: TagSelector,
 } as Meta;
 
-const allTags = ['NY', 'NJ', 'VC', 'FL', 'AL', 'CA'];
+const allTags = [
+  'NY',
+  'NJ',
+  'VC',
+  'FL',
+  'AL',
+  'CALIFORNIA_SUPER_LONG_TAG',
+  'ANOTHER_REALLY_LONG_TAG',
+  'LONG_TAGS_ARE_GREAT_FOR_TESTING_DECEMBER_2020',
+];
 
 export const Basic = () => {
   const [selectedTags, setSelectedTags] = React.useState<string[]>(['NY', 'NJ']);
   return (
-    <TagSelector
-      allTags={['NY', 'NJ', 'VC', 'FL', 'AL', 'CA']}
-      selectedTags={selectedTags}
-      setSelectedTags={setSelectedTags}
-    />
+    <TagSelector allTags={allTags} selectedTags={selectedTags} setSelectedTags={setSelectedTags} />
   );
 };
 
@@ -36,6 +41,7 @@ export const Styled = () => {
       allTags={['NY', 'NJ', 'VC', 'FL', 'AL', 'CA']}
       selectedTags={selectedTags}
       setSelectedTags={setSelectedTags}
+      placeholder="Select a partition or create one"
       renderDropdownItem={(tag, dropdownItemProps) => {
         return (
           <MenuItem
@@ -82,6 +88,12 @@ export const Styled = () => {
             </Box>
           </Menu>
         );
+      }}
+      renderTagList={(tags) => {
+        if (tags.length > 3) {
+          return <span>{tags.length} partitions selected</span>;
+        }
+        return tags;
       }}
     />
   );

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
@@ -46,6 +46,7 @@ export const Styled = () => {
         return (
           <label>
             <MenuItem
+              tagName="div"
               text={
                 <Box flex={{alignItems: 'center', gap: 12}}>
                   <Checkbox
@@ -80,6 +81,7 @@ export const Styled = () => {
               <MenuDivider />
               <label>
                 <MenuItem
+                  tagName="div"
                   text={
                     <Box flex={{alignItems: 'center', gap: 8}}>
                       <Checkbox checked={isAllSelected} onChange={toggleAll} />

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
@@ -44,18 +44,20 @@ export const Styled = () => {
       placeholder="Select a partition or create one"
       renderDropdownItem={(tag, dropdownItemProps) => {
         return (
-          <MenuItem
-            text={
-              <Box as="label" flex={{alignItems: 'center', gap: 12}}>
-                <Checkbox
-                  checked={dropdownItemProps.selected}
-                  onChange={dropdownItemProps.toggle}
-                />
-                <Dot color={Math.random() > 0.5 ? Colors.Green500 : Colors.Gray500} />
-                <span>{tag}</span>
-              </Box>
-            }
-          />
+          <label>
+            <MenuItem
+              text={
+                <Box flex={{alignItems: 'center', gap: 12}}>
+                  <Checkbox
+                    checked={dropdownItemProps.selected}
+                    onChange={dropdownItemProps.toggle}
+                  />
+                  <Dot color={Math.random() > 0.5 ? Colors.Green500 : Colors.Gray500} />
+                  <span>{tag}</span>
+                </Box>
+              }
+            />
+          </label>
         );
       }}
       renderDropdown={(dropdown) => {
@@ -76,14 +78,16 @@ export const Styled = () => {
                 </Box>
               </Box>
               <MenuDivider />
-              <MenuItem
-                text={
-                  <Box as="label" flex={{alignItems: 'center', gap: 8}}>
-                    <Checkbox checked={isAllSelected} onChange={toggleAll} />
-                    <span>Select All ({allTags.length})</span>
-                  </Box>
-                }
-              />
+              <label>
+                <MenuItem
+                  text={
+                    <Box flex={{alignItems: 'center', gap: 8}}>
+                      <Checkbox checked={isAllSelected} onChange={toggleAll} />
+                      <span>Select All ({allTags.length})</span>
+                    </Box>
+                  }
+                />
+              </label>
               {dropdown}
             </Box>
           </Menu>

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
@@ -38,7 +38,7 @@ export const Styled = () => {
   const isAllSelected = selectedTags.length === 6;
   return (
     <TagSelector
-      allTags={['NY', 'NJ', 'VC', 'FL', 'AL', 'CA']}
+      allTags={allTags}
       selectedTags={selectedTags}
       setSelectedTags={setSelectedTags}
       placeholder="Select a partition or create one"

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.stories.tsx
@@ -1,0 +1,100 @@
+import {Meta} from '@storybook/react/types-6-0';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+
+import {Box} from './Box';
+import {Checkbox} from './Checkbox';
+import {Colors} from './Colors';
+import {Icon} from './Icon';
+import {Menu, MenuDivider, MenuItem} from './Menu';
+import {TagSelector} from './TagSelector';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'TagSelector',
+  component: TagSelector,
+} as Meta;
+
+const allTags = ['NY', 'NJ', 'VC', 'FL', 'AL', 'CA'];
+
+export const Basic = () => {
+  const [selectedTags, setSelectedTags] = React.useState<string[]>(['NY', 'NJ']);
+  return (
+    <TagSelector
+      allTags={['NY', 'NJ', 'VC', 'FL', 'AL', 'CA']}
+      selectedTags={selectedTags}
+      setSelectedTags={setSelectedTags}
+    />
+  );
+};
+
+export const Styled = () => {
+  const [selectedTags, setSelectedTags] = React.useState<string[]>(allTags.slice(0, 2));
+  const isAllSelected = selectedTags.length === 6;
+  return (
+    <TagSelector
+      allTags={['NY', 'NJ', 'VC', 'FL', 'AL', 'CA']}
+      selectedTags={selectedTags}
+      setSelectedTags={setSelectedTags}
+      renderDropdownItem={(tag, dropdownItemProps) => {
+        return (
+          <MenuItem
+            text={
+              <Box as="label" flex={{alignItems: 'center', gap: 12}}>
+                <Checkbox
+                  checked={dropdownItemProps.selected}
+                  onChange={dropdownItemProps.toggle}
+                />
+                <Dot color={Math.random() > 0.5 ? Colors.Green500 : Colors.Gray500} />
+                <span>{tag}</span>
+              </Box>
+            }
+          />
+        );
+      }}
+      renderDropdown={(dropdown) => {
+        const toggleAll = () => {
+          if (isAllSelected) {
+            setSelectedTags([]);
+          } else {
+            setSelectedTags(allTags);
+          }
+        };
+        return (
+          <Menu>
+            <Box padding={4}>
+              <Box flex={{direction: 'column'}} padding={{horizontal: 8}}>
+                <Box flex={{direction: 'row', alignItems: 'center'}}>
+                  <StyledIcon name="add" size={24} />
+                  <span>Create Partition</span>
+                </Box>
+              </Box>
+              <MenuDivider />
+              <MenuItem
+                text={
+                  <Box as="label" flex={{alignItems: 'center', gap: 8}}>
+                    <Checkbox checked={isAllSelected} onChange={toggleAll} />
+                    <span>Select All ({allTags.length})</span>
+                  </Box>
+                }
+              />
+              {dropdown}
+            </Box>
+          </Menu>
+        );
+      }}
+    />
+  );
+};
+
+const StyledIcon = styled(Icon)`
+  font-weight: 500;
+`;
+
+const Dot = styled.div<{color: string}>`
+  width: 8px;
+  height: 8px;
+  border-radius: 4px;
+  background-color: ${({color}) => color};
+  display: inline-block;
+`;

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
@@ -8,9 +8,10 @@ import {Icon} from './Icon';
 import {MenuItem, Menu} from './Menu';
 import {Popover} from './Popover';
 import {Tag} from './Tag';
+import {TextInputStyles} from './TextInput';
 
 type TagProps = {
-  close: (ev: React.SyntheticEvent<HTMLDivElement>) => void;
+  remove: (ev: React.SyntheticEvent<HTMLDivElement>) => void;
 };
 type DropdownItemProps = {
   toggle: () => void;
@@ -33,7 +34,7 @@ const defaultRenderTag = (tag: string, tagProps: TagProps) => {
     <Tag>
       <Box flex={{direction: 'row', gap: 4, justifyContent: 'space-between', alignItems: 'center'}}>
         <span>{tag}</span>
-        <Box style={{cursor: 'pointer'}} onClick={tagProps.close}>
+        <Box style={{cursor: 'pointer'}} onClick={tagProps.remove}>
           <Icon name="close" />
         </Box>
       </Box>
@@ -51,6 +52,7 @@ const defaultRenderDropdownItem = (tag: string, dropdownItemProps: DropdownItemP
             <span>{tag}</span>
           </Box>
         }
+        tagName="div"
       />
     </label>
   );
@@ -105,7 +107,7 @@ export const TagSelector = ({
     }
     const tags = selectedTags.map((tag) =>
       (renderTag || defaultRenderTag)(tag, {
-        close: (ev) => {
+        remove: (ev) => {
           setSelectedTags((tags) => tags.filter((t) => t !== tag));
           ev.stopPropagation();
         },
@@ -119,7 +121,7 @@ export const TagSelector = ({
 
   return (
     <Popover
-      placement="bottom"
+      placement="bottom-start"
       isOpen={isDropdownOpen}
       onInteraction={(nextOpenState, e) => {
         const target = e?.target;
@@ -133,10 +135,7 @@ export const TagSelector = ({
       content={<div ref={dropdownContainer}>{dropdown}</div>}
       targetTagName="div"
     >
-      <Box
-        as={Container}
-        padding={{vertical: 4, horizontal: 6 as any}}
-        flex={{gap: 6, alignItems: 'center'}}
+      <Container
         onClick={() => {
           setIsDropdownOpen((isOpen) => !isOpen);
         }}
@@ -145,14 +144,17 @@ export const TagSelector = ({
         <div style={{cursor: 'pointer'}}>
           <Icon name={isDropdownOpen ? 'expand_less' : 'expand_more'} />
         </div>
-      </Box>
+      </Container>
     </Popover>
   );
 };
 
 const Container = styled.div`
-  border: 1px solid ${Colors.Gray300};
-  border-radius: 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  ${TextInputStyles}
 `;
 
 const Placeholder = styled.div`

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
@@ -22,9 +22,9 @@ type Props = {
   selectedTags: string[];
   setSelectedTags: (tags: React.SetStateAction<string[]>) => void;
   renderTag?: (tag: string, tagProps: TagProps) => React.ReactNode;
-  renderTagList?: (tags: React.ReactElement[]) => React.ReactNode;
-  renderDropdown?: (dropdown: React.ReactElement) => React.ReactNode;
-  renderDropdownItem?: (tag: string, dropdownItemProps: DropdownItemProps) => React.ReactElement;
+  renderTagList?: (tags: React.ReactNode[]) => React.ReactNode;
+  renderDropdown?: (dropdown: React.ReactNode) => React.ReactNode;
+  renderDropdownItem?: (tag: string, dropdownItemProps: DropdownItemProps) => React.ReactNode;
   dropdownStyles?: React.CSSProperties;
 };
 

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+
+import {Box} from './Box';
+import {Checkbox} from './Checkbox';
+import {Colors} from './Colors';
+import {Icon} from './Icon';
+import {MenuItem, Menu} from './Menu';
+import {Popover} from './Popover';
+import {Tag} from './Tag';
+
+type TagProps = {
+  close: (ev: React.SyntheticEvent<HTMLDivElement>) => void;
+};
+type DropdownItemProps = {
+  toggle: () => void;
+  selected: boolean;
+};
+type Props = {
+  allTags: string[];
+  selectedTags: string[];
+  setSelectedTags: (tags: React.SetStateAction<string[]>) => void;
+  renderTag?: (tag: string, tagProps: TagProps) => JSX.Element;
+  renderDropdown?: (dropdown: JSX.Element) => JSX.Element;
+  renderDropdownItem?: (tag: string, dropdownItemProps: DropdownItemProps) => JSX.Element;
+  dropdownStyles?: React.CSSProperties;
+};
+
+const defaultRenderTag = (tag: string, tagProps: TagProps) => {
+  return (
+    <Tag>
+      <Box flex={{direction: 'row', gap: 4, justifyContent: 'space-between', alignItems: 'center'}}>
+        <span>{tag}</span>
+        <Box style={{cursor: 'pointer'}} onClick={tagProps.close}>
+          <Icon name="close" />
+        </Box>
+      </Box>
+    </Tag>
+  );
+};
+
+const defaultRenderDropdownItem = (tag: string, dropdownItemProps: DropdownItemProps) => {
+  return (
+    <MenuItem
+      text={
+        <Box flex={{alignItems: 'center', gap: 8}}>
+          <Checkbox
+            checked={dropdownItemProps.selected}
+            onChange={() => {}}
+            onClick={(ev) => {
+              ev.stopPropagation();
+            }}
+          />
+          <span>{tag}</span>
+        </Box>
+      }
+      onClick={dropdownItemProps.toggle}
+    />
+  );
+};
+
+export const TagSelector = ({
+  allTags,
+  selectedTags,
+  setSelectedTags,
+  renderTag,
+  renderDropdownItem,
+  renderDropdown,
+  dropdownStyles,
+}: Props) => {
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const dropdown = React.useMemo(() => {
+    const dropdownContent = (
+      <Box
+        style={{
+          maxHeight: '500px',
+          overflowY: 'auto',
+          ...dropdownStyles,
+        }}
+      >
+        {allTags.map((tag) => {
+          const selected = selectedTags.includes(tag);
+          const toggle = () => {
+            setSelectedTags(
+              selected ? selectedTags.filter((t) => t !== tag) : [...selectedTags, tag],
+            );
+          };
+          if (renderDropdownItem) {
+            return <div key={tag}>{renderDropdownItem(tag, {toggle, selected})}</div>;
+          }
+          return defaultRenderDropdownItem(tag, {toggle, selected});
+        })}
+      </Box>
+    );
+    if (renderDropdown) {
+      return renderDropdown(dropdownContent);
+    }
+    return <Menu>{dropdownContent}</Menu>;
+  }, [allTags, dropdownStyles, renderDropdown, renderDropdownItem, selectedTags, setSelectedTags]);
+
+  const dropdownContainer = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <Popover
+      placement="bottom"
+      isOpen={isDropdownOpen}
+      onInteraction={(nextOpenState, e) => {
+        const target = e?.target;
+        if (isDropdownOpen && target instanceof HTMLElement) {
+          const isClickInside = dropdownContainer.current?.contains(target);
+          if (!isClickInside) {
+            setIsDropdownOpen(nextOpenState);
+          }
+        }
+      }}
+      content={<div ref={dropdownContainer}>{dropdown}</div>}
+      targetTagName="div"
+    >
+      <Box
+        as={Container}
+        padding={{vertical: 4, horizontal: 6 as any}}
+        flex={{gap: 6, alignItems: 'center'}}
+        onClick={() => {
+          setIsDropdownOpen((isOpen) => !isOpen);
+        }}
+      >
+        <Box flex={{grow: 1, gap: 6}}>
+          {selectedTags.map((tag) =>
+            (renderTag || defaultRenderTag)(tag, {
+              close: (ev) => {
+                setSelectedTags((tags) => tags.filter((t) => t !== tag));
+                ev.stopPropagation();
+              },
+            }),
+          )}
+        </Box>
+        <div style={{cursor: 'pointer'}}>
+          <Icon name={isDropdownOpen ? 'expand_less' : 'expand_more'} />
+        </div>
+      </Box>
+    </Popover>
+  );
+};
+
+const Container = styled.div`
+  border: 1px solid ${Colors.Gray300};
+  border-radius: 8px;
+`;

--- a/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
@@ -43,21 +43,16 @@ const defaultRenderTag = (tag: string, tagProps: TagProps) => {
 
 const defaultRenderDropdownItem = (tag: string, dropdownItemProps: DropdownItemProps) => {
   return (
-    <MenuItem
-      text={
-        <Box flex={{alignItems: 'center', gap: 8}}>
-          <Checkbox
-            checked={dropdownItemProps.selected}
-            onChange={() => {}}
-            onClick={(ev) => {
-              ev.stopPropagation();
-            }}
-          />
-          <span>{tag}</span>
-        </Box>
-      }
-      onClick={dropdownItemProps.toggle}
-    />
+    <label>
+      <MenuItem
+        text={
+          <Box flex={{alignItems: 'center', gap: 8}}>
+            <Checkbox checked={dropdownItemProps.selected} onChange={dropdownItemProps.toggle} />
+            <span>{tag}</span>
+          </Box>
+        }
+      />
+    </label>
   );
 };
 


### PR DESCRIPTION
### Summary & Motivation
Adding a Tag Selector component.

Considered using Blueprint's Multi-select component: https://blueprintjs.com/docs/versions/3/#select/multi-select but it has a few limitations:
1. We can't provide a collapsed view for all of the selected tags
2. We don't want to allow typing

### How I Tested These Changes

I played around with the component in Storybook. Created 2 examples, a basic one and a more advanced one using the render props.
<img width="1161" alt="Screen Shot 2023-02-27 at 2 54 00 PM" src="https://user-images.githubusercontent.com/2286579/221669263-83529f4c-5d57-4935-9a1a-acd2cf43d2e9.png">
<img width="1172" alt="Screen Shot 2023-02-27 at 2 53 56 PM" src="https://user-images.githubusercontent.com/2286579/221669265-0515f4c8-c6ef-4c76-904a-29a1499a558c.png">


