### PR TITLE
Allow sensors that don't target a particular job (or jobs) to launch runs against a particular job in the repository

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -145,9 +145,27 @@ def get_toys_sensors():
         for i in range(3):
             yield RunRequest(
                 run_key=str(i),
-                run_config={"ops": {"the_op": {"config": {"foo": "bar"}}}},
+                run_config={"ops": {"requires_config": {"config": {"num": i}}}},
                 tags={"fee": "fifofum"},
             )
+
+    @sensor(jobs=[simple_config_job, log_s3_job])
+    def multi_job_math_sensor(context):
+        return RunRequest(
+            job_name="simple_config_job",
+            run_key=str(1),
+            run_config={"ops": {"requires_config": {"config": {"num": 1}}}},
+            tags={"fee": "fifofum"},
+        )
+
+    @sensor()
+    def all_jobs_math_sensor(context):
+        return RunRequest(
+            job_name="simple_config_job",
+            run_key=str(1),
+            run_config={"ops": {"requires_config": {"config": {"num": 1}}}},
+            tags={"fee": "fifofum"},
+        )
 
     return [
         toy_file_sensor,
@@ -156,4 +174,6 @@ def get_toys_sensors():
         custom_slack_on_job_failure,
         built_in_slack_on_run_failure_sensor,
         math_sensor,
+        multi_job_math_sensor,
+        all_jobs_math_sensor,
     ]

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -48,6 +48,12 @@ def sensor(
 
     Takes a :py:class:`~dagster.SensorEvaluationContext`.
 
+    Sensors can target one or more jobs with either the `job` or `jobs` arguments. A sensor and any
+    jobs that it targets will be linked together in the Dagster UI. If a sensor does not target a
+    single job, any `RunRequest` objects that it returns must have a `job_name` set to identify
+    which that should be launched. If neither the `job` or `jobs` arguments are set, the sensor's
+    `RunRequest`s can launch a run for any job in the same repository as the sensor.
+
     Args:
         name (Optional[str]): The name of the sensor. Defaults to the name of the decorated
             function.

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -638,9 +638,7 @@ def _evaluate_sensor(
                     asset_selection=stale_assets, stale_assets_only=False
                 )
 
-        target_data: ExternalTargetData = check.not_none(
-            external_sensor.get_target_data(run_request.job_name)
-        )
+        target_data: ExternalTargetData = external_sensor.get_target_data(run_request.job_name)
 
         pipeline_selector = PipelineSelector(
             location_name=repo_location.name,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -121,27 +121,6 @@ def test_instance_access_with_mock():
     assert build_sensor_context(instance=mock_instance).instance == mock_instance
 
 
-def test_sensor_w_no_job():
-    @sensor()
-    def no_job_sensor():
-        pass
-
-    with pytest.raises(
-        Exception,
-        match=r".* Sensor evaluation function returned a RunRequest for a sensor lacking a "
-        r"specified target .*",
-    ):
-        no_job_sensor.check_valid_run_requests(
-            [
-                RunRequest(
-                    run_key=None,
-                    run_config=None,
-                    tags=None,
-                )
-            ]
-        )
-
-
 def test_run_status_sensor():
     @run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
     def status_sensor(context):


### PR DESCRIPTION
### Summary & Motivation
This extends sensor functionality to allow untargeted jobs - given that we already allow you to have run requests that target arbitrary assets I don't see any particular reason to not allow this as well.