### PR TITLE
[dagit] Allow the lineage tab to appear before the asset definition has loaded (#12191)

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineage.tsx
@@ -4,16 +4,16 @@ import styled from 'styled-components/macro';
 
 import {GraphData, LiveData} from '../asset-graph/Utils';
 import {AssetGraphQueryItem, calculateGraphDistances} from '../asset-graph/useAssetGraphData';
+import {AssetKeyInput} from '../graphql/types';
 
 import {AssetLineageScope, AssetNodeLineageGraph} from './AssetNodeLineageGraph';
 import {AssetViewParams} from './AssetView';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
-import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
 
 export const AssetNodeLineage: React.FC<{
   params: AssetViewParams;
   setParams: (params: AssetViewParams) => void;
-  assetNode: AssetNodeDefinitionFragment;
+  assetKey: AssetKeyInput;
   assetGraphData: GraphData;
   liveDataByNode: LiveData;
   requestedDepth: number;
@@ -21,16 +21,16 @@ export const AssetNodeLineage: React.FC<{
 }> = ({
   params,
   setParams,
-  assetNode,
+  assetKey,
   liveDataByNode,
   assetGraphData,
   graphQueryItems,
   requestedDepth,
 }) => {
-  const maxDistances = React.useMemo(
-    () => calculateGraphDistances(graphQueryItems, assetNode.assetKey),
-    [graphQueryItems, assetNode],
-  );
+  const maxDistances = React.useMemo(() => calculateGraphDistances(graphQueryItems, assetKey), [
+    graphQueryItems,
+    assetKey,
+  ]);
   const maxDepth =
     params.lineageScope === 'upstream'
       ? maxDistances.upstream
@@ -83,7 +83,7 @@ export const AssetNodeLineage: React.FC<{
         </DepthHidesAssetsNotice>
       )}
       <AssetNodeLineageGraph
-        assetNode={assetNode}
+        assetKey={assetKey}
         liveDataByNode={liveDataByNode}
         assetGraphData={assetGraphData}
         params={params}

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeLineageGraph.tsx
@@ -11,24 +11,24 @@ import {AssetNodeLink} from '../asset-graph/ForeignNode';
 import {GraphData, LiveData, toGraphId} from '../asset-graph/Utils';
 import {SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
+import {AssetKeyInput} from '../graphql/types';
 import {getJSONForKey} from '../hooks/useStateWithStorage';
 
 import {AssetViewParams} from './AssetView';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetKey} from './types';
-import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
 
 const LINEAGE_GRAPH_ZOOM_LEVEL = 'lineageGraphZoomLevel';
 
 export type AssetLineageScope = 'neighbors' | 'upstream' | 'downstream';
 
 export const AssetNodeLineageGraph: React.FC<{
-  assetNode: AssetNodeDefinitionFragment;
+  assetKey: AssetKeyInput;
   assetGraphData: GraphData;
   liveDataByNode: LiveData;
   params: AssetViewParams;
-}> = ({assetNode, assetGraphData, liveDataByNode, params}) => {
-  const assetGraphId = toGraphId(assetNode.assetKey);
+}> = ({assetKey, assetGraphData, liveDataByNode, params}) => {
+  const assetGraphId = toGraphId(assetKey);
 
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
 


### PR DESCRIPTION
### Summary & Motivation

This PR greatly reduces flicker observed in #12191. Instead of waiting for the asset definition to load and then loading the content of the current tab, this PR moves the loading state determination down into each tab's render method and refactors the lineage tab so that it does not require the loaded definition.

Impact: when clicking between assets on the asset lineage tab, the lineage UI very briefly flickers as it moves between assets rather than taking you through two spinner / loading states.

Caveat: There's still a short flicker. When you navigate to an asset that you haven't visited before, the `AssetsCatalogRoot` requests assetOrError to decide whether to display the catalog table or the asset details view. This is a nasty side effect of our decision to make `assets/123` show either the list of assets at that path OR the asset detail page, depending on whether 123 is the name of an asset. I think we should revisit this separately.

### How I Tested These Changes

I slowed down requests in my browser using the network tab and verified that there is now just a single brief loading state.  I also verified that going to each tab and Cmd-R reloading does not cause any issues (eg: when data is missing / being fetched for the first time and you are viewing each tab)