### PR TITLE
Reflect dynamically-added partitions in asset sidebar immediately 

### DIFF
--- a/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
@@ -124,6 +124,9 @@ export const CreatePartitionDialog = ({
         partitionsDefName: partitionDefinitionName || '',
         partitionKey: partitionName,
       },
+
+      // Add any queries that reference asset partitions here so that they update if they're currently rendered.
+      refetchQueries: ['PartitionHealthQuery', 'AssetEventsQuery'],
     });
     setIsSaving(false);
 


### PR DESCRIPTION
### Summary & Motivation

Addresses https://github.com/dagster-io/dagster/issues/12755

### How I Tested These Changes

Added a partition, saw the sidebar queries refetch. 