### PR TITLE
non-public materialize method on RepositoryDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -38,7 +38,7 @@ from .utils import DEFAULT_IO_MANAGER_KEY
 ASSET_BASE_JOB_PREFIX = "__ASSET_JOB"
 
 
-def is_base_asset_job_name(name) -> bool:
+def is_base_asset_job_name(name: str) -> bool:
     return name.startswith(ASSET_BASE_JOB_PREFIX)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import sys
 from functools import lru_cache
+from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -17,6 +18,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -465,29 +467,51 @@ def reconstructable(target: Callable[..., "PipelineDefinition"]) -> Reconstructa
             )
         )
 
-    try:
-        if (
-            hasattr(target, "__module__")
-            and hasattr(target, "__name__")
-            and getattr(inspect.getmodule(target), "__name__", None) != "__main__"
-        ):
-            return ReconstructablePipeline.for_module(target.__module__, target.__name__)
-    except:
-        pass
-
-    python_file = get_python_file_from_target(target)
-    if not python_file:
+    code_pointer = _find_code_pointer(target)
+    if code_pointer:
+        return bootstrap_standalone_recon_pipeline(code_pointer)
+    else:
         raise DagsterInvariantViolationError(
             "reconstructable() can not reconstruct jobs or pipelines defined in interactive "
             "environments like <stdin>, IPython, or Jupyter notebooks. "
             "Use a pipeline defined in a module or file instead, or use build_reconstructable_job."
         )
 
-    pointer = FileCodePointer(
-        python_file=python_file, fn_name=target.__name__, working_directory=os.getcwd()
-    )
 
-    return bootstrap_standalone_recon_pipeline(pointer)
+def reconstructable_repository(target: "RepositoryDefinition") -> ReconstructableRepository:
+    code_pointer = _find_code_pointer(target)
+
+    if code_pointer:
+        return ReconstructableRepository(code_pointer)
+    else:
+        raise DagsterInvariantViolationError(
+            "Can only reconstruct repositories that are defined within a module, at module scope. "
+            "Cannot reconstruct repositories defined in interactive environments like <stdin>, "
+            "IPython, or Jupyter notebooks."
+        )
+
+
+def _find_code_pointer(target) -> Optional[CodePointer]:
+    try:
+        if (
+            hasattr(target, "__module__")
+            and hasattr(target, "__name__")
+            and cast(ModuleType, inspect.getmodule(target)).__name__ != "__main__"
+        ):
+            if getattr(inspect.getmodule(target), target.__name__, None) != target:
+                return None
+
+            return ModuleCodePointer(target.__module__, target.__name__, os.getcwd())
+    except:
+        pass
+
+    python_file = get_python_file_from_target(target)
+    if python_file:
+        return FileCodePointer(
+            python_file=python_file, fn_name=target.__name__, working_directory=os.getcwd()
+        )
+
+    return None
 
 
 @experimental

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -5,9 +5,12 @@ import pytest
 from dagster import (
     AssetKey,
     AssetsDefinition,
+    AssetSelection,
+    DagsterInstance,
     DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
     GraphDefinition,
+    HourlyPartitionsDefinition,
     IOManager,
     JobDefinition,
     OpDefinition,
@@ -24,16 +27,20 @@ from dagster import (
     io_manager,
     job,
     logger,
+    mem_io_manager,
+    multiprocess_executor,
     op,
     repository,
     resource,
     schedule,
     sensor,
+    with_resources,
 )
 from dagster._check import CheckError
 from dagster._core.definitions.executor_definition import multi_or_in_process_executor
 from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
-from dagster._core.errors import DagsterInvalidSubsetError
+from dagster._core.errors import DagsterInvalidSubsetError, DagsterInvariantViolationError
+from dagster._core.test_utils import instance_for_test
 from dagster._legacy import AssetGroup
 from dagster._loggers import default_loggers
 
@@ -1456,28 +1463,71 @@ def test_default_loggers_keys_conflict():
     assert the_repo.get_job("the_job").loggers == {"foo": some_logger}
 
 
-def test_base_jobs():
+@repository(default_executor_def=in_process_executor)
+def module_level_repo_in_process_executor():
     @asset
     def asset1():
-        ...
+        return 5
 
-    @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
+    return [with_resources([asset1], resource_defs={"io_manager": mem_io_manager})]
+
+
+def test_materialize_in_process_executor():
+    instance = DagsterInstance.ephemeral()
+    assert module_level_repo_in_process_executor.materialize("asset1", instance=instance).success
+    assert module_level_repo_in_process_executor.materialize(
+        AssetSelection.keys("asset1"), instance=instance
+    ).success
+
+
+@repository(default_executor_def=multiprocess_executor)
+def module_level_repo_multiprocess_executor():
+    @asset
+    def asset1():
+        return 5
+
+    return [asset1]
+
+
+def test_materialize_multiprocess_executor():
+    with instance_for_test() as instance:
+        result = module_level_repo_multiprocess_executor.materialize("asset1", instance=instance)
+        assert result.success
+
+
+@repository(default_executor_def=in_process_executor)
+def module_level_repo_with_partitioned_assets():
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2022-06-07"))
+    def asset1():
+        return 5
+
+    @asset(partitions_def=HourlyPartitionsDefinition(start_date="2022-06-06-00:00"))
     def asset2():
-        ...
+        return 5
 
-    @asset(partitions_def=StaticPartitionsDefinition(["x", "y", "z"]))
-    def asset3():
-        ...
+    return [with_resources([asset1, asset2], resource_defs={"io_manager": mem_io_manager})]
 
-    @repository
-    def repo():
-        return [asset1, asset2, asset3]
 
-    assert sorted(repo.get_implicit_asset_job_names()) == ["__ASSET_JOB_0", "__ASSET_JOB_1"]
-    assert repo.get_implicit_job_def_for_assets(
-        [asset1.key, asset2.key]
-    ).asset_layer.asset_keys == {
-        asset1.key,
-        asset2.key,
-    }
-    assert repo.get_implicit_job_def_for_assets([asset2.key, asset3.key]) is None
+def test_materialize_partitions():
+    with instance_for_test() as instance:
+        with pytest.raises(DagsterInvalidSubsetError):
+            module_level_repo_with_partitioned_assets.materialize(
+                ["asset1", "asset2"], instance=instance
+            )
+
+
+def test_repo_not_module_scoped():
+    @repository(default_executor_def=multiprocess_executor)
+    def repo_multiprocess_executor():
+        @asset
+        def asset1():
+            return 5
+
+        return [asset1]
+
+    with instance_for_test() as instance:
+        with pytest.raises(
+            DagsterInvariantViolationError,
+            match="Can only reconstruct repositories that are defined within a module",
+        ):
+            repo_multiprocess_executor.materialize("asset1", instance=instance)


### PR DESCRIPTION
### Summary & Motivation

This is a revival of https://github.com/dagster-io/dagster/pull/10072, but not exposed publicly to users.

The motivation is that I'm working on a `dagster asset materialize` CLI, and I'd like to avoid leaking the job abstraction to that part of the codebase.

### How I Tested These Changes
