### PR TITLE
[pythonic resources] Add with_description utility

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -400,7 +400,7 @@ class ConfigurableResource(
 
     """
 
-    def __init__(self, **data: Any):
+    def __init__(self, _description: Optional[str] = None, **data: Any):
         resource_pointers, data_without_resources = _separate_resource_params(data)
 
         schema = infer_schema_from_config_class(
@@ -423,7 +423,7 @@ class ConfigurableResource(
             self,
             resource_fn=self.initialize_and_run,
             config_schema=curried_schema,
-            description=self.__doc__,
+            description=_description or self.__doc__,
         )
         self._resolved_config_dict = resolved_config_dict
         self._schema = schema
@@ -445,6 +445,12 @@ class ConfigurableResource(
         # signature of any __init__ method will always consist of the fields
         # of this class. We can therefore safely pass in the values as kwargs.
         return self.__class__(**{**self._as_config_dict(), **values})
+
+    def with_description(self, description: str) -> "ConfigurableResource[TResValue]":
+        """
+        Returns a new copy of this resource definition with the given description.
+        """
+        return self.__class__(**{**self._as_config_dict()}, _description=description)
 
     def _resolve_and_update_env_vars(self) -> "ConfigurableResource[TResValue]":
         """

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1330,3 +1330,21 @@ def test_extending_resource_nesting() -> None:
     )
 
     assert executed["yes"]
+
+
+def test_description() -> None:
+    class MyResource(ConfigurableResource):
+        """Hello world"""
+
+        a_str: str
+
+    assert MyResource(a_str="foo").description == "Hello world"
+
+
+def test_with_description() -> None:
+    class MyResource(ConfigurableResource):
+        """Hello world"""
+
+        a_str: str
+
+    assert MyResource(a_str="foo").with_description("Goodbye").description == "Goodbye"


### PR DESCRIPTION
## Summary

I found it a bit odd that you can't easily set a description on an instance of a `ResourceDefinition`. This adds a codepath to vary the description of a `ResourceDefinition` instance that a user creates:

```python
class MyCredentialsResource(ConfigurableResource):
    """Credentials for my cloud service"""

    username: str
    password: str



defs = Definitions(
    ...
    resources={
        "prod_creds": MyCredentialsResource(...).with_description("Production account credentials"),
    }
)
```

## Test Plan

Added unit tests, tested manually by validating that new description appears in Dagit.