### PR TITLE
[dagster-airflow] option for passing dag_run configuration to airflow db resources

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -467,10 +467,10 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         pytest_tox_factors=[
             "default-airflow1",
             "localdb-airflow1",
-            "persistantdb-airflow1",
+            "persistentdb-airflow1",
             "default-airflow2",
             "localdb-airflow2",
-            "persistantdb-airflow2",
+            "persistentdb-airflow2",
         ],
     ),
     PackageSpec(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
@@ -25,8 +25,9 @@ else:
 class AirflowDatabase:
     """Airflow database Dagster resource."""
 
-    def __init__(self, dagster_run: DagsterRun):
+    def __init__(self, dagster_run: DagsterRun, dag_run_config: Optional[dict] = None):
         self.dagster_run = dagster_run
+        self.dag_run_config = dag_run_config
 
     def _parse_execution_date_for_job(
         self, dag: DAG, run_tags: Mapping[str, str]
@@ -87,11 +88,13 @@ class AirflowDatabase:
                     state=DagRunState.RUNNING,
                     execution_date=execution_date,
                     run_type=DagRunType.MANUAL,
+                    conf=self.dag_run_config,
                 )
             else:
                 dagrun = dag.create_dagrun(
                     run_id=f"dagster_airflow_run_{execution_date}",
                     state=State.RUNNING,
                     execution_date=execution_date,
+                    conf=self.dag_run_config,
                 )
         return dagrun

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
@@ -61,7 +61,6 @@ class AirflowEphemeralDatabase(AirflowDatabase):
             airflow_home_path=airflow_home_path,
             connections=[Connection(**c) for c in context.resource_config["connections"]],
         )
-
         return AirflowEphemeralDatabase(
             airflow_home_path=airflow_home_path,
             dagster_run=check.not_none(context.dagster_run, "Context must have run"),
@@ -72,8 +71,7 @@ class AirflowEphemeralDatabase(AirflowDatabase):
 def make_ephemeral_airflow_db_resource(
     connections: List[Connection] = [], dag_run_config: Optional[dict] = None
 ) -> ResourceDefinition:
-    """
-    Creates a Dagster resource that provides an ephemeral Airflow database.
+    """Creates a Dagster resource that provides an ephemeral Airflow database.
 
     Args:
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_ephemeral_db.py
@@ -1,7 +1,7 @@
 import importlib
 import os
 import tempfile
-from typing import List
+from typing import List, Optional
 
 import airflow
 from airflow.models.connection import Connection
@@ -11,6 +11,7 @@ from dagster import (
     DagsterRun,
     Field,
     InitResourceContext,
+    Noneable,
     ResourceDefinition,
     _check as check,
 )
@@ -27,9 +28,11 @@ from dagster_airflow.utils import (
 class AirflowEphemeralDatabase(AirflowDatabase):
     """A ephemeral Airflow database Dagster resource."""
 
-    def __init__(self, airflow_home_path: str, dagster_run: DagsterRun):
+    def __init__(
+        self, airflow_home_path: str, dagster_run: DagsterRun, dag_run_config: Optional[dict] = None
+    ):
         self.airflow_home_path = airflow_home_path
-        super().__init__(dagster_run=dagster_run)
+        super().__init__(dagster_run=dagster_run, dag_run_config=dag_run_config)
 
     @staticmethod
     def _initialize_database(
@@ -62,14 +65,19 @@ class AirflowEphemeralDatabase(AirflowDatabase):
         return AirflowEphemeralDatabase(
             airflow_home_path=airflow_home_path,
             dagster_run=check.not_none(context.dagster_run, "Context must have run"),
+            dag_run_config=context.resource_config.get("dag_run_config"),
         )
 
 
-def make_ephemeral_airflow_db_resource(connections: List[Connection] = []) -> ResourceDefinition:
-    """Creates a Dagster resource that provides an ephemeral Airflow database.
+def make_ephemeral_airflow_db_resource(
+    connections: List[Connection] = [], dag_run_config: Optional[dict] = None
+) -> ResourceDefinition:
+    """
+    Creates a Dagster resource that provides an ephemeral Airflow database.
 
     Args:
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
+        dag_run_config (Optional[dict]): dag_run configuration to be used when creating a DagRun
 
     Returns:
         ResourceDefinition: The ephemeral Airflow DB resource
@@ -82,6 +90,11 @@ def make_ephemeral_airflow_db_resource(connections: List[Connection] = []) -> Re
             "connections": Field(
                 Array(inner_type=dict),
                 default_value=serialized_connections,
+                is_required=False,
+            ),
+            "dag_run_config": Field(
+                Noneable(dict),
+                default_value=dag_run_config,
                 is_required=False,
             ),
         },

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -49,7 +49,7 @@ class AirflowPersistentDatabase(AirflowDatabase):
         return AirflowPersistentDatabase(
             dagster_run=check.not_none(context.dagster_run, "Context must have run"),
             uri=uri,
-            dag_run_config=context.resource_config.get("dag_run_config"),
+            dag_run_config=context.resource_config["dag_run_config"],
         )
 
 
@@ -91,6 +91,12 @@ def make_persistent_airflow_db_resource(
         os.environ["AIRFLOW__CORE__SQL_ALCHEMY_CONN"] = uri
 
     serialized_connections = serialize_connections(connections)
+
+    if is_airflow_2_loaded_in_environment():
+        os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = uri
+    else:
+        os.environ["AIRFLOW__CORE__SQL_ALCHEMY_CONN"] = uri
+
     airflow_db_resource_def = ResourceDefinition(
         resource_fn=AirflowPersistentDatabase.from_resource_context,
         config_schema={

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -92,11 +92,6 @@ def make_persistent_airflow_db_resource(
 
     serialized_connections = serialize_connections(connections)
 
-    if is_airflow_2_loaded_in_environment():
-        os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = uri
-    else:
-        os.environ["AIRFLOW__CORE__SQL_ALCHEMY_CONN"] = uri
-
     airflow_db_resource_def = ResourceDefinition(
         resource_fn=AirflowPersistentDatabase.from_resource_context,
         config_schema={

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -1,6 +1,6 @@
 import importlib
 import os
-from typing import List
+from typing import List, Optional
 
 import airflow
 from airflow.models.connection import Connection
@@ -24,9 +24,9 @@ from dagster_airflow.utils import (
 class AirflowPersistentDatabase(AirflowDatabase):
     """A persistent Airflow database Dagster resource."""
 
-    def __init__(self, dagster_run: DagsterRun, uri: str):
+    def __init__(self, dagster_run: DagsterRun, uri: str, dag_run_config: Optional[dict] = None):
         self.uri = uri
-        super().__init__(dagster_run=dagster_run)
+        super().__init__(dagster_run=dagster_run, dag_run_config=dag_run_config)
 
     @staticmethod
     def _initialize_database(uri: str, connections: List[Connection] = []):
@@ -47,12 +47,16 @@ class AirflowPersistentDatabase(AirflowDatabase):
             uri=uri, connections=[Connection(**c) for c in context.resource_config["connections"]]
         )
         return AirflowPersistentDatabase(
-            dagster_run=check.not_none(context.dagster_run, "Context must have run"), uri=uri
+            dagster_run=check.not_none(context.dagster_run, "Context must have run"),
+            uri=uri,
+            dag_run_config=context.resource_config.get("dag_run_config"),
         )
 
 
 def make_persistent_airflow_db_resource(
-    uri: str = "", connections: List[Connection] = []
+    uri: str = "",
+    connections: List[Connection] = [],
+    dag_run_config: Optional[dict] = {},
 ) -> ResourceDefinition:
     """Creates a Dagster resource that provides an persistent Airflow database.
 
@@ -75,6 +79,7 @@ def make_persistent_airflow_db_resource(
     Args:
         uri: SQLAlchemy URI of the Airflow DB to be used
         connections (List[Connection]): List of Airflow Connections to be created in the Airflow DB
+        dag_run_config (Optional[dict]): dag_run configuration to be used when creating a DagRun
 
     Returns:
         ResourceDefinition: The persistent Airflow DB resource
@@ -97,6 +102,11 @@ def make_persistent_airflow_db_resource(
             "connections": Field(
                 Array(inner_type=dict),
                 default_value=serialized_connections,
+                is_required=False,
+            ),
+            "dag_run_config": Field(
+                dict,
+                default_value=dag_run_config,
                 is_required=False,
             ),
         },

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/marks.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/marks.py
@@ -2,3 +2,4 @@ import pytest
 
 requires_local_db = pytest.mark.requires_local_db  # requires airflow db (but not k8s)
 requires_persistent_db = pytest.mark.requires_persistent_db  # requires persistent airflow db
+requires_no_db = pytest.mark.requires_no_db  # requires no database

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_dag_run_conf.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_dag_run_conf.py
@@ -1,0 +1,53 @@
+import os
+import tempfile
+
+from airflow.models import DagBag, Variable
+from dagster_airflow import (
+    make_dagster_job_from_airflow_dag,
+    make_ephemeral_airflow_db_resource,
+)
+
+from dagster_airflow_tests.marks import requires_local_db
+
+DAG_RUN_CONF_DAG = """
+from airflow import models
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import Variable
+import datetime
+
+default_args = {"start_date": datetime.datetime(2023, 2, 1)}
+
+with models.DAG(
+    dag_id="dag_run_conf_dag", default_args=default_args, schedule_interval='0 0 * * *',
+) as dag_run_conf_dag:
+    def test_function(**kwargs):
+        Variable.set("CONFIGURATION_VALUE", kwargs['config_value'])
+
+    PythonOperator(
+        task_id="previous_macro_test",
+        python_callable=test_function,
+        provide_context=True,
+        op_kwargs={'config_value': '{{dag_run.conf.get("configuration_key")}}'}
+    )
+"""
+
+
+@requires_local_db
+def test_dag_run_conf_local() -> None:
+    with tempfile.TemporaryDirectory() as dags_path:
+        with open(os.path.join(dags_path, "dag.py"), "wb") as f:
+            f.write(bytes(DAG_RUN_CONF_DAG.encode("utf-8")))
+
+        airflow_db = make_ephemeral_airflow_db_resource(dag_run_config={"configuration_key": "foo"})
+
+        dag_bag = DagBag(dag_folder=dags_path)
+        retry_dag = dag_bag.get_dag(dag_id="dag_run_conf_dag")
+
+        job = make_dagster_job_from_airflow_dag(
+            dag=retry_dag, resource_defs={"airflow_db": airflow_db}
+        )
+
+        result = job.execute_in_process()
+        assert result.success
+        assert Variable.get("CONFIGURATION_VALUE") == "foo"

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag_airflow_2.py
@@ -10,7 +10,7 @@ from dagster_airflow import (
     make_dagster_job_from_airflow_dag,
 )
 
-from dagster_airflow_tests.marks import requires_local_db
+from dagster_airflow_tests.marks import requires_local_db, requires_no_db
 
 from ..airflow_utils import (
     test_make_from_dagbag_inputs_airflow_2,
@@ -22,6 +22,7 @@ from ..airflow_utils import (
     "path_and_content_tuples, fn_arg_path, expected_job_names",
     test_make_from_dagbag_inputs_airflow_2,
 )
+@requires_no_db
 def test_make_definition(
     path_and_content_tuples,
     fn_arg_path,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
@@ -13,12 +13,15 @@ from dagster._core.snap import PipelineSnapshot
 from dagster._serdes import serialize_pp
 from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
 
+from dagster_airflow_tests.marks import requires_no_db
+
 default_args = {
     "owner": "dagster",
     "start_date": days_ago(1),
 }
 
 
+@requires_no_db
 def test_one_task_dag(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -46,6 +49,7 @@ def test_one_task_dag(snapshot):
     )
 
 
+@requires_no_db
 def test_two_task_dag_no_dep(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -77,6 +81,7 @@ def test_two_task_dag_no_dep(snapshot):
     )
 
 
+@requires_no_db
 def test_two_task_dag_with_dep(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -110,6 +115,7 @@ def test_two_task_dag_with_dep(snapshot):
     )
 
 
+@requires_no_db
 def test_diamond_task_dag(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -153,6 +159,7 @@ def test_diamond_task_dag(snapshot):
     )
 
 
+@requires_no_db
 def test_multi_root_dag(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -196,6 +203,7 @@ def test_multi_root_dag(snapshot):
     )
 
 
+@requires_no_db
 def test_multi_leaf_dag(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -238,6 +246,7 @@ def test_multi_leaf_dag(snapshot):
     )
 
 
+@requires_no_db
 def test_complex_dag(snapshot):
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -494,6 +503,7 @@ def test_complex_dag(snapshot):
     )
 
 
+@requires_no_db
 def test_one_task_dag_to_job():
     if airflow_version >= "2.0.0":
         dag = DAG(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_load_dag_bag_airflow_2.py
@@ -8,7 +8,7 @@ from dagster_airflow import (
     make_dagster_definitions_from_airflow_example_dags,
 )
 
-from dagster_airflow_tests.marks import requires_local_db
+from dagster_airflow_tests.marks import requires_local_db, requires_no_db
 
 from ..airflow_utils import test_make_from_dagbag_inputs_airflow_2
 
@@ -18,6 +18,7 @@ from ..airflow_utils import test_make_from_dagbag_inputs_airflow_2
     "path_and_content_tuples, fn_arg_path, expected_job_names",
     test_make_from_dagbag_inputs_airflow_2,
 )
+@requires_no_db
 def test_make_repo(
     path_and_content_tuples,
     fn_arg_path,
@@ -76,6 +77,8 @@ def get_examples_airflow_repo_params():
         # runs slow
         "example_sensors",
         "example_dynamic_task_mapping",
+        # wrong state
+        "example_short_circuit_operator",
     ]
     for job_name in repo.job_names:
         params.append(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_solid_execution.py
@@ -27,6 +27,8 @@ from dagster._core.test_utils import instance_for_test
 from dagster._seven import get_current_datetime_in_utc
 from dagster_airflow import make_dagster_job_from_airflow_dag
 
+from dagster_airflow_tests.marks import requires_no_db
+
 default_args = {
     "owner": "dagster",
     "start_date": days_ago(1),
@@ -36,6 +38,7 @@ default_args = {
 # Airflow DAG ids and Task ids allow a larger valid character set (alphanumeric characters,
 # dashes, dots and underscores) than Dagster's naming conventions (alphanumeric characters,
 # underscores), so Dagster will strip invalid characters and replace with '_'
+@requires_no_db
 def test_normalize_name():
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -67,6 +70,7 @@ def test_normalize_name():
 
 
 # Test names with 250 characters, Airflow's max allowed length
+@requires_no_db
 def test_long_name():
     dag_name = "dag-with.dot-dash-lo00ong" * 10
     if airflow_version >= "2.0.0":
@@ -106,6 +110,7 @@ def test_long_name():
     )
 
 
+@requires_no_db
 def test_one_task_dag():
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -136,6 +141,7 @@ def normalize_file_content(s):
     return "\n".join([line for line in s.replace(os.linesep, "\n").split("\n") if line])
 
 
+@requires_no_db
 def test_template_task_dag():
     if airflow_version >= "2.0.0":
         dag = DAG(
@@ -261,6 +267,7 @@ def intercept_spark_submit(*_args, **_kwargs):
     return m
 
 
+@requires_no_db
 @mock.patch("subprocess.Popen", side_effect=intercept_spark_submit)
 def test_spark_dag(mock_subproc_popen):
     # Hack to get around having a Connection

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
@@ -12,6 +12,8 @@ from dagster._core.test_utils import instance_for_test
 from dagster._seven import get_current_datetime_in_utc
 from dagster_airflow import make_dagster_job_from_airflow_dag
 
+from dagster_airflow_tests.marks import requires_no_db
+
 default_args = {
     "owner": "dagster",
     "start_date": days_ago(10),
@@ -83,6 +85,7 @@ def get_dag():
     return dag
 
 
+@requires_no_db
 def test_pipeline_tags():
     dag = get_dag()
 
@@ -103,6 +106,7 @@ def test_pipeline_tags():
         check_captured_logs(manager, result, EXECUTION_DATE_MINUS_WEEK.strftime("%Y-%m-%d"))
 
 
+@requires_no_db
 def test_pipeline_auto_tag():
     dag = get_dag()
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
@@ -272,13 +272,18 @@ with models.DAG(
     dag_id="dag_run_conf_dag", default_args=default_args, schedule_interval='0 0 * * *',
 ) as dag_run_conf_dag:
     def test_function(**kwargs):
+        print("HELLO")
+        print(kwargs)
+        print("CONFIG")
+        print(kwargs['conf'])
+        print("{{dag_run.conf}}")
         Variable.set("CONFIGURATION_VALUE", kwargs['config_value'])
 
     PythonOperator(
         task_id="previous_macro_test",
         python_callable=test_function,
         provide_context=True,
-        op_kwargs={'config_value': '{{dag_run.conf.get("configuration_key")}}'}
+        op_kwargs={'config_value': "{{dag_run.conf.get('configuration_key')}}"}
     )
 """
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_2_db.py
@@ -257,3 +257,50 @@ def test_airflow_example_dags_persistent_db(
         assert result.success
         for event in result.all_events:
             assert event.event_type_value != "STEP_FAILURE"
+
+
+DAG_RUN_CONF_DAG = """
+from airflow import models
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import Variable
+import datetime
+
+default_args = {"start_date": datetime.datetime(2023, 2, 1)}
+
+with models.DAG(
+    dag_id="dag_run_conf_dag", default_args=default_args, schedule_interval='0 0 * * *',
+) as dag_run_conf_dag:
+    def test_function(**kwargs):
+        Variable.set("CONFIGURATION_VALUE", kwargs['config_value'])
+
+    PythonOperator(
+        task_id="previous_macro_test",
+        python_callable=test_function,
+        provide_context=True,
+        op_kwargs={'config_value': '{{dag_run.conf.get("configuration_key")}}'}
+    )
+"""
+
+
+@pytest.mark.skipif(airflow_version < "2.0.0", reason="requires airflow 2")
+@requires_persistent_db
+def test_dag_run_conf_persistent(postgres_airflow_db: str) -> None:
+    with tempfile.TemporaryDirectory() as dags_path:
+        with open(os.path.join(dags_path, "dag.py"), "wb") as f:
+            f.write(bytes(DAG_RUN_CONF_DAG.encode("utf-8")))
+
+        airflow_db = make_persistent_airflow_db_resource(
+            uri=postgres_airflow_db, dag_run_config={"configuration_key": "foo"}
+        )
+
+        definitions = make_dagster_definitions_from_airflow_dags_path(
+            dags_path, resource_defs={"airflow_db": airflow_db}
+        )
+        job = definitions.get_job_def("dag_run_conf_dag")
+
+        result = job.execute_in_process(
+            tags={AIRFLOW_EXECUTION_DATE_STR: datetime.datetime(2023, 2, 2).isoformat()}
+        )
+        assert result.success
+        assert Variable.get("CONFIGURATION_VALUE") == "foo"

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/test_persistent_airflow_db.py
@@ -143,3 +143,50 @@ def test_prev_execution_date(postgres_airflow_db: str) -> None:
             Variable.get("PREVIOUS_EXECUTION")
             == datetime.datetime(2023, 2, 1, tzinfo=pytz.UTC).isoformat()
         )
+
+
+DAG_RUN_CONF_DAG = """
+from airflow import models
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import Variable
+import datetime
+
+default_args = {"start_date": datetime.datetime(2023, 2, 1)}
+
+with models.DAG(
+    dag_id="dag_run_conf_dag", default_args=default_args, schedule_interval='0 0 * * *',
+) as dag_run_conf_dag:
+    def test_function(**kwargs):
+        Variable.set("CONFIGURATION_VALUE", kwargs['config_value'])
+
+    PythonOperator(
+        task_id="previous_macro_test",
+        python_callable=test_function,
+        provide_context=True,
+        op_kwargs={'config_value': '{{dag_run.conf.get("configuration_key")}}'}
+    )
+"""
+
+
+@pytest.mark.skipif(airflow_version >= "2.0.0", reason="requires airflow 1")
+@requires_persistent_db
+def test_dag_run_conf_persistent(postgres_airflow_db: str) -> None:
+    with tempfile.TemporaryDirectory() as dags_path:
+        with open(os.path.join(dags_path, "dag.py"), "wb") as f:
+            f.write(bytes(DAG_RUN_CONF_DAG.encode("utf-8")))
+
+        airflow_db = make_persistent_airflow_db_resource(
+            uri=postgres_airflow_db, dag_run_config={"configuration_key": "foo"}
+        )
+
+        definitions = make_dagster_definitions_from_airflow_dags_path(
+            dags_path, resource_defs={"airflow_db": airflow_db}
+        )
+        job = definitions.get_job_def("dag_run_conf_dag")
+
+        result = job.execute_in_process(
+            tags={AIRFLOW_EXECUTION_DATE_STR: datetime.datetime(2023, 2, 2).isoformat()}
+        )
+        assert result.success
+        assert Variable.get("CONFIGURATION_VALUE") == "foo"

--- a/python_modules/libraries/dagster-airflow/tox.ini
+++ b/python_modules/libraries/dagster-airflow/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}-{default,localdb,persistantdb}-airflow{1,2}
+envlist = py{39,38,37,36}-{unix,windows}-{default,localdb,persistentdb}-airflow{1,2}
 skipsdist = true
 
 [testenv]
@@ -23,9 +23,9 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   localdb-airflow1: airflow initdb
   localdb-airflow2: airflow db init
-  default: pytest -m "not requires_airflow_db" -m "not requires_local_db" -vv {posargs}
+  default: pytest -m requires_no_db -vv {posargs}
   localdb: pytest -m requires_local_db -vv {posargs}
-  persistantdb: pytest -m requires_persistent_db -vv {posargs}
+  persistentdb: pytest -m requires_persistent_db -vv {posargs}
 
 [testenv:mypy]
 commands =


### PR DESCRIPTION
### Summary & Motivation

currently there isn't a very clean way to pass airflow dag_run configuration into the dag_run that is created internally by the the dagster-airflow db resources. For users who lean heavily on this feature it means they need to write shims to persist dag run config outside of the normal usage of dagster-airflow.

This pr adds a config field to the dagster-airflow db resources to pass in dag_run configuration.

### How I Tested These Changes

unit tests, local testing