### PR TITLE
divest permissions for editing sensor from updating sensor cursor

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -11,6 +11,7 @@ export const EXPECTED_PERMISSIONS = {
   start_schedule: true,
   stop_running_schedule: true,
   edit_sensor: true,
+  update_sensor_cursor: true,
   terminate_pipeline_execution: true,
   delete_pipeline_run: true,
   reload_repository_location: true,
@@ -31,6 +32,7 @@ export type PermissionsFromJSON = {
   start_schedule?: PermissionResult;
   stop_running_schedule?: PermissionResult;
   edit_sensor?: PermissionResult;
+  update_sensor_cursor?: PermissionResult
   terminate_pipeline_execution?: PermissionResult;
   delete_pipeline_run?: PermissionResult;
   reload_repository_location?: PermissionResult;

--- a/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
+++ b/js_modules/dagit/packages/core/src/testing/TestProvider.tsx
@@ -24,6 +24,7 @@ export const PERMISSIONS_ALLOW_ALL: PermissionsFromJSON = {
   start_schedule: DEFAULT_PERMISSIONS,
   stop_running_schedule: DEFAULT_PERMISSIONS,
   edit_sensor: DEFAULT_PERMISSIONS,
+  update_sensor_cursor: DEFAULT_PERMISSIONS,
   terminate_pipeline_execution: DEFAULT_PERMISSIONS,
   delete_pipeline_run: DEFAULT_PERMISSIONS,
   reload_repository_location: DEFAULT_PERMISSIONS,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -152,11 +152,11 @@ class GrapheneStartSensorMutation(graphene.Mutation):
         name = "StartSensorMutation"
 
     @capture_error
-    @require_permission_check(Permissions.EDIT_SENSOR)
+    @require_permission_check(Permissions.UPDATE_SENSOR_CURSOR)
     def mutate(self, graphene_info: ResolveInfo, sensor_selector):
         selector = SensorSelector.from_graphql_input(sensor_selector)
         assert_permission_for_location(
-            graphene_info, Permissions.EDIT_SENSOR, selector.location_name
+            graphene_info, Permissions.UPDATE_SENSOR_CURSOR, selector.location_name
         )
         return start_sensor(graphene_info, selector)
 
@@ -217,7 +217,7 @@ class GrapheneSetSensorCursorMutation(graphene.Mutation):
     def mutate(self, graphene_info: ResolveInfo, sensor_selector, cursor=None):
         selector = SensorSelector.from_graphql_input(sensor_selector)
         assert_permission_for_location(
-            graphene_info, Permissions.EDIT_SENSOR, selector.location_name
+            graphene_info, Permissions.UPDATE_SENSOR_CURSOR, selector.location_name
         )
         return set_sensor_cursor(graphene_info, selector, cursor)
 

--- a/python_modules/dagster/dagster/_core/workspace/permissions.py
+++ b/python_modules/dagster/dagster/_core/workspace/permissions.py
@@ -9,6 +9,7 @@ class Permissions(str, Enum):
     START_SCHEDULE = "start_schedule"
     STOP_RUNNING_SCHEDULE = "stop_running_schedule"
     EDIT_SENSOR = "edit_sensor"
+    UPDATE_SENSOR_CURSOR = "update_sensor_cursor"
     TERMINATE_PIPELINE_EXECUTION = "terminate_pipeline_execution"
     DELETE_PIPELINE_RUN = "delete_pipeline_run"
     RELOAD_REPOSITORY_LOCATION = "reload_repository_location"
@@ -27,6 +28,7 @@ VIEWER_PERMISSIONS: Dict[str, bool] = {
     Permissions.START_SCHEDULE: False,
     Permissions.STOP_RUNNING_SCHEDULE: False,
     Permissions.EDIT_SENSOR: False,
+    Permissions.UPDATE_SENSOR_CURSOR: False,
     Permissions.TERMINATE_PIPELINE_EXECUTION: False,
     Permissions.DELETE_PIPELINE_RUN: False,
     Permissions.RELOAD_REPOSITORY_LOCATION: False,
@@ -42,6 +44,7 @@ EDITOR_PERMISSIONS: Dict[str, bool] = {
     Permissions.START_SCHEDULE: True,
     Permissions.STOP_RUNNING_SCHEDULE: True,
     Permissions.EDIT_SENSOR: True,
+    Permissions.UPDATE_SENSOR_CURSOR: True,
     Permissions.TERMINATE_PIPELINE_EXECUTION: True,
     Permissions.DELETE_PIPELINE_RUN: True,
     Permissions.RELOAD_REPOSITORY_LOCATION: True,
@@ -57,6 +60,7 @@ LOCATION_SCOPED_PERMISSIONS = {
     Permissions.START_SCHEDULE,
     Permissions.STOP_RUNNING_SCHEDULE,
     Permissions.EDIT_SENSOR,
+    Permissions.UPDATE_SENSOR_CURSOR,
     Permissions.TERMINATE_PIPELINE_EXECUTION,
     Permissions.DELETE_PIPELINE_RUN,
     Permissions.RELOAD_REPOSITORY_LOCATION,


### PR DESCRIPTION
Creates separate perms set for updating a sensor than from editing a sensor.