### PR TITLE
Only set args, not command, in the dagster user code deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -41,8 +41,7 @@ spec:
           securityContext: {{ $deployment.securityContext | toYaml | nindent 12 }}
           imagePullPolicy: {{ $deployment.image.pullPolicy }}
           image: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}
-          command: ["dagster"]
-          args: ["api", "grpc", "-h", "0.0.0.0", "-p", "{{ $deployment.port }}", "{{- join "\",\"" $deployment.dagsterApiGrpcArgs }}"]
+          args: ["dagster", api", "grpc", "-h", "0.0.0.0", "-p", "{{ $deployment.port }}", "{{- join "\",\"" $deployment.dagsterApiGrpcArgs }}"]
           env:
             - name: DAGSTER_CURRENT_IMAGE
               value: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -71,6 +71,8 @@ def assert_user_deployment_template(
             template.spec.template.spec.containers[0].image_pull_policy
             == deployment_values.image.pullPolicy
         )
+        assert not template.spec.template.spec.containers[0].command
+        assert template.spec.template.spec.containers[0].args[0] == "dagster"
 
         # Assert labels
         assert template.spec.template.metadata.labels["deployment"] == deployment_values.name


### PR DESCRIPTION
Summary:
Similar to how we handle runs in the k8srunlauncher, only set args so that users can inject their own Docker ENTRYPOINT as needed.

Test Plan: Helm schmea tests, k8s e2e tests

### Summary & Motivation

### How I Tested These Changes
