### PR TITLE
cron_schedule validation for time window partitions

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -4,6 +4,7 @@ from typing import cast
 import pendulum.parser
 import pytest
 from dagster import (
+    DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition,
@@ -778,3 +779,13 @@ def test_get_first_partition_window():
     ) == time_window(
         "2023-01-01", "2023-02-01"
     )
+
+
+def test_invalid_cron_schedule():
+    # creating a new partition definition with an invalid cron schedule should raise an error
+    with pytest.raises(DagsterInvalidDefinitionError):
+        TimeWindowPartitionsDefinition(
+            start=pendulum.parse("2021-05-05"),
+            cron_schedule="0 -24 * * *",
+            fmt=DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE,
+        )


### PR DESCRIPTION
### Summary & Motivation
Saw some 500s where an invalid cron schedule bubbled up when generating some asset event metadata.

We have to have some `_legacy` validation flag, so that we can decouple the dagster user code version from the dagster host cloud version.

### How I Tested These Changes
BK