### PR TITLE
Return dynamic partitions in order

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1832,8 +1832,10 @@ class SqlEventLogStorage(EventLogStorage):
             DynamicPartitionsTable.c.partitions_def_name,
             DynamicPartitionsTable.c.partition,
         ]
-        query = db.select(columns).where(
-            DynamicPartitionsTable.c.partitions_def_name == partitions_def_name
+        query = (
+            db.select(columns)
+            .where(DynamicPartitionsTable.c.partitions_def_name == partitions_def_name)
+            .order_by(DynamicPartitionsTable.c.id)
         )
         with self.index_connection() as conn:
             rows = conn.execute(query).fetchall()
@@ -1862,7 +1864,12 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                 )
             ).fetchall()
-            new_keys = set(partition_keys) - set([row[0] for row in existing_rows])
+            existing_keys = set([row[0] for row in existing_rows])
+            new_keys = [
+                partition_key
+                for partition_key in partition_keys
+                if partition_key not in existing_keys
+            ]
 
             if new_keys:
                 conn.execute(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3098,18 +3098,18 @@ class TestEventLogStorage:
         )
         partitions = storage.get_dynamic_partitions("foo")
         assert len(partitions) == 3
-        assert set(partitions) == {"foo", "bar", "baz"}
+        assert partitions == ["foo", "bar", "baz"]
 
         # Test for idempotency
         storage.add_dynamic_partitions(partitions_def_name="foo", partition_keys=["foo"])
         partitions = storage.get_dynamic_partitions("foo")
         assert len(partitions) == 3
-        assert set(partitions) == {"foo", "bar", "baz"}
+        assert partitions == ["foo", "bar", "baz"]
 
         storage.add_dynamic_partitions(partitions_def_name="foo", partition_keys=["foo", "qux"])
         partitions = storage.get_dynamic_partitions("foo")
         assert len(partitions) == 4
-        assert set(partitions) == {"foo", "bar", "baz", "qux"}
+        assert partitions == ["foo", "bar", "baz", "qux"]
 
         assert set(storage.get_dynamic_partitions("baz")) == set()
 


### PR DESCRIPTION
Changes the `get_dynamic_partitions` method to return keys in the order that they exist in the database. Previously the index would cause the keys to be returned alphabetically.