### PR TITLE
[pythonic resources] Add ability to remap resource key -> op/asset arg name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -54,6 +54,7 @@ class _Op:
         retry_policy: Optional[RetryPolicy] = None,
         ins: Optional[Mapping[str, In]] = None,
         out: Optional[Union[Out, Mapping[str, Out]]] = None,
+        resource_key_argument_mapping: Optional[Mapping[str, str]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.decorator_takes_context = check.bool_param(
@@ -73,6 +74,12 @@ class _Op:
 
         self.ins = check.opt_nullable_mapping_param(ins, "ins", key_type=str, value_type=In)
         self.out = out
+        self.resource_key_argument_mapping = resource_key_argument_mapping
+        self.argument_resource_key_mapping = (
+            {v: k for k, v in resource_key_argument_mapping.items()}
+            if resource_key_argument_mapping
+            else None
+        )
 
     def __call__(self, fn: Callable[..., Any]) -> "OpDefinition":
         from dagster._config.pythonic_config import validate_resource_annotated_function
@@ -113,6 +120,11 @@ class _Op:
             outs = check.mapping_param(self.out, "out", key_type=str, value_type=Out)
 
         arg_resource_keys = {arg.name for arg in compute_fn.get_resource_args()}
+        if self.argument_resource_key_mapping:
+            arg_resource_keys = {
+                self.argument_resource_key_mapping.get(arg, arg) for arg in arg_resource_keys
+            }
+
         decorator_resource_keys = set(self.required_resource_keys or [])
         check.param_invariant(
             len(decorator_resource_keys) == 0 or len(arg_resource_keys) == 0,
@@ -135,6 +147,7 @@ class _Op:
             code_version=self.code_version,
             retry_policy=self.retry_policy,
             version=None,  # code_version has replaced version
+            resource_key_argument_mapping=self.resource_key_argument_mapping,
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def
@@ -154,6 +167,7 @@ def op(
     out: Optional[Union[Out, Mapping[str, Out]]] = ...,
     config_schema: Optional[UserConfigSchema] = ...,
     required_resource_keys: Optional[Set[str]] = ...,
+    resource_key_argument_mapping: Optional[Mapping[str, str]] = ...,
     tags: Optional[Mapping[str, Any]] = ...,
     version: Optional[str] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
@@ -171,6 +185,7 @@ def op(
     out: Optional[Union[Out, Mapping[str, Out]]] = None,
     config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
+    resource_key_argument_mapping: Optional[Mapping[str, str]] = None,
     tags: Optional[Mapping[str, Any]] = None,
     version: Optional[str] = None,
     retry_policy: Optional[RetryPolicy] = None,
@@ -265,6 +280,7 @@ def op(
         retry_policy=retry_policy,
         ins=ins,
         out=out,
+        resource_key_argument_mapping=resource_key_argument_mapping,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -124,6 +124,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         version: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
         code_version: Optional[str] = None,
+        resource_key_argument_mapping: Optional[Mapping[str, str]] = None,
     ):
         from .decorators.op_decorator import DecoratedOpFunction, resolve_checked_op_fn_inputs
 
@@ -175,6 +176,8 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
             positional_inputs=positional_inputs,
         )
+        self._resource_key_argument_mapping = resource_key_argument_mapping
+
 
     def dagster_internal_init(
         *,
@@ -189,6 +192,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         version: Optional[str],
         retry_policy: Optional[RetryPolicy],
         code_version: Optional[str],
+        resource_key_argument_mapping: Optional[Mapping[str, str]],
     ) -> "OpDefinition":
         return OpDefinition(
             compute_fn=compute_fn,
@@ -202,6 +206,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             version=version,
             retry_policy=retry_policy,
             code_version=code_version,
+            resource_key_argument_mapping=resource_key_argument_mapping,
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -178,7 +178,6 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         )
         self._resource_key_argument_mapping = resource_key_argument_mapping
 
-
     def dagster_internal_init(
         *,
         compute_fn: Union[Callable[..., Any], "DecoratedOpFunction"],
@@ -365,6 +364,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             code_version=self._version,
             retry_policy=self.retry_policy,
             version=None,  # code_version replaces version
+            resource_key_argument_mapping=self._resource_key_argument_mapping,
         )
 
     def copy_for_configured(

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -45,7 +45,16 @@ def create_op_compute_wrapper(op_def: OpDefinition):
     output_defs = op_def.output_defs
     context_arg_provided = compute_fn.has_context_arg()
     config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
-    resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
+
+    argument_resource_key_mapping = (
+        {v: k for k, v in op_def._resource_key_argument_mapping.items()}
+        if op_def._resource_key_argument_mapping
+        else {}
+    )
+    resource_arg_mapping = {
+        argument_resource_key_mapping.get(arg.name, arg.name): arg.name
+        for arg in compute_fn.get_resource_args()
+    }
 
     input_names = [
         input_def.name

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -47,8 +47,8 @@ def create_op_compute_wrapper(op_def: OpDefinition):
     config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
 
     argument_resource_key_mapping = (
-        {v: k for k, v in op_def._resource_key_argument_mapping.items()}
-        if op_def._resource_key_argument_mapping
+        {v: k for k, v in op_def._resource_key_argument_mapping.items()}  # noqa: SLF001
+        if op_def._resource_key_argument_mapping  # noqa: SLF001
         else {}
     )
     resource_arg_mapping = {

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_remapping.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_remapping.py
@@ -1,0 +1,74 @@
+import pytest
+from dagster import (
+    ConfigurableResource,
+    Definitions,
+    asset,
+    job,
+    op,
+)
+from dagster._core.errors import (
+    DagsterInvalidDefinitionError,
+)
+
+
+def test_remap_resource_args_ops() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    executed = {}
+
+    # Remap the resource key "my_resource_foo" to the input "my_resource"
+    @op(resource_key_argument_mapping={"my_resource_foo": "my_resource"})
+    def an_op(my_resource: MyResource) -> None:
+        assert my_resource.a_str == "foo"
+        executed["yes"] = True
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'my_resource_foo' required by op 'an_op' was not provided",
+    ):
+
+        @job(resource_defs={"my_resource": MyResource(a_str="foo")})
+        def my_non_working_job() -> None:
+            an_op()
+
+    @job(resource_defs={"my_resource_foo": MyResource(a_str="foo")})
+    def my_job() -> None:
+        an_op()
+
+    assert my_job.execute_in_process().success
+    assert executed["yes"]
+
+
+def test_remap_resource_args_assets() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    executed = {}
+
+    # Remap the resource key "my_resource_foo" to the input "my_resource"
+    @asset(resource_key_argument_mapping={"my_resource_foo": "my_resource"})
+    def an_asset(my_resource: MyResource) -> None:
+        assert my_resource.a_str == "foo"
+        executed["yes"] = True
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'my_resource_foo' required by op 'an_asset' was not provided",
+    ):
+        defs = Definitions(
+            assets=[an_asset],
+            resources={
+                "my_resource": MyResource(a_str="foo"),
+            },
+        )
+
+    defs = Definitions(
+        assets=[an_asset],
+        resources={
+            "my_resource_foo": MyResource(a_str="foo"),
+        },
+    )
+    defs.get_implicit_global_asset_job_def().execute_in_process()
+
+    assert executed["yes"]


### PR DESCRIPTION
## Summary

Adds the ability to optionally pass a `resource_key_argument_mapping` to your `@op` or `@asset` decorator. This overrides the mapping of resource key -> resource argument name when passing resources as arguments.

For example:

```python

class MyResource(ConfigurableResource):
    a_str: str
    
@op(resource_key_argument_mapping={"foo": "my_resource"})
def an_op(my_resource: MyResource) -> None:
    pass

@job(resource_defs={"foo": MyResource(a_str="foo")})
def my_job() -> None:
    an_op()


```

This came up during yesterday's dogfooding session as useful in cases with many similar resources or instances of the same resource type.

## Test Plan

New unit tests.
