### PR TITLE
[ESLint] Update missing graphql variable type rule to check mutations and subscriptions too

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -1,7 +1,11 @@
 import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
 
-import {PermissionFragment, PermissionsQuery} from './types/Permissions.types';
+import {
+  PermissionFragment,
+  PermissionsQuery,
+  PermissionsQueryVariables,
+} from './types/Permissions.types';
 
 // used in tests, to ensure against permission renames.  Should make sure that the mapping in
 // extractPermissions is handled correctly
@@ -109,7 +113,7 @@ export const PermissionsContext = React.createContext<PermissionsContextType>({
 });
 
 export const PermissionsProvider: React.FC = (props) => {
-  const {data, loading} = useQuery<PermissionsQuery>(PERMISSIONS_QUERY, {
+  const {data, loading} = useQuery<PermissionsQuery, PermissionsQueryVariables>(PERMISSIONS_QUERY, {
     fetchPolicy: 'cache-first', // Not expected to change after initial load.
   });
 

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -10,7 +10,11 @@ import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
 
 import {ASSET_NODE_FRAGMENT} from './AssetNode';
 import {buildGraphData, GraphData, toGraphId, tokenForAssetKey} from './Utils';
-import {AssetGraphQuery, AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
+import {
+  AssetGraphQuery,
+  AssetGraphQueryVariables,
+  AssetNodeForGraphQueryFragment,
+} from './types/useAssetGraphData.types';
 
 export interface AssetGraphFetchScope {
   hideEdgesToNodesOutsideQuery?: boolean;
@@ -33,7 +37,7 @@ export type AssetGraphQueryItem = GraphQueryItem & {
  * uses this option to implement the "3 of 4 repositories" picker.
  */
 export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScope) {
-  const fetchResult = useQuery<AssetGraphQuery>(ASSET_GRAPH_QUERY, {
+  const fetchResult = useQuery<AssetGraphQuery, AssetGraphQueryVariables>(ASSET_GRAPH_QUERY, {
     notifyOnNetworkStatusChange: true,
     variables: {
       pipelineSelector: options.pipelineSelector,

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -20,6 +20,7 @@ import {AssetsEmptyState} from './AssetsEmptyState';
 import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {
   AssetCatalogTableQuery,
+  AssetCatalogTableQueryVariables,
   AssetCatalogGroupTableQuery,
   AssetCatalogGroupTableNodeFragment,
   AssetCatalogGroupTableQueryVariables,
@@ -36,10 +37,13 @@ function useAllAssets(
   assets: Asset[] | undefined;
   error: PythonErrorFragment | undefined;
 } {
-  const assetsQuery = useQuery<AssetCatalogTableQuery>(ASSET_CATALOG_TABLE_QUERY, {
-    skip: !!groupSelector,
-    notifyOnNetworkStatusChange: true,
-  });
+  const assetsQuery = useQuery<AssetCatalogTableQuery, AssetCatalogTableQueryVariables>(
+    ASSET_CATALOG_TABLE_QUERY,
+    {
+      skip: !!groupSelector,
+      notifyOnNetworkStatusChange: true,
+    },
+  );
   const groupQuery = useQuery<AssetCatalogGroupTableQuery, AssetCatalogGroupTableQueryVariables>(
     ASSET_CATALOG_GROUP_TABLE_QUERY,
     {

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -25,6 +25,7 @@ import {
   InstanceBackfillsQuery,
   InstanceBackfillsQueryVariables,
   InstanceHealthForBackfillsQuery,
+  InstanceHealthForBackfillsQueryVariables,
 } from './types/InstanceBackfills.types';
 
 const PAGE_SIZE = 10;
@@ -33,7 +34,10 @@ export const InstanceBackfills = () => {
   useTrackPageView();
   useDocumentTitle('Overview | Backfills');
 
-  const queryData = useQuery<InstanceHealthForBackfillsQuery>(INSTANCE_HEALTH_FOR_BACKFILLS_QUERY);
+  const queryData = useQuery<
+    InstanceHealthForBackfillsQuery,
+    InstanceHealthForBackfillsQueryVariables
+  >(INSTANCE_HEALTH_FOR_BACKFILLS_QUERY);
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     InstanceBackfillsQuery,

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -21,7 +21,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 
 import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
-import {InstanceConfigQuery} from './types/InstanceConfig.types';
+import {InstanceConfigQuery, InstanceConfigQueryVariables} from './types/InstanceConfig.types';
 
 const InstanceConfigStyle = createGlobalStyle`
   .react-codemirror2 .CodeMirror.cm-s-instance-config {
@@ -40,9 +40,12 @@ export const InstanceConfig = React.memo(() => {
   useDocumentTitle('Configuration');
 
   const {pageTitle} = React.useContext(InstancePageContext);
-  const queryResult = useQuery<InstanceConfigQuery>(INSTANCE_CONFIG_QUERY, {
-    notifyOnNetworkStatusChange: true,
-  });
+  const queryResult = useQuery<InstanceConfigQuery, InstanceConfigQueryVariables>(
+    INSTANCE_CONFIG_QUERY,
+    {
+      notifyOnNetworkStatusChange: true,
+    },
+  );
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const {data} = queryResult;

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -10,16 +10,19 @@ import {DaemonList} from './DaemonList';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
 import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
-import {InstanceHealthQuery} from './types/InstanceHealthPage.types';
+import {InstanceHealthQuery, InstanceHealthQueryVariables} from './types/InstanceHealthPage.types';
 
 export const InstanceHealthPage = () => {
   useTrackPageView();
   useDocumentTitle('Daemons');
 
   const {pageTitle} = React.useContext(InstancePageContext);
-  const queryData = useQuery<InstanceHealthQuery>(INSTANCE_HEALTH_QUERY, {
-    notifyOnNetworkStatusChange: true,
-  });
+  const queryData = useQuery<InstanceHealthQuery, InstanceHealthQueryVariables>(
+    INSTANCE_HEALTH_QUERY,
+    {
+      notifyOnNetworkStatusChange: true,
+    },
+  );
   const refreshState = useQueryRefreshAtInterval(queryData, FIFTEEN_SECONDS);
   const {loading, data} = queryData;
 

--- a/js_modules/dagit/packages/core/src/instance/useCanSeeConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useCanSeeConfig.tsx
@@ -1,9 +1,14 @@
 import {gql, useQuery} from '@apollo/client';
 
-import {InstanceConfigHasInfoQuery} from './types/useCanSeeConfig.types';
+import {
+  InstanceConfigHasInfoQuery,
+  InstanceConfigHasInfoQueryVariables,
+} from './types/useCanSeeConfig.types';
 
 export const useCanSeeConfig = () => {
-  const {data} = useQuery<InstanceConfigHasInfoQuery>(INSTANCE_CONFIG_HAS_INFO);
+  const {data} = useQuery<InstanceConfigHasInfoQuery, InstanceConfigHasInfoQueryVariables>(
+    INSTANCE_CONFIG_HAS_INFO,
+  );
   return !!data?.instance.hasInfo;
 };
 

--- a/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
@@ -6,14 +6,17 @@ import {useRepositoryOptions} from '../workspace/WorkspaceContext';
 
 import {StatusAndMessage} from './DeploymentStatusType';
 import {INSTANCE_HEALTH_FRAGMENT} from './InstanceHealthFragment';
-import {InstanceWarningQuery} from './types/useDaemonStatus.types';
+import {InstanceWarningQuery, InstanceWarningQueryVariables} from './types/useDaemonStatus.types';
 
 export const useDaemonStatus = (skip = false): StatusAndMessage | null => {
   const {options} = useRepositoryOptions();
-  const queryResult = useQuery<InstanceWarningQuery>(INSTANCE_WARNING_QUERY, {
-    notifyOnNetworkStatusChange: true,
-    skip,
-  });
+  const queryResult = useQuery<InstanceWarningQuery, InstanceWarningQueryVariables>(
+    INSTANCE_WARNING_QUERY,
+    {
+      notifyOnNetworkStatusChange: true,
+      skip,
+    },
+  );
 
   useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 

--- a/js_modules/dagit/packages/core/src/instance/useSupportsCapturedLogs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useSupportsCapturedLogs.tsx
@@ -1,9 +1,15 @@
 import {gql, useQuery} from '@apollo/client';
 
-import {InstanceSupportsCapturedLogsQuery} from './types/useSupportsCapturedLogs.types';
+import {
+  InstanceSupportsCapturedLogsQuery,
+  InstanceSupportsCapturedLogsQueryVariables,
+} from './types/useSupportsCapturedLogs.types';
 
 export const useSupportsCapturedLogs = () => {
-  const {data} = useQuery<InstanceSupportsCapturedLogsQuery>(INSTANCE_SUPPORTS_CAPTURED_LOGS);
+  const {data} = useQuery<
+    InstanceSupportsCapturedLogsQuery,
+    InstanceSupportsCapturedLogsQueryVariables
+  >(INSTANCE_SUPPORTS_CAPTURED_LOGS);
   return !!data?.instance.hasCapturedLogManager;
 };
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -65,6 +65,7 @@ import {
 } from './types/LaunchpadRoot.types';
 import {
   PipelineExecutionConfigSchemaQuery,
+  PipelineExecutionConfigSchemaQueryVariables,
   PreviewConfigQuery,
   PreviewConfigQueryVariables,
 } from './types/LaunchpadSession.types';
@@ -193,13 +194,13 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     assetSelection: currentSession.assetSelection?.map(({assetKey: {path}}) => ({path})),
   };
 
-  const configResult = useQuery<PipelineExecutionConfigSchemaQuery>(
-    PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY,
-    {
-      variables: {selector: pipelineSelector, mode: currentSession?.mode},
-      partialRefetch: true,
-    },
-  );
+  const configResult = useQuery<
+    PipelineExecutionConfigSchemaQuery,
+    PipelineExecutionConfigSchemaQueryVariables
+  >(PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY, {
+    variables: {selector: pipelineSelector, mode: currentSession?.mode},
+    partialRefetch: true,
+  });
 
   const configSchemaOrError = configResult?.data?.runConfigSchemaOrError;
 

--- a/js_modules/dagit/packages/core/src/nav/VersionNumber.tsx
+++ b/js_modules/dagit/packages/core/src/nav/VersionNumber.tsx
@@ -2,10 +2,10 @@ import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {VersionNumberQuery} from './types/VersionNumber.types';
+import {VersionNumberQuery, VersionNumberQueryVariables} from './types/VersionNumber.types';
 
 export const VersionNumber = () => {
-  const {data} = useQuery<VersionNumberQuery>(VERSION_NUMBER_QUERY);
+  const {data} = useQuery<VersionNumberQuery, VersionNumberQueryVariables>(VERSION_NUMBER_QUERY);
   return <Version>{data?.version || <span>&nbsp;</span>}</Version>;
 };
 

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -10,7 +10,10 @@ import {RepositoryLocationLoadStatus} from '../graphql/types';
 import {StatusAndMessage} from '../instance/DeploymentStatusType';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
-import {CodeLocationStatusQuery} from './types/useCodeLocationsStatus.types';
+import {
+  CodeLocationStatusQuery,
+  CodeLocationStatusQueryVariables,
+} from './types/useCodeLocationsStatus.types';
 
 type LocationStatusEntry = {
   loadStatus: RepositoryLocationLoadStatus;
@@ -215,12 +218,15 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     }
   };
 
-  const queryData = useQuery<CodeLocationStatusQuery>(CODE_LOCATION_STATUS_QUERY, {
-    fetchPolicy: 'network-only',
-    notifyOnNetworkStatusChange: true,
-    skip,
-    onCompleted: onLocationUpdate,
-  });
+  const queryData = useQuery<CodeLocationStatusQuery, CodeLocationStatusQueryVariables>(
+    CODE_LOCATION_STATUS_QUERY,
+    {
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+      skip,
+      onCompleted: onLocationUpdate,
+    },
+  );
 
   useQueryRefreshAtInterval(queryData, POLL_INTERVAL);
 

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -12,6 +12,7 @@ import {RepositoryLocationLoadStatus} from '../graphql/types';
 
 import {
   RepositoryLocationStatusQuery,
+  RepositoryLocationStatusQueryVariables,
   ReloadRepositoryLocationMutationVariables,
   ReloadWorkspaceMutationVariables,
   ReloadWorkspaceMutation,
@@ -95,105 +96,105 @@ export const useRepositoryLocationReload = ({
 
   const invalidateConfigs = useInvalidateConfigsForRepo();
 
-  const {startPolling, stopPolling} = useQuery<RepositoryLocationStatusQuery>(
-    REPOSITORY_LOCATION_STATUS_QUERY,
-    {
-      skip: state.pollStartTime === null,
-      pollInterval: 5000,
-      fetchPolicy: 'no-cache',
-      // This is irritating, but apparently necessary for now.
-      // https://github.com/apollographql/apollo-client/issues/5531
-      notifyOnNetworkStatusChange: true,
-      onCompleted: (data: RepositoryLocationStatusQuery) => {
-        const workspace = data.workspaceOrError;
+  const {startPolling, stopPolling} = useQuery<
+    RepositoryLocationStatusQuery,
+    RepositoryLocationStatusQueryVariables
+  >(REPOSITORY_LOCATION_STATUS_QUERY, {
+    skip: state.pollStartTime === null,
+    pollInterval: 5000,
+    fetchPolicy: 'no-cache',
+    // This is irritating, but apparently necessary for now.
+    // https://github.com/apollographql/apollo-client/issues/5531
+    notifyOnNetworkStatusChange: true,
+    onCompleted: (data: RepositoryLocationStatusQuery) => {
+      const workspace = data.workspaceOrError;
 
-        if (workspace.__typename === 'PythonError') {
-          dispatch({type: 'error', error: workspace, errorLocationId: null});
-          stopPolling();
-          return;
-        }
-        if (state.pollLocationIds === null) {
-          stopPolling();
-          return;
-        }
-
-        const locationMap = Object.fromEntries(workspace.locationEntries.map((e) => [e.id, e]));
-        const matches = state.pollLocationIds.map((id) => locationMap[id]).filter(Boolean);
-        const missingId = state.pollLocationIds.find((id) => !locationMap[id]);
-
-        if (missingId) {
-          dispatch({
-            type: 'error',
-            error: {message: `Location ${missingId} not found in workspace.`},
-            errorLocationId: missingId,
-          });
-          stopPolling();
-          return;
-        }
-
-        // If we're still loading, there's nothing to do yet. Continue polling unless
-        // we have hit our timeout threshold.
-        if (matches.some((l) => l.loadStatus === RepositoryLocationLoadStatus.LOADING)) {
-          if (Date.now() - Number(state.pollStartTime) > THREE_MINUTES) {
-            const message = `Timed out waiting for the ${
-              matches.length > 1 ? 'locations' : 'location'
-            } to reload.`;
-            dispatch({
-              type: 'error',
-              error: {message},
-              errorLocationId: null,
-            });
-            stopPolling();
-          }
-          return;
-        }
-
-        // If we're done loading and an error persists, show it.
-        const errorLocation = matches.find(
-          (m) => m.locationOrLoadError?.__typename === 'PythonError',
-        );
-
-        if (errorLocation && errorLocation.locationOrLoadError?.__typename === 'PythonError') {
-          dispatch({
-            type: 'error',
-            error: errorLocation.locationOrLoadError,
-            errorLocationId: errorLocation.id,
-          });
-          stopPolling();
-          return;
-        }
-
-        // Otherwise, we have no errors left.
-        dispatch({type: 'finish-polling'});
+      if (workspace.__typename === 'PythonError') {
+        dispatch({type: 'error', error: workspace, errorLocationId: null});
         stopPolling();
+        return;
+      }
+      if (state.pollLocationIds === null) {
+        stopPolling();
+        return;
+      }
 
-        // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
-        SharedToaster.show({
-          message: `${scope === 'location' ? 'Code location' : 'Definitions'} reloaded!`,
-          timeout: 3000,
-          icon: 'check_circle',
-          intent: Intent.SUCCESS,
+      const locationMap = Object.fromEntries(workspace.locationEntries.map((e) => [e.id, e]));
+      const matches = state.pollLocationIds.map((id) => locationMap[id]).filter(Boolean);
+      const missingId = state.pollLocationIds.find((id) => !locationMap[id]);
+
+      if (missingId) {
+        dispatch({
+          type: 'error',
+          error: {message: `Location ${missingId} not found in workspace.`},
+          errorLocationId: missingId,
         });
-        dispatch({type: 'success'});
+        stopPolling();
+        return;
+      }
 
-        // Update run config localStorage, which may now be out of date.
-        const repositories = matches.flatMap((location) =>
-          location?.__typename === 'WorkspaceLocationEntry' &&
-          location.locationOrLoadError?.__typename === 'RepositoryLocation'
-            ? location.locationOrLoadError.repositories.map((repo) => ({
-                ...repo,
-                locationName: location.id,
-              }))
-            : [],
-        );
+      // If we're still loading, there's nothing to do yet. Continue polling unless
+      // we have hit our timeout threshold.
+      if (matches.some((l) => l.loadStatus === RepositoryLocationLoadStatus.LOADING)) {
+        if (Date.now() - Number(state.pollStartTime) > THREE_MINUTES) {
+          const message = `Timed out waiting for the ${
+            matches.length > 1 ? 'locations' : 'location'
+          } to reload.`;
+          dispatch({
+            type: 'error',
+            error: {message},
+            errorLocationId: null,
+          });
+          stopPolling();
+        }
+        return;
+      }
 
-        invalidateConfigs(repositories);
+      // If we're done loading and an error persists, show it.
+      const errorLocation = matches.find(
+        (m) => m.locationOrLoadError?.__typename === 'PythonError',
+      );
 
-        // Refetch all the queries bound to the UI.
-        apollo.refetchQueries({include: 'active'});
-      },
+      if (errorLocation && errorLocation.locationOrLoadError?.__typename === 'PythonError') {
+        dispatch({
+          type: 'error',
+          error: errorLocation.locationOrLoadError,
+          errorLocationId: errorLocation.id,
+        });
+        stopPolling();
+        return;
+      }
+
+      // Otherwise, we have no errors left.
+      dispatch({type: 'finish-polling'});
+      stopPolling();
+
+      // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
+      SharedToaster.show({
+        message: `${scope === 'location' ? 'Code location' : 'Definitions'} reloaded!`,
+        timeout: 3000,
+        icon: 'check_circle',
+        intent: Intent.SUCCESS,
+      });
+      dispatch({type: 'success'});
+
+      // Update run config localStorage, which may now be out of date.
+      const repositories = matches.flatMap((location) =>
+        location?.__typename === 'WorkspaceLocationEntry' &&
+        location.locationOrLoadError?.__typename === 'RepositoryLocation'
+          ? location.locationOrLoadError.repositories.map((repo) => ({
+              ...repo,
+              locationName: location.id,
+            }))
+          : [],
+      );
+
+      invalidateConfigs(repositories);
+
+      // Refetch all the queries bound to the UI.
+      apollo.refetchQueries({include: 'active'});
     },
-  );
+  });
 
   const tryReload = React.useCallback(async () => {
     dispatch({type: 'start-mutation'});

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
@@ -36,6 +36,7 @@ import {
   OverviewSensorsQuery,
   OverviewSensorsQueryVariables,
   UnloadableSensorsQuery,
+  UnloadableSensorsQueryVariables,
 } from './types/OverviewSensorsRoot.types';
 import {visibleRepoKeys} from './visibleRepoKeys';
 
@@ -230,7 +231,9 @@ const UnloadableSensorsAlert: React.FC<{
 };
 
 const UnloadableSensorDialog: React.FC = () => {
-  const {data} = useQuery<UnloadableSensorsQuery>(UNLOADABLE_SENSORS_QUERY);
+  const {data} = useQuery<UnloadableSensorsQuery, UnloadableSensorsQueryVariables>(
+    UNLOADABLE_SENSORS_QUERY,
+  );
   if (!data) {
     return <Spinner purpose="section" />;
   }

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -27,7 +27,7 @@ import {Loading} from '../ui/Loading';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
-import {ResourceRootQuery} from './types/ResourceRoot.types';
+import {ResourceRootQuery, ResourceRootQueryVariables} from './types/ResourceRoot.types';
 
 interface Props {
   repoAddress: RepoAddress;
@@ -57,7 +57,7 @@ export const ResourceRoot: React.FC<Props> = (props) => {
     ...repoAddressToSelector(repoAddress),
     resourceName,
   };
-  const queryResult = useQuery<ResourceRootQuery>(RESOURCE_ROOT_QUERY, {
+  const queryResult = useQuery<ResourceRootQuery, ResourceRootQueryVariables>(RESOURCE_ROOT_QUERY, {
     variables: {
       resourceSelector,
     },

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.test.tsx
@@ -7,7 +7,7 @@ import {RunStatus} from '../graphql/types';
 import {TestProvider} from '../testing/TestProvider';
 
 import {RunDetails, RUN_DETAILS_FRAGMENT} from './RunDetails';
-import {RunDetailsTestQuery} from './types/RunDetails.test.types';
+import {RunDetailsTestQuery, RunDetailsTestQueryVariables} from './types/RunDetails.test.types';
 
 jest.mock('../app/time/browserTimezone.ts', () => ({
   browserTimezone: () => 'America/Los_Angeles',
@@ -28,9 +28,12 @@ describe('RunDetails', () => {
   `;
 
   const Test = () => {
-    const {data, loading} = useQuery<RunDetailsTestQuery>(RUN_DETAILS_TEST_QUERY, {
-      fetchPolicy: 'no-cache',
-    });
+    const {data, loading} = useQuery<RunDetailsTestQuery, RunDetailsTestQueryVariables>(
+      RUN_DETAILS_TEST_QUERY,
+      {
+        fetchPolicy: 'no-cache',
+      },
+    );
 
     if (!data || !data?.pipelineRunOrError || data?.pipelineRunOrError.__typename !== 'Run') {
       return null;

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -34,6 +34,7 @@ import {
 import {RunsPageHeader} from './RunsPageHeader';
 import {
   QueueDaemonStatusQuery,
+  QueueDaemonStatusQueryVariables,
   RunsRootQuery,
   RunsRootQueryVariables,
 } from './types/RunsRoot.types';
@@ -250,7 +251,9 @@ const RUNS_ROOT_QUERY = gql`
 `;
 
 const QueueDaemonAlert = () => {
-  const {data} = useQuery<QueueDaemonStatusQuery>(QUEUE_DAEMON_STATUS_QUERY);
+  const {data} = useQuery<QueueDaemonStatusQuery, QueueDaemonStatusQueryVariables>(
+    QUEUE_DAEMON_STATUS_QUERY,
+  );
   const {pageTitle} = React.useContext(InstancePageContext);
   const status = data?.instance.daemonHealth.daemonStatus;
   if (status?.required && !status?.healthy) {

--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -16,16 +16,22 @@ import {
 import {Loading} from '../ui/Loading';
 
 import {RunsPageHeader} from './RunsPageHeader';
-import {ScheduledRunsListQuery} from './types/ScheduledRunListRoot.types';
+import {
+  ScheduledRunsListQuery,
+  ScheduledRunsListQueryVariables,
+} from './types/ScheduledRunListRoot.types';
 
 export const ScheduledRunListRoot = () => {
   useTrackPageView();
   useDocumentTitle('Runs | Scheduled');
 
-  const queryResult = useQuery<ScheduledRunsListQuery>(SCHEDULED_RUNS_LIST_QUERY, {
-    partialRefetch: true,
-    notifyOnNetworkStatusChange: true,
-  });
+  const queryResult = useQuery<ScheduledRunsListQuery, ScheduledRunsListQueryVariables>(
+    SCHEDULED_RUNS_LIST_QUERY,
+    {
+      partialRefetch: true,
+      notifyOnNetworkStatusChange: true,
+    },
+  );
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
 

--- a/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/runs/TerminationDialog.tsx
@@ -19,7 +19,7 @@ import {TerminateRunPolicy} from '../graphql/types';
 
 import {NavigationBlock} from './NavitationBlock';
 import {TERMINATE_MUTATION} from './RunUtils';
-import {TerminateMutation} from './types/RunUtils.types';
+import {TerminateMutation, TerminateMutationVariables} from './types/RunUtils.types';
 
 export interface Props {
   isOpen: boolean;
@@ -133,7 +133,9 @@ export const TerminationDialog = (props: Props) => {
     }
   }, [isOpen, selectedRuns]);
 
-  const [terminate] = useMutation<TerminateMutation>(TERMINATE_MUTATION);
+  const [terminate] = useMutation<TerminateMutation, TerminateMutationVariables>(
+    TERMINATE_MUTATION,
+  );
   const policy = state.mustForce
     ? TerminateRunPolicy.MARK_AS_CANCELED_IMMEDIATELY
     : TerminateRunPolicy.SAFE_TERMINATE;

--- a/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.test.tsx
+++ b/js_modules/dagit/packages/core/src/testing/ApolloTestProvider.test.tsx
@@ -4,7 +4,10 @@ import {loader} from 'graphql.macro';
 import React from 'react';
 
 import {INSTANCE_CONFIG_QUERY} from '../instance/InstanceConfig';
-import {InstanceConfigQuery} from '../instance/types/InstanceConfig.types';
+import {
+  InstanceConfigQuery,
+  InstanceConfigQueryVariables,
+} from '../instance/types/InstanceConfig.types';
 
 import {ApolloTestProvider} from './ApolloTestProvider';
 
@@ -12,7 +15,9 @@ const typeDefs = loader('../graphql/schema.graphql');
 
 describe('ApolloTestProvider', () => {
   const Thing = () => {
-    const {data} = useQuery<InstanceConfigQuery>(INSTANCE_CONFIG_QUERY);
+    const {data} = useQuery<InstanceConfigQuery, InstanceConfigQueryVariables>(
+      INSTANCE_CONFIG_QUERY,
+    );
     return (
       <>
         <div>Version: {data?.version || ''}</div>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -14,6 +14,7 @@ import {findRepoContainingPipeline} from './findRepoContainingPipeline';
 import {RepoAddress} from './types';
 import {
   RootWorkspaceQuery,
+  RootWorkspaceQueryVariables,
   WorkspaceLocationFragment,
   WorkspaceLocationNodeFragment,
   WorkspaceRepositoryFragment,
@@ -171,7 +172,9 @@ const ROOT_WORKSPACE_QUERY = gql`
  * in the workspace, and loading/error state for the relevant query.
  */
 const useWorkspaceState = (): WorkspaceState => {
-  const {data, loading, refetch} = useQuery<RootWorkspaceQuery>(ROOT_WORKSPACE_QUERY);
+  const {data, loading, refetch} = useQuery<RootWorkspaceQuery, RootWorkspaceQueryVariables>(
+    ROOT_WORKSPACE_QUERY,
+  );
   const workspaceOrError = data?.workspaceOrError;
 
   const locationEntries = React.useMemo(

--- a/js_modules/dagit/packages/eslint-config/rules/__tests__/missing-graphql-variables-type.test.js
+++ b/js_modules/dagit/packages/eslint-config/rules/__tests__/missing-graphql-variables-type.test.js
@@ -20,12 +20,12 @@ fs.readFileSync = (path) => {
     : 'Subscription';
   if (path.includes('WithVariables')) {
     return `
-      export interface Some${api} {}
-      export interface Some${api}Variables {}
+      export type Some${api} {}
+      export type Some${api}Variables {}
     `;
   } else {
     return `
-      export interface Some${api} {}
+      export type Some${api} {}
     `;
   }
 };

--- a/js_modules/dagit/packages/eslint-config/rules/__tests__/missing-graphql-variables-type.test.js
+++ b/js_modules/dagit/packages/eslint-config/rules/__tests__/missing-graphql-variables-type.test.js
@@ -13,14 +13,19 @@ const fs = require('fs');
 const {rule} = require('../missing-graphql-variables-type');
 
 fs.readFileSync = (path) => {
+  const api = path.includes('Query')
+    ? 'Query'
+    : path.includes('Mutation')
+    ? 'Mutation'
+    : 'Subscription';
   if (path.includes('WithVariables')) {
     return `
-      export interface SomeQuery {}
-      export interface SomeQueryVariables {}
+      export interface Some${api} {}
+      export interface Some${api}Variables {}
     `;
   } else {
     return `
-      export interface SomeQuery {}
+      export interface Some${api} {}
     `;
   }
 };
@@ -34,6 +39,22 @@ ruleTester.run('missing-graphql-variables', rule, {
     `
       import { SomeQuery } from '../SomeQueryWithOutVariables';
       useQuery<SomeQuery>();
+    `,
+    `
+      import { SomeMutation, SomeMutationVariables } from '../SomeMutationWithVariables';
+      useMutation<SomeMutation, SomeMutationVariables>();
+    `,
+    `
+      import { SomeMutation } from '../SomeMutationWithOutVariables';
+      useMutation<SomeMutation>();
+    `,
+    `
+      import { SomeSubscription, SomeSubscriptionVariables } from '../SomeSubscriptionWithVariables';
+      useSubscription<SomeSubscription, SomeSubscriptionVariables>();
+    `,
+    `
+      import { SomeSubscription } from '../SomeSubscriptionWithOutVariables';
+      useSubscription<SomeSubscription>();
     `,
   ],
   invalid: [
@@ -61,6 +82,70 @@ ruleTester.run('missing-graphql-variables', rule, {
       output: `
         import { SomeQuery, SomeQueryVariables } from '../SomeQueryWithVariables';
         useQuery<SomeQuery, SomeQueryVariables>();
+      `,
+      errors: [
+        {
+          type: AST_NODE_TYPES.CallExpression,
+          messageId: 'missing-graphql-variables-type',
+        },
+      ],
+    },
+    {
+      code: `
+        import { SomeMutation } from '../SomeMutationWithVariables';
+        useMutation<SomeMutation>();
+      `,
+      output: `
+        import { SomeMutation, SomeMutationVariables } from '../SomeMutationWithVariables';
+        useMutation<SomeMutation, SomeMutationVariables>();
+      `,
+      errors: [
+        {
+          type: AST_NODE_TYPES.CallExpression,
+          messageId: 'missing-graphql-variables-type',
+        },
+      ],
+    },
+    {
+      code: `
+        import { SomeMutation, SomeMutationVariables } from '../SomeMutationWithVariables';
+        useMutation<SomeMutation>();
+      `,
+      output: `
+        import { SomeMutation, SomeMutationVariables } from '../SomeMutationWithVariables';
+        useMutation<SomeMutation, SomeMutationVariables>();
+      `,
+      errors: [
+        {
+          type: AST_NODE_TYPES.CallExpression,
+          messageId: 'missing-graphql-variables-type',
+        },
+      ],
+    },
+    {
+      code: `
+        import { SomeSubscription } from '../SomeSubscriptionWithVariables';
+        useSubscription<SomeSubscription>();
+      `,
+      output: `
+        import { SomeSubscription, SomeSubscriptionVariables } from '../SomeSubscriptionWithVariables';
+        useSubscription<SomeSubscription, SomeSubscriptionVariables>();
+      `,
+      errors: [
+        {
+          type: AST_NODE_TYPES.CallExpression,
+          messageId: 'missing-graphql-variables-type',
+        },
+      ],
+    },
+    {
+      code: `
+        import { SomeSubscription, SomeSubscriptionVariables } from '../SomeSubscriptionWithVariables';
+        useSubscription<SomeSubscription>();
+      `,
+      output: `
+        import { SomeSubscription, SomeSubscriptionVariables } from '../SomeSubscriptionWithVariables';
+        useSubscription<SomeSubscription, SomeSubscriptionVariables>();
       `,
       errors: [
         {

--- a/js_modules/dagit/packages/eslint-config/rules/missing-graphql-variables-type.js
+++ b/js_modules/dagit/packages/eslint-config/rules/missing-graphql-variables-type.js
@@ -71,7 +71,10 @@ module.exports = {
 
           // This part is kind of hacky. I should use the parser service to find the identifier
           // but this is faster then tokenizing the whole file
-          if (!graphqlTypeFile.includes('export type ' + variablesName)) {
+          if (
+            !graphqlTypeFile.includes('export type ' + variablesName) &&
+            !graphqlTypeFile.includes('export interface ' + variablesName)
+          ) {
             return;
           }
           // This is a Query type with a generated QueryVariables type. Make sure we're using it

--- a/js_modules/dagit/packages/eslint-config/rules/missing-graphql-variables-type.js
+++ b/js_modules/dagit/packages/eslint-config/rules/missing-graphql-variables-type.js
@@ -71,7 +71,7 @@ module.exports = {
 
           // This part is kind of hacky. I should use the parser service to find the identifier
           // but this is faster then tokenizing the whole file
-          if (!graphqlTypeFile.includes('export interface ' + variablesName)) {
+          if (!graphqlTypeFile.includes('export type ' + variablesName)) {
             return;
           }
           // This is a Query type with a generated QueryVariables type. Make sure we're using it


### PR DESCRIPTION
### Summary & Motivation

We want to raise an error if you forget to pass the Variables type argument to a `useQuery`, `useMutation`, or `useSubscription`.

This rule already targeted `useQuery`. This updates the rule to target mutations and subscriptions too.

Also fixed the rule to target the new codegen we're using which exports with `export type` instead of `export interface`

### How I Tested These Changes

jest.

```
➜  eslint-config git:(master) ✗ yarn test
 PASS  rules/__tests__/missing-graphql-variables-type.test.js
  missing-graphql-variables
    valid
      ✓ 
      import { SomeQuery, SomeQueryVariables } from '../SomeQueryWithVariables';
      useQuery<SomeQuery, SomeQueryVariables>();
     (316 ms)
      ✓ 
      import { SomeQuery } from '../SomeQueryWithOutVariables';
      useQuery<SomeQuery>();
     (3 ms)
      ✓ 
      import { SomeMutation, SomeMutationVariables } from '../SomeMutationWithVariables';
      useMutation<SomeMutation, SomeMutationVariables>();
     (3 ms)
      ✓ 
      import { SomeMutation } from '../SomeMutationWithOutVariables';
      useMutation<SomeMutation>();
     (2 ms)
      ✓ 
      import { SomeSubscription, SomeSubscriptionVariables } from '../SomeSubscriptionWithVariables';
      useSubscription<SomeSubscription, SomeSubscriptionVariables>();
     (2 ms)
      ✓ 
      import { SomeSubscription } from '../SomeSubscriptionWithOutVariables';
      useSubscription<SomeSubscription>();
     (1 ms)
    invalid
      ✓ 
        import { SomeQuery } from '../SomeQueryWithVariables';
        useQuery<SomeQuery>();
       (5 ms)
      ✓ 
        import { SomeQuery, SomeQueryVariables } from '../SomeQueryWithVariables';
        useQuery<SomeQuery>();
       (6 ms)
      ✓ 
        import { SomeMutation } from '../SomeMutationWithVariables';
        useMutation<SomeMutation>();
       (3 ms)
      ✓ 
        import { SomeMutation, SomeMutationVariables } from '../SomeMutationWithVariables';
        useMutation<SomeMutation>();
       (3 ms)
      ✓ 
        import { SomeSubscription } from '../SomeSubscriptionWithVariables';
        useSubscription<SomeSubscription>();
       (2 ms)
      ✓ 
        import { SomeSubscription, SomeSubscriptionVariables } from '../SomeSubscriptionWithVariables';
        useSubscription<SomeSubscription>();
       (3 ms)
```
