### PR TITLE
iteritems -> items

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -77,7 +77,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                 TableSchema(
                     columns=[
                         TableColumn(name=name, type=str(dtype))
-                        for name, dtype in obj.dtypes.iteritems()
+                        for name, dtype in obj.dtypes.items()
                     ]
                 )
             ),

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -76,7 +76,7 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             "dataframe_columns": MetadataValue.table_schema(
                 TableSchema(
                     columns=[
-                        TableColumn(name=name, type=str(dtype))
+                        TableColumn(name=str(name), type=str(dtype))
                         for name, dtype in obj.dtypes.items()
                     ]
                 )


### PR DESCRIPTION
### Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/12604

`.iteritems` is [deprecated since 1.50 ](https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#other-deprecations) and will be removed in a future version. Changing to `.items`. (https://github.com/pandas-dev/pandas/pull/45321).

### How I Tested These Changes

I did not, but https://github.com/pandas-dev/pandas/pull/45321 appears to indicate it's a safe change to make. If I can somehow install this version of dagster on my machine, I'm happy to test using the code that surfaced the issue, but I'm not sure how to do that.