### PR TITLE
[docs] - Fix link in ops/jobs guides

### DIFF
--- a/docs/content/guides/dagster/intro-to-ops-jobs.mdx
+++ b/docs/content/guides/dagster/intro-to-ops-jobs.mdx
@@ -33,4 +33,4 @@ This installs a few packages:
 
 ## Ready to get started?
 
-When you've fulfilled all the [prerequisites](#prerequisites) for the tutorial, you can get started [creating your first asset](/tutorial/assets/defining-an-asset).
+When you've fulfilled all the [prerequisites](#prerequisites) for the tutorial, you can get started [creating your first op job](/guides/dagster/intro-to-ops-jobs/single-op-job).


### PR DESCRIPTION
This fixes a link in the intro to ops and jobs guide.