### PR TITLE
[ui] Fix space oddities on Schedules overview table

### DIFF
--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -166,12 +166,11 @@ export const OverviewSchedulesRoot = () => {
               count={data.unloadableInstigationStatesOrError.results.length}
             />
           ) : null}
-          <Box
+          <SchedulerInfo
+            daemonHealth={data?.instance.daemonHealth}
             padding={{vertical: 16, horizontal: 24}}
             border={{side: 'top', width: 1, color: Colors.KeylineGray}}
-          >
-            <SchedulerInfo daemonHealth={data?.instance.daemonHealth} />
-          </Box>
+          />
           {content()}
         </>
       )}

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -36,7 +36,7 @@ import {
 } from './types/VirtualizedScheduleRow.types';
 import {workspacePathFromAddress} from './workspacePath';
 
-const TEMPLATE_COLUMNS = '76px 1fr 1fr 148px 180px 80px';
+const TEMPLATE_COLUMNS = '76px 1fr 1fr 148px 210px 92px';
 
 interface ScheduleRowProps {
   name: string;
@@ -216,7 +216,9 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
             >
               <Button icon={<Icon name="expand_more" />} />
             </Popover>
-          ) : null}
+          ) : (
+            <span style={{color: Colors.Gray400}}>{'\u2013'}</span>
+          )}
         </RowCell>
       </RowGrid>
     </Row>
@@ -240,7 +242,7 @@ export const VirtualizedScheduleHeader = () => {
       <HeaderCell>Schedule</HeaderCell>
       <HeaderCell>Last tick</HeaderCell>
       <HeaderCell>Last run</HeaderCell>
-      <HeaderCell />
+      <HeaderCell>Actions</HeaderCell>
     </Box>
   );
 };


### PR DESCRIPTION
### Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/12505.

- Clean up empty whitespace where `SchedulerInfo` renders null
- Add an "Actions" label to the rightmost table header, and render an empty state for cells without actions

### How I Tested These Changes

View Schedules overview, verify changes as noted above. With daemon enabled, verify that the alert appears properly and properly spaced. With daemon disabled, verify that there is no extra whitespace.
