### PR TITLE
Fix ProgrammingError import in snowflake_io_manager 

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -10,7 +10,7 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
-from snowflake.connector import ProgrammingError
+from sqlalchemy.exc import ProgrammingError
 
 from .resources import SnowflakeConnection
 


### PR DESCRIPTION
### Summary & Motivation
I noticed that the `ProgrammingError` class is imported from Snowflake. It should have been from SQLAlchemy instead, as we are using the SQLAlchemy connector here as specified in lines 157-161
```python
            dict(
                schema=table_slice.schema,
                connector="sqlalchemy",
                **cast(Mapping[str, str], no_schema_config),
            ),
```

### How I Tested These Changes
I modified the file locally and tested with Dagit. It works in this way.