### PR TITLE
[dagster-airbyte] Migrate to Pythonic config & resources

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -38,7 +38,6 @@ from dagster._core.definitions.cacheable_assets import (
 )
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
     MetadataValue,
     TableSchemaMetadataValue,
 )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -1,7 +1,6 @@
 from typing import Any, Iterable, List, Optional
 
-from dagster import In, Nothing, Out, Output, op
-from dagster._config.structured_config import Config
+from dagster import Config, In, Nothing, Out, Output, op
 from pydantic import Field
 
 from dagster_airbyte.types import AirbyteOutput

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/ops.py
@@ -63,8 +63,7 @@ class AirbyteSyncConfig(Config):
     tags={"kind": "airbyte"},
 )
 def airbyte_sync_op(context, config: AirbyteSyncConfig, airbyte: AirbyteResource) -> Iterable[Any]:
-    """
-    Executes a Airbyte job sync for a given ``connection_id``, and polls until that sync
+    """Executes a Airbyte job sync for a given ``connection_id``, and polls until that sync
     completes, raising an error if it is unsuccessful. It outputs a AirbyteOutput which contains
     the job details for a given ``connection_id``.
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -12,9 +12,9 @@ from dagster import (
     Failure,
     _check as check,
     get_dagster_logger,
-    infer_schema_from_config_class,
     resource,
 )
+from dagster._config.structured_config import infer_schema_from_config_class
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field as PyField
 from requests.exceptions import RequestException

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -8,12 +8,13 @@ from typing import Any, Dict, List, Mapping, Optional, cast
 
 import requests
 from dagster import (
+    ConfigurableResource,
     Failure,
     _check as check,
     get_dagster_logger,
+    infer_schema_from_config_class,
     resource,
 )
-from dagster._config.structured_config import ConfigurableResource, infer_schema_from_config_class
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field as PyField
 from requests.exceptions import RequestException

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -14,6 +14,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
+from dagster._annotations import quiet_experimental_warnings
 from dagster._config.structured_config import infer_schema_from_config_class
 from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field as PyField
@@ -35,9 +36,7 @@ class AirbyteState:
 
 
 class AirbyteResource(ConfigurableResource):
-    """
-    This class exposes methods on top of the Airbyte REST API.
-    """
+    """This class exposes methods on top of the Airbyte REST API."""
 
     _log: logging.Logger
 
@@ -371,6 +370,7 @@ class AirbyteResource(ConfigurableResource):
 
 
 @resource(config_schema=infer_schema_from_config_class(AirbyteResource))
+@quiet_experimental_warnings
 def airbyte_resource(context) -> AirbyteResource:
     """This resource allows users to programatically interface with the Airbyte REST API to launch
     syncs and monitor their progress. This currently implements only a subset of the functionality


### PR DESCRIPTION
## Summary

Converts the `dagster-airbyte` internals to use the new config and resource systems:

- Assets and ops now use Pythonic config rather than `config_schema`
- Assets and ops retrieve resource dependencies through params rather than the context / `required_resource_keys`
- `AirbyteResource` is now a `ConfigurableResource`, holding its own config schema. The `airbyte_resource` function resource now wraps this class rather than holding the config.

## Test Plan

Existing unit tests.