### PR TITLE
Remove nothing types from asset graph

### DIFF
--- a/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpIOBox.tsx
@@ -72,7 +72,9 @@ export const OpIOBox: React.FC<OpIOBoxProps> = ({
         <>
           <div className="circle" />
           {name !== DEFAULT_RESULT_NAME && <div className="label">{name}</div>}
-          {type.displayName && <div className="type">{type.displayName}</div>}
+          {type.displayName && type.displayName !== 'Nothing' && (
+            <div className="type">{type.displayName}</div>
+          )}
         </>
       )}
       {layoutInfo.collapsed.length > 0 && (
@@ -204,6 +206,7 @@ export function metadataForIO(
       jumpTargetOp = others.length === 1 ? others[0].solid.name : null;
       edges.push(...others.map((o) => ({a: o.solid.name, b: invocation.name})));
     }
+    console.log({title});
     edges.push({a: `${invocation.name}:${item.name}`, b: PARENT_OUT});
   }
 

--- a/python_modules/dagster-test/dagster_test/toys/nothing_assets/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/nothing_assets/__init__.py
@@ -1,0 +1,17 @@
+from dagster import In, Nothing, job, op
+
+
+@op
+def op_with_nothing_output() -> None:
+    ...
+
+
+@op(ins={"in1": In(Nothing)})
+def op_with_nothing_input() -> None:
+    ...
+
+
+@job
+def nothing_job():
+    # pylint: disable=E1121
+    op_with_nothing_input(op_with_nothing_output())

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -131,6 +131,13 @@ def asset_groups_repository():
 
 
 @repository
+def nothing_repository():
+    from .nothing_assets import nothing_job
+
+    return [nothing_job]
+
+
+@repository
 def partitioned_assets_repository():
     from . import partitioned_assets
 


### PR DESCRIPTION
### Summary & Motivation

before:
<img width="632" alt="Screen Shot 2023-03-09 at 1 05 53 PM" src="https://user-images.githubusercontent.com/2286579/224116415-6519fffa-71b3-4049-9bc1-f32ca2908a04.png">

after:
<img width="654" alt="Screen Shot 2023-03-09 at 1 05 44 PM" src="https://user-images.githubusercontent.com/2286579/224116421-3d53a60c-8926-4f8b-bb35-0ae5798afa0f.png">


### How I Tested These Changes

With the nothing job in the toys repo
