### PR TITLE
[ruff] enable T201 (print-found), T203 (p-print-found)

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -16,4 +16,4 @@ def dagster() -> None:
     PythonPackages.load_from_git(GitInfo(directory=Path(".")))
     steps = build_dagster_oss_main_steps()
     buildkite_yaml = buildkite_yaml_for_steps(steps)
-    print(buildkite_yaml)  # pylint: disable=print-call
+    print(buildkite_yaml)  # noqa: T201

--- a/docs/content/concepts/ops-jobs-graphs/nesting-graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/nesting-graphs.mdx
@@ -198,7 +198,7 @@ from dagster import GraphOut
 
 @op
 def echo(i):
-    print(i)
+    print(i)  # noqa: T201
 
 
 @op

--- a/docs/content/guides/dagster/pythonic-config.mdx
+++ b/docs/content/guides/dagster/pythonic-config.mdx
@@ -56,7 +56,7 @@ class MyOpConfig(Config):
 
 @op
 def print_greeting(config: MyOpConfig):
-    print(f"hello {config.person_name}")
+    print(f"hello {config.person_name}")  # noqa: T201
 ```
 
 </TabItem>

--- a/docs/dagit-screenshot/dagit_screenshot/commands/asset_svg.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/asset_svg.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 
 import glob
 import os

--- a/docs/dagit-screenshot/dagit_screenshot/commands/audit.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/audit.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 
 import os
 import sys

--- a/docs/dagit-screenshot/dagit_screenshot/commands/capture.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/capture.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 
 import os
 import signal

--- a/docs/dagit-screenshot/dagit_screenshot/commands/show.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/show.py
@@ -9,4 +9,4 @@ def show(spec_db_path: str, prefix: Optional[str]):
     spec_db = load_spec_db(spec_db_path)
     sorted_db = sorted(spec_db, key=lambda s: s["id"])
     filtered_db = [ s for s in sorted_db if not prefix or s["id"].startswith(prefix) ]
-    print(yaml.dump(filtered_db))  # pylint: disable=print-call
+    print(yaml.dump(filtered_db))  # noqa: T201

--- a/docs/scripts/pack_json.py
+++ b/docs/scripts/pack_json.py
@@ -117,7 +117,7 @@ def main() -> None:
         os.path.join(os.path.dirname(__file__), "../next/public/objects.inv"),
     )
 
-    print("Successfully packed JSON for NextJS.")  # pylint: disable=print-call
+    print("Successfully packed JSON for NextJS.")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/examples/assets_modern_data_stack/assets_modern_data_stack/utils/setup_airbyte.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/utils/setup_airbyte.py
@@ -1,9 +1,9 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 """
 A basic script that will create tables in the source postgres database, then automatically
 create an Airbyte Connection between the source database and destination database.
 """
-# pylint: disable=print-call
+
 import random
 from typing import Any, Dict, Mapping
 

--- a/examples/assets_pandas_type_metadata/scripts/download_stock_data.py
+++ b/examples/assets_pandas_type_metadata/scripts/download_stock_data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# pylint: disable=print-call
+# ruff: noqa: T201
+
 
 import os
 import sys

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/nested_graphs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/nested_graphs.py
@@ -1,6 +1,6 @@
 # isort: skip_file
 # pylint: disable=unused-argument
-# pylint: disable=print-call
+
 
 from dagster import graph, job, op
 
@@ -58,7 +58,7 @@ from dagster import GraphOut
 
 @op
 def echo(i):
-    print(i)
+    print(i)  # noqa: T201
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/ttl_config_job.py
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/ttl_config_job.py
@@ -1,10 +1,10 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 from dagster import job, op
 
 
 @op
 def my_op():
-    print("foo")  # pylint: disable=print-call
+    print("foo")
 
 
 # fmt: off

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -35,7 +35,7 @@ def execute_with_config() -> None:
 
     @op
     def print_greeting(config: MyOpConfig):
-        print(f"hello {config.person_name}")
+        print(f"hello {config.person_name}")  # noqa: T201
 
     # end_basic_op_config
 
@@ -197,9 +197,7 @@ def metadata_config() -> None:
     class MyMetadataConfig(Config):
         # Here, the ellipses `...` indicates that the field is required and has no default value.
         person_name: str = Field(..., description="The name of the person to greet")
-        age: int = Field(
-            ..., gt=0, lt=100, description="The age of the person to greet"
-        )
+        age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
 
     # errors!
     MyMetadataConfig(person_name="Alice", age=200)

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -197,7 +197,9 @@ def metadata_config() -> None:
     class MyMetadataConfig(Config):
         # Here, the ellipses `...` indicates that the field is required and has no default value.
         person_name: str = Field(..., description="The name of the person to greet")
-        age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
+        age: int = Field(
+            ..., gt=0, lt=100, description="The age of the person to greet"
+        )
 
     # errors!
     MyMetadataConfig(person_name="Alice", age=200)

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
@@ -1,4 +1,5 @@
 # isort: skip_file
+# ruff: noqa: T201
 # pylint: disable=unused-argument,reimported,unnecessary-ellipsis
 
 
@@ -172,9 +173,7 @@ def new_resource_runtime() -> None:
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-    update_data_job = define_asset_job(
-        name="update_data_job", selection=[data_from_database]
-    )
+    update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
 
     @sensor(job=update_data_job)
     def table_update_sensor():
@@ -382,9 +381,7 @@ def resource_adapter() -> None:
     def my_asset(writer: Writer):
         writer.output("hello, world!")
 
-    defs = Definitions(
-        assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")}
-    )
+    defs = Definitions(assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")})
 
     # end_resource_adapter
 
@@ -409,9 +406,7 @@ def io_adapter() -> None:
             self.base_path = base_path
 
         def handle_output(self, context: OutputContext, obj):
-            with open(
-                os.path.join(self.base_path, context.step_key, context.name), "w"
-            ) as fd:
+            with open(os.path.join(self.base_path, context.step_key, context.name), "w") as fd:
                 fd.write(obj)
 
         def load_input(self, context: InputContext):

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
@@ -173,7 +173,9 @@ def new_resource_runtime() -> None:
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-    update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
+    update_data_job = define_asset_job(
+        name="update_data_job", selection=[data_from_database]
+    )
 
     @sensor(job=update_data_job)
     def table_update_sensor():
@@ -381,7 +383,9 @@ def resource_adapter() -> None:
     def my_asset(writer: Writer):
         writer.output("hello, world!")
 
-    defs = Definitions(assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")})
+    defs = Definitions(
+        assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")}
+    )
 
     # end_resource_adapter
 
@@ -406,7 +410,9 @@ def io_adapter() -> None:
             self.base_path = base_path
 
         def handle_output(self, context: OutputContext, obj):
-            with open(os.path.join(self.base_path, context.step_key, context.name), "w") as fd:
+            with open(
+                os.path.join(self.base_path, context.step_key, context.name), "w"
+            ) as fd:
                 fd.write(obj)
 
         def load_input(self, context: InputContext):

--- a/examples/with_airflow/with_airflow/airflow_complex_dag.py
+++ b/examples/with_airflow/with_airflow/airflow_complex_dag.py
@@ -158,7 +158,7 @@ with models.DAG(
     # Search
     search_catalog = PythonOperator(
         task_id="search_catalog",
-        python_callable=lambda: print("search_catalog"),  # pylint: disable=print-call
+        python_callable=lambda: print("search_catalog"),  # noqa: T201
     )
 
     search_catalog_result = BashOperator(

--- a/examples/with_airflow/with_airflow/task_flow_dags/airflow_taskflow_dag.py
+++ b/examples/with_airflow/with_airflow/task_flow_dags/airflow_taskflow_dag.py
@@ -54,7 +54,7 @@ def tutorial_taskflow_api():
         A simple Load task which takes in the result of the Transform task and
         instead of saving it to end user review, just prints it out.
         """
-        print(f"Total order value is: {total_order_value:.2f}")
+        print(f"Total order value is: {total_order_value:.2f}")  # noqa: T201
 
     order_data = extract()
     order_summary = transform(order_data)

--- a/examples/with_wandb/with_wandb/assets/example/fashion_data.py
+++ b/examples/with_wandb/with_wandb/assets/example/fashion_data.py
@@ -114,7 +114,7 @@ class fashion(data.Dataset):
                 raise
 
         for url in self.urls:
-            print("Downloading " + url)
+            print("Downloading " + url)  # noqa: T201
             data = urllib.request.urlopen(url)
             filename = url.rpartition("/")[2]
             file_path = os.path.join(self.root, self.raw_folder, filename)
@@ -127,7 +127,7 @@ class fashion(data.Dataset):
             os.unlink(file_path)
 
         # process and save as torch files
-        print("Processing...")
+        print("Processing...")  # noqa: T201
 
         training_set = (
             read_image_file(os.path.join(self.root, self.raw_folder, "train-images-idx3-ubyte")),
@@ -142,7 +142,7 @@ class fashion(data.Dataset):
         with open(os.path.join(self.root, self.processed_folder, self.test_file), "wb") as f:
             torch.save(test_set, f)
 
-        print("Done!")
+        print("Done!")  # noqa: T201
 
 
 def get_int(b):

--- a/examples/with_wandb/with_wandb/assets/example/train.py
+++ b/examples/with_wandb/with_wandb/assets/example/train.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# ruff: noqa: T201
 
 """
 Based on: https://github.com/wandb/examples/blob/master/examples/pytorch/pytorch-cnn-fashion/train.py

--- a/helm/dagster/schema/schema/utils/helm_template.py
+++ b/helm/dagster/schema/schema/utils/helm_template.py
@@ -45,7 +45,7 @@ class HelmTemplate:
             values_json = (
                 json.loads(values.json(exclude_none=True, by_alias=True)) if values else values_dict
             )
-            pprint(values_json)
+            pprint(values_json)  # noqa: T203
             content = yaml.dump(values_json)
             tmp_file.write(content.encode())
             tmp_file.flush()
@@ -71,8 +71,8 @@ class HelmTemplate:
                     command += ["--show-only", self.output]
                     templates = subprocess.check_output(command)
 
-            print("\n--- Helm Templates ---")  # pylint: disable=print-call
-            print(templates.decode())  # pylint: disable=print-call
+            print("\n--- Helm Templates ---")  # noqa: T201
+            print(templates.decode())  # noqa: T201
 
             k8s_objects = [k8s_object for k8s_object in yaml.full_load_all(templates) if k8s_object]
             if self.model:

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/cluster.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 import os
 import subprocess
 import tempfile
@@ -68,7 +68,7 @@ def define_cluster_provider_fixture(additional_kind_images=None):
                     try:
                         client = docker.from_env()
                         client.images.get(docker_image)
-                        print(  # pylint: disable=print-call
+                        print(
                             "Found existing image tagged {image}, skipping image build. To rebuild,"
                             " first run: docker rmi {image}".format(image=docker_image)
                         )

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -1,4 +1,5 @@
-# pylint: disable=print-call, redefined-outer-name, unused-argument
+# ruff: noqa: T201
+# pylint: disable= redefined-outer-name, unused-argument
 import base64
 import os
 import subprocess

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 import json
 import os
 import random

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/kind.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/kind.py
@@ -1,3 +1,5 @@
+# ruff: noqa: T201
+
 import os
 import subprocess
 import time

--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 
 import os
 import subprocess

--- a/integration_tests/test_suites/celery-k8s-test-suite/conftest.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/conftest.py
@@ -30,7 +30,7 @@ def dagster_docker_image():
         try:
             client = docker.from_env()
             client.images.get(docker_image)
-            print(  # pylint: disable=print-call
+            print(  # noqa: T201
                 "Found existing image tagged {image}, skipping image build. To rebuild, first run: "
                 "docker rmi {image}".format(image=docker_image)
             )

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
@@ -19,7 +19,7 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 def log_run_events(instance, run_id):
     for log in instance.all_logs(run_id):
-        print(str(log) + "\n")  # pylint: disable=print-call
+        print(str(log) + "\n")  # noqa: T201
 
 
 def get_celery_job_engine_config(dagster_docker_image, job_namespace):

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_user_code_deployment_subchart.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_user_code_deployment_subchart.py
@@ -72,8 +72,8 @@ def test_execute_on_celery_k8s_subchart_disabled(  # pylint: disable=redefined-o
         stdout=True,
         tty=False,
     )
-    print("Response: ")  #  pylint:disable=print-call
-    print(resp)  # pylint:disable=print-call
+    print("Response: ")  # noqa: T201
+    print(resp)  # noqa: T201
 
     runmaster_job_name = None
     timeout = datetime.timedelta(0, 90)

--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -19,7 +19,7 @@ def _wait_for_dagit_running(dagit_port):
             if dagit_json:
                 return
         except:
-            print("Waiting for Dagit to be ready..")
+            print("Waiting for Dagit to be ready..")  # noqa: T201
 
         if time.time() - start_time > 30:
             raise Exception("Timed out waiting for Dagit to serve requests")

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -50,7 +50,7 @@ def log_run_events(instance, run_id):
         yield
     finally:
         for log in instance.all_logs(run_id):
-            print(str(log) + "\n")  # pylint: disable=print-call
+            print(str(log) + "\n")  # noqa: T201
 
 
 def test_monitoring():

--- a/integration_tests/test_suites/daemon-test-suite/test_memory.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_memory.py
@@ -115,7 +115,7 @@ def test_no_memory_leaks():
                         and "dagster" in inspect.getmodule(obj).__name__,
                     )
                     if not growth:
-                        print(  # pylint: disable=print-call
+                        print(  # noqa: T201
                             f"Memory stopped growing after {int(time.time() - start_time)} seconds"
                         )
                         break
@@ -126,4 +126,4 @@ def test_no_memory_leaks():
                             + str(growth)
                         )
 
-                    print("Growth: " + str(growth))  # pylint: disable=print-call
+                    print("Growth: " + str(growth))  # noqa: T201

--- a/integration_tests/test_suites/k8s-test-suite/conftest.py
+++ b/integration_tests/test_suites/k8s-test-suite/conftest.py
@@ -49,7 +49,7 @@ def dagster_docker_image():
         try:
             client = docker.from_env()
             client.images.get(docker_image)
-            print(  # pylint: disable=print-call
+            print(  # noqa: T201
                 "Found existing image tagged {image}, skipping image build. To rebuild, first run: "
                 "docker rmi {image}".format(image=docker_image)
             )

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -338,7 +338,7 @@ def test_k8s_run_launcher_terminate(
         time.sleep(5)
 
     # useful to have logs here, because the worker pods get deleted
-    print(dagster_instance_for_k8s_run_launcher.all_logs(run_id))  # pylint: disable=print-call
+    print(dagster_instance_for_k8s_run_launcher.all_logs(run_id))  # noqa: T201
 
     assert pipeline_run.status == DagsterRunStatus.CANCELED
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_monitoring.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_monitoring.py
@@ -14,7 +14,7 @@ from dagster_test.test_project import get_test_project_environments_path
 
 def log_run_events(instance, run_id):
     for log in instance.all_logs(run_id):
-        print(str(log) + "\n")  # pylint: disable=print-call
+        print(str(log) + "\n")  # noqa: T201
 
 
 @pytest.mark.integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,11 +181,6 @@ ignore = [
   "D208", # (over-indented docstring)
   "D402", # (first line should not be the function's "signature")
 
-  # (disallow print statements) Allowing until there are file-scoped error-specific ignores and we
-  # can bulk-convert our pylint disables.
-  "T201",  # (no print call)
-  "T203",  # (no pprint call)
-
 ]
 
 # Match black. Note that this also checks comment line length, but black does not format comments.
@@ -222,7 +217,7 @@ select = [
   "RUF",
 
   # (disallow print statements) keep debugging statements out of the codebase
-  "T",
+  "T20",
 
   # (invalid escape sequence) flag errant backslashes
   "W605",

--- a/python_modules/automation/automation/docker/cli.py
+++ b/python_modules/automation/automation/docker/cli.py
@@ -22,7 +22,7 @@ def cli():
 @cli.command()
 def list():  # pylint: disable=redefined-builtin
     for image in list_images():
-        print(image.image)  # pylint: disable=print-call
+        print(image.image)  # noqa: T201
 
 
 # Shared options between `build` and `build_all`

--- a/python_modules/automation/automation/docker/image_defs.py
+++ b/python_modules/automation/automation/docker/image_defs.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 import contextlib
 import os
 import shutil

--- a/python_modules/automation/automation/docker/utils.py
+++ b/python_modules/automation/automation/docker/utils.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 import subprocess
 import sys
 from datetime import datetime, timezone

--- a/python_modules/automation/automation/git.py
+++ b/python_modules/automation/automation/git.py
@@ -150,7 +150,7 @@ def git_commit_updates(repo_dir: str, message: str) -> None:
         'git commit -m "{}"'.format(message),
     ]
 
-    print(  # pylint: disable=print-call
+    print(  # noqa: T201
         "Committing to {} with message {}".format(repo_dir, message)
     )
     for cmd in cmds:

--- a/python_modules/automation/automation/git.py
+++ b/python_modules/automation/automation/git.py
@@ -150,8 +150,6 @@ def git_commit_updates(repo_dir: str, message: str) -> None:
         'git commit -m "{}"'.format(message),
     ]
 
-    print(  # noqa: T201
-        "Committing to {} with message {}".format(repo_dir, message)
-    )
+    print("Committing to {} with message {}".format(repo_dir, message))  # noqa: T201
     for cmd in cmds:
         subprocess.call(cmd, cwd=repo_dir, shell=True)

--- a/python_modules/automation/automation/parse_dataproc_configs.py
+++ b/python_modules/automation/automation/parse_dataproc_configs.py
@@ -128,7 +128,7 @@ class ParsedConfig(namedtuple("_ParsedConfig", "name configs enums")):
 
     def write_configs(self, base_path):
         configs_filename = "configs_%s.py" % self.name
-        print("Writing", configs_filename)  # pylint: disable=print-call
+        print("Writing", configs_filename)  # noqa: T201
         with open(os.path.join(base_path, configs_filename), "wb") as f:
             f.write(self.configs)
 
@@ -185,7 +185,7 @@ class ConfigParser:
 
         # Print type tree
         prefix = "|" + ("-" * 4 * depth) + " " if depth > 0 else ""
-        print(prefix + (name or obj.get("type")))  # pylint: disable=print-call
+        print(prefix + (name or obj.get("type")))  # noqa: T201
 
         # Switch on object type
         obj_type = obj.get("type")

--- a/python_modules/automation/automation/parse_spark_configs.py
+++ b/python_modules/automation/automation/parse_spark_configs.py
@@ -241,7 +241,7 @@ def extract(spark_docs_markdown_text: str) -> SparkConfigNode:
 
         # Traverse spark.app.name key paths, creating SparkConfigNode at each tree node.
         # The leaves of the tree (stored in SparkConfigNode.value) are SparkConfig values.
-        print(spark_config.path, file=sys.stderr)  # pylint: disable=print-call
+        print(spark_config.path, file=sys.stderr)  # noqa: T201
         key_path = spark_config.split_path
 
         d = result

--- a/python_modules/dagit/dagit_tests/webserver/test_app.py
+++ b/python_modules/dagit/dagit_tests/webserver/test_app.py
@@ -42,7 +42,7 @@ query RunQuery($runId: ID!) {
 def _add_run(instance):
     @op
     def my_op():
-        print("STDOUT RULEZ")  # pylint: disable=print-call
+        print("STDOUT RULEZ")  # noqa: T201
 
     @job
     def _simple_job():
@@ -119,8 +119,6 @@ def test_graphql_invalid_json(instance, test_client: TestClient):  # pylint: dis
         content='{"query": "foo}',
         headers={"Content-Type": "application/json"},
     )
-
-    print(str(response.text))
 
     assert response.status_code == 400, response.text
     assert 'GraphQL request is invalid JSON:\n{"query": "foo}' in response.text

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -89,7 +89,7 @@ def execute_query_from_cli(workspace_process_context, query, variables=None, out
         with open(output, "w", encoding="utf8") as f:
             f.write(str_res + "\n")
     else:
-        print(str_res)  # pylint: disable=print-call
+        print(str_res)  # noqa: T201
 
     return str_res
 
@@ -196,7 +196,7 @@ def ui(text, file, predefined, variables, remote, output, ephemeral_instance, **
 
     if remote:
         res = execute_query_against_remote(remote, query, variables)
-        print(res)  # pylint: disable=print-call
+        print(res)  # noqa: T201
     else:
         instance = DagsterInstance.ephemeral() if ephemeral_instance else DagsterInstance.get()
         with get_workspace_process_context_from_kwargs(

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -76,11 +76,7 @@ def define_out_of_process_context(python_file, fn_name, instance, read_only=Fals
     with define_out_of_process_workspace(
         python_file, fn_name, instance, read_only=read_only
     ) as workspace_process_context:
-        x = workspace_process_context.create_request_context()
-        print(python_file)
-        print(x.repository_locations)
-        print(x.repository_location_errors())
-        yield x
+        yield workspace_process_context.create_request_context()
 
 
 def define_out_of_process_workspace(python_file, fn_name, instance, read_only=False):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -737,7 +737,7 @@ def materialization_pipeline():
 def spew_pipeline():
     @op
     def spew(_):
-        print("HELLO WORLD")  # pylint: disable=print-call
+        print("HELLO WORLD")  # noqa: T201
 
     spew()
 
@@ -906,11 +906,11 @@ def disable_gc(_context):
     # Workaround for termination signals being raised during GC and getting swallowed during
     # tests
     try:
-        print("Disabling GC")  # pylint: disable=print-call
+        print("Disabling GC")  # noqa: T201
         gc.disable()
         yield
     finally:
-        print("Re-enabling GC")  # pylint: disable=print-call
+        print("Re-enabling GC")  # noqa: T201
         gc.enable()
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_solids.py
@@ -50,5 +50,5 @@ def test_query_get_solid_exists(graphql_context):
     )
 
     assert not result.errors
-    print(result.data["repositoryOrError"])  # pylint: disable=print-call
+    print(result.data["repositoryOrError"])  # noqa: T201
     assert result.data["repositoryOrError"]["usedSolid"]["definition"]["name"] == "sum_solid"

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -94,7 +94,7 @@ def find_local_test_image(docker_image):
     try:
         client = docker.from_env()
         client.images.get(docker_image)
-        print(  # pylint: disable=print-call
+        print(  # noqa: T201
             "Found existing image tagged {image}, skipping image build. To rebuild, first run: "
             "docker rmi {image}".format(image=docker_image)
         )
@@ -350,5 +350,5 @@ def get_test_project_docker_image():
     final_docker_image = "{repository}/{image_name}:{tag}".format(
         repository=docker_repository, image_name=image_name, tag=docker_image_tag
     )
-    print("Using Docker image: %s" % final_docker_image)  # pylint: disable=print-call
+    print("Using Docker image: %s" % final_docker_image)  # noqa: T201
     return final_docker_image

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -273,7 +273,7 @@ def define_docker_celery_pipeline():
 
     @resource
     def resource_with_output():
-        print("writing to stdout")  # pylint: disable=print-call
+        print("writing to stdout")  # noqa: T201
         return 42
 
     @op(required_resource_keys={"resource_with_output"})

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -108,7 +108,7 @@ def asset_list_command(**kwargs):
         ]
 
     for asset_key in sorted(asset_keys):
-        print(asset_key.to_user_string())
+        print(asset_key.to_user_string())  # noqa: T201
 
 
 @asset_cli.command(name="wipe")

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -242,7 +242,7 @@ def extract_schedule_name(schedule_name: Optional[Union[str, Sequence[str]]]) ->
 def schedule_start_command(schedule_name, start_all, **kwargs):
     schedule_name = extract_schedule_name(schedule_name)
     if schedule_name is None and start_all is False:
-        print(  # pylint: disable=print-call
+        print(  # noqa: T201
             "Noop: dagster schedule start was called without any arguments specifying which "
             "schedules to start. Pass a schedule name or the --start-all flag to start schedules."
         )
@@ -314,7 +314,7 @@ def execute_stop_command(schedule_name, cli_args, print_fn, instance=None):
 def schedule_logs_command(schedule_name, **kwargs):
     schedule_name = extract_schedule_name(schedule_name)
     if schedule_name is None:
-        print(  # pylint: disable=print-call
+        print(  # noqa: T201
             "Noop: dagster schedule logs was called without any arguments specifying which "
             "schedules to retrieve logs for. Pass a schedule name"
         )

--- a/python_modules/dagster/dagster/_core/execution/poll_compute_logs.py
+++ b/python_modules/dagster/dagster/_core/execution/poll_compute_logs.py
@@ -31,7 +31,7 @@ def tail_polling(filepath, stream=sys.stdout, parent_pid=None):
     with open(filepath, "r", encoding="utf8") as file:
         for block in iter(lambda: file.read(1024), None):
             if block:
-                print(block, end="", file=stream)  # pylint: disable=print-call
+                print(block, end="", file=stream)
             else:
                 if pop_captured_interrupt() or (
                     parent_pid and current_process_is_orphaned(parent_pid)

--- a/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
@@ -26,7 +26,7 @@ def _kill_on_cancel(instance_ref: InstanceRef, run_id, shutdown_event):
                 DagsterRunStatus.CANCELING,
                 DagsterRunStatus.CANCELED,
             ]:
-                print(  # pylint: disable=print-call
+                print(  # noqa: T201
                     f"Detected run status {run.status}, sending interrupt to main thread"
                 )
                 send_interrupt()
@@ -36,7 +36,7 @@ def _kill_on_cancel(instance_ref: InstanceRef, run_id, shutdown_event):
 def start_run_cancellation_thread(
     instance: DagsterInstance, run_id
 ) -> Tuple[threading.Thread, threading.Event]:
-    print("Starting run cancellation thread")  # pylint: disable=print-call
+    print("Starting run cancellation thread")  # noqa: T201
     shutdown_event = threading.Event()
     thread = threading.Thread(
         target=_kill_on_cancel,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -108,7 +108,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def upgrade(self) -> None:
         all_run_ids = self.get_all_run_ids()
-        print(  # pylint: disable=print-call
+        print(  # noqa: T201
             f"Updating event log storage for {len(all_run_ids)} runs on disk..."
         )
         alembic_config = get_alembic_config(__file__)
@@ -117,7 +117,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 with self.run_connection(run_id) as conn:
                     run_alembic_upgrade(alembic_config, conn, run_id)
 
-        print("Updating event log storage for index db on disk...")  # pylint: disable=print-call
+        print("Updating event log storage for index db on disk...")  # noqa: T201
         with self.index_connection() as conn:
             run_alembic_upgrade(alembic_config, conn, "index")
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -108,9 +108,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def upgrade(self) -> None:
         all_run_ids = self.get_all_run_ids()
-        print(  # noqa: T201
-            f"Updating event log storage for {len(all_run_ids)} runs on disk..."
-        )
+        print(f"Updating event log storage for {len(all_run_ids)} runs on disk...")  # noqa: T201
         alembic_config = get_alembic_config(__file__)
         if all_run_ids:
             for run_id in tqdm(all_run_ids):

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -438,6 +438,6 @@ def debug_daemon_heartbeats(instance: DagsterInstance) -> None:
     timestamp = pendulum.now("UTC").float_timestamp
     instance.add_daemon_heartbeat(DaemonHeartbeat(timestamp, daemon.daemon_type(), None, None))
     returned_timestamp = instance.get_daemon_heartbeats()[daemon.daemon_type()].timestamp
-    print(  # pylint: disable=print-call
+    print(  # noqa: T201
         f"Written timestamp: {timestamp}\nRead timestamp: {returned_timestamp}"
     )

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -438,6 +438,4 @@ def debug_daemon_heartbeats(instance: DagsterInstance) -> None:
     timestamp = pendulum.now("UTC").float_timestamp
     instance.add_daemon_heartbeat(DaemonHeartbeat(timestamp, daemon.daemon_type(), None, None))
     returned_timestamp = instance.get_daemon_heartbeats()[daemon.daemon_type()].timestamp
-    print(  # noqa: T201
-        f"Written timestamp: {timestamp}\nRead timestamp: {returned_timestamp}"
-    )
+    print(f"Written timestamp: {timestamp}\nRead timestamp: {returned_timestamp}")  # noqa: T201

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -485,7 +485,7 @@ class DagsterGrpcClient:
                     health_pb2.HealthCheckRequest(service="DagsterApi")
                 )
         except grpc.RpcError as e:
-            print(e)  # pylint: disable=print-call
+            print(e)  # noqa: T201
             return health_pb2.HealthCheckResponse.UNKNOWN  # pylint: disable=no-member
 
         status_number = response.status

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -354,7 +354,7 @@ def check_cli_execute_file_pipeline(path, pipeline_fn_name, env_file=None):
         try:
             subprocess.check_output(cli_cmd)
         except subprocess.CalledProcessError as cpe:
-            print(cpe)  # pylint: disable=print-call
+            print(cpe)  # noqa: T201
             raise cpe
 
 

--- a/python_modules/dagster/dagster/_utils/forked_pdb.py
+++ b/python_modules/dagster/dagster/_utils/forked_pdb.py
@@ -1,4 +1,4 @@
-import pdb  # noqa: T100
+import pdb
 import sys
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1467,7 +1467,6 @@ def test_empty_asset_job():
     assert empty_selection.resolve([a, b]) == set()
 
     empty_job = define_asset_job("empty_job", selection=empty_selection).resolve([a, b], [])
-    print(vars(empty_job))
     assert empty_job.all_node_defs == []
 
     result = empty_job.execute_in_process()

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -390,7 +390,7 @@ def test_invalid_configurable_class():
         with instance_for_test(
             overrides={"run_launcher": {"module": "dagster", "class": "MadeUpRunLauncher"}}
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
 
 def test_invalid_configurable_module():
@@ -411,7 +411,7 @@ def test_invalid_configurable_module():
                 }
             }
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
 
 @pytest.mark.parametrize("dirname", (".", ".."))
@@ -542,4 +542,4 @@ def test_configurable_class_missing_methods():
                 }
             }
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_run_launcher_lazy_load.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_run_launcher_lazy_load.py
@@ -63,4 +63,4 @@ def test_lazy_load():
         }
     ) as instance:
         with pytest.raises(Exception, match="Expected init fail"):
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_validation.py
@@ -26,7 +26,7 @@ def test_validators_basic() -> None:
 
     @op
     def greet_user(config: UserConfig) -> None:
-        print(f"Hello {config.name}!")
+        print(f"Hello {config.name}!")  # noqa: T201
         executed["greet_user"] = True
 
     @job

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -1317,7 +1317,7 @@ def test_colliding_args():
 
     @op
     def foo(x, y):
-        print(x, y)
+        print(x, y)  # noqa: T201
 
     # in composition
     with pytest.raises(
@@ -1332,7 +1332,7 @@ def test_colliding_args():
 
     @op
     def bar(x, y=2):
-        print(x, y)
+        print(x, y)  # noqa: T201
 
     # or direct invocation
     with pytest.raises(

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -432,7 +432,7 @@ def test_failure_multiprocessing():
 @op
 def sys_exit(context):
     context.log.info("Informational message")
-    print("Crashy output to stdout")  # pylint: disable=print-call
+    print("Crashy output to stdout")  # noqa: T201
     sys.stdout.flush()
     os._exit(1)  # pylint: disable=W0212
 
@@ -487,7 +487,7 @@ def test_crash_multiprocessing():
 @op
 def segfault_solid(context):
     context.log.info("Informational message")
-    print("Crashy output to stdout")  # pylint: disable=print-call
+    print("Crashy output to stdout")  # noqa: T201
     segfault()
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -60,7 +60,7 @@ class TestStepHandler(StepHandler):
             assert step_handler_context.step_tags["baz_op"] == {"foo": "bar"}
 
         TestStepHandler.launch_step_count += 1
-        print("TestStepHandler Launching Step!")  # pylint: disable=print-call
+        print("TestStepHandler Launching Step!")  # noqa: T201
         TestStepHandler.processes.append(
             subprocess.Popen(step_handler_context.execute_step_args.get_command_args())
         )

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_deletegating_executor_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_deletegating_executor_retries.py
@@ -41,7 +41,7 @@ class TestStepHandler(StepHandler):
         else:
             raise Exception("Unexpected attempt count")
 
-        print("TestStepHandler Launching Step!")  # pylint: disable=print-call
+        print("TestStepHandler Launching Step!")  # noqa: T201
         TestStepHandler.processes.append(
             subprocess.Popen(step_handler_context.execute_step_args.get_command_args())
         )

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
@@ -192,7 +192,7 @@ def test_execution_plan_snapshot_backcompat():
     src_dir = file_relative_path(__file__, "test_execution_plan_snapshots/")
     snapshot_dirs = [f for f in os.listdir(src_dir) if not os.path.isfile(os.path.join(src_dir, f))]
     for snapshot_dir_path in snapshot_dirs:
-        print(f"Executing a saved run from {snapshot_dir_path}")  # pylint: disable=print-call
+        print(f"Executing a saved run from {snapshot_dir_path}")  # noqa: T201
 
         with copy_directory(os.path.join(src_dir, snapshot_dir_path)) as test_dir:
             with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
@@ -247,4 +247,4 @@ if __name__ == "__main__":
             run_config={"solids": {"emit": {"inputs": {"range_input": 5}}}},
         )
 
-        print("Created run for test")  # pylint: disable=print-call
+        print("Created run for test")  # noqa: T201

--- a/python_modules/dagster/dagster_tests/logging_tests/test_log_capture.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_log_capture.py
@@ -14,7 +14,7 @@ from dagster._utils.test import get_temp_file_name
 def test_capture():
     with get_temp_file_name() as capture_filepath:
         with mirror_stream_to_file(sys.stdout, capture_filepath):
-            print("HELLO")  # pylint: disable=print-call
+            print("HELLO")  # noqa: T201
 
         with open(capture_filepath, "r", encoding="utf8") as capture_stream:
             assert "HELLO" in capture_stream.read()

--- a/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
@@ -214,7 +214,7 @@ class CaptureHandler(logging.Handler):
 
     def emit(self, record):
         if self.output:
-            print(self.output + record.msg)  # pylint: disable=print-call
+            print(self.output + record.msg)  # noqa: T201
         self.captured.append(record)
 
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_stdout.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_stdout.py
@@ -25,7 +25,7 @@ SEPARATOR = os.linesep if (os.name == "nt" and sys.version_info < (3,)) else "\n
 
 @resource
 def resource_a(_):
-    print(HELLO_RESOURCE)  # pylint: disable=print-call
+    print(HELLO_RESOURCE)  # noqa: T201
     return "A"
 
 
@@ -36,7 +36,7 @@ def spawn(_):
 
 @op(ins={"num": In(int)}, required_resource_keys={"a"})
 def spew(_, num):
-    print(HELLO_SOLID)  # pylint: disable=print-call
+    print(HELLO_SOLID)  # noqa: T201
     return num
 
 
@@ -230,7 +230,7 @@ def test_compute_log_manager_subscription_updates():
         assert last_chunk.cursor == 0
 
         with open(stdout_path, "a+", encoding="utf8") as f:
-            print(HELLO_SOLID, file=f)  # pylint:disable=print-call
+            print(HELLO_SOLID, file=f)
 
         # wait longer than the watchdog timeout
         time.sleep(1)
@@ -287,9 +287,9 @@ def execute_inner(step_key, pipeline_run, instance_ref):
 def inner_step(instance, pipeline_run, step_key):
     with instance.compute_log_manager.watch(pipeline_run, step_key=step_key):
         time.sleep(0.1)
-        print(step_key, "inner 1")  # pylint: disable=print-call
-        print(step_key, "inner 2")  # pylint: disable=print-call
-        print(step_key, "inner 3")  # pylint: disable=print-call
+        print(step_key, "inner 1")  # noqa: T201
+        print(step_key, "inner 2")  # noqa: T201
+        print(step_key, "inner 3")  # noqa: T201
         time.sleep(0.1)
 
 
@@ -314,9 +314,9 @@ def test_single():
         step_keys = ["A", "B", "C"]
 
         with instance.compute_log_manager.watch(pipeline_run):
-            print("outer 1")  # pylint: disable=print-call
-            print("outer 2")  # pylint: disable=print-call
-            print("outer 3")  # pylint: disable=print-call
+            print("outer 1")  # noqa: T201
+            print("outer 2")  # noqa: T201
+            print("outer 3")  # noqa: T201
 
             for step_key in step_keys:
                 inner_step(instance, pipeline_run, step_key)
@@ -355,9 +355,9 @@ def test_compute_log_base_with_spaces():
             step_keys = ["A", "B", "C"]
 
             with instance.compute_log_manager.watch(pipeline_run):
-                print("outer 1")  # pylint: disable=print-call
-                print("outer 2")  # pylint: disable=print-call
-                print("outer 3")  # pylint: disable=print-call
+                print("outer 1")  # noqa: T201
+                print("outer 2")  # noqa: T201
+                print("outer 3")  # noqa: T201
 
                 for step_key in step_keys:
                     inner_step(instance, pipeline_run, step_key)
@@ -388,9 +388,9 @@ def test_multi():
         step_keys = ["A", "B", "C"]
 
         with instance.compute_log_manager.watch(pipeline_run):
-            print("outer 1")  # pylint: disable=print-call
-            print("outer 2")  # pylint: disable=print-call
-            print("outer 3")  # pylint: disable=print-call
+            print("outer 1")  # noqa: T201
+            print("outer 2")  # noqa: T201
+            print("outer 3")  # noqa: T201
 
             for step_key in step_keys:
                 process = ctx.Process(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_compute_log_manager.py
@@ -210,14 +210,14 @@ def _has_teardown_exception(execute_result):
 @op
 def yay(context):
     context.log.info("yay")
-    print("HELLOOO")  # pylint: disable=print-call
+    print("HELLOOO")  # noqa: T201
     return "yay"
 
 
 @op
 def boo(context):
     context.log.info("boo")
-    print("HELLOOO")  # pylint: disable=print-call
+    print("HELLOOO")  # noqa: T201
     raise Exception("booo")
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
@@ -49,8 +49,8 @@ class TestCapturedLogManager:
         log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
 
         with captured_log_manager.capture_logs(log_key) as context:
-            print("HELLO WORLD")  # pylint: disable=print-call
-            print("HELLO ERROR", file=sys.stderr)  # pylint: disable=print-call
+            print("HELLO WORLD")  # noqa: T201
+            print("HELLO ERROR", file=sys.stderr)  # noqa: T201
             assert not captured_log_manager.is_capture_complete(log_key)
             assert context.log_key == log_key
 
@@ -74,8 +74,8 @@ class TestCapturedLogManager:
         log_key = ["".join(random.choice(string.ascii_lowercase) for x in range(300))]
 
         with captured_log_manager.capture_logs(log_key) as context:
-            print("HELLO WORLD")  # pylint: disable=print-call
-            print("HELLO ERROR", file=sys.stderr)  # pylint: disable=print-call
+            print("HELLO WORLD")  # noqa: T201
+            print("HELLO ERROR", file=sys.stderr)  # noqa: T201
             assert not captured_log_manager.is_capture_complete(log_key)
             assert context.log_key == log_key
 
@@ -110,8 +110,8 @@ class TestCapturedLogManager:
         now = pendulum.now("UTC")
         log_key = ["streaming", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):
-            print("hello stdout")  # pylint: disable=print-call
-            print("hello stderr", file=sys.stderr)  # pylint: disable=print-call
+            print("hello stdout")  # noqa: T201
+            print("hello stderr", file=sys.stderr)  # noqa: T201
 
             # read before the write manager has a chance to upload partial results
             log_data = read_manager.get_log_data(log_key)
@@ -147,8 +147,8 @@ class TestCapturedLogManager:
         now = pendulum.now("UTC")
         log_key = ["complete", "test", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):
-            print("hello stdout")  # pylint: disable=print-call
-            print("hello stderr", file=sys.stderr)  # pylint: disable=print-call
+            print("hello stdout")  # noqa: T201
+            print("hello stderr", file=sys.stderr)  # noqa: T201
             assert not write_manager.is_capture_complete(log_key)
             assert not read_manager.is_capture_complete(log_key)
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
@@ -1,4 +1,5 @@
-# pylint: disable=unused-argument,print-call
+# ruff: noqa: T201
+# pylint: disable=unused-argument
 
 import os
 import time

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/conftest.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/conftest.py
@@ -67,9 +67,9 @@ def postgres_airflow_db(
                     db.initdb()
                     break
                 except OperationalError as e:
-                    print(e)
+                    print(e)  # noqa: T201
                 time.sleep(RETRY_DELAY_SEC)
-                print(
+                print(  # noqa: T201
                     "Waiting for Airflow postgres database to start and initialize"
                     + "." * (3 + (now - start_time).seconds // RETRY_DELAY_SEC)
                 )

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_instance.py
@@ -24,14 +24,14 @@ def test_run_task_kwargs(instance_cm):
 def test_invalid_kwargs_field(instance_cm):
     with pytest.raises(Exception, match="Found an unexpected key foo in run_task_kwargs"):
         with instance_cm(config={"run_task_kwargs": {"foo": "bar"}}) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
     with pytest.raises(Exception):
         with instance_cm(
             config={"taskDefinition": "my-task-def"},
             match="Use the `taskDefinition` config field to pass in a task definition to run",
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
     with pytest.raises(Exception):
         with instance_cm(
@@ -40,7 +40,7 @@ def test_invalid_kwargs_field(instance_cm):
                 "Task overrides are set by the run launcher and cannot be set in run_task_kwargs."
             ),
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
 
 def test_task_definition_config(instance_cm, task_definition):
@@ -56,7 +56,7 @@ def test_task_definition_config(instance_cm, task_definition):
         with instance_cm(
             config={"task_definition": {"env": "FOO"}, "container_name": "dagster"}
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
     with environ({"FOO": "dagster"}):
         with instance_cm(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -683,17 +683,17 @@ def test_launching_custom_task_definition(
 
     # The task definition doesn't exist
     with pytest.raises(Exception), instance_cm({"task_definition": "does not exist"}) as instance:
-        print(instance.run_launcher)  # pylint: disable=print-call
+        print(instance.run_launcher)  # noqa: T201
 
     # The task definition doesn't include the default container name
     with pytest.raises(CheckError), instance_cm({"task_definition": family}) as instance:
-        print(instance.run_launcher)  # pylint: disable=print-call
+        print(instance.run_launcher)  # noqa: T201
 
     # The task definition doesn't include the container name
     with pytest.raises(CheckError), instance_cm(
         {"task_definition": family, "container_name": "does not exist"}
     ) as instance:
-        print(instance.run_launcher)  # pylint: disable=print-call
+        print(instance.run_launcher)  # noqa: T201
 
     # You can provide a family or a task definition ARN
     with instance_cm(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -32,7 +32,7 @@ def test_compute_log_manager(mock_s3_bucket):
     @op
     def easy(context):
         context.log.info("easy")
-        print(HELLO_WORLD)  # pylint: disable=print-call
+        print(HELLO_WORLD)  # noqa: T201
         return "easy"
 
     @job

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -39,7 +39,7 @@ def test_compute_log_manager(
         @op
         def easy(context):
             context.log.info("easy")
-            print(HELLO_WORLD)  # pylint: disable=print-call
+            print(HELLO_WORLD)  # noqa: T201
             return "easy"
 
         easy()
@@ -257,7 +257,7 @@ def test_compute_log_manager_default_azure_credential(
         @op
         def easy(context):
             context.log.info("easy")
-            print(HELLO_WORLD)  # pylint: disable=print-call
+            print(HELLO_WORLD)  # noqa: T201
             return "easy"
 
         easy()

--- a/python_modules/libraries/dagster-celery/dagster_celery/cli.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/cli.py
@@ -249,7 +249,7 @@ def status_command(
 def worker_list_command(config_yaml=None):
     app = get_app(config_yaml)
 
-    print(app.control.inspect(timeout=1).active())  # pylint: disable=print-call
+    print(app.control.inspect(timeout=1).active())  # noqa: T201
 
 
 @click.command(

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/conftest.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/conftest.py
@@ -39,7 +39,7 @@ def rabbitmq():  # pylint: disable=redefined-outer-name
 
     subprocess.check_output(["docker-compose", "-f", docker_compose_file, "up", "-d", service_name])
 
-    print("Waiting for rabbitmq to be ready...")  # pylint: disable=print-call
+    print("Waiting for rabbitmq to be ready...")  # noqa: T201
     while True:
         logs = str(subprocess.check_output(["docker", "logs", service_name]))
         if "started TCP listener on [::]:5672" in logs:
@@ -88,7 +88,7 @@ def dagster_docker_image():
         try:
             client = docker.from_env()
             client.images.get(docker_image)
-            print(  # pylint: disable=print-call
+            print(  # noqa: T201
                 "Found existing image tagged {image}, skipping image build. To rebuild, first run: "
                 "docker rmi {image}".format(image=docker_image)
             )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -634,7 +634,7 @@ class DatabricksConfig:
             name = secret["name"]
             key = secret["key"]
             scope = secret["scope"]
-            print(  # pylint: disable=print-call
+            print(  # noqa: T201
                 "Exporting {} from Databricks secret {}, scope {}".format(name, key, scope)
             )
             val = dbutils.secrets.get(scope=scope, key=key)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_step_main.py
@@ -95,7 +95,7 @@ def main(
 
             with open(step_run_ref_filepath, "rb") as handle:
                 step_run_ref = pickle.load(handle)
-            print("Running dagster job")
+            print("Running dagster job")  # noqa: T201
 
             step_run_dir = os.path.dirname(step_run_ref_filepath)
             if step_run_ref.known_state is not None:

--- a/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/ops/docker_container_op.py
@@ -139,7 +139,7 @@ def execute_docker_container(
     container.start()
 
     for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-        print(line)
+        print(line)  # noqa: T201
 
     exit_status = container.wait()["StatusCode"]
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -353,7 +353,7 @@ def test_cant_combine_network_and_networks(aws_env):
                 }
             }
         ) as instance:
-            print(instance.run_launcher)  # pylint: disable=print-call
+            print(instance.run_launcher)  # noqa: T201
 
 
 def test_terminate(aws_env):

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -105,7 +105,7 @@ def test_image_on_pipeline(monkeypatch, aws_env, from_pending_repository, asset_
             poll_for_finished_run(instance, run.run_id, timeout=60)
 
             for log in instance.all_logs(run.run_id):
-                print(log)  # pylint: disable=print-call
+                print(log)  # noqa: T201
 
             assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
@@ -179,7 +179,7 @@ def test_container_context_on_pipeline(aws_env):
             poll_for_finished_run(instance, run.run_id, timeout=60)
 
             for log in instance.all_logs(run.run_id):
-                print(log)  # pylint: disable=print-call
+                print(log)  # noqa: T201
 
             assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
@@ -261,5 +261,5 @@ def test_recovery(aws_env):
             poll_for_finished_run(instance, run.run_id, timeout=60)
 
             for log in instance.all_logs(run.run_id):
-                print(str(log) + "\n")  # pylint: disable=print-call
+                print(str(log) + "\n")  # noqa: T201
             assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -60,7 +60,6 @@ def temporary_bigquery_table(schema_name: str) -> Iterator[str]:
     )
     table_name = "test_io_manager_" + str(uuid.uuid4()).replace("-", "_")
     try:
-        print(table_name)
         yield table_name
     finally:
         bq_client.query(

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -34,7 +34,7 @@ def test_compute_log_manager(gcs_bucket):
         @op
         def easy(context):
             context.log.info("easy")
-            print(HELLO_WORLD)  # pylint: disable=print-call
+            print(HELLO_WORLD)  # noqa: T201
             return "easy"
 
         easy()
@@ -124,7 +124,7 @@ def test_compute_log_manager_with_envvar(gcs_bucket):
         @op
         def easy(context):
             context.log.info("easy")
-            print(HELLO_WORLD)  # pylint: disable=print-call
+            print(HELLO_WORLD)  # noqa: T201
             return "easy"
 
         easy()

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -332,7 +332,7 @@ def execute_k8s_job(
 
         try:
             log_entry = next(log_stream)
-            print(log_entry)  # pylint: disable=print-call
+            print(log_entry)  # noqa: T201
         except StopIteration:
             break
 

--- a/python_modules/libraries/dagstermill/dagstermill/cli.py
+++ b/python_modules/libraries/dagstermill/dagstermill/cli.py
@@ -34,7 +34,7 @@ def get_kernelspec(kernel: Optional[str] = None):
             )
         ) + list(kernelspecs["kernelspecs"].keys())
         kernel = preferred_kernels[0]
-        print(  # pylint: disable=print-call
+        print(  # noqa: T201
             "No kernel specified, defaulting to '{kernel}'".format(kernel=kernel)
         )
 

--- a/python_modules/libraries/dagstermill/dagstermill/cli.py
+++ b/python_modules/libraries/dagstermill/dagstermill/cli.py
@@ -34,9 +34,7 @@ def get_kernelspec(kernel: Optional[str] = None):
             )
         ) + list(kernelspecs["kernelspecs"].keys())
         kernel = preferred_kernels[0]
-        print(  # noqa: T201
-            "No kernel specified, defaulting to '{kernel}'".format(kernel=kernel)
-        )
+        print("No kernel specified, defaulting to '{kernel}'".format(kernel=kernel))  # noqa: T201
 
     check.invariant(
         kernel in kernelspecs["kernelspecs"],

--- a/scripts/check_schemas.py
+++ b/scripts/check_schemas.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 import importlib
 import pkgutil
 

--- a/scripts/create_dagster_package.py
+++ b/scripts/create_dagster_package.py
@@ -1,3 +1,4 @@
+# ruff: noqa: T201
 import os
 
 import click

--- a/scripts/gen_airbyte_classes.py
+++ b/scripts/gen_airbyte_classes.py
@@ -591,7 +591,7 @@ from dagster._annotations import public
                                 failures.append((connector_name_human_readable, e))
                                 continue
 
-                print("\033[1A\033[K\033[1A\033[K\033[1A\033[K")
+                print("\033[1A\033[K\033[1A\033[K\033[1A\033[K")  # noqa: T201
                 click.secho(f"{successes} successes", fg="green")
                 click.secho(f"{len(failures)} failures", fg="red")
 

--- a/scripts/get_recent_pypi_changes.py
+++ b/scripts/get_recent_pypi_changes.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 
 import datetime
 import subprocess

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -1,4 +1,4 @@
-# pylint: disable=print-call
+# ruff: noqa: T201
 import argparse
 import subprocess
 import sys

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# ruff: noqa: T201
 
 import argparse
 import json


### PR DESCRIPTION
## Summary & Motivation

Enable Ruff `T20` print statement detection.

This wasn't previously enabled because Ruff did not support file-scoped `# noqa` directives until recently. Now that we are using a version that does, I was able to bulk-convert old `# pylint: disable=print-call` comments to get ruff to ignore prints in all the same places.

---

## How I Tested These Changes

BK
