### PR TITLE
Add resource support for more complex sensor types

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -1,8 +1,10 @@
 import inspect
-from typing import TYPE_CHECKING, Callable, Optional, Sequence
+from typing import Any, Callable, NamedTuple, Optional, Sequence, Set
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.resource_annotation import get_resource_args
 
 from .events import AssetKey
 from .run_request import RunRequest, SkipReason
@@ -10,14 +12,29 @@ from .sensor_definition import (
     DefaultSensorStatus,
     RawSensorEvaluationFunctionReturn,
     SensorDefinition,
-    SensorEvaluationContext,
     SensorType,
+    validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name
 
-if TYPE_CHECKING:
-    from dagster._core.events.log import EventLogEntry
+
+class ContextAndEventLogEntryParamNames(NamedTuple):
+    context_param_name: Optional[str]
+    event_log_entry_param_name: Optional[str]
+
+
+def get_context_and_event_log_entry_param_names(fn: Callable) -> ContextAndEventLogEntryParamNames:
+    """
+    Determines the names of the context and event log entry parameters for an asset sensor function.
+    These are assumed to be the first two non-resource params, in order (context param before event log entry).
+    """
+    resource_params = {param.name for param in get_resource_args(fn)}
+
+    non_resource_params = [
+        param.name for param in get_function_params(fn) if param.name not in resource_params
+    ] + [None, None]
+    return ContextAndEventLogEntryParamNames(*non_resource_params[:2])
 
 
 class AssetSensorDefinition(SensorDefinition):
@@ -51,7 +68,7 @@ class AssetSensorDefinition(SensorDefinition):
         asset_key: AssetKey,
         job_name: Optional[str],
         asset_materialization_fn: Callable[
-            [SensorEvaluationContext, "EventLogEntry"],
+            ...,
             RawSensorEvaluationFunctionReturn,
         ],
         minimum_interval_seconds: Optional[int] = None,
@@ -59,14 +76,24 @@ class AssetSensorDefinition(SensorDefinition):
         job: Optional[ExecutableDefinition] = None,
         jobs: Optional[Sequence[ExecutableDefinition]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+        required_resource_keys: Optional[Set[str]] = None,
     ):
         self._asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
 
         from dagster._core.events import DagsterEventType
         from dagster._core.storage.event_log.base import EventRecordsFilter
 
-        def _wrap_asset_fn(materialization_fn):
-            def _fn(context):
+        resource_arg_names: Set[str] = {
+            arg.name for arg in get_resource_args(asset_materialization_fn)
+        }
+
+        combined_required_resource_keys = (
+            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
+            | resource_arg_names
+        )
+
+        def _wrap_asset_fn(materialization_fn) -> Any:
+            def _fn(context) -> Any:
                 after_cursor = None
                 if context.cursor:
                     try:
@@ -91,7 +118,25 @@ class AssetSensorDefinition(SensorDefinition):
                     return
 
                 event_record = event_records[0]
-                result = materialization_fn(context, event_record.event_log_entry)
+
+                (
+                    context_param_name,
+                    event_log_entry_param_name,
+                ) = get_context_and_event_log_entry_param_names(materialization_fn)
+
+                resource_args_populated = validate_and_get_resource_dict(
+                    context.resources, name, resource_arg_names
+                )
+
+                # Build asset sensor function args, which can include any subset of
+                # context arg, event log entry arg, and any resource args
+                args = resource_args_populated
+                if context_param_name:
+                    args[context_param_name] = context
+                if event_log_entry_param_name:
+                    args[event_log_entry_param_name] = event_record.event_log_entry
+
+                result = materialization_fn(**args)
                 if inspect.isgenerator(result) or isinstance(result, list):
                     for item in result:
                         yield item
@@ -112,6 +157,7 @@ class AssetSensorDefinition(SensorDefinition):
             job=job,
             jobs=jobs,
             default_status=default_status,
+            required_resource_keys=combined_required_resource_keys,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -19,12 +19,12 @@ from .target import ExecutableDefinition
 from .utils import check_valid_name
 
 
-class ContextAndEventLogEntryParamNames(NamedTuple):
+class AssetSensorParamNames(NamedTuple):
     context_param_name: Optional[str]
     event_log_entry_param_name: Optional[str]
 
 
-def get_context_and_event_log_entry_param_names(fn: Callable) -> ContextAndEventLogEntryParamNames:
+def get_context_and_event_log_entry_param_names(fn: Callable) -> AssetSensorParamNames:
     """Determines the names of the context and event log entry parameters for an asset sensor function.
     These are assumed to be the first two non-resource params, in order (context param before event log entry).
     """
@@ -32,8 +32,14 @@ def get_context_and_event_log_entry_param_names(fn: Callable) -> ContextAndEvent
 
     non_resource_params = [
         param.name for param in get_function_params(fn) if param.name not in resource_params
-    ] + [None, None]
-    return ContextAndEventLogEntryParamNames(*non_resource_params[:2])
+    ]
+
+    context_param_name = non_resource_params[0] if len(non_resource_params) > 0 else None
+    event_log_entry_param_name = non_resource_params[1] if len(non_resource_params) > 1 else None
+
+    return AssetSensorParamNames(
+        context_param_name=context_param_name, event_log_entry_param_name=event_log_entry_param_name
+    )
 
 
 class AssetSensorDefinition(SensorDefinition):

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -25,8 +25,7 @@ class ContextAndEventLogEntryParamNames(NamedTuple):
 
 
 def get_context_and_event_log_entry_param_names(fn: Callable) -> ContextAndEventLogEntryParamNames:
-    """
-    Determines the names of the context and event log entry parameters for an asset sensor function.
+    """Determines the names of the context and event log entry parameters for an asset sensor function.
     These are assumed to be the first two non-resource params, in order (context param before event log entry).
     """
     resource_params = {param.name for param in get_resource_args(fn)}

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -1,7 +1,7 @@
 import collections.abc
 import inspect
 from functools import update_wrapper
-from typing import Callable, Optional, Sequence, Set, Union
+from typing import Any, Callable, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
@@ -157,8 +157,8 @@ def asset_sensor(
         check.callable_param(fn, "fn")
         sensor_name = name or fn.__name__
 
-        def _wrapped_fn(context, event):
-            result = fn(context, event)
+        def _wrapped_fn(*args, **kwargs) -> Any:
+            result = fn(*args, **kwargs)
 
             if inspect.isgenerator(result) or isinstance(result, list):
                 for item in result:
@@ -183,6 +183,10 @@ def asset_sensor(
                         "RunRequest objects."
                     ).format(sensor_name=sensor_name, result=result, type_=type(result))
                 )
+
+        # Preserve any resource arguments from the underlying function, for when we inspect the
+        # wrapped function later on
+        _wrapped_fn.__signature__ = inspect.signature(fn)
 
         return AssetSensorDefinition(
             name=sensor_name,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -133,7 +133,7 @@ class FreshnessPolicySensorContext(
             if previous_minutes_late is not None
             else None,
             instance=check.inst_param(instance, "instance", DagsterInstance),
-            resources=resources or ScopedResourcesBuilder().build_empty(),
+            resources=resources or ScopedResourcesBuilder.build_empty(),
         )
 
 
@@ -328,7 +328,7 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
         )
 
         resources = validate_and_get_resource_dict(
-            sensor_context.resources if sensor_context else ScopedResourcesBuilder().build_empty(),
+            sensor_context.resources if sensor_context else ScopedResourcesBuilder.build_empty(),
             self._name,
             self._required_resource_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -32,7 +32,7 @@ from .sensor_definition import (
     SensorType,
     SkipReason,
     get_context_param_name,
-    get_or_create_sensor_context_base,
+    get_sensor_context_from_args_or_kwargs,
     validate_and_get_resource_dict,
 )
 
@@ -133,7 +133,7 @@ class FreshnessPolicySensorContext(
             if previous_minutes_late is not None
             else None,
             instance=check.inst_param(instance, "instance", DagsterInstance),
-            resources=resources or ScopedResourcesBuilder().build(None),
+            resources=resources or ScopedResourcesBuilder().build_empty(),
         )
 
 
@@ -317,18 +317,18 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
     def __call__(self, *args, **kwargs) -> None:
         context_param_name = get_context_param_name(self._freshness_policy_sensor_fn)
 
-        sensor_context = get_or_create_sensor_context_base(
+        sensor_context = get_sensor_context_from_args_or_kwargs(
             self._freshness_policy_sensor_fn,
-            *args,
+            args,
+            kwargs,
             context_type=FreshnessPolicySensorContext,
-            **kwargs,
         )
         context_param = (
             {context_param_name: sensor_context} if context_param_name and sensor_context else {}
         )
 
         resources = validate_and_get_resource_dict(
-            sensor_context.resources if sensor_context else ScopedResourcesBuilder().build(None),
+            sensor_context.resources if sensor_context else ScopedResourcesBuilder().build_empty(),
             self._name,
             self._required_resource_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -1,14 +1,15 @@
-from typing import TYPE_CHECKING, Callable, Dict, Mapping, NamedTuple, Optional, cast
+from typing import TYPE_CHECKING, Callable, Dict, Mapping, NamedTuple, Optional, Set, cast
 
 import pendulum
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental
-from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.scoped_resources_builder import Resources, ScopedResourcesBuilder
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -24,13 +25,15 @@ from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
 from dagster._seven import JSONDecodeError
 
-from ..decorator_utils import get_function_params
 from .sensor_definition import (
     DefaultSensorStatus,
     SensorDefinition,
     SensorEvaluationContext,
     SensorType,
     SkipReason,
+    get_context_param_name,
+    get_or_create_sensor_context_base,
+    validate_and_get_resource_dict,
 )
 
 if TYPE_CHECKING:
@@ -90,6 +93,7 @@ class FreshnessPolicySensorContext(
             ("minutes_late", PublicAttr[Optional[float]]),
             ("previous_minutes_late", PublicAttr[Optional[float]]),
             ("instance", PublicAttr[DagsterInstance]),
+            ("resources", Resources),
         ],
     )
 ):
@@ -113,6 +117,7 @@ class FreshnessPolicySensorContext(
         minutes_late: Optional[float],
         previous_minutes_late: Optional[float],
         instance: DagsterInstance,
+        resources: Optional[Resources] = None,
     ):
         minutes_late = check.opt_numeric_param(minutes_late, "minutes_late")
         previous_minutes_late = check.opt_numeric_param(
@@ -128,6 +133,7 @@ class FreshnessPolicySensorContext(
             if previous_minutes_late is not None
             else None,
             instance=check.inst_param(instance, "instance", DagsterInstance),
+            resources=resources or ScopedResourcesBuilder().build(None),
         )
 
 
@@ -139,6 +145,7 @@ def build_freshness_policy_sensor_context(
     minutes_late: Optional[float],
     previous_minutes_late: Optional[float] = None,
     instance: Optional[DagsterInstance] = None,
+    resources: Optional[Resources] = None,
 ) -> FreshnessPolicySensorContext:
     """Builds freshness policy sensor context from provided parameters.
 
@@ -172,6 +179,7 @@ def build_freshness_policy_sensor_context(
         minutes_late=minutes_late,
         previous_minutes_late=previous_minutes_late,
         instance=instance or DagsterInstance.ephemeral(),
+        resources=resources,
     )
 
 
@@ -195,10 +203,11 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
         self,
         name: str,
         asset_selection: AssetSelection,
-        freshness_policy_sensor_fn: Callable[[FreshnessPolicySensorContext], None],
+        freshness_policy_sensor_fn: Callable[..., None],
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+        required_resource_keys: Optional[Set[str]] = None,
     ):
         check.str_param(name, "name")
         check.inst_param(asset_selection, "asset_selection", AssetSelection)
@@ -208,6 +217,15 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
 
         self._freshness_policy_sensor_fn = check.callable_param(
             freshness_policy_sensor_fn, "freshness_policy_sensor_fn"
+        )
+
+        resource_arg_names: Set[str] = {
+            arg.name for arg in get_resource_args(freshness_policy_sensor_fn)
+        }
+
+        combined_required_resource_keys = (
+            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
+            | resource_arg_names
         )
 
         def _wrapped_fn(context: SensorEvaluationContext):
@@ -252,21 +270,31 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
                     asset_key=asset_key,
                 )
 
+                resource_args_populated = validate_and_get_resource_dict(
+                    context.resources, name, resource_arg_names
+                )
+                context_param_name = get_context_param_name(freshness_policy_sensor_fn)
+                freshness_context = FreshnessPolicySensorContext(
+                    sensor_name=name,
+                    asset_key=asset_key,
+                    freshness_policy=freshness_policy,
+                    minutes_late=minutes_late_by_key[asset_key],
+                    previous_minutes_late=previous_minutes_late_by_key.get(asset_key),
+                    instance=context.instance,
+                    resources=context.resources,
+                )
+
                 with user_code_error_boundary(
                     FreshnessPolicySensorExecutionError,
                     lambda: f'Error occurred during the execution of sensor "{name}".',
                 ):
-                    result = freshness_policy_sensor_fn(
-                        FreshnessPolicySensorContext(
-                            sensor_name=name,
-                            asset_key=asset_key,
-                            freshness_policy=freshness_policy,
-                            minutes_late=minutes_late_by_key[asset_key],
-                            previous_minutes_late=previous_minutes_late_by_key.get(asset_key),
-                            instance=context.instance,
-                        )
+                    context_param = (
+                        {context_param_name: freshness_context} if context_param_name else {}
                     )
-
+                    result = freshness_policy_sensor_fn(
+                        **context_param,
+                        **resource_args_populated,
+                    )
                 if result is not None:
                     raise DagsterInvalidDefinitionError(
                         "Functions decorated by `@freshness_policy_sensor` may not return or yield"
@@ -283,50 +311,29 @@ class FreshnessPolicySensorDefinition(SensorDefinition):
             minimum_interval_seconds=minimum_interval_seconds,
             description=description,
             default_status=default_status,
+            required_resource_keys=combined_required_resource_keys,
         )
 
-    def __call__(self, *args, **kwargs):
-        if has_at_least_one_parameter(self._freshness_policy_sensor_fn):
-            if len(args) + len(kwargs) == 0:
-                raise DagsterInvalidInvocationError(
-                    "Freshness policy sensor function expected context argument, but no context"
-                    " argument was provided when invoking."
-                )
-            if len(args) + len(kwargs) > 1:
-                raise DagsterInvalidInvocationError(
-                    "Freshness policy sensor invocation received multiple arguments. Only a first "
-                    "positional context parameter should be provided when invoking."
-                )
+    def __call__(self, *args, **kwargs) -> None:
+        context_param_name = get_context_param_name(self._freshness_policy_sensor_fn)
 
-            context_param_name = get_function_params(self._freshness_policy_sensor_fn)[0].name
+        sensor_context = get_or_create_sensor_context_base(
+            self._freshness_policy_sensor_fn,
+            *args,
+            context_type=FreshnessPolicySensorContext,
+            **kwargs,
+        )
+        context_param = (
+            {context_param_name: sensor_context} if context_param_name and sensor_context else {}
+        )
 
-            if args:
-                context = check.opt_inst_param(
-                    args[0], context_param_name, FreshnessPolicySensorContext
-                )
-            else:
-                if context_param_name not in kwargs:
-                    raise DagsterInvalidInvocationError(
-                        "Freshness policy sensor invocation expected argument"
-                        f" '{context_param_name}'."
-                    )
-                context = check.opt_inst_param(
-                    kwargs[context_param_name],
-                    context_param_name,
-                    FreshnessPolicySensorContext,
-                )
+        resources = validate_and_get_resource_dict(
+            sensor_context.resources if sensor_context else ScopedResourcesBuilder().build(None),
+            self._name,
+            self._required_resource_keys,
+        )
 
-            if not context:
-                raise DagsterInvalidInvocationError(
-                    "Context must be provided for direct invocation of freshness policy sensor."
-                )
-
-            return self._freshness_policy_sensor_fn(context)
-
-        else:
-            raise DagsterInvalidDefinitionError(
-                "Freshness policy sensor must accept a context argument."
-            )
+        return self._freshness_policy_sensor_fn(**context_param, **resources)
 
     @property
     def sensor_type(self) -> SensorType:
@@ -341,7 +348,7 @@ def freshness_policy_sensor(
     minimum_interval_seconds: Optional[int] = None,
     description: Optional[str] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
-) -> Callable[[Callable[[FreshnessPolicySensorContext], None]], FreshnessPolicySensorDefinition,]:
+) -> Callable[[Callable[..., None]], FreshnessPolicySensorDefinition,]:
     """Define a sensor that reacts to the status of a given set of asset freshness policies, where the
     decorated function will be evaluated on every tick for each asset in the selection that has a
     FreshnessPolicy defined.
@@ -362,9 +369,7 @@ def freshness_policy_sensor(
             status can be overridden from Dagit or via the GraphQL API.
     """
 
-    def inner(
-        fn: Callable[[FreshnessPolicySensorContext], None]
-    ) -> FreshnessPolicySensorDefinition:
+    def inner(fn: Callable[..., None]) -> FreshnessPolicySensorDefinition:
         check.callable_param(fn, "fn")
         sensor_name = name or fn.__name__
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1184,7 +1184,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         )
 
         resources = validate_and_get_resource_dict(
-            context.resources if context else ScopedResourcesBuilder().build_empty(),
+            context.resources if context else ScopedResourcesBuilder.build_empty(),
             self._name,
             self._required_resource_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -41,7 +41,7 @@ from .sensor_definition import (
     SensorEvaluationContext,
     SensorType,
     get_context_param_name,
-    get_or_create_sensor_context_base,
+    get_sensor_context_from_args_or_kwargs,
     validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
@@ -1176,15 +1176,15 @@ class MultiAssetSensorDefinition(SensorDefinition):
 
     def __call__(self, *args, **kwargs) -> AssetMaterializationFunctionReturn:
         context_param_name = get_context_param_name(self._raw_asset_materialization_fn)
-        context = get_or_create_sensor_context_base(
+        context = get_sensor_context_from_args_or_kwargs(
             self._raw_asset_materialization_fn,
-            *args,
+            args,
+            kwargs,
             context_type=MultiAssetSensorEvaluationContext,
-            **kwargs,
         )
 
         resources = validate_and_get_resource_dict(
-            context.resources if context else ScopedResourcesBuilder().build(None),
+            context.resources if context else ScopedResourcesBuilder().build_empty(),
             self._name,
             self._required_resource_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1098,7 +1098,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     repository_def=context.repository_def,
                     monitored_assets=monitored_assets,
                     instance=context.instance,
-                    resources=context.resources,
+                    resources=context.resource_defs,
                 )
                 resource_args_populated = validate_and_get_resource_dict(
                     context.resources, name, resource_arg_names

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -19,10 +19,12 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import experimental, public
-from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.definitions.scoped_resources_builder import ScopedResourcesBuilder
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -31,7 +33,6 @@ from dagster._core.errors import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 
-from ..decorator_utils import get_function_params
 from .events import AssetKey
 from .run_request import RunRequest, SensorResult, SkipReason
 from .sensor_definition import (
@@ -39,13 +40,15 @@ from .sensor_definition import (
     SensorDefinition,
     SensorEvaluationContext,
     SensorType,
+    get_context_param_name,
+    get_or_create_sensor_context_base,
+    validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name
 
 if TYPE_CHECKING:
     from dagster._core.definitions.repository_definition import RepositoryDefinition
-    from dagster._core.events.log import EventLogEntry
     from dagster._core.storage.event_log.base import EventLogRecord
 
 MAX_NUM_UNCONSUMED_EVENTS = 25
@@ -215,6 +218,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         repository_def: "RepositoryDefinition",
         monitored_assets: Union[Sequence[AssetKey], AssetSelection],
         instance: Optional[DagsterInstance] = None,
+        resources: Optional[Mapping[str, ResourceDefinition]] = None,
     ):
         from dagster._core.storage.event_log.base import EventLogRecord
 
@@ -257,6 +261,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             repository_name=repository_name,
             instance=instance,
             repository_def=repository_def,
+            resources=resources,
         )
 
     def _cache_initial_unconsumed_events(self) -> None:
@@ -921,6 +926,7 @@ def build_multi_asset_sensor_context(
     cursor: Optional[str] = None,
     repository_name: Optional[str] = None,
     cursor_from_latest_materializations: bool = False,
+    resources: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> MultiAssetSensorEvaluationContext:
     """Builds multi asset sensor execution context for testing purposes using the provided parameters.
 
@@ -939,6 +945,8 @@ def build_multi_asset_sensor_context(
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
         cursor_from_latest_materializations (bool): If True, the cursor will be set to the latest
             materialization for each monitored asset. By default, set to False.
+        resources (Optional[Mapping[str, ResourceDefinition]]): The resource definitions
+            to provide to the sensor.
 
     Examples:
         .. code-block:: python
@@ -995,6 +1003,7 @@ def build_multi_asset_sensor_context(
         instance=instance,
         monitored_assets=monitored_assets,
         repository_def=repository_def,
+        resources=resources,
     )
 
 
@@ -1007,12 +1016,12 @@ AssetMaterializationFunctionReturn = Union[
     SensorResult,
 ]
 AssetMaterializationFunction = Callable[
-    ["SensorEvaluationContext", "EventLogEntry"],
+    ...,
     AssetMaterializationFunctionReturn,
 ]
 
 MultiAssetMaterializationFunction = Callable[
-    ["MultiAssetSensorEvaluationContext"],
+    ...,
     AssetMaterializationFunctionReturn,
 ]
 
@@ -1060,7 +1069,17 @@ class MultiAssetSensorDefinition(SensorDefinition):
         jobs: Optional[Sequence[ExecutableDefinition]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         request_assets: Optional[AssetSelection] = None,
+        required_resource_keys: Optional[Set[str]] = None,
     ):
+        resource_arg_names: Set[str] = {
+            arg.name for arg in get_resource_args(asset_materialization_fn)
+        }
+
+        combined_required_resource_keys = (
+            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
+            | resource_arg_names
+        )
+
         def _wrap_asset_fn(materialization_fn):
             def _fn(context):
                 def _check_cursor_not_set(sensor_result: SensorResult):
@@ -1079,9 +1098,23 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     repository_def=context.repository_def,
                     monitored_assets=monitored_assets,
                     instance=context.instance,
+                    resources=context.resources,
+                )
+                resource_args_populated = validate_and_get_resource_dict(
+                    context.resources, name, resource_arg_names
                 )
 
-                result = materialization_fn(multi_asset_sensor_context)
+                with multi_asset_sensor_context:
+                    context_param_name = get_context_param_name(materialization_fn)
+                    context_param = (
+                        {context_param_name: multi_asset_sensor_context}
+                        if context_param_name
+                        else {}
+                    )
+                    result = materialization_fn(
+                        **context_param,
+                        **resource_args_populated,
+                    )
                 if result is None:
                     return
 
@@ -1138,50 +1171,29 @@ class MultiAssetSensorDefinition(SensorDefinition):
             jobs=jobs,
             default_status=default_status,
             asset_selection=request_assets,
+            required_resource_keys=combined_required_resource_keys,
         )
 
-    def __call__(self, *args, **kwargs):
-        if has_at_least_one_parameter(self._raw_asset_materialization_fn):
-            if len(args) + len(kwargs) == 0:
-                raise DagsterInvalidInvocationError(
-                    "Sensor evaluation function expected context argument, but no context argument "
-                    "was provided when invoking."
-                )
-            if len(args) + len(kwargs) > 1:
-                raise DagsterInvalidInvocationError(
-                    "Sensor invocation received multiple arguments. Only a first "
-                    "positional context parameter should be provided when invoking."
-                )
+    def __call__(self, *args, **kwargs) -> AssetMaterializationFunctionReturn:
+        context_param_name = get_context_param_name(self._raw_asset_materialization_fn)
+        context = get_or_create_sensor_context_base(
+            self._raw_asset_materialization_fn,
+            *args,
+            context_type=MultiAssetSensorEvaluationContext,
+            **kwargs,
+        )
 
-            context_param_name = get_function_params(self._raw_asset_materialization_fn)[0].name
+        resources = validate_and_get_resource_dict(
+            context.resources if context else ScopedResourcesBuilder().build(None),
+            self._name,
+            self._required_resource_keys,
+        )
 
-            if args:
-                context = check.inst_param(
-                    args[0], context_param_name, MultiAssetSensorEvaluationContext
-                )
-            else:
-                if context_param_name not in kwargs:
-                    raise DagsterInvalidInvocationError(
-                        f"Sensor invocation expected argument '{context_param_name}'."
-                    )
-                context = check.inst_param(
-                    kwargs[context_param_name],
-                    context_param_name,
-                    MultiAssetSensorEvaluationContext,
-                )
+        context_param = {context_param_name: context} if context_param_name and context else {}
+        result = self._raw_asset_materialization_fn(**context_param, **resources)
 
-            result = self._raw_asset_materialization_fn(context)
-
-        else:
-            if len(args) + len(kwargs) > 0:
-                raise DagsterInvalidInvocationError(
-                    "Sensor decorated function has no arguments, but arguments were provided to "
-                    "invocation."
-                )
-
-            result = self._raw_asset_materialization_fn()
-
-        context.update_cursor_after_evaluation()
+        if context:
+            context.update_cursor_after_evaluation()
         return result
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -146,8 +146,11 @@ class RunStatusSensorContext:
         )
         self._logger: Optional[logging.Logger] = None
 
-        if context:
-            resources = {**context.resources, **(resources or {})}
+        if self._context and self._context.resource_defs:
+            resources = {
+                **(self._context.resource_defs),
+                **(resources or {}),
+            }
 
         self._resource_defs = resources
 

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -1,13 +1,16 @@
 import logging
 import warnings
+from contextlib import ExitStack
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Callable,
     Iterator,
+    Mapping,
     NamedTuple,
     Optional,
     Sequence,
+    Set,
     Union,
     cast,
     overload,
@@ -18,11 +21,15 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.instigation_logger import InstigationLogger
+from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.scoped_resources_builder import (
+    IContainsGenerator,
+    Resources,
+    ScopedResourcesBuilder,
+)
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
-    DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
     RunStatusSensorExecutionError,
     user_code_error_boundary,
@@ -41,7 +48,6 @@ from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.error import serializable_error_info_from_exc_info
 
-from ..decorator_utils import get_function_params
 from .graph_definition import GraphDefinition
 from .pipeline_definition import PipelineDefinition
 from .sensor_definition import (
@@ -54,11 +60,15 @@ from .sensor_definition import (
     SensorResult,
     SensorType,
     SkipReason,
+    get_context_param_name,
+    get_or_create_sensor_context_base,
+    validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.resource_definition import ResourceDefinition
     from dagster._core.definitions.selector import (
         CodeLocationSelector,
         JobSelector,
@@ -66,12 +76,12 @@ if TYPE_CHECKING:
     )
 
 RunStatusSensorEvaluationFunction: TypeAlias = Union[
-    Callable[[], RawSensorEvaluationFunctionReturn],
-    Callable[["RunStatusSensorContext"], RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
 ]
 RunFailureSensorEvaluationFn: TypeAlias = Union[
-    Callable[[], RawSensorEvaluationFunctionReturn],
-    Callable[["RunFailureSensorContext"], RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
 ]
 
 
@@ -116,13 +126,37 @@ class RunStatusSensorContext:
         log (logging.Logger): the logger for the given sensor evaluation
     """
 
-    def __init__(self, sensor_name, dagster_run, dagster_event, instance, context=None):
+    def __init__(
+        self,
+        sensor_name,
+        dagster_run,
+        dagster_event,
+        instance,
+        context=None,
+        resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
+    ) -> None:
+        from dagster._core.execution.build_resources import build_resources
+
         self._sensor_name = check.str_param(sensor_name, "sensor_name")
         self._dagster_run = check.inst_param(dagster_run, "dagster_run", DagsterRun)
         self._dagster_event = check.inst_param(dagster_event, "dagster_event", DagsterEvent)
         self._instance = check.inst_param(instance, "instance", DagsterInstance)
-        self._context = check.opt_inst_param(context, "context", SensorEvaluationContext)
+        self._context: Optional[SensorEvaluationContext] = check.opt_inst_param(
+            context, "context", SensorEvaluationContext
+        )
         self._logger: Optional[logging.Logger] = None
+
+        if context:
+            resources = {**context.resources, **(resources or {})}
+
+        self._resource_defs = resources
+
+        self._resources_cm = build_resources(resources or {})
+
+        self._resources = self._resources_cm.__enter__()
+        self._resources_contain_cm = isinstance(self._resources, IContainsGenerator)
+        self._cm_scope_entered = False
+        self._exit_stack = ExitStack()
 
     def for_run_failure(self):
         """Converts RunStatusSensorContext to RunFailureSensorContext."""
@@ -173,6 +207,29 @@ class RunStatusSensorContext:
         )
         return self.dagster_run
 
+    def __enter__(self) -> "RunStatusSensorContext":
+        self._cm_scope_entered = True
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._resources_cm.__exit__(*exc)  # pylint: disable=no-member
+        self._exit_stack.close()
+        self._logger = None
+
+    def __del__(self) -> None:
+        if self._resources_contain_cm and not self._cm_scope_entered:
+            self._resources_cm.__exit__(None, None, None)  # pylint: disable=no-member
+
+    @property
+    def resources(self) -> Resources:
+        if self._resources_contain_cm and not self._cm_scope_entered:
+            raise DagsterInvariantViolationError(
+                "At least one provided resource is a generator, but attempting to access "
+                "resources outside of context manager scope. You can use the following syntax to "
+                "open a context manager: `with build_sensor_context(...) as context:`"
+            )
+        return self._resources
+
 
 class RunFailureSensorContext(RunStatusSensorContext):
     """The ``context`` object available to a decorated function of ``run_failure_sensor``.
@@ -194,6 +251,7 @@ def build_run_status_sensor_context(
     dagster_instance: DagsterInstance,
     dagster_run: DagsterRun,
     context: Optional[SensorEvaluationContext] = None,
+    resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
 ) -> RunStatusSensorContext:
     """Builds run status sensor context from provided parameters.
 
@@ -230,6 +288,7 @@ def build_run_status_sensor_context(
         dagster_run=dagster_run,
         dagster_event=dagster_event,
         context=context,
+        resources=resources,
     )
 
 
@@ -365,7 +424,7 @@ def run_failure_sensor(
             request_jobs=request_jobs,
         )
         def _run_failure_sensor(context: RunStatusSensorContext):
-            return fn(context.for_run_failure())  # type: ignore  # fmt: skip
+            return fn(context.for_run_failure())  # fmt: skip
 
         return _run_failure_sensor
 
@@ -426,6 +485,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         request_job: Optional[ExecutableDefinition] = None,
         request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
+        required_resource_keys: Optional[Set[str]] = None,
     ):
         from dagster._core.definitions.selector import (
             CodeLocationSelector,
@@ -453,6 +513,13 @@ class RunStatusSensorDefinition(SensorDefinition):
             ),
         )
         check.inst_param(default_status, "default_status", DefaultSensorStatus)
+
+        resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(run_status_sensor_fn)}
+
+        combined_required_resource_keys = (
+            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
+            | resource_arg_names
+        )
 
         # coerce CodeLocationSelectors to RepositorySelectors with repo name "__repository__"
         monitored_jobs = [
@@ -610,24 +677,32 @@ class RunStatusSensorDefinition(SensorDefinition):
 
                 serializable_error = None
 
+                resource_args_populated = validate_and_get_resource_dict(
+                    context.resources, name, resource_arg_names
+                )
+                sensor_context = RunStatusSensorContext(
+                    sensor_name=name,
+                    dagster_run=pipeline_run,
+                    dagster_event=event_log_entry.dagster_event,
+                    instance=context.instance,
+                    context=context,
+                )
+
                 try:
                     with user_code_error_boundary(
                         RunStatusSensorExecutionError,
                         lambda: f'Error occurred during the execution sensor "{name}".',
                     ):
-                        if has_at_least_one_parameter(run_status_sensor_fn):
-                            # one user code invocation maps to one failure event
-                            sensor_return = run_status_sensor_fn(
-                                RunStatusSensorContext(
-                                    sensor_name=name,
-                                    dagster_run=pipeline_run,
-                                    dagster_event=event_log_entry.dagster_event,
-                                    instance=context.instance,
-                                    context=context,
-                                )
-                            )
-                        else:
-                            sensor_return = run_status_sensor_fn()  # type: ignore
+                        # one user code invocation maps to one failure event
+                        context_param_name = get_context_param_name(run_status_sensor_fn)
+                        context_param = (
+                            {context_param_name: sensor_context} if context_param_name else {}
+                        )
+
+                        sensor_return = run_status_sensor_fn(
+                            **context_param,
+                            **resource_args_populated,
+                        )
 
                         if sensor_return is not None:
                             context.update_cursor(
@@ -683,49 +758,22 @@ class RunStatusSensorDefinition(SensorDefinition):
             default_status=default_status,
             job=request_job,
             jobs=request_jobs,
+            required_resource_keys=combined_required_resource_keys,
         )
 
-    def __call__(self, *args, **kwargs):
-        if has_at_least_one_parameter(self._run_status_sensor_fn):
-            if len(args) + len(kwargs) == 0:
-                raise DagsterInvalidInvocationError(
-                    "Run status sensor function expected context argument, but no context argument "
-                    "was provided when invoking."
-                )
-            if len(args) + len(kwargs) > 1:
-                raise DagsterInvalidInvocationError(
-                    "Run status sensor invocation received multiple arguments. Only a first "
-                    "positional context parameter should be provided when invoking."
-                )
+    def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
+        context_param_name = get_context_param_name(self._run_status_sensor_fn)
+        context = get_or_create_sensor_context_base(
+            self._run_status_sensor_fn, *args, context_type=RunStatusSensorContext, **kwargs
+        )
+        context_param = {context_param_name: context} if context_param_name and context else {}
 
-            context_param_name = get_function_params(self._run_status_sensor_fn)[0].name
-
-            if args:
-                context = check.opt_inst_param(args[0], context_param_name, RunStatusSensorContext)
-            else:
-                if context_param_name not in kwargs:
-                    raise DagsterInvalidInvocationError(
-                        f"Run status sensor invocation expected argument '{context_param_name}'."
-                    )
-                context = check.opt_inst_param(
-                    kwargs[context_param_name], context_param_name, RunStatusSensorContext
-                )
-
-            if not context:
-                raise DagsterInvalidInvocationError(
-                    "Context must be provided for direct invocation of run status sensor."
-                )
-
-            return self._run_status_sensor_fn(context)
-
-        else:
-            if len(args) + len(kwargs) > 0:
-                raise DagsterInvalidInvocationError(
-                    "Run status sensor decorated function has no arguments, but arguments were "
-                    "provided to invocation."
-                )
-
-            return self._run_status_sensor_fn()
+        resources = validate_and_get_resource_dict(
+            context.resources if context else ScopedResourcesBuilder().build(None),
+            self._name,
+            self._required_resource_keys,
+        )
+        return self._run_status_sensor_fn(**context_param, **resources)
 
     @property
     def sensor_type(self) -> SensorType:

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -60,7 +60,7 @@ from .sensor_definition import (
     SensorType,
     SkipReason,
     get_context_param_name,
-    get_or_create_sensor_context_base,
+    get_sensor_context_from_args_or_kwargs,
     validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
@@ -781,13 +781,16 @@ class RunStatusSensorDefinition(SensorDefinition):
 
     def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
         context_param_name = get_context_param_name(self._run_status_sensor_fn)
-        context = get_or_create_sensor_context_base(
-            self._run_status_sensor_fn, *args, context_type=RunStatusSensorContext, **kwargs
+        context = get_sensor_context_from_args_or_kwargs(
+            self._run_status_sensor_fn,
+            args,
+            kwargs,
+            context_type=RunStatusSensorContext,
         )
         context_param = {context_param_name: context} if context_param_name and context else {}
 
         resources = validate_and_get_resource_dict(
-            context.resources if context else ScopedResourcesBuilder().build(None),
+            context.resources if context else ScopedResourcesBuilder().build_empty(),
             self._name,
             self._required_resource_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -790,7 +790,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         context_param = {context_param_name: context} if context_param_name and context else {}
 
         resources = validate_and_get_resource_dict(
-            context.resources if context else ScopedResourcesBuilder().build_empty(),
+            context.resources if context else ScopedResourcesBuilder.build_empty(),
             self._name,
             self._required_resource_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
@@ -103,3 +103,7 @@ class ScopedResourcesBuilder(
                 ...
 
             return _ScopedResources(**resource_instance_dict)  # type: ignore[call-arg]
+
+    def build_empty(self) -> Resources:
+        """Returns an empty Resources object, equivalent to ScopedResourcesBuilder.build(None)."""
+        return self.build(None)

--- a/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
@@ -104,6 +104,7 @@ class ScopedResourcesBuilder(
 
             return _ScopedResources(**resource_instance_dict)  # type: ignore[call-arg]
 
-    def build_empty(self) -> Resources:
-        """Returns an empty Resources object, equivalent to ScopedResourcesBuilder.build(None)."""
-        return self.build(None)
+    @classmethod
+    def build_empty(cls) -> Resources:
+        """Returns an empty Resources object, equivalent to ScopedResourcesBuilder().build(None)."""
+        return cls().build(None)

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -15,6 +15,8 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Type,
+    TypeVar,
     Union,
     cast,
 )
@@ -161,6 +163,10 @@ class SensorEvaluationContext:
     def __exit__(self, *exc) -> None:
         self._exit_stack.close()
         self._logger = None
+
+    @property
+    def resource_defs(self) -> Optional[Mapping[str, "ResourceDefinition"]]:
+        return self._resource_defs
 
     @property
     def resources(self) -> Resources:
@@ -320,57 +326,19 @@ def get_context_param_name(fn: Callable) -> Optional[str]:
     )
 
 
-def _validate_and_get_resource_dict(
-    context: SensorEvaluationContext, sensor_name: str, required_resource_keys: Set[str]
+def validate_and_get_resource_dict(
+    resources: Resources, sensor_name: str, required_resource_keys: Set[str]
 ) -> Dict[str, Any]:
     """Validates that the context has all the required resources and returns a dictionary of
     resource key to resource object.
     """
     for k in required_resource_keys:
-        if not hasattr(context.resources, k):
+        if not hasattr(resources, k):
             raise DagsterInvalidDefinitionError(
                 f"Resource with key '{k}' required by sensor '{sensor_name}' was not provided."
             )
 
-    return {k: getattr(context.resources, k) for k in required_resource_keys}
-
-
-def get_or_create_sensor_context(
-    fn: Callable, *args: Any, **kwargs: Any
-) -> SensorEvaluationContext:
-    """Based on the passed resource function and the arguments passed to it, returns the
-    user-passed SensorEvaluationContext or creates one if it is not passed.
-
-    Raises an exception if the user passes more than one argument or if the user-provided
-    function requires a context parameter but none is passed.
-    """
-    context_param_name_if_present = get_context_param_name(fn)
-
-    if len(args) + len(kwargs) > 1:
-        raise DagsterInvalidInvocationError(
-            "Sensor invocation received multiple arguments. Only a first "
-            "positional context parameter should be provided when invoking."
-        )
-
-    context: Optional[SensorEvaluationContext] = None
-
-    if len(args) > 0:
-        context = check.opt_inst(args[0], SensorEvaluationContext)
-    elif len(kwargs) > 0:
-        if context_param_name_if_present and context_param_name_if_present not in kwargs:
-            raise DagsterInvalidInvocationError(
-                f"Sensor invocation expected argument '{context_param_name_if_present}'."
-            )
-        context_param_name_if_present = context_param_name_if_present or list(kwargs.keys())[0]
-        context = check.opt_inst(kwargs.get(context_param_name_if_present), SensorEvaluationContext)
-    elif context_param_name_if_present:
-        # If the context parameter is present but no value was provided, we error
-        raise DagsterInvalidInvocationError(
-            "Sensor evaluation function expected context argument, but no context argument "
-            "was provided when invoking."
-        )
-
-    return context or build_sensor_context()
+    return {k: getattr(resources, k) for k in required_resource_keys}
 
 
 class SensorDefinition:
@@ -511,8 +479,8 @@ class SensorDefinition:
             {context_param_name_if_present: context} if context_param_name_if_present else {}
         )
 
-        resources = _validate_and_get_resource_dict(
-            context, self.name, self._required_resource_keys
+        resources = validate_and_get_resource_dict(
+            context.resources, self.name, self._required_resource_keys
         )
         return self._raw_fn(**context_param, **resources)
 
@@ -807,8 +775,8 @@ def wrap_sensor_evaluation(
     resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(fn)}
 
     def _wrapped_fn(context: SensorEvaluationContext):
-        resource_args_populated = _validate_and_get_resource_dict(
-            context, sensor_name, resource_arg_names
+        resource_args_populated = validate_and_get_resource_dict(
+            context.resources, sensor_name, resource_arg_names
         )
 
         context_param_name_if_present = get_context_param_name(fn)
@@ -880,6 +848,66 @@ def build_sensor_context(
         repository_def=repository_def,
         sensor_name=sensor_name,
         resources=resources,
+    )
+
+
+T = TypeVar("T")
+
+
+def get_or_create_sensor_context_base(
+    fn: Callable,
+    *args: Any,
+    context_type: Type[T],
+    **kwargs: Any,
+) -> Optional[T]:
+    context_param_name = get_context_param_name(fn)
+
+    if len(args) + len(kwargs) > 1:
+        raise DagsterInvalidInvocationError(
+            "Sensor invocation received multiple arguments. Only a first "
+            "positional context parameter should be provided when invoking."
+        )
+
+    context: Optional[T] = None
+
+    if len(args) > 0:
+        context = check.opt_inst(args[0], context_type)
+    elif len(kwargs) > 0:
+        if context_param_name and context_param_name not in kwargs:
+            raise DagsterInvalidInvocationError(
+                f"Sensor invocation expected argument '{context_param_name}'."
+            )
+        context_param_name = context_param_name or list(kwargs.keys())[0]
+        context = check.opt_inst(kwargs.get(context_param_name), context_type)
+    elif context_param_name:
+        # If the context parameter is present but no value was provided, we error
+        raise DagsterInvalidInvocationError(
+            "Sensor evaluation function expected context argument, but no context argument "
+            "was provided when invoking."
+        )
+
+    return context
+
+
+def get_or_create_sensor_context(
+    fn: Callable,
+    *args: Any,
+    **kwargs: Any,
+) -> SensorEvaluationContext:
+    """Based on the passed resource function and the arguments passed to it, returns the
+    user-passed SensorEvaluationContext or creates one if it is not passed.
+
+    Raises an exception if the user passes more than one argument or if the user-provided
+    function requires a context parameter but none is passed.
+    """
+    return (
+        get_or_create_sensor_context_base(
+            fn,
+            *args,
+            context_type=SensorEvaluationContext,
+            **kwargs,
+        )
+        or build_sensor_context()
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -854,11 +855,11 @@ def build_sensor_context(
 T = TypeVar("T")
 
 
-def get_or_create_sensor_context_base(
+def get_sensor_context_from_args_or_kwargs(
     fn: Callable,
-    *args: Any,
+    args: Tuple[Any],
+    kwargs: Dict[str, Any],
     context_type: Type[T],
-    **kwargs: Any,
 ) -> Optional[T]:
     context_param_name = get_context_param_name(fn)
 
@@ -901,11 +902,11 @@ def get_or_create_sensor_context(
     function requires a context parameter but none is passed.
     """
     return (
-        get_or_create_sensor_context_base(
+        get_sensor_context_from_args_or_kwargs(
             fn,
-            *args,
+            args,
+            kwargs,
             context_type=SensorEvaluationContext,
-            **kwargs,
         )
         or build_sensor_context()
     )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
@@ -39,6 +39,7 @@ from dagster._core.definitions.run_status_sensor_definition import (
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import (
@@ -342,7 +343,7 @@ def test_cant_use_required_resource_keys_and_params_both() -> None:
 )
 def test_resources(
     caplog,
-    instance,
+    instance: DagsterInstance,
     workspace_context_struct_resources,
     external_repo_struct_resources,
     sensor_name,
@@ -485,7 +486,7 @@ def test_resources_freshness_policy_sensor(
 )
 def test_resources_run_status_sensor(
     caplog,
-    instance,
+    instance: DagsterInstance,
     workspace_context_struct_resources,
     external_repo_struct_resources,
     sensor_name,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
@@ -6,22 +6,41 @@ from typing import Iterator, Optional
 import pendulum
 import pytest
 from dagster import (
+    AssetKey,
     SensorEvaluationContext,
     job,
+    multi_asset_sensor,
     op,
     resource,
     sensor,
 )
 from dagster._check import ParameterCheckError
 from dagster._config.structured_config import ConfigurableResource
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.decorators.sensor_decorator import asset_sensor
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.freshness_policy_sensor_definition import (
+    FreshnessPolicySensorContext,
+    freshness_policy_sensor,
+)
+from dagster._core.definitions.multi_asset_sensor_definition import (
+    MultiAssetSensorEvaluationContext,
+)
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
 from dagster._core.definitions.resource_annotation import Resource
 from dagster._core.definitions.run_request import InstigatorType
+from dagster._core.definitions.run_status_sensor_definition import (
+    RunStatusSensorContext,
+    run_status_sensor,
+)
 from dagster._core.definitions.sensor_definition import RunRequest
+from dagster._core.events.log import EventLogEntry
+from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
 )
@@ -33,13 +52,16 @@ from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 from .test_sensor_run import evaluate_sensors, validate_tick, wait_for_all_runs_to_start
 
 
-@op
-def the_op(_):
-    return 1
+@op(out={})
+def the_op(context: OpExecutionContext):
+    yield AssetMaterialization(
+        asset_key=AssetKey("my_asset"),
+        description="my_asset",
+    )
 
 
 @job
-def the_job():
+def the_job() -> None:
     the_op()
 
 
@@ -109,6 +131,117 @@ def sensor_resource_deps(context):
     return RunRequest(context.resources.the_outer, run_config={}, tags={})
 
 
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset(my_resource: MyResource, not_called_context: SensorEvaluationContext):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset_with_cm(
+    my_cm_resource: Resource[str], not_called_context: SensorEvaluationContext
+):
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    assert is_in_cm
+
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset_with_event(
+    my_resource: MyResource,
+    not_called_context: SensorEvaluationContext,
+    my_asset_event: EventLogEntry,
+):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    assert my_asset_event.dagster_event
+    assert my_asset_event.dagster_event.asset_key == AssetKey("my_asset")
+
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset_no_context(
+    my_resource: MyResource,
+):
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@multi_asset_sensor(
+    monitored_assets=[AssetKey("my_asset")],
+    job_name="the_job",
+)
+def sensor_multi_asset(
+    my_resource: MyResource,
+    not_called_context: MultiAssetSensorEvaluationContext,
+) -> RunRequest:
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    asset_events = list(
+        not_called_context.materialization_records_for_key(asset_key=AssetKey("my_asset"), limit=1)
+    )
+    if asset_events:
+        not_called_context.advance_all_cursors()
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@multi_asset_sensor(
+    monitored_assets=[AssetKey("my_asset")],
+    job_name="the_job",
+)
+def sensor_multi_asset_with_cm(
+    my_cm_resource: Resource[str],
+    not_called_context: MultiAssetSensorEvaluationContext,
+) -> RunRequest:
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    assert is_in_cm
+
+    asset_events = list(
+        not_called_context.materialization_records_for_key(asset_key=AssetKey("my_asset"), limit=1)
+    )
+    if asset_events:
+        not_called_context.advance_all_cursors()
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
+@freshness_policy_sensor(asset_selection=AssetSelection.all())
+def sensor_freshness_policy(
+    my_resource: MyResource, not_called_context: FreshnessPolicySensorContext
+):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@freshness_policy_sensor(asset_selection=AssetSelection.all())
+def sensor_freshness_policy_with_cm(
+    my_cm_resource: Resource[str], not_called_context: FreshnessPolicySensorContext
+):
+    assert is_in_cm
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
+@run_status_sensor(
+    monitor_all_repositories=True, run_status=DagsterRunStatus.SUCCESS, request_job=the_job
+)
+def sensor_run_status(my_resource: MyResource, not_called_context: RunStatusSensorContext):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@run_status_sensor(
+    monitor_all_repositories=True, run_status=DagsterRunStatus.SUCCESS, request_job=the_job
+)
+def sensor_run_status_with_cm(
+    my_cm_resource: Resource[str], not_called_context: RunStatusSensorContext
+):
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    assert is_in_cm
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
 the_repo = Definitions(
     jobs=[the_job],
     sensors=[
@@ -119,6 +252,16 @@ the_repo = Definitions(
         sensor_from_fn_arg_no_context,
         sensor_context_arg_not_first_and_weird_name,
         sensor_resource_deps,
+        sensor_asset,
+        sensor_asset_with_cm,
+        sensor_asset_with_event,
+        sensor_asset_no_context,
+        sensor_multi_asset,
+        sensor_multi_asset_with_cm,
+        sensor_freshness_policy,
+        sensor_freshness_policy_with_cm,
+        sensor_run_status,
+        sensor_run_status_with_cm,
     ],
     resources={
         "my_resource": MyResource(a_str="foo"),
@@ -189,6 +332,12 @@ def test_cant_use_required_resource_keys_and_params_both() -> None:
         "sensor_from_fn_arg_no_context",
         "sensor_context_arg_not_first_and_weird_name",
         "sensor_resource_deps",
+        "sensor_asset",
+        "sensor_asset_with_cm",
+        "sensor_asset_with_event",
+        "sensor_asset_no_context",
+        "sensor_multi_asset",
+        "sensor_multi_asset_with_cm",
     ],
 )
 def test_resources(
@@ -197,7 +346,8 @@ def test_resources(
     workspace_context_struct_resources,
     external_repo_struct_resources,
     sensor_name,
-):
+) -> None:
+    assert not is_in_cm
     freeze_datetime = to_timezone(
         create_pendulum_time(
             year=2019,
@@ -212,6 +362,11 @@ def test_resources(
     )
 
     with pendulum.test(freeze_datetime):
+        base_run_count = 0
+        if "asset" in sensor_name:
+            the_job.execute_in_process(instance=instance)
+            base_run_count = 1
+
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
@@ -220,7 +375,7 @@ def test_resources(
                 InstigatorStatus.RUNNING,
             )
         )
-        assert instance.get_runs_count() == 0
+        assert instance.get_runs_count() == base_run_count
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
@@ -229,7 +384,7 @@ def test_resources(
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
 
-        assert instance.get_runs_count() == 1
+        assert instance.get_runs_count() == base_run_count + 1
         run = instance.get_runs()[0]
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -243,3 +398,161 @@ def test_resources(
             TickStatus.SUCCESS,
             expected_run_ids=[run.run_id],
         )
+    assert not is_in_cm
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_freshness_policy",
+        "sensor_freshness_policy_with_cm",
+    ],
+)
+def test_resources_freshness_policy_sensor(
+    caplog,
+    instance,
+    workspace_context_struct_resources,
+    external_repo_struct_resources,
+    sensor_name,
+) -> None:
+    assert not is_in_cm
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+    original_time = freeze_datetime
+
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 0
+
+    # We have to do two ticks because the first tick will be skipped due to the freshness policy
+    # sensor initializing its cursor
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+    freeze_datetime = freeze_datetime.add(seconds=60)
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+
+    with pendulum.test(freeze_datetime):
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+            expected_run_ids=[],
+        )
+        validate_tick(
+            ticks[1],
+            external_sensor,
+            original_time,
+            TickStatus.SKIPPED,
+            expected_run_ids=[],
+        )
+    assert not is_in_cm
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_run_status",
+        "sensor_run_status_with_cm",
+    ],
+)
+def test_resources_run_status_sensor(
+    caplog,
+    instance,
+    workspace_context_struct_resources,
+    external_repo_struct_resources,
+    sensor_name,
+) -> None:
+    assert not is_in_cm
+
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+    original_time = freeze_datetime
+
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 0
+
+    # We have to do two ticks because the first tick will be skipped due to the run status
+    # sensor initializing its cursor
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+    the_job.execute_in_process(instance=instance)
+    freeze_datetime = freeze_datetime.add(seconds=60)
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+
+    with pendulum.test(freeze_datetime):
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+
+        assert instance.get_runs_count() == 2
+        run = instance.get_runs()[0]
+        assert ticks[0].run_keys == ["foo"]
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+            expected_run_ids=[run.run_id],
+        )
+
+        validate_tick(
+            ticks[1],
+            external_sensor,
+            original_time,
+            TickStatus.SKIPPED,
+            expected_run_ids=[],
+        )
+    assert not is_in_cm

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -47,6 +47,7 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.resource_annotation import Resource
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.execution.build_resources import build_resources
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import instance_for_test
 
@@ -176,6 +177,133 @@ def test_sensor_invocation_resources_deferred() -> None:
     with context as open_context:
         with pytest.raises(Exception):
             basic_sensor_resource_req(open_context)
+def test_multi_asset_sensor_invocation_resources() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @op
+    def an_op():
+        return 1
+
+    @job
+    def the_job():
+        an_op()
+
+    @asset
+    def asset_a():
+        return 1
+
+    @asset
+    def asset_b():
+        return 1
+
+    @multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
+    def a_and_b_sensor(context, my_resource: MyResource):
+        asset_events = context.latest_materialization_records_by_key()
+        if all(asset_events.values()):
+            context.advance_all_cursors()
+            return RunRequest(
+                run_key=context.cursor, run_config={"foo": my_resource.a_str}, tags={}
+            )
+
+    @repository
+    def my_repo():
+        return [asset_a, asset_b, a_and_b_sensor]
+
+    with instance_for_test() as instance:
+        materialize([asset_a, asset_b], instance=instance)
+        ctx = build_multi_asset_sensor_context(
+            monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
+            instance=instance,
+            repository_def=my_repo,
+            resources={"my_resource": MyResource(a_str="bar")},
+        )
+        assert cast(RunRequest, a_and_b_sensor(ctx)).run_config == {"foo": "bar"}
+
+
+def test_freshness_policy_sensor_invocation_resources() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @freshness_policy_sensor(asset_selection=AssetSelection.all())
+    def freshness_sensor(context, my_resource: MyResource) -> None:
+        assert context.minutes_late == 10
+        assert context.previous_minutes_late is None
+        assert my_resource.a_str == "bar"
+
+    with build_resources({"my_resource": MyResource(a_str="bar")}) as resources:
+        context = build_freshness_policy_sensor_context(
+            sensor_name="status_sensor",
+            asset_key=AssetKey("a"),
+            freshness_policy=FreshnessPolicy(maximum_lag_minutes=30),
+            minutes_late=10,
+            # This is a bit gross right now, but FressnessPolicySensorContext is not a subclass of
+            # SensorEvaluationContext and isn't set up to be a context manager
+            # Direct invocation of freshness policy sensors should be rare anyway
+            resources=resources,
+        )
+
+        freshness_sensor(context)
+
+
+def test_run_status_sensor_invocation_resources() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
+    def status_sensor(context, my_resource: MyResource):
+        assert context.dagster_event.event_type_value == "PIPELINE_SUCCESS"
+        assert my_resource.a_str == "bar"
+
+    @run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
+    def status_sensor_no_context(my_resource: MyResource):
+        assert my_resource.a_str == "bar"
+
+    @op
+    def succeeds():
+        return 1
+
+    @job
+    def my_job_2():
+        succeeds()
+
+    instance = DagsterInstance.ephemeral()
+    result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
+
+    dagster_run = result.dagster_run
+    dagster_event = result.get_job_success_event()
+
+    context = build_run_status_sensor_context(
+        sensor_name="status_sensor",
+        dagster_instance=instance,
+        dagster_run=dagster_run,
+        dagster_event=dagster_event,
+        resources={"my_resource": MyResource(a_str="bar")},
+    )
+
+    status_sensor(context)
+    status_sensor_no_context(context)
+
+    # also keeps resources from nested `context`
+    context = build_run_status_sensor_context(
+        sensor_name="status_sensor",
+        dagster_instance=instance,
+        dagster_run=dagster_run,
+        dagster_event=dagster_event,
+        context=build_sensor_context(resources={"my_resource": MyResource(a_str="bar")}),
+    )
+
+    status_sensor(context)
+    status_sensor_no_context(context)
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by sensor 'status_sensor_no_context' was not"
+            " provided."
+        ),
+    ):
+        status_sensor_no_context()
 
 
 def test_instance_access_built_sensor():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -177,6 +177,8 @@ def test_sensor_invocation_resources_deferred() -> None:
     with context as open_context:
         with pytest.raises(Exception):
             basic_sensor_resource_req(open_context)
+
+
 def test_multi_asset_sensor_invocation_resources() -> None:
     class MyResource(ConfigurableResource):
         a_str: str


### PR DESCRIPTION
## Summary

Stacks on #12401, adding resource support for all of our various complex sensor types (`@asset_sensor`, `@multi_asset_sensor`, `@freshness_policy_sensor`, and `@run_status_sensor`).

For most cases, this is straightforward replication of what's done in #12401. There are a few interesting cases, e.g. asset sensors currently take two inputs (context and event log entry). This is now set up so that the first two non-resource params are treated as context and event log entry, respectively.

## Test Plan

New unit tests.