### PR TITLE
remove MetadataEntry APIs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -26,7 +26,6 @@ from dagster._serdes.serdes import NamedTupleSerializer
 from dagster._utils.backcompat import experimental_class_param_warning
 
 from .metadata import (
-    MetadataEntry,
     MetadataFieldSerializer,
     MetadataMapping,
     MetadataValue,
@@ -234,9 +233,6 @@ class Output(Generic[T]):
         value (Any): The value returned by the compute function.
         output_name (Optional[str]): Name of the corresponding out. (default:
             "result")
-        metadata_entries (Optional[MetadataEntry]):
-            (Deprecated) A set of metadata entries to attach to events related to this Output. Use
-            `metadata` instead.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -249,7 +245,6 @@ class Output(Generic[T]):
         self,
         value: T,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         data_version: Optional[DataVersion] = None,
     ):
@@ -260,7 +255,6 @@ class Output(Generic[T]):
         self._data_version = check.opt_inst_param(data_version, "data_version", DataVersion)
         self._metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
-            check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
         )
 
     @property
@@ -309,9 +303,6 @@ class DynamicOutput(Generic[T]):
         output_name (Optional[str]):
             Name of the corresponding :py:class:`DynamicOut` defined on the op.
             (default: "result")
-        metadata_entries (Optional[MetadataEntry]):
-            (Deprecated) A set of metadata entries to attach to events related to this Output. Use
-            `metadata` instead.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -323,7 +314,6 @@ class DynamicOutput(Generic[T]):
         value: T,
         mapping_key: str,
         output_name: Optional[str] = DEFAULT_OUTPUT,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
         self._mapping_key = check_valid_name(check.str_param(mapping_key, "mapping_key"))
@@ -331,7 +321,6 @@ class DynamicOutput(Generic[T]):
         self._value = value
         self._metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
-            check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
         )
 
     @property
@@ -363,21 +352,6 @@ class DynamicOutput(Generic[T]):
         )
 
 
-# This is a temporary function to consolidate metadata normalization logic on event classes where
-# we've had to mangle the signature for backcompat reasons. Can be deleted when we remove
-# `metadata_entries`/`MetadataEntry`.
-def _normalize_event_metadata(
-    metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
-    metadata_entries: Optional[Sequence[MetadataEntry]] = None,
-) -> MetadataMapping:
-    metadata_dict = metadata if isinstance(metadata, dict) else {}
-    metadata_entries = metadata if isinstance(metadata, list) else metadata_entries
-    return normalize_metadata(
-        check.opt_mapping_param(metadata_dict, "metadata_dict", key_type=str),
-        check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
-    )
-
-
 @whitelist_for_serdes(
     storage_field_names={"metadata": "metadata_entries"},
     field_serializers={"metadata": MetadataFieldSerializer},
@@ -398,8 +372,6 @@ class AssetObservation(
 
     Args:
         asset_key (Union[str, List[str], AssetKey]): A key to identify the asset.
-        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
-            asset. Use `metadata` instead.
         partition (Optional[str]): The name of a partition of the asset that the metadata
             corresponds to.
         tags (Optional[Mapping[str, str]]): A mapping containing system-populated tags for the
@@ -414,10 +386,9 @@ class AssetObservation(
         cls,
         asset_key: CoercibleToAssetKey,
         description: Optional[str] = None,
-        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ):
         if isinstance(asset_key, AssetKey):
             check.inst_param(asset_key, "asset_key", AssetKey)
@@ -434,7 +405,9 @@ class AssetObservation(
                 "The tags argument is reserved for system-populated tags."
             )
 
-        metadata = _normalize_event_metadata(metadata, metadata_entries)
+        metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+        )
 
         return super(AssetObservation, cls).__new__(
             cls,
@@ -497,8 +470,6 @@ class AssetMaterialization(
         asset_key (Union[str, List[str], AssetKey]): A key to identify the materialized asset across
             job runs
         description (Optional[str]): A longer human-readable description of the materialized value.
-        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary
-            metadata about the materialized value. Use `metadata` instead.
         partition (Optional[str]): The name of the partition
             that was materialized.
         tags (Optional[Mapping[str, str]]): A mapping containing system-populated tags for the
@@ -513,10 +484,9 @@ class AssetMaterialization(
         cls,
         asset_key: CoercibleToAssetKey,
         description: Optional[str] = None,
-        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ):
         from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 
@@ -536,7 +506,9 @@ class AssetMaterialization(
                 " AssetMaterializations. The tags argument is reserved for system-populated tags."
             )
 
-        metadata = _normalize_event_metadata(metadata, metadata_entries)
+        metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+        )
 
         partition = check.opt_str_param(partition, "partition")
 
@@ -612,8 +584,6 @@ class ExpectationResult(
         success (bool): Whether the expectation passed or not.
         label (Optional[str]): Short display name for expectation. Defaults to "result".
         description (Optional[str]): A longer human-readable description of the expectation.
-        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
-            expectation. Use `metadata` instead.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -625,10 +595,11 @@ class ExpectationResult(
         success: bool,
         label: Optional[str] = None,
         description: Optional[str] = None,
-        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
-        metadata = _normalize_event_metadata(metadata, metadata_entries)
+        metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+        )
 
         return super(ExpectationResult, cls).__new__(
             cls,
@@ -666,8 +637,6 @@ class TypeCheck(
     Args:
         success (bool): ``True`` if the type check succeeded, ``False`` otherwise.
         description (Optional[str]): A human-readable description of the type check.
-        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
-            type check. Use `metadata` instead.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -678,10 +647,11 @@ class TypeCheck(
         cls,
         success: bool,
         description: Optional[str] = None,
-        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
-        metadata = _normalize_event_metadata(metadata, metadata_entries)
+        metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+        )
 
         return super(TypeCheck, cls).__new__(
             cls,
@@ -700,8 +670,6 @@ class Failure(Exception):
 
     Args:
         description (Optional[str]): A human-readable description of the failure.
-        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
-            failure. Use `metadata` instead.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -714,7 +682,6 @@ class Failure(Exception):
     def __init__(
         self,
         description: Optional[str] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         allow_retries: Optional[bool] = None,
     ):
@@ -722,7 +689,6 @@ class Failure(Exception):
         self.description = check.opt_str_param(description, "description")
         self.metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
-            check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
         )
         self.allow_retries = check.opt_bool_param(allow_retries, "allow_retries", True)
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -19,7 +19,7 @@ from typing_extensions import Self, TypeAlias, TypeVar
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import PublicAttr, experimental, public
+from dagster._annotations import PublicAttr, deprecated, experimental, public
 from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import (
@@ -72,26 +72,8 @@ T_Packable = TypeVar("T_Packable", bound=PackableValue, default=PackableValue, c
 
 def normalize_metadata(
     metadata: Mapping[str, RawMetadataValue],
-    metadata_entries: Optional[Sequence["MetadataEntry"]] = None,
     allow_invalid: bool = False,
 ) -> Mapping[str, "MetadataValue"]:
-    if metadata and metadata_entries:
-        raise DagsterInvalidMetadata(
-            "Attempted to provide both `metadata` and `metadata_entries` arguments to an event. "
-            "Must provide only one of the two."
-        )
-    elif metadata_entries:
-        deprecation_warning(
-            'Argument "metadata_entries"',
-            "1.0.0",
-            additional_warn_txt=(
-                "Use argument `metadata` instead. The `MetadataEntry` `description` attribute is"
-                " also deprecated-- argument `metadata` takes a label: value dictionary."
-            ),
-            stacklevel=4,  # to get the caller of `normalize_metadata`
-        )
-        return {entry.label: entry.value for entry in metadata_entries}
-
     # This is a stopgap measure to deal with unsupported metadata values, which occur when we try
     # to convert arbitrary metadata (on e.g. OutputDefinition) to a MetadataValue, which is required
     # for serialization. This will cause unsupported values to be silently replaced with a
@@ -149,10 +131,6 @@ def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue[Any]
         f"Its type was {type(raw_value)}. Consider wrapping the value with the appropriate "
         "MetadataValue type."
     )
-
-
-def to_metadata_entries(metadata: Mapping[str, "MetadataValue"]) -> Sequence["MetadataEntry"]:
-    return [MetadataEntry(k, value=v) for k, v in metadata.items()]
 
 
 # ########################
@@ -931,8 +909,12 @@ class NullMetadataValue(NamedTuple("_NullMetadataValue", []), MetadataValue[None
 
 
 # ########################
-# ##### METADATA ENTRY
+# ##### METADATA BACKCOMPAT
 # ########################
+
+# Metadata used to be represented as a `List[MetadataEntry]`, but that class has been deleted. But
+# we still serialize metadata dicts to the serialized representation of `List[MetadataEntry]` for
+# backcompat purposes.
 
 
 class MetadataFieldSerializer(FieldSerializer):
@@ -974,6 +956,7 @@ T_MetadataValue = TypeVar("T_MetadataValue", bound=MetadataValue, covariant=True
 # NOTE: This currently stores value in the `entry_data` NamedTuple attribute. In the next release,
 # we will change the name of the NamedTuple property to `value`, and need to implement custom
 # serialization so that it continues to be saved as `entry_data` for backcompat purposes.
+@deprecated
 @whitelist_for_serdes(storage_name="EventMetadataEntry")
 class MetadataEntry(
     NamedTuple(
@@ -986,7 +969,9 @@ class MetadataEntry(
     ),
     Generic[T_MetadataValue],
 ):
-    """The standard structure for describing metadata for Dagster events.
+    """A structure for describing metadata for Dagster events.
+
+    .. note:: This class is no longer usable in any Dagster API, and will be completely removed in 2.0.
 
     Lists of objects of this type can be passed as arguments to Dagster events and will be displayed
     in Dagit and other tooling.
@@ -1009,11 +994,13 @@ class MetadataEntry(
         entry_data: Optional["RawMetadataValue"] = None,
         value: Optional["RawMetadataValue"] = None,
     ):
-        if description is not None:
-            deprecation_warning(
-                'The "description" attribute on "MetadataEntry"',
-                "1.0.0",
-            )
+        deprecation_warning(
+            (
+                "The `MetadataEntry` class is deprecated. Please use a dict with `MetadataValue`"
+                " values instead."
+            ),
+            "2.0.0",
+        )
         value = cast(
             RawMetadataValue,
             canonicalize_backcompat_args(

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -37,7 +37,6 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.events import DynamicOutput
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
     MetadataValue,
     normalize_metadata,
 )
@@ -611,11 +610,6 @@ def _store_output(
             yield elt
         elif isinstance(elt, AssetMaterialization):
             manager_materializations.append(elt)
-        elif isinstance(elt, MetadataEntry):  # should remove this?
-            experimental_functionality_warning(
-                "Yielding metadata from an IOManager's handle_output() function"
-            )
-            manager_metadata[elt.label] = elt.value
         elif isinstance(elt, dict):  # should remove this?
             experimental_functionality_warning(
                 "Yielding metadata from an IOManager's handle_output() function"
@@ -625,7 +619,7 @@ def _store_output(
             raise DagsterInvariantViolationError(
                 f"IO manager on output {output_def.name} has returned "
                 f"value {elt} of type {type(elt).__name__}. The return type can only be "
-                "one of AssetMaterialization, MetadataEntry."
+                "one of AssetMaterialization, Dict[str, MetadataValue]."
             )
 
     for event in output_context.consume_events():

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -25,7 +25,6 @@ from dagster._config import (
 )
 from dagster._core.definitions.events import DynamicOutput, Output, TypeCheck
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
     MetadataValue,
     RawMetadataValue,
     normalize_metadata,
@@ -111,7 +110,6 @@ class DagsterType(RequiresResources):
         required_resource_keys: t.Optional[t.Set[str]] = None,
         kind: DagsterTypeKind = DagsterTypeKind.REGULAR,
         typing_type: t.Any = t.Any,
-        metadata_entries: t.Optional[t.Sequence[MetadataEntry]] = None,
         metadata: t.Optional[t.Mapping[str, RawMetadataValue]] = None,
     ):
         check.opt_str_param(key, "key")
@@ -157,7 +155,6 @@ class DagsterType(RequiresResources):
 
         self._metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str),
-            check.opt_list_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
         )
 
     @public

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -4,46 +4,13 @@
 import re
 
 import pytest
-from dagster._core.definitions.events import Output
-from dagster._core.definitions.input import InputDefinition
 from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
-from dagster._core.definitions.output import OutputDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
-from dagster._core.types.dagster_type import DagsterType
-
-# ########################
-# ##### METADATA ARGUMENTS
-# ########################
 
 
-def test_metadata_entries():
-    metadata_entry = MetadataEntry("foo", None, MetadataValue.text("bar"))
-
-    # We use `Output` as a stand-in for all events here, they all follow the same pattern of calling
-    # `normalize_metadata`.
-    with pytest.warns(DeprecationWarning, match=re.escape('"metadata_entries" is deprecated')):
-        Output("foo", "bar", metadata_entries=[metadata_entry])
-
-    with pytest.warns(DeprecationWarning, match=re.escape('"metadata_entries" is deprecated')):
-        DagsterType(lambda _, __: True, "foo", metadata_entries=[metadata_entry])
-
-
-def test_arbitrary_metadata():
-    with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
-        OutputDefinition(metadata={"foo": object()})
-
-    with pytest.warns(DeprecationWarning, match=re.escape("arbitrary metadata values")):
-        InputDefinition(name="foo", metadata={"foo": object()})
-
-
-def test_metadata_entry_description():
-    with pytest.warns(DeprecationWarning, match=re.escape('"description" attribute')):
-        MetadataEntry("foo", "bar", MetadataValue.text("baz"))
-
-
-# ########################
-# ##### SCHEDULE ENV VARS
-# ########################
+def test_metadata_entry():
+    with pytest.warns(DeprecationWarning, match=re.escape("MetadataEntry")):
+        MetadataEntry("foo", value=MetadataValue.text("bar"))
 
 
 def test_schedule_environment_vars():

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -16,6 +16,7 @@ from dagster._annotations import experimental
 from dagster._config import Selector
 from dagster._core.definitions.metadata import normalize_metadata
 from dagster._utils import dict_without_keys
+from dagster._utils.backcompat import canonicalize_backcompat_args
 
 from dagster_pandas.constraints import (
     CONSTRAINT_METADATA_KEY,
@@ -146,9 +147,10 @@ def create_dagster_pandas_dataframe_type(
     name,
     description=None,
     columns=None,
-    event_metadata_fn=None,
+    metadata_fn=None,
     dataframe_constraints=None,
     loader=None,
+    event_metadata_fn=None,
 ):
     """Constructs a custom pandas dataframe dagster type.
 
@@ -157,10 +159,9 @@ def create_dagster_pandas_dataframe_type(
         description (Optional[str]): A markdown-formatted string, displayed in tooling.
         columns (Optional[List[PandasColumn]]): A list of :py:class:`~dagster.PandasColumn` objects
             which express dataframe column schemas and constraints.
-        event_metadata_fn (Optional[Callable[[], Union[Dict[str, Union[str, float, int, Dict, MetadataValue]])
+        metadata_fn (Optional[Callable[[], Union[Dict[str, Union[str, float, int, Dict, MetadataValue]])
             A callable which takes your dataframe and returns a dict with string label keys and
-            MetadataValue values. Can optionally return a `List[MetadataEntry]`, but this format is
-            deprecated.
+            MetadataValue values.
         dataframe_constraints (Optional[List[DataFrameConstraint]]): A list of objects that inherit from
             :py:class:`~dagster.DataFrameConstraint`. This allows you to express dataframe-level constraints.
         loader (Optional[DagsterTypeLoader]): An instance of a class that
@@ -171,7 +172,10 @@ def create_dagster_pandas_dataframe_type(
     # dataframes via configuration their own way if the default configs don't suffice. This is
     # purely optional.
     check.str_param(name, "name")
-    event_metadata_fn = check.opt_callable_param(event_metadata_fn, "event_metadata_fn")
+    metadata_fn = canonicalize_backcompat_args(
+        metadata_fn, "metadata_fn", event_metadata_fn, "event_metadata_fn", "1.4.0"
+    )
+    metadata_fn = check.opt_callable_param(metadata_fn, "metadata_fn")
     description = create_dagster_pandas_dataframe_description(
         check.opt_str_param(description, "description", default=""),
         check.opt_list_param(columns, "columns", of_type=PandasColumn),
@@ -197,9 +201,7 @@ def create_dagster_pandas_dataframe_type(
 
         return TypeCheck(
             success=True,
-            metadata=_execute_summary_stats(name, value, event_metadata_fn)
-            if event_metadata_fn
-            else None,
+            metadata=_execute_summary_stats(name, value, metadata_fn) if metadata_fn else None,
         )
 
     return DagsterType(
@@ -290,17 +292,13 @@ def create_structured_dataframe_type(
     )
 
 
-def _execute_summary_stats(type_name, value, event_metadata_fn):
-    if not event_metadata_fn:
+def _execute_summary_stats(type_name, value, metadata_fn):
+    if not metadata_fn:
         return []
 
-    user_metadata = event_metadata_fn(value)
-
+    user_metadata = metadata_fn(value)
     try:
-        metadata_dict, metadata_entries = (
-            ({}, user_metadata) if isinstance(user_metadata, list) else (user_metadata, [])
-        )
-        return normalize_metadata(metadata_dict, metadata_entries)
+        return normalize_metadata(user_metadata)
     except:
         raise DagsterInvariantViolationError(
             "The return value of the user-defined summary_statistics function for pandas "

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -61,7 +61,7 @@ def pandera_schema_to_dagster_type(
     `name` is defined, a name of the form `DagsterPanderaDataframe<n>` is generated.
 
     Additional metadata is also extracted from the Pandera schema and attached to the returned
-    `DagsterType` in an `MetadataEntry` object. The extracted metadata includes:
+    `DagsterType` as a metadata dictionary. The extracted metadata includes:
 
     - Descriptions on the schema and constituent columns and checks.
     - Data types for each column.


### PR DESCRIPTION
### Summary & Motivation

Delete all APIs accepting `MetadataEntry`, but keep `MetadataEntry` itself. Add a formal deprecation to `MetadataEntry` for removal in 2.0.

The reason for this somewhat awkward state is that we deprecated all APIs where you can _use_ `MetadataEntry` a year ago, but forgot to deprecate `MetadataEntry` itself.

The deprecate usage sites for `MetadataEntry` that are being removed in this PR are:
- passing `metadata_entries` to user-constructable events (`AssetObservation`, `AssetMaterialization`, `ExpectationResult`, `TypeCheck`, `Failure`, `Output`, `DynamicOutput`)
- passing `metadata_entries` to `DagsterType`
- returning a value from `event_metadata_fn` in `dagster-pandas`

In all these  cases, passing a list of `MetadataEntry` has been emitting deprecation warnings for approximately a year-- this functionality was supposed to be removed in 0.15.0/0.16.0, but we didn't get around to it.

Note that this PR was enabled by https://github.com/dagster-io/dagster/pull/12770, which updated our internal representation to never use `MetadataEntry`.

### How I Tested These Changes

Existing BK suite w/ some removed tests, plus a new test for a deprecation warning on `MetadataEntry` construction.