### PR TITLE
Don't double-write log events from the execute_run and execute_step CLI calls

### DIFF
--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_integration.py
@@ -74,7 +74,7 @@ def test_execute_on_celery_k8s_default(
         namespace=helm_namespace,
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == dagster_docker_image
@@ -104,7 +104,7 @@ def test_execute_on_celery_k8s_job_api(
         namespace=helm_namespace,
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == dagster_docker_image
@@ -137,7 +137,7 @@ def test_execute_on_celery_k8s_job_api_with_legacy_configmap_set(
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == dagster_docker_image
@@ -166,7 +166,7 @@ def test_execute_on_celery_k8s_image_from_origin(
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == dagster_docker_image
@@ -196,14 +196,19 @@ def test_execute_subset_on_celery_k8s(dagster_docker_image, helm_namespace, webs
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
 
 def test_execute_on_celery_k8s_retry_job(
     dagster_docker_image, dagster_instance, helm_namespace, webserver_url
 ):
     run_config = merge_dicts(
-        merge_yamls([os.path.join(get_test_project_environments_path(), "env_s3.yaml")]),
+        merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env_logger.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
         get_celery_engine_config(
             dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
         ),
@@ -217,7 +222,7 @@ def test_execute_on_celery_k8s_retry_job(
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     stats = dagster_instance.get_run_stats(run_id)
     assert stats.steps_succeeded == 1
@@ -253,6 +258,7 @@ def test_execute_on_celery_k8s_with_resource_requirements(
     run_config = merge_dicts(
         merge_yamls(
             [
+                os.path.join(get_test_project_environments_path(), "env_logger.yaml"),
                 os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
             ]
         ),
@@ -269,7 +275,7 @@ def test_execute_on_celery_k8s_with_resource_requirements(
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
 
 def _test_termination(webserver_url, dagster_instance, run_config):
@@ -481,7 +487,12 @@ def test_memoization_on_celery_k8s(
 ):
     ephemeral_prefix = str(uuid.uuid4())
     run_config = deep_merge_dicts(
-        merge_yamls([os.path.join(get_test_project_environments_path(), "env_s3.yaml")]),
+        merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env_logger.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
         get_celery_engine_config(
             dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
         ),
@@ -504,7 +515,7 @@ def test_memoization_on_celery_k8s(
                 job_name="dagster-run-%s" % run_id, namespace=helm_namespace
             )
 
-            assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+            assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
             run_ids.append(run_id)
 
@@ -525,7 +536,12 @@ def test_memoization_on_celery_k8s(
 @pytest.mark.integration
 def test_volume_mounts(dagster_docker_image, dagster_instance, helm_namespace, webserver_url):
     run_config = deep_merge_dicts(
-        merge_yamls([os.path.join(get_test_project_environments_path(), "env_s3.yaml")]),
+        merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env_logger.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
         get_celery_engine_config(
             dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
         ),
@@ -541,4 +557,4 @@ def test_volume_mounts(dagster_docker_image, dagster_instance, helm_namespace, w
         job_name="dagster-run-%s" % run_id, namespace=helm_namespace
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_user_code_deployment_subchart.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_user_code_deployment_subchart.py
@@ -91,4 +91,4 @@ def test_execute_on_celery_k8s_subchart_disabled(
     result = wait_for_job_and_get_raw_logs(
         job_name=runmaster_job_name, namespace=namespace, wait_timeout=450
     )
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -221,7 +221,7 @@ def _launch_executor_run(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()  # type: ignore  # (possible none)
@@ -269,7 +269,7 @@ def test_k8s_run_launcher_image_from_origin(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()
@@ -373,7 +373,7 @@ def test_k8s_executor_resource_requirements(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()
@@ -411,7 +411,7 @@ def test_execute_on_k8s_retry_job(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     stats = dagster_instance_for_k8s_run_launcher.get_run_stats(run_id)
     assert stats.steps_succeeded == 1
@@ -478,7 +478,7 @@ def test_memoization_k8s_executor(
                 namespace=user_code_namespace_for_k8s_run_launcher,
             )
 
-            assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+            assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
             run_ids.append(run_id)
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
@@ -48,7 +48,7 @@ def test_k8s_run_launcher_default(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"
 
     updated_run = dagster_instance_for_k8s_run_launcher.get_run_by_id(run_id)
     assert updated_run.tags[DOCKER_IMAGE_TAG] == get_test_project_docker_image()
@@ -210,4 +210,4 @@ def test_k8s_run_launcher_secret_from_deployment(
         job_name="dagster-run-%s" % run_id, namespace=user_code_namespace_for_k8s_run_launcher
     )
 
-    assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
+    assert "RUN_SUCCESS" in result, f"no match, result: {result}"

--- a/python_modules/dagster-test/dagster_test/test_project/environments/env_logger.yaml
+++ b/python_modules/dagster-test/dagster_test/test_project/environments/env_logger.yaml
@@ -1,0 +1,4 @@
+loggers:
+  console:
+    config:
+      log_level: DEBUG

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -74,9 +74,6 @@ def execute_run_command(input_json):
                 set_exit_code_on_failure=args.set_exit_code_on_failure or False,
             )
 
-            for line in buffer:
-                click.echo(line)
-
             if return_code != 0:
                 sys.exit(return_code)
 
@@ -174,9 +171,6 @@ def resume_run_command(input_json):
                 send_to_buffer,
                 set_exit_code_on_failure=args.set_exit_code_on_failure or False,
             )
-
-            for line in buffer:
-                click.echo(line)
 
             if return_code != 0:
                 sys.exit(return_code)
@@ -346,8 +340,9 @@ def execute_step_command(input_json, compressed_input_json):
             ):
                 buff.append(serialize_value(event))
 
-            for line in buff:
-                click.echo(line)
+            if args.print_serialized_events:
+                for line in buff:
+                    click.echo(line)
 
 
 def _execute_step_command_body(

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -103,6 +103,7 @@ class StepDelegatingExecutor(Executor):
                 retry_mode=self.retries.for_inner_plan(),
                 known_state=active_execution.get_known_state(),
                 should_verify_step=self._should_verify_step,
+                print_serialized_events=False,
             ),
             dagster_run=plan_context.dagster_run,
         )

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -240,6 +240,7 @@ class ExecuteStepArgs(
             ("retry_mode", Optional[RetryMode]),
             ("known_state", Optional[KnownExecutionState]),
             ("should_verify_step", Optional[bool]),
+            ("print_serialized_events", bool),
         ],
     )
 ):
@@ -252,6 +253,7 @@ class ExecuteStepArgs(
         retry_mode: Optional[RetryMode] = None,
         known_state: Optional[KnownExecutionState] = None,
         should_verify_step: Optional[bool] = None,
+        print_serialized_events: Optional[bool] = None,
     ):
         return super(ExecuteStepArgs, cls).__new__(
             cls,
@@ -265,6 +267,9 @@ class ExecuteStepArgs(
             known_state=check.opt_inst_param(known_state, "known_state", KnownExecutionState),
             should_verify_step=check.opt_bool_param(
                 should_verify_step, "should_verify_step", False
+            ),
+            print_serialized_events=check.opt_bool_param(
+                print_serialized_events, "print_serialized_events", False
             ),
         )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_handler.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_handler.py
@@ -57,6 +57,7 @@ def test_step_handler_context():
             run_id=run.run_id,
             step_keys_to_execute=run.step_keys_to_execute,
             instance_ref=None,
+            print_serialized_events=False,
         )
         ctx = StepHandlerContext(
             instance=instance,

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -197,6 +197,7 @@ def _submit_task_docker(app, plan_context, step, queue, priority, known_state):
         instance_ref=plan_context.instance.get_ref(),
         retry_mode=plan_context.executor.retries.for_inner_plan(),
         known_state=known_state,
+        print_serialized_events=True,
     )
 
     task = create_docker_task(app)

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -206,6 +206,7 @@ def _submit_task_k8s_job(app, plan_context, step, queue, priority, known_state):
         retry_mode=plan_context.executor.retries.for_inner_plan(),
         known_state=known_state,
         should_verify_step=True,
+        print_serialized_events=True,
     )
 
     job_config = plan_context.executor.job_config

--- a/python_modules/libraries/dagster-celery/dagster_celery/executor.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/executor.py
@@ -114,6 +114,7 @@ def _submit_task(app, plan_context, step, queue, priority, known_state):
         instance_ref=plan_context.instance.get_ref(),
         retry_mode=plan_context.executor.retries.for_inner_plan(),
         known_state=known_state,
+        print_serialized_events=True,  # Not actually checked by the celery task
     )
 
     task = create_task(app)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -241,7 +241,10 @@ def _step_handler_context(job_def, dagster_run, instance, executor):
     )
 
     execute_step_args = ExecuteStepArgs(
-        reconstructable(bar).get_python_origin(), dagster_run.run_id, ["foo"]
+        reconstructable(bar).get_python_origin(),
+        dagster_run.run_id,
+        ["foo"],
+        print_serialized_events=False,
     )
 
     return StepHandlerContext(


### PR DESCRIPTION
Summary:
Right now in these API calls we write each event twice;
- one from the dagster logging handler
- one from this structured JSON write at the end

The latter is only needed for celery, so let's leave it for just celery. No reason that I can see to double-write in the execute_run call.
Defaulting the argument to True to backcompat to match old behavior, but setting to to False in the step delegating executor.

Test Plan:
existing e2e tests of executors

### Summary & Motivation

### How I Tested These Changes
