### PR TITLE
add SpecificPartitionsPartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -268,6 +268,7 @@ from dagster._core.definitions.partition_mapping import (
     LastPartitionMapping as LastPartitionMapping,
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
+    SpecificPartitionsPartitionMapping as SpecificPartitionsPartitionMapping,
     StaticPartitionMapping as StaticPartitionMapping,
 )
 from dagster._core.definitions.partitioned_schedule import (


### PR DESCRIPTION
## Summary & Motivation

Inspired by a user request.

Maps to a specific subset of partitions in the upstream asset.

Example:
```python
        from dagster import SpecificPartitionsPartitionMapping, StaticPartitionsDefinition, asset

        @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
        def upstream():
            ...

        @asset(
            ins={
                "upstream": AssetIn(partition_mapping=SpecificPartitionsPartitionMapping(["a"]))
            }
        )
        def a_downstream(upstream):
            ...
```
## How I Tested These Changes
