### PR TITLE
[dagit] Fix yaml editor help context when indented on a new line (#12537)

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/configeditor/codemirror-yaml/mode.tsx
+++ b/js_modules/dagit/packages/ui/src/components/configeditor/codemirror-yaml/mode.tsx
@@ -694,7 +694,11 @@ export function expandAutocompletionContextAtCursor(editor: any) {
 
   let searchString: string;
   let start: number;
-  if (token.type === 'whitespace' || token.string.startsWith(':')) {
+  if (
+    token.type === 'whitespace' ||
+    token.type?.startsWith('indent ') ||
+    token.string.startsWith(':')
+  ) {
     searchString = '';
     start = token.end;
   } else {


### PR DESCRIPTION
### Summary & Motivation

This PR fixes https://github.com/dagster-io/dagster/issues/12537. It's not totally clear why this is necessary now and wasn't before, but I think we upgraded codemirror ages ago and this may have been a regression then.

### How I Tested These Changes

I tested this manually by typing a variety of yaml trees into the config editor, letting the editor auto-indent as well as manually indenting / outdenting via tab and by typing space characters. I also confirmed that the editor help is correct if you use bracket objects on the same line (`ops: { config: { a...}}`)