### PR TITLE
[dagster-snowflake] fix inconsistencies in snowflake resource

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -311,7 +311,7 @@ def test_time_window_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -323,7 +323,7 @@ def test_time_window_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -335,7 +335,7 @@ def test_time_window_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
 
@@ -398,7 +398,7 @@ def test_static_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -410,7 +410,7 @@ def test_static_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -422,7 +422,7 @@ def test_static_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
 
@@ -491,7 +491,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -503,7 +503,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -515,7 +515,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
 
@@ -527,7 +527,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
 
@@ -594,7 +594,7 @@ def test_dynamic_partitions():
             )
 
             out_df = snowflake_conn.execute_query(
-                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -609,7 +609,7 @@ def test_dynamic_partitions():
             )
 
             out_df = snowflake_conn.execute_query(
-                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -622,6 +622,6 @@ def test_dynamic_partitions():
             )
 
             out_df = snowflake_conn.execute_query(
-                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -263,7 +263,7 @@ def test_time_window_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -275,7 +275,7 @@ def test_time_window_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -287,7 +287,7 @@ def test_time_window_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
 
@@ -359,7 +359,7 @@ def test_static_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -371,7 +371,7 @@ def test_static_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -383,7 +383,7 @@ def test_static_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
 
@@ -467,7 +467,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -479,7 +479,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -491,7 +491,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
 
@@ -503,7 +503,7 @@ def test_multi_partitioned_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
 
@@ -583,7 +583,7 @@ def test_dynamic_partitions():
             )
 
             out_df = snowflake_conn.execute_query(
-                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert out_df["A"].tolist() == ["1", "1", "1"]
 
@@ -598,7 +598,7 @@ def test_dynamic_partitions():
             )
 
             out_df = snowflake_conn.execute_query(
-                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]
 
@@ -611,6 +611,6 @@ def test_dynamic_partitions():
             )
 
             out_df = snowflake_conn.execute_query(
-                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+                f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -291,7 +291,7 @@ class SnowflakeConnection:
                     if use_pandas_result:
                         results = results.append(cursor.fetch_pandas_all())  # type: ignore
                     elif fetch_results:
-                        results.append(cursor.fetchall())  # type: ignore
+                        results.append(cursor.fetchall())
 
         return results if len(results) > 0 else None
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -1,7 +1,7 @@
 import sys
 import warnings
 from contextlib import closing, contextmanager
-from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from cryptography.hazmat.backends import default_backend
@@ -201,9 +201,10 @@ class SnowflakeConnection:
             sql (str): the query to be executed
             parameters (Optional[Union[Sequence[Any], Mapping[Any, Any]]]): Parameters to be passed to the query. See
                 https://docs.snowflake.com/en/user-guide/python-connector-example.html#binding-data
-            fetch_results (bool): If True, will return the result of the query. Defaults to False
+            fetch_results (bool): If True, will return the result of the query. Defaults to False. If True
+                and use_pandas_result is also True, results will be returned as a Pandas DataFrame.
             use_pandas_result (bool): If True, will return the result of the query as a Pandas DataFrame.
-                Defaults to False
+                Defaults to False.
 
         Returns:
             The result of the query if fetch_results or use_pandas_result is True, otherwise returns None
@@ -229,10 +230,10 @@ class SnowflakeConnection:
                 self.log.info("Executing query: " + sql)
                 parameters = dict(parameters) if isinstance(parameters, Mapping) else parameters
                 cursor.execute(sql, parameters)
-                if fetch_results:
-                    return cursor.fetchall()
                 if use_pandas_result:
                     return cursor.fetch_pandas_all()
+                if fetch_results:
+                    return cursor.fetchall()
 
     @public
     def execute_queries(
@@ -241,16 +242,17 @@ class SnowflakeConnection:
         parameters: Optional[Union[Sequence[Any], Mapping[Any, Any]]] = None,
         fetch_results: bool = False,
         use_pandas_result: bool = False,
-    ):
+    ) -> Optional[Sequence[Any]]:
         """Execute multiple queries in Snowflake.
 
         Args:
             sql_queries (str): List of queries to be executed in series
             parameters (Optional[Union[Sequence[Any], Mapping[Any, Any]]]): Parameters to be passed to every query. See
                 https://docs.snowflake.com/en/user-guide/python-connector-example.html#binding-data
-            fetch_results (bool): If True, will return the results of the queries as a list. Defaults to False
+            fetch_results (bool): If True, will return the results of the queries as a list. Defaults to False. If True
+                and use_pandas_result is also True, results will be returned as Pandas DataFrames.
             use_pandas_result (bool): If True, will return the results of the queries as a list of a Pandas DataFrames.
-                Defaults to False
+                Defaults to False.
 
         Returns:
             The results of the queries as a list if fetch_results or use_pandas_result is True,
@@ -263,7 +265,7 @@ class SnowflakeConnection:
                 def create_fresh_database(context):
                     queries = ["DROP DATABASE IF EXISTS MY_DATABASE", "CREATE DATABASE MY_DATABASE"]
                     context.resources.snowflake.execute_queries(
-                        sql=queries
+                        sql_queries=queries
                     )
 
         """
@@ -271,12 +273,7 @@ class SnowflakeConnection:
         check.opt_inst_param(parameters, "parameters", (list, dict))
         check.bool_param(fetch_results, "fetch_results")
 
-        if use_pandas_result:
-            import pandas as pd
-
-            results = pd.DataFrame()
-        else:
-            results = []
+        results: List[Any] = []
         with self.get_connection() as conn:
             with closing(conn.cursor()) as cursor:
                 for sql in sql_queries:
@@ -285,13 +282,12 @@ class SnowflakeConnection:
                     self.log.info("Executing query: " + sql)
                     parameters = dict(parameters) if isinstance(parameters, Mapping) else parameters
                     cursor.execute(sql, parameters)
-                    if fetch_results:
-                        if use_pandas_result:
-                            results = results.append(cursor.fetch_pandas_all())  # type: ignore
-                        else:
-                            results.append(cursor.fetchall())  # type: ignore
+                    if use_pandas_result:
+                        results = results.append(cursor.fetch_pandas_all())  # type: ignore
+                    elif fetch_results:
+                        results.append(cursor.fetchall())  # type: ignore
 
-        return results if fetch_results else None
+        return results if len(results) > 0 else None
 
     @public
     def load_table_from_local_parquet(self, src: str, table: str):

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -204,7 +204,8 @@ class SnowflakeConnection:
             fetch_results (bool): If True, will return the result of the query. Defaults to False. If True
                 and use_pandas_result is also True, results will be returned as a Pandas DataFrame.
             use_pandas_result (bool): If True, will return the result of the query as a Pandas DataFrame.
-                Defaults to False.
+                Defaults to False. If fetch_results is False and use_pandas_result is True, an error will be
+                raised.
 
         Returns:
             The result of the query if fetch_results or use_pandas_result is True, otherwise returns None
@@ -221,6 +222,8 @@ class SnowflakeConnection:
         check.str_param(sql, "sql")
         check.opt_inst_param(parameters, "parameters", (list, dict))
         check.bool_param(fetch_results, "fetch_results")
+        if not fetch_results and use_pandas_result:
+            check.failed("If use_pandas_result is True, fetch_results must also be True.")
 
         with self.get_connection() as conn:
             with closing(conn.cursor()) as cursor:
@@ -252,7 +255,8 @@ class SnowflakeConnection:
             fetch_results (bool): If True, will return the results of the queries as a list. Defaults to False. If True
                 and use_pandas_result is also True, results will be returned as Pandas DataFrames.
             use_pandas_result (bool): If True, will return the results of the queries as a list of a Pandas DataFrames.
-                Defaults to False.
+                Defaults to False. If fetch_results is False and use_pandas_result is True, an error will be
+                raised.
 
         Returns:
             The results of the queries as a list if fetch_results or use_pandas_result is True,
@@ -272,6 +276,8 @@ class SnowflakeConnection:
         check.sequence_param(sql_queries, "sql_queries", of_type=str)
         check.opt_inst_param(parameters, "parameters", (list, dict))
         check.bool_param(fetch_results, "fetch_results")
+        if not fetch_results and use_pandas_result:
+            check.failed("If use_pandas_result is True, fetch_results must also be True.")
 
         results: List[Any] = []
         with self.get_connection() as conn:


### PR DESCRIPTION
### Summary & Motivation
Fixes #12084

A user pointed out that the `execute_query` and `execute_queries` methods are inconsistent with each other:
* in `execute_query`, if `fetch_result` is True and `use_pandas_result` is True, the non pandas result is returned
* in `execute_queries`, if `fetch_result` is True and `use_pandas_result` is True, the pandas result is used
* 
* in `execute_query`, if `fetch_result` is False and `use_pandas_result` is True, the pandas result is returned
* in `execute_queries`, if `fetch_result` is False and `use_pandas_result` is True, nothing is returned

This PR makes the two methods consistent according to this chart

`fetch_result` |  `use_pandas_result`   |  outcome
True                 |     True                             | pandas result
True                 |     False                            | non-pandas result
False               |      True                             | ~pandas result~ no result + error (see comments below)
False               |      False                            | no results

 Open to other options for determining which result to return -  for example, we could make the two options mutually exclusive and error if both are True. Just needed to pick one to implement as a starting point for discussion


--- 
Additionally this fixes an issue in `execute_queries` when `use_pandas_result` is True. Before, all of the results of the queries were being put into a single dataframe, which would cause issues if the queries where for different tables. This updates the method to append the dataframes to a list

### How I Tested These Changes
