### PR TITLE
[dagster-gcp-pandas] add timeout config

### DIFF
--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -381,7 +381,7 @@ defs = Definitions(
                 "project": "my-gcp-project",  # required
                 "location": "us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
                 "data": "IRIS",  # optional, defaults to PUBLIC
-                "temporary_gcs_bucket": "my-gcs-bucket",
+                "temporary_gcs_bucket": "my-gcs-bucket",  # optional, defaults to None, which will result in a direct write to BigQuery
             }
         )
     },

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -61,7 +61,6 @@ defs = Definitions(
                 "location": "us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
                 "dataset": "IRIS",  # optional, defaults to PUBLIC
                 "timeout": 15.0,  # optional, defaults to None
-                "retries": 2,  # optional, defaults to BigQuery default
             }
         )
     },

--- a/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
+++ b/docs/content/integrations/bigquery/using-bigquery-with-dagster.mdx
@@ -45,7 +45,7 @@ The BigQuery I/O manager requires some configuration to connect to your Bigquery
 - A `project`
 - One method of authentication. You can follow the GCP authentication instructions [here](https://cloud.google.com/docs/authentication/provide-credentials-adc), or see [Providing credentials as configuration](/integrations/bigquery/reference#providing-credentials-as-configuration) in the BigQuery reference guide.
 
-You can also specify a `location` where data should be stored and processed and `dataset` that should hold the created tables.
+You can also specify a `location` where data should be stored and processed and `dataset` that should hold the created tables. You can also set a `timeout` and number of `retries` when working with Pandas DataFrames.
 
 ```python file=/integrations/bigquery/configuration.py startafter=start_example endbefore=end_example
 from dagster_gcp_pandas import bigquery_pandas_io_manager
@@ -60,6 +60,8 @@ defs = Definitions(
                 "project": "my-gcp-project",  # required
                 "location": "us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
                 "dataset": "IRIS",  # optional, defaults to PUBLIC
+                "timeout": 15.0,  # optional, defaults to None
+                "retries": 2,  # optional, defaults to BigQuery default
             }
         )
     },

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/configuration.py
@@ -20,6 +20,8 @@ defs = Definitions(
                 "project": "my-gcp-project",  # required
                 "location": "us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
                 "dataset": "IRIS",  # optional, defaults to PUBLIC
+                "timeout": 15.0,  # optional, defaults to None
+                "retries": 2,  # optional, defaults to BigQuery default
             }
         )
     },

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/configuration.py
@@ -21,7 +21,6 @@ defs = Definitions(
                 "location": "us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
                 "dataset": "IRIS",  # optional, defaults to PUBLIC
                 "timeout": 15.0,  # optional, defaults to None
-                "retries": 2,  # optional, defaults to BigQuery default
             }
         )
     },

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/pyspark_configuration.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/pyspark_configuration.py
@@ -14,7 +14,7 @@ defs = Definitions(
                 "project": "my-gcp-project",  # required
                 "location": "us-east5",  # optional, defaults to the default location for the project - see https://cloud.google.com/bigquery/docs/locations for a list of locations
                 "data": "IRIS",  # optional, defaults to PUBLIC
-                "temporary_gcs_bucket": "my-gcs-bucket",
+                "temporary_gcs_bucket": "my-gcs-bucket",  # optional, defaults to None, which will result in a direct write to BigQuery
             }
         )
     },

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -39,19 +39,12 @@ class BigQueryPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         """Stores the pandas DataFrame in BigQuery."""
         with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
 
-        kwargs = {}
-        if context.resource_config and context.resource_config["retries"] is not None:
-            # set the num_retries as kwargs so that we can default to the BigQuery default if
-            # retries=None
-            kwargs["num_retries"] = context.resource_config["retries"]
-
         job = connection.load_table_from_dataframe(
             dataframe=with_uppercase_cols,
             destination=f"{table_slice.schema}.{table_slice.table}",
             project=table_slice.database,
             location=context.resource_config["location"] if context.resource_config else None,
             timeout=context.resource_config["timeout"] if context.resource_config else None,
-            **kwargs,
         )
         job.result()
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -151,15 +151,6 @@ def build_bigquery_io_manager(
                     " queries (loading and reading from tables)."
                 ),
             ),
-            "retries": Field(
-                Noneable(int),
-                is_required=False,
-                default_value=None,
-                description=(
-                    "When using Pandas DataFrames, optionally specify a number of retries when"
-                    " loading data into BigQuery."
-                ),
-            ),
         }
     )
     def bigquery_io_manager(init_context):

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -142,6 +142,24 @@ def build_bigquery_io_manager(
                     " store data. If not provided, data will be directly written to BigQuery."
                 ),
             ),
+            "timeout": Field(
+                Noneable(float),
+                is_required=False,
+                default_value=None,
+                description=(
+                    "When using Pandas DataFrames, optionally specify a timeout for the BigQuery"
+                    " queries (loading and reading from tables)."
+                ),
+            ),
+            "retries": Field(
+                Noneable(int),
+                is_required=False,
+                default_value=None,
+                description=(
+                    "When using Pandas DataFrames, optionally specify a number of retries when"
+                    " loading data into BigQuery."
+                ),
+            ),
         }
     )
     def bigquery_io_manager(init_context):


### PR DESCRIPTION
### Summary & Motivation
resolves #12540 

adds timeout configuration for the bigquery io manager. Right now it's only used for pandas, since there isn't a clear equivalent for pyspark 

### How I Tested These Changes
