### PR TITLE
[For 1.2] Make default dagster-shell behavior be to pass through environments from the calling process

### DIFF
--- a/python_modules/libraries/dagster-shell/dagster_shell/utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/utils.py
@@ -60,7 +60,7 @@ def execute_script_file(shell_script_path, output_logging, log, cwd=None, env=No
     check.str_param(shell_script_path, "shell_script_path")
     check.str_param(output_logging, "output_logging")
     check.opt_str_param(cwd, "cwd", default=os.path.dirname(shell_script_path))
-    env = check.opt_dict_param(env, "env")
+    env = check.opt_nullable_dict_param(env, "env")
 
     if output_logging not in OUTPUT_LOGGING_OPTIONS:
         raise Exception("Unrecognized output_logging %s" % output_logging)

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import pytest
+from dagster._core.test_utils import environ
 from dagster_shell.utils import execute, execute_script_file
 
 
@@ -63,6 +64,13 @@ def test_env(tmp_file):
     )
     assert res.strip() == "some_env_value"
     assert retcode == 0
+
+    # By default, pulls in env from the calling process
+    with environ({"TEST_VAR": "some_other_env_value"}):
+        res, retcode = execute(cmd, output_logging="BUFFER", log=logging)
+
+        assert res.strip() == "some_other_env_value"
+        assert retcode == 0
 
     with tmp_file(cmd) as (_, tmp_file):
         res, retcode = execute_script_file(


### PR DESCRIPTION
Summary:
This seems much more likely to be in line with what users would expect. Will lump in with 1.2 as an (unlikely) breaking change since there's a chance it will change behavior for some callsites.

Test Plan: BK

### Summary & Motivation

### How I Tested These Changes
