### PR TITLE
Support requiring resources in schedules, experimentally

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -23,7 +23,7 @@ from dagster._core.definitions.partition import (
     ScheduleTimeBasedPartitionsDefinition,
     ScheduleType,
 )
-from dagster._core.definitions.resource_output import get_resource_args
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.sensor_definition import get_context_param_name
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.partition import (
     ScheduleType,
 )
 from dagster._core.definitions.resource_annotation import get_resource_args
-from dagster._core.definitions.sensor_definition import context_param_name_if_present
+from dagster._core.definitions.sensor_definition import get_context_param_name
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     ScheduleExecutionError,
@@ -139,7 +139,7 @@ def schedule(
         elif tags:
             validated_tags = validate_tags(tags, allow_reserved_tags=False)
 
-        context_param_name = context_param_name_if_present(fn)
+        context_param_name = get_context_param_name(fn)
         resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(fn)}
 
         def _wrapped_fn(context: ScheduleEvaluationContext) -> RunRequestIterator:

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -26,7 +26,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.instigation_logger import InstigationLogger
-from dagster._core.definitions.resource_output import get_resource_args
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.scoped_resources_builder import Resources
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import ensure_gen

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -100,7 +100,7 @@ def get_or_create_schedule_context(
     if len(args) + len(kwargs) > 1:
         raise DagsterInvalidInvocationError(
             "Schedule invocation received multiple arguments. Only a first "
-            "positional context parameter should be provided when invoking."
+            "positional context parameter should be provided."
         )
 
     context: Optional[ScheduleEvaluationContext] = None

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -280,8 +280,19 @@ def get_external_schedule_execution(
         else None
     )
 
+    resources_to_build = {
+        k: v
+        for k, v in repo_def.get_top_level_resources().items()
+        if k in schedule_def.required_resource_keys
+    }
+
+    assert len(resources_to_build) == 1
     with ScheduleEvaluationContext(
-        instance_ref, scheduled_execution_time, repo_def.name, schedule_name
+        instance_ref,
+        scheduled_execution_time,
+        repo_def.name,
+        schedule_name,
+        resource_defs=resources_to_build,
     ) as schedule_context:
         try:
             with user_code_error_boundary(

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -291,7 +291,7 @@ def get_external_schedule_execution(
         scheduled_execution_time,
         repo_def.name,
         schedule_name,
-        resource_defs=resources_to_build,
+        resources=resources_to_build,
     ) as schedule_context:
         try:
             with user_code_error_boundary(

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -286,7 +286,6 @@ def get_external_schedule_execution(
         if k in schedule_def.required_resource_keys
     }
 
-    assert len(resources_to_build) == 1
     with ScheduleEvaluationContext(
         instance_ref,
         scheduled_execution_time,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -50,8 +50,8 @@ def test_incorrect_cron_schedule_invocation():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Schedule decorated function has context argument, but no context argument was "
-            "provided."
+            "Schedule evaluation function expected context argument, but no context argument was "
+            "provided when invoking."
         ),
     ):
         basic_schedule()  # pylint: disable=no-value-for-parameter

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -139,7 +139,7 @@ def test_schedule_invocation_resources() -> None:
         basic_schedule_resource_req(build_schedule_context())
 
     assert hasattr(
-        build_schedule_context(resource_defs={"my_resource": MyResource(a_str="foo")}).resources,
+        build_schedule_context(resources={"my_resource": MyResource(a_str="foo")}).resources,
         "my_resource",
     )
 
@@ -147,6 +147,6 @@ def test_schedule_invocation_resources() -> None:
     assert cast(
         RunRequest,
         basic_schedule_resource_req(
-            build_schedule_context(resource_defs={"my_resource": MyResource(a_str="foo")})
+            build_schedule_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
     ).run_config == {"foo": "foo"}

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -18,6 +18,13 @@ def instance_session_scoped_fixture():
         yield instance
 
 
+@pytest.fixture(name="instance_module_scoped", scope="module")
+def instance_module_scoped_fixture(instance_session_scoped):
+    instance_session_scoped.wipe()
+    instance_session_scoped.wipe_all_schedules()
+    yield instance_session_scoped
+
+
 @pytest.fixture(name="instance", scope="function")
 def instance_fixture(instance_session_scoped):
     instance_session_scoped.wipe()

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_struct_resources.py
@@ -1,0 +1,177 @@
+import os
+import sys
+from typing import Optional, Sequence
+
+import pendulum
+import pytest
+from dagster import (
+    DagsterInstance,
+    ScheduleEvaluationContext,
+    job,
+    op,
+    schedule,
+)
+from dagster._config.structured_config import ConfigurableResource
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.repository_definition.valid_definitions import (
+    SINGLETON_REPOSITORY_NAME,
+)
+from dagster._core.definitions.schedule_definition import RunRequest
+from dagster._core.scheduler.instigation import (
+    InstigatorTick,
+    TickStatus,
+)
+from dagster._core.test_utils import (
+    create_test_daemon_workspace_context,
+)
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.load_target import ModuleTarget
+from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+
+from .test_scheduler_run import evaluate_schedules, validate_tick, wait_for_all_runs_to_start
+
+
+@op
+def the_op(_):
+    return 1
+
+
+@job
+def the_job():
+    the_op()
+
+
+class MyResource(ConfigurableResource):
+    a_str: str
+
+
+@schedule(job_name="the_job", cron_schedule="* * * * *", required_resource_keys={"my_resource"})
+def schedule_from_context(context: ScheduleEvaluationContext):
+    return RunRequest(context.resources.my_resource.a_str, run_config={}, tags={})
+
+
+@schedule(job_name="the_job", cron_schedule="* * * * *")
+def schedule_from_arg(my_resource: MyResource):
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@schedule(job_name="the_job", cron_schedule="* * * * *")
+def schedule_from_weird_name(
+    my_resource: MyResource, not_called_context: ScheduleEvaluationContext
+):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+the_repo = Definitions(
+    jobs=[the_job],
+    schedules=[
+        schedule_from_context,
+        schedule_from_arg,
+        schedule_from_weird_name,
+    ],
+    resources={
+        "my_resource": MyResource(a_str="foo"),
+    },
+)
+
+
+def create_workspace_load_target(attribute: Optional[str] = SINGLETON_REPOSITORY_NAME):
+    return ModuleTarget(
+        module_name="dagster_tests.scheduler_tests.test_struct_resources",
+        attribute=None,
+        working_directory=os.path.dirname(__file__),
+        location_name="test_location",
+    )
+
+
+@pytest.fixture(name="workspace_context_struct_resources", scope="module")
+def workspace_fixture(instance_module_scoped):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=create_workspace_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace:
+        yield workspace
+
+
+@pytest.fixture(name="external_repo_struct_resources", scope="module")
+def external_repo_fixture(workspace_context_struct_resources: WorkspaceProcessContext):
+    repo_loc = next(
+        iter(
+            workspace_context_struct_resources.create_request_context()
+            .get_workspace_snapshot()
+            .values()
+        )
+    ).repository_location
+    assert repo_loc
+    return repo_loc.get_repository(SINGLETON_REPOSITORY_NAME)
+
+
+def loadable_target_origin() -> LoadableTargetOrigin:
+    return LoadableTargetOrigin(
+        executable_path=sys.executable,
+        module_name="dagster_tests.daemon_schedule_tests.test_struct_resources",
+        working_directory=os.getcwd(),
+        attribute=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "schedule_name",
+    ["schedule_from_context", "schedule_from_arg", "schedule_from_weird_name"],
+)
+def test_resources(
+    caplog,
+    instance: DagsterInstance,
+    workspace_context_struct_resources,
+    external_repo_struct_resources,
+    schedule_name,
+) -> None:
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+
+    with pendulum.test(freeze_datetime):
+        external_schedule = external_repo_struct_resources.get_external_schedule(schedule_name)
+        instance.start_schedule(external_schedule)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
+        assert len(ticks) == 0
+    freeze_datetime = freeze_datetime.add(seconds=30)
+
+    with pendulum.test(freeze_datetime):
+        evaluate_schedules(workspace_context_struct_resources, None, pendulum.now("UTC"))
+        wait_for_all_runs_to_start(instance)
+
+        ticks: Sequence[InstigatorTick] = instance.get_ticks(
+            external_schedule.get_external_origin_id(), external_schedule.selector_id
+        )
+
+        assert len(ticks) == 1
+
+        assert instance.get_runs_count() == 1
+        run = list(instance.get_runs())[0]
+        assert ticks[0].run_keys == ["foo"]
+
+        expected_datetime = create_pendulum_time(year=2019, month=2, day=28)
+        validate_tick(
+            ticks[0],
+            external_schedule,
+            expected_datetime,
+            TickStatus.SUCCESS,
+            expected_run_ids=[run.run_id],
+        )


### PR DESCRIPTION
## Summary

Implements very basic resource support for schedules. Effectively just calls `build_resouces` and passes the results to user code.

Resources can be specified through `required_resource_keys` or through annoated params on the schedule fn. They can be accessed through context or through these params:

```python

class MyResource(ConfigurableResource):
    a_str: str
    
@schedule(cron_schedule="* * * * *", job_name="the_job", required_resource_keys={"my_resource"})
def schedule_from_context(context: ScheduleEvaluationContext):
    return RunRequest(context.resources.my_resource.a_str, run_config={}, tags={})


@schedule(cron_schedule="* * * * *", job_name="the_job")
def schedule_from_fn_arg(context: ScheduleEvaluationContext, my_resource: MyResource):
    return RunRequest(my_resource.a_str, run_config={}, tags={})

```


Directly invoking schedule requires that a user only provide the context:

```python
# Here, `resource_defs` is exploded into the various resource args which `schedule_from_fn_arg` expects 
schedule_from_fn_arg(
    build_schedule_context(
        resource_defs={"my_resource": MyResource(a_str="foo")}
    )
)
```

## Test Plan

unit test
