### PR TITLE
MetadataEntryUnion

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -1,5 +1,5 @@
 from math import isnan
-from typing import Any, Iterator, Sequence, Union, cast, no_type_check
+from typing import Any, Iterator, Sequence, cast, no_type_check
 
 import dagster._check as check
 import dagster._seven as seven
@@ -20,7 +20,10 @@ from dagster import (
     TextMetadataValue,
     UrlMetadataValue,
 )
-from dagster._core.definitions.metadata import DagsterRunMetadataValue, PartitionMetadataEntry
+from dagster._core.definitions.metadata import (
+    DagsterRunMetadataValue,
+    MetadataEntryUnion,
+)
 from dagster._core.events import (
     DagsterEventType,
     HandledOutputData,
@@ -35,9 +38,7 @@ MAX_INT = 2147483647
 MIN_INT = -2147483648
 
 
-def iterate_metadata_entries(
-    metadata_entries: Sequence[Union[MetadataEntry, PartitionMetadataEntry]]
-) -> Iterator[Any]:
+def iterate_metadata_entries(metadata_entries: Sequence[MetadataEntryUnion]) -> Iterator[Any]:
     from ..schema.metadata import (
         GrapheneAssetMetadataEntry,
         GrapheneBoolMetadataEntry,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -3,9 +3,8 @@ from typing import Mapping, Optional, Sequence, Union, overload
 from dagster._annotations import experimental
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
+    MetadataEntryUnion,
     MetadataUserInput,
-    PartitionMetadataEntry,
 )
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition
@@ -28,7 +27,7 @@ def observable_source_asset(
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+    _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
     group_name: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> "_ObservableSourceAsset":
@@ -46,7 +45,7 @@ def observable_source_asset(
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+    _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
     group_name: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
@@ -107,7 +106,7 @@ class _ObservableSourceAsset:
         io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ):

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -21,6 +21,7 @@ import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.data_version import DataVersion
+from dagster._core.definitions.metadata import MetadataEntryUnion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
 from dagster._utils import last_file_comp
@@ -225,7 +226,7 @@ class Output(Generic[T]):
         value (Any): The value returned by the compute function.
         output_name (Optional[str]): Name of the corresponding out. (default:
             "result")
-        metadata_entries (Optional[Union[MetadataEntry, PartitionMetadataEntry]]):
+        metadata_entries (Optional[MetadataEntryUnion]):
             (Experimental) A set of metadata entries to attach to events related to this Output.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
@@ -239,7 +240,7 @@ class Output(Generic[T]):
         self,
         value: T,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         data_version: Optional[DataVersion] = None,
     ):
@@ -257,7 +258,7 @@ class Output(Generic[T]):
         self._data_version = check.opt_inst_param(data_version, "data_version", DataVersion)
 
     @property
-    def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
+    def metadata_entries(self) -> Sequence[MetadataEntryUnion]:
         return self._metadata_entries
 
     @public
@@ -303,7 +304,7 @@ class DynamicOutput(Generic[T]):
         output_name (Optional[str]):
             Name of the corresponding :py:class:`DynamicOut` defined on the op.
             (default: "result")
-        metadata_entries (Optional[Union[MetadataEntry, PartitionMetadataEntry]]):
+        metadata_entries (Optional[MetadataEntryUnion]):
             (Experimental) A set of metadata entries to attach to events related to this output.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
@@ -316,7 +317,7 @@ class DynamicOutput(Generic[T]):
         value: T,
         mapping_key: str,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[Sequence[Union[PartitionMetadataEntry, MetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
@@ -329,7 +330,7 @@ class DynamicOutput(Generic[T]):
         self._value = value
 
     @property
-    def metadata_entries(self) -> Sequence[Union[PartitionMetadataEntry, MetadataEntry]]:
+    def metadata_entries(self) -> Sequence[MetadataEntryUnion]:
         return self._metadata_entries
 
     @public
@@ -437,7 +438,7 @@ class AssetMaterialization(
         [
             ("asset_key", PublicAttr[AssetKey]),
             ("description", PublicAttr[Optional[str]]),
-            ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
+            ("metadata_entries", Sequence[MetadataEntryUnion]),
             ("partition", PublicAttr[Optional[str]]),
             ("tags", Optional[Mapping[str, str]]),
         ],
@@ -458,7 +459,7 @@ class AssetMaterialization(
         asset_key (Union[str, List[str], AssetKey]): A key to identify the materialized asset across
             job runs
         description (Optional[str]): A longer human-readable description of the materialized value.
-        metadata_entries (Optional[List[Union[MetadataEntry, PartitionMetadataEntry]]]): Arbitrary
+        metadata_entries (Optional[List[MetadataEntryUnion]]): Arbitrary
             metadata about the materialized value.
         partition (Optional[str]): The name of the partition
             that was materialized.
@@ -474,7 +475,7 @@ class AssetMaterialization(
         cls,
         asset_key: CoercibleToAssetKey,
         description: Optional[str] = None,
-        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -23,6 +23,7 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
+from dagster._core.definitions.metadata import MetadataEntryUnion
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -46,7 +47,7 @@ from .dependency import (
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .logger_definition import LoggerDefinition
-from .metadata import MetadataEntry, PartitionMetadataEntry, RawMetadataValue
+from .metadata import RawMetadataValue
 from .node_container import create_execution_structure, validate_dependency_dict
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
@@ -546,7 +547,7 @@ class GraphDefinition(NodeDefinition):
         asset_layer: Optional["AssetLayer"] = None,
         input_values: Optional[Mapping[str, object]] = None,
         _asset_selection_data: Optional[AssetSelectionData] = None,
-        _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -18,8 +18,7 @@ import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
-    PartitionMetadataEntry,
+    MetadataEntryUnion,
     RawMetadataValue,
     normalize_metadata,
 )
@@ -103,7 +102,7 @@ class InputDefinition:
     _input_manager_key: Optional[str]
     _root_manager_key: Optional[str]
     _metadata: Mapping[str, RawMetadataValue]
-    _metadata_entries: Sequence[Union[MetadataEntry, PartitionMetadataEntry]]
+    _metadata_entries: Sequence[MetadataEntryUnion]
     _asset_key: Optional[Union[AssetKey, Callable[["InputContext"], AssetKey]]]
     _asset_partitions_fn: Optional[Callable[["InputContext"], Set[str]]]
 
@@ -210,7 +209,7 @@ class InputDefinition:
         return self._asset_key is not None
 
     @property
-    def metadata_entries(self) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
+    def metadata_entries(self) -> Sequence[MetadataEntryUnion]:
         return self._metadata_entries
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -37,6 +37,7 @@ from dagster._core.definitions.dependency import (
     NodeOutput,
 )
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.metadata import MetadataEntryUnion
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.policy import RetryPolicy
@@ -65,7 +66,7 @@ from .executor_definition import ExecutorDefinition, multi_or_in_process_executo
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
 from .logger_definition import LoggerDefinition
-from .metadata import MetadataEntry, PartitionMetadataEntry, RawMetadataValue
+from .metadata import RawMetadataValue
 from .mode import ModeDefinition
 from .partition import PartitionedConfig, PartitionsDefinition, PartitionSetDefinition
 from .pipeline_definition import PipelineDefinition
@@ -106,7 +107,7 @@ class JobDefinition(PipelineDefinition):
         _subset_selection_data: Optional[Union[OpSelectionData, AssetSelectionData]] = None,
         asset_layer: Optional[AssetLayer] = None,
         input_values: Optional[Mapping[str, object]] = None,
-        _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -1,5 +1,6 @@
 import os
 from abc import ABC, abstractmethod
+from inspect import Parameter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -10,6 +11,7 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Type,
     Union,
     cast,
     overload,
@@ -22,6 +24,7 @@ import dagster._seven as seven
 from dagster._annotations import PublicAttr, experimental, public
 from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.serdes import DefaultNamedTupleSerializer, WhitelistMap, replace_storage_keys
 from dagster._utils.backcompat import (
     canonicalize_backcompat_args,
     deprecation_warning,

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._core.definitions.metadata import MetadataEntryUnion
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import (
@@ -45,7 +46,7 @@ from .dependency import (
 )
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
-from .metadata import MetadataEntry, PartitionMetadataEntry, RawMetadataValue, normalize_metadata
+from .metadata import RawMetadataValue, normalize_metadata
 from .mode import ModeDefinition
 from .node_definition import NodeDefinition
 from .op_definition import OpDefinition
@@ -156,7 +157,7 @@ class PipelineDefinition:
     _graph_def: GraphDefinition
     _description: Optional[str]
     _tags: Mapping[str, str]
-    _metadata: Sequence[Union[MetadataEntry, PartitionMetadataEntry]]
+    _metadata: Sequence[MetadataEntryUnion]
     _current_level_node_defs: Sequence[NodeDefinition]
     _mode_definitions: Sequence[ModeDefinition]
     _hook_defs: AbstractSet[HookDefinition]
@@ -191,7 +192,7 @@ class PipelineDefinition:
         ] = None,  # https://github.com/dagster-io/dagster/issues/2115
         version_strategy: Optional[VersionStrategy] = None,
         asset_layer: Optional[AssetLayer] = None,
-        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
     ):
         # If a graph is specified directly use it
         if isinstance(graph_def, GraphDefinition):
@@ -334,7 +335,7 @@ class PipelineDefinition:
         return frozentags(**merge_dicts(self._graph_def.tags, self._tags))
 
     @property
-    def metadata(self) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
+    def metadata(self) -> Sequence[MetadataEntryUnion]:
         return self._metadata_entries
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -11,10 +11,9 @@ from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.definitions.events import AssetKey, AssetObservation, CoercibleToAssetKey
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
+    MetadataEntryUnion,
     MetadataMapping,
     MetadataUserInput,
-    PartitionMetadataEntry,
     normalize_metadata,
 )
 from dagster._core.definitions.op_definition import OpDefinition
@@ -84,7 +83,7 @@ class SourceAsset(ResourceAddable):
     """
 
     key: PublicAttr[AssetKey]
-    metadata_entries: Sequence[Union[MetadataEntry, PartitionMetadataEntry]]
+    metadata_entries: Sequence[MetadataEntryUnion]
     io_manager_key: PublicAttr[Optional[str]]
     _io_manager_def: PublicAttr[Optional[IOManagerDefinition]]
     description: PublicAttr[Optional[str]]
@@ -102,7 +101,7 @@ class SourceAsset(ResourceAddable):
         io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        _metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         observe_fn: Optional[SourceAssetObserveFunction] = None,

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -14,7 +14,9 @@ from typing import (
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.events import AssetKey, AssetObservation
-from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
+from dagster._core.definitions.metadata import (
+    MetadataEntryUnion,
+)
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow, TimeWindowPartitionsSubset
@@ -132,7 +134,7 @@ class InputContext:
 
         self._events: List["DagsterEvent"] = []
         self._observations: List[AssetObservation] = []
-        self._metadata_entries: List[Union[MetadataEntry, PartitionMetadataEntry]] = []
+        self._metadata_entries: List[MetadataEntryUnion] = []
         self._instance = instance
 
     def __enter__(self):
@@ -526,7 +528,7 @@ class InputContext:
         """
         return self._observations
 
-    def consume_metadata_entries(self) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
+    def consume_metadata_entries(self) -> Sequence[MetadataEntryUnion]:
         result = self._metadata_entries
         self._metadata_entries = []
         return result

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -21,9 +21,8 @@ from dagster._core.definitions.events import (
     AssetObservation,
     Materialization,
     MetadataEntry,
-    PartitionMetadataEntry,
 )
-from dagster._core.definitions.metadata import RawMetadataValue
+from dagster._core.definitions.metadata import MetadataEntryUnion, RawMetadataValue
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
@@ -690,13 +689,13 @@ class OutputContext:
 
     def get_logged_metadata_entries(
         self,
-    ) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
+    ) -> Sequence[MetadataEntryUnion]:
         """Get the list of metadata entries that have been logged for use with this output."""
         return self._metadata_entries or []
 
     def consume_logged_metadata_entries(
         self,
-    ) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
+    ) -> Sequence[MetadataEntryUnion]:
         """Pops and yields all user-generated metadata entries that have been recorded from this context.
 
         If consume_logged_metadata_entries has not yet been called, this will yield all logged events since the call to `handle_output`. If consume_logged_metadata_entries has been called, it will yield all events since the last time consume_logged_metadata_entries was called. Designed for internal use. Users should never need to invoke this method.

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -41,6 +41,7 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from dagster._core.definitions.events import DynamicOutput
 from dagster._core.definitions.metadata import (
     MetadataEntry,
+    MetadataEntryUnion,
     PartitionMetadataEntry,
     normalize_metadata,
 )
@@ -460,7 +461,7 @@ def _get_output_asset_materializations(
     asset_partitions: AbstractSet[str],
     output: Union[Output, DynamicOutput],
     output_def: OutputDefinition,
-    io_manager_metadata_entries: Sequence[Union[MetadataEntry, PartitionMetadataEntry]],
+    io_manager_metadata_entries: Sequence[MetadataEntryUnion],
     step_context: StepExecutionContext,
 ) -> Iterator[AssetMaterialization]:
     all_metadata = [*output.metadata_entries, *io_manager_metadata_entries]
@@ -499,7 +500,7 @@ def _get_output_asset_materializations(
     if asset_partitions:
         metadata_mapping: Dict[
             str,
-            List[Union[MetadataEntry, PartitionMetadataEntry]],
+            List[MetadataEntryUnion],
         ] = {partition: [] for partition in asset_partitions}
 
         for entry in all_metadata:
@@ -613,7 +614,7 @@ def _store_output(
     output_context = step_context.get_output_context(step_output_handle)
 
     manager_materializations = []
-    manager_metadata_entries: List[Union[PartitionMetadataEntry, MetadataEntry]] = []
+    manager_metadata_entries: List[MetadataEntryUnion] = []
 
     # output_manager.handle_output is either a generator function, or a normal function with or
     # without a return value. In the case that handle_output is a normal function, we need to

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -19,7 +19,9 @@ from typing import (
 import dagster._check as check
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
+from dagster._core.definitions.metadata import (
+    MetadataEntryUnion,
+)
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import (
@@ -420,7 +422,7 @@ class ExternalPipeline(RepresentedPipeline):
         return self._pipeline_index.pipeline_snapshot.tags
 
     @property
-    def metadata(self) -> Sequence[Union[MetadataEntry, PartitionMetadataEntry]]:
+    def metadata(self) -> Sequence[MetadataEntryUnion]:
         return self._pipeline_index.pipeline_snapshot.metadata
 
     @property

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -23,7 +23,9 @@ from dagster._config import (
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
+from dagster._core.definitions.metadata import (
+    MetadataEntryUnion,
+)
 from dagster._core.definitions.pipeline_definition import (
     PipelineDefinition,
     PipelineSubsetDefinition,
@@ -91,7 +93,7 @@ def _pipeline_snapshot_from_storage(
     mode_def_snaps: Sequence[ModeDefSnap],
     lineage_snapshot: Optional["PipelineSnapshotLineage"] = None,
     graph_def_name: Optional[str] = None,
-    metadata: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+    metadata: Optional[Sequence[MetadataEntryUnion]] = None,
     **kwargs,  # pylint: disable=unused-argument
 ) -> "PipelineSnapshot":
     """
@@ -143,7 +145,7 @@ class PipelineSnapshot(
             ("mode_def_snaps", Sequence[ModeDefSnap]),
             ("lineage_snapshot", Optional["PipelineSnapshotLineage"]),
             ("graph_def_name", str),
-            ("metadata", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
+            ("metadata", Sequence[MetadataEntryUnion]),
         ],
     )
 ):
@@ -159,7 +161,7 @@ class PipelineSnapshot(
         mode_def_snaps: Sequence[ModeDefSnap],
         lineage_snapshot: Optional["PipelineSnapshotLineage"],
         graph_def_name: str,
-        metadata: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]],
+        metadata: Optional[Sequence[MetadataEntryUnion]],
     ):
         return super(PipelineSnapshot, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -11,7 +11,10 @@ from dagster._core.definitions import (
     OutputMapping,
     PipelineDefinition,
 )
-from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
+from dagster._core.definitions.metadata import (
+    MetadataEntry,
+    MetadataEntryUnion,
+)
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import DefaultNamedTupleSerializer
 
@@ -35,7 +38,7 @@ class InputDefSnap(
             ("name", str),
             ("dagster_type_key", str),
             ("description", Optional[str]),
-            ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
+            ("metadata_entries", Sequence[MetadataEntryUnion]),
         ],
     )
 ):
@@ -44,7 +47,7 @@ class InputDefSnap(
         name: str,
         dagster_type_key: str,
         description: Optional[str],
-        metadata_entries: Optional[Sequence[Union[MetadataEntry, PartitionMetadataEntry]]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
     ):
         return super(InputDefSnap, cls).__new__(
             cls,
@@ -72,7 +75,7 @@ class OutputDefSnap(
             ("dagster_type_key", str),
             ("description", Optional[str]),
             ("is_required", bool),
-            ("metadata_entries", Sequence[Union[MetadataEntry, PartitionMetadataEntry]]),
+            ("metadata_entries", Sequence[MetadataEntryUnion]),
             ("is_dynamic", bool),
         ],
     )

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -207,7 +207,7 @@ def test_bad_json_metadata_value():
     assert (
         str(exc_info.value)
         == 'Could not resolve the metadata value for "bad" to a known type. '
-        "Value is a dictionary but is not JSON serializable."
+        "Value is not JSON serializable."
     )
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_metadata.py
@@ -50,11 +50,9 @@ def solid_events_for_type(
 
 
 def test_metadata_entry_construction():
-    entry_1 = MetadataEntry("foo", value=MetadataValue.text("bar"))
-    entry_2 = MetadataEntry("foo", entry_data=MetadataValue.text("bar"))
-    assert entry_1.value == MetadataValue.text("bar")
-    assert entry_2.value == MetadataValue.text("bar")
-    assert entry_1 == entry_2
+    entry = MetadataEntry("foo", value=MetadataValue.text("bar"))
+    assert entry.label == "foo"
+    assert entry.value == MetadataValue.text("bar")
 
 
 def test_metadata_asset_materialization():


### PR DESCRIPTION
### Summary & Motivation

Pure typing PR:

- Create a type alias `MetadataEntryUnion` for the common `Union[MetadataEntry, PartitionMetadataEntry]`.
- Make `MetadataValue` and `MetadataEntry` generic.

### How I Tested These Changes

BK
