### PR TITLE
[pythonic config] support Pydantic constrained types

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -14,6 +14,7 @@ from typing import (
     cast,
 )
 
+from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr
 from typing_extensions import TypeAlias
 
 from dagster._annotations import experimental
@@ -27,8 +28,6 @@ from dagster._core.definitions.definition_config_schema import (
     ConfiguredDefinitionConfigSchema,
     DefinitionConfigSchema,
 )
-from pydantic import ConstrainedStr, ConstrainedFloat, ConstrainedInt
-
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.init import InitResourceContext
 

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -27,6 +27,8 @@ from dagster._core.definitions.definition_config_schema import (
     ConfiguredDefinitionConfigSchema,
     DefinitionConfigSchema,
 )
+from pydantic import ConstrainedStr, ConstrainedFloat, ConstrainedInt
+
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.init import InitResourceContext
 
@@ -775,6 +777,14 @@ def _config_type_for_pydantic_field(pydantic_field: ModelField) -> ConfigType:
 
 
 def _config_type_for_type_on_pydantic_field(potential_dagster_type: Any) -> ConfigType:
+    # special case pydantic constrained types to their source equivalents
+    if safe_is_subclass(potential_dagster_type, ConstrainedStr):
+        return StringSource
+    elif safe_is_subclass(potential_dagster_type, ConstrainedFloat):
+        potential_dagster_type = float
+    elif safe_is_subclass(potential_dagster_type, ConstrainedInt):
+        return IntSource
+
     # special case raw python literals to their source equivalents
     if potential_dagster_type is str:
         return StringSource

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -779,6 +779,7 @@ def _config_type_for_type_on_pydantic_field(potential_dagster_type: Any) -> Conf
     # special case pydantic constrained types to their source equivalents
     if safe_is_subclass(potential_dagster_type, ConstrainedStr):
         return StringSource
+    # no FloatSource, so we just return float
     elif safe_is_subclass(potential_dagster_type, ConstrainedFloat):
         potential_dagster_type = float
     elif safe_is_subclass(potential_dagster_type, ConstrainedInt):

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_constraints.py
@@ -1,0 +1,116 @@
+from typing import List
+from dagster import op
+from dagster._config.config_type import ConfigTypeKind
+from dagster._config.structured_config import Config
+from pydantic import Field, ValidationError, constr
+from typing_extensions import Annotated
+
+import pytest
+
+
+def test_str_min_length() -> None:
+    class AStringConfig(Config):
+        a_str: str = Field(min_length=2, max_length=10)
+
+    AStringConfig(a_str="foo")
+    with pytest.raises(ValidationError, match="ensure this value has at least 2 characters"):
+        AStringConfig(a_str="f")
+    with pytest.raises(ValidationError, match="ensure this value has at most 10 characters"):
+        AStringConfig(a_str="foofoofoofoofoo")
+
+
+def test_str_regex() -> None:
+    class AStringConfig(Config):
+        a_str: str = Field(regex=r"^(foo)+$")
+
+    AStringConfig(a_str="foo")
+    AStringConfig(a_str="foofoofoo")
+    with pytest.raises(ValidationError, match="string does not match regex"):
+        AStringConfig(a_str="bar")
+
+
+def test_int_gtlt() -> None:
+    class AnIntConfig(Config):
+        an_int: int = Field(gt=0, lt=10)
+
+    AnIntConfig(an_int=5)
+    with pytest.raises(ValidationError, match="ensure this value is less than 10"):
+        AnIntConfig(an_int=10)
+    with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
+        AnIntConfig(an_int=0)
+
+
+def test_int_gele() -> None:
+    class AnIntConfig(Config):
+        an_int: int = Field(ge=0, le=10)
+
+    AnIntConfig(an_int=5)
+    AnIntConfig(an_int=10)
+    AnIntConfig(an_int=0)
+    with pytest.raises(ValidationError, match="ensure this value is less than or equal to 10"):
+        AnIntConfig(an_int=11)
+    with pytest.raises(ValidationError, match="ensure this value is greater than or equal to 0"):
+        AnIntConfig(an_int=-1)
+
+
+def test_int_multiple() -> None:
+    class AnIntConfig(Config):
+        an_int: int = Field(multiple_of=5)
+
+    AnIntConfig(an_int=5)
+    AnIntConfig(an_int=10)
+    AnIntConfig(an_int=0)
+    AnIntConfig(an_int=-5)
+    with pytest.raises(ValidationError, match="ensure this value is a multiple of 5"):
+        AnIntConfig(an_int=4)
+    with pytest.raises(ValidationError, match="ensure this value is a multiple of 5"):
+        AnIntConfig(an_int=-4)
+
+
+def test_float_gtlt() -> None:
+    class AnFloatConfig(Config):
+        a_float: float = Field(gt=0, lt=10)
+
+    AnFloatConfig(a_float=5)
+    with pytest.raises(ValidationError, match="ensure this value is less than 10"):
+        AnFloatConfig(a_float=10)
+    with pytest.raises(ValidationError, match="ensure this value is greater than 0"):
+        AnFloatConfig(a_float=0)
+
+
+def test_float_gele() -> None:
+    class AnFloatConfig(Config):
+        a_float: float = Field(ge=0, le=10)
+
+    AnFloatConfig(a_float=5)
+    AnFloatConfig(a_float=10)
+    AnFloatConfig(a_float=0)
+    with pytest.raises(ValidationError, match="ensure this value is less than or equal to 10"):
+        AnFloatConfig(a_float=11)
+    with pytest.raises(ValidationError, match="ensure this value is greater than or equal to 0"):
+        AnFloatConfig(a_float=-1)
+
+
+def test_float_multiple() -> None:
+    class AnFloatConfig(Config):
+        a_float: float = Field(multiple_of=0.5)
+
+    AnFloatConfig(a_float=1)
+    AnFloatConfig(a_float=0.5)
+    AnFloatConfig(a_float=0)
+    AnFloatConfig(a_float=-3)
+    with pytest.raises(ValidationError, match="ensure this value is a multiple of 0.5"):
+        AnFloatConfig(a_float=0.25)
+    with pytest.raises(ValidationError, match="ensure this value is a multiple of 0.5"):
+        AnFloatConfig(a_float=-0.3)
+
+
+def test_list_length() -> None:
+    class AListConfig(Config):
+        a_list: List[int] = Field(min_items=2, max_items=10)
+
+    AListConfig(a_list=[1, 2])
+    with pytest.raises(ValidationError, match="ensure this value has at least 2 items"):
+        AListConfig(a_list=[1])
+    with pytest.raises(ValidationError, match="ensure this value has at most 10 items"):
+        AListConfig(a_list=[1] * 11)

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_constraints.py
@@ -1,11 +1,8 @@
 from typing import List
-from dagster import op
-from dagster._config.config_type import ConfigTypeKind
-from dagster._config.structured_config import Config
-from pydantic import Field, ValidationError, constr
-from typing_extensions import Annotated
 
 import pytest
+from dagster._config.structured_config import Config
+from pydantic import Field, ValidationError, conlist, constr
 
 
 def test_str_min_length() -> None:
@@ -108,6 +105,41 @@ def test_float_multiple() -> None:
 def test_list_length() -> None:
     class AListConfig(Config):
         a_list: List[int] = Field(min_items=2, max_items=10)
+
+    AListConfig(a_list=[1, 2])
+    with pytest.raises(ValidationError, match="ensure this value has at least 2 items"):
+        AListConfig(a_list=[1])
+    with pytest.raises(ValidationError, match="ensure this value has at most 10 items"):
+        AListConfig(a_list=[1] * 11)
+
+
+def test_list_uniqueness() -> None:
+    class AListConfig(Config):
+        a_list: List[int] = Field(unique_items=True)
+
+    AListConfig(a_list=[1, 2])
+    with pytest.raises(ValidationError, match="the list has duplicated items"):
+        AListConfig(a_list=[1, 1])
+    with pytest.raises(ValidationError, match="the list has duplicated items"):
+        AListConfig(a_list=[1, 2, 1])
+
+
+def test_with_constr() -> None:
+    # Pydantic does not like it when you use constr(), but this just sanity checks that
+    # we can use it in place of a field
+    class AStringConfig(Config):
+        a_str: constr(min_length=2, max_length=10)  # type: ignore
+
+    AStringConfig(a_str="foo")
+    with pytest.raises(ValidationError, match="ensure this value has at least 2 characters"):
+        AStringConfig(a_str="f")
+    with pytest.raises(ValidationError, match="ensure this value has at most 10 characters"):
+        AStringConfig(a_str="foofoofoofoofoo")
+
+
+def test_with_conlist() -> None:
+    class AListConfig(Config):
+        a_list: conlist(int, min_items=2, max_items=10)  # type: ignore
 
     AListConfig(a_list=[1, 2])
     with pytest.raises(ValidationError, match="ensure this value has at least 2 items"):


### PR DESCRIPTION
## Summary

Adds support for [Pydantic type constraints](https://docs.pydantic.dev/usage/types/#constrained-types), which can be used to easily validate/constrain string/int/float/list values. This came up at yesterday's dogfooding session.

This really only requires a few small tweaks to our Pydantic -> Dagster config mapping, most of the rest of the functionality just works out of the box.

## Test Plan

A bunch of new unit tests.