### PR TITLE
[db io managers] refactor tests to test table creation

### DIFF
--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -24,7 +24,8 @@ from dagster import (
 from dagster_gcp_pandas import bigquery_pandas_io_manager
 from google.cloud import bigquery
 
-IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+# IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+IS_BUILDKITE = False
 
 SHARED_BUILDKITE_BQ_CONFIG = {
     "project": os.getenv("GCP_PROJECT_ID"),
@@ -38,11 +39,13 @@ def temporary_bigquery_table(schema_name: str) -> Iterator[str]:
     )
     table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
     try:
+        print(f"THE TABLE NAME IS {table_name}")
         yield table_name
     finally:
-        bq_client.query(
-            f"drop table {SHARED_BUILDKITE_BQ_CONFIG['project']}.{schema_name}.{table_name}"
-        ).result()
+        # bq_client.query(
+        #     f"drop table {SHARED_BUILDKITE_BQ_CONFIG['project']}.{schema_name}.{table_name}"
+        # ).result()
+        pass
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
@@ -93,8 +96,8 @@ def test_io_manager_with_bigquery_pandas():
         assert res.success
 
 
-@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
-def test_io_manager_with_snowflake_pandas_timestamp_data():
+# @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
+def test_io_manager_with_pandas_timestamp_data():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
@@ -115,6 +118,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
 
         @op
         def read_time_df(df: pd.DataFrame):
+            print(df)
             assert set(df.columns) == {"foo", "date"}
             assert (df["date"] == time_df["date"].dt.tz_localize("UTC")).all()
 

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -111,7 +111,6 @@ def test_io_manager_with_timestamp_conversion():
 
         @op
         def read_time_df(df: pd.DataFrame):
-            print(df)
             assert set(df.columns) == {"foo", "date"}
             assert (df["date"] == time_df["date"]).all()
 

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -32,12 +32,11 @@ SHARED_BUILDKITE_BQ_CONFIG = {
 
 
 @contextmanager
-def temporary_bigquery_table(schema_name: str, column_str: str) -> Iterator[str]:
+def temporary_bigquery_table(schema_name: str) -> Iterator[str]:
     bq_client = bigquery.Client(
         project=SHARED_BUILDKITE_BQ_CONFIG["project"],
     )
     table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
-    bq_client.query(f"create table {schema_name}.{table_name} ({column_str})").result()
     try:
         yield table_name
     finally:
@@ -51,7 +50,6 @@ def test_io_manager_with_bigquery_pandas():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="FOO string, QUUX int",
     ) as table_name:
         # Create a job with the temporary table name as an output, so that it will write to that table
         # and not interfere with other runs of this test
@@ -100,7 +98,6 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="FOO string, DATE TIMESTAMP",
     ) as table_name:
         time_df = pd.DataFrame(
             {
@@ -145,7 +142,6 @@ def test_time_window_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="TIME TIMESTAMP, A string, B int",
     ) as table_name:
         partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
@@ -227,7 +223,6 @@ def test_static_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str=" COLOR string, A string, B int",
     ) as table_name:
         partitions_def = StaticPartitionsDefinition(["red", "yellow", "blue"])
 
@@ -307,7 +302,6 @@ def test_multi_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str=" COLOR string, TIME TIMESTAMP, A string",
     ) as table_name:
         partitions_def = MultiPartitionsDefinition(
             {
@@ -407,7 +401,6 @@ def test_dynamic_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str=" FRUIT string, A string",
     ) as table_name:
         dynamic_fruits = DynamicPartitionsDefinition(name="dynamic_fruits")
 

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -48,7 +48,7 @@ def temporary_bigquery_table(schema_name: Optional[str]) -> Iterator[str]:
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_io_manager_with_bigquery_pandas():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
-    with temporary_bigquery_table(schema=schema) as table_name:
+    with temporary_bigquery_table(schema_name=schema) as table_name:
         # Create a job with the temporary table name as an output, so that it will write to that table
         # and not interfere with other runs of this test
 
@@ -94,7 +94,7 @@ def test_io_manager_with_bigquery_pandas():
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_io_manager_with_timestamp_conversion():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
-    with temporary_bigquery_table(schema=schema) as table_name:
+    with temporary_bigquery_table(schema_name=schema) as table_name:
         time_df = pd.DataFrame(
             {
                 "foo": ["bar", "baz"],
@@ -137,7 +137,7 @@ def test_io_manager_with_timestamp_conversion():
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_time_window_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
-    with temporary_bigquery_table(schema=schema) as table_name:
+    with temporary_bigquery_table(schema_name=schema) as table_name:
         partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
         @asset(
@@ -216,7 +216,7 @@ def test_time_window_partitioned_asset():
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_static_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
-    with temporary_bigquery_table(schema=schema) as table_name:
+    with temporary_bigquery_table(schema_name=schema) as table_name:
         partitions_def = StaticPartitionsDefinition(["red", "yellow", "blue"])
 
         @asset(
@@ -293,7 +293,7 @@ def test_static_partitioned_asset():
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_multi_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
-    with temporary_bigquery_table(schema=schema) as table_name:
+    with temporary_bigquery_table(schema_name=schema) as table_name:
         partitions_def = MultiPartitionsDefinition(
             {
                 "time": DailyPartitionsDefinition(start_date="2022-01-01"),
@@ -390,7 +390,7 @@ def test_multi_partitioned_asset():
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 def test_dynamic_partitioned_asset():
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
-    with temporary_bigquery_table(schema=schema) as table_name:
+    with temporary_bigquery_table(schema_name=schema) as table_name:
         dynamic_fruits = DynamicPartitionsDefinition(name="dynamic_fruits")
 
         @asset(

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -52,12 +52,11 @@ SHARED_BUILDKITE_BQ_CONFIG = {
 
 
 @contextmanager
-def temporary_bigquery_table(schema_name: str, column_str: str) -> Iterator[str]:
+def temporary_bigquery_table(schema_name: str) -> Iterator[str]:
     bq_client = bigquery.Client(
         project=SHARED_BUILDKITE_BQ_CONFIG["project"],
     )
     table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
-    bq_client.query(f"create table {schema_name}.{table_name} ({column_str})").result()
     try:
         print(table_name)
         yield table_name
@@ -135,7 +134,6 @@ def test_io_manager_with_bigquery_pyspark(spark):
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="FOO string, QUUX int",
     ) as table_name:
         # Create a job with the temporary table name as an output, so that it will write to that table
         # and not interfere with other runs of this test
@@ -171,7 +169,6 @@ def test_time_window_partitioned_asset(spark):
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="RAW_TIME string, A string, B int, TIME DATE",
     ) as table_name:
         partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
@@ -261,7 +258,6 @@ def test_static_partitioned_asset(spark):
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="COLOR string, A string, B int",
     ) as table_name:
         partitions_def = StaticPartitionsDefinition(["red", "yellow", "blue"])
 
@@ -345,7 +341,6 @@ def test_multi_partitioned_asset(spark):
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="COLOR string, RAW_TIME string, A string, TIME DATE",
     ) as table_name:
         partitions_def = MultiPartitionsDefinition(
             {
@@ -452,7 +447,6 @@ def test_dynamic_partitions(spark):
     schema = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(
         schema_name=schema,
-        column_str="FRUIT string, A string",
     ) as table_name:
         dynamic_fruits = DynamicPartitionsDefinition(name="dynamic_fruits")
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -57,13 +57,12 @@ SHARED_BUILDKITE_SNOWFLAKE_CONF = {
 
 
 @contextmanager
-def temporary_snowflake_table(schema_name: str, db_name: str, column_str: str) -> Iterator[str]:
+def temporary_snowflake_table(schema_name: str, db_name: str) -> Iterator[str]:
     snowflake_config = dict(database=db_name, **SHARED_BUILDKITE_SNOWFLAKE_CONF)
     table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
     with SnowflakeConnection(
         snowflake_config, logging.getLogger("temporary_snowflake_table")
     ).get_connection() as conn:
-        conn.cursor().execute(f"create table {schema_name}.{table_name} ({column_str})")
         try:
             yield table_name
         finally:
@@ -159,7 +158,6 @@ def test_io_manager_with_snowflake_pandas():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="foo string, quux integer",
     ) as table_name:
         # Create a job with the temporary table name as an output, so that it will write to that table
         # and not interfere with other runs of this test
@@ -204,7 +202,6 @@ def test_io_manager_with_snowflake_pandas_timestamp_data():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="foo string, date TIMESTAMP_NTZ(9)",
     ) as table_name:
         time_df = pandas.DataFrame(
             {
@@ -256,7 +253,6 @@ def test_time_window_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="TIME TIMESTAMP_NTZ(9), A string, B int",
     ) as table_name:
         partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
@@ -345,7 +341,6 @@ def test_static_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str=" COLOR string, A string, B int",
     ) as table_name:
         partitions_def = StaticPartitionsDefinition(["red", "yellow", "blue"])
 
@@ -432,7 +427,6 @@ def test_multi_partitioned_asset():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str=" COLOR string, TIME TIMESTAMP_NTZ(9), A string",
     ) as table_name:
         partitions_def = MultiPartitionsDefinition(
             {
@@ -537,7 +531,6 @@ def test_dynamic_partitions():
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str=" FRUIT string, A string",
     ) as table_name:
         dynamic_fruits = DynamicPartitionsDefinition(name="dynamic_fruits")
 

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -55,13 +55,12 @@ SHARED_BUILDKITE_SNOWFLAKE_CONF = {
 
 
 @contextmanager
-def temporary_snowflake_table(schema_name: str, db_name: str, column_str: str) -> Iterator[str]:
+def temporary_snowflake_table(schema_name: str, db_name: str) -> Iterator[str]:
     snowflake_config = dict(database=db_name, **SHARED_BUILDKITE_SNOWFLAKE_CONF)
     table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
     with SnowflakeConnection(
         snowflake_config, logging.getLogger("temporary_snowflake_table")
     ).get_connection() as conn:
-        conn.cursor().execute(f"create table {schema_name}.{table_name} ({column_str})")
         try:
             yield table_name
         finally:
@@ -135,7 +134,6 @@ def test_io_manager_with_snowflake_pyspark(spark):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="foo string, quux integer",
     ) as table_name:
         # Create a job with the temporary table name as an output, so that it will write to that table
         # and not interfere with other runs of this test
@@ -177,7 +175,6 @@ def test_time_window_partitioned_asset(spark):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="RAW_TIME string, A string, B int, TIME DATE",
     ) as table_name:
         partitions_def = DailyPartitionsDefinition(start_date="2022-01-01")
 
@@ -275,7 +272,6 @@ def test_static_partitioned_asset(spark):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="COLOR string, A string, B int",
     ) as table_name:
         partitions_def = StaticPartitionsDefinition(["red", "yellow", "blue"])
 
@@ -366,7 +362,6 @@ def test_multi_partitioned_asset(spark):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str="COLOR string, RAW_TIME string, A string, TIME DATE",
     ) as table_name:
         partitions_def = MultiPartitionsDefinition(
             {
@@ -481,7 +476,6 @@ def test_dynamic_partitions(spark):
     with temporary_snowflake_table(
         schema_name="SNOWFLAKE_IO_MANAGER_SCHEMA",
         db_name="TEST_SNOWFLAKE_IO_MANAGER",
-        column_str=" FRUIT string, A string",
     ) as table_name:
         dynamic_fruits = DynamicPartitionsDefinition(name="dynamic_fruits")
 


### PR DESCRIPTION
### Summary & Motivation
Right now we create a temporary table to store the assets made in tests. This means that we don't test the code path in the io manger that creates the table. This pr removes the creation of the table so that we test this code path, but still returns a generated table name so that we can delete the table after the test is done

### How I Tested These Changes
