### PR TITLE
[docs] - Add doc checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
 ### Summary & Motivation
 
+> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md)
+
 ### How I Tested These Changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
-### Summary & Motivation
+## Summary & Motivation
 
-> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md)
+> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md).
 
-### How I Tested These Changes
+---
+
+## How I Tested These Changes

--- a/docs/DOC_CHECKLIST.md
+++ b/docs/DOC_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 This checklist outlines some of the most common issues that come up during documentation pull request reviews.
 
-Before submitting a PR for review, please check that your changes follow the guidelines listed here. Please ping @erinkcochran87 with questions.
+Before submitting a PR for review, please check that your changes follow the guidelines listed here. Please ping Erin (@erinkcochran87) with questions.
 
 ---
 
@@ -11,8 +11,14 @@ Before submitting a PR for review, please check that your changes follow the gui
 - Pages should only have one H1 heading, ex: `# Some heading`
 - Use sentence case
 - Shouldn’t include any extra formatting, including backticks, bold, components/tags, and emojis:
-    - **Could-be-better:** ``dagster-dbt` tutorial`
-    - **Better!:** `dagster-dbt tutorial`
+    - **Could-be-better:**
+      ```markdown
+      # `dagster-dbt` tutorial
+      ```
+    - **Better!:**
+      ```markdown
+      # dagster-dbt tutorial
+      ```
 - Level two headings (`## Some heading`) should be preceded by a horizontal rule:
 
    ```markdown
@@ -36,7 +42,7 @@ Before submitting a PR for review, please check that your changes follow the gui
     - **Names of libraries and packages**, ex: “The `dagster-dbt` library”
 - Code examples should:
     - Live in `.py` files and not inline
-    - Be enclosed in fenced backticks **and**include a language. This ensures syntax highlighting/CSS is correctly applied.
+    - Be enclosed in fenced backticks **and** include a language. This ensures syntax highlighting/CSS is correctly applied.
         - **Could-be-better:**
             
             ````markdown
@@ -63,9 +69,12 @@ Before submitting a PR for review, please check that your changes follow the gui
 
 ## Miscellaneous
 
-- The first time a service/app/etc is mentioned, the platform/provider must be included.
+- The first time a service/app/etc is mentioned, the company/platform/etc. must be included.
     - **Could-be-better:** “The BigQuery dataset”
     - **Better!:** “The Google BigQuery dataset”
+- Names of companies, software, apps, etc. should be formatted exactly as the company/software/app/etc. uses them. The exception is if the name is being used as a literal value.
+    - **Could-be-better:** "Your airflow instance..."
+    - **Better!:** "Your Airflow instance..."
 
 ---
 

--- a/docs/DOC_CHECKLIST.md
+++ b/docs/DOC_CHECKLIST.md
@@ -1,0 +1,80 @@
+# Documentation pull request checklist
+
+This checklist outlines some of the most common issues that come up during documentation pull request reviews.
+
+Before submitting a PR for review, please check that your changes follow the guidelines listed here. Please ping @erinkcochran87 with questions.
+
+---
+
+## Headings
+
+- Pages should only have one H1 heading, ex: `# Some heading`
+- Use sentence case
+- Shouldn’t include any extra formatting, including backticks, bold, components/tags, and emojis:
+    - **Could-be-better:** ``dagster-dbt` tutorial`
+    - **Better!:** `dagster-dbt tutorial`
+- Level two headings (`## Some heading`) should be preceded by a horizontal rule:
+
+   ```markdown
+   # Page title
+
+   Some copy
+
+   ---    # horizontal rule
+
+   ## Some heading
+   ```
+
+---
+
+## Formatting
+
+- UI components - buttons, tabs, labels, etc - should use **bold formatting. Ex: “The Materialize all** button”, “The **Reload** button”
+- The following should use `code formatting`:
+    - **Column and table names**, ex: “The `users` table”
+    - **Keys/parameters and values**, ex: “The `In` parameter”,
+    - **Names of libraries and packages**, ex: “The `dagster-dbt` library”
+- Code examples should:
+    - Live in `.py` files and not inline
+    - Be enclosed in fenced backticks **and**include a language. This ensures syntax highlighting/CSS is correctly applied.
+        - **Could-be-better:**
+            
+            ````markdown
+            # Example without language:
+            
+            ```
+            dagster dev
+            ```
+            
+            # Example without backticks:
+            
+               dagster dev
+            ````
+            
+        - **Better!:**
+            
+            ````markdown
+            ```shell      # sometimes you'll just need to pick the closest option
+            dagster dev
+            ```
+            ````
+
+---
+
+## Miscellaneous
+
+- The first time a service/app/etc is mentioned, the platform/provider must be included.
+    - **Could-be-better:** “The BigQuery dataset”
+    - **Better!:** “The Google BigQuery dataset”
+
+---
+
+## Adding, deleting, and moving pages
+
+When adding new pages **or** moving them around:
+
+- Update the sidenav (`/docs/content/_navigation.json`)
+- Add the page(s) to the correct category page. Ex: If adding a new guide, add it to `/docs/content/guides.mdx`
+
+   You might also need to add it to a section page, like in **Guides.** Ex: `/docs/content/guides/best-practices.mdx`. In the near future we should have dynamic lists and won’t need to do this.
+- **If deleting or moving a page**, add a redirect in `/docs/next/util/redirectUrls.json`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Dagster Documentation Site
 
+> **Submitting a pull request to update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md).
+
 This directory contains the code for the Dagster documentation site at https://docs.dagster.io. The site is built with [NextJS](https://nextjs.org/), with the code for the site living in `next`. To serve the site locally in development mode (hot-reloading), run:
 
 ```


### PR DESCRIPTION
### Summary & Motivation

This PR adds the doc PR checklist to the repo and updates the PR template to link to it. Note that the link itself uses a full URL, so it'll 404 until this is merged.

### How I Tested These Changes

👀 
