### PR TITLE
[ui] Update permissions for launching jobs and materializing assets

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -158,6 +158,13 @@ export const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     ? graphQueryItems.map((a) => a.node)
     : Object.values(assetGraphData.nodes).map((a) => a.definition);
 
+  const hasLaunchPermission = React.useMemo(() => {
+    if (selectedDefinitions.length) {
+      return selectedDefinitions.every((definition) => definition.hasMaterializePermission);
+    }
+    return allDefinitionsForMaterialize.every((definition) => definition.hasMaterializePermission);
+  }, [allDefinitionsForMaterialize, selectedDefinitions]);
+
   const onSelectNode = React.useCallback(
     async (
       e: React.MouseEvent<any> | React.KeyboardEvent<any>,
@@ -408,6 +415,7 @@ export const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
               />
               <LaunchAssetObservationButton
                 preferredJobName={explorerPath.pipelineName}
+                hasLaunchPermission={hasLaunchPermission}
                 assetKeys={(selectedDefinitions.length
                   ? selectedDefinitions
                   : allDefinitionsForMaterialize

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -24,6 +24,7 @@ export const AssetNodeFragmentBasic: AssetNodeFragment = {
   computeKind: null,
   description: 'This is a test asset description',
   graphName: null,
+  hasMaterializePermission: true,
   id: '["asset1"]',
   isObservable: false,
   isPartitioned: false,

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -400,6 +400,7 @@ export const ASSET_NODE_FRAGMENT = gql`
   fragment AssetNodeFragment on AssetNode {
     id
     graphName
+    hasMaterializePermission
     jobNames
     opNames
     opVersion

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNode.types.ts
@@ -64,6 +64,7 @@ export type AssetNodeFragment = {
   __typename: 'AssetNode';
   id: string;
   graphName: string | null;
+  hasMaterializePermission: boolean;
   jobNames: Array<string>;
   opNames: Array<string>;
   opVersion: string | null;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -13,6 +13,7 @@ export type AssetGraphQuery = {
     __typename: 'AssetNode';
     id: string;
     groupName: string | null;
+    hasMaterializePermission: boolean;
     graphName: string | null;
     jobNames: Array<string>;
     opNames: Array<string>;
@@ -38,6 +39,7 @@ export type AssetNodeForGraphQueryFragment = {
   __typename: 'AssetNode';
   id: string;
   groupName: string | null;
+  hasMaterializePermission: boolean;
   graphName: string | null;
   jobNames: Array<string>;
   opNames: Array<string>;

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -180,6 +180,7 @@ const ASSET_GRAPH_QUERY = gql`
   fragment AssetNodeForGraphQuery on AssetNode {
     id
     groupName
+    hasMaterializePermission
     repository {
       id
       name

--- a/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetActionMenu.tsx
@@ -32,7 +32,11 @@ export const AssetActionMenu: React.FC<Props> = (props) => {
         content={
           <Menu>
             <Tooltip
-              content="Shift+click to add configuration"
+              content={
+                !canLaunchPipelineExecution.enabled
+                  ? 'You do not have permission to materialize assets'
+                  : 'Shift+click to add configuration'
+              }
               placement="left"
               display="block"
               useDisabledButtonTooltipFix
@@ -40,7 +44,7 @@ export const AssetActionMenu: React.FC<Props> = (props) => {
               <MenuItem
                 text="Materialize"
                 icon={loading ? <Spinner purpose="body-text" /> : 'materialization'}
-                disabled={!canLaunchPipelineExecution || loading}
+                disabled={!canLaunchPipelineExecution.enabled || loading}
                 onClick={(e) => onClick([asset.key], e)}
               />
             </Tooltip>

--- a/js_modules/dagit/packages/core/src/assets/AssetTableFragment.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTableFragment.tsx
@@ -5,6 +5,7 @@ export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
     id
     groupName
     isSource
+    hasMaterializePermission
     partitionDefinition {
       description
     }

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {useConfirmation} from '../app/CustomConfirmationProvider';
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
-import {usePermissionsDEPRECATED} from '../app/Permissions';
 import {
   displayNameForAssetKey,
   isHiddenAssetGroupJob,
@@ -70,12 +69,22 @@ type LaunchAssetsState =
 const countOrBlank = (k: unknown[]) => (k.length > 1 ? ` (${k.length})` : '');
 
 type Asset =
-  | {assetKey: AssetKey; partitionDefinition: {__typename: string} | null; isSource: boolean}
-  | {assetKey: AssetKey; isPartitioned: boolean; isSource: boolean};
+  | {
+      assetKey: AssetKey;
+      hasMaterializePermission: boolean;
+      partitionDefinition: {__typename: string} | null;
+      isSource: boolean;
+    }
+  | {
+      assetKey: AssetKey;
+      hasMaterializePermission: boolean;
+      isPartitioned: boolean;
+      isSource: boolean;
+    };
 
 type AssetsInScope = {all: Asset[]; skipAllTerm?: boolean} | {selected: Asset[]};
 
-type LaunchOption = {assetKeys: AssetKey[]; label: string};
+type LaunchOption = {assetKeys: AssetKey[]; label: string; hasMaterializePermission: boolean};
 
 const isAnyPartitioned = (assets: Asset[]) =>
   assets.some(
@@ -97,16 +106,22 @@ export function optionsForButton(
   // to materialize that selection.
   if ('selected' in scope) {
     const assets = scope.selected.filter((a) => !a.isSource);
+    const hasMaterializePermission = scope.selected.every(
+      (assetNode) => assetNode.hasMaterializePermission,
+    );
+
     return [
       {
         assetKeys: assets.map((a) => a.assetKey),
         label: `Materialize selected${countOrBlank(assets)}${isAnyPartitioned(assets) ? '…' : ''}`,
+        hasMaterializePermission,
       },
     ];
   }
 
   const options: LaunchOption[] = [];
   const assets = scope.all.filter((a) => !a.isSource);
+  const hasMaterializePermission = assets.every((assetNode) => assetNode.hasMaterializePermission);
 
   options.push({
     assetKeys: assets.map((a) => a.assetKey),
@@ -114,6 +129,7 @@ export function optionsForButton(
       assets.length > 1 && !scope.skipAllTerm
         ? `Materialize all${isAnyPartitioned(assets) ? '…' : ''}`
         : `Materialize${isAnyPartitioned(assets) ? '…' : ''}`,
+    hasMaterializePermission,
   });
 
   if (liveDataForStale) {
@@ -126,6 +142,7 @@ export function optionsForButton(
     options.push({
       assetKeys: missingOrStale.map((a) => a.assetKey),
       label: `Materialize stale and missing${countOrBlank(missingOrStale)}`,
+      hasMaterializePermission,
     });
   }
 
@@ -138,12 +155,12 @@ export const LaunchAssetExecutionButton: React.FC<{
   intent?: 'primary' | 'none';
   preferredJobName?: string;
 }> = ({scope, liveDataForStale, preferredJobName, intent = 'primary'}) => {
-  const {canLaunchPipelineExecution} = usePermissionsDEPRECATED();
   const {onClick, loading, launchpadElement} = useMaterializationAction(preferredJobName);
   const [isOpen, setIsOpen] = React.useState(false);
 
   const options = optionsForButton(scope, liveDataForStale);
   const firstOption = options[0];
+  const hasMaterializePermission = firstOption.hasMaterializePermission;
 
   const {MaterializeButton} = useLaunchPadHooks();
 
@@ -151,7 +168,7 @@ export const LaunchAssetExecutionButton: React.FC<{
     return <span />;
   }
 
-  if (!canLaunchPipelineExecution.enabled) {
+  if (!hasMaterializePermission) {
     return (
       <Tooltip content="You do not have permission to materialize assets" position="bottom-right">
         <Button intent={intent} icon={<Icon name="materialization" />} disabled>
@@ -599,6 +616,7 @@ export const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
     opNames
     jobNames
     graphName
+    hasMaterializePermission
     partitionDefinition {
       ...PartitionDefinitionForLaunchAsset
     }

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -3,7 +3,6 @@ import {Button, Spinner, Tooltip, Icon} from '@dagster-io/ui';
 import React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {usePermissionsDEPRECATED} from '../app/Permissions';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -33,10 +32,10 @@ type ObserveAssetsState =
 
 export const LaunchAssetObservationButton: React.FC<{
   assetKeys: AssetKey[]; // Memoization not required
+  hasLaunchPermission: boolean;
   intent?: 'primary' | 'none';
   preferredJobName?: string;
-}> = ({assetKeys, preferredJobName, intent = 'none'}) => {
-  const {canLaunchPipelineExecution} = usePermissionsDEPRECATED();
+}> = ({assetKeys, hasLaunchPermission, preferredJobName, intent = 'none'}) => {
   const {useLaunchWithTelemetry} = useLaunchPadHooks();
   const launchWithTelemetry = useLaunchWithTelemetry();
 
@@ -50,7 +49,7 @@ export const LaunchAssetObservationButton: React.FC<{
     return <span />;
   }
 
-  if (!canLaunchPipelineExecution.enabled) {
+  if (!hasLaunchPermission) {
     return (
       <Tooltip content="You do not have permission to observe source assets">
         <Button intent={intent} icon={<Icon name="observation" />} disabled>

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetsCatalogTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetsCatalogTable.mocks.ts
@@ -66,6 +66,7 @@ export const SingleAssetQueryMaterializedWithLatestRun: MockedResponse<SingleAss
           id: 'test.py.repo.["good_asset"]',
           computeKind: 'duckdb',
           opNames: ['good_asset'],
+          hasMaterializePermission: true,
           repository: {
             id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
             __typename: 'Repository',
@@ -154,6 +155,7 @@ export const SingleAssetQueryMaterializedStaleAndLate: MockedResponse<SingleAsse
           id: 'test.py.repo.["late_asset"]',
           computeKind: null,
           opNames: ['late_asset'],
+          hasMaterializePermission: true,
           repository: {
             id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
             __typename: 'Repository',
@@ -243,6 +245,7 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<SingleAssetQuery> = {
           id: 'test.py.repo.["run_failing_asset"]',
           computeKind: 'snowflake',
           opNames: ['run_failing_asset'],
+          hasMaterializePermission: true,
           repository: {
             id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
             __typename: 'Repository',
@@ -352,6 +355,7 @@ export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
               groupName: 'GROUP2',
               isSource: false,
               partitionDefinition: null,
+              hasMaterializePermission: true,
               description:
                 'This is a super long description that could involve some level of SQL and is just generally very long',
               repository: {
@@ -380,6 +384,7 @@ export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
               isSource: false,
               partitionDefinition: null,
               description: null,
+              hasMaterializePermission: true,
               repository: {
                 id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
                 name: 'repo',
@@ -406,6 +411,7 @@ export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
               isSource: false,
               partitionDefinition: null,
               description: null,
+              hasMaterializePermission: true,
               repository: {
                 id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
                 name: 'repo',
@@ -432,6 +438,7 @@ export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
               isSource: false,
               partitionDefinition: null,
               description: null,
+              hasMaterializePermission: true,
               repository: {
                 id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
                 name: 'repo',

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.mocks.ts
@@ -20,6 +20,7 @@ export const ASSET_DAILY: AssetNodeForGraphQueryFragment = {
   __typename: 'AssetNode',
   id: 'test.py.repo.["asset_daily"]',
   groupName: 'mapped',
+  hasMaterializePermission: true,
   repository: {
     __typename: 'Repository',
     id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -56,6 +57,7 @@ export const ASSET_WEEKLY: AssetNodeForGraphQueryFragment = {
   __typename: 'AssetNode',
   id: 'test.py.repo.["asset_weekly"]',
   groupName: 'mapped',
+  hasMaterializePermission: true,
   repository: {
     __typename: 'Repository',
     id: 'c22d9677b8089be89b1e014b9de34284962f83a7',

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
@@ -37,6 +37,7 @@ export const ReleasesWorkspace_RAW = {
           opNames: ['release_files'],
           jobNames: ['__ASSET_JOB_0'],
           graphName: null,
+          hasMaterializePermission: true,
           partitionDefinition: {
             type: PartitionDefinitionType.DYNAMIC,
             name: 'Foo',
@@ -93,6 +94,7 @@ export const ReleasesWorkspace_RAW = {
           opNames: ['release_files_metadata'],
           jobNames: ['__ASSET_JOB_0'],
           graphName: null,
+          hasMaterializePermission: true,
           partitionDefinition: {
             type: PartitionDefinitionType.DYNAMIC,
             name: 'Foo',
@@ -149,6 +151,7 @@ export const ReleasesWorkspace_RAW = {
           opNames: ['release_zips'],
           jobNames: ['__ASSET_JOB_0'],
           graphName: null,
+          hasMaterializePermission: true,
           partitionDefinition: {
             type: PartitionDefinitionType.DYNAMIC,
             name: 'Foo',
@@ -205,6 +208,7 @@ export const ReleasesWorkspace_RAW = {
           opNames: ['releases_metadata'],
           jobNames: ['__ASSET_JOB_0'],
           graphName: null,
+          hasMaterializePermission: true,
           partitionDefinition: {
             type: PartitionDefinitionType.DYNAMIC,
             name: 'Foo',
@@ -256,6 +260,7 @@ export const ReleasesWorkspace_RAW = {
           opNames: ['releases_summary'],
           jobNames: ['__ASSET_JOB_0'],
           graphName: null,
+          hasMaterializePermission: true,
           partitionDefinition: null,
           isObservable: false,
           isSource: false,

--- a/js_modules/dagit/packages/core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -84,7 +84,7 @@ describe('LaunchAssetExecutionButton', () => {
     expect(await screen.queryByTestId('ranges-as-tags-checkbox')).toBeNull();
 
     const launchButton = await screen.findByTestId('launch-button');
-    expect(launchButton.textContent).toEqual('Launch Backfill');
+    expect(launchButton.textContent).toEqual('Launch backfill');
     await launchButton.click();
 
     // expect that it triggers the mutation (variables checked by mock matching)

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinition.types.ts
@@ -10,6 +10,7 @@ export type AssetNodeDefinitionFragment = {
   opNames: Array<string>;
   opVersion: string | null;
   jobNames: Array<string>;
+  hasMaterializePermission: boolean;
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetTableFragment.types.ts
@@ -7,6 +7,7 @@ export type AssetTableDefinitionFragment = {
   id: string;
   groupName: string | null;
   isSource: boolean;
+  hasMaterializePermission: boolean;
   description: string | null;
   partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
   repository: {
@@ -26,6 +27,7 @@ export type AssetTableFragment = {
     id: string;
     groupName: string | null;
     isSource: boolean;
+    hasMaterializePermission: boolean;
     description: string | null;
     partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
     repository: {

--- a/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
@@ -23,6 +23,7 @@ export type AssetViewDefinitionQuery = {
           opNames: Array<string>;
           opVersion: string | null;
           jobNames: Array<string>;
+          hasMaterializePermission: boolean;
           computeKind: string | null;
           isPartitioned: boolean;
           isObservable: boolean;
@@ -15722,6 +15723,7 @@ export type AssetViewDefinitionNodeFragment = {
   opNames: Array<string>;
   opVersion: string | null;
   jobNames: Array<string>;
+  hasMaterializePermission: boolean;
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetsCatalogTable.types.ts
@@ -18,6 +18,7 @@ export type AssetCatalogTableQuery = {
             id: string;
             groupName: string | null;
             isSource: boolean;
+            hasMaterializePermission: boolean;
             description: string | null;
             partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
             repository: {
@@ -52,6 +53,7 @@ export type AssetCatalogGroupTableQuery = {
     id: string;
     groupName: string | null;
     isSource: boolean;
+    hasMaterializePermission: boolean;
     description: string | null;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
@@ -69,6 +71,7 @@ export type AssetCatalogGroupTableNodeFragment = {
   id: string;
   groupName: string | null;
   isSource: boolean;
+  hasMaterializePermission: boolean;
   description: string | null;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -8,6 +8,7 @@ export type LaunchAssetExecutionAssetNodeFragment = {
   opNames: Array<string>;
   jobNames: Array<string>;
   graphName: string | null;
+  hasMaterializePermission: boolean;
   isObservable: boolean;
   isSource: boolean;
   partitionDefinition: {
@@ -600,6 +601,7 @@ export type LaunchAssetLoaderQuery = {
     opNames: Array<string>;
     jobNames: Array<string>;
     graphName: string | null;
+    hasMaterializePermission: boolean;
     isObservable: boolean;
     isSource: boolean;
     partitionDefinition: {

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchButton.tsx
@@ -215,7 +215,13 @@ const ButtonWithConfiguration: React.FC<ButtonWithConfigurationProps> = ({
   };
 
   return (
-    <Tooltip position="left" openOnTargetFocus={false} targetTagName="div" content={tooltip || ''}>
+    <Tooltip
+      position="left"
+      openOnTargetFocus={false}
+      targetTagName="div"
+      canShow={!!tooltip}
+      content={tooltip || ''}
+    >
       <ButtonContainer
         role="button"
         intent="primary"

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchRootExecutionButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import {IconName} from '../../../ui/src';
-import {usePermissionsDEPRECATED} from '../app/Permissions';
 import {LaunchBehavior} from '../runs/RunUtils';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
 
@@ -10,6 +9,7 @@ import {useLaunchPadHooks} from './LaunchpadHooksContext';
 
 interface LaunchRootExecutionButtonProps {
   disabled: boolean;
+  hasLaunchPermission: boolean;
   warning?: React.ReactNode;
   getVariables: () => undefined | LaunchPipelineExecutionMutationVariables;
   behavior: LaunchBehavior;
@@ -18,10 +18,12 @@ interface LaunchRootExecutionButtonProps {
   icon?: IconName;
 }
 
+export const NO_LAUNCH_PERMISSION_MESSAGE = 'You do not have permission to launch this job';
+
 export const LaunchRootExecutionButton: React.FC<LaunchRootExecutionButtonProps> = (props) => {
+  const {hasLaunchPermission} = props;
   const {useLaunchWithTelemetry} = useLaunchPadHooks();
   const launchWithTelemetry = useLaunchWithTelemetry();
-  const {canLaunchPipelineExecution} = usePermissionsDEPRECATED();
 
   const onLaunch = async () => {
     const variables = props.getVariables();
@@ -39,10 +41,8 @@ export const LaunchRootExecutionButton: React.FC<LaunchRootExecutionButtonProps>
         icon: props.icon || 'open_in_new',
         title: props.title || 'Launch Run',
         warning: props.warning || undefined,
-        disabled: props.disabled || !canLaunchPipelineExecution.enabled,
-        tooltip: !canLaunchPipelineExecution.enabled
-          ? canLaunchPipelineExecution.disabledReason
-          : undefined,
+        disabled: props.disabled || !hasLaunchPermission,
+        tooltip: !hasLaunchPermission ? NO_LAUNCH_PERMISSION_MESSAGE : undefined,
       }}
     />
   );

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -26,6 +26,7 @@ import {
   PipelineRunTag,
   SessionBase,
 } from '../app/ExecutionSessionStorage';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {tokenForAssetKey} from '../asset-graph/Utils';
@@ -174,6 +175,8 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
 
   const client = useApolloClient();
   const [state, dispatch] = React.useReducer(reducer, initialState);
+
+  const {canLaunchPipelineExecution} = usePermissionsForLocation(repoAddress.location);
 
   const mounted = React.useRef<boolean>(false);
   const editor = React.useRef<ConfigEditor | null>(null);
@@ -727,6 +730,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
         <LaunchRootExecutionButton
           title={launchButtonTitle}
           warning={launchButtonWarning}
+          hasLaunchPermission={canLaunchPipelineExecution.enabled}
           pipelineName={pipeline.name}
           getVariables={buildExecutionVariables}
           disabled={preview?.isPipelineConfigValid?.__typename !== 'PipelineConfigValidationValid'}

--- a/js_modules/dagit/packages/core/src/launchpad/useLaunchWithTelemetry.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/useLaunchWithTelemetry.ts
@@ -2,7 +2,6 @@ import {useMutation} from '@apollo/client';
 import * as React from 'react';
 import {useHistory} from 'react-router';
 
-import {usePermissionsDEPRECATED} from '../app/Permissions';
 import {TelemetryAction, useTelemetryAction} from '../app/Telemetry';
 import {
   LAUNCH_PIPELINE_EXECUTION_MUTATION,
@@ -17,7 +16,6 @@ import {
 import {showLaunchError} from './showLaunchError';
 
 export function useLaunchWithTelemetry() {
-  const {canLaunchPipelineExecution} = usePermissionsDEPRECATED();
   const [launchPipelineExecution] = useMutation<
     LaunchPipelineExecutionMutation,
     LaunchPipelineExecutionMutationVariables
@@ -31,9 +29,10 @@ export function useLaunchWithTelemetry() {
         variables.executionParams.selector.jobName ||
         variables.executionParams.selector.pipelineName;
 
-      if (!canLaunchPipelineExecution.enabled || !jobName) {
+      if (!jobName) {
         return;
       }
+
       const metadata: {[key: string]: string | null | undefined} = {
         jobName,
         opSelection: variables.executionParams.selector.solidSelection ? 'provided' : undefined,
@@ -49,6 +48,6 @@ export function useLaunchWithTelemetry() {
 
       return result.data?.launchPipelineExecution;
     },
-    [canLaunchPipelineExecution, history, launchPipelineExecution, logTelemetry],
+    [history, launchPipelineExecution, logTelemetry],
   );
 }

--- a/js_modules/dagit/packages/core/src/ui/TabLink.tsx
+++ b/js_modules/dagit/packages/core/src/ui/TabLink.tsx
@@ -8,14 +8,14 @@ interface TabLinkProps extends TabStyleProps, Omit<LinkProps, 'title'> {
 }
 
 export const TabLink = styled((props: TabLinkProps) => {
-  const {to, title, ...rest} = props;
+  const {to, title, disabled, ...rest} = props;
   const containerProps = getTabA11yProps(props);
   const content = getTabContent(props);
 
   const titleText = typeof title === 'string' ? title : undefined;
 
   return (
-    <Link to={to} title={titleText} {...containerProps} {...rest}>
+    <Link to={disabled ? '#' : to} title={titleText} {...containerProps} {...rest}>
       {content}
     </Link>
   );

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
@@ -25,6 +25,7 @@ export type SingleAssetQuery = {
           staleStatus: Types.StaleStatus | null;
           groupName: string | null;
           isSource: boolean;
+          hasMaterializePermission: boolean;
           description: string | null;
           repository: {
             __typename: 'Repository';


### PR DESCRIPTION
### Summary & Motivation

Eliminate remaining OSS callsites to `usePermissionsDEPRECATED` by replacing them with `usePermissionForLocation` or per-object permission fields retrieved from GraphQL. This PR affects job launching and asset materializations.

I did my best to do the right things with permissioning here, but I'm going to need a ton of help to test this properly.

### How I Tested These Changes

Made myself a viewer in cloud, and verified that I can no longer access the Launchpad for any job.

Unfortunately, the local user cloud code location doesn't have any assets in it, so I can't figure out how to test asset materializations.
