### PR TITLE
update some guide titles and descriptions

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -673,7 +673,7 @@
             "path": "/guides/dagster/how-assets-relate-to-ops-and-graphs"
           },
           {
-            "title": "Enriching with Software-defined assets",
+            "title": "Moving to Software-defined assets",
             "path": "/guides/dagster/enriching-with-software-defined-assets"
           },
           {

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -10,23 +10,23 @@ Learn to apply [Dagster concepts](/concepts) to your work, explore experimental 
 
 ## General
 
-- [Running Dagster locally](/guides/running-dagster-locally) - Learn how to run Dagster and Dagit, Dagster's web UI, on your local machine
+- [Running Dagster locally](/guides/running-dagster-locally) - Learn how to run Dagster and its web UI on your local machine
 
 - [Understanding how assets relate to ops and graphs](/guides/dagster/how-assets-relate-to-ops-and-graphs) - Learn how software-defined assets relate to ops and graphs, and when to use one over the other
 
-- [Enriching with Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Learn to enrich what you've built in Dagster with Software-defined assets
+- [Moving to Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not Software-defined Assets? Learn why and how to use Software-defined Assets
 
-- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined assets, featuring Pandas and PySpark
+- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined Assets, featuring Pandas and PySpark
 
 - [Declarative scheduling for Software-defined assets](/guides/dagster/scheduling-assets) - Create data SLAs and schedule based on desired outcomes, not tasks
 
-- [Re-executing Dagster jobs](/guides/dagster/re-execution) - Learn to re-execute Dagster jobs using both Dagit and Dagster's APIs
+- [Re-executing Dagster jobs](/guides/dagster/re-execution) - Learn to re-execute Dagster jobs using either the UI or Dagster's APIs
 
 - [Validating data with Dagster Type factories](/guides/dagster/dagster_type_factories) - Explore using a Dagster Type factory to validate Pandas dataframes using Pandera
 
 - [Intro to ops and jobs](/guides/dagster/intro-to-ops-jobs) - Learn to execute tasks that don't produce assets
 
-- [Testing assets](/guides/dagster/testing-assets) - Learn to test your assets
+- [Testing assets](/guides/dagster/testing-assets) - Learn to test your Software-defined Assets
 
 - [Assets without I/O](/guides/dagster/non-argument-deps) - Create and use assets without writing back to storage or reading data when used as inputs
 

--- a/docs/content/guides/general.mdx
+++ b/docs/content/guides/general.mdx
@@ -4,24 +4,24 @@ title: General Dagster Guides | Dagster Docs
 
 # General guides
 
-- [Running Dagster locally](/guides/running-dagster-locally) - Learn how to run Dagster and Dagit, Dagster's web UI, on your local machine
+- [Running Dagster locally](/guides/running-dagster-locally) - Learn how to run Dagster and its web UI on your local machine
 
 - [Understanding how assets relate to ops and graphs](/guides/dagster/how-assets-relate-to-ops-and-graphs) - Learn how software-defined assets relate to ops and graphs, and when to use one over the other
 
-- [Enriching with Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Learn to enrich what you've built in Dagster with Software-defined assets
+- [Moving to Software-defined Assets](/guides/dagster/enriching-with-software-defined-assets) - Already using ops and graphs, but not Software-defined Assets? Learn why and how to use Software-defined Assets
 
-- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined assets, featuring Pandas and PySpark
+- [Using Software-defined assets with Pandas and PySpark](/guides/dagster/software-defined-assets) - A quick introduction to Sofware-defined Assets, featuring Pandas and PySpark
 
 - [Declarative scheduling for Software-defined assets](/guides/dagster/scheduling-assets) - Create data SLAs and schedule based on desired outcomes, not tasks
 
-- [Re-executing Dagster jobs](/guides/dagster/re-execution) - Learn to re-execute Dagster jobs using both Dagit and Dagster's APIs
+- [Re-executing Dagster jobs](/guides/dagster/re-execution) - Learn to re-execute Dagster jobs using either the UI or Dagster's APIs
 
 - [Validating data with Dagster Type factories](/guides/dagster/dagster_type_factories) - Explore using a Dagster Type factory to validate Pandas dataframes using Pandera
 
 - [Intro to ops and jobs](/guides/dagster/intro-to-ops-jobs) - Learn to execute tasks that don't produce assets
 
-- [Testing assets](/guides/dagster/testing-assets) - Learn to test your assets
+- [Testing assets](/guides/dagster/testing-assets) - Learn to test your Software-defined Assets
 
 - [Assets without I/O](/guides/dagster/non-argument-deps) - Create and use assets without writing back to storage or reading data when used as inputs
 
-- [Migrating to graphs, jobs, and ops](https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op) - **Legacy.** Migrate to Dagster graphs, jobs, and ops from Dagster solids and pipelines
+- [Migrating to graphs, jobs, and ops](https://docs.dagster.io/0.15.7/guides/dagster/graph_job_op) - **Legacy**. Migrate to Dagster graphs, jobs, and ops from Dagster solids and pipelines


### PR DESCRIPTION
### Summary & Motivation

My motivation for this was to make the difference between /guides/dagster/how-assets-relate-to-ops-and-graphs and /guides/dagster/enriching-with-software-defined-assets more clear.  I made a few other changes as well while there.

### How I Tested These Changes
