### PR TITLE
Set default memory/CPU for new ECS tasks based on runtime platform

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -53,6 +53,10 @@ RUNNING_STATUSES = [
 ]
 STOPPED_STATUSES = ["STOPPED"]
 
+DEFAULT_WINDOWS_RESOURCES = {"cpu": "1024", "memory": "2048"}
+
+DEFAULT_LINUX_RESOURCES = {"cpu": "256", "memory": "512"}
+
 
 class EcsRunLauncher(RunLauncher, ConfigurableClass):
     """RunLauncher that starts a task in ECS for each Dagster job run."""
@@ -505,6 +509,14 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
             family = self._get_run_task_definition_family(run)
 
             if self.task_definition_dict:
+                runtime_platform = container_context.runtime_platform
+                is_windows = container_context.runtime_platform.get(
+                    "operatingSystemFamily"
+                ) not in {None, "LINUX"}
+
+                default_resources = (
+                    DEFAULT_WINDOWS_RESOURCES if is_windows else DEFAULT_LINUX_RESOURCES
+                )
                 task_definition_config = DagsterEcsTaskDefinitionConfig(
                     family,
                     image,
@@ -530,7 +542,11 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     requires_compatibilities=self.task_definition_dict.get(
                         "requires_compatibilities", []
                     ),
-                    runtime_platform=container_context.runtime_platform,
+                    cpu=container_context.run_resources.get("cpu", default_resources["cpu"]),
+                    memory=container_context.run_resources.get(
+                        "memory", default_resources["memory"]
+                    ),
+                    runtime_platform=runtime_platform,
                 )
                 task_definition_dict = task_definition_config.task_definition_dict()
             else:
@@ -545,6 +561,8 @@ class EcsRunLauncher(RunLauncher, ConfigurableClass):
                     include_sidecars=self.include_sidecars,
                     task_role_arn=container_context.task_role_arn,
                     execution_role_arn=container_context.execution_role_arn,
+                    cpu=container_context.run_resources.get("cpu"),
+                    memory=container_context.run_resources.get("memory"),
                     runtime_platform=container_context.runtime_platform,
                 )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -169,6 +169,8 @@ def get_task_definition_dict_from_current_task(
     task_role_arn=None,
     execution_role_arn=None,
     runtime_platform=None,
+    cpu=None,
+    memory=None,
 ):
     current_container_name = current_ecs_container_name()
 
@@ -236,6 +238,8 @@ def get_task_definition_dict_from_current_task(
         **({"taskRoleArn": task_role_arn} if task_role_arn else {}),
         **({"executionRoleArn": execution_role_arn} if execution_role_arn else {}),
         **({"runtimePlatform": runtime_platform} if runtime_platform else {}),
+        **({"cpu": cpu} if cpu else {}),
+        **({"memory": memory} if memory else {}),
     }
 
     return task_definition

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -14,7 +14,12 @@ from dagster._core.launcher import LaunchRunContext
 from dagster._core.launcher.base import WorkerStatus
 from dagster._core.origin import PipelinePythonOrigin, RepositoryPythonOrigin
 from dagster_aws.ecs import EcsEventualConsistencyTimeout
-from dagster_aws.ecs.launcher import RUNNING_STATUSES, STOPPED_STATUSES
+from dagster_aws.ecs.launcher import (
+    DEFAULT_LINUX_RESOURCES,
+    DEFAULT_WINDOWS_RESOURCES,
+    RUNNING_STATUSES,
+    STOPPED_STATUSES,
+)
 from dagster_aws.ecs.tasks import DagsterEcsTaskDefinitionConfig
 
 
@@ -469,6 +474,111 @@ def test_reuse_task_definition(instance, ecs):
     )
 
 
+def test_default_task_definition_resources(
+    ecs, instance_cm, run, workspace, pipeline, external_pipeline
+):
+    task_role_arn = "fake-task-role"
+    execution_role_arn = "fake-execution-role"
+    with instance_cm(
+        {
+            "task_definition": {
+                "task_role_arn": task_role_arn,
+                "execution_role_arn": execution_role_arn,
+            },
+        }
+    ) as instance:
+        run = instance.create_run_for_pipeline(
+            pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        initial_tasks = ecs.list_tasks()["taskArns"]
+
+        instance.launch_run(run.run_id, workspace)
+
+        tasks = ecs.list_tasks()["taskArns"]
+        task_arn = list(set(tasks).difference(initial_tasks))[0]
+
+        task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+
+        task_definition_arn = task["taskDefinitionArn"]
+
+        task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)[
+            "taskDefinition"
+        ]
+
+        # Since this is not a windows task def, the default cpu/memory are 256/512
+        assert task_definition["cpu"] == DEFAULT_LINUX_RESOURCES["cpu"]
+        assert task_definition["memory"] == DEFAULT_LINUX_RESOURCES["memory"]
+
+    # But a windows task def has different defaults that are valid for window
+    with instance_cm(
+        {
+            "task_definition": {
+                "task_role_arn": task_role_arn,
+                "execution_role_arn": execution_role_arn,
+                "runtime_platform": {"operatingSystemFamily": "WINDOWS_SERVER_2019_FULL"},
+            },
+        }
+    ) as instance:
+        run = instance.create_run_for_pipeline(
+            pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        initial_tasks = ecs.list_tasks()["taskArns"]
+
+        instance.launch_run(run.run_id, workspace)
+
+        tasks = ecs.list_tasks()["taskArns"]
+        task_arn = list(set(tasks).difference(initial_tasks))[0]
+
+        task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+
+        task_definition_arn = task["taskDefinitionArn"]
+
+        task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)[
+            "taskDefinition"
+        ]
+
+        # Default cpu/memory is higher on windows
+        assert task_definition["cpu"] == DEFAULT_WINDOWS_RESOURCES["cpu"]
+        assert task_definition["memory"] == DEFAULT_WINDOWS_RESOURCES["memory"]
+
+    # Setting resources on the run launcher ignores the defaults
+    with instance_cm(
+        {
+            "task_definition": {
+                "task_role_arn": task_role_arn,
+                "execution_role_arn": execution_role_arn,
+            },
+            "run_resources": {"cpu": "2048", "memory": "4096"},
+        }
+    ) as instance:
+        run = instance.create_run_for_pipeline(
+            pipeline,
+            external_pipeline_origin=external_pipeline.get_external_origin(),
+            pipeline_code_origin=external_pipeline.get_python_origin(),
+        )
+        initial_tasks = ecs.list_tasks()["taskArns"]
+
+        instance.launch_run(run.run_id, workspace)
+
+        tasks = ecs.list_tasks()["taskArns"]
+        task_arn = list(set(tasks).difference(initial_tasks))[0]
+
+        task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+
+        task_definition_arn = task["taskDefinitionArn"]
+
+        task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)[
+            "taskDefinition"
+        ]
+
+        assert task_definition["cpu"] == "2048"
+        assert task_definition["memory"] == "4096"
+
+
 def test_launching_with_task_definition_dict(
     ecs, instance_cm, run, workspace, pipeline, external_pipeline
 ):
@@ -734,6 +844,8 @@ def test_launch_run_with_container_context(
         task_definition["executionRoleArn"] == container_context_config["ecs"]["execution_role_arn"]
     )
     assert task_definition["runtimePlatform"] == container_context_config["ecs"]["runtime_platform"]
+    assert task_definition["cpu"] == container_context_config["ecs"]["run_resources"]["cpu"]
+    assert task_definition["memory"] == container_context_config["ecs"]["run_resources"]["memory"]
 
 
 def test_memory_and_cpu(ecs, instance, workspace, run, task_definition):


### PR DESCRIPTION
Summary:
Windows task definitions need to be registered with at least 1024 CPU and 2048 memory, even if the cpu/memory are going to be later overridden by a task override / container override. Instead of hard-coding 256/512 for all tasks, check the runtime platform and change the default CPU/memory accordingly.

Additionally, if run_resources have been explicitly set, send those in as the task definition CPU/memory (This is harmless and is another fix for the problem above - it also probably makes it easier to understand what the actual resource limits are if you're inspecting the task).

### Summary & Motivation

### How I Tested These Changes
