### PR TITLE
Remove PartitionMetadataEntry

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -22,7 +22,6 @@ from dagster import (
 )
 from dagster._core.definitions.metadata import (
     DagsterRunMetadataValue,
-    MetadataEntryUnion,
 )
 from dagster._core.events import (
     DagsterEventType,
@@ -38,7 +37,7 @@ MAX_INT = 2147483647
 MIN_INT = -2147483648
 
 
-def iterate_metadata_entries(metadata_entries: Sequence[MetadataEntryUnion]) -> Iterator[Any]:
+def iterate_metadata_entries(metadata_entries: Sequence[MetadataEntry]) -> Iterator[Any]:
     from ..schema.metadata import (
         GrapheneAssetMetadataEntry,
         GrapheneBoolMetadataEntry,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -3,7 +3,7 @@ from typing import Mapping, Optional, Sequence, Union, overload
 from dagster._annotations import experimental
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.metadata import (
-    MetadataEntryUnion,
+    MetadataEntry,
     MetadataUserInput,
 )
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -27,7 +27,7 @@ def observable_source_asset(
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+    _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     group_name: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> "_ObservableSourceAsset":
@@ -45,7 +45,7 @@ def observable_source_asset(
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+    _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     group_name: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
@@ -106,7 +106,7 @@ class _ObservableSourceAsset:
         io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ):

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -21,7 +21,6 @@ import dagster._check as check
 import dagster._seven as seven
 from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.data_version import DataVersion
-from dagster._core.definitions.metadata import MetadataEntryUnion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, SYSTEM_TAG_PREFIX
 from dagster._serdes import DefaultNamedTupleSerializer, whitelist_for_serdes
 from dagster._utils import last_file_comp
@@ -31,7 +30,6 @@ from .metadata import (
     MetadataEntry,
     MetadataMapping,
     MetadataValue,
-    PartitionMetadataEntry,
     RawMetadataValue,
     normalize_metadata,
 )
@@ -226,7 +224,7 @@ class Output(Generic[T]):
         value (Any): The value returned by the compute function.
         output_name (Optional[str]): Name of the corresponding out. (default:
             "result")
-        metadata_entries (Optional[MetadataEntryUnion]):
+        metadata_entries (Optional[MetadataEntry]):
             (Experimental) A set of metadata entries to attach to events related to this Output.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
@@ -240,7 +238,7 @@ class Output(Generic[T]):
         self,
         value: T,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         data_version: Optional[DataVersion] = None,
     ):
@@ -248,7 +246,7 @@ class Output(Generic[T]):
         metadata_entries = check.opt_sequence_param(
             metadata_entries,
             "metadata_entries",
-            of_type=(MetadataEntry, PartitionMetadataEntry),
+            of_type=MetadataEntry,
         )
         self._value = value
         self._output_name = check.str_param(output_name, "output_name")
@@ -258,7 +256,7 @@ class Output(Generic[T]):
         self._data_version = check.opt_inst_param(data_version, "data_version", DataVersion)
 
     @property
-    def metadata_entries(self) -> Sequence[MetadataEntryUnion]:
+    def metadata_entries(self) -> Sequence[MetadataEntry]:
         return self._metadata_entries
 
     @public
@@ -304,7 +302,7 @@ class DynamicOutput(Generic[T]):
         output_name (Optional[str]):
             Name of the corresponding :py:class:`DynamicOut` defined on the op.
             (default: "result")
-        metadata_entries (Optional[MetadataEntryUnion]):
+        metadata_entries (Optional[MetadataEntry]):
             (Experimental) A set of metadata entries to attach to events related to this output.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
@@ -317,7 +315,7 @@ class DynamicOutput(Generic[T]):
         value: T,
         mapping_key: str,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
@@ -330,7 +328,7 @@ class DynamicOutput(Generic[T]):
         self._value = value
 
     @property
-    def metadata_entries(self) -> Sequence[MetadataEntryUnion]:
+    def metadata_entries(self) -> Sequence[MetadataEntry]:
         return self._metadata_entries
 
     @public
@@ -438,7 +436,7 @@ class AssetMaterialization(
         [
             ("asset_key", PublicAttr[AssetKey]),
             ("description", PublicAttr[Optional[str]]),
-            ("metadata_entries", Sequence[MetadataEntryUnion]),
+            ("metadata_entries", Sequence[MetadataEntry]),
             ("partition", PublicAttr[Optional[str]]),
             ("tags", Optional[Mapping[str, str]]),
         ],
@@ -459,7 +457,7 @@ class AssetMaterialization(
         asset_key (Union[str, List[str], AssetKey]): A key to identify the materialized asset across
             job runs
         description (Optional[str]): A longer human-readable description of the materialized value.
-        metadata_entries (Optional[List[MetadataEntryUnion]]): Arbitrary
+        metadata_entries (Optional[List[MetadataEntry]]): Arbitrary
             metadata about the materialized value.
         partition (Optional[str]): The name of the partition
             that was materialized.
@@ -475,7 +473,7 @@ class AssetMaterialization(
         cls,
         asset_key: CoercibleToAssetKey,
         description: Optional[str] = None,
-        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
@@ -500,7 +498,7 @@ class AssetMaterialization(
 
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
         metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=(MetadataEntry, PartitionMetadataEntry)
+            metadata_entries, "metadata_entries", of_type=MetadataEntry
         )
 
         partition = check.opt_str_param(partition, "partition")
@@ -554,8 +552,7 @@ class AssetMaterialization(
     @public
     @property
     def metadata(self) -> MetadataMapping:
-        # PartitionMetadataEntry (unstable API) case is unhandled
-        return {entry.label: entry.value for entry in self.metadata_entries}  # type: ignore
+        return {entry.label: entry.value for entry in self.metadata_entries}
 
 
 class MaterializationSerializer(DefaultNamedTupleSerializer):

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -23,7 +23,7 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
-from dagster._core.definitions.metadata import MetadataEntryUnion
+from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -547,7 +547,7 @@ class GraphDefinition(NodeDefinition):
         asset_layer: Optional["AssetLayer"] = None,
         input_values: Optional[Mapping[str, object]] = None,
         _asset_selection_data: Optional[AssetSelectionData] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ) -> "JobDefinition":
         """
         Make this graph in to an executable Job by providing remaining components required for execution.

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -18,7 +18,7 @@ import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
-    MetadataEntryUnion,
+    MetadataEntry,
     RawMetadataValue,
     normalize_metadata,
 )
@@ -102,7 +102,7 @@ class InputDefinition:
     _input_manager_key: Optional[str]
     _root_manager_key: Optional[str]
     _metadata: Mapping[str, RawMetadataValue]
-    _metadata_entries: Sequence[MetadataEntryUnion]
+    _metadata_entries: Sequence[MetadataEntry]
     _asset_key: Optional[Union[AssetKey, Callable[["InputContext"], AssetKey]]]
     _asset_partitions_fn: Optional[Callable[["InputContext"], Set[str]]]
 
@@ -209,7 +209,7 @@ class InputDefinition:
         return self._asset_key is not None
 
     @property
-    def metadata_entries(self) -> Sequence[MetadataEntryUnion]:
+    def metadata_entries(self) -> Sequence[MetadataEntry]:
         return self._metadata_entries
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -37,7 +37,7 @@ from dagster._core.definitions.dependency import (
     NodeOutput,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import MetadataEntryUnion
+from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.policy import RetryPolicy
@@ -107,7 +107,7 @@ class JobDefinition(PipelineDefinition):
         _subset_selection_data: Optional[Union[OpSelectionData, AssetSelectionData]] = None,
         asset_layer: Optional[AssetLayer] = None,
         input_values: Optional[Mapping[str, object]] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.metadata import MetadataEntryUnion
+from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import (
@@ -157,7 +157,7 @@ class PipelineDefinition:
     _graph_def: GraphDefinition
     _description: Optional[str]
     _tags: Mapping[str, str]
-    _metadata: Sequence[MetadataEntryUnion]
+    _metadata: Sequence[MetadataEntry]
     _current_level_node_defs: Sequence[NodeDefinition]
     _mode_definitions: Sequence[ModeDefinition]
     _hook_defs: AbstractSet[HookDefinition]
@@ -192,7 +192,7 @@ class PipelineDefinition:
         ] = None,  # https://github.com/dagster-io/dagster/issues/2115
         version_strategy: Optional[VersionStrategy] = None,
         asset_layer: Optional[AssetLayer] = None,
-        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ):
         # If a graph is specified directly use it
         if isinstance(graph_def, GraphDefinition):
@@ -335,7 +335,7 @@ class PipelineDefinition:
         return frozentags(**merge_dicts(self._graph_def.tags, self._tags))
 
     @property
-    def metadata(self) -> Sequence[MetadataEntryUnion]:
+    def metadata(self) -> Sequence[MetadataEntry]:
         return self._metadata_entries
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -11,7 +11,7 @@ from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.definitions.events import AssetKey, AssetObservation, CoercibleToAssetKey
 from dagster._core.definitions.metadata import (
-    MetadataEntryUnion,
+    MetadataEntry,
     MetadataMapping,
     MetadataUserInput,
     normalize_metadata,
@@ -83,7 +83,7 @@ class SourceAsset(ResourceAddable):
     """
 
     key: PublicAttr[AssetKey]
-    metadata_entries: Sequence[MetadataEntryUnion]
+    metadata_entries: Sequence[MetadataEntry]
     io_manager_key: PublicAttr[Optional[str]]
     _io_manager_def: PublicAttr[Optional[IOManagerDefinition]]
     description: PublicAttr[Optional[str]]
@@ -101,7 +101,7 @@ class SourceAsset(ResourceAddable):
         io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         observe_fn: Optional[SourceAssetObserveFunction] = None,
@@ -149,8 +149,7 @@ class SourceAsset(ResourceAddable):
     @public
     @property
     def metadata(self) -> MetadataMapping:
-        # PartitionMetadataEntry (unstable API) case is unhandled
-        return {entry.label: entry.value for entry in self.metadata_entries}  # type: ignore
+        return {entry.label: entry.value for entry in self.metadata_entries}
 
     def get_io_manager_key(self) -> str:
         return self.io_manager_key or DEFAULT_IO_MANAGER_KEY

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -15,7 +15,7 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.events import AssetKey, AssetObservation
 from dagster._core.definitions.metadata import (
-    MetadataEntryUnion,
+    MetadataEntry,
 )
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -134,7 +134,7 @@ class InputContext:
 
         self._events: List["DagsterEvent"] = []
         self._observations: List[AssetObservation] = []
-        self._metadata_entries: List[MetadataEntryUnion] = []
+        self._metadata_entries: List[MetadataEntry] = []
         self._instance = instance
 
     def __enter__(self):
@@ -528,7 +528,7 @@ class InputContext:
         """
         return self._observations
 
-    def consume_metadata_entries(self) -> Sequence[MetadataEntryUnion]:
+    def consume_metadata_entries(self) -> Sequence[MetadataEntry]:
         result = self._metadata_entries
         self._metadata_entries = []
         return result

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -20,9 +20,8 @@ from dagster._core.definitions.events import (
     AssetMaterialization,
     AssetObservation,
     Materialization,
-    MetadataEntry,
 )
-from dagster._core.definitions.metadata import MetadataEntryUnion, RawMetadataValue
+from dagster._core.definitions.metadata import MetadataEntry, RawMetadataValue
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
@@ -689,13 +688,13 @@ class OutputContext:
 
     def get_logged_metadata_entries(
         self,
-    ) -> Sequence[MetadataEntryUnion]:
+    ) -> Sequence[MetadataEntry]:
         """Get the list of metadata entries that have been logged for use with this output."""
         return self._metadata_entries or []
 
     def consume_logged_metadata_entries(
         self,
-    ) -> Sequence[MetadataEntryUnion]:
+    ) -> Sequence[MetadataEntry]:
         """Pops and yields all user-generated metadata entries that have been recorded from this context.
 
         If consume_logged_metadata_entries has not yet been called, this will yield all logged events since the call to `handle_output`. If consume_logged_metadata_entries has been called, it will yield all events since the last time consume_logged_metadata_entries was called. Designed for internal use. Users should never need to invoke this method.

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -41,8 +41,6 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from dagster._core.definitions.events import DynamicOutput
 from dagster._core.definitions.metadata import (
     MetadataEntry,
-    MetadataEntryUnion,
-    PartitionMetadataEntry,
     normalize_metadata,
 )
 from dagster._core.definitions.multi_dimensional_partitions import (
@@ -461,7 +459,7 @@ def _get_output_asset_materializations(
     asset_partitions: AbstractSet[str],
     output: Union[Output, DynamicOutput],
     output_def: OutputDefinition,
-    io_manager_metadata_entries: Sequence[MetadataEntryUnion],
+    io_manager_metadata_entries: Sequence[MetadataEntry],
     step_context: StepExecutionContext,
 ) -> Iterator[AssetMaterialization]:
     all_metadata = [*output.metadata_entries, *io_manager_metadata_entries]
@@ -498,28 +496,6 @@ def _get_output_asset_materializations(
         tags[BACKFILL_ID_TAG] = backfill_id
 
     if asset_partitions:
-        metadata_mapping: Dict[
-            str,
-            List[MetadataEntryUnion],
-        ] = {partition: [] for partition in asset_partitions}
-
-        for entry in all_metadata:
-            # TODO: Allow users to specify a multi-dimensional partition key in a PartitionMetadataEntry
-
-            # if you target a given entry at a partition, only apply it to the requested partition
-            # otherwise, apply it to all partitions
-            if isinstance(entry, PartitionMetadataEntry):
-                if entry.partition not in asset_partitions:
-                    raise DagsterInvariantViolationError(
-                        f"Output {output_def.name} associated a metadata entry ({entry}) with the"
-                        f" partition `{entry.partition}`, which is not one of the declared"
-                        f" partition mappings ({asset_partitions})."
-                    )
-                metadata_mapping[entry.partition].append(entry.entry)
-            else:
-                for partition in metadata_mapping.keys():
-                    metadata_mapping[partition].append(entry)
-
         for partition in asset_partitions:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=DeprecationWarning)
@@ -533,16 +509,10 @@ def _get_output_asset_materializations(
                 yield AssetMaterialization(
                     asset_key=asset_key,
                     partition=partition,
-                    metadata_entries=metadata_mapping[partition],
+                    metadata_entries=all_metadata,
                     tags=tags,
                 )
     else:
-        for entry in all_metadata:
-            if isinstance(entry, PartitionMetadataEntry):
-                raise DagsterInvariantViolationError(
-                    f"Output {output_def.name} got a PartitionMetadataEntry ({entry}), but "
-                    "is not associated with any specific partitions."
-                )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=DeprecationWarning)
 
@@ -614,7 +584,7 @@ def _store_output(
     output_context = step_context.get_output_context(step_output_handle)
 
     manager_materializations = []
-    manager_metadata_entries: List[MetadataEntryUnion] = []
+    manager_metadata_entries: List[MetadataEntry] = []
 
     # output_manager.handle_output is either a generator function, or a normal function with or
     # without a return value. In the case that handle_output is a normal function, we need to
@@ -652,7 +622,7 @@ def _store_output(
             yield elt
         elif isinstance(elt, AssetMaterialization):
             manager_materializations.append(elt)
-        elif isinstance(elt, (MetadataEntry, PartitionMetadataEntry)):
+        elif isinstance(elt, MetadataEntry):
             experimental_functionality_warning(
                 "Yielding metadata from an IOManager's handle_output() function"
             )
@@ -661,7 +631,7 @@ def _store_output(
             raise DagsterInvariantViolationError(
                 f"IO manager on output {output_def.name} has returned "
                 f"value {elt} of type {type(elt).__name__}. The return type can only be "
-                "one of AssetMaterialization, MetadataEntry, PartitionMetadataEntry."
+                "one of AssetMaterialization, MetadataEntry."
             )
 
     for event in output_context.consume_events():

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -20,7 +20,7 @@ import dagster._check as check
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
-    MetadataEntryUnion,
+    MetadataEntry,
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
@@ -422,7 +422,7 @@ class ExternalPipeline(RepresentedPipeline):
         return self._pipeline_index.pipeline_snapshot.tags
 
     @property
-    def metadata(self) -> Sequence[MetadataEntryUnion]:
+    def metadata(self) -> Sequence[MetadataEntry]:
         return self._pipeline_index.pipeline_snapshot.metadata
 
     @property

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -24,7 +24,7 @@ from dagster._config import (
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import (
-    MetadataEntryUnion,
+    MetadataEntry,
 )
 from dagster._core.definitions.pipeline_definition import (
     PipelineDefinition,
@@ -93,7 +93,7 @@ def _pipeline_snapshot_from_storage(
     mode_def_snaps: Sequence[ModeDefSnap],
     lineage_snapshot: Optional["PipelineSnapshotLineage"] = None,
     graph_def_name: Optional[str] = None,
-    metadata: Optional[Sequence[MetadataEntryUnion]] = None,
+    metadata: Optional[Sequence[MetadataEntry]] = None,
     **kwargs,  # pylint: disable=unused-argument
 ) -> "PipelineSnapshot":
     """
@@ -145,7 +145,7 @@ class PipelineSnapshot(
             ("mode_def_snaps", Sequence[ModeDefSnap]),
             ("lineage_snapshot", Optional["PipelineSnapshotLineage"]),
             ("graph_def_name", str),
-            ("metadata", Sequence[MetadataEntryUnion]),
+            ("metadata", Sequence[MetadataEntry]),
         ],
     )
 ):
@@ -161,7 +161,7 @@ class PipelineSnapshot(
         mode_def_snaps: Sequence[ModeDefSnap],
         lineage_snapshot: Optional["PipelineSnapshotLineage"],
         graph_def_name: str,
-        metadata: Optional[Sequence[MetadataEntryUnion]],
+        metadata: Optional[Sequence[MetadataEntry]],
     ):
         return super(PipelineSnapshot, cls).__new__(
             cls,

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -13,7 +13,6 @@ from dagster._core.definitions import (
 )
 from dagster._core.definitions.metadata import (
     MetadataEntry,
-    MetadataEntryUnion,
 )
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import DefaultNamedTupleSerializer
@@ -38,7 +37,7 @@ class InputDefSnap(
             ("name", str),
             ("dagster_type_key", str),
             ("description", Optional[str]),
-            ("metadata_entries", Sequence[MetadataEntryUnion]),
+            ("metadata_entries", Sequence[MetadataEntry]),
         ],
     )
 ):
@@ -47,7 +46,7 @@ class InputDefSnap(
         name: str,
         dagster_type_key: str,
         description: Optional[str],
-        metadata_entries: Optional[Sequence[MetadataEntryUnion]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ):
         return super(InputDefSnap, cls).__new__(
             cls,
@@ -75,7 +74,7 @@ class OutputDefSnap(
             ("dagster_type_key", str),
             ("description", Optional[str]),
             ("is_required", bool),
-            ("metadata_entries", Sequence[MetadataEntryUnion]),
+            ("metadata_entries", Sequence[MetadataEntry]),
             ("is_dynamic", bool),
         ],
     )

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_lineage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_lineage.py
@@ -1,7 +1,7 @@
 import pytest
-from dagster import AssetKey, DynamicOut, DynamicOutput, In, Out, Output, job, op
+from dagster import AssetKey, DynamicOut, DynamicOutput, Out, Output, job, op
 from dagster._core.definitions.events import AssetLineageInfo
-from dagster._core.definitions.metadata import MetadataEntry, PartitionMetadataEntry
+from dagster._core.definitions.metadata import MetadataEntry
 
 
 def n_asset_keys(path, n):
@@ -13,79 +13,6 @@ def check_materialization(materialization, asset_key, parent_assets=None, metada
     assert event_data.materialization.asset_key == asset_key
     assert sorted(event_data.materialization.metadata_entries) == sorted(metadata_entries or [])
     assert event_data.asset_lineage == (parent_assets or [])
-
-
-@pytest.mark.skip(reason="no longer supporting lineage feature")
-def test_input_definition_multiple_partition_lineage():
-    entry1 = MetadataEntry("nrows", value=123)
-    entry2 = MetadataEntry("some value", value=3.21)
-
-    partition_entries = [MetadataEntry("partition count", value=123 * i * i) for i in range(3)]
-
-    @op(
-        out={
-            "output1": Out(
-                asset_key=AssetKey("table1"),
-                asset_partitions=set([str(i) for i in range(3)]),
-            )
-        },
-    )
-    def op1(_):
-        return Output(
-            None,
-            "output1",
-            metadata_entries=[
-                entry1,
-                *[
-                    PartitionMetadataEntry(str(i), entry)
-                    for i, entry in enumerate(partition_entries)
-                ],
-            ],
-        )
-
-    @op(
-        ins={
-            "_input1": In(
-                asset_key=AssetKey("table1"),
-                asset_partitions=set(["0"]),
-            )
-        },
-        out={"output2": Out(asset_key=lambda _: AssetKey("table2"))},
-    )
-    def op2(_, _input1):
-        yield Output(
-            7,
-            "output2",
-            metadata_entries=[entry2],
-        )
-
-    @job
-    def my_job():
-        op2(op1())
-
-    result = my_job.execute_in_process()
-    materializations = result.filter_events(lambda evt: evt.is_step_materialization)
-
-    assert len(materializations) == 4
-
-    seen_partitions = set()
-    for i in range(3):
-        partition = materializations[i].partition
-        seen_partitions.add(partition)
-        check_materialization(
-            materializations[i],
-            AssetKey(["table1"]),
-            metadata_entries=[entry1, partition_entries[int(partition)]],
-        )
-
-    assert len(seen_partitions) == 3
-
-    check_materialization(
-        materializations[-1],
-        AssetKey(["table2"]),
-        parent_assets=[n_asset_keys("table1", 1)],
-        metadata_entries=[entry2],
-    )
 
 
 @pytest.mark.skip(reason="no longer supporting dynamic output asset keys")


### PR DESCRIPTION
### Summary & Motivation

Remove `PartitionMetadataEntry`. Consider this an RFC because I don’t have full context here, but here is my understanding from a study of the code:

- `PartitionMetadataEntry` is an experimental class that was added in the past to support creation of metadata entries qualified by a single partition.
- `PartitionMetadataEntry` is not a top-level export— it’s not part of the public API. Unclear whether this is inadvertent.
- Dagit has no concept of a `PartitionMetadataEntry`.
- `PartitionMetadataEntry` is incompatible with our recommended dictionary-based metadata API, since it does not allow the same metadata label (key in the dict) to be used for multiple partititons.
- `PartitionMetadataEntry` is only used in a single test, which is skipped.
- The only place the codebase has `PartitionMetadataEntry`-specific logic is during the generation of `AssetMaterializations` associated with an output. Here is what happens:
    - Metadata entries yielded from the IO manager’s `handle_output` (this runs before output-derived `AssetMaterializations` are generated) and metadata entries passed on the `Output` object are combined.
    - If any of these are `PartitionMetadataEntries`, they are resolved to plain `MetadataEntries` and stored in a dict that maps partitions to `MetadataEntry`.
    - This table is consulted to obtain the `MetadataEntries` that will be placed on each `AssetMaterialization` to be generated from an `Output`.
    - The only way an output generates multiple `AssetMaterializations` is if the run tags specify a `PartitionKeyRange`. In this case, for each asset-associated-output in the run, one `AssetMaterialization` will be generated for each partition in the range.
    - Therefore in theory one could either (a) yield `PartitionMetadataEntry` events from the IO manager while writing an asset-associated output spanning multiple partititons; (b) return an `Output` object in a materialization function with a number of `PartitionMetadataEntry` objects associated to different partitions of the output.

So, IIUC PartitionMetadataEntry was created to solve the problem of providing individual-partitioned-scoped metadata entries for the case whene a single run materializes multiple asset partitions. But:

It’s unclear to me whether materializing multiple partitions in one run is something we even support now or if it’s an old abandoned API. The [Partitions concept page](https://docs.dagster.io/concepts/partitions-schedules-sensors/partitions#partitioned-asset-jobs) doesn’t appear to mention it.

If my understanding above is right, I propose removing PartitionMetadataEntry. It is incompatible with our recommended metadata API and complicates the docstrings we present to users. In the event we want to allow users to provide individual-partition-scoped metadata on an Output object, we can allow passing a Mapping[str, MetadataDict] on the output. We could introduce a similar API for yielding partition-scoped metadata entries from handle_output, though it’s unclear if that’s even something we want to support.

### How I Tested These Changes

BK
