### PR TITLE
[3/n][resources ui] Serialize parent resource information in resource snapshots, surface via GQL

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1915,6 +1915,7 @@ type ResourceDetails {
   configuredValues: [ConfiguredValue!]!
   isTopLevel: Boolean!
   nestedResources: [NestedResourceEntry!]!
+  parentResources: [NestedResourceEntry!]!
   resourceType: String!
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2859,6 +2859,7 @@ export type ResourceDetails = {
   isTopLevel: Scalars['Boolean'];
   name: Scalars['String'];
   nestedResources: Array<NestedResourceEntry>;
+  parentResources: Array<NestedResourceEntry>;
   resourceType: Scalars['String'];
 };
 
@@ -10226,6 +10227,14 @@ export const buildResourceDetails = (
     nestedResources:
       overrides && overrides.hasOwnProperty('nestedResources')
         ? overrides.nestedResources!
+        : [
+            relationshipsToOmit.has('NestedResourceEntry')
+              ? ({} as NestedResourceEntry)
+              : buildNestedResourceEntry({}, relationshipsToOmit),
+          ],
+    parentResources:
+      overrides && overrides.hasOwnProperty('parentResources')
+        ? overrides.parentResources!
         : [
             relationshipsToOmit.has('NestedResourceEntry')
               ? ({} as NestedResourceEntry)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -152,6 +152,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
         return [
             GrapheneNestedResourceEntry(
                 name=attribute,
+                type=NestedResourceType.TOP_LEVEL,
                 resource=get_resource_or_error(
                     graphene_info,
                     ResourceSelector(

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -583,6 +583,10 @@ class ExternalResource:
         return self._external_resource_data.nested_resources
 
     @property
+    def parent_resources(self) -> Dict[str, str]:
+        return self._external_resource_data.parent_resources
+
+    @property
     def resource_type(self) -> str:
         return self._external_resource_data.resource_type
 


### PR DESCRIPTION
## Summary

Exposes nested resources' parent information in the repo serialization bundle, used so that we can backlink to parent resources in the UI in the stacked commit.

## Test Plan

Added unit tests.