### PR TITLE
Use to_python_identifier for naming objects derived from Assets/AssetKeys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -732,9 +732,9 @@ class _GraphBackedAsset:
             if asset_in.partition_mapping
         }
 
-        op_graph = graph(
-            name="__".join(out_asset_key.path).replace("-", "_"), description=self.description
-        )(fn)
+        op_graph = graph(name=out_asset_key.to_python_identifier(), description=self.description)(
+            fn
+        )
         return AssetsDefinition.from_graph(
             op_graph,
             keys_by_input_name=keys_by_input_name,

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -210,7 +210,7 @@ class SourceAsset(ResourceAddable):
         if self._node_def is None:
             self._node_def = OpDefinition(
                 compute_fn=self._get_op_def_compute_fn(self.observe_fn),
-                name="__".join(self.key.path).replace("-", "_"),
+                name=self.key.to_python_identifier(),
                 description=self.description,
             )
         return self._node_def


### PR DESCRIPTION
### Summary & Motivation
Whilst looking into the newly added `@asset_graph` decorator I noticed that there was some duplication of the logic to derive names from an Asset. Given the logic that was there the already existing [`to_python_identifier()` method](https://github.com/dagster-io/dagster/blob/e403d3974c44254a9a500492e12230f2d6d326cc/python_modules/dagster/dagster/_core/definitions/events.py#L129) available on `AssetKey` objects.


### How I Tested These Changes
Ran these changes locally with a `@graph_asset`, the Graph name is the same as it was before.
