### PR TITLE
Fix partition_time_window type error

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -294,7 +294,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
     @public
     @property
-    def partition_time_window(self) -> str:
+    def partition_time_window(self) -> TimeWindow:
         """The partition time window for the current run.
 
         Raises an error if the current run is not a partitioned run, or if the job's partition

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -429,7 +429,7 @@ class PlanExecutionContext(IPlanContext):
             return PartitionKeyRange(partition_key_range_start, tags[ASSET_PARTITION_RANGE_END_TAG])
 
     @property
-    def partition_time_window(self) -> str:
+    def partition_time_window(self) -> TimeWindow:
         partitions_def = self.partitions_def
 
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
@@ -440,8 +440,7 @@ class PlanExecutionContext(IPlanContext):
                 ),
             )
 
-        # mypy thinks partitions_def is <nothing> here because ????
-        return partitions_def.time_window_for_partition_key(self.partition_key)  # type: ignore
+        return partitions_def.time_window_for_partition_key(self.partition_key)
 
     @property
     def has_partition_key(self) -> bool:


### PR DESCRIPTION
### Summary & Motivation
The following PR handles the bug in #12837. The reason to the bug is type ignore statement from when mypy was used to check the type annotations. 

### How I Tested These Changes
I have executed the pyright script to ensure the type check passes.