### PR TITLE
[Launchpad] Allow adding new dynamic partition from launchpad UI

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -580,6 +580,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
                 onSelectPreset={onSelectPreset}
                 onSelectPartition={onSelectPartition}
                 repoAddress={repoAddress}
+                assetSelection={currentSession.assetSelection}
               />
               <SessionSettingsSpacer />
               {launchpadType === 'asset' ? (

--- a/js_modules/dagit/packages/core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
@@ -5,6 +5,7 @@ import * as Types from '../../graphql/types';
 export type ConfigPartitionsQueryVariables = Types.Exact<{
   repositorySelector: Types.RepositorySelector;
   partitionSetName: Types.Scalars['String'];
+  assetKeys?: Types.InputMaybe<Array<Types.AssetKeyInput> | Types.AssetKeyInput>;
 }>;
 
 export type ConfigPartitionsQuery = {
@@ -28,6 +29,15 @@ export type ConfigPartitionsQuery = {
       }
     | {__typename: 'PartitionSetNotFoundError'}
     | {__typename: 'PythonError'};
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    id: string;
+    partitionDefinition: {
+      __typename: 'PartitionDefinition';
+      name: string | null;
+      type: Types.PartitionDefinitionType;
+    } | null;
+  }>;
 };
 
 export type ConfigPartitionResultFragment = {__typename: 'Partition'; name: string};

--- a/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
@@ -71,16 +71,14 @@ export const CreatePartitionDialog = ({
   close,
   repoAddress,
   refetch,
-  selected,
-  setSelected,
+  onCreated,
 }: {
   isOpen: boolean;
   partitionDefinitionName?: string | null;
   close: () => void;
   repoAddress: RepoAddress;
   refetch?: () => Promise<void>;
-  selected: string[];
-  setSelected: (selected: string[]) => void;
+  onCreated: (partitionName: string) => void;
 }) => {
   const [partitionName, setPartitionName] = React.useState('');
 
@@ -156,7 +154,7 @@ export const CreatePartitionDialog = ({
       }
       case 'AddDynamicPartitionSuccess': {
         refetch?.();
-        setSelected([...selected, partitionName]);
+        onCreated(partitionName);
         close();
         invalidatePartitions();
         break;

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -120,8 +120,9 @@ export const DimensionRangeWizard: React.FC<{
             setShowCreatePartition(false);
           }}
           refetch={refetch}
-          selected={selected}
-          setSelected={setSelected}
+          onCreated={(partitionName) => {
+            setSelected([...selected, partitionName]);
+          }}
         />
       )}
     </>

--- a/js_modules/dagit/packages/core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
@@ -7,7 +7,7 @@ import {CreatePartitionDialog} from '../CreatePartitionDialog';
 import {buildCreatePartitionFixture} from '../__fixtures__/CreatePartitionDialog.fixture';
 
 let onCloseMock = jest.fn();
-let onSelectedMock = jest.fn();
+let onCreatedMock = jest.fn();
 
 function Test({mocks}: {mocks?: MockedResponse[]}) {
   return (
@@ -20,8 +20,7 @@ function Test({mocks}: {mocks?: MockedResponse[]}) {
           location: 'testing',
         }}
         partitionDefinitionName="testPartitionDef"
-        selected={['test1']}
-        setSelected={onSelectedMock}
+        onCreated={onCreatedMock}
       />
     </MockedProvider>
   );
@@ -30,7 +29,7 @@ function Test({mocks}: {mocks?: MockedResponse[]}) {
 describe('CreatePartitionDialog', () => {
   beforeEach(() => {
     onCloseMock = jest.fn();
-    onSelectedMock = jest.fn();
+    onCreatedMock = jest.fn();
   });
 
   it('Submits mutation with correct variables and calls setSelected and onClose', async () => {
@@ -46,7 +45,7 @@ describe('CreatePartitionDialog', () => {
     userEvent.click(screen.getByTestId('save-partition-button'));
     await waitFor(() => {
       expect(onCloseMock).toHaveBeenCalled();
-      expect(onSelectedMock).toHaveBeenCalledWith(['test1', 'testPartitionName']);
+      expect(onCreatedMock).toHaveBeenCalledWith('testPartitionName');
       expect(createFixture.result).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
### Summary & Motivation

From the Launchpad we want to allow you to add new partitions if you're viewing a dynamically partitioned asset.

Resolves https://github.com/dagster-io/dagster/issues/12743

### How I Tested These Changes

Added a new partition from the UI.

![Screen Shot 2023-03-06 at 5 02 50 PM](https://user-images.githubusercontent.com/2286579/223245571-66324e18-74b1-44a8-8da7-bcb3d3411c50.png)

