### PR TITLE
[dagit] Update the asset partitions / events view after run failures

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEvents.tsx
@@ -20,11 +20,11 @@ interface Props {
   params: AssetViewParams;
   paramsTimeWindowOnly: boolean;
   setParams: (params: AssetViewParams) => void;
+  assetHasDefinedPartitions: boolean;
 
   // This timestamp is a "hint", when it changes this component will refetch
   // to retrieve new data. Just don't want to poll the entire table query.
-  assetLastMaterializedAt: string | undefined;
-  assetHasDefinedPartitions: boolean;
+  dataRefreshHint: string | undefined;
 
   repository?: RepositorySelector;
   opName?: string | null;
@@ -32,11 +32,11 @@ interface Props {
 
 export const AssetEvents: React.FC<Props> = ({
   assetKey,
-  assetLastMaterializedAt,
   assetHasDefinedPartitions,
   params,
   setParams,
   liveData,
+  dataRefreshHint,
 }) => {
   const {
     xAxis,
@@ -52,7 +52,7 @@ export const AssetEvents: React.FC<Props> = ({
       return;
     }
     refetch();
-  }, [params.asOf, assetLastMaterializedAt, refetch]);
+  }, [params.asOf, dataRefreshHint, refetch]);
 
   const grouped = useGroupedEvents(xAxis, materializations, observations, loadedPartitionKeys);
 

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -38,7 +38,7 @@ interface Props {
 
   // This timestamp is a "hint", when it changes this component will refetch
   // to retrieve new data. Just don't want to poll the entire table query.
-  assetLastMaterializedAt: string | undefined;
+  dataRefreshHint: string | undefined;
 
   repository?: RepositorySelector;
   opName?: string | null;
@@ -49,12 +49,12 @@ const DISPLAYED_STATES = [PartitionState.MISSING, PartitionState.SUCCESS, Partit
 export const AssetPartitions: React.FC<Props> = ({
   assetKey,
   assetPartitionDimensions,
-  assetLastMaterializedAt,
   params,
   setParams,
   liveData,
+  dataRefreshHint,
 }) => {
-  const [assetHealth] = usePartitionHealthData([assetKey], assetLastMaterializedAt);
+  const [assetHealth] = usePartitionHealthData([assetKey], dataRefreshHint);
   const [selections, setSelections] = usePartitionDimensionSelections({
     knownDimensionNames: assetPartitionDimensions,
     modifyQueryString: true,

--- a/js_modules/dagit/packages/core/src/assets/__stories__/AssetPartitions.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/AssetPartitions.stories.tsx
@@ -27,7 +27,7 @@ export const SingleDimensionStaticAsset = () => {
           setParams={setParams}
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['default']}
-          assetLastMaterializedAt={undefined}
+          dataRefreshHint={undefined}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -46,7 +46,7 @@ export const SingleDimensionTimeAsset = () => {
           setParams={setParams}
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['default']}
-          assetLastMaterializedAt={undefined}
+          dataRefreshHint={undefined}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -65,7 +65,7 @@ export const MultiDimensionStaticAsset = () => {
           setParams={setParams}
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['month', 'state']}
-          assetLastMaterializedAt={undefined}
+          dataRefreshHint={undefined}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -84,7 +84,7 @@ export const MultiDimensionTimeFirstAsset = () => {
           setParams={setParams}
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['date', 'zstate']}
-          assetLastMaterializedAt={undefined}
+          dataRefreshHint={undefined}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -103,7 +103,7 @@ export const MultiDimensionTimeSecondAsset = () => {
           setParams={setParams}
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['astate', 'date']}
-          assetLastMaterializedAt={undefined}
+          dataRefreshHint={undefined}
         />
       </MockedProvider>
     </StorybookProvider>

--- a/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -42,7 +42,7 @@ const SingleDimensionAssetPartitions: React.FC<{assetKey: AssetKeyInput}> = ({as
           setParams={setParams}
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['default']}
-          assetLastMaterializedAt={undefined}
+          dataRefreshHint={undefined}
         />
       </MockedProvider>
       <Route


### PR DESCRIPTION
### Summary & Motivation

We use a "hint" value to trigger a refresh of the asset event and asset partition views when the asset's live data has changed (using lightweight data to trigger a refresh of "heavy" requests). Now that we have a partition failure state, we need to refresh the views when a new run(s) have failed.

I also updated the name of the prop that implements this to be more explicit.

### How I Tested These Changes

I manually tested this change by having a run fail and observing that the partitions view refreshes properly to show the red stripe and failed partition dot.