### PR TITLE
Default useful Dagster helm chart features to on

### DIFF
--- a/helm/dagster/templates/helpers/instance/_run-coordinator.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-coordinator.tpl
@@ -4,10 +4,8 @@ module: dagster.core.run_coordinator
 class: QueuedRunCoordinator
 {{- if not (empty (compact (values $queuedRunCoordinatorConfig))) }}
 config:
-  # Workaround to prevent 0 from being interpreted as falsey:
-  # https://github.com/helm/helm/issues/3164#issuecomment-709537506
-  {{- if not (kindIs "invalid" $queuedRunCoordinatorConfig.maxConcurrentRuns) }}
-  max_concurrent_runs: {{ $queuedRunCoordinatorConfig.maxConcurrentRuns }}
+  {{/* Workaround to prevent 0 from being interpreted as falsey: https://github.com/helm/helm/issues/3164#issuecomment-709537506 */}}
+  max_concurrent_runs: {{ if (kindIs "invalid" $queuedRunCoordinatorConfig.maxConcurrentRuns) }}-1{{ else }}{{ $queuedRunCoordinatorConfig.maxConcurrentRuns }}
   {{- end }}
 
   {{- if $queuedRunCoordinatorConfig.tagConcurrencyLimits }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1043,7 +1043,9 @@ dagsterDaemon:
   heartbeatTolerance: 300
 
   runCoordinator:
-    enabled: false
+    # Whether or not to enable the run queue (or some other custom run coordinator). See
+    # https://docs.dagster.io/deployment/run-coordinator for more information.
+    enabled: true
 
     # Type can be one of [
     #   QueuedRunCoordinator,
@@ -1052,11 +1054,21 @@ dagsterDaemon:
     type: QueuedRunCoordinator
     config:
       queuedRunCoordinator:
+        # The maximum number of runs to allow to be running at once. Defaults to no limit.
         maxConcurrentRuns: ~
+        # Tag based concurrency limits. See https://docs.dagster.io/deployment/run-coordinator#usage
+        # for examples.
         tagConcurrencyLimits: []
+        # How frequently in seconds to check for new runs to pull from the queue and launch.
+        # Defaults to 5.
         dequeueIntervalSeconds: ~
-        dequeueUseThreads: ~
-        dequeueNumWorkers: ~
+        # Whether to dequeue runs using an asynchronous thread pool, allowing multiple runs
+        # to be dequeued in parallel.
+        dequeueUseThreads: true
+        # The max number of worker threads to use when dequeing runs. Can be tuned
+        # to allow more runs to be dequeued in parallel, but may require allocating more
+        # resources to the daemon.
+        dequeueNumWorkers: 4
 
     ##  Uncomment this configuration if the CustomRunCoordinator is selected.
     ##  Using this setting requires a custom Daemon image that defines the user specified
@@ -1082,22 +1094,26 @@ dagsterDaemon:
     maxResumeRunAttempts: ~
 
   runRetries:
-    enabled: false
+    enabled: true
     maxRetries: 0
 
   sensors:
-    # Whether to evaluate sensors using an asynchronous thread pool.  Defaults to false
-    useThreads: false
-    # The max number of worker threads to use when asynchronously evaluating sensors. Will use the
-    # default value used by Python, which depends on the number of cores available.
-    numWorkers: ~
+    # Whether to evaluate sensors using an asynchronous thread pool, allowing sensprs
+    # to execute in parallel,
+    useThreads: true
+    # The max number of worker threads to use when evaluating sensors. Can be tuned
+    # to allow more sensors to run in parallel, but may require allocating more resources to the
+    # daemon.
+    numWorkers: 4
 
   schedules:
-    # Whether to evaluate schedules using an asynchronous thread pool.  Defaults to false
-    useThreads: false
-    # The max number of worker threads to use when asynchronously evaluating sensors. Will use the
-    # default value used by Python, which depends on the number of cores available.
-    numWorkers: ~
+    # Whether to evaluate schedules using an asynchronous thread pool, allowing schedules
+    # to execute in parallel
+    useThreads: true
+    # The max number of worker threads to use when evaluating sensors. Can be tuned
+    # to allow more schedules to run in parallel, but may require allocating more resources to the
+    # daemon.
+    numWorkers: 4
 
   # Additional environment variables to set.
   # These will be directly applied to the daemon container. See


### PR DESCRIPTION
Summary:
Right now you have to look into all these nooks and crannies in the Helm chart to enable a bunch of useful Dagster features. This PR enables them by default.

- Run queue is now enabled (but with no fixed limit on the max number of runs to start)
- Run retries are on (but still set to default) - so you can set the tags in code by default
- Sensor/schedule/run queue threading are on by default.

Test Plan: Helm schema tests

### Summary & Motivation

### How I Tested These Changes
