### PR TITLE
Helm: Support valueFrom in user deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
@@ -9,9 +9,8 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 data:
-  # If this is a map (default), we write it to this configmap. If it's a list, we include it
-  # directly on the container (can use more k8s spec like valueFrom). Once we
-  # include this in the k8sContainerContext, we can default it to a list
+  # If this is a map, we write it to this configmap. If it's a list, we include it
+  # directly on the container (can use more k8s spec like valueFrom).
   {{- if and ($deployment.env) (kindIs "map" $deployment.env) }}
   {{- range $name, $value := $deployment.env }}
   {{ $name }}: {{ $value | quote }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
@@ -9,8 +9,13 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 data:
+  # If this is a map (default), we write it to this configmap. If it's a list, we include it
+  # directly on the container (can use more k8s spec like valueFrom). Once we
+  # include this in the k8sContainerContext, we can default it to a list
+  {{- if and ($deployment.env) (kindIs "map" $deployment.env) }}
   {{- range $name, $value := $deployment.env }}
   {{ $name }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
 ---
 {{ end }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -58,6 +58,11 @@ spec:
             - name: DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT
               value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
             {{- end }}
+            # If this is a map (default), we write it to a configmap. If it's a list, we include it here (can use more k8s spec like valueFrom). Once we
+            # include this in the k8sContainerContext, we can default it to a list.
+            {{- if and ($deployment.env) (kindIs "slice" $deployment.env) }}
+            {{- toYaml $deployment.env | nindent 12 }}
+            {{- end}}
           envFrom:
             - configMapRef:
                 name: {{ include "dagster.fullname" $ }}-user-deployments-shared-env

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -58,8 +58,7 @@ spec:
             - name: DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT
               value: {{ include "dagsterUserDeployments.k8sContainerContext" (list $ $deployment) | fromYaml | toJson | quote }}
             {{- end }}
-            # If this is a map (default), we write it to a configmap. If it's a list, we include it here (can use more k8s spec like valueFrom). Once we
-            # include this in the k8sContainerContext, we can default it to a list.
+            # If this is a map, we write it to a configmap. If it's a list, we include it here (can use more k8s spec like valueFrom).
             {{- if and ($deployment.env) (kindIs "slice" $deployment.env) }}
             {{- toYaml $deployment.env | nindent 12 }}
             {{- end}}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -134,5 +134,8 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
     {{- end }}
     namespace: {{ $.Release.Namespace }}
     service_account_name: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
+    {{- if and (.env) (kindIs "slice" .env) }}
+    env: {{- .env | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
 {{- end -}}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -100,6 +100,12 @@
                 "enabled"
             ]
         },
+        "EnvVar": {
+            "title": "EnvVar",
+            "type": "object",
+            "properties": {},
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
+        },
         "ConfigMapEnvSource": {
             "title": "ConfigMapEnvSource",
             "type": "object",
@@ -219,10 +225,20 @@
                 },
                 "env": {
                     "title": "Env",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EnvVar"
+                            }
+                        }
+                    ]
                 },
                 "envConfigMaps": {
                     "title": "Envconfigmaps",

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -71,15 +71,17 @@ deployments:
     volumeMounts: []
 
     # Additional environment variables to set.
-    # A Kubernetes ConfigMap will be created with these environment variables. See:
-    # https://kubernetes.io/docs/concepts/configuration/configmap/
+    # These will be directly applied to the daemon container. See
+    # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
     #
     # Example:
     #
     # env:
-    #   ENV_ONE: one
-    #   ENV_TWO: two
-    env: {}
+    # - name: ENV_ONE
+    #   value: "one"
+    # - name: ENV_TWO
+    #   value: "two"
+    env: []
 
     # Additional environment variables can be retrieved and set from ConfigMaps. See:
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class UserDeployment(BaseModel):
     dagsterApiGrpcArgs: List[str]
     includeConfigInLaunchedRuns: Optional[UserDeploymentIncludeConfigInLaunchedRuns]
     port: int
-    env: Optional[Dict[str, str]]
+    env: Optional[Union[Dict[str, str], List[kubernetes.EnvVar]]]
     envConfigMaps: Optional[List[kubernetes.ConfigMapEnvSource]]
     envSecrets: Optional[List[kubernetes.SecretEnvSource]]
     annotations: Optional[kubernetes.Annotations]

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -1009,6 +1009,41 @@ def test_env(template: HelmTemplate, user_deployment_configmap_template):
     assert dagster_user_deployment.spec.template.spec.containers[0].env[3].value == "test_value"
 
 
+def test_env_container_context(template: HelmTemplate, user_deployment_configmap_template):
+    # new env: list. Gets written to container
+    deployment = UserDeployment.construct(
+        name="foo",
+        image=kubernetes.Image(repository="repo/foo", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", "foo"],
+        port=3030,
+        includeConfigInLaunchedRuns=UserDeploymentIncludeConfigInLaunchedRuns(enabled=True),
+        env=[{"name": "test_env", "value": "test_value"}],
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    [cm] = user_deployment_configmap_template.render(helm_values)
+    assert not cm.data
+
+    [dagster_user_deployment] = template.render(helm_values)
+    assert len(dagster_user_deployment.spec.template.spec.containers[0].env) == 4
+    assert dagster_user_deployment.spec.template.spec.containers[0].env[3].name == "test_env"
+    assert dagster_user_deployment.spec.template.spec.containers[0].env[3].value == "test_value"
+
+    container_context = dagster_user_deployment.spec.template.spec.containers[0].env[2]
+    assert container_context.name == "DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT"
+    assert json.loads(container_context.value) == {
+        "k8s": {
+            "image_pull_policy": "Always",
+            "env_config_maps": ["release-name-dagster-user-deployments-foo-user-env"],
+            "namespace": "default",
+            "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+            "env": [{"name": "test_env", "value": "test_value"}],
+        }
+    }
+
+
 def test_old_env(template: HelmTemplate, user_deployment_configmap_template):
     # old style env: dict. Gets written to configmap
     deployment = UserDeployment.construct(

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -984,3 +984,47 @@ def test_scheduler_name(template: HelmTemplate):
     dagster_user_deployment = dagster_user_deployment[0]
 
     assert dagster_user_deployment.spec.template.spec.scheduler_name == "myscheduler"
+
+
+def test_env(template: HelmTemplate, user_deployment_configmap_template):
+    # new env: list. Gets written to container
+    deployment = UserDeployment.construct(
+        name="foo",
+        image=kubernetes.Image(repository="repo/foo", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", "foo"],
+        port=3030,
+        includeConfigInLaunchedRuns=None,
+        env=[{"name": "test_env", "value": "test_value"}],
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    [cm] = user_deployment_configmap_template.render(helm_values)
+    assert not cm.data
+
+    [dagster_user_deployment] = template.render(helm_values)
+    assert len(dagster_user_deployment.spec.template.spec.containers[0].env) == 4
+    assert dagster_user_deployment.spec.template.spec.containers[0].env[3].name == "test_env"
+    assert dagster_user_deployment.spec.template.spec.containers[0].env[3].value == "test_value"
+
+
+def test_old_env(template: HelmTemplate, user_deployment_configmap_template):
+    # old style env: dict. Gets written to configmap
+    deployment = UserDeployment.construct(
+        name="foo",
+        image=kubernetes.Image(repository="repo/foo", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", "foo"],
+        port=3030,
+        includeConfigInLaunchedRuns=None,
+        env={"test_env": "test_value"},
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    [dagster_user_deployment] = template.render(helm_values)
+    assert len(dagster_user_deployment.spec.template.spec.containers[0].env) == 3
+
+    [cm] = user_deployment_configmap_template.render(helm_values)
+    assert cm.data["test_env"] == "test_value"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -563,10 +563,20 @@
                 },
                 "env": {
                     "title": "Env",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EnvVar"
+                            }
+                        }
+                    ]
                 },
                 "envConfigMaps": {
                     "title": "Envconfigmaps",

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -308,15 +308,17 @@ dagster-user-deployments:
         enabled: true
 
       # Additional environment variables to set.
-      # A Kubernetes ConfigMap will be created with these environment variables. See:
-      # https://kubernetes.io/docs/concepts/configuration/configmap/
+      # These will be directly applied to the daemon container. See
+      # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
       #
       # Example:
       #
       # env:
-      #   ENV_ONE: one
-      #   ENV_TWO: two
-      env: {}
+      # - name: ENV_ONE
+      #   value: "one"
+      # - name: ENV_TWO
+      #   value: "two"
+      env: []
 
       # Additional environment variables can be retrieved and set from ConfigMaps. See:
       # https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -842,7 +842,12 @@ def _deployment_config(docker_image):
             "includeConfigInLaunchedRuns": {
                 "enabled": True,
             },
-            "env": ({"BUILDKITE": os.getenv("BUILDKITE")} if os.getenv("BUILDKITE") else {}),
+            "env": (
+                [{"name": "BUILDKITE", "value": os.getenv("BUILDKITE")}]
+                if os.getenv("BUILDKITE")
+                else []
+            )
+            + [{"name": "MY_POD_NAME", "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}}],
             "envConfigMaps": ([{"name": TEST_AWS_CONFIGMAP_NAME}] if not IS_BUILDKITE else []),
             "envSecrets": [{"name": TEST_DEPLOYMENT_SECRET_NAME}],
             "annotations": {"dagster-integration-tests": "ucd-1-pod-annotation"},

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -176,7 +176,9 @@ class K8sStepHandler(StepHandler):
         assert len(step_keys_to_execute) == 1, "Launching multiple steps is not currently supported"
         return step_keys_to_execute[0]
 
-    def _get_container_context(self, step_handler_context: StepHandlerContext):
+    def _get_container_context(
+        self, step_handler_context: StepHandlerContext
+    ) -> K8sContainerContext:
         step_key = self._get_step_key(step_handler_context)
 
         context = K8sContainerContext.create_for_run(
@@ -249,6 +251,7 @@ class K8sStepHandler(StepHandler):
                     "value": step_handler_context.dagster_run.pipeline_name,
                 },
                 {"name": "DAGSTER_RUN_STEP_KEY", "value": step_key},
+                *container_context.env,
             ],
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -573,6 +573,17 @@ class DagsterK8sJobConfig(
                     is_required=False,
                     description="Raw Kubernetes configuration for launched code servers.",
                 ),
+                "env": Field(
+                    Array(
+                        Permissive(
+                            {
+                                "name": str,
+                            }
+                        )
+                    ),
+                    is_required=False,
+                    default_value=[],
+                ),
             },
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -206,7 +206,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
     def get_container_context_for_run(self, pipeline_run: DagsterRun) -> K8sContainerContext:
         return K8sContainerContext.create_for_run(pipeline_run, self, include_run_tags=True)
 
-    def _launch_k8s_job_with_args(self, job_name, args, run):
+    def _launch_k8s_job_with_args(self, job_name, args, run) -> None:
         container_context = self.get_container_context_for_run(run)
 
         pod_name = job_name
@@ -239,7 +239,8 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                 {
                     "name": "DAGSTER_RUN_JOB_NAME",
                     "value": pipeline_origin.pipeline_name,
-                }
+                },
+                *container_context.env,
             ],
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -49,6 +49,12 @@ def container_context_config():
                 },
                 "job_spec_config": {"backoff_limit": 120},
             },
+            "env": [
+                {
+                    "name": "DD_AGENT_HOST",
+                    "value_from": {"field_ref": {"field_path": "status.hostIP"}},
+                },
+            ],
         },
     }
 
@@ -96,6 +102,7 @@ def other_container_context_config():
                 },
                 "job_spec_config": {"backoffLimit": 240},
             },
+            "env": [{"name": "FOO", "value": "BAR"}],
         },
     }
 
@@ -171,6 +178,7 @@ def test_empty_container_context(empty_container_context):
         empty_container_context.run_k8s_config[key] == {}
         for key in empty_container_context.run_k8s_config
     )
+    assert empty_container_context.env == []
 
 
 def test_invalid_config():
@@ -305,6 +313,13 @@ def test_merge(empty_container_context, container_context, other_container_conte
         "job_spec_config": {"backoff_limit": 240},
         "job_config": {},
     }
+    _check_same_sorted(
+        merged.env,
+        [
+            {"name": "FOO", "value": "BAR"},
+            {"name": "DD_AGENT_HOST", "value_from": {"field_ref": {"field_path": "status.hostIP"}}},
+        ],
+    )
 
     assert container_context.merge(empty_container_context) == container_context
     assert empty_container_context.merge(container_context) == container_context

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -715,6 +715,37 @@ def test_sanitize_labels():
     assert job["metadata"]["labels"]["my_label"] == "WhatsUP"
 
 
+def test_construct_dagster_k8s_job_with_raw_env():
+    cfg = DagsterK8sJobConfig(
+        job_image="test/foo:latest",
+        dagster_home="/opt/dagster/dagster_home",
+        instance_config_map="some-instance-configmap",
+    )
+    with environ({"ENV_VAR_1": "one"}):
+        job = construct_dagster_k8s_job(
+            cfg,
+            ["foo", "bar"],
+            "job",
+            env_vars=[
+                {"name": "FOO", "value": "BAR"},
+                {
+                    "name": "DD_AGENT_HOST",
+                    "value_from": {"field_ref": {"field_path": "status.hostIP"}},
+                },
+            ],
+        ).to_dict()
+
+        env = job["spec"]["template"]["spec"]["containers"][0]["env"]
+        env_mapping = {env_var["name"]: env_var for env_var in env}
+
+        # Has DAGSTER_HOME and two additional env vars
+        assert len(env_mapping) == 3
+        assert env_mapping["FOO"]["value"] == "BAR"
+        assert (
+            env_mapping["DD_AGENT_HOST"]["value_from"]["field_ref"]["field_path"] == "status.hostIP"
+        )
+
+
 # Taken from the k8s error message when a label is invalid
 K8s_LABEL_REGEX = r"(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
 


### PR DESCRIPTION
Follow up https://github.com/dagster-io/dagster/pull/12425 with support for user deployments.

Add a raw `env` field to k8s containerContext that takes k8s spec V1EnvVars

---

Unit tests. Added env var to integration test, and checked that

```
                           {
                                "name": "MY_POD_NAME",
                                "valueFrom": {
                                    "fieldRef": {
                                        "apiVersion": "v1",
                                        "fieldPath": "metadata.name"
                                    }
                                }
                            },
```

shows up in run pod specs ([example](https://s3.amazonaws.com/buildkiteartifacts.com/a43ea0e6-ae44-489a-b2a4-ff6149cb3238/5c800007-afbf-4ece-be06-3fabb1c5fc3a/0186a050-b6aa-4de6-9770-bd035ae786fc/0186a051-0e77-49ba-b7af-2cd53af21150/kind-info-dump/dagster-test-eaf0ff/pods.json?response-content-type=application%2Fjson&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LYCTAJAUW%2F20230302%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230302T033242Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEPT%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCIFvgpBU%2F%2BPNFuK8%2FgaZPGtf%2BHtnTzY%2FY5%2FmcJKJsGhuxAiBffYO2zqZfrjpJsbT7B76HmYTxpH1WHpV7L%2BiA6Er0myr6Awic%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDAzMjM3OTcwNTMwMyIMTAL9iev8dXtEFQbUKs4DCnzctNAL%2BO36FcaRSZPQGFPR8H5z%2FM7w%2FWoJRmT%2F2%2B46IlumG0QlIYuaEmqRXMvXUYHWoS4X64Gguj7mqA0f6NIjeDbLyu6N9MgILbiS2%2Fh%2B5qCaDIKKc%2FRoxyXBWRFAdavMGyrKIQlqAfIOZqGU5qz%2F957Df5Fio0togy31%2Bk5Mblqzv9Ua6RWBrzHtyWBLV3VTVyY6ywbbS9wYiSTBoqVpuMHTg2PYLFGNhgmMeMpGSiwGwSu7Ns9Xppy7mi0Ivw7%2FLz7Ks%2BMfvIXEfJHU3IXVHJYbBoWPF%2FxlTTHaCcNbucd7AYveutkYZRZhC7mJViQL4nuhWyK%2F2pkTKMvD8WZjkWCQoul8A8ddlSbWbaZ8E6N9IXeTx%2B0P0WShemJB8QKLHbsvUS2v%2BIMatpDCqvvlHwgUki1PzqMXhsSKidQtp9NgHgxGfBuo%2FnVZa9Uv6X81ruyXLS0YloyZKLR5d2ZY0kZR2%2B%2Beqq8A1DzEPV0wWhtm0oNeJJUH%2Fw4iexmv2K7jtibijrnv70dc6Pt%2BjQfaJJJzjZXZvqrEX7NrMjVRbMXRvSy9XgvFgGTQQLD8DcRDh13cpX5ctfmkRUrfG4HtpzQZG%2FZpbZVeHNfXMNeogKAGOqYB0AjAeg8yAPY1mJ3VAMAhxbluuldwQOl%2Ba8L0rYuiqvnbpa5Pz6NdwkTYqFk9or9Kfc7cR0cKWKWBRFm2yu9nsx%2B83i9Tkmwv2iVTBKAUn9Cq3CS13ZP8ldTrlcpVWNVvXSky7FjD4gGTWRvysJAk6bmkK%2BxwqLtYlRbO6UPaMFHncv%2B36dZgv3uE1%2FC7KPLCeBr5DqUeuMkMuP3XXw1wNjSeIv%2FSPA%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=02e232f01960d44f171145be3912cdf6828886902c15d678d22ce742c5626732))