### PR TITLE
[dagster-duckdb] convert to new resource system

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-duckdb-pandas.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-duckdb-pandas.rst
@@ -6,6 +6,9 @@ This library provides an integration with the `DuckDB <hhttps://duckdb.org/>`_ d
 
 .. currentmodule:: dagster_duckdb_pandas
 
+.. autoconfigurable:: DuckDBPandasIOManager
+  :annotation: IOManagerDefinition
+
 .. autoconfigurable:: duckdb_pandas_io_manager
   :annotation: IOManagerDefinition
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-duckdb.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-duckdb.rst
@@ -6,5 +6,8 @@ This library provides an integration with the `DuckDB <hhttps://duckdb.org/>`_ d
 
 .. currentmodule:: dagster_duckdb
 
+  .. autoconfigurable:: DuckDBIOManager
+  :annotation: IOManagerDefinition
+
 .. autoconfigurable:: build_duckdb_io_manager
   :annotation: IOManagerDefinition

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-duckdb.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-duckdb.rst
@@ -6,7 +6,7 @@ This library provides an integration with the `DuckDB <hhttps://duckdb.org/>`_ d
 
 .. currentmodule:: dagster_duckdb
 
-  .. autoconfigurable:: DuckDBIOManager
+.. autoconfigurable:: DuckDBIOManager
   :annotation: IOManagerDefinition
 
 .. autoconfigurable:: build_duckdb_io_manager

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
@@ -1,8 +1,8 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .duckdb_pandas_type_handler import (
+    ConfigurableDuckDBPandasIOManager as ConfigurableDuckDBPandasIOManager,
     DuckDBPandasTypeHandler as DuckDBPandasTypeHandler,
-    configurable_duckdb_pandas_io_manager as configurable_duckdb_pandas_io_manager,
     duckdb_pandas_io_manager as duckdb_pandas_io_manager,
 )
 from .version import __version__

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
@@ -1,7 +1,7 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .duckdb_pandas_type_handler import (
-    ConfigurableDuckDBPandasIOManager as ConfigurableDuckDBPandasIOManager,
+    DuckDBPandasIOManager as DuckDBPandasIOManager,
     DuckDBPandasTypeHandler as DuckDBPandasTypeHandler,
     duckdb_pandas_io_manager as duckdb_pandas_io_manager,
 )

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/__init__.py
@@ -2,6 +2,7 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from .duckdb_pandas_type_handler import (
     DuckDBPandasTypeHandler as DuckDBPandasTypeHandler,
+    configurable_duckdb_pandas_io_manager as configurable_duckdb_pandas_io_manager,
     duckdb_pandas_io_manager as duckdb_pandas_io_manager,
 )
 from .version import __version__

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -4,8 +4,8 @@ import pandas as pd
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_duckdb.io_manager import (
-    ConfigurableDuckDBIOManager,
     DuckDbClient,
+    DuckDBIOManager,
     build_duckdb_io_manager,
 )
 
@@ -136,7 +136,58 @@ Examples:
 """
 
 
-class ConfigurableDuckDBPandasIOManager(ConfigurableDuckDBIOManager):
+class DuckDBPandasIOManager(DuckDBIOManager):
+    """An IO manager definition that reads inputs from and writes Pandas DataFrames to DuckDB. When
+    using the duckdb_pandas_io_manager, any inputs and outputs without type annotations will be loaded
+    as Pandas DataFrames.
+
+    Returns:
+        IOManagerDefinition
+
+    Examples:
+        .. code-block:: python
+
+            from dagster_duckdb_pandas import DuckDBPandasIOManager
+
+            @asset(
+                key_prefix=["my_schema"]  # will be used as the schema in DuckDB
+            )
+            def my_table() -> pd.DataFrame:  # the name of the asset will be the table name
+                ...
+
+            defs = Definitions(
+                assets=[my_table],
+                resources={"io_manager": DuckDBPandasIOManager(database="my_db.duckdb")}
+            )
+
+        If you do not provide a schema, Dagster will determine a schema based on the assets and ops using
+        the IO Manager. For assets, the schema will be determined from the asset key, as in the above example.
+        For ops, the schema can be specified by including a "schema" entry in output metadata. If "schema" is not provided
+        via config or on the asset/op, "public" will be used for the schema.
+
+        .. code-block:: python
+
+            @op(
+                out={"my_table": Out(metadata={"schema": "my_schema"})}
+            )
+            def make_my_table() -> pd.DataFrame:
+                # the returned value will be stored at my_schema.my_table
+                ...
+
+        To only use specific columns of a table as input to a downstream op or asset, add the metadata "columns" to the
+        In or AssetIn.
+
+        .. code-block:: python
+
+            @asset(
+                ins={"my_table": AssetIn("my_table", metadata={"columns": ["a"]})}
+            )
+            def my_table_a(my_table: pd.DataFrame) -> pd.DataFrame:
+                # my_table will just contain the data from column "a"
+                ...
+
+    """
+
     @staticmethod
     def type_handlers() -> Sequence[DbTypeHandler]:
         return [DuckDBPandasTypeHandler()]

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -1,7 +1,11 @@
 import pandas as pd
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
-from dagster_duckdb.io_manager import DuckDbClient, build_duckdb_io_manager
+from dagster_duckdb.io_manager import (
+    DuckDbClient,
+    build_configurable_duckdb_io_manager,
+    build_duckdb_io_manager,
+)
 
 
 class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
@@ -128,3 +132,7 @@ Examples:
             ...
 
 """
+
+configurable_duckdb_pandas_io_manager = build_configurable_duckdb_io_manager(
+    [DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
+)

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -1,9 +1,11 @@
+from typing import Optional, Sequence, Type
+
 import pandas as pd
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_duckdb.io_manager import (
+    ConfigurableDuckDBIOManager,
     DuckDbClient,
-    build_configurable_duckdb_io_manager,
     build_duckdb_io_manager,
 )
 
@@ -133,6 +135,12 @@ Examples:
 
 """
 
-configurable_duckdb_pandas_io_manager = build_configurable_duckdb_io_manager(
-    [DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-)
+
+class ConfigurableDuckDBPandasIOManager(ConfigurableDuckDBIOManager):
+    @staticmethod
+    def type_handlers() -> Sequence[DbTypeHandler]:
+        return [DuckDBPandasTypeHandler()]
+
+    @staticmethod
+    def default_load_type() -> Optional[Type]:
+        return pd.DataFrame

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -540,7 +540,6 @@ def test_self_dependent_asset(tmp_path, io_managers):
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.self_dependent_asset").fetch_df()
 
         assert out_df["a"].tolist() == ["1", "1", "1", "2", "2", "2"]
-        duckdb_conn.close()
 
         # drop table so we start with an empty db for the next io manager
         duckdb_conn.execute("DELETE FROM my_schema.dynamic_partitioned")

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -20,12 +20,7 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster_duckdb import build_configurable_duckdb_io_manager
-from dagster_duckdb_pandas import DuckDBPandasTypeHandler, duckdb_pandas_io_manager
-
-configurable_io_manager = build_configurable_duckdb_io_manager(
-    type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-)
+from dagster_duckdb_pandas import configurable_duckdb_pandas_io_manager, duckdb_pandas_io_manager
 
 
 @op(out=Out(metadata={"schema": "a_df"}))
@@ -47,7 +42,7 @@ def add_one_to_dataframe():
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_duckdb_io_manager_with_ops(tmp_path, io_manager):
@@ -89,7 +84,7 @@ def b_plus_one(b_df: pd.DataFrame) -> pd.DataFrame:
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_duckdb_io_manager_with_assets(tmp_path, io_manager):
@@ -120,7 +115,7 @@ def b_plus_one_columns(b_df: pd.DataFrame) -> pd.DataFrame:
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_loading_columns(tmp_path, io_manager):
@@ -158,7 +153,7 @@ def not_supported():
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_not_supported_type(tmp_path, io_manager):
@@ -200,7 +195,7 @@ def daily_partitioned(context) -> pd.DataFrame:
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_time_window_partitioned_asset(tmp_path, io_manager):
@@ -268,7 +263,7 @@ def static_partitioned(context) -> pd.DataFrame:
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_static_partitioned_asset(tmp_path, io_manager):
@@ -338,7 +333,7 @@ def multi_partitioned(context) -> pd.DataFrame:
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_multi_partitioned_asset(tmp_path, io_manager):
@@ -417,7 +412,7 @@ def dynamic_partitioned(context) -> pd.DataFrame:
     "io_manager",
     [
         duckdb_pandas_io_manager,
-        configurable_io_manager,
+        configurable_duckdb_pandas_io_manager,
     ],
 )
 def test_dynamic_partition(tmp_path, io_manager):

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -108,11 +108,17 @@ def b_plus_one_columns(b_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def test_loading_columns(tmp_path):
-    resource_defs = {
-        "io_manager": duckdb_pandas_io_manager.configured(
-            {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-        ),
-    }
+    # resource_defs = {
+    #     "io_manager": duckdb_pandas_io_manager.configured(
+    #         {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    #     ),
+    # }
+
+    io_manager = build_configurable_duckdb_io_manager(
+        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
+    )
+
+    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     # materialize asset twice to ensure that tables get properly deleted
     for _ in range(2):
@@ -178,10 +184,16 @@ def daily_partitioned(context) -> pd.DataFrame:
 
 
 def test_time_window_partitioned_asset(tmp_path):
-    duckdb_io_manager = duckdb_pandas_io_manager.configured(
-        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    # duckdb_io_manager = duckdb_pandas_io_manager.configured(
+    #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    # )
+    # resource_defs = {"io_manager": duckdb_io_manager}
+
+    io_manager = build_configurable_duckdb_io_manager(
+        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
     )
-    resource_defs = {"io_manager": duckdb_io_manager}
+
+    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     materialize(
         [daily_partitioned],
@@ -242,10 +254,16 @@ def static_partitioned(context) -> pd.DataFrame:
 
 
 def test_static_partitioned_asset(tmp_path):
-    duckdb_io_manager = duckdb_pandas_io_manager.configured(
-        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    # duckdb_io_manager = duckdb_pandas_io_manager.configured(
+    #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    # )
+    # resource_defs = {"io_manager": duckdb_io_manager}
+
+    io_manager = build_configurable_duckdb_io_manager(
+        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
     )
-    resource_defs = {"io_manager": duckdb_io_manager}
+
+    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     materialize(
         [static_partitioned],
@@ -308,10 +326,16 @@ def multi_partitioned(context) -> pd.DataFrame:
 
 
 def test_multi_partitioned_asset(tmp_path):
-    duckdb_io_manager = duckdb_pandas_io_manager.configured(
-        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    # duckdb_io_manager = duckdb_pandas_io_manager.configured(
+    #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    # )
+    # resource_defs = {"io_manager": duckdb_io_manager}
+
+    io_manager = build_configurable_duckdb_io_manager(
+        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
     )
-    resource_defs = {"io_manager": duckdb_io_manager}
+
+    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     materialize(
         [multi_partitioned],
@@ -384,10 +408,17 @@ def dynamic_partitioned(context) -> pd.DataFrame:
 
 def test_dynamic_partition(tmp_path):
     with instance_for_test() as instance:
-        duckdb_io_manager = duckdb_pandas_io_manager.configured(
-            {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+        # duckdb_io_manager = duckdb_pandas_io_manager.configured(
+        #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+        # )
+        # resource_defs = {"io_manager": duckdb_io_manager}
+        io_manager = build_configurable_duckdb_io_manager(
+            type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
         )
-        resource_defs = {"io_manager": duckdb_io_manager}
+
+        resource_defs = {
+            "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        }
 
         instance.add_dynamic_partitions(dynamic_fruits.name, ["apple"])
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -20,7 +20,7 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster_duckdb_pandas import ConfigurableDuckDBPandasIOManager, duckdb_pandas_io_manager
+from dagster_duckdb_pandas import DuckDBPandasIOManager, duckdb_pandas_io_manager
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def io_managers(tmp_path):
         duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
-        ConfigurableDuckDBPandasIOManager(database=os.path.join(tmp_path, "unit_test.duckdb")),
+        DuckDBPandasIOManager(database=os.path.join(tmp_path, "unit_test.duckdb")),
     ]
 
 
@@ -113,7 +113,7 @@ def test_duckdb_io_manager_with_schema(tmp_path):
         duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb"), "schema": "custom_schema"}
         ),
-        ConfigurableDuckDBPandasIOManager(
+        DuckDBPandasIOManager(
             database=os.path.join(tmp_path, "unit_test.duckdb"), schema="custom_schema"
         ),
     ]

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -20,7 +20,7 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster_duckdb_pandas import configurable_duckdb_pandas_io_manager, duckdb_pandas_io_manager
+from dagster_duckdb_pandas import ConfigurableDuckDBPandasIOManager, duckdb_pandas_io_manager
 
 
 @op(out=Out(metadata={"schema": "a_df"}))
@@ -38,36 +38,36 @@ def add_one_to_dataframe():
     add_one(a_df())
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_duckdb_io_manager_with_ops(tmp_path, io_manager):
-    resource_defs = {
-        "io_manager": io_manager.configured(
+@pytest.fixture
+def io_managers(tmp_path):
+    return [
+        duckdb_pandas_io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
-    }
+        ConfigurableDuckDBPandasIOManager(database=os.path.join(tmp_path, "unit_test.duckdb")),
+    ]
 
-    job = add_one_to_dataframe.to_job(resource_defs=resource_defs)
 
-    # run the job twice to ensure that tables get properly deleted
-    for _ in range(2):
-        res = job.execute_in_process()
+def test_duckdb_io_manager_with_ops(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
 
-        assert res.success
-        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        job = add_one_to_dataframe.to_job(resource_defs=resource_defs)
 
-        out_df = duckdb_conn.execute("SELECT * FROM a_df.result").fetch_df()
-        assert out_df["a"].tolist() == [1, 2, 3]
+        # run the job twice to ensure that tables get properly deleted
+        for _ in range(2):
+            res = job.execute_in_process()
 
-        out_df = duckdb_conn.execute("SELECT * FROM add_one.result").fetch_df()
-        assert out_df["a"].tolist() == [2, 3, 4]
+            assert res.success
+            duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
 
-        duckdb_conn.close()
+            out_df = duckdb_conn.execute("SELECT * FROM a_df.result").fetch_df()
+            assert out_df["a"].tolist() == [1, 2, 3]
+
+            out_df = duckdb_conn.execute("SELECT * FROM add_one.result").fetch_df()
+            assert out_df["a"].tolist() == [2, 3, 4]
+
+            duckdb_conn.close()
 
 
 @asset(key_prefix=["my_schema"])
@@ -80,30 +80,24 @@ def b_plus_one(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_duckdb_io_manager_with_assets(tmp_path, io_manager):
-    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
+def test_duckdb_io_manager_with_assets(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
 
-    # materialize asset twice to ensure that tables get properly deleted
-    for _ in range(2):
-        res = materialize([b_df, b_plus_one], resources=resource_defs)
-        assert res.success
+        # materialize asset twice to ensure that tables get properly deleted
+        for _ in range(2):
+            res = materialize([b_df, b_plus_one], resources=resource_defs)
+            assert res.success
 
-        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+            duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
 
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_df").fetch_df()
-        assert out_df["a"].tolist() == [1, 2, 3]
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_df").fetch_df()
+            assert out_df["a"].tolist() == [1, 2, 3]
 
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_plus_one").fetch_df()
-        assert out_df["a"].tolist() == [2, 3, 4]
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_plus_one").fetch_df()
+            assert out_df["a"].tolist() == [2, 3, 4]
 
-        duckdb_conn.close()
+            duckdb_conn.close()
 
 
 @asset(key_prefix=["my_schema"], ins={"b_df": AssetIn("b_df", metadata={"columns": ["a"]})})
@@ -111,32 +105,26 @@ def b_plus_one_columns(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_loading_columns(tmp_path, io_manager):
-    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
+def test_loading_columns(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
 
-    # materialize asset twice to ensure that tables get properly deleted
-    for _ in range(2):
-        res = materialize([b_df, b_plus_one_columns], resources=resource_defs)
-        assert res.success
+        # materialize asset twice to ensure that tables get properly deleted
+        for _ in range(2):
+            res = materialize([b_df, b_plus_one_columns], resources=resource_defs)
+            assert res.success
 
-        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+            duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
 
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_df").fetch_df()
-        assert out_df["a"].tolist() == [1, 2, 3]
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_df").fetch_df()
+            assert out_df["a"].tolist() == [1, 2, 3]
 
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_plus_one_columns").fetch_df()
-        assert out_df["a"].tolist() == [2, 3, 4]
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.b_plus_one_columns").fetch_df()
+            assert out_df["a"].tolist() == [2, 3, 4]
 
-        assert out_df.shape[1] == 1
+            assert out_df.shape[1] == 1
 
-        duckdb_conn.close()
+            duckdb_conn.close()
 
 
 @op
@@ -149,27 +137,17 @@ def not_supported():
     non_supported_type()
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_not_supported_type(tmp_path, io_manager):
-    resource_defs = {
-        "io_manager": io_manager.configured(
-            {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-        ),
-    }
+def test_not_supported_type(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
 
-    job = not_supported.to_job(resource_defs=resource_defs)
+        job = not_supported.to_job(resource_defs=resource_defs)
 
-    with pytest.raises(
-        CheckError,
-        match="DuckDBIOManager does not have a handler for type '<class 'int'>'",
-    ):
-        job.execute_in_process()
+        with pytest.raises(
+            CheckError,
+            match="DuckDBIOManager does not have a handler for type '<class 'int'>'",
+        ):
+            job.execute_in_process()
 
 
 @asset(
@@ -191,54 +169,50 @@ def daily_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_time_window_partitioned_asset(tmp_path, io_manager):
-    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
+def test_time_window_partitioned_asset(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {
+            "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        }
 
-    materialize(
-        [daily_partitioned],
-        partition_key="2022-01-01",
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}}},
-    )
+        materialize(
+            [daily_partitioned],
+            partition_key="2022-01-01",
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__daily_partitioned": {"config": {"value": "1"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
 
-    assert out_df["a"].tolist() == ["1", "1", "1"]
-    duckdb_conn.close()
+        assert out_df["a"].tolist() == ["1", "1", "1"]
+        duckdb_conn.close()
 
-    materialize(
-        [daily_partitioned],
-        partition_key="2022-01-02",
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__daily_partitioned": {"config": {"value": "2"}}}},
-    )
+        materialize(
+            [daily_partitioned],
+            partition_key="2022-01-02",
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__daily_partitioned": {"config": {"value": "2"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
 
-    assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
-    duckdb_conn.close()
+        assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+        duckdb_conn.close()
 
-    materialize(
-        [daily_partitioned],
-        partition_key="2022-01-01",
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__daily_partitioned": {"config": {"value": "3"}}}},
-    )
+        materialize(
+            [daily_partitioned],
+            partition_key="2022-01-01",
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__daily_partitioned": {"config": {"value": "3"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
 
-    assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
-    duckdb_conn.close()
+        assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+        duckdb_conn.close()
 
 
 @asset(
@@ -259,51 +233,47 @@ def static_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_static_partitioned_asset(tmp_path, io_manager):
-    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
+def test_static_partitioned_asset(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {
+            "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        }
 
-    materialize(
-        [static_partitioned],
-        partition_key="red",
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "1"}}}},
-    )
+        materialize(
+            [static_partitioned],
+            partition_key="red",
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "1"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
-    assert out_df["a"].tolist() == ["1", "1", "1"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
+        assert out_df["a"].tolist() == ["1", "1", "1"]
+        duckdb_conn.close()
 
-    materialize(
-        [static_partitioned],
-        partition_key="blue",
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "2"}}}},
-    )
+        materialize(
+            [static_partitioned],
+            partition_key="blue",
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "2"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
-    assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
+        assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+        duckdb_conn.close()
 
-    materialize(
-        [static_partitioned],
-        partition_key="red",
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "3"}}}},
-    )
+        materialize(
+            [static_partitioned],
+            partition_key="red",
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "3"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
-    assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
+        assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+        duckdb_conn.close()
 
 
 @asset(
@@ -329,63 +299,57 @@ def multi_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_multi_partitioned_asset(tmp_path, io_manager):
-    resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
+def test_multi_partitioned_asset(tmp_path, io_managers):
+    for io_manager in io_managers:
+        resource_defs = {"io_manager": io_manager}
 
-    materialize(
-        [multi_partitioned],
-        partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
-    )
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "1"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
-    assert out_df["a"].tolist() == ["1", "1", "1"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+        assert out_df["a"].tolist() == ["1", "1", "1"]
+        duckdb_conn.close()
 
-    materialize(
-        [multi_partitioned],
-        partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "2"}}}},
-    )
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "blue"}),
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "2"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
-    assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+        assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+        duckdb_conn.close()
 
-    materialize(
-        [multi_partitioned],
-        partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "3"}}}},
-    )
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-02", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "3"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
-    assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+        assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2", "3", "3", "3"]
+        duckdb_conn.close()
 
-    materialize(
-        [multi_partitioned],
-        partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
-        resources=resource_defs,
-        run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "4"}}}},
-    )
+        materialize(
+            [multi_partitioned],
+            partition_key=MultiPartitionKey({"time": "2022-01-01", "color": "red"}),
+            resources=resource_defs,
+            run_config={"ops": {"my_schema__multi_partitioned": {"config": {"value": "4"}}}},
+        )
 
-    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-    out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
-    assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
-    duckdb_conn.close()
+        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+        out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
+        assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
+        duckdb_conn.close()
 
 
 dynamic_fruits = DynamicPartitionsDefinition(name="dynamic_fruits")
@@ -408,61 +372,53 @@ def dynamic_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parametrize(
-    "io_manager",
-    [
-        duckdb_pandas_io_manager,
-        configurable_duckdb_pandas_io_manager,
-    ],
-)
-def test_dynamic_partition(tmp_path, io_manager):
-    with instance_for_test() as instance:
-        resource_defs = {
-            "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
-        }
+def test_dynamic_partition(tmp_path, io_managers):
+    for io_manager in io_managers:
+        with instance_for_test() as instance:
+            resource_defs = {"io_manager": io_manager}
 
-        instance.add_dynamic_partitions(dynamic_fruits.name, ["apple"])
+            instance.add_dynamic_partitions(dynamic_fruits.name, ["apple"])
 
-        materialize(
-            [dynamic_partitioned],
-            partition_key="apple",
-            resources=resource_defs,
-            instance=instance,
-            run_config={"ops": {"my_schema__dynamic_partitioned": {"config": {"value": "1"}}}},
-        )
+            materialize(
+                [dynamic_partitioned],
+                partition_key="apple",
+                resources=resource_defs,
+                instance=instance,
+                run_config={"ops": {"my_schema__dynamic_partitioned": {"config": {"value": "1"}}}},
+            )
 
-        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
-        assert out_df["a"].tolist() == ["1", "1", "1"]
-        duckdb_conn.close()
+            duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
+            assert out_df["a"].tolist() == ["1", "1", "1"]
+            duckdb_conn.close()
 
-        instance.add_dynamic_partitions(dynamic_fruits.name, ["orange"])
+            instance.add_dynamic_partitions(dynamic_fruits.name, ["orange"])
 
-        materialize(
-            [dynamic_partitioned],
-            partition_key="orange",
-            resources=resource_defs,
-            instance=instance,
-            run_config={"ops": {"my_schema__dynamic_partitioned": {"config": {"value": "2"}}}},
-        )
+            materialize(
+                [dynamic_partitioned],
+                partition_key="orange",
+                resources=resource_defs,
+                instance=instance,
+                run_config={"ops": {"my_schema__dynamic_partitioned": {"config": {"value": "2"}}}},
+            )
 
-        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
-        assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
-        duckdb_conn.close()
+            duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
+            assert sorted(out_df["a"].tolist()) == ["1", "1", "1", "2", "2", "2"]
+            duckdb_conn.close()
 
-        materialize(
-            [dynamic_partitioned],
-            partition_key="apple",
-            resources=resource_defs,
-            instance=instance,
-            run_config={"ops": {"my_schema__dynamic_partitioned": {"config": {"value": "3"}}}},
-        )
+            materialize(
+                [dynamic_partitioned],
+                partition_key="apple",
+                resources=resource_defs,
+                instance=instance,
+                run_config={"ops": {"my_schema__dynamic_partitioned": {"config": {"value": "3"}}}},
+            )
 
-        duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
-        out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
-        assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
-        duckdb_conn.close()
+            duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+            out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
+            assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+            duckdb_conn.close()
 
 
 def test_self_dependent_asset(tmp_path):

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -23,6 +23,10 @@ from dagster._check import CheckError
 from dagster_duckdb import build_configurable_duckdb_io_manager
 from dagster_duckdb_pandas import DuckDBPandasTypeHandler, duckdb_pandas_io_manager
 
+configurable_io_manager = build_configurable_duckdb_io_manager(
+    type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
+)
+
 
 @op(out=Out(metadata={"schema": "a_df"}))
 def a_df() -> pd.DataFrame:
@@ -39,9 +43,16 @@ def add_one_to_dataframe():
     add_one(a_df())
 
 
-def test_duckdb_io_manager_with_ops(tmp_path):
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_duckdb_io_manager_with_ops(tmp_path, io_manager):
     resource_defs = {
-        "io_manager": duckdb_pandas_io_manager.configured(
+        "io_manager": io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
     }
@@ -74,17 +85,15 @@ def b_plus_one(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
-def test_duckdb_io_manager_with_assets(tmp_path):
-    io_manager = build_configurable_duckdb_io_manager(
-        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-    )
-
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_duckdb_io_manager_with_assets(tmp_path, io_manager):
     resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
-    # resource_defs = {
-    #     "io_manager": duckdb_pandas_io_manager.configured(
-    #         {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-    #     ),
-    # }
 
     # materialize asset twice to ensure that tables get properly deleted
     for _ in range(2):
@@ -107,17 +116,14 @@ def b_plus_one_columns(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
-def test_loading_columns(tmp_path):
-    # resource_defs = {
-    #     "io_manager": duckdb_pandas_io_manager.configured(
-    #         {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-    #     ),
-    # }
-
-    io_manager = build_configurable_duckdb_io_manager(
-        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-    )
-
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_loading_columns(tmp_path, io_manager):
     resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     # materialize asset twice to ensure that tables get properly deleted
@@ -148,9 +154,16 @@ def not_supported():
     non_supported_type()
 
 
-def test_not_supported_type(tmp_path):
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_not_supported_type(tmp_path, io_manager):
     resource_defs = {
-        "io_manager": duckdb_pandas_io_manager.configured(
+        "io_manager": io_manager.configured(
             {"database": os.path.join(tmp_path, "unit_test.duckdb")}
         ),
     }
@@ -183,16 +196,14 @@ def daily_partitioned(context) -> pd.DataFrame:
     )
 
 
-def test_time_window_partitioned_asset(tmp_path):
-    # duckdb_io_manager = duckdb_pandas_io_manager.configured(
-    #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-    # )
-    # resource_defs = {"io_manager": duckdb_io_manager}
-
-    io_manager = build_configurable_duckdb_io_manager(
-        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-    )
-
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_time_window_partitioned_asset(tmp_path, io_manager):
     resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     materialize(
@@ -253,16 +264,14 @@ def static_partitioned(context) -> pd.DataFrame:
     )
 
 
-def test_static_partitioned_asset(tmp_path):
-    # duckdb_io_manager = duckdb_pandas_io_manager.configured(
-    #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-    # )
-    # resource_defs = {"io_manager": duckdb_io_manager}
-
-    io_manager = build_configurable_duckdb_io_manager(
-        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-    )
-
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_static_partitioned_asset(tmp_path, io_manager):
     resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     materialize(
@@ -325,16 +334,14 @@ def multi_partitioned(context) -> pd.DataFrame:
     )
 
 
-def test_multi_partitioned_asset(tmp_path):
-    # duckdb_io_manager = duckdb_pandas_io_manager.configured(
-    #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-    # )
-    # resource_defs = {"io_manager": duckdb_io_manager}
-
-    io_manager = build_configurable_duckdb_io_manager(
-        type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-    )
-
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_multi_partitioned_asset(tmp_path, io_manager):
     resource_defs = {"io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))}
 
     materialize(
@@ -406,16 +413,15 @@ def dynamic_partitioned(context) -> pd.DataFrame:
     )
 
 
-def test_dynamic_partition(tmp_path):
+@pytest.mark.parameterize(
+    "io_manager",
+    [
+        duckdb_pandas_io_manager,
+        configurable_io_manager,
+    ],
+)
+def test_dynamic_partition(tmp_path, io_manager):
     with instance_for_test() as instance:
-        # duckdb_io_manager = duckdb_pandas_io_manager.configured(
-        #     {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-        # )
-        # resource_defs = {"io_manager": duckdb_io_manager}
-        io_manager = build_configurable_duckdb_io_manager(
-            type_handlers=[DuckDBPandasTypeHandler()], default_load_type=pd.DataFrame
-        )
-
         resource_defs = {
             "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
         }

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -542,5 +542,5 @@ def test_self_dependent_asset(tmp_path, io_managers):
         assert out_df["a"].tolist() == ["1", "1", "1", "2", "2", "2"]
 
         # drop table so we start with an empty db for the next io manager
-        duckdb_conn.execute("DELETE FROM my_schema.dynamic_partitioned")
+        duckdb_conn.execute("DELETE FROM my_schema.self_dependent_asset")
         duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -38,7 +38,7 @@ def add_one_to_dataframe():
     add_one(a_df())
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -80,7 +80,7 @@ def b_plus_one(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -111,7 +111,7 @@ def b_plus_one_columns(b_df: pd.DataFrame) -> pd.DataFrame:
     return b_df + 1
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -149,7 +149,7 @@ def not_supported():
     non_supported_type()
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -191,7 +191,7 @@ def daily_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -259,7 +259,7 @@ def static_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -329,7 +329,7 @@ def multi_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,
@@ -408,7 +408,7 @@ def dynamic_partitioned(context) -> pd.DataFrame:
     )
 
 
-@pytest.mark.parameterize(
+@pytest.mark.parametrize(
     "io_manager",
     [
         duckdb_pandas_io_manager,

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -171,9 +171,7 @@ def daily_partitioned(context) -> pd.DataFrame:
 
 def test_time_window_partitioned_asset(tmp_path, io_managers):
     for io_manager in io_managers:
-        resource_defs = {
-            "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
-        }
+        resource_defs = {"io_manager": io_manager}
 
         materialize(
             [daily_partitioned],
@@ -212,6 +210,9 @@ def test_time_window_partitioned_asset(tmp_path, io_managers):
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.daily_partitioned").fetch_df()
 
         assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.daily_partitioned")
         duckdb_conn.close()
 
 
@@ -235,9 +236,7 @@ def static_partitioned(context) -> pd.DataFrame:
 
 def test_static_partitioned_asset(tmp_path, io_managers):
     for io_manager in io_managers:
-        resource_defs = {
-            "io_manager": io_manager(database=os.path.join(tmp_path, "unit_test.duckdb"))
-        }
+        resource_defs = {"io_manager": io_manager}
 
         materialize(
             [static_partitioned],
@@ -273,6 +272,9 @@ def test_static_partitioned_asset(tmp_path, io_managers):
         duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.static_partitioned").fetch_df()
         assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.static_partitioned")
         duckdb_conn.close()
 
 
@@ -349,6 +351,9 @@ def test_multi_partitioned_asset(tmp_path, io_managers):
         duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.multi_partitioned").fetch_df()
         assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3", "4", "4", "4"]
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.multi_partitioned")
         duckdb_conn.close()
 
 
@@ -418,6 +423,9 @@ def test_dynamic_partition(tmp_path, io_managers):
             duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
             out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
             assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+            # drop table so we start with an empty db for the next io manager
+            duckdb_conn.execute("DELETE FROM my_schema.dynamic_partitioned")
             duckdb_conn.close()
 
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -23,6 +23,16 @@ from dagster._check import CheckError
 from dagster_duckdb_pandas import ConfigurableDuckDBPandasIOManager, duckdb_pandas_io_manager
 
 
+@pytest.fixture
+def io_managers(tmp_path):
+    return [
+        duckdb_pandas_io_manager.configured(
+            {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+        ),
+        ConfigurableDuckDBPandasIOManager(database=os.path.join(tmp_path, "unit_test.duckdb")),
+    ]
+
+
 @op(out=Out(metadata={"schema": "a_df"}))
 def a_df() -> pd.DataFrame:
     return pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -36,16 +46,6 @@ def add_one(df: pd.DataFrame):
 @graph
 def add_one_to_dataframe():
     add_one(a_df())
-
-
-@pytest.fixture
-def io_managers(tmp_path):
-    return [
-        duckdb_pandas_io_manager.configured(
-            {"database": os.path.join(tmp_path, "unit_test.duckdb")}
-        ),
-        ConfigurableDuckDBPandasIOManager(database=os.path.join(tmp_path, "unit_test.duckdb")),
-    ]
 
 
 def test_duckdb_io_manager_with_ops(tmp_path, io_managers):

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -541,3 +541,7 @@ def test_self_dependent_asset(tmp_path, io_managers):
 
         assert out_df["a"].tolist() == ["1", "1", "1", "2", "2", "2"]
         duckdb_conn.close()
+
+        # drop table so we start with an empty db for the next io manager
+        duckdb_conn.execute("DELETE FROM my_schema.dynamic_partitioned")
+        duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/__init__.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/__init__.py
@@ -1,6 +1,9 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from .io_manager import build_duckdb_io_manager as build_duckdb_io_manager
+from .io_manager import (
+    build_configurable_duckdb_io_manager as build_configurable_duckdb_io_manager,
+    build_duckdb_io_manager as build_duckdb_io_manager,
+)
 from .version import __version__
 
 DagsterLibraryRegistry.register("dagster-duckdb", __version__)

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/__init__.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/__init__.py
@@ -1,7 +1,7 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .io_manager import (
-    build_configurable_duckdb_io_manager as build_configurable_duckdb_io_manager,
+    ConfigurableDuckDBIOManager as ConfigurableDuckDBIOManager,
     build_duckdb_io_manager as build_duckdb_io_manager,
 )
 from .version import __version__

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/__init__.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/__init__.py
@@ -1,7 +1,7 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from .io_manager import (
-    ConfigurableDuckDBIOManager as ConfigurableDuckDBIOManager,
+    DuckDBIOManager as DuckDBIOManager,
     build_duckdb_io_manager as build_duckdb_io_manager,
 )
 from .version import __version__

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -3,7 +3,9 @@ from typing import Optional, Sequence, Type, cast
 
 import duckdb
 from dagster import Field, IOManagerDefinition, OutputContext, StringSource, io_manager
-from dagster._config.structured_config import ConfigurableIOManagerFactory
+from dagster._config.structured_config import (
+    ConfigurableIOManagerFactory,
+)
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,
@@ -112,7 +114,7 @@ def build_configurable_duckdb_io_manager(
 ):
     class ConfigurableDuckDBIOManager(ConfigurableIOManagerFactory):
         database: str
-        schema_: Optional[str] = None
+        schema_: Optional[str] = None  # schema is a reserved word for pydantic
 
         def create_io_manager(self, context) -> DbIOManager:
             return DbIOManager(

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -106,6 +106,57 @@ def build_duckdb_io_manager(
 
 
 class DuckDBIOManager(ConfigurableIOManagerFactory):
+    """Base class for an IO manager definition that reads inputs from and writes outputs to DuckDB.
+
+    Examples:
+        .. code-block:: python
+
+            from dagster_duckdb import DuckDBIOManager
+            from dagster_duckdb_pandas import DuckDBPandasTypeHandler
+
+            class MyDuckDBIOManager(DuckDBIOManager):
+                @staticmethod
+                def type_handlers() -> Sequence[DbTypeHandler]:
+                    return [DuckDBPandasTypeHandler()]
+
+            @asset(
+                key_prefix=["my_schema"]  # will be used as the schema in duckdb
+            )
+            def my_table() -> pd.DataFrame:  # the name of the asset will be the table name
+                ...
+
+            defs = Definitions(
+                assets=[my_table],
+                resources={"io_manager": MyDuckDBIOManager(database="my_db.duckdb")}
+            )
+
+    If you do not provide a schema, Dagster will determine a schema based on the assets and ops using
+    the IO Manager. For assets, the schema will be determined from the asset key, as in the above example.
+    For ops, the schema can be specified by including a "schema" entry in output metadata. If none
+    of these is provided, the schema will default to "public".
+
+    .. code-block:: python
+
+        @op(
+            out={"my_table": Out(metadata={"schema": "my_schema"})}
+        )
+        def make_my_table() -> pd.DataFrame:
+            ...
+
+    To only use specific columns of a table as input to a downstream op or asset, add the metadata "columns" to the
+    In or AssetIn.
+
+    .. code-block:: python
+
+        @asset(
+            ins={"my_table": AssetIn("my_table", metadata={"columns": ["a"]})}
+        )
+        def my_table_a(my_table: pd.DataFrame):
+            # my_table will just contain the data from column "a"
+            ...
+
+    """
+
     database: str = Field(..., description="Path to the DuckDB database.")
     schema_: Optional[str] = Field(
         None, alias="schema", description="Name of the schema to use."

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -115,9 +115,8 @@ class ConfigurableDuckDBIOManager(ConfigurableIOManagerFactory):
         ...
 
     @staticmethod
-    @abstractmethod
     def default_load_type() -> Optional[Type]:
-        ...
+        return None
 
     def create_io_manager(self, context) -> DbIOManager:
         return DbIOManager(

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -106,8 +106,10 @@ def build_duckdb_io_manager(
 
 
 class DuckDBIOManager(ConfigurableIOManagerFactory):
-    database: str
-    schema_: Optional[str] = Field(None, alias="schema")  # schema is a reserved word for pydantic
+    database: str = Field(..., description="Path to the DuckDB database.")
+    schema_: Optional[str] = Field(
+        None, alias="schema", description="Name of the schema to use."
+    )  # schema is a reserved word for pydantic
 
     @staticmethod
     @abstractmethod

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -84,7 +84,7 @@ def build_duckdb_io_manager(
 
     """
 
-    @io_manager(config_schema=infer_schema_from_config_class(ConfigurableDuckDBIOManager))
+    @io_manager(config_schema=infer_schema_from_config_class(DuckDBIOManager))
     def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database.
 
@@ -105,7 +105,7 @@ def build_duckdb_io_manager(
     return duckdb_io_manager
 
 
-class ConfigurableDuckDBIOManager(ConfigurableIOManagerFactory):
+class DuckDBIOManager(ConfigurableIOManagerFactory):
     database: str
     schema_: Optional[str] = Field(None, alias="schema")  # schema is a reserved word for pydantic
 

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -157,7 +157,7 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
 
     """
 
-    database: str = Field(..., description="Path to the DuckDB database.")
+    database: str = Field(description="Path to the DuckDB database.")
     schema_: Optional[str] = Field(
         default=None, alias="schema", description="Name of the schema to use."
     )  # schema is a reserved word for pydantic

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -159,7 +159,7 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
 
     database: str = Field(..., description="Path to the DuckDB database.")
     schema_: Optional[str] = Field(
-        None, alias="schema", description="Name of the schema to use."
+        default=None, alias="schema", description="Name of the schema to use."
     )  # schema is a reserved word for pydantic
 
     @staticmethod


### PR DESCRIPTION
### Summary & Motivation
Converts the DuckDB IO Manager and the pandas type handler to the new pythonic resources system

### How I Tested These Changes
unit tests cover both versions of the io manager