### PR TITLE
[pythonic resources][fix] Fix inheriting attributes when extending Pythonic resources

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -71,12 +71,9 @@ class BaseResourceMeta(pydantic.main.ModelMetaclass):
     accepts either a PartialResource or a Resource as a value for the resource dependency.
     """
 
-    def __new__(cls, name, bases, namespaces, **kwargs):
+    def __new__(cls, name, bases, namespaces, **kwargs) -> Any:
         # Gather all type annotations from the class and its base classes
         annotations = namespaces.get("__annotations__", {})
-        for base in bases:
-            if hasattr(base, "__annotations__"):
-                annotations.update(base.__annotations__)
         for field in annotations:
             if not field.startswith("__"):
                 # Check if the annotation is a ResourceDependency

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1255,3 +1255,28 @@ def test_resource_defs_on_asset() -> None:
         @asset(required_resource_keys={"my_other_resource"})
         def an_other_asset(my_resource: MyResource):
             pass
+
+
+def test_extending_resource() -> None:
+    executed = {}
+
+    class BaseResource(ConfigurableResource):
+        a_str: str = "bar"
+        an_int: int = 1
+
+    class ExtendingResource(BaseResource):
+        a_float: float = 1.0
+
+    @op
+    def hello_world_op(writer: ExtendingResource):
+        assert writer.a_str == "foo"
+        assert writer.an_int == 1
+        assert writer.a_float == 1.0
+        executed["yes"] = True
+
+    @job(resource_defs={"writer": ExtendingResource(a_str="foo")})
+    def no_prefix_job() -> None:
+        hello_world_op()
+
+    assert no_prefix_job.execute_in_process().success
+    assert executed["yes"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1280,3 +1280,53 @@ def test_extending_resource() -> None:
 
     assert no_prefix_job.execute_in_process().success
     assert executed["yes"]
+
+
+def test_extending_resource_nesting() -> None:
+    executed = {}
+
+    class NestedResource(ConfigurableResource):
+        a_str: str
+
+    class BaseResource(ConfigurableResource):
+        nested: NestedResource
+        a_str: str = "bar"
+        an_int: int = 1
+
+    class ExtendingResource(BaseResource):
+        a_float: float = 1.0
+
+    @asset
+    def an_asset(writer: ExtendingResource):
+        assert writer.a_str == "foo"
+        assert writer.nested.a_str == "baz"
+        assert writer.an_int == 1
+        assert writer.a_float == 1.0
+        executed["yes"] = True
+
+    defs = Definitions(
+        assets=[an_asset],
+        resources={"writer": ExtendingResource(a_str="foo", nested=NestedResource(a_str="baz"))},
+    )
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+
+    assert executed["yes"]
+    executed.clear()
+
+    nested_defer = NestedResource.configure_at_launch()
+    defs = Definitions(
+        assets=[an_asset],
+        resources={
+            "nested_deferred": nested_defer,
+            "writer": ExtendingResource(a_str="foo", nested=nested_defer),
+        },
+    )
+    assert (
+        defs.get_implicit_global_asset_job_def()
+        .execute_in_process(
+            run_config={"resources": {"nested_deferred": {"config": {"a_str": "baz"}}}}
+        )
+        .success
+    )
+
+    assert executed["yes"]


### PR DESCRIPTION
## Summary

Fixes an error where extending a `ConfigurableResource` class would drop any defaults associated with the base class, e.g.

```python

class BaseResource(ConfigurableResource):
    a_str: str = "bar"
    an_int: int = 1

class ExtendingResource(BaseResource):
    a_float: float = 1.0

# errors because `a_str` is unset, since default is discarded
ExtendingResource()

```

This was caused by unnecessarily merging attributes of upstream classes in the metaclass.

## Test Plan

Added unit test to verify that this now works (& added unit test to ensure this pattern works on `Config` too).
