### PR TITLE
[ui] Affordance for copying asset key

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -1,13 +1,39 @@
 // eslint-disable-next-line no-restricted-imports
 import {BreadcrumbProps, Breadcrumbs} from '@blueprintjs/core';
-import {Box, Colors, PageHeader, Heading, Icon} from '@dagster-io/ui';
+import {Box, Colors, PageHeader, Heading, Icon, Tooltip, IconWrapper} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {SharedToaster} from '../app/DomUtils';
+import {useCopyToClipboard} from '../app/browser';
+
 type Props = {assetKey: {path: string[]}} & Partial<React.ComponentProps<typeof PageHeader>>;
 
 export const AssetPageHeader: React.FC<Props> = ({assetKey, ...extra}) => {
+  const copy = useCopyToClipboard();
+  const copyableString = assetKey.path.join('/');
+  const [didCopy, setDidCopy] = React.useState(false);
+  const iconTimeout = React.useRef<NodeJS.Timeout>();
+
+  const performCopy = React.useCallback(() => {
+    if (iconTimeout.current) {
+      clearTimeout(iconTimeout.current);
+    }
+
+    copy(copyableString);
+    setDidCopy(true);
+    SharedToaster.show({
+      icon: 'done',
+      intent: 'primary',
+      message: 'Copied asset key!',
+    });
+
+    iconTimeout.current = setTimeout(() => {
+      setDidCopy(false);
+    }, 2000);
+  }, [copy, copyableString]);
+
   const breadcrumbs = React.useMemo(() => {
     const list: BreadcrumbProps[] = [{text: 'Assets', href: '/assets'}];
 
@@ -36,12 +62,40 @@ export const AssetPageHeader: React.FC<Props> = ({assetKey, ...extra}) => {
               </Heading>
             )}
           />
+          <Tooltip placement="bottom" content="Copy asset key">
+            <CopyButton onClick={performCopy}>
+              <Icon
+                name={didCopy ? 'copy_to_clipboard_done' : 'copy_to_clipboard'}
+                color={Colors.Gray400}
+              />
+            </CopyButton>
+          </Tooltip>
         </Box>
       }
       {...extra}
     />
   );
 };
+
+const CopyButton = styled.button`
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 3px;
+  margin-top: 2px;
+
+  :focus {
+    outline: none;
+  }
+
+  ${IconWrapper} {
+    transition: background-color 100ms linear;
+  }
+
+  :hover ${IconWrapper} {
+    background-color: ${Colors.Gray800};
+  }
+`;
 
 export const AssetGlobalLineageLink = () => (
   <Link to="/asset-groups">


### PR DESCRIPTION
### Summary & Motivation

Add a small icon button next to the asset path breadcrumbs in the asset page, allowing the user to copy the asset key path, joined by slashes.

https://user-images.githubusercontent.com/2823852/223870030-cc6cefd9-0fd7-42d3-ad66-a65fd44ac9c3.mov

### How I Tested These Changes

View an asset, hover on copy button and click it. Verify that copy occurs properly, that the toaster appears, and that the icon changes briefly.

Repeat with an asset that has many path keys, verify same.
