### PR TITLE
Change format of staleness root causes and remove old resolvers

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -10,7 +10,6 @@ export const MockStaleReason: StaleStatusCause = {
     __typename: 'AssetKey',
   },
   reason: 'stale input',
-  status: StaleStatus.STALE,
   dependency: {
     path: ['asset0'],
     __typename: 'AssetKey',

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -679,7 +679,6 @@ type AssetNode {
   partitionDefinition: PartitionDefinition
   partitionKeys: [String!]!
   partitionKeysByDimension(startIdx: Int, endIdx: Int): [DimensionPartitionKeys!]!
-  projectedLogicalVersion: String
   repository: Repository!
   requiredResources: [ResourceRequirement!]!
   staleStatus: StaleStatus
@@ -788,7 +787,6 @@ enum StaleStatus {
 }
 
 type StaleStatusCause {
-  status: StaleStatus!
   key: AssetKey!
   reason: String!
   dependency: AssetKey

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -215,7 +215,6 @@ export type AssetNode = {
   partitionKeys: Array<Scalars['String']>;
   partitionKeysByDimension: Array<DimensionPartitionKeys>;
   partitionStats: Maybe<PartitionStats>;
-  projectedLogicalVersion: Maybe<Scalars['String']>;
   repository: Repository;
   requiredResources: Array<ResourceRequirement>;
   staleStatus: Maybe<StaleStatus>;
@@ -3493,7 +3492,6 @@ export type StaleStatusCause = {
   dependency: Maybe<AssetKey>;
   key: AssetKey;
   reason: Scalars['String'];
-  status: StaleStatus;
 };
 
 export type StartScheduleMutation = {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -151,10 +151,8 @@ GET_ASSET_LOGICAL_VERSIONS = """
               path
             }
             currentLogicalVersion
-            projectedLogicalVersion
             staleStatus
             staleStatusCauses {
-                status
                 key { path }
                 reason
                 dependency { path }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_logical_versions.py
@@ -73,7 +73,6 @@ def test_stale_status():
             assert foo["staleStatus"] == "MISSING"
             assert foo["staleStatusCauses"] == [
                 {
-                    "status": "MISSING",
                     "reason": "never materialized",
                     "key": {"path": ["foo"]},
                     "dependency": None,
@@ -135,8 +134,8 @@ def test_partitioned_self_dep():
             result = _fetch_logical_versions(context, repo)
             assert result
             assert result.data
-            assert _get_asset_node("a", result)["projectedLogicalVersion"] is None
-            assert _get_asset_node("b", result)["projectedLogicalVersion"] is None
+            assert _get_asset_node("a", result)["staleStatus"] == "MISSING"
+            assert _get_asset_node("b", result)["staleStatus"] == "MISSING"
 
 
 def _materialize_assets(


### PR DESCRIPTION
### Summary & Motivation

- Enhance clarity of GQL stale status reasons
- Drop `status` field from `GrapheneAssetStaleCause`
- Remove `projectedLogicalVersion` field on GQL assetNode
- Completely remove `projectedLogicalVersion` from code base

### How I Tested These Changes

Updated logical versioning test suite
