### PR TITLE
Remove deprecated MetadataEntry constructors, update `entry_data` internal refs

### DIFF
--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/resources/csv_io_manager.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/resources/csv_io_manager.py
@@ -5,7 +5,6 @@ import pandas as pd
 from dagster import (
     AssetKey,
     MemoizableIOManager,
-    MetadataEntry,
     TableSchemaMetadataValue,
     io_manager,
 )
@@ -30,13 +29,14 @@ class LocalCsvIOManager(MemoizableIOManager):
         with open(fpath + ".version", "w", encoding="utf8") as f:
             f.write(context.version if context.version else "None")
 
-        yield MetadataEntry("Rows", value=MetadataValue.int(obj.shape[0]))
-        yield MetadataEntry("Path", value=MetadataValue.path(fpath))
-        yield MetadataEntry("Sample", value=MetadataValue.md(obj.head(5).to_markdown()))
-        yield MetadataEntry("Resolved version", value=MetadataValue.text(context.version))  # type: ignore
-        yield MetadataEntry(
-            "Schema",
-            value=MetadataValue.table_schema(self.get_schema(context.dagster_type)),
+        context.add_output_metadata(
+            {
+                "Rows": MetadataValue.int(obj.shape[0]),
+                "Path": MetadataValue.path(fpath),
+                "Sample": MetadataValue.md(obj.head(5).to_markdown()),
+                "Resolved version": MetadataValue.text(context.version),  # type: ignore
+                "Schema": MetadataValue.table_schema(self.get_schema(context.dagster_type)),
+            }
         )
 
     def get_schema(self, dagster_type):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -60,51 +60,44 @@ def iterate_metadata_entries(
     check.sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry)
     for metadata_entry in metadata_entries:
         metadata_entry = cast(MetadataEntry, metadata_entry)
-        if isinstance(metadata_entry.entry_data, PathMetadataValue):
+        if isinstance(metadata_entry.value, PathMetadataValue):
             yield GraphenePathMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                path=metadata_entry.entry_data.path,
+                path=metadata_entry.value.path,
             )
-        elif isinstance(metadata_entry.entry_data, NotebookMetadataValue):
+        elif isinstance(metadata_entry.value, NotebookMetadataValue):
             yield GrapheneNotebookMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                path=metadata_entry.entry_data.path,
+                path=metadata_entry.value.path,
             )
-        elif isinstance(metadata_entry.entry_data, JsonMetadataValue):
+        elif isinstance(metadata_entry.value, JsonMetadataValue):
             yield GrapheneJsonMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                jsonString=seven.json.dumps(metadata_entry.entry_data.data),
+                jsonString=seven.json.dumps(metadata_entry.value.data),
             )
-        elif isinstance(metadata_entry.entry_data, TextMetadataValue):
+        elif isinstance(metadata_entry.value, TextMetadataValue):
             yield GrapheneTextMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                text=metadata_entry.entry_data.text,
+                text=metadata_entry.value.text,
             )
-        elif isinstance(metadata_entry.entry_data, UrlMetadataValue):
+        elif isinstance(metadata_entry.value, UrlMetadataValue):
             yield GrapheneUrlMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                url=metadata_entry.entry_data.url,
+                url=metadata_entry.value.url,
             )
-        elif isinstance(metadata_entry.entry_data, MarkdownMetadataValue):
+        elif isinstance(metadata_entry.value, MarkdownMetadataValue):
             yield GrapheneMarkdownMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                md_str=metadata_entry.entry_data.md_str,
+                md_str=metadata_entry.value.md_str,
             )
-        elif isinstance(metadata_entry.entry_data, PythonArtifactMetadataValue):
+        elif isinstance(metadata_entry.value, PythonArtifactMetadataValue):
             yield GraphenePythonArtifactMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                module=metadata_entry.entry_data.module,
-                name=metadata_entry.entry_data.name,
+                module=metadata_entry.value.module,
+                name=metadata_entry.value.name,
             )
-        elif isinstance(metadata_entry.entry_data, FloatMetadataValue):
-            float_val = metadata_entry.entry_data.value
+        elif isinstance(metadata_entry.value, FloatMetadataValue):
+            float_val = metadata_entry.value.value
 
             # coerce NaN to null
             if float_val is not None and isnan(float_val):
@@ -112,73 +105,64 @@ def iterate_metadata_entries(
 
             yield GrapheneFloatMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
                 floatValue=float_val,
             )
-        elif isinstance(metadata_entry.entry_data, IntMetadataValue):
+        elif isinstance(metadata_entry.value, IntMetadataValue):
             # coerce > 32 bit ints to null
             int_val = None
             if (
-                isinstance(metadata_entry.entry_data.value, int)
-                and MIN_INT <= metadata_entry.entry_data.value <= MAX_INT
+                isinstance(metadata_entry.value.value, int)
+                and MIN_INT <= metadata_entry.value.value <= MAX_INT
             ):
-                int_val = metadata_entry.entry_data.value
+                int_val = metadata_entry.value.value
 
             yield GrapheneIntMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
                 intValue=int_val,
                 # make string representation available to allow for > 32bit int
-                intRepr=str(metadata_entry.entry_data.value),
+                intRepr=str(metadata_entry.value.value),
             )
-        elif isinstance(metadata_entry.entry_data, BoolMetadataValue):
+        elif isinstance(metadata_entry.value, BoolMetadataValue):
             yield GrapheneBoolMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                boolValue=metadata_entry.entry_data.value,
+                boolValue=metadata_entry.value.value,
             )
-        elif isinstance(metadata_entry.entry_data, NullMetadataValue):
+        elif isinstance(metadata_entry.value, NullMetadataValue):
             yield GrapheneNullMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
             )
-        elif isinstance(metadata_entry.entry_data, DagsterRunMetadataValue):
+        elif isinstance(metadata_entry.value, DagsterRunMetadataValue):
             yield GraphenePipelineRunMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                runId=metadata_entry.entry_data.run_id,
+                runId=metadata_entry.value.run_id,
             )
-        elif isinstance(metadata_entry.entry_data, DagsterAssetMetadataValue):
+        elif isinstance(metadata_entry.value, DagsterAssetMetadataValue):
             yield GrapheneAssetMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
-                assetKey=metadata_entry.entry_data.asset_key,
+                assetKey=metadata_entry.value.asset_key,
             )
-        elif isinstance(metadata_entry.entry_data, TableMetadataValue):
+        elif isinstance(metadata_entry.value, TableMetadataValue):
             yield GrapheneTableMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
                 table=GrapheneTable(
-                    schema=metadata_entry.entry_data.schema,
+                    schema=metadata_entry.value.schema,
                     records=[
-                        seven.json.dumps(record.data)
-                        for record in metadata_entry.entry_data.records
+                        seven.json.dumps(record.data) for record in metadata_entry.value.records
                     ],
                 ),
             )
-        elif isinstance(metadata_entry.entry_data, TableSchemaMetadataValue):
+        elif isinstance(metadata_entry.value, TableSchemaMetadataValue):
             yield GrapheneTableSchemaMetadataEntry(
                 label=metadata_entry.label,
-                description=metadata_entry.description,
                 schema=GrapheneTableSchema(
-                    constraints=metadata_entry.entry_data.schema.constraints,
-                    columns=metadata_entry.entry_data.schema.columns,
+                    constraints=metadata_entry.value.schema.constraints,
+                    columns=metadata_entry.value.schema.columns,
                 ),
             )
         else:
             # skip rest for now
             check.not_implemented(
-                "{} unsupported metadata entry for now".format(type(metadata_entry.entry_data))
+                "{} unsupported metadata entry for now".format(type(metadata_entry.value))
             )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -23,6 +23,7 @@ from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
+from dagster._utils import last_file_comp
 from dagster._utils.backcompat import experimental_class_param_warning
 
 from .metadata import (
@@ -31,7 +32,6 @@ from .metadata import (
     MetadataValue,
     PartitionMetadataEntry,
     RawMetadataValue,
-    last_file_comp,
     normalize_metadata,
 )
 from .utils import DEFAULT_OUTPUT, check_valid_name
@@ -554,7 +554,7 @@ class AssetMaterialization(
     @property
     def metadata(self) -> MetadataMapping:
         # PartitionMetadataEntry (unstable API) case is unhandled
-        return {entry.label: entry.entry_data for entry in self.metadata_entries}  # type: ignore
+        return {entry.label: entry.value for entry in self.metadata_entries}  # type: ignore
 
 
 class MaterializationSerializer(DefaultNamedTupleSerializer):

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -1,6 +1,4 @@
-import functools
 import os
-import re
 from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -16,6 +14,8 @@ from typing import (
     cast,
     overload,
 )
+
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 import dagster._seven as seven
@@ -49,12 +49,8 @@ RawMetadataValue = Union[
     None,
 ]
 
-MetadataMapping = Mapping[str, "MetadataValue"]
-MetadataUserInput = Mapping[str, RawMetadataValue]
-
-
-def last_file_comp(path: str) -> str:
-    return os.path.basename(os.path.normpath(path))
+MetadataMapping: TypeAlias = Mapping[str, "MetadataValue"]
+MetadataUserInput: TypeAlias = Mapping[str, RawMetadataValue]
 
 
 # ########################
@@ -126,7 +122,7 @@ def normalize_metadata(
                 )
                 metadata_entries.append(
                     MetadataEntry(
-                        entry_data=TextMetadataValue(f"[{v.__class__.__name__}] (unserializable)"),
+                        value=TextMetadataValue(f"[{v.__class__.__name__}] (unserializable)"),
                         label=k,
                     )
                 )
@@ -950,28 +946,6 @@ class NullMetadataValue(NamedTuple("_NullMetadataValue", []), MetadataValue):
 # ########################
 
 
-def deprecated_metadata_entry_constructor(fn):
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        deprecation_warning(
-            f"Function `MetadataEntry.{fn.__name__}`",
-            "1.0.0",
-            additional_warn_txt=re.sub(
-                r"\n\s*",
-                " ",
-                """
-            The recommended way to supply metadata is to pass a `Dict[str,
-            MetadataValue]` to the `metadata` keyword argument. To construct `MetadataEntry`
-            directly, call constructor and pass a `MetadataValue`: `MetadataEntry(label="foo",
-            value=MetadataValue.text("bar")",
-            """,
-            ),
-        )
-        return fn(*args, **kwargs)
-
-    return wrapper
-
-
 # NOTE: This would better be implemented as a generic with `MetadataValue` set as a
 # typevar, but as of 2022-01-25 mypy does not support generics on NamedTuple.
 #
@@ -997,9 +971,6 @@ class MetadataEntry(
     Should be yielded from within an IO manager to append metadata for a given input/output event.
     For other event types, passing a dict with `MetadataValue` values to the `metadata` argument
     is preferred.
-
-    **NOTE**: MetadataEntry static constructors are deprecated. Instead you should use:
-    MetadataEntry(<label>, value=MetadataValue.<type>(<value>)).
 
     Args:
         label (str): Short display label for this metadata entry.
@@ -1043,339 +1014,6 @@ class MetadataEntry(
     def value(self):
         """Alias of `entry_data`."""
         return self.entry_data
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def text(text: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing text as
-        :py:class:`TextMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata_entries=[
-                        MetadataEntry.text("Text-based metadata for this event", "text_metadata")
-                    ],
-                )
-
-        Args:
-            text (Optional[str]): The text of this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, TextMetadataValue(text))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def url(url: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing a URL as
-        :py:class:`UrlMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context):
-                yield AssetMaterialization(
-                    asset_key="my_dashboard",
-                    metadata_entries=[
-                        MetadataEntry.url(
-                            "http://mycoolsite.com/my_dashboard", label="dashboard_url"
-                        ),
-                    ],
-                )
-
-        Args:
-            url (Optional[str]): The URL contained by this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, UrlMetadataValue(url))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def path(path: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing a path as
-        :py:class:`PathMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata_entries=[MetadataEntry.path("path/to/file", label="filepath")],
-                )
-
-        Args:
-            path (Optional[str]): The path contained by this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, PathMetadataValue(path))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def fspath(
-        path: Optional[str], label: Optional[str] = None, description: Optional[str] = None
-    ) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing a filesystem path as
-        :py:class:`PathMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata_entries=[MetadataEntry.fspath("path/to/file")],
-                )
-
-        Args:
-            path (Optional[str]): The path contained by this metadata entry.
-            label (Optional[str]): Short display label for this metadata entry. Defaults to the
-              base name of the path.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        if not label:
-            path = cast(str, check.str_param(path, "path"))
-            label = last_file_comp(path)
-
-        return MetadataEntry.path(path, label, description)
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def json(
-        data: Optional[Mapping[str, Any]],
-        label: str,
-        description: Optional[str] = None,
-    ) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing JSON data as
-        :py:class:`JsonMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context):
-                yield ExpectationResult(
-                    success=not missing_things,
-                    label="is_present",
-                    metadata_entries=[
-                        MetadataEntry.json(
-                            label="metadata", data={"missing_columns": missing_things},
-                        )
-                    ],
-                )
-
-        Args:
-            data (Optional[Union[Sequence[Any], Mapping[str, Any]]]): The JSON data contained by this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, JsonMetadataValue(data))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def md(md_str: Optional[str], label: str, description: Optional[str] = None) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing markdown data as
-        :py:class:`MarkdownMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context, md_str):
-                yield AssetMaterialization(
-                    asset_key="info",
-                    metadata_entries=[MetadataEntry.md(md_str=md_str)],
-                )
-
-        Args:
-            md_str (Optional[str]): The markdown contained by this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, MarkdownMetadataValue(md_str))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def python_artifact(
-        python_artifact: Callable[..., Any], label: str, description: Optional[str] = None
-    ) -> "MetadataEntry":
-        check.callable_param(python_artifact, "python_artifact")
-        return MetadataEntry(
-            label,
-            description,
-            PythonArtifactMetadataValue(python_artifact.__module__, python_artifact.__name__),
-        )
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def float(
-        value: Optional[float], label: str, description: Optional[str] = None
-    ) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing float as
-        :py:class:`FloatMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata_entries=[MetadataEntry.float(calculate_bytes(df), "size (bytes)")],
-                )
-
-        Args:
-            value (Optional[float]): The float value contained by this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, FloatMetadataValue(value))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def int(value: Optional[int], label: str, description: Optional[str] = None) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing int as
-        :py:class:`IntMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata_entries=[MetadataEntry.int(len(df), "number of rows")],
-                )
-
-        Args:
-            value (Optional[int]): The int value contained by this metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(label, description, IntMetadataValue(value))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def pipeline_run(run_id: str, label: str, description: Optional[str] = None) -> "MetadataEntry":
-        check.str_param(run_id, "run_id")
-        return MetadataEntry(label, description, DagsterRunMetadataValue(run_id))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def asset(
-        asset_key: "AssetKey", label: str, description: Optional[str] = None
-    ) -> "MetadataEntry":
-        """Static constructor for a metadata entry referencing a Dagster asset, by key.
-        For example:
-
-        .. code-block:: python
-
-            @op
-            def validate_table(context, df):
-                yield AssetMaterialization(
-                    asset_key=AssetKey("my_table"),
-                    metadata_entries=[
-                         MetadataEntry.asset(AssetKey('my_other_table'), "Related asset"),
-                    ],
-                )
-
-        Args:
-            asset_key (AssetKey): The asset key referencing the asset.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        from dagster._core.definitions.events import AssetKey
-
-        check.inst_param(asset_key, "asset_key", AssetKey)
-        return MetadataEntry(label, description, DagsterAssetMetadataValue(asset_key))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    @experimental
-    def table(
-        records: Sequence[TableRecord],
-        label: str,
-        description: Optional[str] = None,
-        schema: Optional[TableSchema] = None,
-    ) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing tabluar data as
-        :py:class:`TableMetadataValue`. For example:
-
-        .. code-block:: python
-
-            @op
-            def emit_metadata(context):
-                yield ExpectationResult(
-                    success=not has_errors,
-                    label="is_valid",
-                    metadata_entries=[
-                        MetadataEntry.table(
-                            label="errors",
-                            records=[
-                                TableRecord(code="invalid-data-type", row=2, col="name"),
-                            ],
-                            schema=TableSchema(
-                                columns=[
-                                    TableColumn(name="code", type="string"),
-                                    TableColumn(name="row", type="int"),
-                                    TableColumn(name="col", type="string"),
-                                ]
-                            )
-                        ),
-                    ],
-                )
-
-        Args:
-            records (List[TableRecord]): The data as a list of records (i.e. rows).
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-            schema (Optional[TableSchema]): A schema for the table. If none is provided, one will be
-              automatically generated by examining the first record. The schema will include as columns all
-              field names present in the first record, with a type of `"string"`, `"int"`,
-              `"bool"` or `"float"` inferred from the first record's values. If a value does
-              not directly match one of the above types, it will be treated as a string.
-        """
-        return MetadataEntry(label, description, TableMetadataValue(records, schema))
-
-    @staticmethod
-    @deprecated_metadata_entry_constructor
-    def table_schema(
-        schema: TableSchema, label: str, description: Optional[str] = None
-    ) -> "MetadataEntry":
-        """Static constructor for a metadata entry containing a table schema as
-        :py:class:`TableSchemaMetadataValue`. For example:
-
-        .. code-block:: python
-
-            schema = TableSchema(
-                columns = [
-                    TableColumn(name="id", type="int"),
-                    TableColumn(name="status", type="bool"),
-                ]
-            )
-            DagsterType(
-                type_check_fn=some_validation_fn,
-                name='MyTable',
-                metadata_entries=[
-                    MetadataEntry.table_schema(
-                        schema,
-                        label='schema',
-                    )
-                ]
-            )
-
-        Args:
-            schema (TableSchema): The table schema for a metadata entry.
-            label (str): Short display label for this metadata entry.
-            description (Optional[str]): A human-readable description of this metadata entry.
-        """
-        return MetadataEntry(
-            label,
-            description,
-            TableSchemaMetadataValue(schema),
-        )
 
 
 class PartitionMetadataEntry(

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -151,7 +151,7 @@ class SourceAsset(ResourceAddable):
     @property
     def metadata(self) -> MetadataMapping:
         # PartitionMetadataEntry (unstable API) case is unhandled
-        return {entry.label: entry.entry_data for entry in self.metadata_entries}  # type: ignore
+        return {entry.label: entry.value for entry in self.metadata_entries}  # type: ignore
 
     def get_io_manager_key(self) -> str:
         return self.io_manager_key or DEFAULT_IO_MANAGER_KEY

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -738,3 +738,7 @@ def iter_to_list(iterable: Iterable[T]) -> List[T]:
     if isinstance(iterable, List):
         return iterable
     return list(iterable)
+
+
+def last_file_comp(path: str) -> str:
+    return os.path.basename(os.path.normpath(path))

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset.py
@@ -6,11 +6,10 @@ from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
 def test_source_asset_metadata():
     sa = SourceAsset(key=AssetKey("foo"), metadata={"foo": "bar", "baz": object()})
     assert sa.metadata_entries == [
-        MetadataEntry(label="foo", description=None, entry_data=MetadataValue.text("bar")),
+        MetadataEntry(label="foo", value=MetadataValue.text("bar")),
         MetadataEntry(
             label="baz",
-            description=None,
-            entry_data=MetadataValue.text("[object] (unserializable)"),
+            value=MetadataValue.text("[object] (unserializable)"),
         ),
     ]
     assert sa.metadata == {

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -505,7 +505,7 @@ def test_raise_on_error_true_type_check_returns_unsuccessful_type_check():
     with pytest.raises(DagsterTypeCheckDidNotPass) as e:
         foo_job.execute_in_process()
     assert e.value.metadata_entries[0].label == "bar"
-    assert e.value.metadata_entries[0].entry_data.text == "foo"
+    assert e.value.metadata_entries[0].value.text == "foo"
     assert isinstance(e.value.dagster_type, DagsterType)
 
     pipeline_result = foo_job.execute_in_process(raise_on_error=False)
@@ -596,10 +596,7 @@ def test_raise_on_error_true_type_check_returns_successful_type_check():
         if event.event_type_value == DagsterEventType.STEP_OUTPUT.value:
             assert event.event_specific_data.type_check_data
             assert event.event_specific_data.type_check_data.metadata_entries[0].label == "bar"
-            assert (
-                event.event_specific_data.type_check_data.metadata_entries[0].entry_data.text
-                == "foo"
-            )
+            assert event.event_specific_data.type_check_data.metadata_entries[0].value.text == "foo"
             assert event.event_specific_data.type_check_data.metadata_entries[0]
 
     pipeline_result = foo_job.execute_in_process(raise_on_error=False)

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -565,7 +565,7 @@ def test_metadata_logging():
     assert len(events[1].event_specific_data.metadata_entries) == 1
     metadata_entry = events[1].event_specific_data.metadata_entries[0]
     assert metadata_entry.label == "foo"
-    assert metadata_entry.entry_data.text == "bar"
+    assert metadata_entry.value.text == "bar"
 
 
 def test_metadata_logging_multiple_entries():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1108,7 +1108,7 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
                 my_asset.key
             ].event_log_entry.dagster_event.materialization.metadata_entries[
                 0
-            ].entry_data == BoolMetadataValue(
+            ].value == BoolMetadataValue(
                 value=True
             )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -426,7 +426,7 @@ def test_failure_multiprocessing():
         # from Failure
         assert failure_data.user_failure_data.description == "it Failure"
         assert failure_data.user_failure_data.metadata_entries[0].label == "label"
-        assert failure_data.user_failure_data.metadata_entries[0].entry_data.text == "text"
+        assert failure_data.user_failure_data.metadata_entries[0].value.text == "text"
 
 
 @op

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -33,6 +33,7 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.no_step_launcher import no_step_launcher
 from dagster._core.definitions.reconstruct import ReconstructablePipeline, ReconstructableRepository
 from dagster._core.events import DagsterEventType
@@ -484,7 +485,7 @@ def test_explicit_failure():
             fd = run.result_for_node("retry_op").failure_data
             assert fd.user_failure_data.description == "some failure description"
             assert fd.user_failure_data.metadata_entries == [
-                MetadataEntry.float(label="foo", value=1.23)
+                MetadataEntry(label="foo", value=MetadataValue.float(1.23))
             ]
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -607,8 +607,8 @@ def test_backcompat_multipartitions_fs_io_manager():
         get_path_metadata_entry = lambda materialization: next(
             iter([me for me in materialization.metadata_entries if me.label == "path"])
         )
-        assert "c/2020-04-22" in get_path_metadata_entry(materializations[0]).entry_data.path
+        assert "c/2020-04-22" in get_path_metadata_entry(materializations[0]).value.path
 
         materializations = result.asset_materializations_for_node("downstream_of_multipartitioned")
         assert len(materializations) == 1
-        assert "c/2020-04-22" in get_path_metadata_entry(materializations[0]).entry_data.path
+        assert "c/2020-04-22" in get_path_metadata_entry(materializations[0]).value.path

--- a/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
@@ -648,7 +648,7 @@ def test_input_manager_with_failure():
 
         assert failure_data.user_failure_data.description == "Foolure"
         assert failure_data.user_failure_data.metadata_entries[0].label == "label"
-        assert failure_data.user_failure_data.metadata_entries[0].entry_data.text == "text"
+        assert failure_data.user_failure_data.metadata_entries[0].value.text == "text"
 
 
 def test_input_manager_with_retries():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -395,7 +395,7 @@ def test_step_subset_with_custom_paths():
         assert os.path.join(tmpdir_path, test_metadata_dict["op_b"]["path"]) == (
             step_materialization_events[0]
             .event_specific_data.materialization.metadata_entries[0]
-            .entry_data.path
+            .value.path
         )
 
         # test reexecution via backfills (not via re-execution apis)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -417,6 +417,6 @@ def test_upath_io_manager_custom_metadata(tmp_path: Path, json_data: Any):
 
     assert handled_output_events[0].event_specific_data.metadata_entries[  # type: ignore[index,union-attr]
         1
-    ].entry_data.value == get_length(
+    ].value.value == get_length(
         json_data
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -178,7 +178,7 @@ def _build_airbyte_assets_from_metadata(
                     value=None,
                     output_name=table_name,
                     metadata={
-                        entry.label: entry.entry_data for entry in materialization.metadata_entries
+                        entry.label: entry.value for entry in materialization.metadata_entries
                     },
                 )
                 # Also materialize any normalization tables affiliated with this destination
@@ -270,7 +270,7 @@ def build_airbyte_assets(
                     value=None,
                     output_name=table_name,
                     metadata={
-                        entry.label: entry.entry_data for entry in materialization.metadata_entries
+                        entry.label: entry.value for entry in materialization.metadata_entries
                     },
                 )
                 # Also materialize any normalization tables affiliated with this destination

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
@@ -41,7 +41,6 @@ def test_successful_file_handle_to_s3(mock_s3_bucket):
     assert len(materializations) == 1
     assert len(materializations[0].metadata_entries) == 1
     assert (
-        materializations[0].metadata_entries[0].entry_data.path
-        == f"s3://{mock_s3_bucket.name}/some-key"
+        materializations[0].metadata_entries[0].value.path == f"s3://{mock_s3_bucket.name}/some-key"
     )
     assert materializations[0].metadata_entries[0].label == "some-key"

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -94,7 +94,7 @@ def _build_fivetran_assets(
                     value=None,
                     output_name="_".join(materialization.asset_key.path),
                     metadata={
-                        cast(MetadataEntry, entry).label: cast(MetadataEntry, entry).entry_data
+                        cast(MetadataEntry, entry).label: cast(MetadataEntry, entry).value
                         for entry in materialization.metadata_entries
                     },
                 )

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
@@ -91,7 +91,7 @@ def test_yielded_results_config_pandas(snapshot, job_def, ge_dir):
     mainexpect = expectations[0]
     assert mainexpect.success
     # purge system specific metadata for testing
-    metadata = mainexpect.metadata_entries[0].entry_data.md_str.split("### Info")[0]
+    metadata = mainexpect.metadata_entries[0].value.md_str.split("### Info")[0]
     snapshot.assert_match(metadata)
 
 
@@ -110,5 +110,5 @@ def test_yielded_results_config_pyspark_v2(snapshot):  # pylint:disable=unused-a
     mainexpect = expectations[0]
     assert mainexpect.success
     # purge system specific metadata for testing
-    metadata = mainexpect.metadata_entries[0].entry_data.md_str.split("### Info")[0]
+    metadata = mainexpect.metadata_entries[0].value.md_str.split("### Info")[0]
     snapshot.assert_match(metadata)

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
@@ -563,7 +563,7 @@ class MultiColumnConstraintWithMetadata(ColumnConstraintWithMetadata):
                     result_val = result.success
                     if result_val:
                         continue
-                    result_dict = result.metadata_entries[0].entry_data.data
+                    result_dict = result.metadata_entries[0].value.data
                     truthparam = truthparam and result_val
                     for key in result_dict.keys():
                         if "constraint" not in key:

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -251,7 +251,7 @@ def create_structured_dataframe_type(
             if result_val:
                 continue
             typechecks_succeeded = typechecks_succeeded and result_val
-            result_dict = result.metadata_entries[0].entry_data.data
+            result_dict = result.metadata_entries[0].value.data
             metadata.append(
                 MetadataEntry(
                     "{}-constraint-metadata".format(key),

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
@@ -145,7 +145,7 @@ def test_execute_summary_stats_null_function():
     )
     assert len(metadata_entries) == 1
     assert metadata_entries[0].label == "qux"
-    assert metadata_entries[0].entry_data.text == "baz"
+    assert metadata_entries[0].value.text == "baz"
 
 
 def test_execute_summary_stats_error():

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
@@ -49,7 +49,7 @@ def test_basic():
 
 
 def test_failed_multi():
-    mul_val = basic_multi_constraint.validate([]).metadata_entries[0].entry_data.data
+    mul_val = basic_multi_constraint.validate([]).metadata_entries[0].value.data
     assert mul_val["expected"] == {"basic_validation_function": "a DataFrame"}
     assert mul_val["actual"] == {"basic_validation_function": "a list"}
 
@@ -81,7 +81,7 @@ def test_column_constraint():
         ColumnWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = column_val.validate(df, *df.columns).metadata_entries[0].entry_data.data
+    val = column_val.validate(df, *df.columns).metadata_entries[0].value.data
     assert {"bar": ["row 0"], "baz": ["row 1"]} == val["offending"]
     assert {"bar": ["a"], "baz": ["a"]} == val["actual"]
 
@@ -97,7 +97,7 @@ def test_multi_val_constraint():
         ColumnWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = column_val.validate(df, *df.columns).metadata_entries[0].entry_data.data
+    val = column_val.validate(df, *df.columns).metadata_entries[0].value.data
     assert {"foo": ["row 0", "row 1"], "bar": ["row 1"], "baz": ["row 0"]} == val["offending"]
     assert {"foo": [1, 2], "bar": [2], "baz": [1]} == val["actual"]
 
@@ -122,7 +122,7 @@ def test_multi_column_constraint():
         ColumnWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = column_val.validate(df).metadata_entries[0].entry_data.data
+    val = column_val.validate(df).metadata_entries[0].value.data
     assert {
         "bar": {
             "col_val_two": "values less than 2.",
@@ -156,7 +156,7 @@ def test_aggregate_constraint():
         ConstraintWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = aggregate_val.validate(df, *df.columns).metadata_entries[0].entry_data.data
+    val = aggregate_val.validate(df, *df.columns).metadata_entries[0].value.data
     assert ["foo"] == val["offending"]
     assert [1, 2] == val["actual"]["foo"]
 
@@ -182,7 +182,7 @@ def test_multi_agg_constraint():
         ConstraintWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = aggregate_val.validate(df).metadata_entries[0].entry_data.data
+    val = aggregate_val.validate(df).metadata_entries[0].value.data
     assert val["expected"] == {
         "bar": {"column_val_2": "checks column mean equal to 1.5."},
         "foo": {"column_val_1": "checks column mean equal to 1."},
@@ -196,7 +196,7 @@ def test_multi_agg_constraint():
 def test_range_constraint():
     df = DataFrame({"foo": [1, 2], "bar": [3, 2], "baz": [1, 4]})
     range_val = ColumnRangeConstraintWithMetadata(1, 2.5, raise_or_typecheck=False)
-    val = range_val.validate(df).metadata_entries[0].entry_data.data
+    val = range_val.validate(df).metadata_entries[0].value.data
     assert {"bar": ["row 0"], "baz": ["row 1"]} == val["offending"]
     assert {"bar": [3], "baz": [4]} == val["actual"]
     range_val = ColumnRangeConstraintWithMetadata(raise_or_typecheck=False)

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_metadata.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_metadata.py
@@ -31,7 +31,7 @@ def test_basic_pd_df_metadata():
     metadata_entries = input_event.step_input_data.type_check_data.metadata_entries
 
     assert metadata_entries[0].label == "row_count"
-    assert metadata_entries[0].entry_data.text == "2"
+    assert metadata_entries[0].value.text == "2"
 
     assert metadata_entries[1].label == "metadata"
-    assert metadata_entries[1].entry_data.data["columns"] == ["num1", "num2"]
+    assert metadata_entries[1].value.data["columns"] == ["num1", "num2"]

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_structured_df_types.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_structured_df_types.py
@@ -95,7 +95,7 @@ def test_failing_type_eval_column():
     assert len(output_metadata) == 1
     column_const = output_metadata[0]
     assert column_const.label == "columns-constraint-metadata"
-    column_const_data = column_const.entry_data.data
+    column_const_data = column_const.value.data
     assert column_const_data["expected"] == {
         "foo": {
             "in_range_validation_fn": in_range_validator.__doc__.strip(),
@@ -139,7 +139,7 @@ def test_failing_type_eval_aggregate():
     assert len(output_metadata) == 1
     column_const = output_metadata[0]
     assert column_const.label == "column-aggregates-constraint-metadata"
-    column_const_data = column_const.entry_data.data
+    column_const_data = column_const.value.data
     assert column_const_data["expected"] == {
         "bar": {"all_unique_validator": all_unique_validator.__doc__.strip()}
     }
@@ -173,7 +173,7 @@ def test_failing_type_eval_dataframe():
     assert len(output_metadata) == 1
     column_const = output_metadata[0]
     assert column_const.label == "dataframe-constraint-metadata"
-    column_const_data = column_const.entry_data.data
+    column_const_data = column_const.value.data
     assert column_const_data["expected"] == ["foo", "bar"]
     assert column_const_data["actual"] == {"extra_columns": ["baz"], "missing_columns": ["bar"]}
 
@@ -205,7 +205,7 @@ def test_failing_type_eval_multi_error():
     agg_data = output_metadata[0]
 
     assert agg_data.label == "column-aggregates-constraint-metadata"
-    agg_metadata = agg_data.entry_data.data
+    agg_metadata = agg_data.value.data
     assert agg_metadata["expected"] == {
         "bar": {"all_unique_validator": all_unique_validator.__doc__.strip()}
     }
@@ -213,7 +213,7 @@ def test_failing_type_eval_multi_error():
     assert agg_metadata["actual"] == {"bar": {"all_unique_validator": [10.0]}}
     column_const = output_metadata[1]
     assert column_const.label == "columns-constraint-metadata"
-    column_const_data = column_const.entry_data.data
+    column_const_data = column_const.value.data
     assert column_const_data["expected"] == {
         "foo": {
             "in_range_validation_fn": in_range_validator.__doc__.strip(),
@@ -232,6 +232,6 @@ def test_failing_type_eval_multi_error():
 
     df_data = output_metadata[2]
     assert df_data.label == "dataframe-constraint-metadata"
-    df_metadata = df_data.entry_data.data
+    df_metadata = df_data.value.data
     assert df_metadata["expected"] == ["foo", "bar"]
     assert df_metadata["actual"] == {"extra_columns": ["baz"], "missing_columns": []}

--- a/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
@@ -118,8 +118,8 @@ def test_pandera_schema_to_dagster_type(schema):
     assert isinstance(dagster_type, DagsterType)
     assert len(dagster_type.metadata_entries) == 1
     schema_entry = dagster_type.metadata_entries[0]
-    assert isinstance(schema_entry.entry_data, TableSchemaMetadataValue)
-    assert schema_entry.entry_data.schema == TableSchema(
+    assert isinstance(schema_entry.value, TableSchemaMetadataValue)
+    assert schema_entry.value.schema == TableSchema(
         constraints=TableConstraints(other=["sum(a) > sum(b)."]),
         columns=[
             TableColumn(

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
@@ -15,8 +15,8 @@ def get_path(materialization_event):
     for (
         metadata_entry
     ) in materialization_event.event_specific_data.materialization.metadata_entries:
-        if isinstance(metadata_entry.entry_data, (NotebookMetadataValue, PathMetadataValue)):
-            return metadata_entry.entry_data.path
+        if isinstance(metadata_entry.value, (NotebookMetadataValue, PathMetadataValue)):
+            return metadata_entry.value.path
 
 
 def cleanup_result_notebook(result):

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -62,9 +62,7 @@ def test_yes_output_notebook_yes_io_manager():
         assert result.output_for_node("hello_world", "notebook")
 
         output_path = (
-            materializations[0]
-            .event_specific_data.materialization.metadata_entries[0]
-            .entry_data.path
+            materializations[0].event_specific_data.materialization.metadata_entries[0].value.path
         )
         assert os.path.exists(output_path)
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -28,8 +28,8 @@ def get_path(materialization_event):
     for (
         metadata_entry
     ) in materialization_event.event_specific_data.materialization.metadata_entries:
-        if isinstance(metadata_entry.entry_data, (PathMetadataValue, NotebookMetadataValue)):
-            return metadata_entry.entry_data.path
+        if isinstance(metadata_entry.value, (PathMetadataValue, NotebookMetadataValue)):
+            return metadata_entry.value.path
 
 
 def cleanup_result_notebook(result):


### PR DESCRIPTION
### Summary & Motivation

- Remove static `MetadataEntry` APIs originally deprecated for `0.15.0` that should have been removed on past releases.
- Updates internal references to `MetadataEntry` to use `value` instead of `entry_data` (which is deprecated).

Internal Companion PR: https://github.com/dagster-io/internal/pull/5066

### How I Tested These Changes

Existing BK suite w/ new unit test for backcompat.
