### PR TITLE
[ui] Disable repo location reload based on permissions

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -167,7 +167,7 @@ export const usePermissionsForLocation = (locationName: string | null | undefine
 // todo dish: Update callsites to either location-based perms or intentionally unscoped perms.
 export const usePermissionsDEPRECATED = useUnscopedPermissions;
 
-const PERMISSIONS_QUERY = gql`
+export const PERMISSIONS_QUERY = gql`
   query PermissionsQuery {
     unscopedPermissions: permissions {
       ...PermissionFragment

--- a/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.test.tsx
@@ -1,0 +1,59 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen, waitFor} from '@testing-library/react';
+import * as React from 'react';
+
+import {PermissionsProvider, usePermissionsForLocation} from '../app/Permissions';
+
+import {ChildProps, ReloadRepositoryLocationButton} from './ReloadRepositoryLocationButton';
+import {buildPermissionsQuery} from './__fixtures__/ReloadRepositoryLocationButton.fixtures';
+
+describe('ReloadRepositoryLocationButton', () => {
+  const Test: React.FC<ChildProps> = (props) => {
+    const {tryReload, hasReloadPermission} = props;
+    const {loading} = usePermissionsForLocation(props.codeLocation);
+    return (
+      <div>
+        <div>Loading permissions? {loading ? 'Yes' : 'No'}</div>
+        <button onClick={tryReload} disabled={!hasReloadPermission}>
+          Reload
+        </button>
+      </div>
+    );
+  };
+
+  it('renders an disabled reload button if not permissioned', async () => {
+    render(
+      <MockedProvider mocks={[buildPermissionsQuery(false)]}>
+        <PermissionsProvider>
+          <ReloadRepositoryLocationButton location="foobar" ChildComponent={Test} />
+        </PermissionsProvider>
+      </MockedProvider>,
+    );
+
+    const button = screen.getByRole('button', {name: /reload/i});
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading permissions\? no/i)).not.toBeNull();
+    });
+
+    expect(button).toBeDisabled();
+  });
+
+  it('renders an enabled reload button if permissioned', async () => {
+    render(
+      <MockedProvider mocks={[buildPermissionsQuery(true)]}>
+        <PermissionsProvider>
+          <ReloadRepositoryLocationButton location="foobar" ChildComponent={Test} />
+        </PermissionsProvider>
+      </MockedProvider>,
+    );
+
+    const button = screen.getByRole('button', {name: /reload/i});
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading permissions\? no/i)).not.toBeNull();
+    });
+
+    expect(button).toBeEnabled();
+  });
+});

--- a/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
+++ b/js_modules/dagit/packages/core/src/nav/ReloadRepositoryLocationButton.tsx
@@ -1,25 +1,33 @@
 import * as React from 'react';
 
 import {AppContext} from '../app/AppContext';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {RepositoryLocationErrorDialog} from '../workspace/RepositoryLocationErrorDialog';
 
 import {buildReloadFnForLocation, useRepositoryLocationReload} from './useRepositoryLocationReload';
 
-type ChildProps = {
+export type ChildProps = {
+  codeLocation: string;
   tryReload: () => void;
   reloading: boolean;
+  hasReloadPermission: boolean;
 };
 
 interface Props {
-  children: (childProps: ChildProps) => React.ReactNode;
+  ChildComponent: React.FC<ChildProps>;
   location: string;
 }
 
+export const NO_RELOAD_PERMISSION_TEXT = 'You do not have permission to reload this code location';
+
 export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
-  const {children, location} = props;
+  const {ChildComponent, location} = props;
   const [shown, setShown] = React.useState(false);
 
   const {basePath} = React.useContext(AppContext);
+
+  const {canReloadRepositoryLocation} = usePermissionsForLocation(location);
+  const hasReloadPermission = canReloadRepositoryLocation.enabled;
 
   const reloadFn = React.useMemo(() => buildReloadFnForLocation(location), [location]);
   const {reloading, error, tryReload} = useRepositoryLocationReload({
@@ -31,7 +39,7 @@ export const ReloadRepositoryLocationButton: React.FC<Props> = (props) => {
 
   return (
     <>
-      {children({tryReload, reloading})}
+      <ChildComponent {...{tryReload, reloading, hasReloadPermission, codeLocation: location}} />
       <RepositoryLocationErrorDialog
         location={location}
         isOpen={shown}

--- a/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagit/packages/core/src/nav/RepoSelector.tsx
@@ -13,13 +13,15 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {usePermissionsDEPRECATED} from '../app/Permissions';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
-import {ReloadRepositoryLocationButton} from './ReloadRepositoryLocationButton';
+import {
+  NO_RELOAD_PERMISSION_TEXT,
+  ReloadRepositoryLocationButton,
+} from './ReloadRepositoryLocationButton';
 
 export interface RepoSelectorOption {
   repositoryLocation: {name: string};
@@ -41,7 +43,6 @@ interface Props {
 
 export const RepoSelector: React.FC<Props> = (props) => {
   const {onBrowse, onToggle, options, selected} = props;
-  const {canReloadRepositoryLocation} = usePermissionsDEPRECATED();
 
   const optionCount = options.length;
   const selectedCount = selected.length;
@@ -106,11 +107,9 @@ export const RepoSelector: React.FC<Props> = (props) => {
                     Browse
                   </Link>
                 </td>
-                {canReloadRepositoryLocation.enabled ? (
-                  <td>
-                    <ReloadButton repoAddress={repoAddress} />
-                  </td>
-                ) : null}
+                <td>
+                  <ReloadButton repoAddress={repoAddress} />
+                </td>
               </tr>
             );
           })}
@@ -147,30 +146,38 @@ const RepoLocation = styled.div`
 
 const ReloadButton: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) => {
   return (
-    <ReloadRepositoryLocationButton location={repoAddress.location}>
-      {({tryReload, reloading}) => (
-        <Tooltip
-          placement="right"
-          content={
-            reloading ? (
-              'Reloading…'
-            ) : (
-              <>
-                Reload <strong>{repoAddress.location}</strong>
-              </>
-            )
+    <ReloadRepositoryLocationButton
+      location={repoAddress.location}
+      ChildComponent={({codeLocation, tryReload, reloading, hasReloadPermission}) => {
+        const tooltipContent = () => {
+          if (!hasReloadPermission) {
+            return NO_RELOAD_PERMISSION_TEXT;
           }
-        >
-          <ReloadButtonInner onClick={tryReload}>
-            {reloading ? (
-              <Spinner purpose="body-text" />
-            ) : (
-              <Icon name="refresh" color={Colors.Gray200} />
-            )}
-          </ReloadButtonInner>
-        </Tooltip>
-      )}
-    </ReloadRepositoryLocationButton>
+          return reloading ? (
+            'Reloading…'
+          ) : (
+            <>
+              Reload <strong>{codeLocation}</strong>
+            </>
+          );
+        };
+
+        return (
+          <Tooltip placement="right" content={tooltipContent()} useDisabledButtonTooltipFix>
+            <ReloadButtonInner disabled={!hasReloadPermission} onClick={tryReload}>
+              {reloading ? (
+                <Spinner purpose="body-text" />
+              ) : (
+                <Icon
+                  name="refresh"
+                  color={hasReloadPermission ? Colors.Gray200 : Colors.Gray100}
+                />
+              )}
+            </ReloadButtonInner>
+          </Tooltip>
+        );
+      }}
+    />
   );
 };
 
@@ -182,12 +189,21 @@ const ReloadButtonInner = styled.button`
   margin: -6px;
   outline: none;
 
+  :disabled {
+    cursor: default;
+  }
+
+  :disabled ${IconWrapper} {
+    background-color: ${Colors.Gray300};
+    transition: background-color 100ms;
+  }
+
   ${IconWrapper} {
     background-color: ${Colors.Gray600};
     transition: background-color 100ms;
   }
 
-  :hover ${IconWrapper} {
+  :hover:not(:disabled) ${IconWrapper} {
     background-color: ${Colors.Gray800};
   }
 

--- a/js_modules/dagit/packages/core/src/nav/__fixtures__/ReloadRepositoryLocationButton.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__fixtures__/ReloadRepositoryLocationButton.fixtures.tsx
@@ -1,0 +1,36 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {PERMISSIONS_QUERY} from '../../app/Permissions';
+import {PermissionsQuery} from '../../app/types/Permissions.types';
+
+export const buildPermissionsQuery = (canReload: boolean): MockedResponse<PermissionsQuery> => {
+  return {
+    request: {
+      query: PERMISSIONS_QUERY,
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        unscopedPermissions: [],
+        workspaceOrError: {
+          __typename: 'Workspace',
+          locationEntries: [
+            {
+              __typename: 'WorkspaceLocationEntry',
+              id: 'foobar',
+              name: 'foobar',
+              permissions: [
+                {
+                  __typename: 'Permission',
+                  permission: 'reload_repository_location',
+                  value: canReload,
+                  disabledReason: canReload ? null : 'nope',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+};

--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
@@ -12,8 +12,10 @@ import {
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
-import {usePermissionsForLocation} from '../app/Permissions';
-import {ReloadRepositoryLocationButton} from '../nav/ReloadRepositoryLocationButton';
+import {
+  NO_RELOAD_PERMISSION_TEXT,
+  ReloadRepositoryLocationButton,
+} from '../nav/ReloadRepositoryLocationButton';
 import {
   buildReloadFnForLocation,
   useRepositoryLocationReload,
@@ -198,31 +200,30 @@ const LocationStatus: React.FC<{
   );
 };
 
-const ReloadButton: React.FC<{
-  location: string;
-}> = (props) => {
-  const {location} = props;
-  const {canReloadRepositoryLocation} = usePermissionsForLocation(location);
-
-  if (!canReloadRepositoryLocation.enabled) {
-    return (
-      <Tooltip content={canReloadRepositoryLocation.disabledReason} useDisabledButtonTooltipFix>
-        <Button icon={<Icon name="refresh" />} disabled>
-          Reload
-        </Button>
-      </Tooltip>
-    );
-  }
-
+const ReloadButton: React.FC<{location: string}> = ({location}) => {
   return (
-    <ReloadRepositoryLocationButton location={location}>
-      {({reloading, tryReload}) => (
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-          <Button icon={<Icon name="refresh" />} loading={reloading} onClick={() => tryReload()}>
-            Reload
-          </Button>
-        </Box>
-      )}
-    </ReloadRepositoryLocationButton>
+    <ReloadRepositoryLocationButton
+      location={location}
+      ChildComponent={({reloading, tryReload, hasReloadPermission}) => {
+        return (
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+            <Tooltip
+              content={hasReloadPermission ? '' : NO_RELOAD_PERMISSION_TEXT}
+              canShow={!hasReloadPermission}
+              useDisabledButtonTooltipFix
+            >
+              <Button
+                icon={<Icon name="refresh" />}
+                disabled={!hasReloadPermission}
+                loading={reloading}
+                onClick={() => tryReload()}
+              >
+                Reload
+              </Button>
+            </Tooltip>
+          </Box>
+        );
+      }}
+    />
   );
 };

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceHeader.tsx
@@ -1,10 +1,13 @@
 import {QueryResult} from '@apollo/client';
-import {PageHeader, Box, Heading, Colors, Button, Icon} from '@dagster-io/ui';
+import {PageHeader, Box, Heading, Colors, Button, Icon, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {QueryRefreshState} from '../app/QueryRefresh';
-import {ReloadRepositoryLocationButton} from '../nav/ReloadRepositoryLocationButton';
+import {
+  NO_RELOAD_PERMISSION_TEXT,
+  ReloadRepositoryLocationButton,
+} from '../nav/ReloadRepositoryLocationButton';
 
 import {WorkspaceTabs} from './WorkspaceTabs';
 import {repoAddressAsHumanString} from './repoAddressAsString';
@@ -42,19 +45,27 @@ export const WorkspaceHeader = <TData extends Record<string, any>>(props: Props<
         />
       }
       right={
-        <ReloadRepositoryLocationButton location={repoAddress.location}>
-          {({tryReload, reloading}) => {
+        <ReloadRepositoryLocationButton
+          location={repoAddress.location}
+          ChildComponent={({tryReload, reloading, hasReloadPermission}) => {
             return (
-              <Button
-                onClick={() => tryReload()}
-                loading={reloading}
-                icon={<Icon name="refresh" />}
+              <Tooltip
+                canShow={!hasReloadPermission}
+                content={hasReloadPermission ? '' : NO_RELOAD_PERMISSION_TEXT}
+                useDisabledButtonTooltipFix
               >
-                Reload definitions
-              </Button>
+                <Button
+                  onClick={() => tryReload()}
+                  loading={reloading}
+                  disabled={!hasReloadPermission}
+                  icon={<Icon name="refresh" />}
+                >
+                  Reload definitions
+                </Button>
+              </Tooltip>
             );
           }}
-        </ReloadRepositoryLocationButton>
+        />
       }
     />
   );


### PR DESCRIPTION
### Summary & Motivation

Clean up permissioning on code location reload. Pass a `hasReloadPermission` to the rendered `children` prop of `ReloadRepositoryLocationButton`, and use that value to show tooltips and disabled states accordingly.

<img width="720" alt="Screenshot 2023-03-02 at 10 16 03 AM" src="https://user-images.githubusercontent.com/2823852/222487559-53109dc8-587e-455b-b8eb-d12eb7225a25.png">
<img width="530" alt="Screenshot 2023-03-02 at 10 16 11 AM" src="https://user-images.githubusercontent.com/2823852/222487565-1d0598e0-a663-4260-a0ee-bc0fd6bea86a.png">
<img width="971" alt="Screenshot 2023-03-02 at 10 16 23 AM" src="https://user-images.githubusercontent.com/2823852/222487567-3fd8e4fe-914a-4e20-9a34-851b34a607ae.png">


### How I Tested These Changes

Force reload permission to be disabled, navigate to code location reload buttons throughout the app, verify disabled state and tooltip display.
