### PR TITLE
[db io managers] support self dependent assets in db io managers

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -45,6 +45,7 @@ class TableSlice(NamedTuple):
     database: Optional[str] = None
     columns: Optional[Sequence[str]] = None
     partition_dimensions: Optional[Sequence[TablePartitionDimension]] = None
+    is_self_dependent: bool = False
 
 
 class DbTypeHandler(ABC, Generic[T]):
@@ -223,9 +224,11 @@ class DbIOManager(IOManager):
                                 " column of the database contains data for the"
                                 f" {part.name} partition."
                             )
+
                         partition_dimensions.append(
                             TablePartitionDimension(
-                                partition_expr=cast(str, partition_expr_str), partitions=partitions
+                                partition_expr=cast(str, partition_expr_str),
+                                partitions=partitions,
                             )
                         )
                 elif isinstance(context.asset_partitions_def, TimeWindowPartitionsDefinition):
@@ -258,12 +261,17 @@ class DbIOManager(IOManager):
             else:
                 schema = "public"
 
+        is_self_dependent = False
+        if isinstance(context, InputContext) and context.asset_key == output_context.asset_key:
+            is_self_dependent = True
+
         return TableSlice(
             table=table,
             schema=schema,
             database=self._database,
             partition_dimensions=partition_dimensions,
             columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
+            is_self_dependent=is_self_dependent,
         )
 
     def _check_supported_type(self, obj_type):

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -223,11 +223,9 @@ class DbIOManager(IOManager):
                                 " column of the database contains data for the"
                                 f" {part.name} partition."
                             )
-
                         partition_dimensions.append(
                             TablePartitionDimension(
-                                partition_expr=cast(str, partition_expr_str),
-                                partitions=partitions,
+                                partition_expr=cast(str, partition_expr_str), partitions=partitions
                             )
                         )
                 elif isinstance(context.asset_partitions_def, TimeWindowPartitionsDefinition):

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -45,7 +45,6 @@ class TableSlice(NamedTuple):
     database: Optional[str] = None
     columns: Optional[Sequence[str]] = None
     partition_dimensions: Optional[Sequence[TablePartitionDimension]] = None
-    is_self_dependent: bool = False
 
 
 class DbTypeHandler(ABC, Generic[T]):
@@ -261,17 +260,12 @@ class DbIOManager(IOManager):
             else:
                 schema = "public"
 
-        is_self_dependent = False
-        if isinstance(context, InputContext) and context.asset_key == output_context.asset_key:
-            is_self_dependent = True
-
         return TableSlice(
             table=table,
             schema=schema,
             database=self._database,
             partition_dimensions=partition_dimensions,
             columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
-            is_self_dependent=is_self_dependent,
         )
 
     def _check_supported_type(self, obj_type):

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -70,10 +70,7 @@ class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                 "Schema with name" in e.args[0] or "Table with name" in e.args[0]
             ) and "does not exist" in e.args[0]:
                 # table does not exist, so check if we are in a self dependent asset
-                if (
-                    context.upstream_output
-                    and context.asset_key == context.upstream_output.asset_key
-                ):
+                if table_slice.is_self_dependent:
                     return pd.DataFrame()
             raise e
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -5,12 +5,14 @@ import pandas as pd
 import pytest
 from dagster import (
     AssetIn,
+    AssetKey,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
     asset,
     graph,
     instance_for_test,
@@ -423,3 +425,92 @@ def test_dynamic_partition(tmp_path):
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
         assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
         duckdb_conn.close()
+
+
+def test_self_dependent_asset(tmp_path):
+    daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
+
+    @asset(
+        partitions_def=daily_partitions,
+        key_prefix=["my_schema"],
+        ins={
+            "self_dependent_asset": AssetIn(
+                key=AssetKey(["my_schema", "self_dependent_asset"]),
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            ),
+        },
+        metadata={
+            "partition_expr": "start",
+        },
+        config_schema={"value": str},
+    )
+    def self_dependent_asset(context, self_dependent_asset: pd.DataFrame) -> pd.DataFrame:
+        start, end = context.output_asset_partitions_time_window()
+        value = context.op_config["value"]
+        return pd.DataFrame(
+            {
+                "start": [start, start, start],
+                "end": [end, end, end],
+                "a": [value, value, value],
+            }
+        )
+
+    duckdb_io_manager = duckdb_pandas_io_manager.configured(
+        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    )
+    resource_defs = {"io_manager": duckdb_io_manager}
+
+    # test when the schema doesn't exist yet
+    materialize(
+        [self_dependent_asset],
+        partition_key="2023-01-01",
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__self_dependent_asset": {"config": {"value": "1"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.self_dependent_asset").fetch_df()
+
+    assert out_df["a"].tolist() == ["1", "1", "1"]
+    duckdb_conn.close()
+
+    @asset(
+        partitions_def=daily_partitions,
+        key_prefix=["my_schema"],
+        ins={
+            "another_self_dependent_asset": AssetIn(
+                key=AssetKey(["my_schema", "another_self_dependent_asset"]),
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            ),
+        },
+        metadata={
+            "partition_expr": "start",
+        },
+        config_schema={"value": str},
+    )
+    def another_self_dependent_asset(
+        context, another_self_dependent_asset: pd.DataFrame
+    ) -> pd.DataFrame:
+        start, end = context.output_asset_partitions_time_window()
+        value = context.op_config["value"]
+        return pd.DataFrame(
+            {
+                "start": [start, start, start],
+                "end": [end, end, end],
+                "a": [value, value, value],
+            }
+        )
+
+    # test when the schema already exists, but the table doesn't exist yet
+    materialize(
+        [another_self_dependent_asset],
+        partition_key="2023-01-01",
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__another_self_dependent_asset": {"config": {"value": "1"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.another_self_dependent_asset").fetch_df()
+
+    assert out_df["a"].tolist() == ["1", "1", "1"]
+    duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -440,20 +440,25 @@ def test_self_dependent_asset(tmp_path):
             ),
         },
         metadata={
-            "partition_expr": "start",
+            "partition_expr": "strptime(key, '%Y-%m-%d')",
         },
-        config_schema={"value": str},
+        config_schema={"value": str, "last_partition_key": str},
     )
     def self_dependent_asset(context, self_dependent_asset: pd.DataFrame) -> pd.DataFrame:
-        start, end = context.output_asset_partitions_time_window()
+        key = context.asset_partition_key_for_output()
+
+        if not self_dependent_asset.empty:
+            assert len(self_dependent_asset.index) == 3
+            assert (self_dependent_asset["key"] == context.op_config["last_partition_key"]).all()
         value = context.op_config["value"]
-        return pd.DataFrame(
+        pd_df = pd.DataFrame(
             {
-                "start": [start, start, start],
-                "end": [end, end, end],
+                "key": [key, key, key],
                 "a": [value, value, value],
             }
         )
+
+        return pd_df
 
     duckdb_io_manager = duckdb_pandas_io_manager.configured(
         {"database": os.path.join(tmp_path, "unit_test.duckdb")}
@@ -464,11 +469,36 @@ def test_self_dependent_asset(tmp_path):
         [self_dependent_asset],
         partition_key="2023-01-01",
         resources=resource_defs,
-        run_config={"ops": {"my_schema__self_dependent_asset": {"config": {"value": "1"}}}},
+        run_config={
+            "ops": {
+                "my_schema__self_dependent_asset": {
+                    "config": {"value": "1", "last_partition_key": "NA"}
+                }
+            }
+        },
     )
 
     duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
     out_df = duckdb_conn.execute("SELECT * FROM my_schema.self_dependent_asset").fetch_df()
 
     assert out_df["a"].tolist() == ["1", "1", "1"]
+    duckdb_conn.close()
+
+    materialize(
+        [self_dependent_asset],
+        partition_key="2023-01-02",
+        resources=resource_defs,
+        run_config={
+            "ops": {
+                "my_schema__self_dependent_asset": {
+                    "config": {"value": "2", "last_partition_key": "2023-01-01"}
+                }
+            }
+        },
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.self_dependent_asset").fetch_df()
+
+    assert out_df["a"].tolist() == ["1", "1", "1", "2", "2", "2"]
     duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -450,6 +450,8 @@ def test_self_dependent_asset(tmp_path):
         if not self_dependent_asset.empty:
             assert len(self_dependent_asset.index) == 3
             assert (self_dependent_asset["key"] == context.op_config["last_partition_key"]).all()
+        else:
+            assert context.op_config["last_partition_key"] == "NA"
         value = context.op_config["value"]
         pd_df = pd.DataFrame(
             {

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars/duckdb_polars_type_handler.py
@@ -64,6 +64,8 @@ class DuckDBPolarsTypeHandler(DbTypeHandler[pl.DataFrame]):
         self, context: InputContext, table_slice: TableSlice, connection
     ) -> pl.DataFrame:
         """Loads the input as a Polars DataFrame."""
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return pl.DataFrame()
         select_statement = connection.execute(
             DuckDbClient.get_select_statement(table_slice=table_slice)
         )

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -455,7 +455,7 @@ def test_self_dependent_asset(tmp_path):
     def self_dependent_asset(context, self_dependent_asset: pl.DataFrame) -> pl.DataFrame:
         key = context.asset_partition_key_for_output()
 
-        if not self_dependent_asset.is_empty:
+        if not self_dependent_asset.is_empty():
             assert len(self_dependent_asset["key"]) == 3
             assert (self_dependent_asset["key"] == context.op_config["last_partition_key"]).all()
         else:

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -5,12 +5,14 @@ import polars as pl
 import pytest
 from dagster import (
     AssetIn,
+    AssetKey,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
     asset,
     graph,
     instance_for_test,
@@ -431,3 +433,52 @@ def test_dynamic_partition(tmp_path):
         )
         assert sorted(out_df["a"].to_list()) == ["2", "2", "2", "3", "3", "3"]
         duckdb_conn.close()
+
+
+def test_self_dependent_asset(tmp_path):
+    daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
+
+    @asset(
+        partitions_def=daily_partitions,
+        key_prefix=["my_schema"],
+        ins={
+            "self_dependent_asset": AssetIn(
+                key=AssetKey(["my_schema", "self_dependent_asset"]),
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            ),
+        },
+        metadata={
+            "partition_expr": "start",
+        },
+        config_schema={"value": str},
+    )
+    def self_dependent_asset(context, self_dependent_asset: pl.DataFrame) -> pl.DataFrame:
+        start, end = context.output_asset_partitions_time_window()
+        value = context.op_config["value"]
+        return pl.DataFrame(
+            {
+                "start": [start, start, start],
+                "end": [end, end, end],
+                "a": [value, value, value],
+            }
+        )
+
+    duckdb_io_manager = duckdb_polars_io_manager.configured(
+        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    )
+    resource_defs = {"io_manager": duckdb_io_manager}
+
+    materialize(
+        [self_dependent_asset],
+        partition_key="2023-01-01",
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__self_dependent_asset": {"config": {"value": "1"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = pl.DataFrame(
+        duckdb_conn.execute("SELECT * FROM my_schema.self_dependent_asset").arrow()
+    )
+
+    assert out_df["a"].to_list() == ["1", "1", "1"]
+    duckdb_conn.close()

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -4,6 +4,7 @@ from dagster import InputContext, MetadataValue, OutputContext, TableColumn, Tab
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_duckdb.io_manager import DuckDbClient, build_duckdb_io_manager
 from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType
 
 
 class DuckDBPySparkTypeHandler(DbTypeHandler[pyspark.sql.DataFrame]):
@@ -71,7 +72,7 @@ class DuckDBPySparkTypeHandler(DbTypeHandler[pyspark.sql.DataFrame]):
         """Loads the return of the query as the correct type."""
         spark = SparkSession.builder.getOrCreate()
         if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
-            return spark.createDataFrame([])
+            return spark.createDataFrame([], StructType([]))
 
         pd_df = connection.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
         return spark.createDataFrame(pd_df)

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -69,8 +69,11 @@ class DuckDBPySparkTypeHandler(DbTypeHandler[pyspark.sql.DataFrame]):
         self, context: InputContext, table_slice: TableSlice, connection
     ) -> pyspark.sql.DataFrame:
         """Loads the return of the query as the correct type."""
-        pd_df = connection.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
         spark = SparkSession.builder.getOrCreate()
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return spark.createDataFrame([])
+
+        pd_df = connection.execute(DuckDbClient.get_select_statement(table_slice)).fetchdf()
         return spark.createDataFrame(pd_df)
 
     @property

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -438,6 +438,8 @@ def test_self_dependent_asset(tmp_path):
             pd_df = self_dependent_asset.toPandas()
             assert len(pd_df.index) == 3
             assert (pd_df["key"] == context.op_config["last_partition_key"]).all()
+        else:
+            assert context.op_config["last_partition_key"] == "NA"
         value = context.op_config["value"]
         pd_df = pd.DataFrame(
             {

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -4,12 +4,15 @@ import duckdb
 import pandas as pd
 import pytest
 from dagster import (
+    AssetIn,
+    AssetKey,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
     asset,
     graph,
     instance_for_test,
@@ -409,3 +412,53 @@ def test_dynamic_partition(tmp_path):
         out_df = duckdb_conn.execute("SELECT * FROM my_schema.dynamic_partitioned").fetch_df()
         assert sorted(out_df["a"].tolist()) == ["2", "2", "2", "3", "3", "3"]
         duckdb_conn.close()
+
+
+def test_self_dependent_asset(tmp_path):
+    daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
+
+    @asset(
+        partitions_def=daily_partitions,
+        key_prefix=["my_schema"],
+        ins={
+            "self_dependent_asset": AssetIn(
+                key=AssetKey(["my_schema", "self_dependent_asset"]),
+                partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            ),
+        },
+        metadata={
+            "partition_expr": "start",
+        },
+        config_schema={"value": str},
+    )
+    def self_dependent_asset(context, self_dependent_asset: pd.DataFrame) -> pd.DataFrame:
+        start, end = context.output_asset_partitions_time_window()
+        value = context.op_config["value"]
+        pd_df = pd.DataFrame(
+            {
+                "start": [start, start, start],
+                "end": [end, end, end],
+                "a": [value, value, value],
+            }
+        )
+
+        spark = SparkSession.builder.getOrCreate()
+        return spark.createDataFrame(pd_df)
+
+    duckdb_io_manager = duckdb_pyspark_io_manager.configured(
+        {"database": os.path.join(tmp_path, "unit_test.duckdb")}
+    )
+    resource_defs = {"io_manager": duckdb_io_manager}
+
+    materialize(
+        [self_dependent_asset],
+        partition_key="2023-01-01",
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__self_dependent_asset": {"config": {"value": "1"}}}},
+    )
+
+    duckdb_conn = duckdb.connect(database=os.path.join(tmp_path, "unit_test.duckdb"))
+    out_df = duckdb_conn.execute("SELECT * FROM my_schema.self_dependent_asset").fetch_df()
+
+    assert out_df["a"].tolist() == ["1", "1", "1"]
+    duckdb_conn.close()

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -66,6 +66,8 @@ class BigQueryPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         self, context: InputContext, table_slice: TableSlice, connection
     ) -> pd.DataFrame:
         """Loads the input as a Pandas DataFrame."""
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return pd.DataFrame()
         result = connection.query(
             query=BigQueryClient.get_select_statement(table_slice),
             project=table_slice.database,

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -471,12 +471,13 @@ def test_dynamic_partitioned_asset():
             )
             assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
 
+
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_self_dependent_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="START TIMESTAMP, END TIMESTAMP, A string",
+        column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 
@@ -490,21 +491,29 @@ def test_self_dependent_asset():
                 ),
             },
             metadata={
-                "partition_expr": "start",
+                "partition_expr": "TIMESTAMP(key)",
             },
-            config_schema={"value": str},
-            name=table_name,
+            config_schema={"value": str, "last_partition_key": str},
         )
         def self_dependent_asset(context, self_dependent_asset: pd.DataFrame) -> pd.DataFrame:
-            start, end = context.output_asset_partitions_time_window()
+            key = context.asset_partition_key_for_output()
+
+            if not self_dependent_asset.empty:
+                assert len(self_dependent_asset.index) == 3
+                assert (
+                    self_dependent_asset["key"] == context.op_config["last_partition_key"]
+                ).all()
+            else:
+                assert context.op_config["last_partition_key"] == "NA"
             value = context.op_config["value"]
-            return pd.DataFrame(
+            pd_df = pd.DataFrame(
                 {
-                    "start": [start, start, start],
-                    "end": [end, end, end],
+                    "key": [key, key, key],
                     "a": [value, value, value],
                 }
             )
+
+            return pd_df
 
         asset_full_name = f"{schema}__{table_name}"
         bq_table_path = f"{schema}.{table_name}"
@@ -516,10 +525,28 @@ def test_self_dependent_asset():
             [self_dependent_asset],
             partition_key="2023-01-01",
             resources=resource_defs,
-            run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+            run_config={
+                "ops": {asset_full_name: {"config": {"value": "1", "last_partition_key": "NA"}}}
+            },
         )
 
         out_df = pandas_gbq.read_gbq(
             f"SELECT * FROM {bq_table_path}", project_id=SHARED_BUILDKITE_BQ_CONFIG["project"]
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1"]
+
+        materialize(
+            [self_dependent_asset],
+            partition_key="2023-01-02",
+            resources=resource_defs,
+            run_config={
+                "ops": {
+                    asset_full_name: {"config": {"value": "1", "last_partition_key": "2023-01-01"}}
+                }
+            },
+        )
+
+        out_df = pandas_gbq.read_gbq(
+            f"SELECT * FROM {bq_table_path}", project_id=SHARED_BUILDKITE_BQ_CONFIG["project"]
+        )
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -486,7 +486,7 @@ def test_self_dependent_asset():
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey([schema, "self_dependent_asset"]),
+                    key=AssetKey([schema, table_name]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -486,7 +486,7 @@ def test_self_dependent_asset():
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey(["my_schema", "self_dependent_asset"]),
+                    key=AssetKey([schema, "self_dependent_asset"]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },
@@ -519,7 +519,7 @@ def test_self_dependent_asset():
         bq_table_path = f"{schema}.{table_name}"
 
         bq_io_manager = bigquery_pandas_io_manager.configured(SHARED_BUILDKITE_BQ_CONFIG)
-        resource_defs = {"io_manager": bq_io_manager, "fs_io": fs_io_manager}
+        resource_defs = {"io_manager": bq_io_manager}
 
         materialize(
             [self_dependent_asset],

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -8,12 +8,14 @@ import pandas_gbq
 import pytest
 from dagster import (
     AssetIn,
+    AssetKey,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     MultiPartitionKey,
     MultiPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
+    TimeWindowPartitionMapping,
     asset,
     fs_io_manager,
     instance_for_test,
@@ -468,3 +470,56 @@ def test_dynamic_partitioned_asset():
                 f"SELECT * FROM {bq_table_path}", project_id=SHARED_BUILDKITE_BQ_CONFIG["project"]
             )
             assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
+def test_self_dependent_asset():
+    schema = "BIGQUERY_IO_MANAGER_SCHEMA"
+    with temporary_bigquery_table(
+        schema_name=schema,
+        column_str="START TIMESTAMP, END TIMESTAMP, A string",
+    ) as table_name:
+        daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
+
+        @asset(
+            partitions_def=daily_partitions,
+            key_prefix=schema,
+            ins={
+                "self_dependent_asset": AssetIn(
+                    key=AssetKey(["my_schema", "self_dependent_asset"]),
+                    partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+                ),
+            },
+            metadata={
+                "partition_expr": "start",
+            },
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def self_dependent_asset(context, self_dependent_asset: pd.DataFrame) -> pd.DataFrame:
+            start, end = context.output_asset_partitions_time_window()
+            value = context.op_config["value"]
+            return pd.DataFrame(
+                {
+                    "start": [start, start, start],
+                    "end": [end, end, end],
+                    "a": [value, value, value],
+                }
+            )
+
+        asset_full_name = f"{schema}__{table_name}"
+        bq_table_path = f"{schema}.{table_name}"
+
+        bq_io_manager = bigquery_pandas_io_manager.configured(SHARED_BUILDKITE_BQ_CONFIG)
+        resource_defs = {"io_manager": bq_io_manager, "fs_io": fs_io_manager}
+
+        materialize(
+            [self_dependent_asset],
+            partition_key="2023-01-01",
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+        )
+
+        out_df = pandas_gbq.read_gbq(
+            f"SELECT * FROM {bq_table_path}", project_id=SHARED_BUILDKITE_BQ_CONFIG["project"]
+        )
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1"]

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -494,6 +494,7 @@ def test_self_dependent_asset():
                 "partition_expr": "TIMESTAMP(key)",
             },
             config_schema={"value": str, "last_partition_key": str},
+            name=table_name,
         )
         def self_dependent_asset(context, self_dependent_asset: pd.DataFrame) -> pd.DataFrame:
             key = context.asset_partition_key_for_output()

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -477,7 +477,6 @@ def test_self_dependent_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -542,7 +542,7 @@ def test_self_dependent_asset():
             resources=resource_defs,
             run_config={
                 "ops": {
-                    asset_full_name: {"config": {"value": "1", "last_partition_key": "2023-01-01"}}
+                    asset_full_name: {"config": {"value": "2", "last_partition_key": "2023-01-01"}}
                 }
             },
         )

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -6,6 +6,7 @@ from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_gcp import build_bigquery_io_manager
 from dagster_gcp.bigquery.io_manager import BigQueryClient
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
 
 
 def _get_bigquery_write_options(
@@ -80,7 +81,7 @@ class BigQueryPySparkTypeHandler(DbTypeHandler[DataFrame]):
         spark = SparkSession.builder.getOrCreate()
 
         if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
-            return spark.createDataFrame([])
+            return spark.createDataFrame([], StructType([]))
 
         df = (
             spark.read.format("bigquery")

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark/bigquery/bigquery_pyspark_type_handler.py
@@ -79,6 +79,9 @@ class BigQueryPySparkTypeHandler(DbTypeHandler[DataFrame]):
         options = _get_bigquery_read_options(table_slice)
         spark = SparkSession.builder.getOrCreate()
 
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return spark.createDataFrame([])
+
         df = (
             spark.read.format("bigquery")
             .options(**options)

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -552,7 +552,7 @@ def test_self_dependent_asset(spark):
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey(["my_schema", "self_dependent_asset"]),
+                    key=AssetKey([schema, "self_dependent_asset"]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -557,7 +557,7 @@ def test_self_dependent_asset(spark):
                 ),
             },
             metadata={
-                "partition_expr": "strptime(key, '%Y-%m-%d')",
+                "partition_expr": "TIMESTAMP(key)",
             },
             config_schema={"value": str, "last_partition_key": str},
             name=table_name,

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -552,7 +552,7 @@ def test_self_dependent_asset(spark):
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey([schema, "self_dependent_asset"]),
+                    key=AssetKey([schema, table_name]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -543,7 +543,6 @@ def test_self_dependent_asset(spark):
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -560,6 +560,7 @@ def test_self_dependent_asset(spark):
                 "partition_expr": "strptime(key, '%Y-%m-%d')",
             },
             config_schema={"value": str, "last_partition_key": str},
+            name=table_name,
         )
         def self_dependent_asset(context, self_dependent_asset: DataFrame) -> DataFrame:
             key = context.asset_partition_key_for_output()

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -86,6 +86,8 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     def load_input(
         self, context: InputContext, table_slice: TableSlice, connection
     ) -> pd.DataFrame:
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return pd.DataFrame()
         result = pd.read_sql(
             sql=SnowflakeDbClient.get_select_statement(table_slice), con=connection
         )

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -637,7 +637,7 @@ def test_self_dependent_asset():
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey([schema, "self_dependent_asset"]),
+                    key=AssetKey([schema, table_name]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -627,7 +627,7 @@ def test_self_dependent_asset():
     schema = "SNOWFLAKE_IO_MANAGER_SCHEMA"
     with temporary_snowflake_table(
         schema_name=schema,
-        column_str="START TIMESTAMP_NTZ(9), END TIMESTAMP_NTZ(9), A string",
+        column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 
@@ -641,21 +641,29 @@ def test_self_dependent_asset():
                 ),
             },
             metadata={
-                "partition_expr": "start",
+                "partition_expr": "TO_TIMESTAMP(key)",
             },
-            config_schema={"value": str},
-            name=table_name,
+            config_schema={"value": str, "last_partition_key": str},
         )
         def self_dependent_asset(context, self_dependent_asset: DataFrame) -> DataFrame:
-            start, end = context.output_asset_partitions_time_window()
+            key = context.asset_partition_key_for_output()
+
+            if not self_dependent_asset.empty:
+                assert len(self_dependent_asset.index) == 3
+                assert (
+                    self_dependent_asset["key"] == context.op_config["last_partition_key"]
+                ).all()
+            else:
+                assert context.op_config["last_partition_key"] == "NA"
             value = context.op_config["value"]
-            return DataFrame(
+            pd_df = DataFrame(
                 {
-                    "start": [start, start, start],
-                    "end": [end, end, end],
+                    "key": [key, key, key],
                     "a": [value, value, value],
                 }
             )
+
+            return pd_df
 
         asset_full_name = f"{schema}__{table_name}"
         snowflake_table_path = f"{schema}.{table_name}"
@@ -675,10 +683,28 @@ def test_self_dependent_asset():
             [self_dependent_asset],
             partition_key="2023-01-01",
             resources=resource_defs,
-            run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+            run_config={
+                "ops": {asset_full_name: {"config": {"value": "1", "last_partition_key": "NA"}}}
+            },
         )
 
         out_df = snowflake_conn.execute_query(
             f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1"]
+
+        materialize(
+            [self_dependent_asset],
+            partition_key="2023-01-02",
+            resources=resource_defs,
+            run_config={
+                "ops": {
+                    asset_full_name: {"config": {"value": "2", "last_partition_key": "2023-01-01"}}
+                }
+            },
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -9,6 +9,7 @@ import pandas
 import pytest
 from dagster import (
     AssetIn,
+    AssetKey,
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     IOManagerDefinition,
@@ -19,6 +20,7 @@ from dagster import (
     StaticPartitionsDefinition,
     TableColumn,
     TableSchema,
+    TimeWindowPartitionMapping,
     asset,
     build_input_context,
     build_output_context,
@@ -618,3 +620,65 @@ def test_dynamic_partitions():
                 f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
             )
             assert sorted(out_df["A"].tolist()) == ["2", "2", "2", "3", "3", "3"]
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+def test_self_dependent_asset():
+    schema = "SNOWFLAKE_IO_MANAGER_SCHEMA"
+    with temporary_snowflake_table(
+        schema_name=schema,
+        column_str="START TIMESTAMP_NTZ(9), END TIMESTAMP_NTZ(9), A string",
+    ) as table_name:
+        daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
+
+        @asset(
+            partitions_def=daily_partitions,
+            key_prefix=schema,
+            ins={
+                "self_dependent_asset": AssetIn(
+                    key=AssetKey(["my_schema", "self_dependent_asset"]),
+                    partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+                ),
+            },
+            metadata={
+                "partition_expr": "start",
+            },
+            config_schema={"value": str},
+            name=table_name,
+        )
+        def self_dependent_asset(context, self_dependent_asset: DataFrame) -> DataFrame:
+            start, end = context.output_asset_partitions_time_window()
+            value = context.op_config["value"]
+            return DataFrame(
+                {
+                    "start": [start, start, start],
+                    "end": [end, end, end],
+                    "a": [value, value, value],
+                }
+            )
+
+        asset_full_name = f"{schema}__{table_name}"
+        snowflake_table_path = f"{schema}.{table_name}"
+
+        snowflake_config = {
+            **SHARED_BUILDKITE_SNOWFLAKE_CONF,
+            "database": "TEST_SNOWFLAKE_IO_MANAGER",
+        }
+        snowflake_conn = SnowflakeConnection(
+            snowflake_config, logging.getLogger("temporary_snowflake_table")
+        )
+
+        snowflake_io_manager = snowflake_pandas_io_manager.configured(snowflake_config)
+        resource_defs = {"io_manager": snowflake_io_manager}
+
+        materialize(
+            [self_dependent_asset],
+            partition_key="2023-01-01",
+            resources=resource_defs,
+            run_config={"ops": {asset_full_name: {"config": {"value": "1"}}}},
+        )
+
+        out_df = snowflake_conn.execute_query(
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+        )
+        assert sorted(out_df["A"].tolist()) == ["1", "1", "1"]

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -628,7 +628,6 @@ def test_self_dependent_asset():
     with temporary_snowflake_table(
         schema_name=schema,
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -627,6 +627,7 @@ def test_self_dependent_asset():
     schema = "SNOWFLAKE_IO_MANAGER_SCHEMA"
     with temporary_snowflake_table(
         schema_name=schema,
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
@@ -644,6 +645,7 @@ def test_self_dependent_asset():
                 "partition_expr": "TO_TIMESTAMP(key)",
             },
             config_schema={"value": str, "last_partition_key": str},
+            name=table_name,
         )
         def self_dependent_asset(context, self_dependent_asset: DataFrame) -> DataFrame:
             key = context.asset_partition_key_for_output()

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -691,7 +691,7 @@ def test_self_dependent_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1"]
 
@@ -707,6 +707,6 @@ def test_self_dependent_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -636,7 +636,7 @@ def test_self_dependent_asset():
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey(["my_schema", "self_dependent_asset"]),
+                    key=AssetKey([schema, "self_dependent_asset"]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -7,6 +7,7 @@ from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
 
 SNOWFLAKE_CONNECTOR = "net.snowflake.spark.snowflake"
 
@@ -96,7 +97,7 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
         )
 
         if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
-            return spark.createDataFrame([])
+            return spark.createDataFrame([], StructType([]))
 
         return df.toDF(*[c.lower() for c in df.columns])
 

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -95,6 +95,9 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
             .load()
         )
 
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return spark.createDataFrame([])
+
         return df.toDF(*[c.lower() for c in df.columns])
 
     @property

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -89,16 +89,15 @@ class SnowflakePySparkTypeHandler(DbTypeHandler[DataFrame]):
         options = _get_snowflake_options(context.resource_config, table_slice)
 
         spark = SparkSession.builder.getOrCreate()
+        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
+            return spark.createDataFrame([], StructType([]))
+
         df = (
             spark.read.format(SNOWFLAKE_CONNECTOR)
             .options(**options)
             .option("query", SnowflakeDbClient.get_select_statement(table_slice))
             .load()
         )
-
-        if table_slice.partition_dimensions and len(context.asset_partition_keys) == 0:
-            return spark.createDataFrame([], StructType([]))
-
         return df.toDF(*[c.lower() for c in df.columns])
 
     @property

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -576,12 +576,11 @@ def test_dynamic_partitions(spark):
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
-def test_self_dependent_asset():
+def test_self_dependent_asset(spark):
     schema = "SNOWFLAKE_IO_MANAGER_SCHEMA"
     with temporary_snowflake_table(
         schema_name=schema,
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
 
@@ -621,10 +620,6 @@ def test_self_dependent_asset():
                 (key, value),
                 (key, value),
             ]
-            spark = SparkSession.builder.config(
-                key="spark.jars.packages",
-                value=SNOWFLAKE_JARS,
-            ).getOrCreate()
 
             df = spark.createDataFrame(data, schema=schema)
             return df

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -653,7 +653,7 @@ def test_self_dependent_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1"]
 
@@ -669,6 +669,6 @@ def test_self_dependent_asset():
         )
 
         out_df = snowflake_conn.execute_query(
-            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True
+            f"SELECT * FROM {snowflake_table_path}", use_pandas_result=True, fetch_results=True
         )
         assert sorted(out_df["A"].tolist()) == ["1", "1", "1", "2", "2", "2"]

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -580,6 +580,7 @@ def test_self_dependent_asset():
     schema = "SNOWFLAKE_IO_MANAGER_SCHEMA"
     with temporary_snowflake_table(
         schema_name=schema,
+        db_name="TEST_SNOWFLAKE_IO_MANAGER",
         column_str="KEY string, A string",
     ) as table_name:
         daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
@@ -597,6 +598,7 @@ def test_self_dependent_asset():
                 "partition_expr": "TO_TIMESTAMP(key)",
             },
             config_schema={"value": str, "last_partition_key": str},
+            name=table_name,
         )
         def self_dependent_asset(context, self_dependent_asset: DataFrame) -> DataFrame:
             key = context.asset_partition_key_for_output()

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -589,7 +589,7 @@ def test_self_dependent_asset():
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey(["my_schema", "self_dependent_asset"]),
+                    key=AssetKey([schema, "self_dependent_asset"]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -590,7 +590,7 @@ def test_self_dependent_asset():
             key_prefix=schema,
             ins={
                 "self_dependent_asset": AssetIn(
-                    key=AssetKey([schema, "self_dependent_asset"]),
+                    key=AssetKey([schema, table_name]),
                     partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
                 ),
             },

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -663,7 +663,7 @@ def test_self_dependent_asset():
             resources=resource_defs,
             run_config={
                 "ops": {
-                    asset_full_name: {"config": {"value": "1", "last_partition_key": "2023-01-01"}}
+                    asset_full_name: {"config": {"value": "2", "last_partition_key": "2023-01-01"}}
                 }
             },
         )


### PR DESCRIPTION
### Summary & Motivation

This PR adds support for self-dependent assets. For a self-dependent asset, the "base case" partition doesn't depend on previous partitions, so the `InputContext.asset_partition_keys` will be an empty list. We check to see if this is the case and if so we return an empty DataFrame. Otherwise we perform the SELECT query as normal

----
Original comment:

Starting to think about how we'll manage self-dependent assets (see #11845). This is one option where we attempt to select from the table, catch the exception if the table doesn't exist, and then confirm that the asset depends on itself. We then make the assumption that that means it's the "base case" of the self dependent asset and return an empty dataframe. I'm not 100% sure what the expectations are around self-dependent asset behavior, so would like some feedback!

I implemented this for the duckdb io manager and pandas type handler as an example. if this approach makes sense i'll implement for the remaining io managers/type handlers

One issue with this approach: imagine we have a self-dependent asset with daily partition starting on `2023-01-01`
where each partition is dependent on the one before it. partition `2023-01-01` is the "base case". if we materialize partition `2023-01-15` first, the io manager will return an empty dataframe (since `2023-01-14` hasn't been materialized yet), which i think (?) would be unexpected behavior. 

If in the case above, returning an empty dataframe is expected, then this approach would work. However, if we want to only return the empty dataframe for the first partition in the partition definition i'll need to do some more work to make that determination in the io manager. 

I think comparing the partition key of the asset to the start of the partitions definition could work in all cases except for static partitions. For static partitions i'm not sure how we know what partition is considered the "first"


### How I Tested These Changes
