### PR TITLE
[RFC] Enable returning SensorTickResult containing DynamicPartitionsRequests

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
@@ -41,7 +41,7 @@ def image_sensor(context):
     context.instance.add_dynamic_partitions(images_partitions_def.name, new_images)
 
     run_requests = [
-        images_job.run_request_for_partition(img_filename, instance=context.instance)
+        images_job.run_request_for_partition(img_filename)
         for img_filename in new_images
     ]
     return run_requests

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -250,7 +250,6 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         # At the end of each tick, must call update_cursor_after_evaluation to update the serialized
         # cursor.
         self._unpacked_cursor = MultiAssetSensorContextCursor(cursor, self)
-        self._cursor_has_been_updated = False
         self._cursor_advance_state_mutation = MultiAssetSensorCursorAdvances()
 
         self._initial_unconsumed_events_by_id: Dict[int, EventLogRecord] = {}
@@ -743,7 +742,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 will not be updated.
         """
         self._cursor_advance_state_mutation.add_advanced_records(materialization_records_by_key)
-        self._cursor_has_been_updated = True
+        self._cursor_updated = True
 
     @public
     def advance_all_cursors(self):
@@ -757,7 +756,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
 
         self._cursor_advance_state_mutation.add_advanced_records(materializations_by_key)
         self._cursor_advance_state_mutation.advance_all_cursors_called = True
-        self._cursor_has_been_updated = True
+        self._cursor_updated = True
 
     @public
     @property
@@ -1113,7 +1112,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
 
                 if (
                     runs_yielded
-                    and not multi_asset_sensor_context._cursor_has_been_updated  # pylint: disable=protected-access
+                    and not multi_asset_sensor_context.cursor_updated  # pylint: disable=protected-access
                 ):
                     raise DagsterInvalidDefinitionError(
                         "Asset materializations have been handled in this sensor, but the cursor"

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -53,6 +53,7 @@ from .sensor_definition import (
     SensorType,
     SkipReason,
     has_at_least_one_parameter,
+    SensorTickResult,
 )
 from .target import ExecutableDefinition
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
@@ -490,7 +491,7 @@ class RunStatusSensorDefinition(SensorDefinition):
 
         def _wrapped_fn(
             context: SensorEvaluationContext,
-        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction]]:
+        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction, SensorTickResult]]:
             # initiate the cursor to (most recent event id, current timestamp) when:
             # * it's the first time starting the sensor
             # * or, the cursor isn't in valid format (backcompt)
@@ -640,7 +641,8 @@ class RunStatusSensorDefinition(SensorDefinition):
                             )
 
                             if isinstance(
-                                sensor_return, (RunRequest, SkipReason, PipelineRunReaction)
+                                sensor_return,
+                                (RunRequest, SkipReason, PipelineRunReaction, SensorTickResult),
                             ):
                                 yield sensor_return
                             else:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -13,7 +13,11 @@ import pendulum
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._core.definitions.run_request import InstigatorType, RunRequest
+from dagster._core.definitions.run_request import (
+    DynamicPartitionsAction,
+    InstigatorType,
+    RunRequest,
+)
 from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorExecutionData
 from dagster._core.definitions.utils import validate_tags
@@ -564,6 +568,32 @@ def _evaluate_sensor(
         context.add_log_info(sensor_runtime_data.captured_log_key)
 
     assert isinstance(sensor_runtime_data, SensorExecutionData)
+
+    if sensor_runtime_data.dynamic_partitions_requests:
+        for request in sensor_runtime_data.dynamic_partitions_requests:
+            if request.action == DynamicPartitionsAction.ADD:
+                instance.add_dynamic_partitions(
+                    request.partitions_def_name,
+                    request.partition_keys,
+                )
+                context.logger.info(
+                    "Added partition keys to dynamic partitions definition"
+                    f" '{request.partitions_def_name}': {request.partition_keys}"
+                )
+            else:
+                if request.action is not DynamicPartitionsAction.DELETE:
+                    check.failed(
+                        f"Unexpected action {request.action} for dynamic partition request"
+                    )
+
+                # TODO add a bulk delete method to the instance
+                for partition in request.partition_keys:
+                    instance.delete_dynamic_partition(request.partitions_def_name, partition)
+
+                context.logger.info(
+                    "Deleted partition keys from dynamic partitions definition"
+                    f" '{request.partitions_def_name}': {request.partition_keys}"
+                )
     if not sensor_runtime_data.run_requests:
         if sensor_runtime_data.pipeline_run_reactions:
             for pipeline_run_reaction in sensor_runtime_data.pipeline_run_reactions:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -17,6 +17,7 @@ from dagster import (
     AssetSelection,
     CodeLocationSelector,
     DagsterRunStatus,
+    DynamicPartitionsDefinition,
     Field,
     HourlyPartitionsDefinition,
     JobSelector,
@@ -39,7 +40,12 @@ from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, 
 from dagster._core.definitions.instigation_logger import get_instigation_log_records
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.run_status_sensor_definition import run_status_sensor
-from dagster._core.definitions.sensor_definition import DefaultSensorStatus, RunRequest, SkipReason
+from dagster._core.definitions.sensor_definition import (
+    DefaultSensorStatus,
+    RunRequest,
+    SensorTickResult,
+    SkipReason,
+)
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import execute_pipeline
 from dagster._core.host_representation import ExternalInstigatorOrigin, ExternalRepositoryOrigin
@@ -520,6 +526,47 @@ def logging_status_sensor(context):
     context.log.info(f"run succeeded: {context.dagster_run.run_id}")
 
 
+quux = DynamicPartitionsDefinition(name="quux")
+
+
+@asset(partitions_def=quux)
+def quux_asset(context):
+    return 1
+
+
+quux_asset_job = define_asset_job("quux_asset_job", [quux_asset], partitions_def=quux)
+
+
+@sensor()
+def add_dynamic_partitions_sensor(context):
+    return SensorTickResult(
+        dynamic_partitions_requests=[
+            quux.request_for_adding_partitions(["baz"]),
+        ],
+    )
+
+
+@sensor(job=quux_asset_job)
+def add_delete_dynamic_partitions_and_yield_run_requests_sensor(context):
+    return SensorTickResult(
+        dynamic_partitions_requests=[
+            quux.request_for_adding_partitions(["1"]),
+            quux.request_for_deleting_partitions(["2"]),
+        ],
+        run_requests=[quux_asset_job.run_request_for_partition("1")],
+    )
+
+
+@sensor(job=quux_asset_job)
+def error_on_deleted_dynamic_partitions_run_requests_sensor(context):
+    return SensorTickResult(
+        dynamic_partitions_requests=[
+            quux.request_for_deleting_partitions(["2"]),
+        ],
+        run_requests=[quux_asset_job.run_request_for_partition("2")],
+    )
+
+
 @repository
 def the_repo():
     return [
@@ -570,6 +617,10 @@ def the_repo():
         multi_asset_sensor_targets_asset_selection,
         logging_sensor,
         logging_status_sensor,
+        add_delete_dynamic_partitions_and_yield_run_requests_sensor,
+        add_dynamic_partitions_sensor,
+        quux_asset_job,
+        error_on_deleted_dynamic_partitions_run_requests_sensor,
     ]
 
 
@@ -824,7 +875,8 @@ def validate_tick(
     assert tick_data.instigator_name == external_sensor.name
     assert tick_data.instigator_type == InstigatorType.SENSOR
     assert tick_data.status == expected_status
-    assert tick_data.timestamp == expected_datetime.timestamp()
+    if expected_datetime is not None:
+        assert tick_data.timestamp == expected_datetime.timestamp()
     if expected_run_ids is not None:
         assert set(tick_data.run_ids) == set(expected_run_ids)
     if expected_error:
@@ -2855,6 +2907,115 @@ def test_sensor_logging(executor, instance, workspace_context, external_repo):
     record = records[0]
     assert record[DAGSTER_META_KEY]["orig_message"] == "hello hello"
     instance.compute_log_manager.delete_logs(log_key=tick.log_key)
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_add_dynamic_partitions_sensor(
+    caplog, executor, instance, workspace_context, external_repo
+):
+    execute_pipeline(foo_pipeline, instance=instance)  # creates event log storage tables
+    assert set(instance.get_dynamic_partitions("quux")) == set()
+    external_sensor = external_repo.get_external_sensor("add_dynamic_partitions_sensor")
+    instance.add_instigator_state(
+        InstigatorState(
+            external_sensor.get_external_origin(),
+            InstigatorType.SENSOR,
+            InstigatorStatus.RUNNING,
+        )
+    )
+    ticks = instance.get_ticks(
+        external_sensor.get_external_origin_id(), external_sensor.selector_id
+    )
+    assert len(ticks) == 0
+
+    evaluate_sensors(workspace_context, executor)
+
+    assert set(instance.get_dynamic_partitions("quux")) == set(["baz"])
+    ticks = instance.get_ticks(
+        external_sensor.get_external_origin_id(), external_sensor.selector_id
+    )
+
+    assert "Added partition keys to dynamic partitions definition 'quux': ['baz']" in caplog.text
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_add_dynamic_partitions_and_launch_runs(
+    caplog, executor, instance, workspace_context, external_repo
+):
+    execute_pipeline(foo_pipeline, instance=instance)  # creates event log storage tables
+    instance.add_dynamic_partitions("quux", ["2"])
+    assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
+    external_sensor = external_repo.get_external_sensor(
+        "add_delete_dynamic_partitions_and_yield_run_requests_sensor"
+    )
+    instance.add_instigator_state(
+        InstigatorState(
+            external_sensor.get_external_origin(),
+            InstigatorType.SENSOR,
+            InstigatorStatus.RUNNING,
+        )
+    )
+    ticks = instance.get_ticks(
+        external_sensor.get_external_origin_id(), external_sensor.selector_id
+    )
+    assert len(ticks) == 0
+
+    evaluate_sensors(workspace_context, executor)
+
+    ticks = instance.get_ticks(
+        external_sensor.get_external_origin_id(), external_sensor.selector_id
+    )
+    assert len(ticks) == 1
+    assert set(instance.get_dynamic_partitions("quux")) == set(["1"])
+
+    assert instance.get_runs_count() == 2
+    assert "Added partition keys to dynamic partitions definition 'quux': ['1']" in caplog.text
+    assert "Deleted partition keys from dynamic partitions definition 'quux': ['2']" in caplog.text
+    run = instance.get_runs()[0]
+    assert run.run_config == {}
+    assert run.tags
+    assert run.tags.get("dagster/partition") == "1"
+
+
+@pytest.mark.parametrize("executor", get_sensor_executors())
+def test_error_on_deleted_dynamic_partitions_run_request(
+    executor, instance, workspace_context, external_repo
+):
+    execute_pipeline(foo_pipeline, instance=instance)  # creates event log storage tables
+    instance.add_dynamic_partitions("quux", ["2"])
+    assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
+    external_sensor = external_repo.get_external_sensor(
+        "error_on_deleted_dynamic_partitions_run_requests_sensor"
+    )
+    instance.add_instigator_state(
+        InstigatorState(
+            external_sensor.get_external_origin(),
+            InstigatorType.SENSOR,
+            InstigatorStatus.RUNNING,
+        )
+    )
+    ticks = instance.get_ticks(
+        external_sensor.get_external_origin_id(), external_sensor.selector_id
+    )
+    assert len(ticks) == 0
+
+    evaluate_sensors(workspace_context, executor)
+
+    ticks = instance.get_ticks(
+        external_sensor.get_external_origin_id(), external_sensor.selector_id
+    )
+    assert len(ticks) == 1
+    validate_tick(
+        ticks[0],
+        external_repo.get_external_sensor(
+            "error_on_deleted_dynamic_partitions_run_requests_sensor"
+        ),
+        expected_datetime=None,
+        expected_status=TickStatus.FAILURE,
+        expected_run_ids=None,
+        expected_error="Cannot create run request for partition 2 because it does not exist.",
+    )
+    assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
 
 
 def test_code_location_construction():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1254,7 +1254,7 @@ def test_dynamic_partitions_sensor():
     @sensor(job=my_job)
     def test_sensor(context):
         context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["apple"])
-        return my_job.run_request_for_partition("apple", instance=context.instance)
+        return my_job.run_request_for_partition("apple")
 
     with instance_for_test() as instance:
         ctx = build_sensor_context(


### PR DESCRIPTION
This PR introduces a more fault tolerant way of mutating dynamic partitions definitions through sensors, by introducing a `SensorTickResult` object that can be returned from a sensor. This object when returned will contain everything intended to be returned from the sensor (run requests, new cursor, skip reason, dynamic partitions requests, pipeline run reactions). 

Run requests are evaluated using the state of the partitions after dynamic partitions requests are applied, meaning that the following is valid:
```
quux = DynamicPartitionsDefinition(name="quux")

SensorTickResult(
        dynamic_partitions_requests=[
            quux.request_for_adding_partitions(["1"]),
        ],
        run_requests=[quux_asset_job.run_request_for_partition("1")],
    )
```
Within `evaluate_tick`, run requests and dynamic partitions requests are validated, throwing an error for invalid requests. In this situation, no changes are applied--so the partitions def is not mutated and the run request is not created.

```
return SensorTickResult(
        dynamic_partitions_requests=[
            quux.request_for_deleting_partitions(["2"]),
        ],
        run_requests=[quux_asset_job.run_request_for_partition("2")],
    )
```

These dynamic partitions requests are only applied (added/deleted from the instance) within `_evaluate_sensor`, where we do other things like submitting runs. This enables us to have logging for partitions that are added and deleted. In the future, we could also persist the mutations in the tick so that we have a record of changes and can display them in Dagit. 