### PR TITLE
[ui] Always show "Reload all" button

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/CodeLocationsPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/CodeLocationsPage.tsx
@@ -43,10 +43,10 @@ export const CodeLocationsPage = () => {
       <Box
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-        style={{height: '64px'}} // Preserve height whether "Reload all" is present or not
+        style={{height: '64px'}}
       >
         <Subheading id="repository-locations">{subheadingText()}</Subheading>
-        {entryCount > 1 ? <ReloadAllButton /> : null}
+        <ReloadAllButton />
       </Box>
       <RepositoryLocationsList />
     </>


### PR DESCRIPTION
### Summary & Motivation

Always show the "Reload all" button to avoid situations like: user has a single code location and is adding a second code location, and needs to reload in order for the location to appear.

### How I Tested These Changes

View code location page, verify that the "Reload all" button is present. Repeat with empty workspace, verify same.
