### PR TITLE
Move docs style guidelines from pull request template to contribution guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
 ## Summary & Motivation
 
-> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md).
-
----
-
 ## How I Tested These Changes

--- a/docs/content/community/contributing.mdx
+++ b/docs/content/community/contributing.mdx
@@ -96,6 +96,8 @@ To run all of them together, run `yarn test`.
 
 ## Developing Docs
 
+The [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md) includes a set of style guidelines to adhere to when adding or modifying docs.
+
 To run the Dagster documentation website locally, run the following commands:
 
 ```bash


### PR DESCRIPTION
## Summary & Motivation

I am a huge fan of our docs style guidelines and making them publicly available.

However, I'd also like to advocate for keeping our pull request template as lightweight as possible, to minimize cognitive load when submitting a PR. It used to have a lot more in it, and @alangenfeld made a change to trim it down to the bare essentials: https://github.com/dagster-io/dagster/pull/7538. That change improved my quality of life.

This change adds the style guidelines to the top of the docs section of the contribution and removes it from the PR template.

## How I Tested These Changes
