### PR TITLE
Add a way to cause partition health data to refetch without passing around refetch callbacks

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/PartitionSubscribers.ts
+++ b/js_modules/dagit/packages/core/src/assets/PartitionSubscribers.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const subscriptions: Array<() => void> = [];
+
+export function usePartitionDataSubscriber(onInvalidate: () => void) {
+  // Use a ref so that if the callback changes we don't retrigger the useEffect below
+  const onInvalidateRef = React.useRef(onInvalidate);
+  onInvalidateRef.current = onInvalidate;
+
+  React.useEffect(() => {
+    const cb = () => onInvalidateRef.current();
+    subscriptions.push(cb);
+    return () => {
+      const index = subscriptions.indexOf(cb);
+      if (index !== -1) {
+        subscriptions.splice(index, 1);
+      }
+    };
+  }, []);
+}
+
+export function invalidatePartitions() {
+  subscriptions.forEach((s) => s());
+}

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -8,6 +8,7 @@ import {PartitionState} from '../partitions/PartitionStatus';
 import {assembleIntoSpans} from '../partitions/SpanRepresentation';
 
 import {assembleRangesFromTransitions, Transition} from './MultipartitioningSupport';
+import {usePartitionDataSubscriber} from './PartitionSubscribers';
 import {AssetKey} from './types';
 import {
   PartitionHealthQuery,
@@ -468,9 +469,16 @@ export function rangesForKeys(keys: string[], allKeys: string[]): Range[] {
 //
 export function usePartitionHealthData(
   assetKeys: AssetKey[],
-  cacheKey = '',
+  assetsCacheKey = '',
   cacheClearStrategy: 'immediate' | 'background' = 'background',
 ) {
+  const [partitionsLastUpdated, setPartitionsLastUpdatedAt] = React.useState<string>('');
+  usePartitionDataSubscriber(() => {
+    setPartitionsLastUpdatedAt(Date.now().toString());
+  });
+
+  const cacheKey = `${assetsCacheKey}-${partitionsLastUpdated}`;
+
   const [result, setResult] = React.useState<(PartitionHealthData & {fetchedAt: string})[]>([]);
   const client = useApolloClient();
 

--- a/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
@@ -17,6 +17,7 @@ import styled from 'styled-components/macro';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {invalidatePartitions} from '../assets/PartitionSubscribers';
 import {testId} from '../testing/testId';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
@@ -157,6 +158,7 @@ export const CreatePartitionDialog = ({
         refetch?.();
         setSelected([...selected, partitionName]);
         close();
+        invalidatePartitions();
         break;
       }
       default: {


### PR DESCRIPTION
### Summary & Motivation

In the AssetView page we show a sidebar with all of our partitions for an asset which currently doesn't update when you create a new partition after clicking the "Materialize" button. 
Instead of threading through refetch callbacks through the MaterializeButton all the way down to the CreatePartitionDialog I'm adding this new module which allows CreatePartitionDialog to notify any subscribers of partition health data that they need to refetch.

Normally we could just add the query to `refetchQueries` however, in this case, the queries are being made without using `useQuery` so `refetchQueries` doesn't work.

https://www.loom.com/share/7c020e6034d94013828eb83d7dd6c51a

### How I Tested These Changes

On the asset view page I added a new partition and saw the sidebar reflect the new partition.