### PR TITLE
Fix config w/ dynamic partitions error

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -71,7 +71,9 @@ def create_and_launch_partition_backfill(
         external_partition_set = next(iter(matches))
 
         if backfill_params.get("allPartitions"):
-            result = graphene_info.context.get_external_partition_names(external_partition_set)
+            result = graphene_info.context.get_external_partition_names(
+                external_partition_set, instance=graphene_info.context.instance
+            )
             partition_names = result.partition_names
         elif backfill_params.get("partitionNames"):
             partition_names = backfill_params["partitionNames"]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -153,7 +153,9 @@ def get_partitions(
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.inst_param(partition_set, "partition_set", ExternalPartitionSet)
-    result = graphene_info.context.get_external_partition_names(partition_set)
+    result = graphene_info.context.get_external_partition_names(
+        partition_set, instance=graphene_info.context.instance
+    )
     assert isinstance(result, ExternalPartitionNamesData)
 
     partition_names = _apply_cursor_limit_reverse(result.partition_names, cursor, limit, reverse)
@@ -193,7 +195,9 @@ def _apply_cursor_limit_reverse(items, cursor, limit, reverse):
 
 
 @capture_error
-def get_partition_set_partition_statuses(graphene_info, external_partition_set):
+def get_partition_set_partition_statuses(
+    graphene_info: ResolveInfo, external_partition_set: ExternalPartitionSet
+):
     check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
 
     repository_handle = external_partition_set.repository_handle
@@ -207,7 +211,9 @@ def get_partition_set_partition_statuses(graphene_info, external_partition_set):
             },
         )
     )
-    names_result = graphene_info.context.get_external_partition_names(external_partition_set)
+    names_result = graphene_info.context.get_external_partition_names(
+        external_partition_set, graphene_info.context.instance
+    )
 
     return partition_statuses_from_run_partition_data(
         partition_set_name, run_partition_data, names_result.partition_names
@@ -274,7 +280,9 @@ def get_partition_set_partition_runs(graphene_info: ResolveInfo, partition_set):
     from ..schema.partition_sets import GraphenePartitionRun
     from ..schema.pipelines.pipeline import GrapheneRun
 
-    result = graphene_info.context.get_external_partition_names(partition_set)
+    result = graphene_info.context.get_external_partition_names(
+        partition_set, instance=graphene_info.context.instance
+    )
     assert isinstance(result, ExternalPartitionNamesData)
     run_records = graphene_info.context.instance.get_run_records(
         RunsFilter(tags={PARTITION_SET_TAG: partition_set.name})

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_partition_sets.py
@@ -7,372 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestPartitionSets.test_get_partition_set[non_launchable_in_memory_instance_lazy_repository] 1'] = {
-    'partitionSetOrError': {
-        '__typename': 'PartitionSet',
-        'mode': 'default',
-        'name': 'integer_partition',
-        'partitionsOrError': {
-            'results': [
-                {
-                    'name': '0',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '1',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '2',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '3',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '4',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '5',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '6',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '7',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '8',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '9',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                }
-            ]
-        },
-        'pipelineName': 'no_config_pipeline',
-        'solidSelection': [
-            'return_hello'
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_set[non_launchable_in_memory_instance_lazy_repository] 2'] = {
-    'partitionSetOrError': {
-        '__typename': 'PartitionSetNotFoundError'
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_set[non_launchable_in_memory_instance_managed_grpc_env] 1'] = {
-    'partitionSetOrError': {
-        '__typename': 'PartitionSet',
-        'mode': 'default',
-        'name': 'integer_partition',
-        'partitionsOrError': {
-            'results': [
-                {
-                    'name': '0',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '1',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '2',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '3',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '4',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '5',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '6',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '7',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '8',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '9',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                }
-            ]
-        },
-        'pipelineName': 'no_config_pipeline',
-        'solidSelection': [
-            'return_hello'
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_set[non_launchable_in_memory_instance_managed_grpc_env] 2'] = {
-    'partitionSetOrError': {
-        '__typename': 'PartitionSetNotFoundError'
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_set[non_launchable_in_memory_instance_multi_location] 1'] = {
-    'partitionSetOrError': {
-        '__typename': 'PartitionSet',
-        'mode': 'default',
-        'name': 'integer_partition',
-        'partitionsOrError': {
-            'results': [
-                {
-                    'name': '0',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '1',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '2',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '3',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '4',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '5',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '6',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '7',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '8',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                },
-                {
-                    'name': '9',
-                    'runConfigOrError': {
-                        'yaml': '''{}
-'''
-                    },
-                    'tagsOrError': {
-                        '__typename': 'PartitionTags'
-                    }
-                }
-            ]
-        },
-        'pipelineName': 'no_config_pipeline',
-        'solidSelection': [
-            'return_hello'
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_set[non_launchable_in_memory_instance_multi_location] 2'] = {
-    'partitionSetOrError': {
-        '__typename': 'PartitionSetNotFoundError'
-    }
-}
-
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_lazy_repository] 1'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSet',
@@ -492,6 +126,20 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_inst
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_lazy_repository] 2'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSetNotFoundError'
+    }
+}
+
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_lazy_repository] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
     }
 }
 
@@ -617,6 +265,20 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_inst
     }
 }
 
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_managed_grpc_env] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
+    }
+}
+
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_multi_location] 1'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSet',
@@ -736,6 +398,20 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_inst
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_multi_location] 2'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSetNotFoundError'
+    }
+}
+
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_postgres_instance_multi_location] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
     }
 }
 
@@ -861,6 +537,20 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instan
     }
 }
 
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_deployed_grpc_env] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
+    }
+}
+
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_lazy_repository] 1'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSet',
@@ -980,6 +670,20 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instan
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_lazy_repository] 2'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSetNotFoundError'
+    }
+}
+
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_lazy_repository] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
     }
 }
 
@@ -1105,6 +809,20 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instan
     }
 }
 
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_managed_grpc_env] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
+    }
+}
+
 snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_multi_location] 1'] = {
     'partitionSetOrError': {
         '__typename': 'PartitionSet',
@@ -1227,219 +945,17 @@ snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instan
     }
 }
 
-snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable_in_memory_instance_lazy_repository] 1'] = {
-    'partitionSetsOrError': {
-        '__typename': 'PartitionSets',
-        'results': [
-            {
-                'mode': 'default',
-                'name': 'alpha_partition',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'integer_partition',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': [
-                    'return_hello'
-                ]
-            },
-            {
-                'mode': 'default',
-                'name': 'partition_based_decorator_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'run_config_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'running_in_code_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'scheduled_integer_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'should_execute_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'tags_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'timezone_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable_in_memory_instance_lazy_repository] 2'] = {
-    'partitionSetsOrError': {
-        '__typename': 'PartitionSets',
-        'results': [
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable_in_memory_instance_managed_grpc_env] 1'] = {
-    'partitionSetsOrError': {
-        '__typename': 'PartitionSets',
-        'results': [
-            {
-                'mode': 'default',
-                'name': 'alpha_partition',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'integer_partition',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': [
-                    'return_hello'
-                ]
-            },
-            {
-                'mode': 'default',
-                'name': 'partition_based_decorator_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'run_config_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'running_in_code_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'scheduled_integer_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'should_execute_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'tags_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'timezone_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable_in_memory_instance_managed_grpc_env] 2'] = {
-    'partitionSetsOrError': {
-        '__typename': 'PartitionSets',
-        'results': [
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable_in_memory_instance_multi_location] 1'] = {
-    'partitionSetsOrError': {
-        '__typename': 'PartitionSets',
-        'results': [
-            {
-                'mode': 'default',
-                'name': 'alpha_partition',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'integer_partition',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': [
-                    'return_hello'
-                ]
-            },
-            {
-                'mode': 'default',
-                'name': 'partition_based_decorator_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'run_config_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'running_in_code_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'scheduled_integer_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'should_execute_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'tags_error_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            },
-            {
-                'mode': 'default',
-                'name': 'timezone_schedule_partitions',
-                'pipelineName': 'no_config_pipeline',
-                'solidSelection': None
-            }
-        ]
-    }
-}
-
-snapshots['TestPartitionSets.test_get_partition_sets_for_pipeline[non_launchable_in_memory_instance_multi_location] 2'] = {
-    'partitionSetsOrError': {
-        '__typename': 'PartitionSets',
-        'results': [
-        ]
+snapshots['TestPartitionSets.test_get_partition_set[non_launchable_sqlite_instance_multi_location] 3'] = {
+    'partitionSetOrError': {
+        '__typename': 'PartitionSet',
+        'mode': 'default',
+        'name': 'dynamic_partitioned_assets_job_partition_set',
+        'partitionsOrError': {
+            'results': [
+            ]
+        },
+        'pipelineName': 'dynamic_partitioned_assets_job',
+        'solidSelection': None
     }
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_sets.py
@@ -63,6 +63,10 @@ GET_PARTITION_SET_QUERY = """
                             }
                         }
                     }
+                    ... on PythonError {
+                        message
+                        stack
+                    }
                 }
             }
         }
@@ -182,6 +186,18 @@ class TestPartitionSets(NonLaunchableGraphQLContextTestMatrix):
         assert invalid_partition_set_result.data
 
         snapshot.assert_match(invalid_partition_set_result.data)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_PARTITION_SET_QUERY,
+            variables={
+                "partitionSetName": "dynamic_partitioned_assets_job_partition_set",
+                "repositorySelector": selector,
+            },
+        )
+
+        assert result.data
+        snapshot.assert_match(result.data)
 
     def test_get_partition_tags(self, graphql_context):
         selector = infer_repository_selector(graphql_context)

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -785,7 +785,9 @@ def _execute_backfill_command_at_location(
     )
 
     try:
-        partition_names_or_error = repo_location.get_external_partition_names(partition_set)
+        partition_names_or_error = repo_location.get_external_partition_names(
+            partition_set, instance=instance
+        )
     except Exception as e:
         error_info = serializable_error_info_from_exc_info(sys.exc_info())
         raise DagsterBackfillFailedError(

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -42,6 +42,7 @@ from dagster._core.host_representation.origin import (
     ExternalPipelineOrigin,
     ExternalRepositoryOrigin,
 )
+from dagster._core.instance import DagsterInstance
 from dagster._core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
 from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
@@ -888,9 +889,9 @@ class ExternalPartitionSet:
         # names
         return self._external_partition_set_data.external_partitions_data is not None
 
-    def get_partition_names(self) -> Sequence[str]:
+    def get_partition_names(self, instance: DagsterInstance) -> Sequence[str]:
         check.invariant(self.has_partition_name_data())
         partitions = (
             self._external_partition_set_data.external_partitions_data.get_partitions_definition()  # type: ignore
         )
-        return partitions.get_partition_keys()
+        return partitions.get_partition_keys(dynamic_partitions_store=instance)

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1504,6 +1504,12 @@ def external_partition_set_data_from_def(
         partitions_def_data = external_time_window_partitions_definition_from_def(partitions_def)
     elif isinstance(partitions_def, StaticPartitionsDefinition):
         partitions_def_data = external_static_partitions_definition_from_def(partitions_def)
+    elif (
+        isinstance(partitions_def, DynamicPartitionsDefinition) and partitions_def.name is not None
+    ):
+        partitions_def_data = external_dynamic_partitions_definition_from_def(partitions_def)
+    elif isinstance(partitions_def, MultiPartitionsDefinition):
+        partitions_def_data = external_multi_partitions_definition_from_def(partitions_def)
     else:
         partitions_def_data = None
 

--- a/python_modules/dagster/dagster/_core/host_representation/repository_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/repository_location.py
@@ -179,7 +179,7 @@ class RepositoryLocation(AbstractContextManager):
 
     @abstractmethod
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet
+        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
     ) -> Union["ExternalPartitionNamesData", "ExternalPartitionExecutionErrorData"]:
         pass
 
@@ -453,7 +453,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         )
 
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet
+        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
     ) -> Union["ExternalPartitionNamesData", "ExternalPartitionExecutionErrorData"]:
         check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
 
@@ -461,7 +461,7 @@ class InProcessRepositoryLocation(RepositoryLocation):
         # partition set allows it
         if external_partition_set.has_partition_name_data():
             return ExternalPartitionNamesData(
-                partition_names=external_partition_set.get_partition_names()
+                partition_names=external_partition_set.get_partition_names(instance)
             )
 
         return get_partition_names(
@@ -812,7 +812,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         )
 
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet
+        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
     ) -> "ExternalPartitionNamesData":
         check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
 
@@ -820,7 +820,7 @@ class GrpcServerRepositoryLocation(RepositoryLocation):
         # partition set allows it
         if external_partition_set.has_partition_name_data():
             return ExternalPartitionNamesData(
-                partition_names=external_partition_set.get_partition_names()
+                partition_names=external_partition_set.get_partition_names(instance=instance)
             )
 
         return sync_get_external_partition_names_grpc(

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -275,11 +275,11 @@ class BaseWorkspaceRequestContext(IWorkspace):
         )
 
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet
+        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
     ) -> Union["ExternalPartitionNamesData", "ExternalPartitionExecutionErrorData"]:
         return self.get_repository_location(
             external_partition_set.repository_handle.location_name
-        ).get_external_partition_names(external_partition_set)
+        ).get_external_partition_names(external_partition_set, instance=instance)
 
     def get_external_partition_set_execution_param_data(
         self,


### PR DESCRIPTION
Reported here: https://dagster.slack.com/archives/C01U5LFUZJS/p1677774811927269

The config launchpad uses the same partition set queries as op jobs, causing a query for partition names to raise an error as the instance wasn't being propagated. This PR fixes this error.