### PR TITLE
[ui] Support Ctrl+K to trigger search

### DIFF
--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -96,6 +96,18 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
     [history],
   );
 
+  const shortcutFilter = React.useCallback((e: KeyboardEvent) => {
+    if (e.altKey || e.shiftKey) {
+      return false;
+    }
+
+    if (e.ctrlKey || e.metaKey) {
+      return e.code === 'KeyK';
+    }
+
+    return e.code === 'Slash';
+  }, []);
+
   const highlightedResult = renderedResults[highlight] || null;
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -137,17 +149,7 @@ export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlace
 
   return (
     <>
-      <ShortcutHandler
-        onShortcut={openSearch}
-        shortcutLabel="/"
-        shortcutFilter={(e) =>
-          (e.key === '/' || (e.code === 'KeyK' && e.metaKey)) &&
-          !(e.key === '/' && e.metaKey) &&
-          !e.altKey &&
-          !e.shiftKey &&
-          !e.ctrlKey
-        }
-      >
+      <ShortcutHandler onShortcut={openSearch} shortcutLabel="/" shortcutFilter={shortcutFilter}>
         <SearchTrigger onClick={openSearch}>
           <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
             <Box flex={{alignItems: 'center', gap: 8}}>


### PR DESCRIPTION
### Summary & Motivation

Resolves #12688.

Support <kbd>Ctrl</kbd>+<kbd>K</kbd> to trigger the global search dialog. This means that (unmodified) <kbd>/</kbd>, <kbd>Cmd</kbd>+<kbd>K</kbd>, and <kbd>Ctrl</kbd>+<kbd>K</kbd> will all work, across operating systems.

### How I Tested These Changes

Test `/` with and without modifiers, verify that only unmodified `/` triggers search. Test modified-K, verify that Ctrl and Cmd modifiers trigger search.
