### PR TITLE
[Sensor Testing] Add "Test again" button 

### DIFF
--- a/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
@@ -123,9 +123,20 @@ const SensorDryRun: React.FC<Props> = ({repoAddress, name, currentCursor, onClos
   const buttons = React.useMemo(() => {
     if (sensorExecutionData || error) {
       return (
-        <Button intent="primary" onClick={onClose}>
-          Close
-        </Button>
+        <Box flex={{direction: 'row', gap: 8}}>
+          <Button
+            data-testid={testId('test-again')}
+            onClick={() => {
+              setSensorExecutionData(null);
+              setError(null);
+            }}
+          >
+            Test again
+          </Button>
+          <Button intent="primary" onClick={onClose}>
+            Close
+          </Button>
+        </Box>
       );
     }
     if (submitting) {

--- a/js_modules/dagit/packages/core/src/ticks/tests/SensorDryRunDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/tests/SensorDryRunDialog.test.tsx
@@ -73,6 +73,23 @@ describe('SensorDryRunTest', () => {
     });
   });
 
+  it('allows you to test again', async () => {
+    await act(async () => {
+      render(<Test mocks={[SensorDryRunMutationError]} />);
+    });
+    const cursorInput = screen.getByTestId('cursor-input');
+    userEvent.type(cursorInput, 'testing123');
+    userEvent.click(screen.getByTestId('evaluate'));
+    await waitFor(() => {
+      expect(screen.getByText('Failed')).toBeVisible();
+      expect(screen.queryByText('Skipped')).toBe(null);
+    });
+    userEvent.click(screen.getByTestId('test-again'));
+    expect(screen.queryByText('Failed')).toBe(null);
+    expect(screen.queryByText('Skipped')).toBe(null);
+    expect(screen.getByTestId('cursor-input')).toBeVisible();
+  });
+
   it('renders skip reason', async () => {
     await act(async () => {
       render(<Test mocks={[SensorDryRunMutationSkipped]} />);


### PR DESCRIPTION
### Summary & Motivation

We want to allow users to easily test their sensor again without closing the dialog and having to click the test sensor button again. The "test again" button resets the dialog back to its initial state

### How I Tested These Changes

jest