### PR TITLE
[refactor] Update internal representation of metadata to always use metadata dict

### DIFF
--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/resources/csv_io_manager.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/resources/csv_io_manager.py
@@ -40,16 +40,12 @@ class LocalCsvIOManager(MemoizableIOManager):
         )
 
     def get_schema(self, dagster_type):
-        schema_entry = next(
-            (
-                x
-                for x in dagster_type.metadata_entries
-                if isinstance(x.value, TableSchemaMetadataValue)
-            ),
+        schema_value = next(
+            (x for x in dagster_type.metadata.values() if isinstance(x, TableSchemaMetadataValue)),
             None,
         )
-        assert schema_entry
-        return schema_entry.value.schema
+        assert schema_value
+        return schema_value.schema
 
     def load_input(self, context):
         """This reads a dataframe from a CSV."""

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_build_io_context.py
@@ -118,7 +118,7 @@ def test_context_logging_metadata():
 
     context.add_output_metadata({"foo": "bar"})
 
-    assert [entry.label for entry in context.get_logged_metadata_entries()] == ["foo"]
+    assert "foo" in context.get_logged_metadata()
 
 
 def test_output_context_partition_key():

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_materialization_metadata.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_materialization_metadata.py
@@ -2,4 +2,4 @@ from docs_snippets.concepts.assets.asset_materialization_metadata import table1
 
 
 def test():
-    assert table1().metadata_entries
+    assert table1().metadata

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_materialization_metadata_none.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_materialization_metadata_none.py
@@ -2,4 +2,4 @@ from docs_snippets.concepts.assets.asset_materialization_metadata_none import ta
 
 
 def test():
-    assert table1().metadata_entries
+    assert table1().metadata

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -853,7 +853,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_metadata_entries(
         self, _graphene_info: ResolveInfo
     ) -> Sequence[GrapheneMetadataEntry]:
-        return list(iterate_metadata_entries(self._external_asset_node.metadata_entries))
+        return list(iterate_metadata_entries(self._external_asset_node.metadata))
 
     def resolve_op(
         self, _graphene_info: ResolveInfo

--- a/python_modules/dagster-graphql/dagster_graphql/schema/dagster_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/dagster_types.py
@@ -60,7 +60,7 @@ def to_dagster_type(
                 dagster_type_meta.type_param_keys,
             )
         ),
-        metadata_entries=list(iterate_metadata_entries(dagster_type_meta.metadata_entries)),
+        metadata_entries=list(iterate_metadata_entries(dagster_type_meta.metadata)),
     )
 
     if dagster_type_meta.kind == DagsterTypeKind.LIST:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -200,7 +200,7 @@ class GrapheneObjectStoreOperationResult(graphene.ObjectType):
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
-        return _to_metadata_entries(self.metadata_entries)
+        return _to_metadata_entries(self.metadata)
 
 
 class GrapheneExpectationResult(graphene.ObjectType):
@@ -213,7 +213,7 @@ class GrapheneExpectationResult(graphene.ObjectType):
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
-        return _to_metadata_entries(self.metadata_entries)
+        return _to_metadata_entries(self.metadata)
 
 
 class GrapheneTypeCheck(graphene.ObjectType):
@@ -226,7 +226,7 @@ class GrapheneTypeCheck(graphene.ObjectType):
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
-        return _to_metadata_entries(self.metadata_entries)
+        return _to_metadata_entries(self.metadata)
 
 
 class GrapheneFailureMetadata(graphene.ObjectType):
@@ -345,7 +345,7 @@ class AssetEventMixin:
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
-        return _to_metadata_entries(self._metadata.metadata_entries)
+        return _to_metadata_entries(self._metadata.metadata)
 
     def resolve_partition(self, _graphene_info: ResolveInfo):
         return self._metadata.partition

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -65,7 +65,7 @@ class GrapheneInputDefinition(graphene.ObjectType):
         return build_solid_definition(self._represented_pipeline, self._solid_def_snap.name)
 
     def resolve_metadata_entries(self, _graphene_info):
-        return list(iterate_metadata_entries(self._input_def_snap.metadata_entries))
+        return list(iterate_metadata_entries(self._input_def_snap.metadata))
 
 
 class GrapheneOutputDefinition(graphene.ObjectType):
@@ -113,7 +113,7 @@ class GrapheneOutputDefinition(graphene.ObjectType):
         return build_solid_definition(self._represented_pipeline, self._solid_def_snap.name)
 
     def resolve_metadata_entries(self, _graphene_info):
-        return list(iterate_metadata_entries(self._output_def_snap.metadata_entries))
+        return list(iterate_metadata_entries(self._output_def_snap.metadata))
 
 
 class GrapheneInput(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -34,7 +34,6 @@ from dagster import (
     IOManager,
     IOManagerDefinition,
     Map,
-    MetadataEntry,
     Noneable,
     Nothing,
     OpExecutionContext,
@@ -706,48 +705,39 @@ def materialization_pipeline():
         yield AssetMaterialization(
             asset_key="all_types",
             description="a materialization with all metadata types",
-            metadata_entries=[
-                MetadataEntry("text", value="text is cool"),
-                MetadataEntry("url", value=MetadataValue.url("https://bigty.pe/neato")),
-                MetadataEntry("path", value=MetadataValue.path("/tmp/awesome")),
-                MetadataEntry("json", value={"is_dope": True}),
-                MetadataEntry("python class", value=MetadataValue.python_artifact(MetadataEntry)),
-                MetadataEntry(
-                    "python function",
-                    value=MetadataValue.python_artifact(file_relative_path),
+            metadata={
+                "text": "text is cool",
+                "url": MetadataValue.url("https://bigty.pe/neato"),
+                "path": MetadataValue.path("/tmp/awesome"),
+                "json": {"is_dope": True},
+                "python class": MetadataValue.python_artifact(AssetMaterialization),
+                "python_function": MetadataValue.python_artifact(file_relative_path),
+                "float": 1.2,
+                "int": 1,
+                "float NaN": float("nan"),
+                "long int": LONG_INT,
+                "pipeline run": MetadataValue.dagster_run("fake_run_id"),
+                "my asset": AssetKey("my_asset"),
+                "table": MetadataValue.table(
+                    records=[
+                        TableRecord(dict(foo=1, bar=2)),
+                        TableRecord(dict(foo=3, bar=4)),
+                    ],
                 ),
-                MetadataEntry("float", value=1.2),
-                MetadataEntry("int", value=1),
-                MetadataEntry("float NaN", value=float("nan")),
-                MetadataEntry("long int", value=LONG_INT),
-                MetadataEntry("pipeline run", value=MetadataValue.dagster_run("fake_run_id")),
-                MetadataEntry("my asset", value=AssetKey("my_asset")),
-                MetadataEntry(
-                    "table",
-                    value=MetadataValue.table(
-                        records=[
-                            TableRecord(dict(foo=1, bar=2)),
-                            TableRecord(dict(foo=3, bar=4)),
-                        ],
-                    ),
-                ),
-                MetadataEntry(
-                    "table_schema",
-                    value=TableSchema(
-                        columns=[
-                            TableColumn(
-                                name="foo",
-                                type="integer",
-                                constraints=TableColumnConstraints(unique=True),
-                            ),
-                            TableColumn(name="bar", type="string"),
-                        ],
-                        constraints=TableConstraints(
-                            other=["some constraint"],
+                "table_schema": TableSchema(
+                    columns=[
+                        TableColumn(
+                            name="foo",
+                            type="integer",
+                            constraints=TableColumnConstraints(unique=True),
                         ),
+                        TableColumn(name="bar", type="string"),
+                    ],
+                    constraints=TableConstraints(
+                        other=["some constraint"],
                     ),
                 ),
-            ],
+            },
         )
         yield Output(None)
 

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -15,7 +15,7 @@ from dagster._cli.workspace.cli_target import (
     get_working_directory_from_kwargs,
     python_origin_target_argument,
 )
-from dagster._core.definitions.metadata import MetadataEntry
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
 from dagster._core.execution.api import create_execution_plan, execute_plan_iterator
@@ -399,11 +399,7 @@ def _execute_step_command_body(
             pipeline_run.pipeline_name,
             message="Step worker started"
             + (f' for "{single_step_key}".' if single_step_key else "."),
-            metadata_entries=(
-                [
-                    MetadataEntry("pid", value=str(os.getpid())),
-                ]
-            ),
+            metadata={"pid": MetadataValue.text(str(os.getpid()))},
             step_key=single_step_key,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_in.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_in.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, NamedTuple, Optional, Sequence, Type, Union
+from typing import Mapping, NamedTuple, Optional, Sequence, Type, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
@@ -8,6 +8,7 @@ from dagster._core.definitions.events import (
     CoercibleToAssetKeyPrefix,
 )
 from dagster._core.definitions.input import NoValueSentinel
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.types.dagster_type import DagsterType, resolve_dagster_type
 from dagster._utils.backcompat import canonicalize_backcompat_args
 
@@ -19,7 +20,7 @@ class AssetIn(
         "_AssetIn",
         [
             ("key", PublicAttr[Optional[AssetKey]]),
-            ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
+            ("metadata", PublicAttr[Optional[ArbitraryMetadataMapping]]),
             ("key_prefix", PublicAttr[Optional[Sequence[str]]]),
             ("input_manager_key", PublicAttr[Optional[str]]),
             ("partition_mapping", PublicAttr[Optional[PartitionMapping]]),
@@ -50,7 +51,7 @@ class AssetIn(
     def __new__(
         cls,
         key: Optional[CoercibleToAssetKey] = None,
-        metadata: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[ArbitraryMetadataMapping] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         asset_key: Optional[CoercibleToAssetKey] = None,
         input_manager_key: Optional[str] = None,

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -18,7 +18,9 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.metadata import MetadataUserInput, RawMetadataValue
+from dagster._core.definitions.metadata import (
+    ArbitraryMetadataMapping,
+)
 from dagster._core.selector.subset_selector import AssetSelectionData
 
 from ..errors import DagsterInvalidSubsetError
@@ -643,14 +645,12 @@ class AssetLayer:
         else:
             return None
 
-    def metadata_for_asset(self, asset_key: AssetKey) -> Optional[MetadataUserInput]:
+    def metadata_for_asset(
+        self, asset_key: AssetKey
+    ) -> Optional[Mapping[str, ArbitraryMetadataMapping]]:
         if asset_key in self._source_assets_by_key:
-            metadata = self._source_assets_by_key[asset_key].metadata
-            return (
-                {key: cast(RawMetadataValue, value.value) for key, value in metadata.items()}
-                if metadata
-                else None
-            )
+            raw_metadata = self._source_assets_by_key[asset_key].raw_metadata
+            return raw_metadata or None
         elif asset_key in self._assets_defs_by_key:
             return self._assets_defs_by_key[asset_key].metadata_by_key[asset_key]
         else:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -21,7 +21,7 @@ from dagster._annotations import public
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_layer import get_dep_node_handles_of_graph_backed_asset
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.metadata import MetadataUserInput
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
@@ -82,7 +82,7 @@ class AssetsDefinition(ResourceAddable):
     _group_names_by_key: Mapping[AssetKey, str]
     _selected_asset_keys: AbstractSet[AssetKey]
     _can_subset: bool
-    _metadata_by_key: Mapping[AssetKey, MetadataUserInput]
+    _metadata_by_key: Mapping[AssetKey, ArbitraryMetadataMapping]
     _freshness_policies_by_key: Mapping[AssetKey, FreshnessPolicy]
     _code_versions_by_key: Mapping[AssetKey, Optional[str]]
     _descriptions_by_key: Mapping[AssetKey, str]
@@ -100,7 +100,7 @@ class AssetsDefinition(ResourceAddable):
         can_subset: bool = False,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
-        metadata_by_key: Optional[Mapping[AssetKey, MetadataUserInput]] = None,
+        metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
         freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]] = None,
         descriptions_by_key: Optional[Mapping[AssetKey, str]] = None,
         # if adding new fields, make sure to handle them in the with_prefix_or_group
@@ -271,7 +271,7 @@ class AssetsDefinition(ResourceAddable):
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[ArbitraryMetadataMapping]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
     ) -> "AssetsDefinition":
@@ -355,7 +355,7 @@ class AssetsDefinition(ResourceAddable):
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[ArbitraryMetadataMapping]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
     ) -> "AssetsDefinition":
@@ -432,7 +432,7 @@ class AssetsDefinition(ResourceAddable):
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[ArbitraryMetadataMapping]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
     ) -> "AssetsDefinition":
@@ -653,7 +653,7 @@ class AssetsDefinition(ResourceAddable):
         return self._partitions_def
 
     @property
-    def metadata_by_key(self) -> Mapping[AssetKey, MetadataUserInput]:
+    def metadata_by_key(self) -> Mapping[AssetKey, ArbitraryMetadataMapping]:
         return self._metadata_by_key
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/assets_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets_job.py
@@ -201,7 +201,7 @@ def build_assets_job(
             partitions_def=partitions_def,
             asset_layer=asset_layer,
             _asset_selection_data=_asset_selection_data,
-            _metadata_entries=original_job._metadata_entries,  # noqa: SLF001
+            metadata=original_job.metadata,
             logger_defs=original_job.get_mode_definition().loggers,
             hooks=original_job.hook_defs,
             op_retry_policy=original_job._solid_retry_policy,  # noqa: SLF001
@@ -300,7 +300,7 @@ def build_source_asset_observation_job(
             partitions_def=partitions_def,
             asset_layer=asset_layer,
             _asset_selection_data=_asset_selection_data,
-            _metadata_entries=original_job._metadata_entries,  # noqa: SLF001
+            metadata=original_job.metadata,
             logger_defs=original_job.get_mode_definition().loggers,
             hooks=original_job.hook_defs,
             op_retry_policy=original_job._solid_retry_policy,  # noqa: SLF001

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -19,7 +19,7 @@ from dagster._builtins import Nothing
 from dagster._config import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params, get_valid_name_permutations
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.metadata import MetadataUserInput
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataUserInput
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.io_manager import IOManagerDefinition
@@ -85,7 +85,7 @@ def asset(
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     ins: Optional[Mapping[str, AssetIn]] = None,
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
-    metadata: Optional[Mapping[str, Any]] = None,
+    metadata: Optional[ArbitraryMetadataMapping] = None,
     description: Optional[str] = None,
     config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
@@ -225,7 +225,7 @@ class _Asset:
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         ins: Optional[Mapping[str, AssetIn]] = None,
         non_argument_deps: Optional[Set[AssetKey]] = None,
-        metadata: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[ArbitraryMetadataMapping] = None,
         description: Optional[str] = None,
         config_schema: Optional[UserConfigSchema] = None,
         required_resource_keys: Optional[Set[str]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -1,9 +1,8 @@
-from typing import Mapping, Optional, Sequence, Union, overload
+from typing import Mapping, Optional, Union, overload
 
 from dagster._annotations import experimental
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
     MetadataUserInput,
 )
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -27,7 +26,6 @@ def observable_source_asset(
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     group_name: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> "_ObservableSourceAsset":
@@ -45,7 +43,6 @@ def observable_source_asset(
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     group_name: Optional[str] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
@@ -90,7 +87,6 @@ def observable_source_asset(
         io_manager_def,
         description,
         partitions_def,
-        _metadata_entries,
         group_name,
         resource_defs,
     )
@@ -106,7 +102,6 @@ class _ObservableSourceAsset:
         io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ):
@@ -121,7 +116,6 @@ class _ObservableSourceAsset:
         self.io_manager_def = io_manager_def
         self.description = description
         self.partitions_def = partitions_def
-        self._metadata_entries = _metadata_entries
         self.group_name = group_name
         self.resource_defs = resource_defs
 
@@ -136,7 +130,6 @@ class _ObservableSourceAsset:
             io_manager_def=self.io_manager_def,
             description=self.description,
             partitions_def=self.partitions_def,
-            _metadata_entries=self._metadata_entries,
             group_name=self.group_name,
             resource_defs=self.resource_defs,
             observe_fn=observe_fn,

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -27,6 +27,7 @@ from dagster._utils.backcompat import experimental_class_param_warning
 
 from .metadata import (
     MetadataEntry,
+    MetadataFieldSerializer,
     MetadataMapping,
     MetadataValue,
     RawMetadataValue,
@@ -219,7 +220,8 @@ class Output(Generic[T]):
         output_name (Optional[str]): Name of the corresponding out. (default:
             "result")
         metadata_entries (Optional[MetadataEntry]):
-            (Experimental) A set of metadata entries to attach to events related to this Output.
+            (Deprecated) A set of metadata entries to attach to events related to this Output. Use
+            `metadata` instead.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -236,22 +238,19 @@ class Output(Generic[T]):
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         data_version: Optional[DataVersion] = None,
     ):
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries,
-            "metadata_entries",
-            of_type=MetadataEntry,
-        )
         self._value = value
         self._output_name = check.str_param(output_name, "output_name")
-        self._metadata_entries = normalize_metadata(metadata, metadata_entries)
         if data_version is not None:
             experimental_class_param_warning("data_version", "Output")
         self._data_version = check.opt_inst_param(data_version, "data_version", DataVersion)
+        self._metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+            check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
+        )
 
     @property
-    def metadata_entries(self) -> Sequence[MetadataEntry]:
-        return self._metadata_entries
+    def metadata(self) -> MetadataMapping:
+        return self._metadata
 
     @public
     @property
@@ -273,7 +272,7 @@ class Output(Generic[T]):
             isinstance(other, Output)
             and self.value == other.value
             and self.output_name == other.output_name
-            and self.metadata_entries == other.metadata_entries
+            and self.metadata == other.metadata
         )
 
 
@@ -296,7 +295,8 @@ class DynamicOutput(Generic[T]):
             Name of the corresponding :py:class:`DynamicOut` defined on the op.
             (default: "result")
         metadata_entries (Optional[MetadataEntry]):
-            (Experimental) A set of metadata entries to attach to events related to this output.
+            (Deprecated) A set of metadata entries to attach to events related to this Output. Use
+            `metadata` instead.
         metadata (Optional[Dict[str, Union[str, float, int, MetadataValue]]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -311,18 +311,17 @@ class DynamicOutput(Generic[T]):
         metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
         self._mapping_key = check_valid_name(check.str_param(mapping_key, "mapping_key"))
         self._output_name = check.str_param(output_name, "output_name")
-        self._metadata_entries = normalize_metadata(metadata, metadata_entries)
         self._value = value
+        self._metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+            check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
+        )
 
     @property
-    def metadata_entries(self) -> Sequence[MetadataEntry]:
-        return self._metadata_entries
+    def metadata(self) -> Mapping[str, MetadataValue]:
+        return self._metadata
 
     @public
     @property
@@ -345,18 +344,36 @@ class DynamicOutput(Generic[T]):
             and self.value == other.value
             and self.output_name == other.output_name
             and self.mapping_key == other.mapping_key
-            and self.metadata_entries == other.metadata_entries
+            and self.metadata == other.metadata
         )
 
 
-@whitelist_for_serdes
+# This is a temporary function to consolidate metadata normalization logic on event classes where
+# we've had to mangle the signature for backcompat reasons. Can be deleted when we remove
+# `metadata_entries`/`MetadataEntry`.
+def _normalize_event_metadata(
+    metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
+    metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+) -> MetadataMapping:
+    metadata_dict = metadata if isinstance(metadata, dict) else {}
+    metadata_entries = metadata if isinstance(metadata, list) else metadata_entries
+    return normalize_metadata(
+        check.opt_mapping_param(metadata_dict, "metadata_dict", key_type=str),
+        check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
+    )
+
+
+@whitelist_for_serdes(
+    storage_field_names={"metadata": "metadata_entries"},
+    field_serializers={"metadata": MetadataFieldSerializer},
+)
 class AssetObservation(
     NamedTuple(
         "_AssetObservation",
         [
             ("asset_key", PublicAttr[AssetKey]),
             ("description", PublicAttr[Optional[str]]),
-            ("metadata_entries", Sequence[MetadataEntry]),
+            ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
             ("partition", PublicAttr[Optional[str]]),
             ("tags", PublicAttr[Mapping[str, str]]),
         ],
@@ -366,7 +383,8 @@ class AssetObservation(
 
     Args:
         asset_key (Union[str, List[str], AssetKey]): A key to identify the asset.
-        metadata_entries (Optional[List[MetadataEntry]]): Arbitrary metadata about the asset.
+        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
+            asset. Use `metadata` instead.
         partition (Optional[str]): The name of a partition of the asset that the metadata
             corresponds to.
         tags (Optional[Mapping[str, str]]): A mapping containing system-populated tags for the
@@ -381,10 +399,10 @@ class AssetObservation(
         cls,
         asset_key: CoercibleToAssetKey,
         description: Optional[str] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ):
         if isinstance(asset_key, AssetKey):
             check.inst_param(asset_key, "asset_key", AssetKey)
@@ -401,18 +419,13 @@ class AssetObservation(
                 "The tags argument is reserved for system-populated tags."
             )
 
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
+        metadata = _normalize_event_metadata(metadata, metadata_entries)
 
         return super(AssetObservation, cls).__new__(
             cls,
             asset_key=asset_key,
             description=check.opt_str_param(description, "description"),
-            metadata_entries=cast(
-                List[MetadataEntry], normalize_metadata(metadata, metadata_entries)
-            ),
+            metadata=metadata,
             tags=tags,
             partition=check.opt_str_param(partition, "partition"),
         )
@@ -437,7 +450,10 @@ class AssetMaterializationSerializer(NamedTupleSerializer):
 
 
 @whitelist_for_serdes(
-    old_storage_names={"Materialization"}, serializer=AssetMaterializationSerializer
+    old_storage_names={"Materialization"},
+    serializer=AssetMaterializationSerializer,
+    storage_field_names={"metadata": "metadata_entries"},
+    field_serializers={"metadata": MetadataFieldSerializer},
 )
 class AssetMaterialization(
     NamedTuple(
@@ -445,7 +461,7 @@ class AssetMaterialization(
         [
             ("asset_key", PublicAttr[AssetKey]),
             ("description", PublicAttr[Optional[str]]),
-            ("metadata_entries", Sequence[MetadataEntry]),
+            ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
             ("partition", PublicAttr[Optional[str]]),
             ("tags", Optional[Mapping[str, str]]),
         ],
@@ -466,8 +482,8 @@ class AssetMaterialization(
         asset_key (Union[str, List[str], AssetKey]): A key to identify the materialized asset across
             job runs
         description (Optional[str]): A longer human-readable description of the materialized value.
-        metadata_entries (Optional[List[MetadataEntry]]): Arbitrary
-            metadata about the materialized value.
+        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary
+            metadata about the materialized value. Use `metadata` instead.
         partition (Optional[str]): The name of the partition
             that was materialized.
         tags (Optional[Mapping[str, str]]): A mapping containing system-populated tags for the
@@ -482,10 +498,10 @@ class AssetMaterialization(
         cls,
         asset_key: CoercibleToAssetKey,
         description: Optional[str] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ):
         from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 
@@ -505,10 +521,7 @@ class AssetMaterialization(
                 " AssetMaterializations. The tags argument is reserved for system-populated tags."
             )
 
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
+        metadata = _normalize_event_metadata(metadata, metadata_entries)
 
         partition = check.opt_str_param(partition, "partition")
 
@@ -527,7 +540,7 @@ class AssetMaterialization(
             cls,
             asset_key=asset_key,
             description=check.opt_str_param(description, "description"),
-            metadata_entries=normalize_metadata(metadata, metadata_entries),
+            metadata=metadata,
             tags=tags,
             partition=partition,
         )
@@ -558,13 +571,11 @@ class AssetMaterialization(
             metadata={"path": MetadataValue.path(path)},
         )
 
-    @public
-    @property
-    def metadata(self) -> MetadataMapping:
-        return {entry.label: entry.value for entry in self.metadata_entries}
 
-
-@whitelist_for_serdes
+@whitelist_for_serdes(
+    storage_field_names={"metadata": "metadata_entries"},
+    field_serializers={"metadata": MetadataFieldSerializer},
+)
 class ExpectationResult(
     NamedTuple(
         "_ExpectationResult",
@@ -572,7 +583,7 @@ class ExpectationResult(
             ("success", PublicAttr[bool]),
             ("label", PublicAttr[Optional[str]]),
             ("description", PublicAttr[Optional[str]]),
-            ("metadata_entries", Sequence[MetadataEntry]),
+            ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
         ],
     )
 ):
@@ -586,8 +597,8 @@ class ExpectationResult(
         success (bool): Whether the expectation passed or not.
         label (Optional[str]): Short display name for expectation. Defaults to "result".
         description (Optional[str]): A longer human-readable description of the expectation.
-        metadata_entries (Optional[List[MetadataEntry]]): Arbitrary metadata about the
-            expectation.
+        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
+            expectation. Use `metadata` instead.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -599,25 +610,24 @@ class ExpectationResult(
         success: bool,
         label: Optional[str] = None,
         description: Optional[str] = None,
+        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
         metadata_entries: Optional[Sequence[MetadataEntry]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
+        metadata = _normalize_event_metadata(metadata, metadata_entries)
 
         return super(ExpectationResult, cls).__new__(
             cls,
             success=check.bool_param(success, "success"),
             label=check.opt_str_param(label, "label", "result"),
             description=check.opt_str_param(description, "description"),
-            metadata_entries=cast(
-                List[MetadataEntry], normalize_metadata(metadata, metadata_entries)
-            ),
+            metadata=metadata,
         )
 
 
+@whitelist_for_serdes(
+    storage_field_names={"metadata": "metadata_entries"},
+    field_serializers={"metadata": MetadataFieldSerializer},
+)
 @whitelist_for_serdes
 class TypeCheck(
     NamedTuple(
@@ -625,7 +635,7 @@ class TypeCheck(
         [
             ("success", PublicAttr[bool]),
             ("description", PublicAttr[Optional[str]]),
-            ("metadata_entries", PublicAttr[Sequence[MetadataEntry]]),
+            ("metadata", PublicAttr[Mapping[str, MetadataValue]]),
         ],
     )
 ):
@@ -641,8 +651,8 @@ class TypeCheck(
     Args:
         success (bool): ``True`` if the type check succeeded, ``False`` otherwise.
         description (Optional[str]): A human-readable description of the type check.
-        metadata_entries (Optional[List[MetadataEntry]]): Arbitrary metadata about the
-            type check.
+        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
+            type check. Use `metadata` instead.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -653,21 +663,16 @@ class TypeCheck(
         cls,
         success: bool,
         description: Optional[str] = None,
+        metadata: Optional[Union[Mapping[str, RawMetadataValue], Sequence[MetadataEntry]]] = None,
         metadata_entries: Optional[Sequence[MetadataEntry]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     ):
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
+        metadata = _normalize_event_metadata(metadata, metadata_entries)
 
         return super(TypeCheck, cls).__new__(
             cls,
             success=check.bool_param(success, "success"),
             description=check.opt_str_param(description, "description"),
-            metadata_entries=cast(
-                List[MetadataEntry], normalize_metadata(metadata, metadata_entries)
-            ),
+            metadata=metadata,
         )
 
 
@@ -680,8 +685,8 @@ class Failure(Exception):
 
     Args:
         description (Optional[str]): A human-readable description of the failure.
-        metadata_entries (Optional[List[MetadataEntry]]): Arbitrary metadata about the
-            failure.
+        metadata_entries (Optional[List[MetadataEntry]]): (Deprecated) Arbitrary metadata about the
+            failure. Use `metadata` instead.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary metadata about the failure.  Keys are displayed string labels, and values are
             one of the following: string, float, int, JSON-serializable dict, JSON-serializable
@@ -698,14 +703,12 @@ class Failure(Exception):
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         allow_retries: Optional[bool] = None,
     ):
-        metadata_entries = check.opt_sequence_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
-        metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
-
         super(Failure, self).__init__(description)
         self.description = check.opt_str_param(description, "description")
-        self.metadata_entries = normalize_metadata(metadata, metadata_entries)
+        self.metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+            check.opt_sequence_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
+        )
         self.allow_retries = check.opt_bool_param(allow_retries, "allow_retries", True)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -47,7 +47,7 @@ from .dependency import (
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .logger_definition import LoggerDefinition
-from .metadata import MetadataEntry, RawMetadataValue
+from .metadata import RawMetadataValue
 from .node_container import create_execution_structure, normalize_dependency_dict
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
@@ -563,7 +563,6 @@ class GraphDefinition(NodeDefinition):
         asset_layer: Optional["AssetLayer"] = None,
         input_values: Optional[Mapping[str, object]] = None,
         _asset_selection_data: Optional[AssetSelectionData] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
     ) -> "JobDefinition":
         """Make this graph in to an executable Job by providing remaining components required for execution.
 
@@ -642,7 +641,6 @@ class GraphDefinition(NodeDefinition):
             asset_layer=asset_layer,
             input_values=input_values,
             _subset_selection_data=_asset_selection_data,
-            _metadata_entries=_metadata_entries,
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self) -> "JobDefinition":

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -37,7 +37,6 @@ from dagster._core.definitions.dependency import (
     NodeOutput,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.policy import RetryPolicy
@@ -106,7 +105,6 @@ class JobDefinition(PipelineDefinition):
         _subset_selection_data: Optional[Union[OpSelectionData, AssetSelectionData]] = None,
         asset_layer: Optional[AssetLayer] = None,
         input_values: Optional[Mapping[str, object]] = None,
-        _metadata_entries: Optional[Sequence[MetadataEntry]] = None,
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
@@ -168,7 +166,6 @@ class JobDefinition(PipelineDefinition):
         )
         asset_layer = check.opt_inst_param(asset_layer, "asset_layer", AssetLayer)
         input_values = check.opt_mapping_param(input_values, "input_values", key_type=str)
-        _metadata_entries = check.opt_sequence_param(_metadata_entries, "_metadata_entries")
         _preset_defs = check.opt_sequence_param(
             _preset_defs, "preset_defs", of_type=PresetDefinition
         )
@@ -252,7 +249,6 @@ class JobDefinition(PipelineDefinition):
             preset_defs=presets or _preset_defs,
             tags=tags,
             metadata=metadata,
-            metadata_entries=_metadata_entries,
             hook_defs=hook_defs,
             solid_retry_policy=op_retry_policy,
             graph_def=graph_def,
@@ -702,7 +698,7 @@ class JobDefinition(PipelineDefinition):
             version_strategy=self.version_strategy,
             _subset_selection_data=self._subset_selection_data,
             asset_layer=self._asset_layer,
-            _metadata_entries=self._metadata_entries,
+            metadata=self._metadata,
             _executor_def_specified=self._executor_def_specified,
             _logger_defs_specified=self._logger_defs_specified,
             _preset_defs=self._preset_defs,
@@ -742,7 +738,7 @@ class JobDefinition(PipelineDefinition):
             name=self.name,
             description=self.description,
             tags=self.tags,
-            _metadata_entries=self.metadata,
+            metadata=self._metadata,
             hook_defs=self.hook_defs,
             op_retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,
@@ -764,7 +760,7 @@ class JobDefinition(PipelineDefinition):
             name=self.name,
             description=self.description,
             tags=self.tags,
-            _metadata_entries=self.metadata,
+            metadata=self._metadata,
             hook_defs=self.hook_defs,
             op_retry_policy=self._solid_retry_policy,
             version_strategy=self.version_strategy,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -11,13 +11,11 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
-    TypeVar,
     Union,
     cast,
-    overload,
 )
 
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, TypeVar
 
 import dagster._check as check
 import dagster._seven as seven
@@ -25,7 +23,11 @@ from dagster._annotations import PublicAttr, experimental, public
 from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import (
+    FieldSerializer,
     PackableValue,
+    WhitelistMap,
+    pack_value,
+    unpack_value,
 )
 from dagster._utils.backcompat import (
     canonicalize_backcompat_args,
@@ -43,6 +45,8 @@ from .table import (  # re-exported
 if TYPE_CHECKING:
     from dagster._core.definitions.events import AssetKey
 
+ArbitraryMetadataMapping: TypeAlias = Mapping[str, Any]
+
 RawMetadataValue = Union[
     "MetadataValue",
     TableSchema,
@@ -59,43 +63,24 @@ RawMetadataValue = Union[
 MetadataMapping: TypeAlias = Mapping[str, "MetadataValue"]
 MetadataUserInput: TypeAlias = Mapping[str, RawMetadataValue]
 
-T_Packable = TypeVar("T_Packable", bound=PackableValue)
+T_Packable = TypeVar("T_Packable", bound=PackableValue, default=PackableValue, covariant=True)
 
 # ########################
 # ##### NORMALIZATION
 # ########################
 
 
-@overload
 def normalize_metadata(
     metadata: Mapping[str, RawMetadataValue],
-    metadata_entries: Sequence["MetadataEntry"],
+    metadata_entries: Optional[Sequence["MetadataEntry"]] = None,
     allow_invalid: bool = False,
-) -> Sequence["MetadataEntry"]:
-    ...
-
-
-@overload
-def normalize_metadata(
-    metadata: Mapping[str, RawMetadataValue],
-    metadata_entries: Sequence["MetadataEntry"],
-    allow_invalid: bool = False,
-) -> Sequence["MetadataEntry"]:
-    ...
-
-
-def normalize_metadata(
-    metadata: Mapping[str, RawMetadataValue],
-    metadata_entries: Sequence["MetadataEntry"],
-    allow_invalid: bool = False,
-) -> Sequence["MetadataEntry"]:
+) -> Mapping[str, "MetadataValue"]:
     if metadata and metadata_entries:
         raise DagsterInvalidMetadata(
             "Attempted to provide both `metadata` and `metadata_entries` arguments to an event. "
             "Must provide only one of the two."
         )
-
-    if metadata_entries:
+    elif metadata_entries:
         deprecation_warning(
             'Argument "metadata_entries"',
             "1.0.0",
@@ -105,42 +90,38 @@ def normalize_metadata(
             ),
             stacklevel=4,  # to get the caller of `normalize_metadata`
         )
-        return check.sequence_param(metadata_entries, "metadata_entries", MetadataEntry)
+        return {entry.label: entry.value for entry in metadata_entries}
 
     # This is a stopgap measure to deal with unsupported metadata values, which occur when we try
     # to convert arbitrary metadata (on e.g. OutputDefinition) to a MetadataValue, which is required
     # for serialization. This will cause unsupported values to be silently replaced with a
     # string placeholder.
-    elif allow_invalid:
-        metadata_entries = []
-        for k, v in metadata.items():
-            try:
-                metadata_entries.append(package_metadata_value(k, v))
-            except DagsterInvalidMetadata:
+    normalized_metadata: Dict[str, MetadataValue] = {}
+    for k, v in metadata.items():
+        try:
+            normalized_value = normalize_metadata_value(v)
+        except DagsterInvalidMetadata as e:
+            if allow_invalid:
                 deprecation_warning(
                     "Support for arbitrary metadata values",
-                    "1.0.0",
+                    "1.4.0",
                     additional_warn_txt=(
                         "In the future, all user-supplied metadata values must be one of"
                         f" {RawMetadataValue}"
                     ),
                     stacklevel=4,  # to get the caller of `normalize_metadata`
                 )
-                metadata_entries.append(
-                    MetadataEntry(
-                        value=TextMetadataValue(f"[{v.__class__.__name__}] (unserializable)"),
-                        label=k,
-                    )
-                )
-        return metadata_entries
+                normalized_value = TextMetadataValue(f"[{v.__class__.__name__}] (unserializable)")
+            else:
+                raise DagsterInvalidMetadata(
+                    f'Could not resolve the metadata value for "{k}" to a known type. {e}'
+                ) from None
+        normalized_metadata[k] = normalized_value
 
-    return [
-        package_metadata_value(k, v)
-        for k, v in check.opt_mapping_param(metadata, "metadata", key_type=str).items()
-    ]
+    return normalized_metadata
 
 
-def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue":
+def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue[Any]":
     from dagster._core.definitions.events import AssetKey
 
     if isinstance(raw_value, MetadataValue):
@@ -170,21 +151,8 @@ def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue":
     )
 
 
-def package_metadata_value(label: str, raw_value: RawMetadataValue) -> "MetadataEntry":
-    check.str_param(label, "label")
-
-    if isinstance(raw_value, MetadataEntry):
-        raise DagsterInvalidMetadata(
-            f"Expected a metadata value, found an instance of {raw_value.__class__.__name__}."
-            " Consider instead using a MetadataValue wrapper for the value."
-        )
-    try:
-        value = normalize_metadata_value(raw_value)
-    except DagsterInvalidMetadata as e:
-        raise DagsterInvalidMetadata(
-            f'Could not resolve the metadata value for "{label}" to a known type. {e}'
-        ) from None
-    return MetadataEntry(label=label, value=value)
+def to_metadata_entries(metadata: Mapping[str, "MetadataValue"]) -> Sequence["MetadataEntry"]:
+    return [MetadataEntry(k, value=v) for k, v in metadata.items()]
 
 
 # ########################
@@ -965,6 +933,50 @@ class NullMetadataValue(NamedTuple("_NullMetadataValue", []), MetadataValue[None
 # ########################
 # ##### METADATA ENTRY
 # ########################
+
+
+class MetadataFieldSerializer(FieldSerializer):
+    """Converts between metadata dict (new) and metadata entries list (old)."""
+
+    storage_name = "metadata_entries"
+    loaded_name = "metadata"
+
+    def pack(
+        self,
+        metadata_dict: Mapping[str, MetadataValue],
+        whitelist_map: WhitelistMap,
+        descent_path: str,
+    ) -> Sequence[Mapping[str, Any]]:
+        return [
+            {
+                "__class__": "EventMetadataEntry",
+                "label": k,
+                # MetadataValue itself can't inherit from NamedTuple and so isn't a PackableValue,
+                # but one of its subclasses will always be returned here.
+                "entry_data": pack_value(v, whitelist_map, descent_path),  # type: ignore
+                "description": None,
+            }
+            for k, v in metadata_dict.items()
+        ]
+
+    def unpack(
+        self,
+        metadata_entries: List[Mapping[str, Any]],
+        whitelist_map: WhitelistMap,
+        descent_path: str,
+    ) -> Mapping[str, MetadataValue]:
+        return {
+            e["label"]: unpack_value(
+                e["entry_data"],
+                # MetadataValue itself can't inherit from NamedTuple and so isn't a PackableValue,
+                # but one of its subclasses will always be returned here.
+                as_type=MetadataValue,  # type: ignore
+                whitelist_map=whitelist_map,
+                descent_path=descent_path,
+            )
+            for e in metadata_entries
+        }
+
 
 T_MetadataValue = TypeVar("T_MetadataValue", bound=MetadataValue, covariant=True)
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -226,7 +226,7 @@ def _resolve_inputs(
                     f'expected type "{dagster_type.display_name}". '
                     f"Description: {type_check.description}"
                 ),
-                metadata_entries=type_check.metadata_entries,
+                metadata=type_check.metadata,
                 dagster_type=dagster_type,
             )
 
@@ -377,7 +377,7 @@ def _type_check_output(
                     f'expected type "{dagster_type.display_name}". '
                     f"Description: {type_check.description}"
                 ),
-                metadata_entries=type_check.metadata_entries,
+                metadata=type_check.metadata,
                 dagster_type=dagster_type,
             )
 
@@ -395,7 +395,7 @@ def _type_check_output(
                     f'expected type "{dagster_type.display_name}". '
                     f"Description: {type_check.description}"
                 ),
-                metadata_entries=type_check.metadata_entries,
+                metadata=type_check.metadata,
                 dagster_type=dagster_type,
             )
         return output

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -487,13 +487,14 @@ class DagsterTypeCheckDidNotPass(DagsterError):
     ``False`` or an instance of :py:class:`~dagster.TypeCheck` whose ``success`` member is ``False``.
     """
 
-    def __init__(self, description=None, metadata_entries=None, dagster_type=None):
-        from dagster import DagsterType, MetadataEntry
+    def __init__(self, description=None, metadata=None, dagster_type=None):
+        from dagster import DagsterType
+        from dagster._core.definitions.metadata import normalize_metadata
 
         super(DagsterTypeCheckDidNotPass, self).__init__(description)
         self.description = check.opt_str_param(description, "description")
-        self.metadata_entries = check.opt_list_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
+        self.metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str)
         )
         self.dagster_type = check.opt_inst_param(dagster_type, "dagster_type", DagsterType)
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -105,7 +105,7 @@ def _validate_event(event: Any, step_context: StepExecutionContext) -> OpOutputU
                 "`return` instead of `yield` in the body of your {node_type} compute function. If "
                 "you are already using `return`, and you expected to return a value of type "
                 "{type_}, you may be inadvertently returning a generator rather than the value "
-                "you expected."
+                # f"you expected. Value is {str(event[0])}"
             ).format(
                 described_node=step_context.describe_op(),
                 type_=type(event),

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -241,7 +241,7 @@ def validate_and_coerce_op_result_to_iterator(
                             output_name=output_def.name,
                             value=dynamic_output.value,
                             mapping_key=dynamic_output.mapping_key,
-                            metadata_entries=list(dynamic_output.metadata_entries),
+                            metadata=dynamic_output.metadata,
                         )
             elif isinstance(element, Output):
                 if annotation != inspect.Parameter.empty and not is_generic_output_annotation(
@@ -260,7 +260,7 @@ def validate_and_coerce_op_result_to_iterator(
                     yield Output(
                         output_name=output_def.name,
                         value=element.value,
-                        metadata_entries=element.metadata_entries,
+                        metadata=element.metadata,
                         data_version=element.data_version,
                     )
             else:

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -323,7 +323,7 @@ def dagster_event_sequence_for_step(
             UserFailureData(
                 label="intentional-failure",
                 description=failure.description,
-                metadata_entries=failure.metadata_entries,
+                metadata=failure.metadata,
             ),
         )
         if step_context.raise_on_error:

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -19,7 +19,6 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._core.definitions import InputDefinition, NodeHandle, PipelineDefinition
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.metadata import MetadataEntry
 from dagster._core.definitions.version_strategy import ResourceVersionContext
 from dagster._core.errors import (
     DagsterExecutionLoadInputError,
@@ -188,15 +187,13 @@ class FromSourceAsset(
 
         yield from _load_input_with_input_manager(loader, load_input_context)
 
-        metadata_entries = load_input_context.consume_metadata_entries()
+        metadata = load_input_context.consume_metadata()
 
         yield DagsterEvent.loaded_input(
             step_context,
             input_name=input_def.name,
             manager_key=input_manager_key,
-            metadata_entries=[
-                entry for entry in metadata_entries if isinstance(entry, MetadataEntry)
-            ],
+            metadata=metadata,
         )
 
     def compute_version(
@@ -323,15 +320,13 @@ class FromRootInputManager(
 
         yield from _load_input_with_input_manager(loader, load_input_context)
 
-        metadata_entries = load_input_context.consume_metadata_entries()
+        metadata = load_input_context.consume_metadata()
 
         yield DagsterEvent.loaded_input(
             step_context,
             input_name=input_def.name,
             manager_key=input_manager_key,
-            metadata_entries=[
-                entry for entry in metadata_entries if isinstance(entry, MetadataEntry)
-            ],
+            metadata=metadata,
         )
 
     def compute_version(
@@ -515,7 +510,7 @@ class FromStepOutput(
         )
         yield from _load_input_with_input_manager(input_manager, load_input_context)
 
-        metadata_entries = load_input_context.consume_metadata_entries()
+        metadata = load_input_context.consume_metadata()
 
         yield DagsterEvent.loaded_input(
             step_context,
@@ -523,9 +518,7 @@ class FromStepOutput(
             manager_key=manager_key,
             upstream_output_name=source_handle.output_name,
             upstream_step_key=source_handle.step_key,
-            metadata_entries=[
-                entry for entry in metadata_entries if isinstance(entry, MetadataEntry)
-            ],
+            metadata=metadata,
         )
 
     def compute_version(

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -5,9 +5,9 @@ from multiprocessing.context import BaseContext as MultiprocessingBaseContext
 from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 from dagster import (
-    MetadataEntry,
     _check as check,
 )
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
 from dagster._core.definitions.repository_definition import RepositoryLoadData
 from dagster._core.errors import (
@@ -84,9 +84,9 @@ class MultiprocessExecutorChildProcessCommand(ChildProcessCommand):
                 log_manager,
                 self.pipeline_run.pipeline_name,
                 message=f'Executing step "{self.step_key}" in subprocess.',
-                metadata_entries=[
-                    MetadataEntry("pid", value=str(os.getpid())),
-                ],
+                metadata={
+                    "pid": MetadataValue.text(str(os.getpid())),
+                },
                 step_key=self.step_key,
             )
 
@@ -351,7 +351,7 @@ def execute_step_out_of_process(
     yield DagsterEvent.step_worker_starting(
         step_context,
         f'Launching subprocess for "{step.key}".',
-        metadata_entries=[],
+        metadata={},
     )
 
     for ret in execute_child_process_command(multiproc_ctx, command):

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional, Sequence, cast
 import pendulum
 
 import dagster._check as check
-from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData, MetadataEntry
+from dagster._core.definitions.metadata import MetadataValue
+from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
 from dagster._core.execution.context.system import PlanOrchestrationContext
 from dagster._core.execution.plan.active import ActiveExecution
 from dagster._core.execution.plan.objects import StepFailureData
@@ -212,11 +213,9 @@ class StepDelegatingExecutor(Executor):
                                 " because run will be resumed"
                             ),
                             EngineEventData(
-                                metadata_entries=[
-                                    MetadataEntry(
-                                        "steps_in_flight", value=str(running_steps.keys())
-                                    )
-                                ]
+                                metadata={
+                                    "steps_in_flight": MetadataValue.text(str(running_steps.keys()))
+                                },
                             ),
                         )
 

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -20,7 +20,7 @@ import dagster._check as check
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (
-    MetadataEntry,
+    MetadataValue,
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
@@ -429,7 +429,7 @@ class ExternalPipeline(RepresentedPipeline):
         return self._pipeline_index.pipeline_snapshot.tags
 
     @property
-    def metadata(self) -> Sequence[MetadataEntry]:
+    def metadata(self) -> Mapping[str, MetadataValue]:
         return self._pipeline_index.pipeline_snapshot.metadata
 
     @property

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -54,7 +54,12 @@ from dagster._core.definitions.definition_config_schema import ConfiguredDefinit
 from dagster._core.definitions.dependency import NodeOutputHandle
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.metadata import MetadataEntry, MetadataUserInput, normalize_metadata
+from dagster._core.definitions.metadata import (
+    MetadataFieldSerializer,
+    MetadataUserInput,
+    MetadataValue,
+    normalize_metadata,
+)
 from dagster._core.definitions.mode import DEFAULT_MODE_NAME
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
@@ -997,7 +1002,10 @@ class ExternalResourceData(
         )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(
+    storage_field_names={"metadata": "metadata_entries"},
+    field_serializers={"metadata": MetadataFieldSerializer},
+)
 class ExternalAssetNode(
     NamedTuple(
         "_ExternalAssetNode",
@@ -1018,7 +1026,7 @@ class ExternalAssetNode(
             ("partitions_def_data", Optional[ExternalPartitionsDefinitionData]),
             ("output_name", Optional[str]),
             ("output_description", Optional[str]),
-            ("metadata_entries", Sequence[MetadataEntry]),
+            ("metadata", Mapping[str, MetadataValue]),
             ("group_name", Optional[str]),
             ("freshness_policy", Optional[FreshnessPolicy]),
             ("is_source", bool),
@@ -1052,7 +1060,7 @@ class ExternalAssetNode(
         partitions_def_data: Optional[ExternalPartitionsDefinitionData] = None,
         output_name: Optional[str] = None,
         output_description: Optional[str] = None,
-        metadata_entries: Optional[Sequence[MetadataEntry]] = None,
+        metadata: Optional[Mapping[str, MetadataValue]] = None,
         group_name: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
         is_source: Optional[bool] = None,
@@ -1094,8 +1102,8 @@ class ExternalAssetNode(
             ),
             output_name=check.opt_str_param(output_name, "output_name"),
             output_description=check.opt_str_param(output_description, "output_description"),
-            metadata_entries=check.opt_sequence_param(
-                metadata_entries, "metadata_entries", of_type=MetadataEntry
+            metadata=normalize_metadata(
+                check.opt_mapping_param(metadata, "metadata", key_type=str)
             ),
             group_name=check.opt_str_param(group_name, "group_name"),
             freshness_policy=check.opt_inst_param(
@@ -1291,10 +1299,6 @@ def external_asset_graph_from_defs(
 
     for source_asset in source_assets_by_key.values():
         if source_asset.key not in node_defs_by_asset_key:
-            # TODO: For now we are dropping partition metadata entries
-            metadata_entries = [
-                entry for entry in source_asset.metadata_entries if isinstance(entry, MetadataEntry)
-            ]
             asset_nodes.append(
                 ExternalAssetNode(
                     asset_key=source_asset.key,
@@ -1302,7 +1306,7 @@ def external_asset_graph_from_defs(
                     depended_by=list(dep_by[source_asset.key].values()),
                     job_names=[ASSET_BASE_JOB_PREFIX] if source_asset.node_def is not None else [],
                     op_description=source_asset.description,
-                    metadata_entries=metadata_entries,
+                    metadata=source_asset.metadata,
                     group_name=source_asset.group_name,
                     is_source=True,
                     is_observable=source_asset.is_observable,
@@ -1326,17 +1330,13 @@ def external_asset_graph_from_defs(
         if isinstance(node_def, OpDefinition):
             required_top_level_resources = list(node_def.required_resource_keys)
 
-        asset_metadata_entries = (
-            cast(
-                Sequence,
-                normalize_metadata(
-                    metadata=metadata_by_asset_key[asset_key],
-                    metadata_entries=[],
-                    allow_invalid=True,
-                ),
+        asset_metadata = (
+            normalize_metadata(
+                metadata_by_asset_key[asset_key],
+                allow_invalid=True,
             )
             if asset_key in metadata_by_asset_key
-            else cast(Sequence, output_def.metadata_entries)
+            else output_def.metadata
         )
 
         job_names = [job_def.name for _, job_def in node_tuple_list]
@@ -1372,7 +1372,7 @@ def external_asset_graph_from_defs(
                 job_names=job_names,
                 partitions_def_data=partitions_def_data,
                 output_name=output_def.name,
-                metadata_entries=asset_metadata_entries,
+                metadata=asset_metadata,
                 # assets defined by Out(asset_key="k") do not have any group
                 # name specified we default to DEFAULT_GROUP_NAME here to ensure
                 # such assets are part of the default group

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1923,7 +1923,7 @@ class DagsterInstance(DynamicPartitionsStore):
             engine_event_data,
             "engine_event_data",
             EngineEventData,
-            EngineEventData([]),
+            EngineEventData({}),
         )
 
         if cls:

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -263,7 +263,7 @@ class DbIOManager(IOManager):
             schema=schema,
             database=self._database,
             partition_dimensions=partition_dimensions,
-            columns=(context.metadata or {}).get("columns"),  # type: ignore  # (mypy bug)
+            columns=(context.metadata or {}).get("columns"),
         )
 
     def _check_supported_type(self, obj_type):

--- a/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/fs_io_manager.py
@@ -9,7 +9,7 @@ from dagster import DagsterInvariantViolationError
 from dagster._annotations import experimental
 from dagster._config import Field, StringSource
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
-from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
@@ -211,9 +211,7 @@ class CustomPathPickledObjectFilesystemIOManager(IOManager):
 
         return AssetMaterialization(
             asset_key=AssetKey([context.pipeline_name, context.step_key, context.name]),
-            metadata_entries=[
-                MetadataEntry("path", value=MetadataValue.path(os.path.abspath(filepath)))
-            ],
+            metadata={"path": MetadataValue.path(os.path.abspath(filepath))},
         )
 
     def load_input(self, context: InputContext) -> object:

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -24,7 +24,12 @@ from dagster._config import (
     Noneable as ConfigNoneable,
 )
 from dagster._core.definitions.events import DynamicOutput, Output, TypeCheck
-from dagster._core.definitions.metadata import MetadataEntry, RawMetadataValue, normalize_metadata
+from dagster._core.definitions.metadata import (
+    MetadataEntry,
+    MetadataValue,
+    RawMetadataValue,
+    normalize_metadata,
+)
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._serdes import whitelist_for_serdes
 from dagster._seven import is_subclass
@@ -150,11 +155,9 @@ class DagsterType(RequiresResources):
 
         self._typing_type = typing_type
 
-        metadata_entries = check.opt_list_param(
-            metadata_entries, "metadata_entries", of_type=MetadataEntry
-        )
-        self._metadata_entries = normalize_metadata(
-            check.opt_mapping_param(metadata, "metadata", key_type=str), metadata_entries
+        self._metadata = normalize_metadata(
+            check.opt_mapping_param(metadata, "metadata", key_type=str),
+            check.opt_list_param(metadata_entries, "metadata_entries", of_type=MetadataEntry),
         )
 
     @public
@@ -187,8 +190,8 @@ class DagsterType(RequiresResources):
         return _RUNTIME_MAP[builtin_enum]
 
     @property
-    def metadata_entries(self) -> t.Sequence[MetadataEntry]:
-        return self._metadata_entries
+    def metadata(self) -> t.Mapping[str, MetadataValue]:
+        return self._metadata
 
     @public
     @property

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Iterator, Optional, Sequence, Tuple, cast
 
-from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.events import EngineEventData
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
@@ -135,15 +135,13 @@ def retry_run(
     instance.report_engine_event(
         "Retrying the run",
         failed_run,
-        engine_event_data=EngineEventData(
-            [MetadataEntry("new run", value=MetadataValue.dagster_run(new_run.run_id))]
-        ),
+        engine_event_data=EngineEventData({"new run": MetadataValue.dagster_run(new_run.run_id)}),
     )
     instance.report_engine_event(
         "Launched as an automatic retry",
         new_run,
         engine_event_data=EngineEventData(
-            [MetadataEntry("failed run", value=MetadataValue.dagster_run(failed_run.run_id))]
+            {"failed run": MetadataValue.dagster_run(failed_run.run_id)}
         ),
     )
 

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -651,8 +651,7 @@ def deserialize_value(
     """
     check.str_param(val, "val")
 
-    # `metadata_entries` as a constructor argument is deprecated, but it is still used by serdes
-    # machinery.
+    # Never issue warnings when deserializing deprecated objects.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1,6 +1,7 @@
 import ast
 import datetime
 import tempfile
+from typing import Sequence
 
 import pytest
 from dagster import (
@@ -37,6 +38,7 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvalidPropertyError,
 )
+from dagster._core.instance import DagsterInstance
 from dagster._core.storage.mem_io_manager import InMemoryIOManager
 from dagster._core.test_utils import instance_for_test
 
@@ -800,17 +802,13 @@ def test_from_op_w_configured():
     assert the_asset.keys_by_output_name["result"].path == ["foo2"]
 
 
-def get_step_keys_from_run(instance):
+def get_step_keys_from_run(instance: DagsterInstance) -> Sequence[str]:
     engine_events = list(
         instance.get_event_records(EventRecordsFilter(DagsterEventType.ENGINE_EVENT))
     )
-    metadata_entries = engine_events[
-        0
-    ].event_log_entry.dagster_event.engine_event_data.metadata_entries
-    step_metadata = next(
-        iter([metadata for metadata in metadata_entries if metadata.label == "step_keys"])
-    )
-    return ast.literal_eval(step_metadata.value.value)
+    metadata = engine_events[0].event_log_entry.get_dagster_event().engine_event_data.metadata
+    step_metadata = metadata["step_keys"]
+    return ast.literal_eval(step_metadata.value)  # type: ignore
 
 
 def get_num_events(instance, run_id, event_type):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -42,7 +42,11 @@ def check_experimental_warnings():
         for w in record:
             # Expect experimental warnings to be thrown for direct
             # resource_defs and io_manager_def arguments.
-            if "resource_defs" in w.message.args[0] or "io_manager_def" in w.message.args[0]:
+            if (
+                "resource_defs" in w.message.args[0]
+                or "io_manager_def" in w.message.args[0]
+                or "SQLALCHEMY" in w.message.args[0]
+            ):
                 continue
             assert False, f"Unexpected warning: {str(w)}"
 
@@ -57,9 +61,9 @@ def test_basic_materialize():
         with instance_for_test(temp_dir=temp_dir) as instance:
             result = materialize([the_asset], instance=instance)
             assert result.success
-            assert result.asset_materializations_for_node("the_asset")[0].metadata_entries[
-                0
-            ].value == MetadataValue.path(os.path.join(temp_dir, "storage", "the_asset"))
+            assert result.asset_materializations_for_node("the_asset")[0].metadata[
+                "path"
+            ] == MetadataValue.path(os.path.join(temp_dir, "storage", "the_asset"))
 
 
 def test_materialize_config():
@@ -302,7 +306,7 @@ def test_materialize_provided_resources():
         [the_asset], resources={"foo": foo_resource, "bar": 4, "io_manager": mem_io_manager}
     )
     assert result.success
-    assert result.asset_materializations_for_node("the_asset")[0].metadata_entries == []
+    assert result.asset_materializations_for_node("the_asset")[0].metadata == {}
 
 
 def test_conditional_materialize():
@@ -327,15 +331,15 @@ def test_conditional_materialize():
             result = materialize([the_asset, downstream], instance=instance)
             assert result.success
 
-            assert result.asset_materializations_for_node("the_asset")[0].metadata_entries[
-                0
-            ].value == MetadataValue.path(os.path.join(temp_dir, "storage", "the_asset"))
+            assert result.asset_materializations_for_node("the_asset")[0].metadata[
+                "path"
+            ] == MetadataValue.path(os.path.join(temp_dir, "storage", "the_asset"))
             with open(os.path.join(temp_dir, "storage", "the_asset"), "rb") as f:
                 assert pickle.load(f) == 5
 
-            assert result.asset_materializations_for_node("downstream")[0].metadata_entries[
-                0
-            ].value == MetadataValue.path(os.path.join(temp_dir, "storage", "downstream"))
+            assert result.asset_materializations_for_node("downstream")[0].metadata[
+                "path"
+            ] == MetadataValue.path(os.path.join(temp_dir, "storage", "downstream"))
             with open(os.path.join(temp_dir, "storage", "downstream"), "rb") as f:
                 assert pickle.load(f) == 6
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -31,7 +31,7 @@ def test_basic_materialize_to_memory():
 
     result = materialize_to_memory([the_asset])
     assert result.success
-    assert len(result.asset_materializations_for_node("the_asset")[0].metadata_entries) == 0
+    assert len(result.asset_materializations_for_node("the_asset")[0].metadata) == 0
     assert result.asset_value(the_asset.key) == 5
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset.py
@@ -1,17 +1,10 @@
 from dagster._core.definitions import SourceAsset
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
+from dagster._core.definitions.metadata import MetadataValue
 
 
 def test_source_asset_metadata():
     sa = SourceAsset(key=AssetKey("foo"), metadata={"foo": "bar", "baz": object()})
-    assert sa.metadata_entries == [
-        MetadataEntry(label="foo", value=MetadataValue.text("bar")),
-        MetadataEntry(
-            label="baz",
-            value=MetadataValue.text("[object] (unserializable)"),
-        ),
-    ]
     assert sa.metadata == {
         "foo": MetadataValue.text("bar"),
         "baz": MetadataValue.text("[object] (unserializable)"),

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
@@ -12,7 +12,7 @@ from dagster import (
 )
 
 
-def make_io_manager(source_asset: SourceAsset, input_value=5, expected_metadata=None):
+def make_io_manager(source_asset: SourceAsset, input_value=5, expected_metadata={}):
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
             ...

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -211,7 +211,7 @@ def test_assets_excluded_from_subset_not_in_job():
             job_names=["as_job"],  # the important line
             output_name="a",
             group_name=DEFAULT_GROUP_NAME,
-            metadata_entries=normalize_metadata(out_metadata, [], allow_invalid=True),
+            metadata=normalize_metadata(out_metadata, allow_invalid=True),
         )
         in external_asset_nodes
     )
@@ -459,7 +459,7 @@ def test_inter_op_dependency():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -476,7 +476,7 @@ def test_inter_op_dependency():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -490,7 +490,7 @@ def test_inter_op_dependency():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -530,7 +530,7 @@ def test_inter_op_dependency():
             op_description=None,
             job_names=["assets_job"],
             output_name="only_in",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -699,7 +699,7 @@ def test_graph_output_metadata_and_description():
                 dependencies=sorted(node.dependencies, key=lambda d: d.upstream_asset_key),
                 depended_by=sorted(node.depended_by, key=lambda d: d.downstream_asset_key),
                 op_names=sorted(node.op_names),
-                metadata_entries=sorted(node.metadata_entries),
+                metadata=node.metadata,
             )
             for node in external_asset_nodes
         ],
@@ -718,9 +718,7 @@ def test_graph_output_metadata_and_description():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=sorted(
-                normalize_metadata({**asset_metadata, **out_metadata}, [], allow_invalid=True)
-            ),
+            metadata=(normalize_metadata({**asset_metadata, **out_metadata}, allow_invalid=True)),
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -734,7 +732,7 @@ def test_graph_output_metadata_and_description():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]
@@ -840,7 +838,7 @@ def test_nasty_nested_graph_asset():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -857,7 +855,7 @@ def test_nasty_nested_graph_asset():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -876,7 +874,7 @@ def test_nasty_nested_graph_asset():
             op_description=None,
             job_names=["assets_job"],
             output_name="result",
-            metadata_entries=[],
+            metadata={},
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -108,7 +108,6 @@ def test_create_reexecuted_run_from_failure(
 
     assert run.tags[RESUME_RETRY_TAG] == "true"
     assert set(run.step_keys_to_execute) == {"conditional_fail", "after_failure"}  # type: ignore
-
     instance.launch_run(run.run_id, workspace)
     run = poll_for_finished_run(instance, run.run_id)
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -5,12 +5,12 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterTypeCheckDidNotPass,
     DependencyDefinition,
-    MetadataEntry,
     Output,
     _check as check,
 )
 from dagster._core.definitions.decorators import op
 from dagster._core.definitions.input import In
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.output import Out
 from dagster._legacy import (
@@ -219,7 +219,7 @@ def test_explicit_failure():
     def throws_failure():
         raise DagsterTypeCheckDidNotPass(
             description="Always fails.",
-            metadata_entries=[MetadataEntry("always_fails", value="why")],
+            metadata={"always_fails": MetadataValue.text("why")},
         )
 
     @pipeline
@@ -230,4 +230,4 @@ def test_explicit_failure():
         execute_pipeline(pipe)
 
     assert exc_info.value.description == "Always fails."
-    assert exc_info.value.metadata_entries == [MetadataEntry("always_fails", value="why")]
+    assert exc_info.value.metadata == {"always_fails": MetadataValue.text("why")}

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -554,10 +554,8 @@ def test_metadata_logging():
     assert result.success
     assert result.output_for_node("basic") == "baz"
     events = result.events_for_node("basic")
-    assert len(events[1].event_specific_data.metadata_entries) == 1
-    metadata_entry = events[1].event_specific_data.metadata_entries[0]
-    assert metadata_entry.label == "foo"
-    assert metadata_entry.value.text == "bar"
+    assert len(events[1].event_specific_data.metadata) == 1
+    assert events[1].event_specific_data.metadata["foo"].text == "bar"
 
 
 def test_metadata_logging_multiple_entries():
@@ -601,8 +599,8 @@ def test_log_metadata_multi_output():
     first_output_event = events[1]
     second_output_event = events[3]
 
-    assert first_output_event.event_specific_data.metadata_entries[0].label == "foo"
-    assert second_output_event.event_specific_data.metadata_entries[0].label == "bar"
+    assert "foo" in first_output_event.event_specific_data.metadata
+    assert "bar" in second_output_event.event_specific_data.metadata
 
 
 def test_log_metadata_after_output():
@@ -638,16 +636,16 @@ def test_log_metadata_multiple_dynamic_outputs():
     events = result.all_node_events
     output_event_one = events[1]
     assert output_event_one.event_specific_data.mapping_key == "one"
-    assert output_event_one.event_specific_data.metadata_entries[0].label == "one"
+    assert "one" in output_event_one.event_specific_data.metadata
     output_event_two = events[3]
     assert output_event_two.event_specific_data.mapping_key == "two"
-    assert output_event_two.event_specific_data.metadata_entries[0].label == "two"
+    assert "two" in output_event_two.event_specific_data.metadata
     output_event_three = events[5]
     assert output_event_three.event_specific_data.mapping_key == "three"
-    assert output_event_three.event_specific_data.metadata_entries[0].label == "three"
+    assert "three" in output_event_three.event_specific_data.metadata
     output_event_four = events[7]
     assert output_event_four.event_specific_data.mapping_key == "four"
-    assert output_event_four.event_specific_data.metadata_entries[0].label == "four"
+    assert "four" in output_event_four.event_specific_data.metadata
 
 
 def test_log_metadata_after_dynamic_output():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -8,7 +8,6 @@ from dagster import (
     AssetKey,
     AssetOut,
     AssetSelection,
-    BoolMetadataValue,
     DagsterEventType,
     DagsterInstance,
     DagsterInvariantViolationError,
@@ -42,6 +41,7 @@ from dagster import (
     sensor,
 )
 from dagster._config.structured_config import ConfigurableResource
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.resource_annotation import Resource
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
@@ -1163,10 +1163,10 @@ def test_build_multi_asset_sensor_context_set_to_latest_materializations():
             # Test that materialization exists
             assert context.latest_materialization_records_by_key()[
                 my_asset.key
-            ].event_log_entry.dagster_event.materialization.metadata_entries[
-                0
-            ].value == BoolMetadataValue(
-                value=True
+            ].event_log_entry.dagster_event.materialization.metadata[
+                "evaluated"
+            ] == MetadataValue.bool(
+                True
             )
 
     @repository

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -6,7 +6,6 @@ import pytest
 from dagster import (
     Failure,
     Field,
-    MetadataEntry,
     Nothing,
     Output,
     String,
@@ -15,6 +14,7 @@ from dagster import (
 )
 from dagster._core.definitions import op
 from dagster._core.definitions.input import In
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.output import Out
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
 from dagster._core.events import DagsterEvent, DagsterEventType
@@ -396,7 +396,7 @@ def test_optional_outputs():
 def throw():
     raise Failure(
         description="it Failure",
-        metadata_entries=[MetadataEntry("label", value="text")],
+        metadata={"label": "text"},
     )
 
 
@@ -424,8 +424,7 @@ def test_failure_multiprocessing():
         assert failure_data.user_failure_data.label == "intentional-failure"
         # from Failure
         assert failure_data.user_failure_data.description == "it Failure"
-        assert failure_data.user_failure_data.metadata_entries[0].label == "label"
-        assert failure_data.user_failure_data.metadata_entries[0].value.text == "text"
+        assert failure_data.user_failure_data.metadata["label"] == MetadataValue.text("text")
 
 
 @op

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -13,7 +13,6 @@ from dagster import (
     DynamicOutput,
     Failure,
     Field,
-    MetadataEntry,
     ResourceDefinition,
     RetryPolicy,
     RetryRequested,
@@ -484,9 +483,7 @@ def test_explicit_failure():
             )
             fd = run.result_for_node("retry_op").failure_data
             assert fd.user_failure_data.description == "some failure description"
-            assert fd.user_failure_data.metadata_entries == [
-                MetadataEntry(label="foo", value=MetadataValue.float(1.23))
-            ]
+            assert fd.user_failure_data.metadata == {"foo": MetadataValue.float(1.23)}
 
 
 def test_arbitrary_error():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_failure.py
@@ -1,5 +1,6 @@
-from dagster import Failure, MetadataEntry
+from dagster import Failure
 from dagster._core.definitions.decorators import op
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._legacy import execute_pipeline, pipeline
 
 
@@ -8,7 +9,7 @@ def test_failure():
     def throw():
         raise Failure(
             description="it Failure",
-            metadata_entries=[MetadataEntry("label", value="text")],
+            metadata={"label": "text"},
         )
 
     @pipeline
@@ -25,5 +26,4 @@ def test_failure():
     assert failure_data.user_failure_data.label == "intentional-failure"
     # from Failure
     assert failure_data.user_failure_data.description == "it Failure"
-    assert failure_data.user_failure_data.metadata_entries[0].label == "label"
-    assert failure_data.user_failure_data.metadata_entries[0].value.text == "text"
+    assert failure_data.user_failure_data.metadata["label"] == MetadataValue.text("text")

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -24,10 +24,10 @@ def n_asset_keys(path, n):
     return AssetLineageInfo(AssetKey(path), set([str(i) for i in range(n)]))
 
 
-def check_materialization(materialization, asset_key, parent_assets=None, metadata_entries=None):
+def check_materialization(materialization, asset_key, parent_assets=None, metadata=None):
     event_data = materialization.event_specific_data
     assert event_data.materialization.asset_key == asset_key
-    assert sorted(event_data.materialization.metadata_entries) == sorted(metadata_entries or [])
+    assert sorted(event_data.materialization.metadata) == metadata or {}
     assert event_data.asset_lineage == (parent_assets or [])
 
 
@@ -42,8 +42,8 @@ def test_io_manager_add_input_metadata():
 
             observations = context.get_observations()
             assert observations[0].asset_key == context.asset_key
-            assert observations[0].metadata_entries[0].label == "foo"
-            assert observations[1].metadata_entries[0].label == "baz"
+            assert "foo" in observations[0].metadata
+            assert "baz" in observations[1].metadata
             return 1
 
     @asset
@@ -77,10 +77,10 @@ def test_io_manager_add_input_metadata():
         event for event in result.all_events if event.event_type_value == "LOADED_INPUT"
     ][0]
     assert loaded_input_event
-    loaded_input_event_metadata = loaded_input_event.event_specific_data.metadata_entries
+    loaded_input_event_metadata = loaded_input_event.event_specific_data.metadata
     assert len(loaded_input_event_metadata) == 2
-    assert loaded_input_event_metadata[0].label == "foo"
-    assert loaded_input_event_metadata[1].label == "baz"
+    assert "foo" in loaded_input_event_metadata
+    assert "baz" in loaded_input_event_metadata
 
 
 def test_root_input_manager_add_input_metadata():
@@ -102,10 +102,10 @@ def test_root_input_manager_add_input_metadata():
     loaded_input_event = [
         event for event in result.all_events if event.event_type_value == "LOADED_INPUT"
     ][0]
-    metadata_entries = loaded_input_event.event_specific_data.metadata_entries
-    assert len(metadata_entries) == 2
-    assert metadata_entries[0].label == "foo"
-    assert metadata_entries[1].label == "baz"
+    metadata = loaded_input_event.event_specific_data.metadata
+    assert len(metadata) == 2
+    assert "foo" in metadata
+    assert "baz" in metadata
 
 
 def test_io_manager_single_partition_add_input_metadata():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -359,6 +359,7 @@ def test_non_asset_out():
     )
 
     assert len(handler.handle_input_calls) == 1
+
     assert handler.handle_input_calls[0][1] == table_slice
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -27,6 +27,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions import build_assets_job
+from dagster._core.events import HandledOutputData
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._core.storage.upath_io_manager import UPathIOManager
 from upath import UPath
@@ -409,10 +410,8 @@ def test_upath_io_manager_custom_metadata(tmp_path: Path, json_data: Any):
         [my_asset],
         resources={"io_manager": manager},
     )
-    handled_output_events = list(filter(lambda evt: evt.is_handled_output, result.all_node_events))
-
-    assert handled_output_events[0].event_specific_data.metadata_entries[  # type: ignore[index,union-attr]
-        1
-    ].value.value == get_length(
-        json_data
-    )
+    handled_output_data = list(filter(lambda evt: evt.is_handled_output, result.all_node_events))[
+        0
+    ].event_specific_data
+    assert isinstance(handled_output_data, HandledOutputData)
+    assert handled_output_data.metadata["length"] == MetadataValue.int(get_length(json_data))

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -177,9 +177,7 @@ def _build_airbyte_assets_from_metadata(
                 yield Output(
                     value=None,
                     output_name=table_name,
-                    metadata={
-                        entry.label: entry.value for entry in materialization.metadata_entries
-                    },
+                    metadata=materialization.metadata,
                 )
                 # Also materialize any normalization tables affiliated with this destination
                 # e.g. nested objects, lists etc
@@ -268,9 +266,7 @@ def build_airbyte_assets(
                 yield Output(
                     value=None,
                     output_name=table_name,
-                    metadata={
-                        entry.label: entry.value for entry in materialization.metadata_entries
-                    },
+                    metadata=materialization.metadata,
                 )
                 # Also materialize any normalization tables affiliated with this destination
                 # e.g. nested objects, lists etc

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -3,11 +3,11 @@ import responses
 from dagster import (
     AssetKey,
     FreshnessPolicy,
-    MetadataEntry,
     TableColumn,
     TableSchema,
     build_init_resource_context,
 )
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._legacy import build_assets_job
 from dagster_airbyte import airbyte_resource, build_airbyte_assets
@@ -83,19 +83,15 @@ def test_assets(schema_prefix):
         AssetKey(["some", "prefix", schema_prefix + "bar"]),
         AssetKey(["some", "prefix", schema_prefix + "baz"]),
     }
-    assert MetadataEntry("bytesEmitted", value=1234) in materializations[0].metadata_entries
-    assert MetadataEntry("recordsCommitted", value=4321) in materializations[0].metadata_entries
-    assert (
-        MetadataEntry(
-            "schema",
-            value=TableSchema(
-                columns=[
-                    TableColumn(name="a", type="str"),
-                    TableColumn(name="b", type="int"),
-                ]
-            ),
+    assert materializations[0].metadata["bytesEmitted"] == MetadataValue.int(1234)
+    assert materializations[0].metadata["recordsCommitted"] == MetadataValue.int(4321)
+    assert materializations[0].metadata["schema"] == MetadataValue.table_schema(
+        TableSchema(
+            columns=[
+                TableColumn(name="a", type="str"),
+                TableColumn(name="b", type="int"),
+            ]
         )
-        in materializations[0].metadata_entries
     )
 
 
@@ -183,20 +179,14 @@ def test_assets_with_normalization(schema_prefix, source_asset, freshness_policy
         AssetKey(["some", "prefix", schema_prefix + "bar_baz"]),
         AssetKey(["some", "prefix", schema_prefix + "bar_qux"]),
     }
-    assert MetadataEntry("bytesEmitted", value=1234) in materializations[0].metadata_entries
-    assert MetadataEntry("recordsCommitted", value=4321) in materializations[0].metadata_entries
-    assert (
-        MetadataEntry(
-            "schema",
-            value=TableSchema(
-                columns=[
-                    TableColumn(name="a", type="str"),
-                    TableColumn(name="b", type="int"),
-                ]
-            ),
-        )
-        in materializations[0].metadata_entries
+    assert materializations[0].metadata["bytesEmitted"] == MetadataValue.int(1234)
+    assert materializations[0].metadata["recordsCommitted"] == MetadataValue.int(4321)
+    assert materializations[0].metadata["schema"].value == TableSchema(
+        columns=[
+            TableColumn(name="a", type="str"),
+            TableColumn(name="b", type="int"),
+        ]
     )
 
     # No metadata for normalized materializations, for now
-    assert not materializations[3].metadata_entries
+    assert not materializations[3].metadata

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_resources.py
@@ -5,10 +5,10 @@ import responses
 from dagster import (
     DagsterExecutionInterruptedError,
     Failure,
-    MetadataEntry,
     _check as check,
     build_init_resource_context,
 )
+from dagster._core.definitions.metadata import MetadataValue
 from dagster_airbyte import AirbyteOutput, AirbyteState, airbyte_resource
 from dagster_airbyte.utils import generate_materializations
 
@@ -336,8 +336,8 @@ def test_assets(forward_logs):
     materializations = list(generate_materializations(airbyte_output, []))
     assert len(materializations) == 3
 
-    assert MetadataEntry("bytesEmitted", value=1234) in materializations[0].metadata_entries
-    assert MetadataEntry("recordsCommitted", value=4321) in materializations[0].metadata_entries
+    assert materializations[0].metadata["bytesEmitted"] == MetadataValue.int(1234)
+    assert materializations[0].metadata["recordsCommitted"] == MetadataValue.int(4321)
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -17,7 +17,7 @@ from dagster import (
     StringSource,
     _check as check,
 )
-from dagster._core.events import EngineEventData, MetadataEntry
+from dagster._core.events import EngineEventData
 from dagster._core.instance import T_DagsterInstance
 from dagster._core.launcher.base import (
     CheckRunHealthResult,
@@ -421,17 +421,17 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     ):
         # Extracted method to allow for subclasses to customize the launch reporting behavior
 
-        metadata_entries = []
+        metadata = {}
         if arn:
-            metadata_entries.append(MetadataEntry("ECS Task ARN", value=arn))
+            metadata["ECS Task ARN"] = arn
         if cluster:
-            metadata_entries.append(MetadataEntry("ECS Cluster", value=cluster))
+            metadata["ECS Cluster"] = cluster
 
-        metadata_entries.append(MetadataEntry("Run ID", value=run.run_id))
+        metadata["Run ID"] = run.run_id
         self._instance.report_engine_event(
             message="Launching run in ECS task",
             pipeline_run=run,
-            engine_event_data=EngineEventData(metadata_entries),
+            engine_event_data=EngineEventData(metadata),
             cls=self.__class__,
         )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Mapping, Optional
 
-from dagster._core.events import EngineEventData, MetadataEntry
+from dagster._core.events import EngineEventData
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._serdes.config_class import ConfigurableClassData
 from typing_extensions import Self
@@ -58,5 +58,5 @@ class CustomECSRunLauncher(EcsRunLauncher):
         self._instance.report_engine_event(
             message="Launching run in custom ECS task",
             pipeline_run=run,
-            engine_event_data=EngineEventData([MetadataEntry("Run ID", value=run.run_id)]),
+            engine_event_data=EngineEventData({"Run ID": run.run_id}),
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
@@ -1,4 +1,5 @@
 from dagster import DagsterEventType, job, op
+from dagster._core.definitions.metadata import MetadataValue
 from dagster_aws.s3 import S3FileHandle, file_handle_to_s3, s3_file_manager, s3_resource
 
 
@@ -39,8 +40,7 @@ def test_successful_file_handle_to_s3(mock_s3_bucket):
         if event.event_type == DagsterEventType.ASSET_MATERIALIZATION
     ]
     assert len(materializations) == 1
-    assert len(materializations[0].metadata_entries) == 1
-    assert (
-        materializations[0].metadata_entries[0].value.path == f"s3://{mock_s3_bucket.name}/some-key"
+    assert len(materializations[0].metadata) == 1
+    assert materializations[0].metadata["some-key"] == MetadataValue.path(
+        f"s3://{mock_s3_bucket.name}/some-key"
     )
-    assert materializations[0].metadata_entries[0].label == "some-key"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -211,4 +211,4 @@ def test_nothing(mock_s3_bucket):
     assert len(handled_output_events) == 2
 
     for event in handled_output_events:
-        assert len(event.event_specific_data.metadata_entries) == 0
+        assert len(event.event_specific_data.metadata) == 0

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -336,4 +336,4 @@ def test_nothing():
     assert len(handled_output_events) == 2
 
     for event in handled_output_events:
-        assert len(event.event_specific_data.metadata_entries) == 0
+        assert len(event.event_specific_data.metadata) == 0

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -9,7 +9,6 @@ from dagster import (
     DagsterEventType,
     DagsterInstance,
     Executor,
-    MetadataEntry,
     _check as check,
     executor,
     multiple_process_executor_requirements,
@@ -325,10 +324,10 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             f"Task for step {step_key} picked up by Celery",
             pipeline_run,
             EngineEventData(
-                [
-                    MetadataEntry("Celery worker name", value=celery_worker_name),
-                    MetadataEntry("Celery worker Kubernetes Pod name", value=celery_pod_name),
-                ]
+                {
+                    "Celery worker name": celery_worker_name,
+                    "Celery worker Kubernetes Pod name": celery_pod_name,
+                }
             ),
             CeleryK8sJobExecutor,
             step_key=step_key,
@@ -339,9 +338,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 "Not scheduling step because dagster run status is not STARTED",
                 pipeline_run,
                 EngineEventData(
-                    [
-                        MetadataEntry("Step key", value=step_key),
-                    ]
+                    {
+                        "Step key": step_key,
+                    }
                 ),
                 CeleryK8sJobExecutor,
                 step_key=step_key,
@@ -393,16 +392,14 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             f'Executing step "{step_key}" in Kubernetes job {job_name}.',
             pipeline_run,
             EngineEventData(
-                [
-                    MetadataEntry("Step key", value=step_key),
-                    MetadataEntry("Kubernetes Job name", value=job_name),
-                    MetadataEntry("Job image", value=job_config.job_image),
-                    MetadataEntry("Image pull policy", value=job_config.image_pull_policy),
-                    MetadataEntry("Image pull secrets", value=str(job_config.image_pull_secrets)),
-                    MetadataEntry(
-                        "Service account name", value=str(job_config.service_account_name)
-                    ),
-                ],
+                {
+                    "Step key": step_key,
+                    "Kubernetes Job name": job_name,
+                    "Job image": job_config.job_image,
+                    "Image pull policy": job_config.image_pull_policy,
+                    "Image pull secrets": str(job_config.image_pull_secrets),
+                    "Service account name": str(job_config.service_account_name),
+                },
                 marker_end=DELEGATE_MARKER,
             ),
             CeleryK8sJobExecutor,
@@ -421,10 +418,10 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                     "exists, proceeding with existing job.".format(job_name, step_key),
                     pipeline_run,
                     EngineEventData(
-                        [
-                            MetadataEntry("Step key", value=step_key),
-                            MetadataEntry("Kubernetes Job name", value=job_name),
-                        ],
+                        {
+                            "Step key": step_key,
+                            "Kubernetes Job name": job_name,
+                        },
                         marker_end=DELEGATE_MARKER,
                     ),
                     CeleryK8sJobExecutor,
@@ -436,9 +433,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                     "exiting.".format(job_name, step_key),
                     pipeline_run,
                     EngineEventData(
-                        [
-                            MetadataEntry("Step key", value=step_key),
-                        ],
+                        {
+                            "Step key": step_key,
+                        },
                         error=serializable_error_info_from_exc_info(sys.exc_info()),
                     ),
                     CeleryK8sJobExecutor,
@@ -464,11 +461,11 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 "Terminating Kubernetes Job because dagster run status is not STARTED",
                 pipeline_run,
                 EngineEventData(
-                    [
-                        MetadataEntry("Step key", value=step_key),
-                        MetadataEntry("Kubernetes Job name", value=job_name),
-                        MetadataEntry("Kubernetes Job namespace", value=job_namespace),
-                    ]
+                    {
+                        "Step key": step_key,
+                        "Kubernetes Job name": job_name,
+                        "Kubernetes Job namespace": job_namespace,
+                    }
                 ),
                 CeleryK8sJobExecutor,
                 step_key=step_key,
@@ -488,9 +485,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 "exiting.".format(job_name, step_key),
                 pipeline_run,
                 EngineEventData(
-                    [
-                        MetadataEntry("Step key", value=step_key),
-                    ],
+                    {
+                        "Step key": step_key,
+                    },
                     error=serializable_error_info_from_exc_info(sys.exc_info()),
                 ),
                 CeleryK8sJobExecutor,
@@ -506,9 +503,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                 "exiting.".format(job_name, step_key),
                 pipeline_run,
                 EngineEventData(
-                    [
-                        MetadataEntry("Step key", value=step_key),
-                    ],
+                    {
+                        "Step key": step_key,
+                    },
                     error=serializable_error_info_from_exc_info(sys.exc_info()),
                 ),
                 CeleryK8sJobExecutor,
@@ -520,7 +517,7 @@ def create_k8s_job_task(celery_app, **task_kwargs):
         engine_event = instance.report_engine_event(
             "Retrieving logs from Kubernetes Job pods",
             pipeline_run,
-            EngineEventData([MetadataEntry("Pod names", value="\n".join(pod_names))]),
+            EngineEventData({"Pod names": "\n".join(pod_names)}),
             CeleryK8sJobExecutor,
             step_key=step_key,
         )
@@ -539,9 +536,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
                     ),
                     pipeline_run,
                     EngineEventData(
-                        [
-                            MetadataEntry("Step key", value=step_key),
-                        ],
+                        {
+                            "Step key": step_key,
+                        },
                         error=serializable_error_info_from_exc_info(sys.exc_info()),
                     ),
                     CeleryK8sJobExecutor,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -4,7 +4,6 @@ from typing import Optional, cast
 import kubernetes
 from dagster import (
     DagsterInvariantViolationError,
-    MetadataEntry,
     _check as check,
 )
 from dagster._config import process_config, resolve_to_config_type
@@ -230,11 +229,11 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             "Creating Kubernetes run worker job",
             run,
             EngineEventData(
-                [
-                    MetadataEntry("Kubernetes Job name", value=job_name),
-                    MetadataEntry("Kubernetes Namespace", value=job_namespace),
-                    MetadataEntry("Run ID", value=run.run_id),
-                ]
+                {
+                    "Kubernetes Job name": job_name,
+                    "Kubernetes Namespace": job_namespace,
+                    "Run ID": run.run_id,
+                }
             ),
             cls=self.__class__,
         )
@@ -244,11 +243,11 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             "Kubernetes run worker job created",
             run,
             EngineEventData(
-                [
-                    MetadataEntry("Kubernetes Job name", value=job_name),
-                    MetadataEntry("Kubernetes Namespace", value=job_namespace),
-                    MetadataEntry("Run ID", value=run.run_id),
-                ]
+                {
+                    "Kubernetes Job name": job_name,
+                    "Kubernetes Namespace": job_namespace,
+                    "Run ID": run.run_id,
+                }
             ),
             cls=self.__class__,
         )

--- a/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/tasks.py
@@ -1,6 +1,5 @@
 from dagster import (
     DagsterInstance,
-    MetadataEntry,
     _check as check,
 )
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
@@ -48,10 +47,10 @@ def create_task(celery_app, **task_kwargs):
             f"Executing steps {step_keys_str} in celery worker",
             pipeline_run,
             EngineEventData(
-                [
-                    MetadataEntry("step_keys", value=step_keys_str),
-                    MetadataEntry("Celery worker", value=self.request.hostname),
-                ],
+                {
+                    "step_keys": step_keys_str,
+                    "Celery worker": self.request.hostname,
+                },
                 marker_end=DELEGATE_MARKER,
             ),
             CeleryExecutor,

--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -15,7 +15,6 @@ from dagster import (
     EnumValue,
     Field,
     Int,
-    MetadataEntry,
     Permissive,
     Selector,
     Shape,
@@ -502,10 +501,8 @@ def df_type_check(_, value):
         return TypeCheck(success=False)
     return TypeCheck(
         success=True,
-        metadata_entries=[
-            # string cast columns since they may be things like datetime
-            MetadataEntry("metadata", value={"columns": list(map(str, value.columns))}),
-        ],
+        # string cast columns since they may be things like datetime
+        metadata={"metadata": {"columns": list(map(str, value.columns))}},
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -10,7 +10,6 @@ from dagster import (
     DailyPartitionsDefinition,
     FreshnessPolicy,
     IOManager,
-    MetadataEntry,
     ResourceDefinition,
     asset,
     io_manager,
@@ -18,6 +17,7 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions import build_assets_job
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._legacy import AssetGroup
 from dagster._utils import file_relative_path
 from dagster_dbt import dbt_cli_resource
@@ -119,11 +119,10 @@ def test_runtime_metadata_fn(
         if event.event_type_value == "ASSET_MATERIALIZATION"
     ]
     assert len(materializations) == 4
-    for entry in [
-        MetadataEntry("op_name", value=dbt_assets[0].op.name),
-        MetadataEntry("dbt_model", value=materializations[0].asset_key.path[-1]),
-    ]:
-        assert entry in materializations[0].metadata_entries
+    assert materializations[0].metadata["op_name"] == MetadataValue.text(dbt_assets[0].op.name)
+    assert materializations[0].metadata["dbt_model"] == MetadataValue.text(
+        materializations[0].asset_key.path[-1]
+    )
 
 
 def test_fail_immediately(dbt_seed, conn_string, test_project_dir, dbt_config_dir):

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -6,7 +6,7 @@ import docker.errors
 from dagster import Field, IntSource, executor
 from dagster._annotations import experimental
 from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
-from dagster._core.events import DagsterEvent, EngineEventData, MetadataEntry
+from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.retries import RetryMode, get_retries_config
 from dagster._core.execution.tags import get_tag_concurrency_limits_config
 from dagster._core.executor.base import Executor
@@ -244,9 +244,9 @@ class DockerStepHandler(StepHandler):
         yield DagsterEvent.step_worker_starting(
             step_handler_context.get_step_context(step_key),
             message="Launching step in Docker container.",
-            metadata_entries=[
-                MetadataEntry("Docker container id", value=step_container.id),
-            ],
+            metadata={
+                "Docker container id": step_container.id,
+            },
         )
         step_container.start()
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.cacheable_assets import (
 )
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.load_assets_from_modules import with_group
-from dagster._core.definitions.metadata import MetadataEntry, MetadataUserInput
+from dagster._core.definitions.metadata import MetadataUserInput
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterStepOutputNotFoundError
 from dagster._core.execution.context.init import build_init_resource_context
@@ -93,10 +93,7 @@ def _build_fivetran_assets(
                 yield Output(
                     value=None,
                     output_name="_".join(materialization.asset_key.path),
-                    metadata={
-                        cast(MetadataEntry, entry).label: cast(MetadataEntry, entry).value
-                        for entry in materialization.metadata_entries
-                    },
+                    metadata=materialization.metadata,
                 )
                 materialized_asset_keys.add(materialization.asset_key)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -242,4 +242,4 @@ def test_nothing(gcs_bucket):
     assert len(handled_output_events) == 2
 
     for event in handled_output_events:
-        assert len(event.event_specific_data.metadata_entries) == 0
+        assert len(event.event_specific_data.metadata) == 0

--- a/python_modules/libraries/dagster-ge/dagster_ge/factory.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge/factory.py
@@ -5,7 +5,6 @@ import great_expectations as ge
 from dagster import (
     ExpectationResult,
     In,
-    MetadataEntry,
     MetadataValue,
     Noneable,
     Out,
@@ -116,12 +115,9 @@ def ge_validation_op_factory(
         )
         md_str = " ".join(DefaultMarkdownPageView().render(rendered_document_content_list))
 
-        meta_stats = MetadataEntry("Expectation Results", value=MetadataValue.md(md_str))
         yield ExpectationResult(
             success=res["success"],
-            metadata_entries=[
-                meta_stats,
-            ],
+            metadata={"Expectation Results": MetadataValue.md(md_str)},
         )
         yield Output(res)
 
@@ -221,10 +217,9 @@ def ge_validation_op_factory_v3(
         )
         md_str = "".join(DefaultMarkdownPageView().render(rendered_document_content_list))
 
-        meta_stats = MetadataEntry("Expectation Results", value=MetadataValue.md(md_str))
         yield ExpectationResult(
             success=bool(results["success"]),
-            metadata_entries=[meta_stats],
+            metadata={"Expectation Results": MetadataValue.md(md_str)},
         )
         yield Output(results.to_json_dict())
 

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/test_basic_integ.py
@@ -89,7 +89,7 @@ def test_yielded_results_config_pandas(snapshot, job_def, ge_dir):
     mainexpect = expectations[0]
     assert mainexpect.success
     # purge system specific metadata for testing
-    metadata = mainexpect.metadata_entries[0].value.md_str.split("### Info")[0]
+    metadata = mainexpect.metadata["Expectation Results"].md_str.split("### Info")[0]
     snapshot.assert_match(metadata)
 
 
@@ -108,5 +108,5 @@ def test_yielded_results_config_pyspark_v2(snapshot):  # pylint:disable=unused-a
     mainexpect = expectations[0]
     assert mainexpect.success
     # purge system specific metadata for testing
-    metadata = mainexpect.metadata_entries[0].value.md_str.split("### Info")[0]
+    metadata = mainexpect.metadata["Expectation Results"].md_str.split("### Info")[0]
     snapshot.assert_match(metadata)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -9,8 +9,9 @@ from dagster import (
     executor,
 )
 from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.errors import DagsterUnmetExecutorRequirementsError
-from dagster._core.events import DagsterEvent, EngineEventData, MetadataEntry
+from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.retries import RetryMode, get_retries_config
 from dagster._core.execution.tags import get_tag_concurrency_limits_config
 from dagster._core.executor.base import Executor
@@ -256,9 +257,9 @@ class K8sStepHandler(StepHandler):
         yield DagsterEvent.step_worker_starting(
             step_handler_context.get_step_context(step_key),
             message=f'Executing step "{step_key}" in Kubernetes job {job_name}.',
-            metadata_entries=[
-                MetadataEntry("Kubernetes Job name", value=job_name),
-            ],
+            metadata={
+                "Kubernetes Job name": MetadataValue.text(job_name),
+            },
         )
 
         self._api_client.batch_api.create_namespaced_job(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -3,7 +3,6 @@ from typing import Any, Mapping, Optional, Sequence
 
 import kubernetes
 from dagster import (
-    MetadataEntry,
     _check as check,
 )
 from dagster._cli.api import ExecuteRunArgs
@@ -240,11 +239,11 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             "Creating Kubernetes run worker job",
             run,
             EngineEventData(
-                [
-                    MetadataEntry("Kubernetes Job name", value=job_name),
-                    MetadataEntry("Kubernetes Namespace", value=container_context.namespace),
-                    MetadataEntry("Run ID", value=run.run_id),
-                ]
+                {
+                    "Kubernetes Job name": job_name,
+                    "Kubernetes Namespace": container_context.namespace,
+                    "Run ID": run.run_id,
+                }
             ),
             cls=self.__class__,
         )

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -3,7 +3,6 @@ from dagster import (
     DagsterInvariantViolationError,
     DagsterType,
     Field,
-    MetadataEntry,
     MetadataValue,
     StringSource,
     TableColumn,
@@ -14,13 +13,12 @@ from dagster import (
     dagster_type_loader,
 )
 from dagster._annotations import experimental
-from dagster._check import CheckError
 from dagster._config import Selector
 from dagster._core.definitions.metadata import normalize_metadata
-from dagster._core.errors import DagsterInvalidMetadata
 from dagster._utils import dict_without_keys
 
 from dagster_pandas.constraints import (
+    CONSTRAINT_METADATA_KEY,
     ColumnDTypeFnConstraint,
     ColumnDTypeInSetConstraint,
     ConstraintViolationException,
@@ -64,11 +62,11 @@ def df_type_check(_, value):
         return TypeCheck(success=False)
     return TypeCheck(
         success=True,
-        metadata_entries=[
-            MetadataEntry("row_count", value=str(len(value))),
+        metadata={
+            "row_count": str(len(value)),
             # string cast columns since they may be things like datetime
-            MetadataEntry("metadata", value={"columns": list(map(str, value.columns))}),
-        ],
+            "metadata": {"columns": list(map(str, value.columns))},
+        },
     )
 
 
@@ -159,9 +157,10 @@ def create_dagster_pandas_dataframe_type(
         description (Optional[str]): A markdown-formatted string, displayed in tooling.
         columns (Optional[List[PandasColumn]]): A list of :py:class:`~dagster.PandasColumn` objects
             which express dataframe column schemas and constraints.
-        event_metadata_fn (Optional[Callable[[], Union[Dict[str, Union[str, float, int, Dict, MetadataValue]], List[MetadataEntry]]]]):
+        event_metadata_fn (Optional[Callable[[], Union[Dict[str, Union[str, float, int, Dict, MetadataValue]])
             A callable which takes your dataframe and returns a dict with string label keys and
-            MetadataValue values. Can optionally return a List[MetadataEntry].
+            MetadataValue values. Can optionally return a `List[MetadataEntry]`, but this format is
+            deprecated.
         dataframe_constraints (Optional[List[DataFrameConstraint]]): A list of objects that inherit from
             :py:class:`~dagster.DataFrameConstraint`. This allows you to express dataframe-level constraints.
         loader (Optional[DagsterTypeLoader]): An instance of a class that
@@ -198,7 +197,7 @@ def create_dagster_pandas_dataframe_type(
 
         return TypeCheck(
             success=True,
-            metadata_entries=_execute_summary_stats(name, value, event_metadata_fn)
+            metadata=_execute_summary_stats(name, value, event_metadata_fn)
             if event_metadata_fn
             else None,
         )
@@ -264,7 +263,7 @@ def create_structured_dataframe_type(
             )
 
         typechecks_succeeded = True
-        metadata = []
+        metadata = {}
         overall_description = "Failed Constraints: {}"
         constraint_clauses = []
         for key, result in individual_result_dict.items():
@@ -272,19 +271,14 @@ def create_structured_dataframe_type(
             if result_val:
                 continue
             typechecks_succeeded = typechecks_succeeded and result_val
-            result_dict = result.metadata_entries[0].value.data
-            metadata.append(
-                MetadataEntry(
-                    f"{key}-constraint-metadata",
-                    value=result_dict,
-                )
-            )
+            result_dict = result.metadata[CONSTRAINT_METADATA_KEY].data
+            metadata[f"{key}-constraint-metadata"] = MetadataValue.json(result_dict)
             constraint_clauses.append(f"{key} failing constraints, {result.description}")
         # returns aggregates, then column, then dataframe
         return TypeCheck(
             success=typechecks_succeeded,
             description=overall_description.format(constraint_clauses),
-            metadata_entries=sorted(metadata, key=lambda x: x.label),
+            metadata=metadata,
         )
 
     description = check.opt_str_param(description, "description", default="")
@@ -300,25 +294,16 @@ def _execute_summary_stats(type_name, value, event_metadata_fn):
     if not event_metadata_fn:
         return []
 
-    metadata_or_metadata_entries = event_metadata_fn(value)
-
-    invalid_message = (
-        "The return value of the user-defined summary_statistics function for pandas "
-        f"data frame type {type_name} returned {value}. This function must return "
-        "Union[Dict[str, Union[str, float, int, Dict, MetadataValue]], List[MetadataEntry]]"
-    )
-
-    metadata = None
-    metadata_entries = None
-
-    if isinstance(metadata_or_metadata_entries, list):
-        metadata_entries = metadata_or_metadata_entries
-    elif isinstance(metadata_or_metadata_entries, dict):
-        metadata = metadata_or_metadata_entries
-    else:
-        raise DagsterInvariantViolationError(invalid_message)
+    user_metadata = event_metadata_fn(value)
 
     try:
-        return normalize_metadata(metadata, metadata_entries)
-    except (DagsterInvalidMetadata, CheckError):
-        raise DagsterInvariantViolationError(invalid_message)
+        metadata_dict, metadata_entries = (
+            ({}, user_metadata) if isinstance(user_metadata, list) else (user_metadata, [])
+        )
+        return normalize_metadata(metadata_dict, metadata_entries)
+    except:
+        raise DagsterInvariantViolationError(
+            "The return value of the user-defined summary_statistics function for pandas "
+            f"data frame type {type_name} returned {value}. This function must return "
+            "Dict[str, RawMetadataValue]."
+        )

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
@@ -1,4 +1,5 @@
 from dagster_pandas.constraints import (
+    CONSTRAINT_METADATA_KEY,
     ColumnAggregateConstraintWithMetadata,
     ColumnConstraintWithMetadata,
     ColumnRangeConstraintWithMetadata,
@@ -49,7 +50,7 @@ def test_basic():
 
 
 def test_failed_multi():
-    mul_val = basic_multi_constraint.validate([]).metadata_entries[0].value.data
+    mul_val = basic_multi_constraint.validate([]).metadata[CONSTRAINT_METADATA_KEY].data
     assert mul_val["expected"] == {"basic_validation_function": "a DataFrame"}
     assert mul_val["actual"] == {"basic_validation_function": "a list"}
 
@@ -57,7 +58,7 @@ def test_failed_multi():
 def test_success_multi():
     mul_val = basic_multi_constraint.validate(DataFrame())
     assert mul_val.success is True
-    assert mul_val.metadata_entries == []
+    assert mul_val.metadata == {}
 
 
 def test_failed_strict():
@@ -81,7 +82,7 @@ def test_column_constraint():
         ColumnWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = column_val.validate(df, *df.columns).metadata_entries[0].value.data
+    val = column_val.validate(df, *df.columns).metadata[CONSTRAINT_METADATA_KEY].data
     assert {"bar": ["row 0"], "baz": ["row 1"]} == val["offending"]
     assert {"bar": ["a"], "baz": ["a"]} == val["actual"]
 
@@ -97,7 +98,7 @@ def test_multi_val_constraint():
         ColumnWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = column_val.validate(df, *df.columns).metadata_entries[0].value.data
+    val = column_val.validate(df, *df.columns).metadata[CONSTRAINT_METADATA_KEY].data
     assert {"foo": ["row 0", "row 1"], "bar": ["row 1"], "baz": ["row 0"]} == val["offending"]
     assert {"foo": [1, 2], "bar": [2], "baz": [1]} == val["actual"]
 
@@ -118,7 +119,7 @@ def test_multi_column_constraint():
         ColumnWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = column_val.validate(df).metadata_entries[0].value.data
+    val = column_val.validate(df).metadata[CONSTRAINT_METADATA_KEY].data
     assert {
         "bar": {
             "col_val_two": "values less than 2.",
@@ -152,7 +153,7 @@ def test_aggregate_constraint():
         ConstraintWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = aggregate_val.validate(df, *df.columns).metadata_entries[0].value.data
+    val = aggregate_val.validate(df, *df.columns).metadata[CONSTRAINT_METADATA_KEY].data
     assert ["foo"] == val["offending"]
     assert [1, 2] == val["actual"]["foo"]
 
@@ -178,7 +179,7 @@ def test_multi_agg_constraint():
         ConstraintWithMetadataException,
         raise_or_typecheck=False,
     )
-    val = aggregate_val.validate(df).metadata_entries[0].value.data
+    val = aggregate_val.validate(df).metadata[CONSTRAINT_METADATA_KEY].data
     assert val["expected"] == {
         "bar": {"column_val_2": "Checks column mean equal to 1.5."},
         "foo": {"column_val_1": "Checks column mean equal to 1."},
@@ -192,7 +193,7 @@ def test_multi_agg_constraint():
 def test_range_constraint():
     df = DataFrame({"foo": [1, 2], "bar": [3, 2], "baz": [1, 4]})
     range_val = ColumnRangeConstraintWithMetadata(1, 2.5, raise_or_typecheck=False)
-    val = range_val.validate(df).metadata_entries[0].value.data
+    val = range_val.validate(df).metadata[CONSTRAINT_METADATA_KEY].data
     assert {"bar": ["row 0"], "baz": ["row 1"]} == val["offending"]
     assert {"bar": [3], "baz": [4]} == val["actual"]
     range_val = ColumnRangeConstraintWithMetadata(raise_or_typecheck=False)

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_metadata.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_metadata.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from dagster import DagsterEventType, In, file_relative_path, graph, op
+from dagster._core.definitions.metadata import MetadataValue
 from dagster_pandas import DataFrame
 
 
@@ -28,10 +29,7 @@ def test_basic_pd_df_metadata():
 
     assert input_event.step_input_data.input_name == "df"
 
-    metadata_entries = input_event.step_input_data.type_check_data.metadata_entries
+    metadata = input_event.step_input_data.type_check_data.metadata
 
-    assert metadata_entries[0].label == "row_count"
-    assert metadata_entries[0].value.text == "2"
-
-    assert metadata_entries[1].label == "metadata"
-    assert metadata_entries[1].value.data["columns"] == ["num1", "num2"]
+    assert metadata["row_count"] == MetadataValue.text("2")
+    assert metadata["metadata"].data["columns"] == ["num1", "num2"]

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_structured_df_types.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_structured_df_types.py
@@ -91,11 +91,9 @@ def test_failing_type_eval_column():
     result = basic_graph.execute_in_process(raise_on_error=False)
     output = [item for item in result.all_node_events if item.is_successful_output][0]
     output_data = output.event_specific_data.type_check_data
-    output_metadata = output_data.metadata_entries
+    output_metadata = output_data.metadata
     assert len(output_metadata) == 1
-    column_const = output_metadata[0]
-    assert column_const.label == "columns-constraint-metadata"
-    column_const_data = column_const.value.data
+    column_const_data = output_metadata["columns-constraint-metadata"].data
     assert column_const_data["expected"] == {
         "foo": {
             "in_range_validation_fn": in_range_validator.__doc__.strip(),
@@ -135,11 +133,10 @@ def test_failing_type_eval_aggregate():
     result = basic_graph.execute_in_process(raise_on_error=False)
     output = [item for item in result.all_node_events if item.is_successful_output][0]
     output_data = output.event_specific_data.type_check_data
-    output_metadata = output_data.metadata_entries
+    output_metadata = output_data.metadata
     assert len(output_metadata) == 1
-    column_const = output_metadata[0]
-    assert column_const.label == "column-aggregates-constraint-metadata"
-    column_const_data = column_const.value.data
+    column_const = output_metadata["column-aggregates-constraint-metadata"]
+    column_const_data = column_const.data
     assert column_const_data["expected"] == {
         "bar": {"all_unique_validator": all_unique_validator.__doc__.strip()}
     }
@@ -169,11 +166,9 @@ def test_failing_type_eval_dataframe():
     result = basic_graph.execute_in_process(raise_on_error=False)
     output = [item for item in result.all_node_events if item.is_successful_output][0]
     output_data = output.event_specific_data.type_check_data
-    output_metadata = output_data.metadata_entries
+    output_metadata = output_data.metadata
     assert len(output_metadata) == 1
-    column_const = output_metadata[0]
-    assert column_const.label == "dataframe-constraint-metadata"
-    column_const_data = column_const.value.data
+    column_const_data = output_metadata["dataframe-constraint-metadata"].data
     assert column_const_data["expected"] == ["foo", "bar"]
     assert column_const_data["actual"] == {"extra_columns": ["baz"], "missing_columns": ["bar"]}
 
@@ -200,20 +195,16 @@ def test_failing_type_eval_multi_error():
     result = basic_graph.execute_in_process(raise_on_error=False)
     output = [item for item in result.all_node_events if item.is_successful_output][0]
     output_data = output.event_specific_data.type_check_data
-    output_metadata = output_data.metadata_entries
+    output_metadata = output_data.metadata
     assert len(output_metadata) == 3
-    agg_data = output_metadata[0]
-
-    assert agg_data.label == "column-aggregates-constraint-metadata"
-    agg_metadata = agg_data.value.data
+    agg_data = output_metadata["column-aggregates-constraint-metadata"]
+    agg_metadata = agg_data.data
     assert agg_metadata["expected"] == {
         "bar": {"all_unique_validator": all_unique_validator.__doc__.strip()}
     }
     assert agg_metadata["offending"] == {"bar": {"all_unique_validator": "a violation"}}
     assert agg_metadata["actual"] == {"bar": {"all_unique_validator": [10.0]}}
-    column_const = output_metadata[1]
-    assert column_const.label == "columns-constraint-metadata"
-    column_const_data = column_const.value.data
+    column_const_data = output_metadata["columns-constraint-metadata"].data
     assert column_const_data["expected"] == {
         "foo": {
             "in_range_validation_fn": in_range_validator.__doc__.strip(),
@@ -230,8 +221,6 @@ def test_failing_type_eval_multi_error():
         "foo": {"dtype_in_set_validation_fn": ["a"], "in_range_validation_fn": ["a", 7]}
     }
 
-    df_data = output_metadata[2]
-    assert df_data.label == "dataframe-constraint-metadata"
-    df_metadata = df_data.value.data
+    df_metadata = output_metadata["dataframe-constraint-metadata"].data
     assert df_metadata["expected"] == ["foo", "bar"]
     assert df_metadata["actual"] == {"extra_columns": ["baz"], "missing_columns": []}

--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pandera as pa
 from dagster import (
     DagsterType,
-    MetadataEntry,
     TableColumn,
     TableColumnConstraints,
     TableConstraints,
@@ -106,9 +105,9 @@ def pandera_schema_to_dagster_type(
         type_check_fn=type_check_fn,
         name=name,
         description=norm_schema.description,
-        metadata_entries=[
-            MetadataEntry("schema", value=MetadataValue.table_schema(tschema)),
-        ],
+        metadata={
+            "schema": MetadataValue.table_schema(tschema),
+        },
         typing_type=pd.DataFrame,
     )
 

--- a/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
@@ -114,10 +114,10 @@ def dagster_type():
 def test_pandera_schema_to_dagster_type(schema):
     dagster_type = pandera_schema_to_dagster_type(schema)
     assert isinstance(dagster_type, DagsterType)
-    assert len(dagster_type.metadata_entries) == 1
-    schema_entry = dagster_type.metadata_entries[0]
-    assert isinstance(schema_entry.value, TableSchemaMetadataValue)
-    assert schema_entry.value.schema == TableSchema(
+    assert len(dagster_type.metadata) == 1
+    schema_metadata = dagster_type.metadata["schema"]
+    assert isinstance(schema_metadata, TableSchemaMetadataValue)
+    assert schema_metadata.schema == TableSchema(
         constraints=TableConstraints(other=["sum(a) > sum(b)."]),
         columns=[
             TableColumn(

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -180,7 +180,7 @@ class ArtifactsIOManager(IOManager):
         with self.wandb_run() as run:
             parameters = context.metadata.get("wandb_artifact_configuration", {})  # type: ignore
 
-            serialization_module = parameters.get("serialization_module", {})  # type: ignore
+            serialization_module = parameters.get("serialization_module", {})
             serialization_module_name = serialization_module.get("name", "pickle")
 
             if serialization_module_name not in ACCEPTED_SERIALIZATION_MODULES:
@@ -194,8 +194,8 @@ class ArtifactsIOManager(IOManager):
                 **serialization_module_parameters,
             }
 
-            artifact_type = parameters.get("type", "artifact")  # type: ignore
-            artifact_description = parameters.get("description")  # type: ignore
+            artifact_type = parameters.get("type", "artifact")
+            artifact_description = parameters.get("description")
             artifact_metadata = {
                 "source_integration": "dagster_wandb",
                 "source_integration_version": __version__,
@@ -204,14 +204,14 @@ class ArtifactsIOManager(IOManager):
                 "source_python_version": platform.python_version(),
             }
             if isinstance(obj, Artifact):
-                if parameters.get("name") is not None:  # type: ignore
+                if parameters.get("name") is not None:
                     raise WandbArtifactsIOManagerError(
                         "A 'name' property was provided in the 'wandb_artifact_configuration'"
                         " metadata dictionary. A 'name' property can only be provided for output"
                         " that is not already an Artifact object."
                     )
 
-                if parameters.get("type") is not None:  # type: ignore
+                if parameters.get("type") is not None:
                     raise WandbArtifactsIOManagerError(
                         "A 'type' property was provided in the 'wandb_artifact_configuration'"
                         " metadata dictionary. A 'type' property can only be provided for output"
@@ -248,7 +248,7 @@ class ArtifactsIOManager(IOManager):
                     artifact.description = artifact_description
             else:
                 if context.has_asset_key:
-                    if parameters.get("name") is not None:  # type: ignore
+                    if parameters.get("name") is not None:
                         raise WandbArtifactsIOManagerError(
                             "A 'name' property was provided in the 'wandb_artifact_configuration'"
                             " metadata dictionary. A 'name' property is only required when no"
@@ -259,13 +259,13 @@ class ArtifactsIOManager(IOManager):
                         )
                     artifact_name = context.get_asset_identifier()[0]  # name of asset
                 else:
-                    if parameters.get("name") is None:  # type: ignore
+                    if parameters.get("name") is None:
                         raise WandbArtifactsIOManagerError(
                             "Missing 'name' property in the 'wandb_artifact_configuration' metadata"
                             " dictionary. A 'name' property is required for Artifacts created from"
                             " an @op. Alternatively you can use an @asset."
                         )
-                    artifact_name = parameters.get("name")  # type: ignore
+                    artifact_name = parameters.get("name")
 
                 if context.has_partition_key:
                     artifact_name = f"{artifact_name}.{context.partition_key}"
@@ -418,25 +418,25 @@ class ArtifactsIOManager(IOManager):
                                 ) from exception
 
             # Add any files: https://docs.wandb.ai/ref/python/artifact#add_file
-            add_files = parameters.get("add_files")  # type: ignore
+            add_files = parameters.get("add_files")
             if add_files is not None and len(add_files) > 0:
                 for add_file in add_files:
                     artifact.add_file(**add_file)
 
             # Add any dirs: https://docs.wandb.ai/ref/python/artifact#add_dir
-            add_dirs = parameters.get("add_dirs")  # type: ignore
+            add_dirs = parameters.get("add_dirs")
             if add_dirs is not None and len(add_dirs) > 0:
                 for add_dir in add_dirs:
                     artifact.add_dir(**add_dir)
 
             # Add any reference: https://docs.wandb.ai/ref/python/artifact#add_reference
-            add_references = parameters.get("add_references")  # type: ignore
+            add_references = parameters.get("add_references")
             if add_references is not None and len(add_references) > 0:
                 for add_reference in add_references:
                     artifact.add_reference(**add_reference)
 
             # Augments the aliases
-            aliases = parameters.get("aliases", [])  # type: ignore
+            aliases = parameters.get("aliases", [])
             aliases.append(f"dagster-run-{self.dagster_run_id[0:8]}")
             if "latest" not in aliases:
                 aliases.append("latest")

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
@@ -12,11 +12,9 @@ from dagstermill.examples.repository import custom_io_mgr_key_asset
 
 
 def get_path(materialization_event):
-    for (
-        metadata_entry
-    ) in materialization_event.event_specific_data.materialization.metadata_entries:
-        if isinstance(metadata_entry.value, (NotebookMetadataValue, PathMetadataValue)):
-            return metadata_entry.value.path
+    for key, value in materialization_event.event_specific_data.materialization.metadata.items():
+        if isinstance(value, (NotebookMetadataValue, PathMetadataValue)):
+            return value.path
 
 
 def cleanup_result_notebook(result):

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -66,7 +66,9 @@ def test_yes_output_notebook_yes_io_manager():
         assert result.output_for_node("hello_world", "notebook")
 
         output_path = (
-            materializations[0].event_specific_data.materialization.metadata_entries[0].value.path
+            materializations[0]
+            .event_specific_data.materialization.metadata["Executed notebook"]
+            .path
         )
         assert os.path.exists(output_path)
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -25,11 +25,9 @@ MATPLOTLIB_PRESENT = importlib.util.find_spec("matplotlib") is not None
 
 
 def get_path(materialization_event):
-    for (
-        metadata_entry
-    ) in materialization_event.event_specific_data.materialization.metadata_entries:
-        if isinstance(metadata_entry.value, (PathMetadataValue, NotebookMetadataValue)):
-            return metadata_entry.value.path
+    for value in materialization_event.event_specific_data.materialization.metadata.values():
+        if isinstance(value, (PathMetadataValue, NotebookMetadataValue)):
+            return value.path
 
 
 def cleanup_result_notebook(result):


### PR DESCRIPTION
### Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5257

Update internal representation of `metadata` from `metadata_entries` to the dict form we have been pushing to users for almost a year.

- Remove `metadata_entries` from all non-public constructor args
- Introduce `MetadataSerializer` custom field serializer to serialize metadata dict to list of metadata entries and deserialize list of metadata entries to metadata dict (for backcompat). Apply to all serdes classes holding `metadata_entries`

**Context**

More than a year ago, it was decided that Dagster's preferred representation of metadata was to be the metadata dict, as opposed to the metadata entries list:

```
### metadata dict (yes)
{
    "foo": MetadataValue.text("bar"),
    "baz": MetadataValue.int(1)
}

### metadata entries list (no)
[
    MetadataEntry("foo", value=MetadataValue.text("bar")),
    MetadataEntry("baz", value=MetadataValue.int(1)),
]
```

Reasons for this transition:

- metadata dict is more user-friendly
- we deprecated the `description` field on `MetadataEntry` so `MetadataEntry` no longer had any greater expressive power over a dict

There was a hitch in this plan though-- `metadata_entries: Sequence[MetadataEntry]` was widely used as an internal representation of metadata throughout the codebase, including on many serdes-whitelisted objects. So we couldn't just replace the metadata entry list everywhere. Instead, we decided on a temporary solution of:

- offer `metadata` kwarg on user-facing APIs to allow them to pass a metadata dict
- internally convert to list of metadata entries
- keep using list of metadata entries everywhere for internal repr

This has a few problems:

- we have a lot of constructors that take either `metadata` or `metadata_entries`. Sometimes `metadata_entries` is marked private (`_metadata_entries`) other times not. It's confusing.
- we inconsistently reexpose metadata as a dict-- but if we do this, and we are using a `MetadataEntry` list for the internal representation, then we have to reconvert to a dict

All in all the current situation is inconsistent and introduces unnecessary complexity to the code.

This PR should be viewed as a stepping stone to the complete elimination of `MetadataEntry` and passing metadata as `List[MetadataEntry]`, which is done upstack: https://github.com/dagster-io/dagster/pull/12769

### How I Tested These Changes

Existing test suite.