### PR TITLE
[bk] Add changelog check step

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -86,7 +86,6 @@ def build_check_changelog_steps() -> List[CommandStep]:
         CommandStepBuilder(":memo: changelog")
         .on_test_image(AvailablePythonVersion.get_default())
         .run(f"python scripts/check_changelog.py {release_number}")
-        .with_skip(skip_mysql_if_no_changes_to_dependencies(["dagster"]))
         .build()
     ]
 

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,0 +1,33 @@
+import os
+import re
+import sys
+
+
+def _get_release_version(change_name: str) -> str:
+    return change_name.split(" ")[0]
+
+
+def main(args) -> None:
+    assert len(args) == 2, "Usage: python check_changelog.py <version>"
+
+    version = str(args[1]).strip()
+    changes_file = os.path.join(os.path.dirname(__file__), "../CHANGES.md")
+
+    with open(changes_file, "r") as f:
+        changes = f.read()
+
+    change_entries = re.split(r"\n#+ (\d+\.\d+\.\d+.*)\n", changes)[1:]
+    release_name_by_version = {
+        _get_release_version(change_entries[i]): change_entries[i].strip()
+        for i in range(0, len(change_entries), 2)
+    }
+
+    versions_str = "\n  ".join(list(release_name_by_version.keys())[:10])
+    assert version in release_name_by_version, (
+        f"Version {version} change entries not found in CHANGES.md\n\nFound entries for versions:\n"
+        f"  {versions_str}\n  ..."
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary

Adds a small BK step that runs on release branches which validates that the release branch has a changelog entry set.


## Test Plan
 - failure: https://buildkite.com/dagster/dagster/builds/51925#0186c8a7-debe-4632-8547-ac590ac3032c
 - success: https://buildkite.com/dagster/dagster/builds/51932#0186c8ad-68b2-429c-a722-09aeb4e42249