### PR TITLE
[dagster-dbt] add support for node_info_to_definition_metadata_fn

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -43,7 +43,7 @@ from dagster._core.definitions.events import (
     Output,
 )
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
-from dagster._core.definitions.metadata import RawMetadataValue
+from dagster._core.definitions.metadata import MetadataUserInput, RawMetadataValue
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._legacy import OpExecutionContext
 from dagster._utils.backcompat import experimental_arg_warning
@@ -563,7 +563,7 @@ def _dbt_nodes_to_assets(
         [Mapping[str, Any]], Optional[FreshnessPolicy]
     ] = _get_node_freshness_policy,
     node_info_to_definition_metadata_fn: Callable[
-        [Mapping[str, Any]], Mapping[str, Any]
+        [Mapping[str, Any]], Mapping[str, MetadataUserInput]
     ] = _get_node_metadata,
     display_raw_sql: bool = True,
 ) -> AssetsDefinition:
@@ -651,7 +651,7 @@ def load_assets_from_dbt_project(
         [Mapping[str, Any]], Optional[FreshnessPolicy]
     ] = _get_node_freshness_policy,
     node_info_to_definition_metadata_fn: Callable[
-        [Mapping[str, Any]], Mapping[str, Any]
+        [Mapping[str, Any]], Mapping[str, MetadataUserInput]
     ] = _get_node_metadata,
     display_raw_sql: Optional[bool] = None,
     dbt_resource_key: str = "dbt",
@@ -703,10 +703,10 @@ def load_assets_from_dbt_project(
             `dagster_freshness_policy={"maximum_lag_minutes": 60, "cron_schedule": "0 9 * * *"}`
             will result in that model being assigned
             `FreshnessPolicy(maximum_lag_minutes=60, cron_schedule="0 9 * * *")`
-        node_info_to_definition_metadata_fn (Dict[str, Any] -> Optional[Dict[str, Any]]): A function
-            that takes a dictionary of dbt node info and optionally returns a dictionary of metadata
-            to be attached to the corresponding definition. This is added to the default metadata
-            assigned to the node, which consists of the node's schema (if present).
+        node_info_to_definition_metadata_fn (Dict[str, Any] -> Optional[Dict[str, MetadataUserInput]]):
+            A function that takes a dictionary of dbt node info and optionally returns a dictionary
+            of metadata to be attached to the corresponding definition. This is added to the default
+            metadata assigned to the node, which consists of the node's schema (if present).
         display_raw_sql (Optional[bool]): [Experimental] A flag to indicate if the raw sql associated
             with each model should be included in the asset description. For large projects, setting
             this flag to False is advised to reduce the size of the resulting snapshot.
@@ -766,7 +766,7 @@ def load_assets_from_dbt_manifest(
         [Mapping[str, Any]], Optional[FreshnessPolicy]
     ] = _get_node_freshness_policy,
     node_info_to_definition_metadata_fn: Callable[
-        [Mapping[str, Any]], Mapping[str, Any]
+        [Mapping[str, Any]], Mapping[str, MetadataUserInput]
     ] = _get_node_metadata,
     display_raw_sql: Optional[bool] = None,
     dbt_resource_key: str = "dbt",
@@ -816,10 +816,10 @@ def load_assets_from_dbt_manifest(
             `dagster_freshness_policy={"maximum_lag_minutes": 60, "cron_schedule": "0 9 * * *"}`
             will result in that model being assigned
             `FreshnessPolicy(maximum_lag_minutes=60, cron_schedule="0 9 * * *")`
-        node_info_to_definition_metadata_fn (Dict[str, Any] -> Optional[Dict[str, Any]]): A function
-            that takes a dictionary of dbt node info and optionally returns a dictionary of metadata
-            to be attached to the corresponding definition. This is added to the default metadata
-            assigned to the node, which consists of the node's schema (if present).
+        node_info_to_definition_metadata_fn (Dict[str, Any] -> Optional[Dict[str, MetadataUserInput]]):
+            A function that takes a dictionary of dbt node info and optionally returns a dictionary
+            of metadata to be attached to the corresponding definition. This is added to the default
+            metadata assigned to the node, which consists of the node's schema (if present).
         display_raw_sql (Optional[bool]): [Experimental] A flag to indicate if the raw sql associated
             with each model should be included in the asset description. For large projects, setting
             this flag to False is advised to reduce the size of the resulting snapshot.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -44,6 +44,7 @@ from ..asset_defs import (
     _get_node_asset_key,
     _get_node_freshness_policy,
     _get_node_group_name,
+    _get_node_metadata,
 )
 from ..errors import DagsterDbtCloudJobInvariantViolationError
 from ..utils import ASSET_RESOURCE_TYPES, result_to_events
@@ -319,6 +320,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             node_info_to_asset_key=self._node_info_to_asset_key,
             node_info_to_group_fn=self._node_info_to_group_fn,
             node_info_to_freshness_policy_fn=self._node_info_to_freshness_policy_fn,
+            # TODO: In the future, allow this function to be specified
+            node_info_to_definition_metadata_fn=_get_node_metadata,
             # TODO: In the future, allow the IO manager to be specified.
             io_manager_key=None,
             # We shouldn't display the raw sql. Instead, inspect if dbt docs were generated,
@@ -552,6 +555,10 @@ def load_assets_from_dbt_cloud_job(
             `dagster_freshness_policy={"maximum_lag_minutes": 60, "cron_schedule": "0 9 * * *"}`
             will result in that model being assigned
             `FreshnessPolicy(maximum_lag_minutes=60, cron_schedule="0 9 * * *")`
+        node_info_to_definition_metadata_fn (Dict[str, Any] -> Optional[Dict[str, MetadataUserInput]]):
+            A function that takes a dictionary of dbt node info and optionally returns a dictionary
+            of metadata to be attached to the corresponding definition. This is added to the default
+            metadata assigned to the node, which consists of the node's schema (if present).
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the dbt assets.
         partition_key_to_vars_fn (Optional[str -> Dict[str, Any]]): A function to translate a given

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -285,6 +285,33 @@ def test_custom_freshness_policy():
     }
 
 
+def test_custom_definition_metadata():
+    manifest_path = file_relative_path(__file__, "sample_manifest.json")
+    with open(manifest_path, "r", encoding="utf8") as f:
+        manifest_json = json.load(f)
+
+    dbt_assets_default = load_assets_from_dbt_manifest(manifest_json=manifest_json)
+
+    dbt_assets_custom = load_assets_from_dbt_manifest(
+        manifest_json=manifest_json,
+        node_info_to_definition_metadata_fn=lambda node_info: {
+            "foo_key": node_info["name"],
+            "bar_key": 1.0,
+        },
+    )
+
+    has_some_schema = False
+    for asset_key, custom_metadata in dbt_assets_custom[0].metadata_by_key.items():
+        default_metadata = dbt_assets_default[0].metadata_by_key[asset_key]
+        if custom_metadata.get("table_schema") is not None:
+            has_some_schema = True
+        assert custom_metadata.get("table_schema") == default_metadata.get("table_schema")
+        assert custom_metadata["foo_key"] == asset_key.path[-1]
+        assert custom_metadata["bar_key"] == 1.0
+
+    assert has_some_schema
+
+
 def test_partitions(
     dbt_seed, conn_string, test_project_dir, dbt_config_dir
 ):  # pylint: disable=unused-argument


### PR DESCRIPTION
### Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/12727

It hurts a bit to add yet another `node_info_to...` parameter to these signatures, and I think in the future we should investigate a nicer way to expose this sort of flexibility. However, in the short term this addresses an issue that many users are running into, and does not significantly diverge from the existing pattern.

Open to suggestions on the name. My goal was to disambiguate this from the `runtime_metadata_fn` parameter, and make it clear that this metadata will be wrapped up into the definition of the asset.

### How I Tested These Changes
