### PR TITLE
[pythonic resources] Add ability to specify nested resources by key, lazily fetch

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -106,6 +106,7 @@ from dagster._config.structured_config import (
     ConfigurableLegacyResourceAdapter as ConfigurableLegacyResourceAdapter,
     ConfigurableResource as ConfigurableResource,
     PermissiveConfig as PermissiveConfig,
+    ResourceByKey as ResourceByKey,
     ResourceDependency as ResourceDependency,
 )
 from dagster._core.definitions.asset_in import AssetIn as AssetIn

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -534,6 +534,20 @@ def _is_fully_configured(resource: ResourceDefinition) -> bool:
     return res
 
 
+class ResourceByKey(ResourceDefinition):
+    def __init__(self, resource_key: str):
+        def resource_fn(context: InitResourceContext):
+            return getattr(context.resources, resource_key)
+
+        ResourceDefinition.__init__(
+            self,
+            resource_fn=resource_fn,
+            config_schema=Any,
+            description="",
+            required_resource_keys={resource_key},
+        )
+
+
 class PartialResource(
     Generic[TResValue], ResourceDefinition, AllowDelayedDependencies, MakeConfigCacheable
 ):
@@ -567,7 +581,6 @@ class PartialResource(
         )
 
 
-ResourceOrPartial: TypeAlias = Union[ConfigurableResource[TResValue], PartialResource[TResValue]]
 ResourceOrPartialOrValue: TypeAlias = Union[
     ConfigurableResource[TResValue], PartialResource[TResValue], ResourceDefinition, TResValue
 ]
@@ -971,4 +984,5 @@ LateBoundTypesForResourceTypeChecking.set_actual_types_for_type_checking(
     resource_dep_type=ResourceDependency,
     resource_type=ConfigurableResource,
     partial_resource_type=PartialResource,
+    resource_by_key_type=ResourceByKey,
 )


### PR DESCRIPTION
## Summary

Adds a way to pass in nested resources using a resource key pointer, instead of requiring users to pass the actual value.

Before:

```python

class MyInnerResource(ConfigurableResource):
    a_str: str

class MyOuterResource(ConfigurableResource):
    inner: MyInnerResource

defs = Definitions(
    ...
    resources={
        "my_resource": MyOuterResource(inner=MyInnerResource(a_str="foo"))
    }
)
```

After:

```python

class MyInnerResource(ConfigurableResource):
    a_str: str

class MyOuterResource(ConfigurableResource):
    inner: MyInnerResource

defs = Definitions(
    ...
    resources={
        "my_resource": MyOuterResource(inner=ResourceByKey("my_inner"))
	"my_inner": MyInnerResource(a_str="foo")
    }
)
```

## Test Plan

Unit tests.


