### PR TITLE
take grpcio-health-checking pins out of backcompat suite

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/dagit_service/pins.txt
@@ -1,6 +1,5 @@
 # pins for recently released packages that cause problems in older dagster versions
 markupsafe<=2.0.1
-grpcio-health-checking<1.44.0
 
 # 5.2+ stops pulling in `ipython_genutils`, on which the old version of `nbconvert` we use
 # implicitly depends. Can remove this pin when/if dagit cap on nbconvert is lifted.


### PR DESCRIPTION
## Summary & Motivation

> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md).

---

## How I Tested These Changes
