### PR TITLE
Update stale reasons to remove UNKNOWN, add MISSING

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -782,15 +782,16 @@ type DimensionPartitionKeys {
 }
 
 enum StaleStatus {
+  MISSING
   STALE
   FRESH
-  UNKNOWN
 }
 
 type StaleStatusCause {
   status: StaleStatus!
   key: AssetKey!
   reason: String!
+  dependency: AssetKey
 }
 
 enum EvaluationErrorReason {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3444,12 +3444,13 @@ export type SolidStepStatusUnavailableError = Error & {
 
 export enum StaleStatus {
   FRESH = 'FRESH',
+  MISSING = 'MISSING',
   STALE = 'STALE',
-  UNKNOWN = 'UNKNOWN',
 }
 
 export type StaleStatusCause = {
   __typename: 'StaleStatusCause';
+  dependency: Maybe<AssetKey>;
   key: AssetKey;
   reason: Scalars['String'];
   status: StaleStatus;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -87,6 +87,7 @@ class GrapheneAssetStaleStatusCause(graphene.ObjectType):
     status = graphene.NonNull(GrapheneAssetStaleStatus)
     key = graphene.NonNull(GrapheneAssetKey)
     reason = graphene.NonNull(graphene.String)
+    dependency = graphene.Field(GrapheneAssetKey)
 
     class Meta:
         name = "StaleStatusCause"
@@ -568,6 +569,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 cause.status,
                 GrapheneAssetKey(path=cause.key.path),
                 cause.reason,
+                GrapheneAssetKey(path=cause.dependency.path) if cause.dependency else None,
             )
             for cause in causes
         ]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -157,6 +157,7 @@ GET_ASSET_LOGICAL_VERSIONS = """
                 status
                 key { path }
                 reason
+                dependency { path }
             }
             assetMaterializations {
                 tags {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
@@ -70,9 +70,14 @@ def test_stale_status():
             result = _fetch_logical_versions(context, repo)
             foo = _get_asset_node("foo", result)
             assert foo["currentLogicalVersion"] is None
-            assert foo["staleStatus"] == "STALE"
+            assert foo["staleStatus"] == "MISSING"
             assert foo["staleStatusCauses"] == [
-                {"status": "STALE", "reason": "never materialized", "key": {"path": ["foo"]}}
+                {
+                    "status": "MISSING",
+                    "reason": "never materialized",
+                    "key": {"path": ["foo"]},
+                    "dependency": None,
+                }
             ]
 
             assert _materialize_assets(context, repo)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -34,7 +34,7 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, Run
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._scheduler.stale import resolve_stale_or_unknown_assets
+from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
 
@@ -629,7 +629,7 @@ def _evaluate_sensor(
 
     for run_request in sensor_runtime_data.run_requests:
         if run_request.stale_assets_only:
-            stale_assets = resolve_stale_or_unknown_assets(workspace_process_context, run_request, external_sensor)  # type: ignore
+            stale_assets = resolve_stale_or_missing_assets(workspace_process_context, run_request, external_sensor)  # type: ignore
             # asset selection is empty set after filtering for stale
             if len(stale_assets) == 0:
                 continue

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -35,7 +35,7 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, Run
 from dagster._core.storage.tags import RUN_KEY_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.telemetry import SCHEDULED_RUN_CREATED, hash_name, log_action
 from dagster._core.workspace.context import IWorkspaceProcessContext
-from dagster._scheduler.stale import resolve_stale_or_unknown_assets
+from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._seven.compat.pendulum import to_timezone
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.log import default_date_format_string
@@ -610,7 +610,7 @@ def _schedule_runs_at_time(
 
     for run_request in schedule_execution_data.run_requests:
         if run_request.stale_assets_only:
-            stale_assets = resolve_stale_or_unknown_assets(workspace_process_context, run_request, external_schedule)  # type: ignore
+            stale_assets = resolve_stale_or_missing_assets(workspace_process_context, run_request, external_schedule)  # type: ignore
             # asset selection is empty set after filtering for stale
             if len(stale_assets) == 0:
                 continue

--- a/python_modules/dagster/dagster/_scheduler/stale.py
+++ b/python_modules/dagster/dagster/_scheduler/stale.py
@@ -15,7 +15,7 @@ from dagster._core.host_representation.external import (
 from dagster._core.workspace.context import WorkspaceProcessContext
 
 
-def resolve_stale_or_unknown_assets(
+def resolve_stale_or_missing_assets(
     context: WorkspaceProcessContext,
     run_request: RunRequest,
     instigator: Union[ExternalSensor, ExternalSchedule],
@@ -29,6 +29,6 @@ def resolve_stale_or_unknown_assets(
     resolver = CachingStaleStatusResolver(context.instance, asset_graph)
     stale_or_unknown_keys: List[AssetKey] = []
     for asset_key in asset_selection:
-        if resolver.get_status(asset_key) in [StaleStatus.STALE, StaleStatus.UNKNOWN]:
+        if resolver.get_status(asset_key) in [StaleStatus.STALE, StaleStatus.MISSING]:
             stale_or_unknown_keys.append(asset_key)
     return stale_or_unknown_keys


### PR DESCRIPTION
### Summary & Motivation

Wrap up a few changes to stale status resolution. This should enable dagit to remove any remaining staleness logic and just display what it receives from the server.

- `MISSING` has been added as a stale status for assets that have never been materialized.
- `UNKNOWN` is no longer a defined stale reason-- all assets are `STALE`, `FRESH` or `MISSING`. Some nodes that would have previously been `UNKNOWN` are now `STALE` (non-code-versioned node with upstream dep changed, node with no provenance), others are `FRESH` (non-code-versioned node with upstream not changed)
- Partitioned assets or assets downstream of partitioned assets are only ever `MISSING` or `FRESH`. (This will change in the future.)
- `StaleStatusReason` now has an optional `dependency` field (null for code-version-related reasons), and the `reason` field is simpler. That allows the reason to be straightforwardly displayed in dagit.

### How I Tested These Changes

Added some new staleness tests
