### PR TITLE
[ruff] update: 0.0.241 -> 0.0.255

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
       # Make sure black reads its config from root `pyproject.toml`
       args: ["--config", "pyproject.toml"]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.241
+  rev: v0.0.255
   hooks:
     - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,21 +126,6 @@ extend-exclude = [
 
 ignore = [
 
-  # (non-google docstring)  These docstring rules are collectively incompatible
-  # with the Google-style docstrings we use. List taken from:
-  # https://github.com/charliermarsh/ruff#does-ruff-support-numpy--or-google-style-docstrings
-  "D203",
-  "D204",
-  "D213",
-  "D215",
-  "D400",
-  "D404",
-  "D406",
-  "D407",
-  "D408",
-  "D409",
-  "D413",
-
   # (missing public docstrings) These work off of the Python sense of "public", rather than our
   # bespoke definition based off of `@public`. When ruff supports custom plugins then we can write
   # appropriate rules to require docstrings for `@public`.
@@ -176,9 +161,6 @@ ignore = [
   # readable.
   "E731",
 
-  # (no redundant alias) Allow redundant import aliases for explicit re-exports.
-  "PLC0414",
-
   # (no concatenation) Existing codebase has many concatentations, no reason to disallow them.
   "RUF005",
 
@@ -199,6 +181,9 @@ ignore = [
   "D208", # (over-indented docstring)
   "D402", # (first line should not be the function's "signature")
 
+  # (redefined-loop-name) Many instances of this in the code.
+  "PLW2901",
+
   # (disallow print statements) Allowing until there are file-scoped error-specific ignores and we
   # can bulk-convert our pylint disables.
   "T201",  # (no print call)
@@ -213,9 +198,8 @@ line-length = 100
 # Here we append to the defaults.
 select = [
 
-  # (pydocstyle) Docstring-related rules. See above ignore section for selected
-  # exclusions that sculpt the rules to fit Google-style docstrings. See:
-  # https://github.com/charliermarsh/ruff#does-ruff-support-numpy--or-google-style-docstrings
+  # (pydocstyle) Docstring-related rules. A large subset of these are ignored by the
+  # "convention=google" setting, we set under tool.ruff.pydocstyle.
   "D",
 
   # (pycodestyle) use all pycodestyle rules
@@ -227,9 +211,8 @@ select = [
   # (isort) detect improperly sorted imports
   "I001",
 
-  # (pylint) use all pylint rules (ruff currently implements only a subset of
-  # pylint's rules)
-  "PLC",
+  # (pylint) use all pylint rules from categories "Convention", "Error", and "Warning" (ruff
+  # currently implements only a subset of pylint's rules)
   "PLE",
   "PLW",
 
@@ -246,7 +229,7 @@ select = [
 ]
 
 # Fail if Ruff is not running this version.
-required-version = "0.0.241"
+required-version = "0.0.255"
 
 [tool.ruff.isort]
 
@@ -257,6 +240,18 @@ combine-as-imports = true
 # Imports of the form `from foo import bar as baz` show one `import bar as baz`
 # per line. Useful for __init__.py files that just re-export symbols.
 force-wrap-aliases = true
+
+[tool.ruff.per-file-ignores]
+
+# Don't format docstrings in alembic migrations.
+"**/alembic/versions/*.py" = ["D"]
+
+[tool.ruff.pydocstyle]
+
+# Enforce google-style docstrings. This is equivalent to ignoring a large number of pydocstyle (D)
+# rules incompatible with google-style docstrings. See:
+# https://google.github.io/styleguide/pyguide.html#383-functions-and-methods
+convention = "google"
 
 [tool.dagster]
 module_name = "dagster_test.toys.repo"

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -205,15 +205,14 @@ def config_from_pkg_resources(pkg_resource_defs: Sequence[Tuple[str, str]]) -> M
     """Load a run config from a package resource, using :py:func:`pkg_resources.resource_string`.
 
     Example:
+        .. code-block:: python
 
-    .. code-block:: python
-
-        config_from_pkg_resources(
-            pkg_resource_defs=[
-                ('dagster_examples.airline_demo.environments', 'local_base.yaml'),
-                ('dagster_examples.airline_demo.environments', 'local_warehouse.yaml'),
-            ],
-        )
+            config_from_pkg_resources(
+                pkg_resource_defs=[
+                    ('dagster_examples.airline_demo.environments', 'local_base.yaml'),
+                    ('dagster_examples.airline_demo.environments', 'local_warehouse.yaml'),
+                ],
+            )
 
 
     Args:

--- a/python_modules/dagster/dagster/_core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/utils.py
@@ -45,10 +45,10 @@ _UPGRADING_INSTANCE = None
 
 @contextmanager
 def upgrading_instance(instance: DagsterInstance) -> Iterator[None]:
-    global _UPGRADING_INSTANCE  # pylint: disable=global-statement,global-variable-not-assigned
+    global _UPGRADING_INSTANCE  # noqa: PLW0603
     check.invariant(_UPGRADING_INSTANCE is None, "update already in progress")
     try:
-        _UPGRADING_INSTANCE = instance
+        _UPGRADING_INSTANCE = instance  # noqa: PLW0603
         yield
     finally:
         _UPGRADING_INSTANCE = None

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -724,7 +724,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
         self._stack.close()
 
     def copy_for_test_instance(self, instance: DagsterInstance) -> "WorkspaceProcessContext":
-        """make a copy with a different instance, created for tests."""
+        """Make a copy with a different instance, created for tests."""
         return WorkspaceProcessContext(
             instance=instance,
             workspace_load_target=self.workspace_load_target,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_struct_resources.py
@@ -63,8 +63,8 @@ is_in_cm = False
 @resource
 @contextmanager
 def my_cm_resource(_) -> Iterator[str]:
-    global is_in_cm
-    is_in_cm = True
+    global is_in_cm  # noqa: PLW0603
+    is_in_cm = True  # noqa: PLW0603
     yield "foo"
     is_in_cm = False
 

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -1,3 +1,5 @@
+# ruff: noqa: D416
+
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -142,18 +142,18 @@ def test_get_run_by_id():
         assert instance.get_run_by_id(run.run_id) is None
 
     # Run is created after we check whether it exists, but deleted before we can get it
-    global MOCK_HAS_RUN_CALLED  # pylint:disable=global-statement
+    global MOCK_HAS_RUN_CALLED  # noqa: PLW0603
     MOCK_HAS_RUN_CALLED = False
     with tempfile.TemporaryDirectory() as tmpdir_path:
         instance = DagsterInstance.from_ref(InstanceRef.from_dir(tmpdir_path))
         run = DagsterRun(pipeline_name="foo_pipeline", run_id="bar_run")
 
         def _has_run(self, run_id):
-            global MOCK_HAS_RUN_CALLED  # pylint: disable=global-statement
+            global MOCK_HAS_RUN_CALLED  # noqa: PLW0603
             # pylint: disable=protected-access
             if not self._run_storage.has_run(run_id) and not MOCK_HAS_RUN_CALLED:
                 self._run_storage.add_run(DagsterRun(pipeline_name="foo_pipeline", run_id=run_id))
-                MOCK_HAS_RUN_CALLED = True
+                MOCK_HAS_RUN_CALLED = True  # noqa: PLW0603
                 return False
             elif self._run_storage.has_run(run_id) and MOCK_HAS_RUN_CALLED:
                 MOCK_HAS_RUN_CALLED = False

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -153,7 +153,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.0.241",
+            "ruff==0.0.255",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -159,6 +159,8 @@ def make_dagster_definitions_from_airflow_example_dags(
             `dagit -f path/to/make_dagster_definitions.py`
 
     Args:
+        resource_defs: Optional[Mapping[str, ResourceDefinition]]
+            Resource definitions to be used with the definitions
 
     Returns:
         Definitions

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py
@@ -364,7 +364,7 @@ class EmrJobRunner:
             cluster_id (str): EMR cluster ID
             step_id (str): EMR step ID for the job that was submitted.
 
-        Returns
+        Returns:
             (str, str): Tuple of stdout log string contents, and stderr log string contents
         """
         check.str_param(cluster_id, "cluster_id")

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -98,7 +98,7 @@ class DataprocResource:
         ).execute()
 
     def wait_for_job(self, job_id, wait_timeout=TWENTY_MINUTES):
-        """This method polls job status every 5 seconds."""  # noqa: D202
+        """This method polls job status every 5 seconds."""
 
         # TODO: Add logging here print('Waiting for job ID {} to finish...'.format(job_id))
         def iter_fn():

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_metadata_constraints.py
@@ -163,11 +163,11 @@ def test_aggregate_constraint():
 
 def test_multi_agg_constraint():
     def column_val_1(data):
-        """checks column mean equal to 1."""
+        """Checks column mean equal to 1."""
         return (data.mean() == 1, {})
 
     def column_val_2(data):
-        """checks column mean equal to 1.5."""
+        """Checks column mean equal to 1.5."""
         return (data.mean() == 1.5, {})
 
     df = DataFrame(
@@ -177,15 +177,15 @@ def test_multi_agg_constraint():
         }
     )
     aggregate_val = MultiAggregateConstraintWithMetadata(
-        "Confirms column means equal to 1",
+        "Confirms column means equal to 1.",
         dict([("bar", [column_val_1, column_val_2]), ("foo", [column_val_1, column_val_2])]),
         ConstraintWithMetadataException,
         raise_or_typecheck=False,
     )
     val = aggregate_val.validate(df).metadata_entries[0].value.data
     assert val["expected"] == {
-        "bar": {"column_val_2": "checks column mean equal to 1.5."},
-        "foo": {"column_val_1": "checks column mean equal to 1."},
+        "bar": {"column_val_2": "Checks column mean equal to 1.5."},
+        "foo": {"column_val_1": "Checks column mean equal to 1."},
     }
     assert val["offending"] == {
         "bar": {"column_val_2": "a violation"},

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_user_error.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_pandas_user_error.py
@@ -30,7 +30,7 @@ def test_wrong_input_value():
 
     @op
     def pass_str():
-        """not a dataframe."""
+        """Not a dataframe."""
 
     @graph
     def input_fails():


### PR DESCRIPTION
## Summary & Motivation

Update `ruff` from 0.0.241 -> 0.0.255.

Addition of some new rules and bugfixes on old rules required fixes of a few errors with the update. There were also a large number of errors from the new `PLW2901` (rename loop var) rule (which I believe was previously enforced by pylint but isnewly implemented in ruff), which I ignored in this PR but have fixed upstack.

Also used the new `ruff.pydocstyle.convention = "google"` to replace a large number of docstring rule-ignores.

---

## How I Tested These Changes

BK
