### PR TITLE
[1.2] make ScheduleEvaluationContext.scheduled_execution_time non-optional

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -48,7 +48,7 @@ def configurable_job():
 
 @schedule(job=configurable_job, cron_schedule="0 0 * * *")
 def configurable_job_schedule(context: ScheduleEvaluationContext):
-    scheduled_date = context.scheduled_execution_time.strftime("%Y-%m-%d")  # type: ignore  # (didactic)
+    scheduled_date = context.scheduled_execution_time.strftime("%Y-%m-%d")
     return RunRequest(
         run_key=None,
         run_config={

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -169,7 +169,13 @@ class ScheduleEvaluationContext:
 
     @public
     @property
-    def scheduled_execution_time(self) -> Optional[datetime]:
+    def scheduled_execution_time(self) -> datetime:
+        if self._scheduled_execution_time is None:
+            check.failed(
+                "Attempting to access scheduled_execution_time, but no scheduled_execution_time was"
+                " set on this context"
+            )
+
         return self._scheduled_execution_time
 
     @property

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -199,7 +199,7 @@ class RepositoryLocation(AbstractContextManager):
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
         schedule_name: str,
-        scheduled_execution_time,
+        scheduled_execution_time: datetime.datetime,
     ) -> "ScheduleExecutionData":
         pass
 
@@ -485,12 +485,8 @@ class InProcessRepositoryLocation(RepositoryLocation):
             self._get_repo_def(repository_handle.repository_name),
             instance_ref=instance.get_ref(),
             schedule_name=schedule_name,
-            scheduled_execution_timestamp=scheduled_execution_time.timestamp()
-            if scheduled_execution_time
-            else None,
-            scheduled_execution_timezone=scheduled_execution_time.timezone.name  # type: ignore
-            if scheduled_execution_time
-            else None,
+            scheduled_execution_timestamp=scheduled_execution_time.timestamp(),
+            scheduled_execution_timezone=scheduled_execution_time.timezone.name,  # type: ignore
         )
         if isinstance(result, ExternalScheduleExecutionErrorData):
             raise DagsterUserCodeProcessError.from_error_info(result.error)

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -15,6 +15,7 @@ from dagster import (
     schedule,
     validate_run_config,
 )
+from dagster._core.errors import ScheduleExecutionError
 from dagster._utils.merger import merge_dicts
 
 # This file tests a lot of parameter name stuff, so these warnings are spurious
@@ -58,10 +59,8 @@ def test_scheduler():
 
     context_with_time = build_schedule_context(scheduled_execution_time=execution_time)
 
-    execution_data = echo_time_schedule.evaluate_tick(context_without_time)
-    assert execution_data.run_requests
-    assert len(execution_data.run_requests) == 1
-    assert execution_data.run_requests[0].run_config == {"echo_time": ""}
+    with pytest.raises(ScheduleExecutionError):
+        echo_time_schedule.evaluate_tick(context_without_time)
 
     execution_data = echo_time_schedule.evaluate_tick(context_with_time)
     assert execution_data.run_requests


### PR DESCRIPTION
### Summary & Motivation

Motivation: doing basic schedule things raises a TypeError. E.g. look at the example that's changed in this PR.

In normal operation, this property will always be set, but it's possible for someone to construct a test context using `build_schedule_context` and leave it out.

This makes `ScheduleEvaluationContext` follow the same pattern that we use in other contexts when users omit fields when building a test context.

I would consider this a bug, but it's arguably a breaking change, so I'm going to merge it with 1.2 instead of in a patch release.

### How I Tested These Changes
