### PR TITLE
Add root stale causes for assets

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -563,7 +563,9 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_staleStatusCauses(
         self, graphene_info: ResolveInfo
     ) -> Sequence[GrapheneAssetStaleStatusCause]:
-        causes = self.stale_status_loader.get_status_causes(self._external_asset_node.asset_key)
+        causes = self.stale_status_loader.get_status_root_causes(
+            self._external_asset_node.asset_key
+        )
         return [
             GrapheneAssetStaleStatusCause(
                 cause.status,


### PR DESCRIPTION
### Summary & Motivation

- Change `stale_causes` returned from `CachingStaleStatusResolver` to return a tree.
- Add `stale_root_causes` that returns a flat list of causes representing root causes.
- Change the `staleStatusCauses` GQL resolver to return just the root causes, which are more suitabel for display in dagit.
- Add "missing input" staleness reason.

### How I Tested These Changes

New test testing for root causes
