### PR TITLE
Only create instance when necessary in GRPC server in partitions endpoints

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -429,7 +429,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
             partition_name=partition_name,
-            instance=instance,
+            instance_ref=instance.get_ref(),
         )
 
     def get_external_partition_tags(
@@ -448,7 +448,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
             partition_name=partition_name,
-            instance=instance,
+            instance_ref=instance.get_ref(),
         )
 
     def get_external_partition_names(
@@ -529,7 +529,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
             self._get_repo_def(repository_handle.repository_name),
             partition_set_name=partition_set_name,
             partition_names=partition_names,
-            instance=instance,
+            instance_ref=instance.get_ref(),
         )
 
     def get_external_notebook_data(self, notebook_path: str) -> bytes:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -9,7 +9,6 @@ import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import nullcontext
 from multiprocessing.synchronize import Event as MPEvent
 from subprocess import Popen
 from threading import Event as ThreadingEventType
@@ -449,15 +448,14 @@ class DagsterApiServer(DagsterApiServicer):
 
         instance_ref = args.instance_ref if args.instance_ref else self._instance_ref
 
-        with DagsterInstance.from_ref(instance_ref) if instance_ref else nullcontext() as instance:
-            serialized_data = serialize_value(
-                get_partition_set_execution_param_data(
-                    self._get_repo_for_origin(args.repository_origin),
-                    partition_set_name=args.partition_set_name,
-                    partition_names=args.partition_names,
-                    instance=instance,
-                )
+        serialized_data = serialize_value(
+            get_partition_set_execution_param_data(
+                self._get_repo_for_origin(args.repository_origin),
+                partition_set_name=args.partition_set_name,
+                partition_names=args.partition_names,
+                instance_ref=instance_ref,
             )
+        )
 
         yield from self._split_serialized_data_into_chunk_events(serialized_data)
 
@@ -466,15 +464,14 @@ class DagsterApiServer(DagsterApiServicer):
 
         instance_ref = args.instance_ref if args.instance_ref else self._instance_ref
 
-        with DagsterInstance.from_ref(instance_ref) if instance_ref else nullcontext() as instance:
-            serialized_data = serialize_value(
-                get_partition_config(
-                    self._get_repo_for_origin(args.repository_origin),
-                    args.partition_set_name,
-                    args.partition_name,
-                    instance=instance,
-                )
+        serialized_data = serialize_value(
+            get_partition_config(
+                self._get_repo_for_origin(args.repository_origin),
+                args.partition_set_name,
+                args.partition_name,
+                instance_ref=instance_ref,
             )
+        )
 
         return api_pb2.ExternalPartitionConfigReply(
             serialized_external_partition_config_or_external_partition_execution_error=serialized_data
@@ -487,15 +484,14 @@ class DagsterApiServer(DagsterApiServicer):
             partition_args.instance_ref if partition_args.instance_ref else self._instance_ref
         )
 
-        with DagsterInstance.from_ref(instance_ref) if instance_ref else nullcontext() as instance:
-            serialized_data = serialize_value(
-                get_partition_tags(
-                    self._get_repo_for_origin(partition_args.repository_origin),
-                    partition_args.partition_set_name,
-                    partition_args.partition_name,
-                    instance=instance,
-                )
+        serialized_data = serialize_value(
+            get_partition_tags(
+                self._get_repo_for_origin(partition_args.repository_origin),
+                partition_args.partition_set_name,
+                partition_args.partition_name,
+                instance_ref=instance_ref,
             )
+        )
 
         return api_pb2.ExternalPartitionTagsReply(  # type: ignore
             serialized_external_partition_tags_or_external_partition_execution_error=serialized_data


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/12440

The gRPC server attempts to instantiate the dagster instance for methods such as fetching partition tags / config / execution data. This causes these endpoints to fail when instantiating the instance if the gRPC server does not have access to the instance (for example if its deployed as a container). This PR fixes the issue by checking if the requested partitions def is dynamic, only instantiating the instance if it is.