### PR TITLE
Fix places in the docs where example dagster_cloud.yaml files were not formatted correctly

### DIFF
--- a/docs/content/dagster-cloud/deployment/agents/kubernetes/configuration-reference.mdx
+++ b/docs/content/dagster-cloud/deployment/agents/kubernetes/configuration-reference.mdx
@@ -41,7 +41,7 @@ When [adding a code location](/dagster-cloud/developing-testing/code-locations) 
 The following example `dagster_cloud.yaml` file illustrates the available fields:
 
 ```yaml
-## dagster_cloud.yaml
+# dagster_cloud.yaml
 
 locations:
   - location_name: cloud-examples
@@ -97,15 +97,20 @@ locations:
 Using the `container_context.k8s.env_vars` and `container_context.k8s.env_secrets` properties, you can specify environment variables and secrets for a specific code location. For example:
 
 ```yaml
-## dagster_cloud.yaml
+# dagster_cloud.yaml
 
-container_context:
-  k8s:
-    env_vars:
-      - database_name
-      - database_username=hooli_testing
-    env_secrets:
-      - database_password
+location:
+  - location_name: cloud-examples
+    image: dagster/dagster-cloud-examples:latest
+    code_source:
+      package_name: dagster_cloud_examples
+    container_context:
+      k8s:
+        env_vars:
+          - database_name
+          - database_username=hooli_testing
+        env_secrets:
+          - database_password
 ```
 
 <ReferenceTable>

--- a/docs/next/components/mdx/includes/dagster-cloud/agents/AmazonEcsEnvVarsConfiguration.mdx
+++ b/docs/next/components/mdx/includes/dagster-cloud/agents/AmazonEcsEnvVarsConfiguration.mdx
@@ -3,18 +3,23 @@ Using the `container_context.ecs.env_vars` and `container_context.ecs.secrets` p
 ```yaml
 # dagster_cloud.yaml
 
-container_context:
-  ecs:
-    env_vars:
-      - DATABASE_NAME=testing
-      - DATABASE_PASSWORD
-    secrets:
-      - name: "MY_API_TOKEN"
-        valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::"
-      - name: "MY_PASSWORD"
-        valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::"
-    secrets_tags:
-      - "my_tag_name"
+locations:
+  - location_name: cloud-examples
+    image: dagster/dagster-cloud-examples:latest
+    code_source:
+      package_name: dagster_cloud_examples
+    container_context:
+      ecs:
+        env_vars:
+          - DATABASE_NAME=testing
+          - DATABASE_PASSWORD
+        secrets:
+          - name: "MY_API_TOKEN"
+            valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::"
+          - name: "MY_PASSWORD"
+            valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::"
+        secrets_tags:
+          - "my_tag_name"
 ```
 
 <ReferenceTable>

--- a/docs/next/components/mdx/includes/dagster-cloud/agents/DockerEnvVarsConfiguration.mdx
+++ b/docs/next/components/mdx/includes/dagster-cloud/agents/DockerEnvVarsConfiguration.mdx
@@ -1,13 +1,17 @@
 Using the `container_context.docker.env_vars` property, you can include environment variables and secrets in the Docker container associated with a specific code location. For example:
 
 ```yaml
-## dagster_cloud.yaml
-
-container_context:
-  docker:
-    env_vars:
-      - DATABASE_NAME
-      - DATABASE_USERNAME=hooli_testing
+# dagster_cloud.yaml
+locations:
+  - location_name: cloud-examples
+    image: dagster/dagster-cloud-examples:latest
+    code_source:
+      package_name: dagster_cloud_examples
+    container_context:
+      docker:
+        env_vars:
+          - DATABASE_NAME
+          - DATABASE_USERNAME=hooli_testing
 ```
 
 The `container_context.docker.env_vars` property is a list, where each item can be either `KEY` or `KEY=VALUE`. If only `KEY` is specified, the value will be pulled from the local environment.

--- a/docs/next/components/mdx/includes/dagster-cloud/agents/K8sEnvVarsConfiguration.mdx
+++ b/docs/next/components/mdx/includes/dagster-cloud/agents/K8sEnvVarsConfiguration.mdx
@@ -3,13 +3,18 @@ Using the `container_context.k8s.env_vars` and `container_context.k8s.env_secret
 ```yaml
 # dagster_cloud.yaml
 
-container_context:
-  k8s:
-    env_vars:
-      - database_name        # value pulled from agent's environment
-      - database_username=hooli_testing
-    env_secrets:
-      - database_password
+locations:
+  - location_name: cloud-examples
+    image: dagster/dagster-cloud-examples:latest
+    code_source:
+      package_name: dagster_cloud_examples
+    container_context:
+      k8s:
+        env_vars:
+          - database_name        # value pulled from agent's environment
+          - database_username=hooli_testing
+        env_secrets:
+          - database_password
 ```
 
 <ReferenceTable>


### PR DESCRIPTION
Summary:
These say dagster_cloud.yaml but would not work as dagster_cloud.yaml files - fix that so that people know where to put the config in their own dagster_cloud.yaml fiels

Test Plan: View docs pages

### Summary & Motivation

### How I Tested These Changes
