### PR TITLE
[dagit] Update asset node styling to match new Figma designs, show failed count

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -354,6 +354,29 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
   },
 };
 
+export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
+  stepKey: 'partitioned_asset',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterialization: {
+    __typename: 'MaterializationEvent',
+    runId: 'ABCDEF',
+    timestamp: TIMESTAMP,
+  },
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  staleStatus: StaleStatus.FRESH,
+  staleStatusCauses: [],
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 5,
+    numPartitions: 1500,
+    numFailed: 850,
+  },
+};
+
 export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
   stepKey: 'partitioned_asset',
   unstartedRunIds: [],
@@ -381,6 +404,25 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
   stepKey: 'asset1',
   unstartedRunIds: [],
   inProgressRunIds: [],
+  lastMaterialization: null,
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  runWhichFailedToMaterialize: null,
+  staleStatus: StaleStatus.MISSING,
+  staleStatusCauses: [],
+  freshnessInfo: null,
+  freshnessPolicy: null,
+  partitionStats: {
+    numMaterialized: 0,
+    numPartitions: 1500,
+    numFailed: 0,
+  },
+};
+
+export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: ['LMAANO'],
+  inProgressRunIds: ['ABCDEF', 'CDEFG', 'HIHKA'],
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
@@ -643,6 +685,13 @@ export const AssetNodeScenariosPartitioned = [
   },
 
   {
+    title: 'Partitioned Asset - Some Failed',
+    liveData: LiveDataForNodePartitionedSomeFailed,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '850 failed'],
+  },
+
+  {
     title: 'Partitioned Asset - None Missing',
     liveData: LiveDataForNodePartitionedNoneMissing,
     definition: AssetNodeFragmentPartitioned,
@@ -652,6 +701,13 @@ export const AssetNodeScenariosPartitioned = [
   {
     title: 'Never Materialized',
     liveData: LiveDataForNodePartitionedNeverMaterialized,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['1,500 partitions', '1,500 missing'],
+  },
+
+  {
+    title: 'Materializing...',
+    liveData: LiveDataForNodePartitionedMaterializing,
     definition: AssetNodeFragmentPartitioned,
     expectedText: ['1,500 partitions', '1,500 missing'],
   },
@@ -682,5 +738,11 @@ export const AssetNodeScenariosPartitioned = [
     liveData: LiveDataForNodePartitionedLatestRunFailed,
     definition: AssetNodeFragmentPartitioned,
     expectedText: ['1,500 partitions', '0 missing'],
+  },
+  {
+    title: 'Partitioned Asset - Live Data Loading',
+    liveData: undefined,
+    definition: AssetNodeFragmentPartitioned,
+    expectedText: ['Loading'],
   },
 ];

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -541,9 +541,9 @@ export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
   freshnessInfo: null,
   freshnessPolicy: null,
   partitionStats: {
-    numMaterialized: 1500,
+    numMaterialized: 1495,
     numPartitions: 1500,
-    numFailed: 0,
+    numFailed: 1,
   },
 };
 

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -348,7 +348,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
   freshnessInfo: null,
   freshnessPolicy: null,
   partitionStats: {
-    numMaterialized: 5,
+    numMaterialized: 6,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -371,9 +371,9 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
   freshnessInfo: null,
   freshnessPolicy: null,
   partitionStats: {
-    numMaterialized: 5,
+    numMaterialized: 6,
     numPartitions: 1500,
-    numFailed: 850,
+    numFailed: 849,
   },
 };
 
@@ -681,63 +681,63 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Partitioned Asset - Some Missing',
     liveData: LiveDataForNodePartitionedSomeMissing,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '1,495 missing'],
+    expectedText: ['999+', '6', '1,494 missing partitions'],
   },
 
   {
     title: 'Partitioned Asset - Some Failed',
     liveData: LiveDataForNodePartitionedSomeFailed,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '850 failed'],
+    expectedText: ['645', '849 failed partitions'],
   },
 
   {
     title: 'Partitioned Asset - None Missing',
     liveData: LiveDataForNodePartitionedNoneMissing,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '0 missing'],
+    expectedText: ['1,500 partitions', 'All'],
   },
 
   {
     title: 'Never Materialized',
     liveData: LiveDataForNodePartitionedNeverMaterialized,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '1,500 missing'],
+    expectedText: ['1,500 missing partitions'],
   },
 
   {
     title: 'Materializing...',
     liveData: LiveDataForNodePartitionedMaterializing,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '1,500 missing'],
+    expectedText: ['Materializing', 'ABCDEF'],
   },
 
   {
     title: 'Partitioned Asset - Stale',
     liveData: LiveDataForNodePartitionedStale,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '0 missing'],
+    expectedText: ['1,500 partitions', 'All'],
   },
 
   {
     title: 'Partitioned Asset - Stale and Late',
     liveData: LiveDataForNodePartitionedStaleAndLate,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '12 minutes late'],
+    expectedText: ['All', '12 minutes late'],
   },
 
   {
     title: 'Partitioned Asset - Stale and Fresh',
     liveData: LiveDataForNodePartitionedStaleAndFresh,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '0 missing'],
+    expectedText: ['1,500 partitions', 'All'],
   },
 
   {
     title: 'Partitioned Asset - Last Run Failed',
     liveData: LiveDataForNodePartitionedLatestRunFailed,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 partitions', '0 missing'],
+    expectedText: ['4', '999+', '1 failed partition'],
   },
   {
     title: 'Partitioned Asset - Live Data Loading',

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -62,7 +62,7 @@ export const AssetNode: React.FC<{
   );
 }, isEqual);
 
-export const AssetNodeStatusBox: React.FC<{background: string}> = ({background, children}) => (
+const AssetNodeStatusBox: React.FC<{background: string}> = ({background, children}) => (
   <Box
     padding={{horizontal: 8}}
     style={{
@@ -79,7 +79,7 @@ export const AssetNodeStatusBox: React.FC<{background: string}> = ({background, 
   </Box>
 );
 
-export const AssetNodePartitionsRow: React.FC<StatusRowProps> = (props) => {
+const AssetNodePartitionsRow: React.FC<StatusRowProps> = (props) => {
   const data = props.liveData?.partitionStats;
   return (
     <Box
@@ -158,25 +158,35 @@ const AssetNodePartitionCountBox: React.FC<{
       canShow={value !== undefined}
       content={partitionStateToString(value, style.adjective)}
     >
-      <Box
-        style={{width: '100%', color: foreground, borderRadius: 6, fontSize: 12}}
-        flex={{gap: 4, alignItems: 'center', justifyContent: 'center'}}
-        padding={{horizontal: 4, vertical: 4}}
-        background={background}
-      >
+      <AssetNodePartitionCountContainer style={{color: foreground, background}}>
         <Icon name={style.icon} color={foreground} size={16} />
         {value === undefined ? '—' : value === total ? 'All' : value > 1000 ? '999+' : value}
-      </Box>
+      </AssetNodePartitionCountContainer>
     </Tooltip>
   );
 };
+
+// Necessary to remove the outline we get with the tooltip applying a tabIndex
+const AssetNodePartitionCountContainer = styled.div`
+  width: 100%;
+  border-radius: 6px;
+  font-size: 12px;
+  gap: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  &:focus {
+    outline: 0;
+  }
+`;
 
 interface StatusRowProps {
   definition: AssetNodeFragment;
   liveData: LiveDataForNode | undefined;
 }
 
-export const AssetNodeStatusRow: React.FC<StatusRowProps> = (props) => {
+const AssetNodeStatusRow: React.FC<StatusRowProps> = (props) => {
   const info = buildAssetNodeStatusRow(props);
   return <AssetNodeStatusBox background={info.background}>{info.content}</AssetNodeStatusBox>;
 };
@@ -188,7 +198,7 @@ function getStepKey(definition: AssetNodeFragment) {
   return firstOp || '';
 }
 
-export function buildAssetNodeStatusRow({
+function buildAssetNodeStatusRow({
   definition,
   liveData,
 }: {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -137,6 +137,11 @@ const StyleForPartitionState: {
   },
 };
 
+const partitionStateToString = (count: number | undefined, adjective = '') =>
+  `${count === undefined ? '-' : count.toLocaleString()} ${adjective}${adjective ? ' ' : ''}${
+    count === 1 ? 'partition' : 'partitions'
+  }`;
+
 const AssetNodePartitionCountBox: React.FC<{
   state: PartitionState;
   value: number | undefined;
@@ -151,9 +156,7 @@ const AssetNodePartitionCountBox: React.FC<{
       display="block"
       position="top"
       canShow={value !== undefined}
-      content={`${value?.toLocaleString()} ${style.adjective} ${
-        value === 1 ? 'partition' : 'partitions'
-      }`}
+      content={partitionStateToString(value, style.adjective)}
     >
       <Box
         style={{width: '100%', color: foreground, borderRadius: 6, fontSize: 12}}
@@ -310,10 +313,10 @@ export function buildAssetNodeStatusRow({
             {late
               ? humanizedLateString(liveData.freshnessInfo.currentMinutesLate)
               : numFailed
-              ? `${numFailed.toLocaleString()} failed partitions`
+              ? partitionStateToString(numFailed, 'failed')
               : numMissing
-              ? `${numMissing.toLocaleString()} missing partitions`
-              : `${numPartitions.toLocaleString()} partitions`}
+              ? partitionStateToString(numMissing, 'missing')
+              : partitionStateToString(numPartitions)}
           </Link>
         </Caption>
       ),

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -241,6 +241,9 @@ export const getAssetNodeDimensions = (def: {
   } else {
     let height = 70; // name + description
 
+    if (def.isPartitioned) {
+      height += 40;
+    }
     if (def.isSource) {
       height += 30; // observed
     } else {

--- a/js_modules/dagit/packages/ui/src/components/Icon.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Icon.tsx
@@ -88,6 +88,10 @@ import panel_show_left from '../icon-svgs/panel_show_left.svg';
 import panel_show_right from '../icon-svgs/panel_show_right.svg';
 import panel_show_top from '../icon-svgs/panel_show_top.svg';
 import partition from '../icon-svgs/partition.svg';
+import partition_failure from '../icon-svgs/partition_failure.svg';
+import partition_missing from '../icon-svgs/partition_missing.svg';
+import partition_stale from '../icon-svgs/partition_stale.svg';
+import partition_success from '../icon-svgs/partition_success.svg';
 import people from '../icon-svgs/people.svg';
 import refresh from '../icon-svgs/refresh.svg';
 import replay from '../icon-svgs/replay.svg';
@@ -150,6 +154,10 @@ export const Icons = {
   op_dynamic: bolt,
   partition_set: schedule,
   partition,
+  partition_missing,
+  partition_success,
+  partition_stale,
+  partition_failure,
   repo: source,
   resource: layers,
   run: history,

--- a/js_modules/dagit/packages/ui/src/icon-svgs/partition_failure.svg
+++ b/js_modules/dagit/packages/ui/src/icon-svgs/partition_failure.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.6188 6L14.2376 14H5L9.6188 6Z" fill="#171615"/>
+</svg>

--- a/js_modules/dagit/packages/ui/src/icon-svgs/partition_missing.svg
+++ b/js_modules/dagit/packages/ui/src/icon-svgs/partition_missing.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="4" stroke="#171615" stroke-width="2"/>
+</svg>

--- a/js_modules/dagit/packages/ui/src/icon-svgs/partition_stale.svg
+++ b/js_modules/dagit/packages/ui/src/icon-svgs/partition_stale.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 7L10 13C11.6569 13 13 11.6569 13 10C13 8.34315 11.6569 7 10 7ZM10 5C12.7614 5 15 7.23858 15 10C15 12.7614 12.7614 15 10 15C7.23858 15 5 12.7614 5 10C5 7.23858 7.23858 5 10 5Z" fill="#171615"/>
+</svg>

--- a/js_modules/dagit/packages/ui/src/icon-svgs/partition_success.svg
+++ b/js_modules/dagit/packages/ui/src/icon-svgs/partition_success.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="5" fill="#171615"/>
+</svg>


### PR DESCRIPTION
Loom video:
https://www.loom.com/share/ce1692fd7418444793e06ed5cc8f22ce

Figma: 
https://www.figma.com/file/9fKEG70MqgrPbtKOkpzZmV/Asset-Nodes?node-id=38%3A917&t=MtocD9yfCwYaBjGZ-0

### Summary & Motivation

![image](https://user-images.githubusercontent.com/1037212/222827534-54e76fa2-c6bf-472e-ad3f-d425e089bb15.png)
![image](https://user-images.githubusercontent.com/1037212/222827543-6a0bd799-6d82-4931-b0e8-98ecb4559b4f.png)
![image](https://user-images.githubusercontent.com/1037212/222827564-48a617d2-3f6f-4521-9e40-c379a79c31b7.png)


### How I Tested These Changes

We have extensive storybook coverage of these states so I referenced those to check over the colors and styles. We also have automated tests that verify the correct labels appear and I'm updating those to test the new designs.