### PR TITLE
Update pyright 1.1.293 -> 1.1.298

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -256,7 +256,8 @@ class _ExecutorDecoratorCallable:
             requirements=self.requirements,
         )
 
-        update_wrapper(executor_def, wrapped=fn)
+        # `update_wrapper` typing cannot currently handle a Union of Callables correctly
+        update_wrapper(executor_def, wrapped=fn)  # type: ignore
 
         return executor_def
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -294,7 +294,8 @@ class _ResourceDecoratorCallable:
             required_resource_keys=self.required_resource_keys,
         )
 
-        update_wrapper(resource_def, wrapped=resource_fn)
+        # `update_wrapper` typing cannot currently handle a Union of Callables correctly
+        update_wrapper(resource_def, wrapped=resource_fn)  # type: ignore
 
         return resource_def
 

--- a/python_modules/dagster/dagster/_core/storage/input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/input_manager.py
@@ -241,6 +241,7 @@ class _InputManagerDecoratorCallable:
             required_resource_keys=self.required_resource_keys,
         )
 
-        update_wrapper(root_input_manager_def, wrapped=load_fn)
+        # `update_wrapper` typing cannot currently handle a Union of Callables correctly
+        update_wrapper(root_input_manager_def, wrapped=load_fn)  # type: ignore
 
         return root_input_manager_def

--- a/python_modules/dagster/dagster/_core/storage/io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/io_manager.py
@@ -273,6 +273,7 @@ class _IOManagerDecoratorCallable:
             input_config_schema=self.input_config_schema,
         )
 
-        update_wrapper(io_manager_def, wrapped=fn)
+        # `update_wrapper` typing cannot currently handle a Union of Callables correctly
+        update_wrapper(io_manager_def, wrapped=fn)  # type: ignore
 
         return io_manager_def

--- a/python_modules/dagster/dagster/_core/storage/root_input_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/root_input_manager.py
@@ -223,6 +223,7 @@ class _InputManagerDecoratorCallable:
             required_resource_keys=self.required_resource_keys,
         )
 
-        update_wrapper(root_input_manager_def, wrapped=load_fn)
+        # `update_wrapper` typing cannot currently handle a Union of Callables correctly
+        update_wrapper(root_input_manager_def, wrapped=load_fn)  # type: ignore
 
         return root_input_manager_def

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -129,7 +129,7 @@ setup(
             "mypy==0.991",
         ],
         "pyright": [
-            "pyright==1.1.293",
+            "pyright==1.1.298",
             ### Stub packages
             "pandas-stubs",  # version will be resolved against pandas
             "types-backports",  # version will be resolved against backports


### PR DESCRIPTION
## Summary & Motivation

Update Pyright from 1.1.293 -> 1.1.298.

This triggered detection of some new type errors around use of `functools.update_wrapper`. Unfortunately there doesn't appear to be a good solution for these as present, so I added ignores for them. Further context here: https://github.com/microsoft/pyright/issues/4760#issuecomment-1464042138.

Internal passes `1.1.298` with no issue so no companion PR is needed.

## How I Tested These Changes

BK
