### PR TITLE
[dagit] Asset node rendering tweaks (#12764, #12765)

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -682,14 +682,14 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Partitioned Asset - Some Missing',
     liveData: LiveDataForNodePartitionedSomeMissing,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['999+', '6', '1,494 missing partitions'],
+    expectedText: ['999+', '6', '1,500 partitions'],
   },
 
   {
     title: 'Partitioned Asset - Some Failed',
     liveData: LiveDataForNodePartitionedSomeFailed,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['645', '849 failed partitions'],
+    expectedText: ['645', '849', '1,500 partitions'],
   },
 
   {
@@ -703,7 +703,7 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Never Materialized',
     liveData: LiveDataForNodePartitionedNeverMaterialized,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['1,500 missing partitions'],
+    expectedText: ['1,500 partitions'],
   },
 
   {
@@ -738,7 +738,7 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Partitioned Asset - Last Run Failed',
     liveData: LiveDataForNodePartitionedLatestRunFailed,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['4', '999+', '1 failed partition'],
+    expectedText: ['4', '999+', '1,500 partitions'],
   },
   {
     title: 'Partitioned Asset - Live Data Loading',

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -87,13 +87,13 @@ const AssetNodePartitionsRow: React.FC<StatusRowProps> = (props) => {
       padding={{bottom: 8, horizontal: 8}}
     >
       <AssetNodePartitionCountBox
-        state={PartitionState.MISSING}
-        value={data ? data.numPartitions - data.numFailed - data.numMaterialized : undefined}
+        state={PartitionState.SUCCESS}
+        value={data?.numMaterialized}
         total={data?.numPartitions}
       />
       <AssetNodePartitionCountBox
-        state={PartitionState.SUCCESS}
-        value={data?.numMaterialized}
+        state={PartitionState.MISSING}
+        value={data ? data.numPartitions - data.numFailed - data.numMaterialized : undefined}
         total={data?.numPartitions}
       />
       <AssetNodePartitionCountBox
@@ -322,10 +322,6 @@ function buildAssetNodeStatusRow({
           >
             {late
               ? humanizedLateString(liveData.freshnessInfo.currentMinutesLate)
-              : numFailed
-              ? partitionStateToString(numFailed, 'failed')
-              : numMissing
-              ? partitionStateToString(numMissing, 'missing')
               : partitionStateToString(numPartitions)}
           </Link>
         </Caption>


### PR DESCRIPTION
### Summary & Motivation

This PR resolves #12764, #12765

One small caveat of always showing the total count in the bottom bar is that it's a little less clear why the box is red vs green vs gray. I think it might just require getting used to the new counts.

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/1037212/223617054-dd75a542-d6c3-483b-80b7-155d61db1f51.png">

<img width="1332" alt="image" src="https://user-images.githubusercontent.com/1037212/223617072-f726ebec-65bf-4d6e-88ad-9b231d0a1597.png">

### How I Tested These Changes

Updated storybooks and the accompanying tests