### PR TITLE
feat(dbt): add support for `--debug`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/constants.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/constants.py
@@ -110,4 +110,9 @@ CLI_COMMON_OPTIONS_CONFIG_SCHEMA = {
         description="When True, logs emitted from dbt will be logged to the Dagster event log.",
         default_value=True,
     ),
+    "debug": Field(
+        config=bool,
+        description="When True, dbt will be invoked with the `--debug` flag.",
+        default_value=False,
+    ),
 }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -39,6 +39,7 @@ class DbtCliResource(DbtResource):
         docs_url: Optional[str] = None,
         json_log_format: bool = True,
         capture_logs: bool = True,
+        debug: bool = False,
     ):
         self._default_flags = default_flags
         self._executable = executable
@@ -48,6 +49,7 @@ class DbtCliResource(DbtResource):
         self._docs_url = docs_url
         self._json_log_format = json_log_format
         self._capture_logs = capture_logs
+        self._debug = debug
         super().__init__(logger)
 
     @property
@@ -105,6 +107,7 @@ class DbtCliResource(DbtResource):
             docs_url=self._docs_url,
             json_log_format=self._json_log_format,
             capture_logs=self._capture_logs,
+            debug=self._debug,
         )
 
     def cli_stream_json(self, command: str, **kwargs) -> Iterator[Mapping[str, Any]]:
@@ -126,6 +129,7 @@ class DbtCliResource(DbtResource):
             ignore_handled_error=self._ignore_handled_error,
             json_log_format=self._json_log_format,
             capture_logs=self._capture_logs,
+            debug=self._debug,
         ):
             if event.parsed_json_line is not None:
                 yield event.parsed_json_line
@@ -399,4 +403,5 @@ def dbt_cli_resource(context) -> DbtCliResource:
         docs_url=context.resource_config.get("docs_url"),
         capture_logs=context.resource_config["capture_logs"],
         json_log_format=context.resource_config["json_log_format"],
+        debug=context.resource_config["debug"],
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -80,12 +80,15 @@ def _create_command_list(
     json_log_format: bool,
     command: str,
     flags_dict: Mapping[str, Any],
+    debug: bool,
 ) -> Sequence[str]:
     prefix = [executable]
     if warn_error:
         prefix += ["--warn-error"]
     if json_log_format:
         prefix += ["--no-use-color", "--log-format", "json"]
+    if debug:
+        prefix += ["--debug"]
 
     full_command = command.split(" ")
     for flag, value in flags_dict.items():
@@ -164,6 +167,7 @@ def execute_cli_stream(
     ignore_handled_error: bool,
     json_log_format: bool = True,
     capture_logs: bool = True,
+    debug: bool = False,
 ) -> Iterator[DbtCliEvent]:
     """Executes a command on the dbt CLI in a subprocess."""
     command_list = _create_command_list(
@@ -172,6 +176,7 @@ def execute_cli_stream(
         json_log_format=json_log_format,
         command=command,
         flags_dict=flags_dict,
+        debug=debug,
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 
@@ -201,6 +206,7 @@ def execute_cli(
     docs_url: Optional[str] = None,
     json_log_format: bool = True,
     capture_logs: bool = True,
+    debug: bool = False,
 ) -> DbtCliOutput:
     """Executes a command on the dbt CLI in a subprocess."""
     check.str_param(executable, "executable")
@@ -215,6 +221,7 @@ def execute_cli(
         json_log_format=json_log_format,
         command=command,
         flags_dict=flags_dict,
+        debug=debug,
     )
     log.info(f"Executing command: {' '.join(command_list)}")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_utils.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import sys
+from typing import List
 
 import dagster._check as check
 import pytest
-from dagster_dbt.cli.utils import execute_cli
+from dagster_dbt.cli.utils import _create_command_list, execute_cli
 
 
 def test_execute_cli_requires_dbt_installed(monkeypatch, test_project_dir, dbt_config_dir):
@@ -26,3 +27,23 @@ def test_execute_cli_requires_dbt_installed(monkeypatch, test_project_dir, dbt_c
             ignore_handled_error=False,
             target_path=os.path.join(test_project_dir, "target"),
         )
+
+
+@pytest.mark.parametrize(
+    argnames=["debug", "prefix"],
+    argvalues=[
+        (True, ["dbt", "--debug"]),
+        (False, ["dbt"]),
+    ],
+    ids=["debug", "no-debug"],
+)
+def test_create_command_list_debug(debug: bool, prefix: List[str]):
+    command_list = _create_command_list(
+        executable="dbt",
+        warn_error=False,
+        json_log_format=False,
+        command="run",
+        flags_dict={},
+        debug=debug,
+    )
+    assert command_list == prefix + ["run"]


### PR DESCRIPTION
### Summary & Motivation
As the title. 

In the future, we should support reading this from environment variables/yaml config (as documented in https://docs.getdbt.com/reference/profiles.yml). Passing these as explicit command line flags can get unwieldy, and makes us subject to needing to support new configuration every time a new command line flag is added. We should excise ourselves from this dependency by natively supporting dbt's existing precedence hierachy.

### How I Tested These Changes
pytest
