### PR TITLE
small updates to automating pipelines guide

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -727,7 +727,7 @@
         "children": [
           {
             "title": "Automating your data pipelines",
-            "path": "/guides/dagster/automated_pipelines"
+            "path": "/guides/dagster/automating-pipelines"
           },
           {
             "title": "Using environment variables and secrets",

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -32,7 +32,7 @@ Learn to apply [Dagster concepts](/concepts) to your work, explore experimental 
 
 ## Best practices
 
-- [Automating your data pipelines](/guides/dagster/automated_pipelines) - Learn how to automate your data pipelines with Dagster using schedules and sensors
+- [Automating your data pipelines](/guides/dagster/automating-pipelines) - Learn how to automate your data pipelines with Dagster using schedules and sensors
 
 - [Using environment variables and secrets in Dagster](/guides/dagster/using-environment-variables-and-secrets) - Learn to define environment variables and use them to securely use secrets and parameterize your Dagster pipelines
 

--- a/docs/content/guides/best-practices.mdx
+++ b/docs/content/guides/best-practices.mdx
@@ -4,7 +4,7 @@ title: Dagster Best Practice Guides | Dagster Docs
 
 # Best practice guides
 
-- [Automating your data pipelines](/guides/dagster/automated_pipelines) - Learn how to automate your data pipelines with Dagster using schedules and sensors
+- [Automating your data pipelines](/guides/dagster/automating-pipelines) - Learn how to automate your data pipelines with Dagster using schedules and sensors
 
 - [Using environment variables and secrets in Dagster](/guides/dagster/using-environment-variables-and-secrets) - Learn to define environment variables and use them to securely use secrets and parameterize your Dagster pipelines
 

--- a/docs/content/guides/dagster/automating-pipelines.mdx
+++ b/docs/content/guides/dagster/automating-pipelines.mdx
@@ -159,10 +159,10 @@ Partitions can be used with both schedules and sensors. You can use schedules to
 
 Use this table as a quick reference when building out your data pipelines!
 
-| Name                         | Good for automating data pipelines that need to be refreshed: | Asset Support | Op/Graph Support |
-| ---------------------------- | ------------------------------------------------------------- | ------------- | ---------------- |
-| Basic and Cron scheduling    | by kicking off updates at a predictable time interval         | ✅             | ✅                |
-| Sensors                      | when a specific event occurs                                  | ✅             | ✅                |
-| Asset sensors                | after an asset or set of assets materialize                   | ✅             |                  |
-| Asset reconciliation sensors | when assets are out of date with other assets                 | ✅             |                  |
-| Freshness policy sensors     | when assets are beyond an acceptable lag time                 | ✅             |                  |
+| Name                                             | Good for automating data pipelines that need to be refreshed: | Asset Support | Op/Graph Support |
+| ------------------------------------------------ | ------------------------------------------------------------- | ------------- | ---------------- |
+| Basic (cron) scheduling                          | by kicking off updates at a predictable time interval         | ✅             | ✅                |
+| Sensors                                          | when a specific event occurs                                  | ✅             | ✅                |
+| Asset sensors                                    | after an asset or set of assets materialize                   | ✅             |                  |
+| Asset reconciliation sensors                     | when assets are out of date with other assets                 | ✅             |                  |
+| Asset reconciliation sensors w/freshness polices | when assets are beyond an acceptable lag time                 | ✅             |                  |


### PR DESCRIPTION
### Summary & Motivation
- Change URL to end in automating-pipelines instead of automated_pipelines, because we prefer hyphens over dashes and to match the title more closely
- Small tweaks to table at the bottom
  - "Basic and Cron Scheduling" could imply that Basic and Cron are two different options, which they are not
  - "Freshness policy sensors" are actually a different thing than what's being discussed here (they allow users to run arbitrary code when a freshness policy is violated, which is different than materializing assets based on their freshness policies)


### How I Tested These Changes
