### PR TITLE
[refactor] ConfigurableClass APIs

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -524,12 +524,12 @@ class DagsterInstance(DynamicPartitionsStore):
         return klass(
             instance_type=InstanceType.PERSISTENT,
             local_artifact_storage=instance_ref.local_artifact_storage,
-            run_storage=run_storage,
-            event_storage=event_storage,
+            run_storage=run_storage,  # type: ignore  # (possible none)
+            event_storage=event_storage,  # type: ignore  # (possible none)
             schedule_storage=schedule_storage,
             compute_log_manager=instance_ref.compute_log_manager,
             scheduler=instance_ref.scheduler,
-            run_coordinator=instance_ref.run_coordinator,
+            run_coordinator=instance_ref.run_coordinator,  # type: ignore  # (possible none)
             run_launcher=None,  # lazy load
             settings=instance_ref.settings,
             secrets_loader=instance_ref.secrets_loader,

--- a/python_modules/dagster/dagster/_core/launcher/sync_in_memory_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/sync_in_memory_run_launcher.py
@@ -1,7 +1,13 @@
+from typing import Any, Mapping, Optional
+
+from typing_extensions import Self
+
 import dagster._check as check
+from dagster._config.config_schema import UserConfigSchema
 from dagster._core.execution.api import execute_run
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
 from dagster._utils.hosted_user_process import recon_pipeline_from_origin
 
 
@@ -11,7 +17,7 @@ class SyncInMemoryRunLauncher(RunLauncher, ConfigurableClass):
     Use the :py:class:`dagster.DefaultRunLauncher`.
     """
 
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data
         self._repository = None
         self._instance_ref = None
@@ -19,15 +25,17 @@ class SyncInMemoryRunLauncher(RunLauncher, ConfigurableClass):
         super().__init__()
 
     @property
-    def inst_data(self):
+    def inst_data(self) -> Optional[ConfigurableClassData]:
         return self._inst_data
 
     @classmethod
-    def config_type(cls):
+    def config_type(cls) -> UserConfigSchema:
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return SyncInMemoryRunLauncher(inst_data=inst_data)
 
     def launch_run(self, context: LaunchRunContext) -> None:

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import dagster._check as check
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
@@ -10,7 +11,7 @@ from .base import RunCoordinator, SubmitRunContext
 class DefaultRunCoordinator(RunCoordinator, ConfigurableClass):
     """Immediately send runs to the run launcher."""
 
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self._logger = logging.getLogger("dagster.run_coordinator.default_run_coordinator")
         super().__init__()

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -59,7 +59,7 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
         dequeue_num_workers=None,
         max_user_code_failure_retries=None,
         user_code_failure_retry_delay=None,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self._max_concurrent_runs = check.opt_int_param(

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -1,6 +1,8 @@
 import abc
 import os
-from typing import NamedTuple, Optional, Sequence
+from typing import Any, Mapping, NamedTuple, Optional, Sequence
+
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._config import Field, IntSource
@@ -14,6 +16,7 @@ from dagster._core.scheduler.instigation import (
     ScheduleInstigatorData,
 )
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
 from dagster._seven import get_current_datetime_in_utc
 from dagster._utils import mkdir_p
 
@@ -175,7 +178,10 @@ class DagsterDaemonScheduler(Scheduler, ConfigurableClass):
     """
 
     def __init__(
-        self, max_catchup_runs=DEFAULT_MAX_CATCHUP_RUNS, max_tick_retries=0, inst_data=None
+        self,
+        max_catchup_runs=DEFAULT_MAX_CATCHUP_RUNS,
+        max_tick_retries=0,
+        inst_data: Optional[ConfigurableClassData] = None,
     ):
         self.max_catchup_runs = check.opt_int_param(
             max_catchup_runs, "max_catchup_runs", DEFAULT_MAX_CATCHUP_RUNS
@@ -216,8 +222,10 @@ class DagsterDaemonScheduler(Scheduler, ConfigurableClass):
             ),
         }
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return DagsterDaemonScheduler(inst_data=inst_data, **config_value)
 
     def debug_info(self):

--- a/python_modules/dagster/dagster/_core/secrets/env_file.py
+++ b/python_modules/dagster/dagster/_core/secrets/env_file.py
@@ -1,12 +1,14 @@
 import logging
 import os
-from typing import Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 from dotenv import dotenv_values
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._config import Field, StringSource
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
 
 from .loader import SecretsLoader
 
@@ -14,7 +16,7 @@ from .loader import SecretsLoader
 class EnvFileLoader(SecretsLoader, ConfigurableClass):
     def __init__(
         self,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         base_dir=None,
     ):
         self._inst_data = inst_data
@@ -50,6 +52,8 @@ class EnvFileLoader(SecretsLoader, ConfigurableClass):
     def config_type(cls):
         return {"base_dir": Field(StringSource, is_required=False)}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return EnvFileLoader(inst_data=inst_data, **config_value)

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Callable, cast
+from typing import Callable, Optional, cast
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.pool import NullPool
@@ -10,6 +10,7 @@ from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.sql import create_engine, get_alembic_config, stamp_alembic_rev
 from dagster._core.storage.sqlite import create_in_memory_conn_string
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
 
 from .schema import SqlEventLogStorageMetadata
 from .sql_event_log import SqlEventLogStorage
@@ -22,7 +23,7 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     WARNING: Dagit and other core functionality will not work if this is used on a real DagsterInstance
     """
 
-    def __init__(self, inst_data=None, preload=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None, preload=None):
         self._inst_data = inst_data
         self._engine = None
         self._conn = None

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -2,9 +2,10 @@ import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from sqlalchemy.pool import NullPool
+from typing_extensions import Self
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
@@ -50,7 +51,7 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     The ``base_dir`` param tells the event log storage where on disk to store the database.
     """
 
-    def __init__(self, base_dir, inst_data=None):
+    def __init__(self, base_dir, inst_data: Optional[ConfigurableClassData] = None):
         self._base_dir = check.str_param(base_dir, "base_dir")
         self._conn_string = create_db_conn_string(base_dir, SQLITE_EVENT_LOG_FILENAME)
         self._secondary_index_cache = {}
@@ -71,8 +72,10 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def config_type(cls):
         return {"base_dir": StringSource}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return ConsolidatedSqliteEventLogStorage(inst_data=inst_data, **config_value)
 
     def _init_db(self):

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -131,9 +131,9 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: "SqliteStorageConfig"
+        cls, inst_data: Optional[ConfigurableClassData], config_value: "SqliteStorageConfig"
     ) -> "SqliteEventLogStorage":
         return SqliteEventLogStorage(inst_data=inst_data, **config_value)
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -7,7 +7,6 @@ from typing import (
     Set,
     Tuple,
     Union,
-    cast,
 )
 
 from dagster import _check as check
@@ -103,37 +102,30 @@ class CompositeStorage(DagsterStorage, ConfigurableClass):
             },
         }
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, Mapping[str, str]]
+        cls,
+        inst_data: Optional[ConfigurableClassData],
+        config_value: Mapping[str, Mapping[str, str]],
     ) -> "CompositeStorage":
         run_storage_config = config_value["run_storage"]
-        run_storage = cast(
-            RunStorage,
-            ConfigurableClassData(
-                module_name=run_storage_config["module_name"],
-                class_name=run_storage_config["class_name"],
-                config_yaml=run_storage_config["config_yaml"],
-            ).rehydrate(),
-        )
+        run_storage = ConfigurableClassData(
+            module_name=run_storage_config["module_name"],
+            class_name=run_storage_config["class_name"],
+            config_yaml=run_storage_config["config_yaml"],
+        ).rehydrate(as_type=RunStorage)
         event_log_storage_config = config_value["event_log_storage"]
-        event_log_storage = cast(
-            EventLogStorage,
-            ConfigurableClassData(
-                module_name=event_log_storage_config["module_name"],
-                class_name=event_log_storage_config["class_name"],
-                config_yaml=event_log_storage_config["config_yaml"],
-            ).rehydrate(),
-        )
+        event_log_storage = ConfigurableClassData(
+            module_name=event_log_storage_config["module_name"],
+            class_name=event_log_storage_config["class_name"],
+            config_yaml=event_log_storage_config["config_yaml"],
+        ).rehydrate(as_type=EventLogStorage)
         schedule_storage_config = config_value["schedule_storage"]
-        schedule_storage = cast(
-            ScheduleStorage,
-            ConfigurableClassData(
-                module_name=schedule_storage_config["module_name"],
-                class_name=schedule_storage_config["class_name"],
-                config_yaml=schedule_storage_config["config_yaml"],
-            ).rehydrate(),
-        )
+        schedule_storage = ConfigurableClassData(
+            module_name=schedule_storage_config["module_name"],
+            class_name=schedule_storage_config["class_name"],
+            config_yaml=schedule_storage_config["config_yaml"],
+        ).rehydrate(as_type=ScheduleStorage)
         return CompositeStorage(
             run_storage, event_log_storage, schedule_storage, inst_data=inst_data
         )
@@ -177,18 +169,16 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
             "config_yaml": str,
         }
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, str]
+        cls, inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, str]
     ) -> "LegacyRunStorage":
         storage = ConfigurableClassData(
             module_name=config_value["module_name"],
             class_name=config_value["class_name"],
             config_yaml=config_value["config_yaml"],
-        ).rehydrate()
-        # Type checker says LegacyRunStorage is abstract and can't be instantiated. Not sure whether
-        # type check is wrong, or is unused code path.
-        return LegacyRunStorage(storage, inst_data=inst_data)  # type: ignore
+        ).rehydrate(as_type=DagsterStorage)
+        return LegacyRunStorage(storage, inst_data=inst_data)
 
     def add_run(self, pipeline_run: "DagsterRun") -> "DagsterRun":
         return self._storage.run_storage.add_run(pipeline_run)
@@ -364,18 +354,15 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             "config_yaml": str,
         }
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, str]
+        cls, inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, str]
     ) -> "LegacyEventLogStorage":
-        storage = cast(
-            DagsterStorage,
-            ConfigurableClassData(
-                module_name=config_value["module_name"],
-                class_name=config_value["class_name"],
-                config_yaml=config_value["config_yaml"],
-            ).rehydrate(),
-        )
+        storage = ConfigurableClassData(
+            module_name=config_value["module_name"],
+            class_name=config_value["class_name"],
+            config_yaml=config_value["config_yaml"],
+        ).rehydrate(as_type=DagsterStorage)
         # Type checker says LegacyEventStorage is abstract and can't be instantiated. Not sure whether
         # type check is wrong, or is unused code path.
         return LegacyEventLogStorage(storage, inst_data=inst_data)
@@ -563,18 +550,15 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
             "config_yaml": str,
         }
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, str]
+        cls, inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, str]
     ) -> "LegacyScheduleStorage":
-        storage = cast(
-            DagsterStorage,
-            ConfigurableClassData(
-                module_name=config_value["module_name"],
-                class_name=config_value["class_name"],
-                config_yaml=config_value["config_yaml"],
-            ).rehydrate(),
-        )
+        storage = ConfigurableClassData(
+            module_name=config_value["module_name"],
+            class_name=config_value["class_name"],
+            config_yaml=config_value["config_yaml"],
+        ).rehydrate(as_type=DagsterStorage)
         return LegacyScheduleStorage(storage, inst_data=inst_data)
 
     @property

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -82,9 +82,9 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
             "polling_timeout": Field(Float, is_required=False),
         }
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value
+        cls, inst_data: Optional[ConfigurableClassData], config_value
     ) -> "LocalComputeLogManager":
         return LocalComputeLogManager(inst_data=inst_data, **config_value)
 

--- a/python_modules/dagster/dagster/_core/storage/noop_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/noop_compute_log_manager.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
-from typing import IO, Generator, Optional, Sequence
+from typing import IO, Any, Generator, Mapping, Optional, Sequence
+
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._core.storage.captured_log_manager import (
@@ -20,7 +22,7 @@ from .compute_log_manager import (
 
 
 class NoOpComputeLogManager(CapturedLogManager, ComputeLogManager, ConfigurableClass):
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
     @property
@@ -31,8 +33,10 @@ class NoOpComputeLogManager(CapturedLogManager, ComputeLogManager, ConfigurableC
     def config_type(cls):
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return NoOpComputeLogManager(inst_data=inst_data, **config_value)
 
     def enabled(self, _pipeline_run, _step_key):

--- a/python_modules/dagster/dagster/_core/storage/root.py
+++ b/python_modules/dagster/dagster/_core/storage/root.py
@@ -40,9 +40,9 @@ class LocalArtifactStorage(ConfigurableClass):
     def schedules_dir(self) -> str:
         return os.path.join(self.base_dir, "schedules")
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: LocalArtifactStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: LocalArtifactStorageConfig
     ) -> "LocalArtifactStorage":
         return LocalArtifactStorage(inst_data=inst_data, **config_value)
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin, urlparse
 import sqlalchemy as db
 from sqlalchemy.engine import Connection
 from sqlalchemy.pool import NullPool
+from typing_extensions import Self
 
 from dagster import (
     StringSource,
@@ -70,16 +71,14 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: "SqliteStorageConfig"
+        cls, inst_data: Optional[ConfigurableClassData], config_value: "SqliteStorageConfig"
     ) -> "SqliteRunStorage":
         return SqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
     @classmethod
-    def from_local(
-        cls, base_dir: str, inst_data: Optional[ConfigurableClassData] = None
-    ) -> "SqliteRunStorage":
+    def from_local(cls, base_dir: str, inst_data: Optional[ConfigurableClassData] = None) -> Self:
         check.str_param(base_dir, "base_dir")
         mkdir_p(base_dir)
         conn_string = create_db_conn_string(base_dir, "runs")

--- a/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -46,9 +46,9 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value
+        cls, inst_data: Optional[ConfigurableClassData], config_value
     ) -> "SqliteScheduleStorage":
         return SqliteScheduleStorage.from_local(inst_data=inst_data, **config_value)
 

--- a/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
@@ -74,9 +74,9 @@ class DagsterSqliteStorage(DagsterStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return {"base_dir": StringSource}
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: ConfigurableClassData, config_value: SqliteStorageConfig
+        cls, inst_data: ConfigurableClassData, config_value: SqliteStorageConfig
     ) -> "DagsterSqliteStorage":
         return DagsterSqliteStorage.from_local(inst_data=inst_data, **config_value)
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -5,9 +5,10 @@ import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Generator, NamedTuple, Optional, Sequence, TypeVar
+from typing import Any, Generator, Mapping, NamedTuple, Optional, Sequence, TypeVar
 
 import pendulum
+from typing_extensions import Self
 
 from dagster import (
     Permissive,
@@ -32,6 +33,7 @@ from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._legacy import ModeDefinition, pipeline
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
 from dagster._seven.compat.pendulum import create_pendulum_time, mock_pendulum_timezone
 from dagster._utils import Counter, get_terminate_signal, traced, traced_counter
 from dagster._utils.log import configure_loggers
@@ -266,7 +268,7 @@ def today_at_midnight(timezone_name="UTC"):
 
 
 class ExplodingRunLauncher(RunLauncher, ConfigurableClass):
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data
 
         super().__init__()
@@ -279,8 +281,10 @@ class ExplodingRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return ExplodingRunLauncher(inst_data=inst_data)
 
     def launch_run(self, context):
@@ -294,7 +298,12 @@ class ExplodingRunLauncher(RunLauncher, ConfigurableClass):
 
 
 class MockedRunLauncher(RunLauncher, ConfigurableClass):
-    def __init__(self, inst_data=None, bad_run_ids=None, bad_user_code_run_ids=None):
+    def __init__(
+        self,
+        inst_data: Optional[ConfigurableClassData] = None,
+        bad_run_ids=None,
+        bad_user_code_run_ids=None,
+    ):
         self._inst_data = inst_data
         self._queue = []
         self._launched_run_ids = set()
@@ -346,7 +355,7 @@ class MockedRunLauncher(RunLauncher, ConfigurableClass):
 
 
 class MockedRunCoordinator(RunCoordinator, ConfigurableClass):
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data
         self._queue = []
 
@@ -399,8 +408,10 @@ class TestSecretsLoader(SecretsLoader, ConfigurableClass):
     def config_type(cls):
         return {"env_vars": Field(Permissive())}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return TestSecretsLoader(inst_data=inst_data, **config_value)
 
 

--- a/python_modules/dagster/dagster/_utils/test/__init__.py
+++ b/python_modules/dagster/dagster/_utils/test/__init__.py
@@ -423,9 +423,9 @@ class FilesystemTestScheduler(Scheduler, ConfigurableClass):
     def config_type(cls):
         return {"base_dir": str}
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: object, config_value: Mapping[str, object]
+        cls, inst_data: object, config_value: Mapping[str, object]
     ) -> "FilesystemTestScheduler":
         artifacts_dir = cast(str, config_value["base_dir"])
         return FilesystemTestScheduler(artifacts_dir=artifacts_dir, inst_data=inst_data)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, Mapping, Optional
 
 import pytest
 import yaml
@@ -42,6 +43,7 @@ from dagster._core.test_utils import (
 from dagster._legacy import PipelineDefinition
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 from dagster_tests.api_tests.utils import get_bar_workspace
 
@@ -261,7 +263,7 @@ def test_get_required_daemon_types():
 
 
 class TestNonResumeRunLauncher(RunLauncher, ConfigurableClass):
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data
         super().__init__()
 
@@ -273,8 +275,10 @@ class TestNonResumeRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return TestNonResumeRunLauncher(inst_data=inst_data)
 
     def launch_run(self, context):

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_run_launcher_lazy_load.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_run_launcher_lazy_load.py
@@ -1,14 +1,15 @@
-# pylint: disable=redefined-outer-name
-
+from typing import Any, Mapping, Optional
 
 import pytest
 from dagster._core.launcher import RunLauncher
 from dagster._core.test_utils import instance_for_test
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 
 class InitFailRunLauncher(RunLauncher, ConfigurableClass):
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         super().__init__()
         self._inst_data = inst_data
         raise Exception("Expected init fail")
@@ -21,8 +22,10 @@ class InitFailRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return InitFailRunLauncher(inst_data=inst_data)
 
     def launch_run(self, context):

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -1,10 +1,9 @@
 # pylint: disable=redefined-outer-name
-
 import logging
 import os
 import time
 from logging import Logger
-from typing import cast
+from typing import Any, Mapping, Optional, cast
 
 import pytest
 from dagster._core.events import DagsterEvent, DagsterEventType
@@ -23,10 +22,12 @@ from dagster._core.workspace.load_target import EmptyWorkspaceTarget
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.monitoring.monitoring_daemon import monitor_started_run, monitor_starting_run
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 
 class TestRunLauncher(RunLauncher, ConfigurableClass):
-    def __init__(self, inst_data=None):
+    def __init__(self, inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data
         self.launch_run_calls = 0
         self.resume_run_calls = 0
@@ -40,8 +41,10 @@ class TestRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return TestRunLauncher(inst_data=inst_data)
 
     def launch_run(self, context):

--- a/python_modules/dagster/dagster_tests/storage_tests/test_polling_event_watcher.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_polling_event_watcher.py
@@ -1,13 +1,15 @@
 import tempfile
 import time
 from contextlib import contextmanager
-from typing import Callable, Union
+from typing import Any, Callable, Mapping, Union
 
 import dagster._check as check
 from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
 from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.event_log import SqliteEventLogStorage, SqlPollingEventWatcher
 from dagster._core.storage.event_log.base import EventLogCursor
+from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 
 class SqlitePollingEventLogStorage(SqliteEventLogStorage):
@@ -23,8 +25,10 @@ class SqlitePollingEventLogStorage(SqliteEventLogStorage):
         self._watcher = SqlPollingEventWatcher(self)
         self._disposed = False
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return SqlitePollingEventLogStorage(inst_data=inst_data, **config_value)
 
     def watch(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -1,11 +1,14 @@
 import tempfile
 from contextlib import contextmanager
+from typing import Any, Mapping
 
 import mock
 import pytest
 from dagster._core.storage.legacy_storage import LegacyRunStorage
 from dagster._core.storage.runs import InMemoryRunStorage, SqliteRunStorage
 from dagster._core.storage.sqlite_storage import DagsterSqliteStorage
+from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
@@ -27,8 +30,10 @@ class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
     def supports_bucket_queries(self):
         return False
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return NonBucketQuerySqliteRunStorage.from_local(inst_data=inst_data, **config_value)
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -28,7 +28,9 @@ from dagster._core.launcher.base import (
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._grpc.types import ExecuteRunArgs
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
 from dagster._utils.backoff import backoff
+from typing_extensions import Self
 
 from ..secretsmanager import get_secrets_from_arns
 from .container_context import SHARED_ECS_SCHEMA, EcsContainerContext
@@ -64,7 +66,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
     def __init__(
         self,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         task_definition=None,
         container_name="run",
         secrets=None,
@@ -311,8 +313,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             **SHARED_ECS_SCHEMA,
         }
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return EcsRunLauncher(inst_data=inst_data, **config_value)
 
     def _set_run_tags(self, run_id: str, cluster: str, task_arn: str):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
@@ -2,6 +2,8 @@ from typing import Any, Mapping, Optional
 
 from dagster._core.events import EngineEventData, MetadataEntry
 from dagster._core.storage.pipeline_run import DagsterRun
+from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 from .container_context import EcsContainerContext
 from .launcher import EcsRunLauncher
@@ -10,7 +12,7 @@ from .launcher import EcsRunLauncher
 class CustomECSRunLauncher(EcsRunLauncher):
     def __init__(
         self,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         task_definition=None,
         container_name="run",
         secrets=None,
@@ -36,8 +38,10 @@ class CustomECSRunLauncher(EcsRunLauncher):
     def config_type(cls):
         return {}
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return CustomECSRunLauncher(inst_data=inst_data, **config_value)
 
     def get_cpu_and_memory_overrides(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 import boto3
 import dagster._seven as seven
@@ -22,6 +22,7 @@ from dagster._core.storage.local_compute_log_manager import (
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import ensure_dir, ensure_file
+from typing_extensions import Self
 
 POLLING_INTERVAL = 5
 
@@ -68,7 +69,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         self,
         bucket,
         local_dir=None,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         prefix="dagster",
         use_ssl=True,
         verify=True,
@@ -118,8 +119,10 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
             ),
         }
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return S3ComputeLogManager(inst_data=inst_data, **config_value)
 
     @property

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import contextmanager
-from typing import Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 import dagster._seven as seven
 from azure.identity import DefaultAzureCredential
@@ -22,6 +22,7 @@ from dagster._core.storage.local_compute_log_manager import (
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import ensure_dir, ensure_file
+from typing_extensions import Self
 
 from .utils import create_blob_client, generate_blob_sas
 
@@ -70,7 +71,7 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         container,
         secret_key=None,
         local_dir=None,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         prefix="dagster",
         upload_interval=None,
         default_azure_credential=None,
@@ -133,8 +134,10 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
             "upload_interval": Field(Noneable(int), is_required=False, default_value=None),
         }
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return AzureBlobComputeLogManager(inst_data=inst_data, **config_value)
 
     @property

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -1,5 +1,5 @@
 import sys
-from typing import cast
+from typing import Optional, cast
 
 import kubernetes
 from dagster import (
@@ -72,7 +72,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         include=None,
         config_source=None,
         retries=None,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         k8s_client_batch_api=None,
         env_config_maps=None,
         env_secrets=None,

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping, Optional
+
 import dagster._check as check
 import docker
 from dagster._core.launcher.base import (
@@ -12,6 +14,8 @@ from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._core.utils import parse_env_var
 from dagster._grpc.types import ExecuteRunArgs, ResumeRunArgs
 from dagster._serdes import ConfigurableClass
+from dagster._serdes.config_class import ConfigurableClassData
+from typing_extensions import Self
 
 from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
 
@@ -25,7 +29,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
 
     def __init__(
         self,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         image=None,
         registry=None,
         env_vars=None,
@@ -61,8 +65,10 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
     def config_type(cls):
         return DOCKER_CONFIG_SCHEMA
 
-    @staticmethod
-    def from_config_value(inst_data, config_value):
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
         return DockerRunLauncher(inst_data=inst_data, **config_value)
 
     def get_container_context(self, pipeline_run: DagsterRun) -> DockerContainerContext:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -53,7 +53,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         image_pull_secrets=None,
         load_incluster_config=True,
         kubeconfig_file=None,
-        inst_data=None,
+        inst_data: Optional[ConfigurableClassData] = None,
         job_namespace="default",
         env_config_maps=None,
         env_secrets=None,

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -114,9 +114,9 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
     ) -> "MySQLEventLogStorage":
         return MySQLEventLogStorage(
             inst_data=inst_data, mysql_url=mysql_url_from_config(config_value)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -115,9 +115,9 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
 
         return row[0]
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
     ) -> "MySQLRunStorage":
         return MySQLRunStorage(inst_data=inst_data, mysql_url=mysql_url_from_config(config_value))
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -97,9 +97,9 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
     ) -> "MySQLScheduleStorage":
         return MySQLScheduleStorage(
             inst_data=inst_data, mysql_url=mysql_url_from_config(config_value)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/storage.py
@@ -33,7 +33,7 @@ class DagsterMySQLStorage(DagsterStorage, ConfigurableClass):
     :py:class:`~dagster.IntSource` and can be configured from environment variables.
     """
 
-    def __init__(self, mysql_url, inst_data=None):
+    def __init__(self, mysql_url, inst_data: Optional[ConfigurableClassData] = None):
         self.mysql_url = mysql_url
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self._run_storage = MySQLRunStorage(mysql_url)
@@ -49,9 +49,9 @@ class DagsterMySQLStorage(DagsterStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return mysql_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: MySqlStorageConfig
     ) -> "DagsterMySQLStorage":
         return DagsterMySQLStorage(
             inst_data=inst_data,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -140,9 +140,9 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, Any]
+        cls, inst_data: Optional[ConfigurableClassData], config_value: Mapping[str, Any]
     ) -> "PostgresEventLogStorage":
         return PostgresEventLogStorage(
             inst_data=inst_data,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -128,9 +128,9 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
     ):
         return PostgresRunStorage(
             inst_data=inst_data,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -119,9 +119,9 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
     ) -> "PostgresScheduleStorage":
         return PostgresScheduleStorage(
             inst_data=inst_data,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
@@ -34,7 +34,12 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
     :py:class:`~dagster.IntSource` and can be configured from environment variables.
     """
 
-    def __init__(self, postgres_url, should_autocreate_tables=True, inst_data=None):
+    def __init__(
+        self,
+        postgres_url,
+        should_autocreate_tables=True,
+        inst_data: Optional[ConfigurableClassData] = None,
+    ):
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
             should_autocreate_tables, "should_autocreate_tables"
@@ -53,9 +58,9 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
     def config_type(cls) -> UserConfigSchema:
         return pg_config()
 
-    @staticmethod
+    @classmethod
     def from_config_value(
-        inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
+        cls, inst_data: Optional[ConfigurableClassData], config_value: PostgresStorageConfig
     ) -> "DagsterPostgresStorage":
         return DagsterPostgresStorage(
             inst_data=inst_data,


### PR DESCRIPTION
### Summary & Motivation

Update `ConfigurableClass` and related APIs for better typing.

- `ConfigurableClassData.rehydrate` now takes as an `as_type` kwarg which enforces return of a typed value (matching API of `serdes.deserialize_value`. Callsites accordingly (mostly in the `InstanceRef`) updated.
- `ConfigurableClass.from_config_value` and `config_type` are now class methods instead of static methods. This makes sense since the return type of `from_config_value` depends on the class the method is attached to (it should return an instance of the class). Implementations of from_config_value accordingly updated.
- Add `ConfigurableClass` as a superclass of abstract component classes, remove from subclasses.
- Improve some related docstrings for clarity.
- Add some type annotations

Internal Companion PR: https://github.com/dagster-io/internal/pull/5067

### How I Tested These Changes

Existing test suite