### PR TITLE
[refactor] Refactor of serdes serializers

### DIFF
--- a/python_modules/dagster/dagster/_config/snap.py
+++ b/python_modules/dagster/dagster/_config/snap.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Mapping, NamedTuple, Optional, Sequence, Set, cast
 
 import dagster._check as check
-from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes import whitelist_for_serdes
 
 from .config_type import ConfigScalarKind, ConfigType, ConfigTypeKind
 from .field import Field
@@ -52,13 +52,7 @@ class ConfigSchemaSnapshot(
         return key in self.all_config_snaps_by_key
 
 
-class ConfigTypeSnapSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {"field_aliases"}  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=ConfigTypeSnapSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"field_aliases"})
 class ConfigTypeSnap(
     NamedTuple(
         "_ConfigTypeSnap",

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -2,7 +2,9 @@ from typing import Mapping, NamedTuple, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental, public
-from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._serdes.serdes import (
+    whitelist_for_serdes,
+)
 from dagster._utils import frozenlist
 
 # ########################
@@ -19,7 +21,7 @@ class TableRecord(
     strings, integers, floats, or bools.
     """
 
-    def __new__(cls, data):
+    def __new__(cls, data: Mapping[str, Union[str, int, float, bool]]):
         check.dict_param(
             data,
             "data",

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -6,19 +6,14 @@ from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._serdes.serdes import register_serdes_enum_fallbacks, whitelist_for_serdes
+from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(old_storage_names={"JobType"})
 class InstigatorType(Enum):
     SCHEDULE = "SCHEDULE"
     SENSOR = "SENSOR"
-
-
-register_serdes_enum_fallbacks({"JobType": InstigatorType})
-# for internal backcompat
-JobType = InstigatorType
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -34,7 +34,7 @@ from dagster._serdes import (
     whitelist_for_serdes,
 )
 from dagster._serdes.errors import DeserializationError
-from dagster._serdes.serdes import deserialize_value, register_serdes_tuple_fallbacks
+from dagster._serdes.serdes import deserialize_value
 from dagster._seven import JSONDecodeError
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.backcompat import deprecation_warning
@@ -73,7 +73,7 @@ RunFailureSensorEvaluationFn: TypeAlias = Union[
 ]
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(old_storage_names={"PipelineSensorCursor"})
 class RunStatusSensorCursor(
     NamedTuple(
         "_RunStatusSensorCursor",
@@ -101,10 +101,6 @@ class RunStatusSensorCursor(
     @staticmethod
     def from_json(json_str: str) -> "RunStatusSensorCursor":
         return deserialize_value(json_str, RunStatusSensorCursor)
-
-
-# handle backcompat
-register_serdes_tuple_fallbacks({"PipelineSensorCursor": RunStatusSensorCursor})
 
 
 class RunStatusSensorContext:

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 from enum import Enum
-from inspect import Parameter
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -13,7 +12,7 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
-    Type,
+    Tuple,
     Union,
     cast,
 )
@@ -42,12 +41,9 @@ from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.captured_log_manager import CapturedLogContext
 from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._serdes import (
-    DefaultNamedTupleSerializer,
-    WhitelistMap,
-    register_serdes_tuple_fallbacks,
+    NamedTupleSerializer,
     whitelist_for_serdes,
 )
-from dagster._serdes.serdes import replace_storage_keys
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.timing import format_duration
 
@@ -314,47 +310,36 @@ def log_resource_event(log_manager: DagsterLogManager, event: "DagsterEvent") ->
     log_manager.log_dagster_event(level=log_level, msg=event.message or "", dagster_event=event)
 
 
-class DagsterEventSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def value_from_storage_dict(
-        cls,
-        storage_dict: Dict[str, Any],
-        klass: Type,
-        args_for_class: Mapping[str, Parameter],
-        whitelist_map: WhitelistMap,
-        descent_path: str,
-    ) -> NamedTuple:
-        event_type_value = storage_dict["event_type_value"]
-        pipeline_name = storage_dict["pipeline_name"]
-        message = storage_dict.get("message")
-        step_key = storage_dict.get("step_key")
-        event_specific_data = storage_dict.get("event_specific_data")
-
+class DagsterEventSerializer(NamedTupleSerializer["DagsterEvent"]):
+    def before_unpack(self, **storage_dict: Any) -> Dict[str, Any]:
         event_type_value, event_specific_data = _handle_back_compat(
-            event_type_value, event_specific_data
+            storage_dict["event_type_value"], storage_dict.get("event_specific_data")
         )
         storage_dict["event_type_value"] = event_type_value
         storage_dict["event_specific_data"] = event_specific_data
 
-        try:
-            return super().value_from_storage_dict(
-                storage_dict, klass, args_for_class, whitelist_map, descent_path
-            )
-        except Exception:
-            new_message = (
-                f"Could not deserialize event of type {event_type_value}. This event may have been"
-                " written by a newer version of Dagster."
-                + (f' Original message: "{message}"' if message else "")
-            )
-            return DagsterEvent(
-                event_type_value=DagsterEventType.ENGINE_EVENT.value,
-                pipeline_name=pipeline_name,
-                message=new_message,
-                step_key=step_key,
-                event_specific_data=EngineEventData(
-                    error=serializable_error_info_from_exc_info(sys.exc_info())
-                ),
-            )
+        return storage_dict
+
+    def handle_unpack_error(self, exc: Exception, **storage_dict: Any) -> "DagsterEvent":
+        event_type_value, _ = _handle_back_compat(
+            storage_dict["event_type_value"], storage_dict.get("event_specific_data")
+        )
+        step_key = storage_dict.get("step_key")
+        orig_message = storage_dict.get("message")
+        new_message = (
+            f"Could not deserialize event of type {event_type_value}. This event may have been"
+            " written by a newer version of Dagster."
+            + (f' Original message: "{orig_message}"' if orig_message else "")
+        )
+        return DagsterEvent(
+            event_type_value=DagsterEventType.ENGINE_EVENT.value,
+            pipeline_name=storage_dict["pipeline_name"],
+            message=new_message,
+            step_key=step_key,
+            event_specific_data=EngineEventData(
+                error=serializable_error_info_from_exc_info(sys.exc_info())
+            ),
+        )
 
 
 @whitelist_for_serdes(serializer=DagsterEventSerializer)
@@ -1695,44 +1680,7 @@ class LoadedInputData(
         )
 
 
-class ComputeLogsDataSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def value_from_storage_dict(
-        cls,
-        storage_dict,
-        klass,
-        args_for_class,
-        whitelist_map,
-        descent_path,
-    ):
-        storage_dict = replace_storage_keys(storage_dict, {"log_key": "file_key"})
-        return super().value_from_storage_dict(
-            storage_dict, klass, args_for_class, whitelist_map, descent_path
-        )
-
-    @classmethod
-    def value_to_storage_dict(
-        cls,
-        value: NamedTuple,
-        whitelist_map: WhitelistMap,
-        descent_path: str,
-    ) -> Dict[str, Any]:
-        storage = super().value_to_storage_dict(
-            value,
-            whitelist_map,
-            descent_path,
-        )
-        # For backcompat, we store:
-        # file_key as log_key
-        return replace_storage_keys(
-            storage,
-            {
-                "file_key": "log_key",
-            },
-        )
-
-
-@whitelist_for_serdes(serializer=ComputeLogsDataSerializer)
+@whitelist_for_serdes(storage_field_names={"file_key": "log_key"})
 class ComputeLogsCaptureData(
     NamedTuple(
         "_ComputeLogsCaptureData",
@@ -1768,69 +1716,77 @@ class ComputeLogsCaptureData(
 ###################################################################################################
 
 
-# Keep these around to prevent issues like https://github.com/dagster-io/dagster/issues/3533
-@whitelist_for_serdes
-class AssetStoreOperationData(NamedTuple):
-    op: str
-    step_key: str
-    output_name: str
-    asset_store_key: str
+# Old data structures referenced below
+# class AssetStoreOperationData(NamedTuple):
+#     op: str
+#     step_key: str
+#     output_name: str
+#     asset_store_key: str
+#
+#
+# class AssetStoreOperationType(Enum):
+#     SET_ASSET = "SET_ASSET"
+#     GET_ASSET = "GET_ASSET"
+#
+#
+# class PipelineInitFailureData(NamedTuple):
+#     error: SerializableErrorInfo
 
 
-@whitelist_for_serdes
-class AssetStoreOperationType(Enum):
-    SET_ASSET = "SET_ASSET"
-    GET_ASSET = "GET_ASSET"
-
-
-@whitelist_for_serdes
-class PipelineInitFailureData(NamedTuple):
-    error: SerializableErrorInfo
-
-
-def _handle_back_compat(event_type_value, event_specific_data):
+def _handle_back_compat(
+    event_type_value: str, event_specific_data: Optional[Dict[str, Any]]
+) -> Tuple[str, Optional[Dict[str, Any]]]:
     # transform old specific process events in to engine events
-    if event_type_value == "PIPELINE_PROCESS_START":
-        return DagsterEventType.ENGINE_EVENT.value, EngineEventData([])
-    elif event_type_value == "PIPELINE_PROCESS_STARTED":
-        return DagsterEventType.ENGINE_EVENT.value, EngineEventData([])
-    elif event_type_value == "PIPELINE_PROCESS_EXITED":
-        return DagsterEventType.ENGINE_EVENT.value, EngineEventData([])
+    if event_type_value in [
+        "PIPELINE_PROCESS_START",
+        "PIPELINE_PROCESS_STARTED",
+        "PIPELINE_PROCESS_EXITED",
+    ]:
+        return "ENGINE_EVENT", {"__class__": "EngineEventData"}
 
     # changes asset store ops in to get/set asset
     elif event_type_value == "ASSET_STORE_OPERATION":
-        if event_specific_data.op in ("GET_ASSET", AssetStoreOperationType.GET_ASSET):
+        assert (
+            event_specific_data is not None
+        ), "ASSET_STORE_OPERATION event must have specific data"
+        if event_specific_data["op"] in (
+            "GET_ASSET",
+            '{"__enum__": "AssetStoreOperationType.GET_ASSET"}',
+        ):
             return (
-                DagsterEventType.LOADED_INPUT.value,
-                LoadedInputData(
-                    event_specific_data.output_name, event_specific_data.asset_store_key
-                ),
+                "LOADED_INPUT",
+                {
+                    "__class__": "LoadedInputData",
+                    "input_name": event_specific_data["output_name"],
+                    "manager_key": event_specific_data["asset_store_key"],
+                },
             )
-        if event_specific_data.op in ("SET_ASSET", AssetStoreOperationType.SET_ASSET):
+        if event_specific_data["op"] in (
+            "SET_ASSET",
+            '{"__enum__": "AssetStoreOperationType.SET_ASSET"}',
+        ):
             return (
-                DagsterEventType.HANDLED_OUTPUT.value,
-                HandledOutputData(
-                    event_specific_data.output_name, event_specific_data.asset_store_key, []
-                ),
+                "HANDLED_OUTPUT",
+                {
+                    "__class__": "HandledOutputData",
+                    "output_name": event_specific_data["output_name"],
+                    "manager_key": event_specific_data["asset_store_key"],
+                },
             )
 
     # previous name for ASSET_MATERIALIZATION was STEP_MATERIALIZATION
     if event_type_value == "STEP_MATERIALIZATION":
-        return DagsterEventType.ASSET_MATERIALIZATION.value, event_specific_data
+        assert event_specific_data is not None, "STEP_MATERIALIZATION event must have specific data"
+        return "ASSET_MATERIALIZATION", event_specific_data
 
     # transform PIPELINE_INIT_FAILURE to PIPELINE_FAILURE
     if event_type_value == "PIPELINE_INIT_FAILURE":
-        return DagsterEventType.PIPELINE_FAILURE.value, PipelineFailureData(
-            event_specific_data.error
-        )
+        assert (
+            event_specific_data is not None
+        ), "PIPELINE_INIT_FAILURE event must have specific data"
+        return "PIPELINE_FAILURE", {
+            "__class__": "PipelineFailureData",
+            "error": event_specific_data.get("error"),
+        }
 
     return event_type_value, event_specific_data
-
-
-register_serdes_tuple_fallbacks(
-    {
-        "PipelineProcessStartedData": None,
-        "PipelineProcessExitedData": None,
-        "PipelineProcessStartData": None,
-    }
-)

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping, NamedTuple, Optional, Union
+from typing import Mapping, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
@@ -7,10 +7,7 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.utils import coerce_valid_log_level
 from dagster._serdes.serdes import (
-    DefaultNamedTupleSerializer,
-    WhitelistMap,
     deserialize_value,
-    register_serdes_tuple_fallbacks,
     serialize_value,
     whitelist_for_serdes,
 )
@@ -23,21 +20,14 @@ from dagster._utils.log import (
 )
 
 
-class EventLogEntrySerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def value_to_storage_dict(
-        cls,
-        value: NamedTuple,
-        whitelist_map: WhitelistMap,
-        descent_path: str,
-    ) -> Dict[str, Any]:
-        storage_dict = super().value_to_storage_dict(value, whitelist_map, descent_path)
-        # include an empty string for the message field to allow older versions of dagster to load the events
-        storage_dict["message"] = ""
-        return storage_dict
-
-
-@whitelist_for_serdes(serializer=EventLogEntrySerializer)
+@whitelist_for_serdes(
+    # These were originally distinguished from each other but ended up being empty subclasses
+    # of EventLogEntry -- instead of using the subclasses we were relying on
+    # EventLogEntry.is_dagster_event to distinguish events that originate in the logging
+    # machinery from events that are yielded by user code
+    old_storage_names={"DagsterEventRecord", "LogMessageRecord", "EventRecord"},
+    old_fields={"message": ""},
+)
 class EventLogEntry(
     NamedTuple(
         "_EventLogEntry",
@@ -237,17 +227,3 @@ def construct_json_event_logger(json_path):
             ),
         ),
     )
-
-
-register_serdes_tuple_fallbacks(
-    {
-        # These were originally distinguished from each other but ended up being empty subclasses
-        # of EventLogEntry -- instead of using the subclasses we were relying on
-        # EventLogEntry.is_dagster_event to distinguish events that originate in the logging
-        # machinery from events that are yielded by user code
-        "DagsterEventRecord": EventLogEntry,
-        "LogMessageRecord": EventLogEntry,
-        # renamed EventRecord -> EventLogEntry
-        "EventRecord": EventLogEntry,
-    }
-)

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Type,
     Union,
     cast,
 )
@@ -18,7 +17,7 @@ from typing_extensions import TypeGuard
 
 import dagster._check as check
 from dagster._core.definitions.utils import validate_tags
-from dagster._serdes.serdes import DefaultEnumSerializer, whitelist_for_serdes
+from dagster._serdes.serdes import EnumSerializer, whitelist_for_serdes
 from dagster._utils.merger import merge_dicts
 
 from .handle import ResolvedFromDynamicStepHandle, StepHandle, UnresolvedStepHandle
@@ -29,15 +28,13 @@ if TYPE_CHECKING:
     from dagster._core.definitions.dependency import NodeHandle
 
 
-class StepKindSerializer(DefaultEnumSerializer):
-    @classmethod
-    def value_from_storage_str(cls, storage_str: str, klass: Type) -> Enum:
+class StepKindSerializer(EnumSerializer["StepKind"]):
+    def unpack(self, storage_str: str) -> "StepKind":
         # old name for unresolved mapped
         if storage_str == "UNRESOLVED":
-            value = "UNRESOLVED_MAPPED"
+            return StepKind.UNRESOLVED_MAPPED
         else:
-            value = storage_str
-        return super().value_from_storage_str(value, klass)
+            return StepKind[storage_str]
 
 
 @whitelist_for_serdes(serializer=StepKindSerializer)

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -74,7 +74,7 @@ from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.snap import PipelineSnapshot
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
-from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
 
@@ -348,13 +348,7 @@ class ExternalPresetData(
         )
 
 
-class ExternalScheduleDataSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {"default_status"}  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=ExternalScheduleDataSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"default_status"})
 class ExternalScheduleData(
     NamedTuple(
         "_ExternalScheduleData",
@@ -451,16 +445,7 @@ class ExternalSensorMetadata(
         )
 
 
-class ExternalSensorDataSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {
-            "default_status",
-            "sensor_type",
-        }  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=ExternalSensorDataSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"default_status", "sensor_type"})
 class ExternalSensorData(
     NamedTuple(
         "_ExternalSensorData",

--- a/python_modules/dagster/dagster/_core/snap/dagster_types.py
+++ b/python_modules/dagster/dagster/_core/snap/dagster_types.py
@@ -1,10 +1,10 @@
-from typing import Mapping, NamedTuple, Optional, Sequence, Set
+from typing import Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
-from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes import whitelist_for_serdes
 
 
 def build_dagster_type_namespace_snapshot(
@@ -54,13 +54,7 @@ class DagsterTypeNamespaceSnapshot(
         return self.all_dagster_type_snaps_by_key[key]
 
 
-class DagsterTypeSnapSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {"metadata_entries"}  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=DagsterTypeSnapSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"metadata_entries"})
 class DagsterTypeSnap(
     NamedTuple(
         "_DagsterTypeSnap",

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -1,4 +1,4 @@
-from typing import Mapping, NamedTuple, Optional, Sequence, Set
+from typing import Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions import NodeHandle
@@ -19,7 +19,7 @@ from dagster._core.execution.plan.step import (
     UnresolvedCollectExecutionStep,
     UnresolvedMappedExecutionStep,
 )
-from dagster._serdes import DefaultNamedTupleSerializer, create_snapshot_id, whitelist_for_serdes
+from dagster._serdes import create_snapshot_id, whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
 # Can be incremented on breaking changes to the snapshot (since it is used to reconstruct
@@ -33,13 +33,7 @@ def create_execution_plan_snapshot_id(execution_plan_snapshot: "ExecutionPlanSna
     return create_snapshot_id(execution_plan_snapshot)
 
 
-class ExecutionPlanSnapshotSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {"repository_load_data"}  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=ExecutionPlanSnapshotSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"repository_load_data"})
 class ExecutionPlanSnapshot(
     NamedTuple(
         "_ExecutionPlanSnapshot",

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -1,4 +1,4 @@
-from typing import Mapping, NamedTuple, Optional, Sequence, Set, Union
+from typing import Mapping, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._config import ConfigFieldSnap, snap_from_field
@@ -15,7 +15,6 @@ from dagster._core.definitions.metadata import (
     MetadataEntry,
 )
 from dagster._serdes import whitelist_for_serdes
-from dagster._serdes.serdes import DefaultNamedTupleSerializer
 
 from .dep_snapshot import (
     DependencyStructureSnapshot,
@@ -23,13 +22,7 @@ from .dep_snapshot import (
 )
 
 
-class InputDefSnapSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {"metadata_entries"}  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=InputDefSnapSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"metadata_entries"})
 class InputDefSnap(
     NamedTuple(
         "_InputDefSnap",
@@ -59,13 +52,7 @@ class InputDefSnap(
         )
 
 
-class OutputDefSnapSerializer(DefaultNamedTupleSerializer):
-    @classmethod
-    def skip_when_empty(cls) -> Set[str]:
-        return {"metadata_entries"}  # Maintain stable snapshot ID for back-compat purposes
-
-
-@whitelist_for_serdes(serializer=OutputDefSnapSerializer)
+@whitelist_for_serdes(skip_when_empty_fields={"metadata_entries"})
 class OutputDefSnap(
     NamedTuple(
         "_OutputDefSnap",

--- a/python_modules/dagster/dagster/_daemon/types.py
+++ b/python_modules/dagster/dagster/_daemon/types.py
@@ -1,57 +1,24 @@
-from enum import Enum
-from typing import NamedTuple, Optional, Sequence, cast
+from typing import Any, NamedTuple, Optional, Sequence
 
 import dagster._check as check
-from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
-from dagster._serdes.serdes import unpack_value
+from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.serdes import NamedTupleSerializer, is_packed_enum
 from dagster._utils.error import SerializableErrorInfo
 
 
-# DEPRECATED - daemon types are now strings, only exists in code for deserializing old heartbeats
-@whitelist_for_serdes
-class DaemonType(Enum):
-    SENSOR = "SENSOR"
-    SCHEDULER = "SCHEDULER"
-    QUEUED_RUN_COORDINATOR = "QUEUED_RUN_COORDINATOR"
+class DaemonHeartbeatSerializer(NamedTupleSerializer["DaemonHeartbeat"]):
+    def before_unpack(self, **packed_dict: Any):
+        # Previously daemon types were enums, now they are strings. If we find a packed enum,
+        # just extract the name, which is the string we want.
+        if is_packed_enum(packed_dict.get("daemon_type")):
+            packed_dict["daemon_type"] = packed_dict["daemon_type"]["__enum__"].split(".")[-1]
+        if packed_dict.get("error"):
+            packed_dict["errors"] = [packed_dict["error"]]
+            del packed_dict["error"]
+        return packed_dict
 
 
-class DaemonBackcompat(DefaultNamedTupleSerializer):
-    @classmethod
-    def value_from_storage_dict(
-        cls,
-        storage_dict,
-        klass,
-        args_for_class,
-        whitelist_map,
-        descent_path,
-    ):
-        # Handle case where daemon_type used to be an enum (e.g. DaemonType.SCHEDULER)
-        daemon_type = unpack_value(
-            storage_dict.get("daemon_type"),
-            whitelist_map=whitelist_map,
-            descent_path=f"{descent_path}.daemon_type",
-        )
-        return DaemonHeartbeat(
-            timestamp=cast(float, storage_dict.get("timestamp")),
-            daemon_type=(daemon_type.value if isinstance(daemon_type, DaemonType) else daemon_type),
-            daemon_id=cast(str, storage_dict.get("daemon_id")),
-            errors=[
-                unpack_value(
-                    storage_dict.get("error"),
-                    whitelist_map=whitelist_map,
-                    descent_path=f"{descent_path}.error",
-                )
-            ]  # error was replaced with errors
-            if storage_dict.get("error")
-            else unpack_value(
-                storage_dict.get("errors"),
-                whitelist_map=whitelist_map,
-                descent_path=f"{descent_path}.errors",
-            ),
-        )
-
-
-@whitelist_for_serdes(serializer=DaemonBackcompat)
+@whitelist_for_serdes(serializer=DaemonHeartbeatSerializer)
 class DaemonHeartbeat(
     NamedTuple(
         "_DaemonHeartbeat",

--- a/python_modules/dagster/dagster/_serdes/__init__.py
+++ b/python_modules/dagster/dagster/_serdes/__init__.py
@@ -4,11 +4,11 @@ from .config_class import (
     class_from_code_pointer as class_from_code_pointer,
 )
 from .serdes import (
-    DefaultNamedTupleSerializer as DefaultNamedTupleSerializer,
+    EnumSerializer as EnumSerializer,
+    NamedTupleSerializer as NamedTupleSerializer,
     WhitelistMap as WhitelistMap,
     deserialize_value as deserialize_value,
     pack_value as pack_value,
-    register_serdes_tuple_fallbacks as register_serdes_tuple_fallbacks,
     serialize_value as serialize_value,
     unpack_value as unpack_value,
     whitelist_for_serdes as whitelist_for_serdes,

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -9,22 +9,18 @@ from dagster._config.config_schema import UserConfigSchema
 from dagster._utils import convert_dagster_submodule_name
 from dagster._utils.yaml_utils import load_run_config_yaml
 
-from .serdes import DefaultNamedTupleSerializer, WhitelistMap, whitelist_for_serdes
+from .serdes import (
+    NamedTupleSerializer,
+    whitelist_for_serdes,
+)
 
 T_ConfigurableClass = TypeVar("T_ConfigurableClass")
 
 
-class ConfigurableClassDataSerializer(DefaultNamedTupleSerializer["ConfigurableClassData"]):
-    @classmethod
-    def value_to_storage_dict(
-        cls,
-        value: "ConfigurableClassData",
-        whitelist_map: WhitelistMap,
-        descent_path: str,
-    ) -> Dict[str, Any]:
-        dct = super().value_to_storage_dict(value, whitelist_map, descent_path)
-        dct["module_name"] = convert_dagster_submodule_name(value.module_name, "public")
-        return dct
+class ConfigurableClassDataSerializer(NamedTupleSerializer["ConfigurableClassData"]):
+    def after_pack(self, **packed: Any) -> Dict[str, Any]:
+        packed["module_name"] = convert_dagster_submodule_name(packed["module_name"], "public")
+        return packed
 
 
 @whitelist_for_serdes(serializer=ConfigurableClassDataSerializer)

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -215,8 +215,8 @@ def test_table_metadata_value_schema_inference():
         "foo",
         value=MetadataValue.table(
             records=[
-                TableRecord(dict(name="foo", status=False)),
-                TableRecord(dict(name="bar", status=True)),
+                TableRecord(data=dict(name="foo", status=False)),
+                TableRecord(data=dict(name="bar", status=True)),
             ],
         ),
     )

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -37,7 +37,7 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus, Run
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._legacy import execute_pipeline, pipeline
-from dagster._serdes import DefaultNamedTupleSerializer, create_snapshot_id
+from dagster._serdes import create_snapshot_id
 from dagster._serdes.serdes import (
     WhitelistMap,
     _whitelist_for_serdes,
@@ -643,12 +643,7 @@ def test_external_job_origin_instigator_origin():
             def get_id(self):
                 return create_snapshot_id(self)
 
-        class GrpcServerOriginSerializer(DefaultNamedTupleSerializer):
-            @classmethod
-            def skip_when_empty(cls):
-                return {"use_ssl"}
-
-        @_whitelist_for_serdes(whitelist_map=legacy_env, serializer=GrpcServerOriginSerializer)
+        @_whitelist_for_serdes(whitelist_map=legacy_env, skip_when_empty_fields={"use_ssl"})
         class GrpcServerRepositoryLocationOrigin(
             namedtuple(
                 "_GrpcServerRepositoryLocationOrigin",


### PR DESCRIPTION
### Summary & Motivation

Makeover of serdes `Serializer` APIs. This makes custom serialization more declarative and will help evolve deprecated APIs that need to support back/forward compat.

TL; DR:

- makes `whitelist_for_serdes` more powerful through new args
- provides more granular hooks for custom serialization
- standardizes backcompat strategy to manipulate dictionaries/lists rather than deprecated domain objects; allows deleting deprecated classes
- simplifies serialization internals (registry, `Serializer` class hierarchy)
-  deletion of many custom serializers, replaced by declarative args on `whitelist_for_serdes`

Overview of the status quo before this PR:

- Custom serialization is done by defining a class inheriting from `DefaultNamedTupleSerializer` or `DefaultEnumSerializer`. These classes are themselves derived from abstract classes `NamedTupleSerializer` and `EnumSerializer` (though it is not clear why the extra abstract base class is needed).
- Overriding namedtuple serialization logic requires overriding methods with large complex type signatures (`value_to_storage_dict` and `value_from_storage_dict`). Because of this coarse-grained overriding, one often needed to reimplement logic already present in the base implementation. A very simple operation like renaming a few fields for storage requires a large amount of code.
- The approach to backcompat is inconsistent:
    - Some old classes are maintained in the code purely for backcompat purposes— they are created during the `unpack` phase of deserialization, but are never actually used because custom deserialize logic immediately replaces them with something else.
    - Other old classes have been deleted, because, even though they may exist in storage, they are never unpacked because the default deserialization logic drops them first (because they are stored under a field that is not on the target constructor (`args_for_class` param).
    - Still other old classes are deserialized to `None`.

After this PR:

- `Serializer` class hierarchy is consolidated. `NamedTupleSerializer`/`DefaultNamedTupleSerializer` and `EnumSerializer`/`DefaultEnumSerializer` have been collapsed into just `NamedTupleSerializer` and `EnumSerializer` respectively. These classes are no longer abstract.
- Instances of `NamedTupleSerializer` and `EnumSerializer` are stored in the whitelist map rather than new classes. This allows easier parameterization of serializers and simplification of the whitelist map internals.
- `whitelist_for_serdes` now takes additional parameters that are passed onto and become attributes of the registered `Serializer` instance. These parameters allow the patterns implemented by the majority of custom serializers to be expressed declaratively, allowing for elimination of most custom serializer classes. The new parameters are:
    - `old_storage_names`: a set of old names for the target class. If one of these names is encountered during deserialization, it will be deserialized to the target class. Replaces `register_serdes_tuple/enum_fallbacks`.
    - `storage_field_names` : maps field names to the names under which they should be stored. Also works in reverse (during deserialization the values in this mapping are renamed to the keys)
    - `old_fields`: a mapping of old fields to default values. These fields are set on serialized objects after packing.
    - `skip_when_empty_fields`: a set of fields to skip when empty (previously this was expressed as a class method on a custom serializer)
- Overriding namedtuple serializer logic is done through hooks `before_unpack` and `after_pack`, which allow modification of a packed namedtuple when it when it is in list/dict (i.e. json-serializable) format. These hooks have a much simpler signature than the old `value_to_storage_dict` and `value_from_storage_dict`. This cuts down on boilerplate in the few cases that custom serializer logic is needed. (There are no cases that require custom logic during serialization, so I did not define corresponding `before_pack`/`after_unpack` hooks.)
- No longer necessary to use `register_serdes_*_fallback` calls-- this is done with `old_storage_names` on `whitelist_for_serdes`. So these methods are deleted.
- The approach to backcompat is standardized. All backcompat custom deseriailzation logic is applied in `before_unpack`, when we are dealing with only plain python lists/dicts. This allows us to delete throwaway backcompat classes and also avoid the need to deserialize any class to `None`.

### How I Tested These Changes

Adjust old serdes tests, add unit tests for new args of `whitelist_for_serdes`.

**Internal Companion PR**: https://github.com/dagster-io/internal/pull/5068