### PR TITLE
Add a tooltip on asset nodes in the graph

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -421,7 +421,12 @@ export const AssetNodeMinimal: React.FC<{
   return (
     <AssetInsetForHoverEffect>
       <MinimalAssetNodeContainer $selected={selected}>
-        <TooltipStyled content={displayName} canShow={displayName.length > 14}>
+        <TooltipStyled
+          content={displayName}
+          canShow={displayName.length > 14}
+          targetTagName="div"
+          position="top"
+        >
           <MinimalAssetNodeBox
             $selected={selected}
             $isSource={isSource}
@@ -629,6 +634,5 @@ const Description = styled.div<{$color: string}>`
 `;
 
 const TooltipStyled = styled(Tooltip)`
-  display: block;
   height: 100%;
 `;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -417,24 +417,25 @@ export const AssetNodeMinimal: React.FC<{
   const {isSource, assetKey} = definition;
   const {border, background} = buildAssetNodeStatusRow({definition, liveData});
   const displayName = assetKey.path[assetKey.path.length - 1];
-
+  withMiddleTruncation(displayName, {maxLength: 14});
   return (
     <AssetInsetForHoverEffect>
       <MinimalAssetNodeContainer $selected={selected}>
-        <MinimalAssetNodeBox
-          $selected={selected}
-          $isSource={isSource}
-          $background={background}
-          $border={border}
-        >
-          <div style={{position: 'absolute', bottom: 6, left: 6}}>
-            <AssetLatestRunSpinner liveData={liveData} purpose="section" />
-          </div>
-
-          <MinimalName style={{fontSize: 30}} $isSource={isSource}>
-            {withMiddleTruncation(displayName, {maxLength: 14})}
-          </MinimalName>
-        </MinimalAssetNodeBox>
+        <TooltipStyled content={displayName} canShow={displayName.length > 14}>
+          <MinimalAssetNodeBox
+            $selected={selected}
+            $isSource={isSource}
+            $background={background}
+            $border={border}
+          >
+            <div style={{position: 'absolute', bottom: 6, left: 6}}>
+              <AssetLatestRunSpinner liveData={liveData} purpose="section" />
+            </div>
+            <MinimalName style={{fontSize: 30}} $isSource={isSource}>
+              {withMiddleTruncation(displayName, {maxLength: 14})}
+            </MinimalName>
+          </MinimalAssetNodeBox>
+        </TooltipStyled>
       </MinimalAssetNodeContainer>
     </AssetInsetForHoverEffect>
   );
@@ -625,4 +626,9 @@ const Description = styled.div<{$color: string}>`
   border-top: 1px solid ${Colors.Blue50};
   background: ${Colors.White};
   font-size: 12px;
+`;
+
+const TooltipStyled = styled(Tooltip)`
+  display: block;
+  height: 100%;
 `;

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -417,7 +417,6 @@ export const AssetNodeMinimal: React.FC<{
   const {isSource, assetKey} = definition;
   const {border, background} = buildAssetNodeStatusRow({definition, liveData});
   const displayName = assetKey.path[assetKey.path.length - 1];
-  withMiddleTruncation(displayName, {maxLength: 14});
   return (
     <AssetInsetForHoverEffect>
       <MinimalAssetNodeContainer $selected={selected}>


### PR DESCRIPTION
### Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/12602

### How I Tested These Changes

<img width="441" alt="Screen Shot 2023-03-09 at 2 39 52 PM" src="https://user-images.githubusercontent.com/2286579/224135964-3ec2c6bc-a25c-486b-bf97-59b1ca5fe967.png">
<img width="317" alt="Screen Shot 2023-03-09 at 2 39 49 PM" src="https://user-images.githubusercontent.com/2286579/224135965-6c9bbed3-d4cd-4cb7-a74f-f98a6b6251bb.png">
