### PR TITLE
Add ExternalRepositoryErrorData to dagster._core.host_representation ns

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/host_representation/__init__.py
@@ -29,6 +29,7 @@ from .external_data import (
     ExternalPipelineSubsetResult as ExternalPipelineSubsetResult,
     ExternalPresetData as ExternalPresetData,
     ExternalRepositoryData as ExternalRepositoryData,
+    ExternalRepositoryErrorData as ExternalRepositoryErrorData,
     ExternalScheduleData as ExternalScheduleData,
     ExternalScheduleExecutionErrorData as ExternalScheduleExecutionErrorData,
     ExternalSensorExecutionErrorData as ExternalSensorExecutionErrorData,


### PR DESCRIPTION
### Summary & Motivation
Minor API ergonomics tweak
Allow `from dagster._core.host_representation import ExternalRepositoryErrorData` similar to `ExternalRepositoryData` as these are used in similar contexts.


### How I Tested These Changes
bk