### PR TITLE
[pythonic config] Allow using 'resource_defs' with resource args in assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -310,7 +310,6 @@ class _Asset:
             )
 
             op_required_resource_keys = decorator_resource_keys - arg_resource_keys
-            print("op_required_resource_keys", op_required_resource_keys)
 
             op = _Op(
                 name=out_asset_key.to_python_identifier(),

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -276,11 +276,13 @@ class _Asset:
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
             arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
-            decorator_resource_keys = set(self.required_resource_keys).union(
-                set(self.resource_defs.keys())
-            )
+
+            bare_required_resource_keys = set(self.required_resource_keys)
+            resource_defs_keys = set(self.resource_defs.keys())
+            decorator_resource_keys = bare_required_resource_keys | resource_defs_keys
+
             check.param_invariant(
-                len(decorator_resource_keys) == 0 or len(arg_resource_keys) == 0,
+                len(bare_required_resource_keys) == 0 or len(arg_resource_keys) == 0,
                 (
                     "Cannot specify resource requirements in both @asset decorator and as arguments"
                     " to the decorated function"
@@ -307,6 +309,9 @@ class _Asset:
                 code_version=self.code_version,
             )
 
+            op_required_resource_keys = decorator_resource_keys - arg_resource_keys
+            print("op_required_resource_keys", op_required_resource_keys)
+
             op = _Op(
                 name=out_asset_key.to_python_identifier(),
                 description=self.description,
@@ -314,7 +319,7 @@ class _Asset:
                 out=out,
                 # Any resource requirements specified as arguments will be identified as
                 # part of the Op definition instantiation
-                required_resource_keys=decorator_resource_keys,
+                required_resource_keys=op_required_resource_keys,
                 tags={
                     **({"kind": self.compute_kind} if self.compute_kind else {}),
                     **(self.op_tags or {}),
@@ -426,7 +431,9 @@ def multi_asset(
         additional_message="Only dicts are supported for asset config_schema.",
     )
 
-    required_resource_keys = set(required_resource_keys).union(set(resource_defs.keys()))
+    bare_required_resource_keys = set(required_resource_keys)
+    resource_defs_keys = set(resource_defs.keys())
+    required_resource_keys = bare_required_resource_keys | resource_defs_keys
 
     for out in outs.values():
         if isinstance(out, Out) and not isinstance(out, AssetOut):
@@ -445,7 +452,7 @@ def multi_asset(
 
         arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
         check.param_invariant(
-            len(required_resource_keys or []) == 0 or len(arg_resource_keys) == 0,
+            len(bare_required_resource_keys or []) == 0 or len(arg_resource_keys) == 0,
             (
                 "Cannot specify resource requirements in both @multi_asset decorator and as"
                 " arguments to the decorated function"
@@ -477,12 +484,14 @@ def multi_asset(
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
+            op_required_resource_keys = required_resource_keys - arg_resource_keys
+
             op = _Op(
                 name=op_name,
                 description=description,
                 ins=dict(asset_ins.values()),
                 out=dict(asset_outs.values()),
-                required_resource_keys=required_resource_keys,
+                required_resource_keys=op_required_resource_keys,
                 tags={
                     **({"kind": compute_kind} if compute_kind else {}),
                     **(op_tags or {}),

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1229,3 +1229,29 @@ def test_env_var_nested_config() -> None:
     ):
         assert defs.get_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
+
+
+def test_resource_defs_on_asset() -> None:
+    executed = {}
+
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @asset(resource_defs={"my_resource": MyResource(a_str="foo")})
+    def an_asset(my_resource: MyResource):
+        assert my_resource.a_str == "foo"
+        executed["yes"] = True
+
+    defs = Definitions(
+        assets=[an_asset],
+    )
+    defs.get_implicit_global_asset_job_def().execute_in_process()
+
+    assert executed["yes"]
+
+    # Cannot specify both required_resource_keys and resources as args
+    with pytest.raises(Exception):
+
+        @asset(required_resource_keys={"my_other_resource"})
+        def an_other_asset(my_resource: MyResource):
+            pass

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1250,7 +1250,7 @@ def test_resource_defs_on_asset() -> None:
     assert executed["yes"]
 
     # Cannot specify both required_resource_keys and resources as args
-    with pytest.raises(Exception):
+    with pytest.raises(CheckError):
 
         @asset(required_resource_keys={"my_other_resource"})
         def an_other_asset(my_resource: MyResource):


### PR DESCRIPTION
## Summary

Fixes small bug discovered in dogfooding today w/ #12664. Ensures that asset decorators can be passed both `resource_defs` and specify a list of resources as parameters:

```python
@asset(
    resource_defs = {"my_resource": MyResource(...)}
)
def my_asset(my_resource: MyResource):
    pass
```

## Test Plan

New unit test.