### PR TITLE
add a local download url fallback for GCS

### DIFF
--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -7,6 +7,7 @@ from typing import Generic, List, TypeVar
 import dagster._check as check
 from dagster import __version__ as dagster_version
 from dagster._core.debug import DebugRunPayload
+from dagster._core.storage.cloud_storage_compute_log_manager import CloudStorageComputeLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
@@ -175,15 +176,26 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
     async def download_captured_logs_endpoint(self, request: Request):
         [*log_key, file_extension] = request.path_params["path"].split("/")
         context = self.make_request_context(request)
+        compute_log_manager = context.instance.compute_log_manager
 
-        if not isinstance(context.instance.compute_log_manager, LocalComputeLogManager):
+        if not isinstance(
+            compute_log_manager, (LocalComputeLogManager, CloudStorageComputeLogManager)
+        ):
             raise HTTPException(
                 404, detail="Compute log manager is not compatible for local downloads"
             )
 
-        location = context.instance.compute_log_manager.get_captured_local_path(
-            log_key, file_extension
-        )
+        if isinstance(compute_log_manager, CloudStorageComputeLogManager):
+            io_type = ComputeIOType.STDOUT if file_extension == "out" else ComputeIOType.STDERR
+            if compute_log_manager.cloud_storage_has_logs(
+                log_key, io_type
+            ) and not compute_log_manager.has_local_file(log_key, io_type):
+                compute_log_manager.download_from_cloud_storage(log_key, io_type)
+            location = compute_log_manager.local_manager.get_captured_local_path(
+                log_key, file_extension
+            )
+        else:
+            location = compute_log_manager.get_captured_local_path(log_key, file_extension)
 
         if not location or not path.exists(location):
             raise HTTPException(404, detail="No log files available for download")

--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -124,7 +124,7 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
     def log_data_for_type(
         self, log_key: Sequence[str], io_type: ComputeIOType, offset: int, max_bytes: Optional[int]
     ):
-        if self._has_local_file(log_key, io_type):
+        if self.has_local_file(log_key, io_type):
             local_path = self.local_manager.get_captured_local_path(
                 log_key, IO_TYPE_EXTENSION[io_type]
             )
@@ -190,12 +190,12 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
     def unsubscribe(self, subscription):
         self.on_unsubscribe(subscription)
 
-    def _has_local_file(self, log_key: Sequence[str], io_type: ComputeIOType):
+    def has_local_file(self, log_key: Sequence[str], io_type: ComputeIOType):
         local_path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
         return os.path.exists(local_path)
 
     def _should_download(self, log_key: Sequence[str], io_type: ComputeIOType):
-        return not self._has_local_file(log_key, io_type) and self.cloud_storage_has_logs(
+        return not self.has_local_file(log_key, io_type) and self.cloud_storage_has_logs(
             log_key, io_type
         )
 
@@ -256,7 +256,7 @@ class CloudStorageComputeLogManager(CapturedLogManager, ComputeLogManager):
     def read_logs_file(self, run_id, key, io_type, cursor=0, max_bytes=MAX_BYTES_FILE_READ):
         log_key = self.local_manager.build_log_key_for_run(run_id, key)
 
-        if self._has_local_file(log_key, io_type):
+        if self.has_local_file(log_key, io_type):
             data = self.local_manager.read_logs_file(run_id, key, io_type, cursor, max_bytes)
             return self._from_local_file_data(run_id, key, io_type, data)
         elif self.cloud_storage_has_logs(log_key, io_type):


### PR DESCRIPTION
### Summary & Motivation
Some forms of GCS authentication (stemming from short-lived auth tokens, maybe from cloud run or compute engine) either don't have the permissions or have some other issue in creating signed urls.   The signed urls are used to provide download links directly in the UI.

We can fall-back on using a locally referenced URL pointing at dagit, where the local dagit server can download the compute files locally and serve them (should the user click on the download link).

Originally reported in https://github.com/dagster-io/dagster/issues/11855

### How I Tested These Changes
Created BK test, where the generate_signed_url method throws an exception, see that the local download url is generated.
