### PR TITLE
[dagit] Do not capitalize tag keys in the Dagit op metadata panel

### DIFF
--- a/js_modules/dagit/packages/core/src/plugins/generic.tsx
+++ b/js_modules/dagit/packages/core/src/plugins/generic.tsx
@@ -1,5 +1,4 @@
 import {Button, DialogBody, DialogFooter, Dialog, Icon} from '@dagster-io/ui';
-import startCase from 'lodash/startCase';
 import * as React from 'react';
 
 import {IPluginSidebarProps} from '../plugins';
@@ -48,7 +47,7 @@ export const SidebarComponent: React.FC<IPluginSidebarProps> = (props) => {
               <tbody>
                 {metadata.map(({key, value}) => (
                   <tr key={key}>
-                    <td>{startCase(key)}</td>
+                    <td>{key}</td>
                     <td>
                       <code style={{whiteSpace: 'pre-wrap'}}>{value}</code>
                     </td>


### PR DESCRIPTION
### Summary & Motivation

I'm not sure what the original motivation was for capitalizing the keys shown in the modal in #11823, but it's safe to say it's inconsistent with the rest of Dagit.

### How I Tested These Changes

This modal is probably due for a design refresh at some point + added tests, but for now I just removed the uppercasing. 

I also confirmed there are no other uses of startCase in dagit.