### PR TITLE
[ui] Run logs: make Timestamp the first column

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -208,15 +208,15 @@ const StructuredMemoizedContent: React.FC<{
       onMouseLeave={() => setHighlightedGanttChartTime(null)}
       highlighted={highlighted}
     >
-      <OpColumn stepKey={'stepKey' in node && node.stepKey} />
-      <StructuredContent>
-        <LogsRowStructuredContent node={node} metadata={metadata} />
-      </StructuredContent>
       <TimestampColumn
         time={'timestamp' in node ? node.timestamp : null}
         runStartTime={metadata.startedPipelineAt}
         stepStartTime={stepStartTime}
       />
+      <OpColumn stepKey={'stepKey' in node && node.stepKey} />
+      <StructuredContent>
+        <LogsRowStructuredContent node={node} metadata={metadata} />
+      </StructuredContent>
     </Row>
   );
 });
@@ -279,6 +279,11 @@ const UnstructuredMemoizedContent: React.FC<{
       onMouseLeave={() => setHighlightedGanttChartTime(null)}
       highlighted={highlighted}
     >
+      <TimestampColumn
+        time={node.timestamp}
+        runStartTime={metadata.startedPipelineAt}
+        stepStartTime={stepStartTime}
+      />
       <OpColumn stepKey={node.stepKey} />
       <EventTypeColumn>
         <span style={{marginLeft: 8}}>{node.level}</span>
@@ -286,11 +291,6 @@ const UnstructuredMemoizedContent: React.FC<{
       <Box padding={{horizontal: 12}} style={{flex: 1}}>
         {node.message}
       </Box>
-      <TimestampColumn
-        time={node.timestamp}
-        runStartTime={metadata.startedPipelineAt}
-        stepStartTime={stepStartTime}
-      />
     </Row>
   );
 });

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTableHeader.tsx
@@ -122,6 +122,12 @@ export const Headers = () => {
   const widths = React.useContext(ColumnWidthsContext);
   return (
     <HeadersContainer>
+      <Header
+        width={widths.timestamp}
+        onResize={(width) => widths.onChange({...widths, timestamp: width})}
+      >
+        Timestamp
+      </Header>
       <Header width={widths.solid} onResize={(width) => widths.onChange({...widths, solid: width})}>
         Op
       </Header>
@@ -132,13 +138,6 @@ export const Headers = () => {
         Event Type
       </Header>
       <HeaderContainer style={{flex: 1}}>Info</HeaderContainer>
-      <Header
-        handleSide="left"
-        width={widths.timestamp}
-        onResize={(width) => widths.onChange({...widths, timestamp: width})}
-      >
-        Timestamp
-      </Header>
     </HeadersContainer>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/12254.

Move the "Timestamp" column to be the leftmost column in the Run logs table, to make it easier to visually line up the time, op, and step.

<img width="1335" alt="Screenshot 2023-03-08 at 12 13 31 PM" src="https://user-images.githubusercontent.com/2823852/223797108-a7d81c32-31f3-4b7b-848c-51d2b7b9df57.png">
<img width="414" alt="Screenshot 2023-03-08 at 12 13 37 PM" src="https://user-images.githubusercontent.com/2823852/223797142-f893c084-c558-484d-b6ae-58ba03799098.png">


### How I Tested These Changes

View a run, verify that the timestamp renders at the left. Adjust column widths, verify that resizing occurs correctly.
