### PR TITLE
[dagit] Show “Observe” on source asset details pages, not “Materialize"

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -158,13 +158,6 @@ export const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
     ? graphQueryItems.map((a) => a.node)
     : Object.values(assetGraphData.nodes).map((a) => a.definition);
 
-  const hasLaunchPermission = React.useMemo(() => {
-    if (selectedDefinitions.length) {
-      return selectedDefinitions.every((definition) => definition.hasMaterializePermission);
-    }
-    return allDefinitionsForMaterialize.every((definition) => definition.hasMaterializePermission);
-  }, [allDefinitionsForMaterialize, selectedDefinitions]);
-
   const onSelectNode = React.useCallback(
     async (
       e: React.MouseEvent<any> | React.KeyboardEvent<any>,
@@ -415,13 +408,11 @@ export const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
               />
               <LaunchAssetObservationButton
                 preferredJobName={explorerPath.pipelineName}
-                hasLaunchPermission={hasLaunchPermission}
-                assetKeys={(selectedDefinitions.length
-                  ? selectedDefinitions
-                  : allDefinitionsForMaterialize
-                )
-                  .filter((a) => a.isObservable)
-                  .map((n) => n.assetKey)}
+                scope={
+                  selectedDefinitions.length
+                    ? {selected: selectedDefinitions.filter((a) => a.isObservable)}
+                    : {all: allDefinitionsForMaterialize.filter((a) => a.isObservable)}
+                }
               />
               <LaunchAssetExecutionButton
                 preferredJobName={explorerPath.pipelineName}

--- a/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useAssetGraphData.tsx
@@ -169,7 +169,7 @@ export const calculateGraphDistances = (items: GraphQueryItem[], assetKey: Asset
   };
 };
 
-const ASSET_GRAPH_QUERY = gql`
+export const ASSET_GRAPH_QUERY = gql`
   query AssetGraphQuery($pipelineSelector: PipelineSelector, $groupSelector: AssetGroupSelector) {
     assetNodes(pipeline: $pipelineSelector, group: $groupSelector) {
       id

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -47,6 +47,7 @@ import {AssetPartitions} from './AssetPartitions';
 import {AssetPlots} from './AssetPlots';
 import {CurrentMinutesLateTag} from './CurrentMinutesLateTag';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
+import {LaunchAssetObservationButton} from './LaunchAssetObservationButton';
 import {AssetKey} from './types';
 import {
   AssetViewDefinitionNodeFragment,
@@ -197,9 +198,14 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
         }
         right={
           <Box style={{margin: '-4px 0'}}>
-            {definition && definition.jobNames.length > 0 && upstream && (
+            {definition && definition.isObservable ? (
+              <LaunchAssetObservationButton
+                intent="primary"
+                scope={{all: [definition], skipAllTerm: true}}
+              />
+            ) : definition && definition.jobNames.length > 0 && upstream ? (
               <LaunchAssetExecutionButton scope={{all: [definition]}} />
-            )}
+            ) : undefined}
           </Box>
         }
       />
@@ -342,7 +348,7 @@ const useAssetViewAssetDefinition = (assetKey: AssetKey) => {
   };
 };
 
-const ASSET_VIEW_DEFINITION_QUERY = gql`
+export const ASSET_VIEW_DEFINITION_QUERY = gql`
   query AssetViewDefinitionQuery($assetKey: AssetKeyInput!) {
     assetOrError(assetKey: $assetKey) {
       ... on Asset {

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -82,7 +82,7 @@ type Asset =
       isSource: boolean;
     };
 
-type AssetsInScope = {all: Asset[]; skipAllTerm?: boolean} | {selected: Asset[]};
+export type AssetsInScope = {all: Asset[]; skipAllTerm?: boolean} | {selected: Asset[]};
 
 type LaunchOption = {assetKeys: AssetKey[]; label: string; hasMaterializePermission: boolean};
 

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetObservationButton.tsx
@@ -9,12 +9,12 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
 import {
+  AssetsInScope,
   buildAssetCollisionsAlert,
   executionParamsForAssetJob,
   getCommonJob,
   LAUNCH_ASSET_LOADER_QUERY,
 } from './LaunchAssetExecutionButton';
-import {AssetKey} from './types';
 import {
   LaunchAssetExecutionAssetNodeFragment,
   LaunchAssetLoaderQuery,
@@ -31,25 +31,31 @@ type ObserveAssetsState =
     };
 
 export const LaunchAssetObservationButton: React.FC<{
-  assetKeys: AssetKey[]; // Memoization not required
-  hasLaunchPermission: boolean;
+  scope: AssetsInScope;
   intent?: 'primary' | 'none';
   preferredJobName?: string;
-}> = ({assetKeys, hasLaunchPermission, preferredJobName, intent = 'none'}) => {
+}> = ({scope, preferredJobName, intent = 'none'}) => {
   const {useLaunchWithTelemetry} = useLaunchPadHooks();
   const launchWithTelemetry = useLaunchWithTelemetry();
 
   const [state, setState] = React.useState<ObserveAssetsState>({type: 'none'});
   const client = useApolloClient();
 
-  const count = assetKeys.length > 1 ? ` (${assetKeys.length})` : '';
-  const label = `Observe sources ${count}`;
-
-  if (!assetKeys.length) {
+  const scopeAssets = 'selected' in scope ? scope.selected : scope.all;
+  if (!scopeAssets.length) {
     return <span />;
   }
 
-  if (!hasLaunchPermission) {
+  const count = scopeAssets.length > 1 ? ` (${scopeAssets.length})` : '';
+  const label =
+    'selected' in scope
+      ? `Observe selected${count}`
+      : scope.skipAllTerm
+      ? `Observe${count}`
+      : `Observe sources ${count}`;
+
+  const hasMaterializePermission = scopeAssets.every((a) => a.hasMaterializePermission);
+  if (!hasMaterializePermission) {
     return (
       <Tooltip content="You do not have permission to observe source assets">
         <Button intent={intent} icon={<Icon name="observation" />} disabled>
@@ -67,7 +73,7 @@ export const LaunchAssetObservationButton: React.FC<{
 
     const result = await client.query<LaunchAssetLoaderQuery, LaunchAssetLoaderQueryVariables>({
       query: LAUNCH_ASSET_LOADER_QUERY,
-      variables: {assetKeys: assetKeys.map(({path}) => ({path}))},
+      variables: {assetKeys: scopeAssets.map((a) => ({path: a.assetKey.path}))},
     });
 
     if (result.data.assetNodeDefinitionCollisions.length) {

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetViewDefinition.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetViewDefinition.mocks.ts
@@ -1,0 +1,166 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {AssetGraphQuery} from '../../asset-graph/types/useAssetGraphData.types';
+import {ASSET_GRAPH_QUERY} from '../../asset-graph/useAssetGraphData';
+import {ASSET_VIEW_DEFINITION_QUERY} from '../AssetView';
+import {AssetViewDefinitionQuery} from '../types/AssetView.types';
+
+export const LatestMaterializationTimestamp = '1671568270073';
+
+export const AssetGraphEmpty: MockedResponse<AssetGraphQuery> = {
+  request: {
+    query: ASSET_GRAPH_QUERY,
+    variables: {},
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodes: [],
+    },
+  },
+};
+
+export const AssetViewDefinitionNonSDA: MockedResponse<AssetViewDefinitionQuery> = {
+  request: {
+    query: ASSET_VIEW_DEFINITION_QUERY,
+    variables: {
+      assetKey: {path: ['non_sda_asset']},
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: '["non_sda_asset"]',
+        key: {
+          path: ['non_sda_asset'],
+          __typename: 'AssetKey',
+        },
+        assetMaterializations: [
+          {
+            timestamp: LatestMaterializationTimestamp,
+            __typename: 'MaterializationEvent',
+          },
+        ],
+        definition: null,
+        __typename: 'Asset',
+      },
+    },
+  },
+};
+
+export const AssetViewDefinitionSourceAsset: MockedResponse<AssetViewDefinitionQuery> = {
+  request: {
+    query: ASSET_VIEW_DEFINITION_QUERY,
+    variables: {
+      assetKey: {path: ['observable_source_asset']},
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: 'test.py.repo.["observable_source_asset"]',
+        key: {
+          path: ['observable_source_asset'],
+          __typename: 'AssetKey',
+        },
+        assetMaterializations: [],
+        definition: {
+          id: 'test.py.repo.["observable_source_asset"]',
+          groupName: 'GROUP3',
+          partitionDefinition: null,
+          partitionKeysByDimension: [],
+          repository: {
+            id: '4d0b1967471d9a4682ccc97d12c1c508d0d9c2e1',
+            name: 'repo',
+            location: {
+              id: 'test.py',
+              name: 'test.py',
+              __typename: 'RepositoryLocation',
+            },
+            __typename: 'Repository',
+          },
+          jobs: [],
+          __typename: 'AssetNode',
+          description: null,
+          graphName: null,
+          opNames: [],
+          opVersion: null,
+          jobNames: ['__ASSET_JOB'],
+          configField: null,
+          hasMaterializePermission: true,
+          computeKind: null,
+          isPartitioned: false,
+          isObservable: true,
+          isSource: true,
+          assetKey: {
+            path: ['observable_source_asset'],
+            __typename: 'AssetKey',
+          },
+          metadataEntries: [],
+          type: null,
+        },
+        __typename: 'Asset',
+      },
+    },
+  },
+};
+
+export const AssetViewDefinitionSDA: MockedResponse<AssetViewDefinitionQuery> = {
+  request: {
+    query: ASSET_VIEW_DEFINITION_QUERY,
+    variables: {
+      assetKey: {path: ['sda_asset']},
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        id: 'test.py.repo.["sda_asset"]',
+        key: {
+          path: ['sda_asset'],
+          __typename: 'AssetKey',
+        },
+        assetMaterializations: [],
+        definition: {
+          id: 'test.py.repo.["sda_asset"]',
+          groupName: 'GROUP3',
+          partitionDefinition: null,
+          partitionKeysByDimension: [],
+          repository: {
+            id: '4d0b1967471d9a4682ccc97d12c1c508d0d9c2e1',
+            name: 'repo',
+            location: {
+              id: 'test.py',
+              name: 'test.py',
+              __typename: 'RepositoryLocation',
+            },
+            __typename: 'Repository',
+          },
+          jobs: [],
+          __typename: 'AssetNode',
+          description: null,
+          graphName: null,
+          opNames: [],
+          opVersion: null,
+          jobNames: ['__ASSET_JOB'],
+          configField: null,
+          hasMaterializePermission: true,
+          computeKind: null,
+          isPartitioned: false,
+          isObservable: false,
+          isSource: false,
+          assetKey: {
+            path: ['sda_asset'],
+            __typename: 'AssetKey',
+          },
+          metadataEntries: [],
+          type: null,
+        },
+        __typename: 'Asset',
+      },
+    },
+  },
+};

--- a/js_modules/dagit/packages/core/src/assets/__tests__/AssetView.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/AssetView.test.tsx
@@ -1,74 +1,111 @@
-import {act, render, screen} from '@testing-library/react';
-import faker from 'faker';
+import {MockedProvider} from '@apollo/client/testing';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import * as React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
-import {TestProvider} from '../../testing/TestProvider';
+import {AssetKeyInput} from '../../graphql/types';
 import {AssetView} from '../AssetView';
+import {
+  AssetViewDefinitionSourceAsset,
+  AssetViewDefinitionNonSDA,
+  LatestMaterializationTimestamp,
+  AssetViewDefinitionSDA,
+  AssetGraphEmpty,
+} from '../__fixtures__/AssetViewDefinition.mocks';
 
 // This file must be mocked because Jest can't handle `import.meta.url`.
 jest.mock('../../graph/asyncGraphLayout', () => ({}));
 
-// This file must be mocked because useVirtualizer tries to create a ResizeObserver,
+// These files must be mocked because useVirtualizer tries to create a ResizeObserver,
 // and the component tree fails to mount.
 jest.mock('../AssetPartitions', () => ({AssetPartitions: () => <div />}));
+jest.mock('../AssetEvents', () => ({AssetEvents: () => <div />}));
 
 describe('AssetView', () => {
-  const mocks = {
-    AssetNode: () => ({
-      partitionKeys: () => [...new Array(0)],
-      partitionKeysByDimension: () => [...new Array(1)],
-    }),
-    Asset: () => ({
-      assetMaterializations: () => [...new Array(1)],
-      assetObservations: () => [...new Array(0)],
-    }),
-    MaterializationEvent: () => ({
-      timestamp: () => '100',
-    }),
-    MetadataEntry: () => ({
-      __typename: 'TextMetadataEntry',
-      label: () => faker.random.word().toLocaleLowerCase(),
-    }),
-  };
-
-  const Test = ({path}: {path: string}) => {
+  const Test = ({path, assetKey}: {path: string; assetKey: AssetKeyInput}) => {
     return (
-      <TestProvider apolloProps={{mocks}}>
+      <MockedProvider
+        mocks={[
+          AssetGraphEmpty,
+          AssetViewDefinitionSDA,
+          AssetViewDefinitionNonSDA,
+          AssetViewDefinitionSourceAsset,
+        ]}
+      >
         <MemoryRouter initialEntries={[path]}>
-          <AssetView assetKey={{path: ['foo']}} />
+          <AssetView assetKey={assetKey} />
         </MemoryRouter>
-      </TestProvider>
+      </MockedProvider>
     );
   };
 
   const MESSAGE = /this is a historical view of materializations as of \./i;
 
+  describe('Launch button', () => {
+    it('shows the "Materialize" button for a software-defined asset', async () => {
+      await act(async () => {
+        render(<Test path="/sda_asset" assetKey={{path: ['sda_asset']}} />);
+      });
+      await waitFor(async () => {
+        expect(screen.queryByText('Materialize')).toBeVisible();
+      });
+    });
+
+    it('shows the "Observe" button for a software-defined source asset', async () => {
+      await act(async () => {
+        render(
+          <Test path="/observable_source_asset" assetKey={{path: ['observable_source_asset']}} />,
+        );
+      });
+      await waitFor(async () => {
+        expect(screen.queryByText('Observe')).toBeVisible();
+      });
+    });
+
+    it('shows no button for a non-software defined asset', async () => {
+      await act(async () => {
+        render(<Test path="/non_sda_asset" assetKey={{path: ['non_sda_asset']}} />);
+      });
+      expect(screen.queryByText('Observe')).toBeNull();
+      expect(screen.queryByText('Materialize')).toBeNull();
+    });
+  });
+
   describe('Historical view alert', () => {
     it('shows historical view alert if `asOf` is old', async () => {
       await act(async () => {
-        render(<Test path="/foo?asOf=10" />);
+        render(<Test path="/non_sda_asset?asOf=10" assetKey={{path: ['non_sda_asset']}} />);
       });
       expect(screen.queryByText(MESSAGE)).toBeVisible();
     });
 
     it('does not show historical view alert if `asOf` is past latest materialization', async () => {
       await act(async () => {
-        render(<Test path="/foo?asOf=200" />);
+        render(
+          <Test
+            path={`/non_sda_asset?asOf=${Number(LatestMaterializationTimestamp) + 1000}`}
+            assetKey={{path: ['non_sda_asset']}}
+          />,
+        );
       });
       expect(screen.queryByText(MESSAGE)).toBeNull();
     });
 
     it('does not show historical view alert if `asOf` is equal to latest materialization', async () => {
       await act(async () => {
-        render(<Test path="/foo?asOf=100" />);
+        render(
+          <Test
+            path={`/non_sda_asset?asOf=${LatestMaterializationTimestamp}`}
+            assetKey={{path: ['non_sda_asset']}}
+          />,
+        );
       });
       expect(screen.queryByText(MESSAGE)).toBeNull();
     });
 
     it('does not show historical view alert if no `asOf` is specified', async () => {
       await act(async () => {
-        render(<Test path="/foo" />);
+        render(<Test path="/non_sda_asset" assetKey={{path: ['non_sda_asset']}} />);
       });
       expect(screen.queryByText(MESSAGE)).toBeNull();
     });

--- a/js_modules/dagit/packages/core/src/assets/__tests__/AssetView.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/AssetView.test.tsx
@@ -43,29 +43,23 @@ describe('AssetView', () => {
 
   describe('Launch button', () => {
     it('shows the "Materialize" button for a software-defined asset', async () => {
-      await act(async () => {
-        render(<Test path="/sda_asset" assetKey={{path: ['sda_asset']}} />);
-      });
+      render(<Test path="/sda_asset" assetKey={{path: ['sda_asset']}} />);
       await waitFor(async () => {
         expect(screen.queryByText('Materialize')).toBeVisible();
       });
     });
 
     it('shows the "Observe" button for a software-defined source asset', async () => {
-      await act(async () => {
-        render(
-          <Test path="/observable_source_asset" assetKey={{path: ['observable_source_asset']}} />,
-        );
-      });
+      render(
+        <Test path="/observable_source_asset" assetKey={{path: ['observable_source_asset']}} />,
+      );
       await waitFor(async () => {
         expect(screen.queryByText('Observe')).toBeVisible();
       });
     });
 
     it('shows no button for a non-software defined asset', async () => {
-      await act(async () => {
-        render(<Test path="/non_sda_asset" assetKey={{path: ['non_sda_asset']}} />);
-      });
+      render(<Test path="/non_sda_asset" assetKey={{path: ['non_sda_asset']}} />);
       expect(screen.queryByText('Observe')).toBeNull();
       expect(screen.queryByText('Materialize')).toBeNull();
     });


### PR DESCRIPTION
This PR resolves #12795

### Summary & Motivation

On the asset details page, the materialize button in the top right should be replaced by the "Observe" button if the asset is a source asset.

I also updated the Observe button to have a props shape similar to the Materialize button, which allowed me to make the button say "Observe" instead of "Observe sources" on the asset details page.

![image](https://user-images.githubusercontent.com/1037212/223790975-58f5d868-9c4b-457b-a0a4-66b59becd066.png)


### How I Tested These Changes

I added test coverage for this button and converted the existing AssetView tests from the old Apollo mocks to the new MockedProvider.