### PR TITLE
[docs] Completing Picking a Github Issue code block correctly so docs render

### DIFF
--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -127,6 +127,7 @@ To change the code snippet, update the `.py` file, then run the following from t
 
 ```bash
 make mdx-format
+```
 
 You can find more information about developing documentation in `docs/README.md`.
 
@@ -147,4 +148,3 @@ In the PR template, please describe the change, including the motivation/context
 A Core reviewer will review your PR in around one business day and provide feedback on any changes it requires to be approved. Once approved and all the tests (including Buildkite!) pass, the reviewer will click the Squash and merge button in Github 🥳.
 
 Your PR is now merged into Dagster! We’ll shout out your contribution in the weekly release notes.
-```


### PR DESCRIPTION
### Summary & Motivation
- The contributing doc block  `Picking a Github Issue` isn't correctly rendering.
- I moved backticks to the end of the code block so the doc block renders correctly.

### How I Tested These Changes
- Rendered locally as expected