### PR TITLE
[dagster-airflow] mark non-success task instance state as failures + remove double encoding of timezones

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/airflow_dag_converter.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/airflow_dag_converter.py
@@ -3,6 +3,7 @@ import importlib
 import airflow
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
+from airflow.utils.state import DagRunState
 from dagster import (
     DependencyDefinition,
     In,
@@ -120,5 +121,11 @@ def make_dagster_op_from_airflow_task(
             ti = dagrun.get_task_instance(task_id=task.task_id)
             ti.task = dag.get_task(task_id=task.task_id)
             ti.run(ignore_ti_state=True)
+            if ti.state != DagRunState.SUCCESS:
+                raise Exception(
+                    "Airflow task failed: {task_id}, view compute logs for more details".format(
+                        task_id=task.task_id
+                    )
+                )
 
     return _op

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
@@ -46,7 +46,6 @@ class AirflowDatabase:
         check.str_param(execution_date_str, "execution_date_str")
         try:
             execution_date = parse(execution_date_str)
-            execution_date = execution_date.replace(tzinfo=pytz.timezone(dag.timezone.name))
         except ValueError:
             raise DagsterInvariantViolationError(
                 'Could not parse execution_date "{execution_date_str}". Please use datetime'
@@ -70,7 +69,6 @@ class AirflowDatabase:
         if not execution_date_str:
             raise DagsterInvariantViolationError("dagster/partition is not set")
         execution_date = parse(execution_date_str)
-        execution_date = execution_date.replace(tzinfo=pytz.timezone(dag.timezone.name))
         return execution_date
 
     def get_dagrun(self, dag: DAG) -> DagRun:


### PR DESCRIPTION
### Summary & Motivation

this pr fixes two bugs:
1. airflow task instance state is not being propagated to dagster allowing for task failures to look like successful runs in dagster
2. double encoding of airflow start date is means that non-utc start dates don't work atm

### How I Tested These Changes
