### PR TITLE
need to explicitly return a known existing column for updates

### DIFF
--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -187,6 +187,11 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
                     daemon_id=daemon_heartbeat.daemon_id,
                     body=serialize_value(daemon_heartbeat),
                 )
+                .returning(
+                    # required because sqlalchemy might by default return the declared primary key,
+                    # which might not exist
+                    DaemonHeartbeatsTable.c.daemon_type,
+                )
             )
 
     def kvs_set(self, pairs: Mapping[str, str]) -> None:
@@ -198,6 +203,10 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             conn.execute(
                 insert_stmt.on_duplicate_key_update(
                     value=insert_stmt.inserted.value,
+                ).returning(
+                    # required because sqlalchemy might by default return the declared primary key,
+                    # which might not exist
+                    KeyValueStoreTable.c.key,
                 )
             )
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -187,11 +187,6 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
                     daemon_id=daemon_heartbeat.daemon_id,
                     body=serialize_value(daemon_heartbeat),
                 )
-                .returning(
-                    # required because sqlalchemy might by default return the declared primary key,
-                    # which might not exist
-                    DaemonHeartbeatsTable.c.daemon_type,
-                )
             )
 
     def kvs_set(self, pairs: Mapping[str, str]) -> None:
@@ -203,10 +198,6 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             conn.execute(
                 insert_stmt.on_duplicate_key_update(
                     value=insert_stmt.inserted.value,
-                ).returning(
-                    # required because sqlalchemy might by default return the declared primary key,
-                    # which might not exist
-                    KeyValueStoreTable.c.key,
                 )
             )
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -1,4 +1,5 @@
 # pylint: disable=protected-access
+import datetime
 import os
 import subprocess
 import tempfile
@@ -18,6 +19,7 @@ from dagster import (
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
+from dagster._daemon.types import DaemonHeartbeat
 from dagster._utils import file_relative_path
 from sqlalchemy import create_engine, inspect
 
@@ -405,6 +407,10 @@ def test_add_primary_keys(backcompat_conn_string):
 
         with DagsterInstance.from_config(tempdir) as instance:
             assert "id" not in get_columns(instance, "kvs")
+            # trigger insert, and update
+            instance.run_storage.kvs_set({"a": "A"})
+            instance.run_storage.kvs_set({"a": "A"})
+
             kvs_row_count = _get_table_row_count(instance.run_storage, KeyValueStoreTable)
             assert kvs_row_count > 0
 
@@ -413,6 +419,11 @@ def test_add_primary_keys(backcompat_conn_string):
             assert instance_info_row_count > 0
 
             assert "id" not in get_columns(instance, "daemon_heartbeats")
+            heartbeat = DaemonHeartbeat(
+                timestamp=datetime.datetime.now().timestamp(), daemon_type="test", daemon_id="test"
+            )
+            instance.run_storage.add_daemon_heartbeat(heartbeat)
+            instance.run_storage.add_daemon_heartbeat(heartbeat)
             daemon_heartbeats_row_count = _get_table_row_count(
                 instance.run_storage, DaemonHeartbeatsTable
             )

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -189,6 +189,11 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                         "body": serialize_value(daemon_heartbeat),
                     },
                 )
+                .returning(
+                    # required because sqlalchemy might by default return the declared primary key,
+                    # which might not exist
+                    DaemonHeartbeatsTable.c.daemon_type,
+                )
             )
 
     def kvs_set(self, pairs: Mapping[str, str]) -> None:
@@ -203,6 +208,10 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 KeyValueStoreTable.c.key,
             ],
             set_={"value": insert_stmt.excluded.value},
+        ).returning(
+            # required because sqlalchemy might by default return the declared primary key,
+            # which might not exist
+            KeyValueStoreTable.c.key
         )
 
         with self.connect() as conn:


### PR DESCRIPTION
## Summary & Motivation

User reported an issue with inserts in postgres failing because of an unknown column.


## How I Tested These Changes
Added BK test against the backcompat snapshot where we try to add old heartbeats.