### PR TITLE
Refactor flatten_time_window_ranges

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
@@ -1,0 +1,273 @@
+from datetime import datetime
+from typing import cast
+
+import pendulum
+from dagster import (
+    DailyPartitionsDefinition,
+    PartitionKeyRange,
+)
+from dagster._core.definitions.time_window_partitions import (
+    PartitionRangeStatus,
+    PartitionTimeWindowStatus,
+    TimeWindow,
+    fetch_flattened_time_window_ranges,
+)
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+def time_window(start: str, end: str) -> TimeWindow:
+    return TimeWindow(
+        cast(datetime, pendulum.parser.parse(start)), cast(datetime, pendulum.parser.parse(end))
+    )
+
+
+def _check_flatten_time_window_ranges(materialized, failed, expected_result):
+    ranges = fetch_flattened_time_window_ranges(materialized, failed)
+    assert ranges == [
+        PartitionTimeWindowStatus(time_window(window["start"], window["end"]), window["status"])
+        for window in expected_result
+    ]
+
+
+partitions_def = DailyPartitionsDefinition(start_date="2021-12-01")
+empty_subset = partitions_def.empty_subset()
+
+
+def test_no_overlap() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05")),
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-06", "2022-01-06")),
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-06",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {"start": "2022-01-06", "end": "2022-01-07", "status": PartitionRangeStatus.FAILED},
+        ],
+    )
+
+
+def test_overlapped() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05")),
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-05", "2022-01-06")),
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-05",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {"start": "2022-01-05", "end": "2022-01-07", "status": PartitionRangeStatus.FAILED},
+        ],
+    )
+
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-05", "2022-01-06")),
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05")),
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-06",
+                "status": PartitionRangeStatus.FAILED,
+            },
+            {
+                "start": "2022-01-06",
+                "end": "2022-01-07",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+        ],
+    )
+
+
+def test_materialized_spans_failed() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-10")),
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-05", "2022-01-06")),
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-05",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {"start": "2022-01-05", "end": "2022-01-07", "status": PartitionRangeStatus.FAILED},
+            {
+                "start": "2022-01-07",
+                "end": "2022-01-11",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+        ],
+    )
+
+
+def test_materialized_spans_many_failed() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-01", "2022-12-10")),
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-05", "2022-01-06"))
+        .with_partition_key_range(PartitionKeyRange("2022-03-01", "2022-03-10"))
+        .with_partition_key_range(PartitionKeyRange("2022-09-01", "2022-10-01")),
+        [
+            {
+                "start": "2022-01-01",
+                "end": "2022-01-05",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {
+                "start": "2022-01-05",
+                "end": "2022-01-07",
+                "status": PartitionRangeStatus.FAILED,
+            },
+            {
+                "start": "2022-01-07",
+                "end": "2022-03-01",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {
+                "start": "2022-03-01",
+                "end": "2022-03-11",
+                "status": PartitionRangeStatus.FAILED,
+            },
+            {
+                "start": "2022-03-11",
+                "end": "2022-09-01",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {
+                "start": "2022-09-01",
+                "end": "2022-10-02",
+                "status": PartitionRangeStatus.FAILED,
+            },
+            {
+                "start": "2022-10-02",
+                "end": "2022-12-11",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+        ],
+    )
+
+
+def test_empty() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset,
+        empty_subset,
+        [],
+    )
+
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(
+            PartitionKeyRange("2022-01-02", "2022-01-10")
+        ).with_partition_key_range(PartitionKeyRange("2022-01-20", "2022-02-10")),
+        empty_subset,
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-11",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {
+                "start": "2022-01-20",
+                "end": "2022-02-11",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+        ],
+    )
+
+    _check_flatten_time_window_ranges(
+        empty_subset,
+        empty_subset.with_partition_key_range(
+            PartitionKeyRange("2022-01-02", "2022-01-10")
+        ).with_partition_key_range(PartitionKeyRange("2022-01-20", "2022-02-10")),
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-11",
+                "status": PartitionRangeStatus.FAILED,
+            },
+            {
+                "start": "2022-01-20",
+                "end": "2022-02-11",
+                "status": PartitionRangeStatus.FAILED,
+            },
+        ],
+    )
+
+
+def test_cancels_out() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(
+            PartitionKeyRange("2022-01-02", "2022-01-05")
+        ).with_partition_key_range(PartitionKeyRange("2022-01-12", "2022-01-13")),
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05")),
+        [
+            {
+                "start": "2022-01-02",
+                "end": "2022-01-06",
+                "status": PartitionRangeStatus.FAILED,
+            },
+            {
+                "start": "2022-01-12",
+                "end": "2022-01-14",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+        ],
+    )
+
+
+def test_lots() -> None:
+    _check_flatten_time_window_ranges(
+        empty_subset.with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05"))
+        .with_partition_key_range(PartitionKeyRange("2022-01-12", "2022-01-13"))
+        .with_partition_key_range(PartitionKeyRange("2022-01-15", "2022-01-17"))
+        .with_partition_key_range(PartitionKeyRange("2022-01-19", "2022-01-20"))
+        .with_partition_key_range(PartitionKeyRange("2022-01-22", "2022-01-24")),
+        empty_subset.with_partition_key_range(
+            PartitionKeyRange("2021-12-30", "2021-12-31")
+        )  # before materialized subset
+        .with_partition_key_range(
+            PartitionKeyRange("2022-01-02", "2022-01-03")
+        )  # within materialized subset
+        .with_partition_key_range(
+            PartitionKeyRange("2022-01-05", "2022-01-06")
+        )  # directly after materialized subset
+        .with_partition_key_range(
+            PartitionKeyRange("2022-01-08", "2022-01-09")
+        )  # between materialized subsets
+        .with_partition_key_range(
+            PartitionKeyRange("2022-01-11", "2022-01-14")
+        )  # encompasses materialized subset
+        .with_partition_keys(["2022-01-20"])  # at end materialized subset
+        .with_partition_keys(
+            ["2022-01-22", "2022-01-24"]
+        ),  # multiple overlaps within same materialized range
+        [
+            {"start": "2021-12-30", "end": "2022-01-01", "status": PartitionRangeStatus.FAILED},
+            {"start": "2022-01-02", "end": "2022-01-04", "status": PartitionRangeStatus.FAILED},
+            {
+                "start": "2022-01-04",
+                "end": "2022-01-05",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {"start": "2022-01-05", "end": "2022-01-07", "status": PartitionRangeStatus.FAILED},
+            {"start": "2022-01-08", "end": "2022-01-10", "status": PartitionRangeStatus.FAILED},
+            {"start": "2022-01-11", "end": "2022-01-15", "status": PartitionRangeStatus.FAILED},
+            {
+                "start": "2022-01-15",
+                "end": "2022-01-18",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {
+                "start": "2022-01-19",
+                "end": "2022-01-20",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {"start": "2022-01-20", "end": "2022-01-21", "status": PartitionRangeStatus.FAILED},
+            {"start": "2022-01-22", "end": "2022-01-23", "status": PartitionRangeStatus.FAILED},
+            {
+                "start": "2022-01-23",
+                "end": "2022-01-24",
+                "status": PartitionRangeStatus.MATERIALIZED,
+            },
+            {"start": "2022-01-24", "end": "2022-01-25", "status": PartitionRangeStatus.FAILED},
+        ],
+    )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -16,12 +16,9 @@ from dagster import (
     weekly_partitioned_config,
 )
 from dagster._core.definitions.time_window_partitions import (
-    PartitionRangeStatus,
-    PartitionTimeWindowStatus,
     ScheduleType,
     TimeWindow,
     TimeWindowPartitionsSubset,
-    fetch_flattened_time_window_ranges,
 )
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
@@ -781,63 +778,3 @@ def test_get_first_partition_window():
     ) == time_window(
         "2023-01-01", "2023-02-01"
     )
-
-
-def test_flatten_time_window_ranges():
-    partitions_def = DailyPartitionsDefinition(start_date="2021-12-01")
-    # with partition key range methods are inclusive
-    materialized = (
-        partitions_def.empty_subset()
-        .with_partition_key_range(PartitionKeyRange("2022-01-02", "2022-01-05"))
-        .with_partition_key_range(PartitionKeyRange("2022-01-12", "2022-01-13"))
-        .with_partition_key_range(PartitionKeyRange("2022-01-15", "2022-01-17"))
-        .with_partition_key_range(PartitionKeyRange("2022-01-19", "2022-01-20"))
-        .with_partition_key_range(PartitionKeyRange("2022-01-22", "2022-01-24"))
-    )
-    failed = (
-        partitions_def.empty_subset()
-        .with_partition_key_range(
-            PartitionKeyRange("2021-12-30", "2021-12-31")
-        )  # before materialized subset
-        .with_partition_key_range(
-            PartitionKeyRange("2022-01-02", "2022-01-03")
-        )  # within materialized subset
-        .with_partition_key_range(
-            PartitionKeyRange("2022-01-05", "2022-01-06")
-        )  # directly after materialized subset
-        .with_partition_key_range(
-            PartitionKeyRange("2022-01-08", "2022-01-09")
-        )  # between materialized subsets
-        .with_partition_key_range(
-            PartitionKeyRange("2022-01-11", "2022-01-14")
-        )  # encompasses materialized subset
-        .with_partition_keys(["2022-01-20"])  # at end materialized subset
-        .with_partition_keys(
-            ["2022-01-22", "2022-01-24"]
-        )  # multiple overlaps within same materialized range
-    )
-
-    ranges = fetch_flattened_time_window_ranges(
-        [(materialized, PartitionRangeStatus.MATERIALIZED), (failed, PartitionRangeStatus.FAILED)]
-    )
-    for r in ranges:
-        print(r)
-
-    expected_result = [
-        {"start": "2021-12-30", "end": "2022-01-01", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-02", "end": "2022-01-04", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-04", "end": "2022-01-05", "status": PartitionRangeStatus.MATERIALIZED},
-        {"start": "2022-01-05", "end": "2022-01-07", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-08", "end": "2022-01-10", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-11", "end": "2022-01-15", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-15", "end": "2022-01-18", "status": PartitionRangeStatus.MATERIALIZED},
-        {"start": "2022-01-19", "end": "2022-01-20", "status": PartitionRangeStatus.MATERIALIZED},
-        {"start": "2022-01-20", "end": "2022-01-21", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-22", "end": "2022-01-23", "status": PartitionRangeStatus.FAILED},
-        {"start": "2022-01-23", "end": "2022-01-24", "status": PartitionRangeStatus.MATERIALIZED},
-        {"start": "2022-01-24", "end": "2022-01-25", "status": PartitionRangeStatus.FAILED},
-    ]
-    assert ranges == [
-        PartitionTimeWindowStatus(time_window(window["start"], window["end"]), window["status"])
-        for window in expected_result
-    ]


### PR DESCRIPTION
The current implementation fails at least a couple edge cases. 

This replaces it with a simplified version that knows about materialized and failed statuses, rather than trying to be generic. We can revisit this when we also factor in stale etc.

Also added more tests