### PR TITLE
[Asset Details Page] Auto-select partition in materialization dialog.

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -47,12 +47,10 @@ export const DimensionRangeWizard: React.FC<{
 
   const didSetInitialPartition = React.useRef(false);
   React.useEffect(() => {
-    if (didSetInitialPartition.current) {
+    if (didSetInitialPartition.current || !partitionKeys.length) {
       return;
     }
-    if (partitionKeys.length) {
-      didSetInitialPartition.current = true;
-    }
+    didSetInitialPartition.current = true;
     const query = qs.parse(window.location.search, {ignoreQueryPrefix: true});
     const partition = query.partition as string;
     if (partition && partitionKeys.includes(partition)) {

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -9,6 +9,7 @@ import {
   MenuItem,
   TagSelector,
 } from '@dagster-io/ui';
+import qs from 'qs';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
@@ -43,6 +44,22 @@ export const DimensionRangeWizard: React.FC<{
   const isTimeseries = isTimeseriesPartition(partitionKeys[0]);
 
   const [showCreatePartition, setShowCreatePartition] = React.useState(false);
+
+  const didSetInitialPartition = React.useRef(false);
+  React.useEffect(() => {
+    if (didSetInitialPartition.current) {
+      return;
+    }
+    if (partitionKeys.length) {
+      didSetInitialPartition.current = true;
+    }
+    const query = qs.parse(window.location.search, {ignoreQueryPrefix: true});
+    const partition = query.partition as string;
+    if (partition && partitionKeys.includes(partition)) {
+      setSelected([partition]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [partitionKeys]);
 
   return (
     <>


### PR DESCRIPTION
### Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/12420

We rely on the "partition" query string parameter that the asset detail page uses to track the selected partition.

### How I Tested These Changes

Tested this with a statically partitioned and dynamically partitioned asset. 
1. Visit the asset detail page
2. Select a partition
3. Click Materialize
4. See dialog has automatically selected the partition that was selected on the details page.


