### PR TITLE
[ruff] Enable D415 (docstring period)

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/trigger.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/trigger.py
@@ -11,11 +11,12 @@ def build_trigger_step(
     if_condition: Optional[str] = None,
     env: Optional[Dict[str, str]] = None,
 ) -> TriggerStep:
-    """trigger_step: Trigger a build of another pipeline. See:
+    """Trigger a build of another pipeline.
 
+    See:
         https://buildkite.com/docs/pipelines/trigger-step
 
-    Parameters:
+    Args:
         pipeline (str): The pipeline to trigger
         branches (List[str]): List of branches to trigger
         async_step (bool): If set to true the step will immediately continue, regardless of the

--- a/docs/content/concepts/configuration/configured.mdx
+++ b/docs/content/concepts/configuration/configured.mdx
@@ -92,7 +92,7 @@ from dagster import configured, resource
 
 @resource(config_schema={"region": str, "use_unsigned_session": bool})
 def s3_session(_init_context):
-    """Connect to S3"""
+    """Connect to S3."""
 
 
 @configured(s3_session, config_schema={"region": str})

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -656,12 +656,12 @@ For example, if your job produces DataFrames to populate tables in a data wareho
 ```python file=/concepts/io_management/metadata.py startafter=ops_start_marker endbefore=ops_end_marker
 @op(out=Out(metadata={"schema": "some_schema", "table": "some_table"}))
 def op_1():
-    """Return a Pandas DataFrame"""
+    """Return a Pandas DataFrame."""
 
 
 @op(out=Out(metadata={"schema": "other_schema", "table": "other_table"}))
 def op_2(_input_dataframe):
-    """Return a Pandas DataFrame"""
+    """Return a Pandas DataFrame."""
 ```
 
 The IO manager can then access this metadata when storing or retrieving data, via the <PyObject module="dagster" object="OutputContext" />.

--- a/docs/content/concepts/io-management/unconnected-inputs.mdx
+++ b/docs/content/concepts/io-management/unconnected-inputs.mdx
@@ -133,7 +133,7 @@ def simple_table_1_manager():
 
 @op(ins={"dataframe": In(input_manager_key="simple_load_input_manager")})
 def my_op(dataframe):
-    """Do some stuff"""
+    """Do some stuff."""
     dataframe.head()
 
 
@@ -244,12 +244,12 @@ def my_subselection_input_manager():
 
 @op
 def op1():
-    """Do stuff"""
+    """Do stuff."""
 
 
 @op(ins={"dataframe": In(input_manager_key="my_input_manager")})
 def op2(dataframe):
-    """Do stuff"""
+    """Do stuff."""
     dataframe.head()
 
 

--- a/docs/content/getting-started/hello-dagster.mdx
+++ b/docs/content/getting-started/hello-dagster.mdx
@@ -28,7 +28,8 @@ from dagster import MetadataValue, Output, asset
 def hackernews_top_story_ids():
     """
     Get top stories from the HackerNews top stories endpoint.
-    API Docs: https://github.com/HackerNews/API#new-top-and-best-stories
+
+    API Docs: https://github.com/HackerNews/API#new-top-and-best-stories.
     """
     top_story_ids = requests.get(
         "https://hacker-news.firebaseio.com/v0/topstories.json"
@@ -39,7 +40,7 @@ def hackernews_top_story_ids():
 # asset dependencies can be inferred from parameter names
 @asset
 def hackernews_top_stories(hackernews_top_story_ids):
-    """Get items based on story ids from the HackerNews items endpoint"""
+    """Get items based on story ids from the HackerNews items endpoint."""
     results = []
     for item_id in hackernews_top_story_ids:
         item = requests.get(

--- a/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
+++ b/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
@@ -302,7 +302,7 @@ import requests
 
 class HNAPIClient:
     """
-    Hacker News client that fetches live data
+    Hacker News client that fetches live data.
     """
 
     def fetch_item_by_id(self, item_id: int) -> Optional[Dict[str, Any]]:
@@ -371,7 +371,7 @@ Now we can write a stubbed version of the Hacker News resource. We want to make 
 
 class StubHNClient:
     """
-    Hacker News Client that returns fake data
+    Hacker News Client that returns fake data.
     """
 
     def __init__(self):

--- a/docs/dagit-screenshot/dagit_screenshot/commands/asset_svg.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/asset_svg.py
@@ -133,8 +133,13 @@ def generate_svg_for_file(code_path: str, destination_path: str, snippet_fn: Opt
 
 def parse_params(param_str: str) -> Dict[str, str]:
     """
-    Parses a set of params for a markdown code block, e.g. returns {"foo": "bar", "baz": "qux"} for
-    ```python foo=bar baz=qux
+    Parses a set of params for a markdown code block.
+
+    For example, returns {"foo": "bar", "baz": "qux"} for:
+
+    ```python
+    foo=bar baz=qux.
+    ```
     """
     params = re.split(r"\s+", param_str)
     return {param.split("=")[0]: param.split("=")[1] for param in params if len(param) > 0}

--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions/assets.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions/assets.py
@@ -17,7 +17,7 @@ releases_partitions_def = DynamicPartitionsDefinition(name="releases")
     metadata={"partition_expr": "release_tag"},
 )
 def releases_metadata(context) -> DataFrame:
-    """Table with a single row per release"""
+    """Table with a single row per release."""
     release_tag = context.partition_key
 
     response = requests.get(
@@ -49,7 +49,7 @@ def _get_release_zip_path(release_tag: str) -> str:
 
 @asset(partitions_def=releases_partitions_def)
 def release_zips(context, releases_metadata: DataFrame) -> None:
-    """Directory containing a zip file for each release"""
+    """Directory containing a zip file for each release."""
     zipball_url = releases_metadata.iloc[0]["zipball_url"]
 
     target_zip_path = _get_release_zip_path(context.partition_key)
@@ -63,7 +63,7 @@ def _get_release_files_dir(release_tag: str) -> str:
 
 @asset(partitions_def=releases_partitions_def, non_argument_deps={"release_zips"})
 def release_files(context) -> None:
-    """Directory with a subdirectory for each release"""
+    """Directory with a subdirectory for each release."""
     release_files_dir = _get_release_files_dir(context.partition_key)
     os.mkdir(release_files_dir)
     with zipfile.ZipFile(_get_release_zip_path(context.partition_key), "r") as zip_ref:
@@ -78,7 +78,7 @@ def release_files(context) -> None:
 )
 def release_files_metadata(context) -> DataFrame:
     """
-    Table with a row for every release file
+    Table with a row for every release file.
 
     Partitioned by release, because all the files for a release are added/updated atomically
     """

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/config_map_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/config_map_example.py
@@ -3,7 +3,7 @@ from dagster import configured, resource
 
 @resource(config_schema={"region": str, "use_unsigned_session": bool})
 def s3_session(_init_context):
-    """Connect to S3"""
+    """Connect to S3."""
 
 
 @configured(s3_session, config_schema={"region": str})

--- a/examples/docs_snippets/docs_snippets/concepts/configuration/configured_example.py
+++ b/examples/docs_snippets/docs_snippets/concepts/configuration/configured_example.py
@@ -5,7 +5,7 @@ from dagster import configured, resource
 
 @resource(config_schema={"region": str, "use_unsigned_session": bool})
 def s3_session(_init_context):
-    """Connect to S3"""
+    """Connect to S3."""
 
 
 # end_op_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/config_input_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/config_input_manager.py
@@ -8,7 +8,7 @@ def read_dataframe_from_table(**_kwargs):
 
 @op(ins={"dataframe": In(root_manager_key="my_root_manager")})
 def my_op(dataframe):
-    """Do some stuff"""
+    """Do some stuff."""
 
 
 # def_start_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -156,7 +156,7 @@ def simple_table_1_manager():
 
 @op(ins={"dataframe": In(input_manager_key="simple_load_input_manager")})
 def my_op(dataframe):
-    """Do some stuff"""
+    """Do some stuff."""
     dataframe.head()
 
 
@@ -231,12 +231,12 @@ def my_subselection_input_manager():
 
 @op
 def op1():
-    """Do stuff"""
+    """Do stuff."""
 
 
 @op(ins={"dataframe": In(input_manager_key="my_input_manager")})
 def op2(dataframe):
-    """Do stuff"""
+    """Do stuff."""
     dataframe.head()
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
@@ -16,12 +16,12 @@ def read_dataframe_from_table(**_kwargs):
 # ops_start_marker
 @op(out=Out(metadata={"schema": "some_schema", "table": "some_table"}))
 def op_1():
-    """Return a Pandas DataFrame"""
+    """Return a Pandas DataFrame."""
 
 
 @op(out=Out(metadata={"schema": "other_schema", "table": "other_table"}))
 def op_2(_input_dataframe):
-    """Return a Pandas DataFrame"""
+    """Return a Pandas DataFrame."""
 
 
 # ops_end_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/output_config.py
@@ -15,12 +15,12 @@ def read_dataframe_from_table(**_kwargs):
 
 @op
 def op_1():
-    """Return a Pandas DataFrame"""
+    """Return a Pandas DataFrame."""
 
 
 @op
 def op_2(_input_dataframe):
-    """Return a Pandas DataFrame"""
+    """Return a Pandas DataFrame."""
 
 
 # io_manager_start_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/root_input_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/root_input_manager.py
@@ -9,7 +9,7 @@ def read_dataframe_from_table(**_kwargs):
 # start_marker
 @op(ins={"dataframe": In(root_manager_key="my_root_manager")})
 def my_op(dataframe):
-    """Do some stuff"""
+    """Do some stuff."""
 
 
 @root_input_manager

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/subselection.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/subselection.py
@@ -32,12 +32,12 @@ def my_io_manager(_):
 
 @op(out=Out(io_manager_key="my_io_manager"))
 def op1():
-    """Do stuff"""
+    """Do stuff."""
 
 
 @op(ins={"dataframe": In(root_manager_key="my_root_input_manager")})
 def op2(dataframe):
-    """Do stuff"""
+    """Do stuff."""
 
 
 @job(

--- a/examples/docs_snippets/docs_snippets/getting-started/hello-dagster/hello-dagster.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/hello-dagster/hello-dagster.py
@@ -8,7 +8,8 @@ from dagster import MetadataValue, Output, asset
 def hackernews_top_story_ids():
     """
     Get top stories from the HackerNews top stories endpoint.
-    API Docs: https://github.com/HackerNews/API#new-top-and-best-stories
+
+    API Docs: https://github.com/HackerNews/API#new-top-and-best-stories.
     """
     top_story_ids = requests.get(
         "https://hacker-news.firebaseio.com/v0/topstories.json"
@@ -19,7 +20,7 @@ def hackernews_top_story_ids():
 # asset dependencies can be inferred from parameter names
 @asset
 def hackernews_top_stories(hackernews_top_story_ids):
-    """Get items based on story ids from the HackerNews items endpoint"""
+    """Get items based on story ids from the HackerNews items endpoint."""
     results = []
     for item_id in hackernews_top_story_ids:
         item = requests.get(

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/cereal.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/cereal.py
@@ -37,7 +37,7 @@ def cereals():
 
 @asset
 def nabisco_cereals(cereals):
-    """Cereals manufactured by Nabisco"""
+    """Cereals manufactured by Nabisco."""
     return [row for row in cereals if row["mfr"] == "N"]
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/complex_asset_graph.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/complex_asset_graph.py
@@ -14,7 +14,7 @@ def cereals():
 
 @asset
 def nabisco_cereals(cereals):
-    """Cereals manufactured by Nabisco"""
+    """Cereals manufactured by Nabisco."""
     return [row for row in cereals if row["mfr"] == "N"]
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/complex_asset_graph_tests.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/complex_asset_graph_tests.py
@@ -1,4 +1,4 @@
-"""isort:skip_file"""
+# isort: skip_file
 from docs_snippets.guides.dagster.asset_tutorial.complex_asset_graph import (
     cereal_protein_fractions,
     cereals,

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/non_argument_deps.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/non_argument_deps.py
@@ -1,4 +1,4 @@
-"""isort:skip_file"""
+# isort: skip_file
 import csv
 
 import requests
@@ -15,7 +15,7 @@ def cereals():
 
 @asset
 def nabisco_cereals(cereals):
-    """Cereals manufactured by Nabisco"""
+    """Cereals manufactured by Nabisco."""
     return [row for row in cereals if row["mfr"] == "N"]
 
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/serial_asset_graph.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/asset_tutorial/serial_asset_graph.py
@@ -14,5 +14,5 @@ def cereals():
 
 @asset
 def nabisco_cereals(cereals):
-    """Cereals manufactured by Nabisco"""
+    """Cereals manufactured by Nabisco."""
     return [row for row in cereals if row["mfr"] == "N"]

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v1.py
@@ -7,7 +7,7 @@ import requests
 
 class HNAPIClient:
     """
-    Hacker News client that fetches live data
+    Hacker News client that fetches live data.
     """
 
     def fetch_item_by_id(self, item_id: int) -> Optional[Dict[str, Any]]:

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/resources/resources_v2.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 
 class StubHNClient:
     """
-    Hacker News Client that returns fake data
+    Hacker News Client that returns fake data.
     """
 
     def __init__(self):

--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/assets/recommender/user_story_matrix.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/assets/recommender/user_story_matrix.py
@@ -8,7 +8,7 @@ from scipy.sparse import coo_matrix
 
 @dataclass
 class IndexedCooMatrix:
-    """A matrix with indexes for the rows and columns"""
+    """A matrix with indexes for the rows and columns."""
 
     matrix: coo_matrix
 

--- a/examples/with_wandb/with_wandb/ops/partitioned_job.py
+++ b/examples/with_wandb/with_wandb/ops/partitioned_job.py
@@ -46,7 +46,7 @@ def region(partition_key: str):
     ),
 )
 def write_partitioned_artifact() -> List[int]:
-    """Example of a simple op that writes a partitioned Artifact"""
+    """Example of a simple op that writes a partitioned Artifact."""
     return [1, 2, 3]
 
 
@@ -63,7 +63,7 @@ def write_partitioned_artifact() -> List[int]:
     },
 )
 def read_partitioned_artifact(context: OpExecutionContext, content: List[int]) -> None:
-    """Example of a simple op that reads a partitioned Artifact"""
+    """Example of a simple op that reads a partitioned Artifact."""
     context.log.info(f"Result: {content}")  # Result: [1, 2, 3]
 
 
@@ -79,5 +79,5 @@ def read_partitioned_artifact(context: OpExecutionContext, content: List[int]) -
     },
 )
 def partitioned_job_example() -> None:
-    """Example of a simple job that writes and reads a partitioned Artifact"""
+    """Example of a simple job that writes and reads a partitioned Artifact."""
     read_partitioned_artifact(write_partitioned_artifact())

--- a/examples/with_wandb/with_wandb/ops/simple_job.py
+++ b/examples/with_wandb/with_wandb/ops/simple_job.py
@@ -75,5 +75,5 @@ def create_my_final_list(downloaded_artifact: List[int]) -> List[int]:
     }
 )
 def simple_job_example():
-    """Example of a simple job using the Artifact integration"""
+    """Example of a simple job using the Artifact integration."""
     create_my_final_list(create_my_first_list())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,6 @@ ignore = [
   "D200",  # (one-line docstring should fit)
   "D205",  # (blank line after summary)
   "D212",  # (multi-line docstring summary should start at 1st line)
-  "D415",  # (docstring summary should end with a period)
   "D417",  # (missing arg in docstring)
 
   # (indent docstring rules) These rules should be enabled when ruff lands

--- a/python_modules/automation/automation_tests/docker_tests/test_image_defs.py
+++ b/python_modules/automation/automation_tests/docker_tests/test_image_defs.py
@@ -6,7 +6,8 @@ from automation.docker.image_defs import copy_directories, get_image
 
 @pytest.fixture(name="repo")
 def repo_fixture(tmpdir):
-    """
+    """Test repo.
+
     repo/
     ├── .git/
     ├── bar/

--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -205,7 +205,7 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
 
     def index_html_endpoint(self, request: Request):
         """
-        Serves root html
+        Serves root html.
         """
         index_path = self.relative_path("webapp/build/index.html")
 
@@ -327,7 +327,8 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
 
 
 class DagsterTracedCounterMiddleware:
-    """Middleware for counting traced dagster calls
+    """Middleware for counting traced dagster calls.
+
     Args:
       app (ASGI application): ASGI application
     """

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -681,7 +681,7 @@ class GrapheneLogTelemetryMutation(graphene.Mutation):
 
 
 class GrapheneSetNuxSeenMutation(graphene.Mutation):
-    """Store whether we've shown the nux to any user and they've dismissed or submitted it"""
+    """Store whether we've shown the nux to any user and they've dismissed or submitted it."""
 
     Output = graphene.NonNull(graphene.Boolean)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo_definitions.py
@@ -18,7 +18,7 @@ def my_asset():
 
 
 class MyResource(ConfigurableResource):
-    """my description"""
+    """My description."""
 
     a_string: str = "baz"
     an_unset_string: str = "defaulted"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_top_level_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_top_level_resources.py
@@ -7,186 +7,111 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_fetch_top_level_resource 1'] = {
-    'topLevelResourceDetailsOrError': {
-        '__typename': 'ResourceDetails',
-        'configFields': [
+snapshots["test_fetch_top_level_resource 1"] = {
+    "topLevelResourceDetailsOrError": {
+        "__typename": "ResourceDetails",
+        "configFields": [
+            {"configType": {"key": "StringSourceType"}, "description": None, "name": "a_string"},
             {
-                'configType': {
-                    'key': 'StringSourceType'
-                },
-                'description': None,
-                'name': 'a_string'
+                "configType": {"key": "StringSourceType"},
+                "description": None,
+                "name": "an_unset_string",
             },
-            {
-                'configType': {
-                    'key': 'StringSourceType'
-                },
-                'description': None,
-                'name': 'an_unset_string'
-            }
         ],
-        'configuredValues': [
-            {
-                'key': 'a_string',
-                'type': 'VALUE',
-                'value': '"foo"'
-            },
-            {
-                'key': 'an_unset_string',
-                'type': 'VALUE',
-                'value': '"defaulted"'
-            }
+        "configuredValues": [
+            {"key": "a_string", "type": "VALUE", "value": '"foo"'},
+            {"key": "an_unset_string", "type": "VALUE", "value": '"defaulted"'},
         ],
-        'description': 'my description',
-        'name': 'my_resource'
+        "description": "My description.",
+        "name": "my_resource",
     }
 }
 
-snapshots['test_fetch_top_level_resource_env_var 1'] = {
-    'topLevelResourceDetailsOrError': {
-        '__typename': 'ResourceDetails',
-        'configFields': [
+snapshots["test_fetch_top_level_resource_env_var 1"] = {
+    "topLevelResourceDetailsOrError": {
+        "__typename": "ResourceDetails",
+        "configFields": [
+            {"configType": {"key": "StringSourceType"}, "description": None, "name": "a_string"},
             {
-                'configType': {
-                    'key': 'StringSourceType'
-                },
-                'description': None,
-                'name': 'a_string'
+                "configType": {"key": "StringSourceType"},
+                "description": None,
+                "name": "an_unset_string",
             },
-            {
-                'configType': {
-                    'key': 'StringSourceType'
-                },
-                'description': None,
-                'name': 'an_unset_string'
-            }
         ],
-        'configuredValues': [
-            {
-                'key': 'a_string',
-                'type': 'ENV_VAR',
-                'value': 'MY_STRING'
-            },
-            {
-                'key': 'an_unset_string',
-                'type': 'VALUE',
-                'value': '"defaulted"'
-            }
+        "configuredValues": [
+            {"key": "a_string", "type": "ENV_VAR", "value": "MY_STRING"},
+            {"key": "an_unset_string", "type": "VALUE", "value": '"defaulted"'},
         ],
-        'description': 'my description',
-        'name': 'my_resource_env_vars'
+        "description": "My description.",
+        "name": "my_resource_env_vars",
     }
 }
 
-snapshots['test_fetch_top_level_resources 1'] = {
-    'allTopLevelResourceDetailsOrError': {
-        '__typename': 'ResourceDetailsList',
-        'results': [
+snapshots["test_fetch_top_level_resources 1"] = {
+    "allTopLevelResourceDetailsOrError": {
+        "__typename": "ResourceDetailsList",
+        "results": [
+            {"configFields": [], "configuredValues": [], "description": None, "name": "foo"},
             {
-                'configFields': [
+                "configFields": [
+                    {
+                        "configType": {"key": "StringSourceType"},
+                        "description": None,
+                        "name": "a_string",
+                    },
+                    {
+                        "configType": {"key": "StringSourceType"},
+                        "description": None,
+                        "name": "an_unset_string",
+                    },
                 ],
-                'configuredValues': [
+                "configuredValues": [
+                    {"key": "a_string", "type": "VALUE", "value": '"foo"'},
+                    {"key": "an_unset_string", "type": "VALUE", "value": '"defaulted"'},
                 ],
-                'description': None,
-                'name': 'foo'
+                "description": "My description.",
+                "name": "my_resource",
             },
             {
-                'configFields': [
+                "configFields": [
                     {
-                        'configType': {
-                            'key': 'StringSourceType'
-                        },
-                        'description': None,
-                        'name': 'a_string'
+                        "configType": {"key": "StringSourceType"},
+                        "description": None,
+                        "name": "a_string",
                     },
                     {
-                        'configType': {
-                            'key': 'StringSourceType'
-                        },
-                        'description': None,
-                        'name': 'an_unset_string'
-                    }
-                ],
-                'configuredValues': [
-                    {
-                        'key': 'a_string',
-                        'type': 'VALUE',
-                        'value': '"foo"'
+                        "configType": {"key": "StringSourceType"},
+                        "description": None,
+                        "name": "an_unset_string",
                     },
-                    {
-                        'key': 'an_unset_string',
-                        'type': 'VALUE',
-                        'value': '"defaulted"'
-                    }
                 ],
-                'description': 'my description',
-                'name': 'my_resource'
+                "configuredValues": [
+                    {"key": "a_string", "type": "ENV_VAR", "value": "MY_STRING"},
+                    {"key": "an_unset_string", "type": "VALUE", "value": '"defaulted"'},
+                ],
+                "description": "My description.",
+                "name": "my_resource_env_vars",
             },
             {
-                'configFields': [
+                "configFields": [
                     {
-                        'configType': {
-                            'key': 'StringSourceType'
-                        },
-                        'description': None,
-                        'name': 'a_string'
+                        "configType": {"key": "StringSourceType"},
+                        "description": None,
+                        "name": "a_string",
                     },
                     {
-                        'configType': {
-                            'key': 'StringSourceType'
-                        },
-                        'description': None,
-                        'name': 'an_unset_string'
-                    }
-                ],
-                'configuredValues': [
-                    {
-                        'key': 'a_string',
-                        'type': 'ENV_VAR',
-                        'value': 'MY_STRING'
+                        "configType": {"key": "StringSourceType"},
+                        "description": None,
+                        "name": "an_unset_string",
                     },
-                    {
-                        'key': 'an_unset_string',
-                        'type': 'VALUE',
-                        'value': '"defaulted"'
-                    }
                 ],
-                'description': 'my description',
-                'name': 'my_resource_env_vars'
+                "configuredValues": [
+                    {"key": "a_string", "type": "ENV_VAR", "value": "MY_STRING"},
+                    {"key": "an_unset_string", "type": "ENV_VAR", "value": "MY_OTHER_STRING"},
+                ],
+                "description": "My description.",
+                "name": "my_resource_two_env_vars",
             },
-            {
-                'configFields': [
-                    {
-                        'configType': {
-                            'key': 'StringSourceType'
-                        },
-                        'description': None,
-                        'name': 'a_string'
-                    },
-                    {
-                        'configType': {
-                            'key': 'StringSourceType'
-                        },
-                        'description': None,
-                        'name': 'an_unset_string'
-                    }
-                ],
-                'configuredValues': [
-                    {
-                        'key': 'a_string',
-                        'type': 'ENV_VAR',
-                        'value': 'MY_STRING'
-                    },
-                    {
-                        'key': 'an_unset_string',
-                        'type': 'ENV_VAR',
-                        'value': 'MY_OTHER_STRING'
-                    }
-                ],
-                'description': 'my description',
-                'name': 'my_resource_two_env_vars'
-            }
-        ]
+        ],
     }
 }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_top_level_resources.py
@@ -102,7 +102,7 @@ def test_fetch_top_level_resource(definitions_graphql_context, snapshot):
     assert result.data["topLevelResourceDetailsOrError"]
     my_resource = result.data["topLevelResourceDetailsOrError"]
 
-    assert my_resource["description"] == "my description"
+    assert my_resource["description"] == "My description."
     assert len(my_resource["configFields"]) == 2
     assert sorted(my_resource["configuredValues"], key=lambda cv: cv["key"]) == [
         {
@@ -133,7 +133,7 @@ def test_fetch_top_level_resource_env_var(definitions_graphql_context, snapshot)
     assert result.data["topLevelResourceDetailsOrError"]
     my_resource = result.data["topLevelResourceDetailsOrError"]
 
-    assert my_resource["description"] == "my description"
+    assert my_resource["description"] == "My description."
     assert len(my_resource["configFields"]) == 2
     assert sorted(my_resource["configuredValues"], key=lambda cv: cv["key"]) == [
         {

--- a/python_modules/dagster-test/dagster_test/toys/software_defined_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/software_defined_assets.py
@@ -31,8 +31,10 @@ def daily_temperature_highs(sfo_q2_weather_sample: DataFrame) -> DataFrame:
 
 @asset
 def hottest_dates(daily_temperature_highs: DataFrame) -> DataFrame:
-    """Computes the 10 hottest dates. In a more advanced demo, this might perform a complex
-    SQL query to aggregate the data. For now, just imagine that this implements something like:
+    """Computes the 10 hottest dates.
+
+    In a more advanced demo, this might perform a complex SQL query to aggregate the data. For now,
+    just imagine that this implements something like:
 
     ```sql
     SELECT temp, date_part('day', date) FROM daily_temperature_highs ORDER BY date DESC;

--- a/python_modules/dagster/dagster/_config/config_schema.py
+++ b/python_modules/dagster/dagster/_config/config_schema.py
@@ -23,8 +23,10 @@ UserConfigSchema: TypeAlias = Union[
 
 
 class ConfigSchema:
-    """This is a placeholder type. Any time that it appears in documentation, it means that any of
-    the following types are acceptable:
+    """Placeholder type for config schemas.
+
+    Any time that it appears in documentation, it means that any of the following types are
+    acceptable:
 
     #. A Python scalar type that resolves to a Dagster config type
        (:py:class:`~python:int`, :py:class:`~python:float`, :py:class:`~python:bool`,

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -215,7 +215,7 @@ def _process_config_values(
 
 
 def _curry_config_schema(schema_field: Field, data: Any) -> DefinitionConfigSchema:
-    """Return a new config schema configured with the passed in data"""
+    """Return a new config schema configured with the passed in data."""
     return DefinitionConfigSchema(_apply_defaults_to_schema_field(schema_field, data))
 
 
@@ -669,7 +669,7 @@ class ConfigurableIOManagerFactory(ConfigurableResource[TIOManagerValue], IOMana
 
     @abstractmethod
     def create_io_manager(self, context) -> TIOManagerValue:
-        """Implement as one would implement a @io_manager decorator function"""
+        """Implement as one would implement a @io_manager decorator function."""
         raise NotImplementedError()
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -321,7 +321,7 @@ class AssetGraph:
         return asset_key in self.source_asset_keys or asset_key not in self.all_asset_keys
 
     def has_non_source_parents(self, asset_key: AssetKey) -> bool:
-        """Determines if an asset has any parents which are not source assets"""
+        """Determines if an asset has any parents which are not source assets."""
         if self.is_source(asset_key):
             return False
         return any(
@@ -385,10 +385,11 @@ class AssetGraph:
         initial_subset: "AssetGraphSubset",
     ) -> "AssetGraphSubset":
         """
-        Returns asset partitions within the graph that
+        Returns asset partitions within the graph that satisfy supplied criteria.
+
         - Are >= initial_asset_partitions
         - Asset matches the condition_fn
-        - Any of their ancestors >= initial_asset_partitions match the condition_fn
+        - Any of their ancestors >= initial_asset_partitions match the condition_fn.
 
         Visits parents before children.
         """
@@ -463,7 +464,8 @@ class AssetGraph:
         initial_asset_partitions: Iterable[AssetKeyPartitionKey],
     ) -> AbstractSet[AssetKeyPartitionKey]:
         """
-        Returns asset partitions within the graph that
+        Returns asset partitions within the graph that satisfy supplied criteria.
+
         - Are >= initial_asset_partitions
         - Match the condition_fn
         - Any of their ancestors >= initial_asset_partitions match the condition_fn
@@ -542,7 +544,7 @@ class InternalAssetGraph(AssetGraph):
 
 
 class ToposortedPriorityQueue:
-    """Queue that returns parents before their children"""
+    """Queue that returns parents before their children."""
 
     @functools.total_ordering
     class QueueItem(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -348,7 +348,7 @@ def allowable_time_window_for_partitions_def(
     partitions_def: TimeWindowPartitionsDefinition,
 ) -> Optional[TimeWindow]:
     """Returns a time window encompassing the partitions that the reconciliation sensor is currently
-    allowed to materialize for this partitions_def
+    allowed to materialize for this partitions_def.
     """
     latest_partition_window = partitions_def.get_last_partition_window()
     if latest_partition_window is None:

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -202,6 +202,7 @@ def configured(
 ) -> Callable[[object], T_Configurable]:
     """
     A decorator that makes it easy to create a function-configured version of an object.
+
     The following definition types can be configured using this function:
 
     * :py:class:`GraphDefinition`

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -40,7 +40,7 @@ class CachingDataTimeResolver:
         cursor: int,
         partitions_def: TimeWindowPartitionsDefinition,
     ) -> Optional[datetime.datetime]:
-        """Returns the time up until which all available data has been consumed for this asset
+        """Returns the time up until which all available data has been consumed for this asset.
 
         At a high level, this algorithm works as follows:
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -38,8 +38,9 @@ def sensor(
     required_resource_keys: Optional[Set[str]] = None,
 ) -> Callable[[RawSensorEvaluationFunction], SensorDefinition]:
     """
-    Creates a sensor where the decorated function is used as the sensor's evaluation function.  The
-    decorated function may:
+    Creates a sensor where the decorated function is used as the sensor's evaluation function.
+
+    The decorated function may:
 
     1. Return a `RunRequest` object.
     2. Return a list of `RunRequest` objects.
@@ -102,7 +103,9 @@ def asset_sensor(
 ) -> Callable[[AssetMaterializationFunction,], AssetSensorDefinition,]:
     """
     Creates an asset sensor where the decorated function is used as the asset sensor's evaluation
-    function.  The decorated function may:
+    function.
+
+    The decorated function may:
 
     1. Return a `RunRequest` object.
     2. Return a list of `RunRequest` objects.

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -218,18 +218,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def text(text: str) -> "TextMetadataValue":
         """Static constructor for a metadata value wrapping text as
         :py:class:`TextMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "my_text_label": MetadataValue.text("hello")
-                    },
-                )
+                @op
+                def emit_metadata(context, df):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "my_text_label": MetadataValue.text("hello")
+                        },
+                    )
 
         Args:
             text (str): The text string for a metadata entry.
@@ -241,19 +242,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def url(url: str) -> "UrlMetadataValue":
         """Static constructor for a metadata value wrapping a URL as
         :py:class:`UrlMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context):
-                yield AssetMaterialization(
-                    asset_key="my_dashboard",
-                    metadata={
-                        "dashboard_url": MetadataValue.url("http://mycoolsite.com/my_dashboard"),
-                    }
-                )
-
+                @op
+                def emit_metadata(context):
+                    yield AssetMaterialization(
+                        asset_key="my_dashboard",
+                        metadata={
+                            "dashboard_url": MetadataValue.url("http://mycoolsite.com/my_dashboard"),
+                        }
+                    )
 
         Args:
             url (str): The URL for a metadata entry.
@@ -264,18 +265,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     @staticmethod
     def path(path: Union[str, os.PathLike]) -> "PathMetadataValue":
         """Static constructor for a metadata value wrapping a path as
-        :py:class:`PathMetadataValue`. For example:
+        :py:class:`PathMetadataValue`.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "filepath": MetadataValue.path("path/to/file"),
-                    }
-                )
+                @op
+                def emit_metadata(context):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "filepath": MetadataValue.path("path/to/file"),
+                        }
+                    )
 
         Args:
             path (str): The path for a metadata entry.
@@ -286,18 +288,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     @staticmethod
     def notebook(path: Union[str, os.PathLike]) -> "NotebookMetadataValue":
         """Static constructor for a metadata value wrapping a notebook path as
-        :py:class:`NotebookMetadataValue`. For example:
+        :py:class:`NotebookMetadataValue`.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "notebook_path": MetadataValue.notebook("path/to/notebook.ipynb"),
-                    }
-                )
+                @op
+                def emit_metadata(context):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "notebook_path": MetadataValue.notebook("path/to/notebook.ipynb"),
+                        }
+                    )
 
         Args:
             path (str): The path to a notebook for a metadata entry.
@@ -309,19 +312,20 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def json(data: Union[Sequence[Any], Mapping[str, Any]]) -> "JsonMetadataValue":
         """Static constructor for a metadata value wrapping a json-serializable list or dict
         as :py:class:`JsonMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context):
-                yield ExpectationResult(
-                    success=not missing_things,
-                    label="is_present",
-                    metadata={
-                        "about my dataset": MetadataValue.json({"missing_columns": missing_things})
-                    },
-                )
+                @op
+                def emit_metadata(context):
+                    yield ExpectationResult(
+                        success=not missing_things,
+                        label="is_present",
+                        metadata={
+                            "about my dataset": MetadataValue.json({"missing_columns": missing_things})
+                        },
+                    )
 
         Args:
             data (Union[Sequence[Any], Mapping[str, Any]]): The JSON data for a metadata entry.
@@ -333,19 +337,20 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def md(data: str) -> "MarkdownMetadataValue":
         """Static constructor for a metadata value wrapping markdown data as
         :py:class:`MarkdownMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context, md_str):
-                yield AssetMaterialization(
-                    asset_key="info",
-                    metadata={
-                        'Details': MetadataValue.md(md_str)
-                    },
-                )
+                @op
+                def emit_metadata(context, md_str):
+                    yield AssetMaterialization(
+                        asset_key="info",
+                        metadata={
+                            'Details': MetadataValue.md(md_str)
+                        },
+                    )
 
         Args:
             md_str (str): The markdown for a metadata entry.
@@ -357,19 +362,20 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def python_artifact(python_artifact: Callable) -> "PythonArtifactMetadataValue":
         """Static constructor for a metadata value wrapping a python artifact as
         :py:class:`PythonArtifactMetadataValue`. Can be used as the value type for the
-        `metadata` parameter for supported events. For example:
+        `metadata` parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "class": MetadataValue.python_artifact(MyClass),
-                        "function": MetadataValue.python_artifact(my_function),
-                    }
-                )
+                @op
+                def emit_metadata(context, df):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "class": MetadataValue.python_artifact(MyClass),
+                            "function": MetadataValue.python_artifact(my_function),
+                        }
+                    )
 
         Args:
             value (Callable): The python class or function for a metadata entry.
@@ -382,18 +388,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def float(value: float) -> "FloatMetadataValue":
         """Static constructor for a metadata value wrapping a float as
         :py:class:`FloatMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "size (bytes)": MetadataValue.float(calculate_bytes(df)),
-                    }
-                )
+                @op
+                def emit_metadata(context, df):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "size (bytes)": MetadataValue.float(calculate_bytes(df)),
+                        }
+                    )
 
         Args:
             value (float): The float value for a metadata entry.
@@ -405,18 +412,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def int(value: int) -> "IntMetadataValue":
         """Static constructor for a metadata value wrapping an int as
         :py:class:`IntMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "number of rows": MetadataValue.int(len(df)),
-                    },
-                )
+                @op
+                def emit_metadata(context, df):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "number of rows": MetadataValue.int(len(df)),
+                        },
+                    )
 
         Args:
             value (int): The int value for a metadata entry.
@@ -428,18 +436,19 @@ class MetadataValue(ABC, Generic[T_Packable]):
     def bool(value: bool) -> "BoolMetadataValue":
         """Static constructor for a metadata value wrapping a bool as
         :py:class:`BoolMetadataValuye`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context, df):
-                yield AssetMaterialization(
-                    asset_key="my_dataset",
-                    metadata={
-                        "num rows > 1000": MetadataValue.bool(len(df) > 1000),
-                    },
-                )
+                @op
+                def emit_metadata(context, df):
+                    yield AssetMaterialization(
+                        asset_key="my_dataset",
+                        metadata={
+                            "num rows > 1000": MetadataValue.bool(len(df) > 1000),
+                        },
+                    )
 
         Args:
             value (bool): The bool value for a metadata entry.
@@ -490,30 +499,31 @@ class MetadataValue(ABC, Generic[T_Packable]):
     ) -> "TableMetadataValue":
         """Static constructor for a metadata value wrapping arbitrary tabular data as
         :py:class:`TableMetadataValue`. Can be used as the value type for the `metadata`
-        parameter for supported events. For example:
+        parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            @op
-            def emit_metadata(context):
-                yield ExpectationResult(
-                    success=not has_errors,
-                    label="is_valid",
-                    metadata={
-                        "errors": MetadataValue.table(
-                            records=[
-                                TableRecord(code="invalid-data-type", row=2, col="name"),
-                            ],
-                            schema=TableSchema(
-                                columns=[
-                                    TableColumn(name="code", type="string"),
-                                    TableColumn(name="row", type="int"),
-                                    TableColumn(name="col", type="string"),
-                                ]
-                            )
-                        ),
-                    },
-                )
+                @op
+                def emit_metadata(context):
+                    yield ExpectationResult(
+                        success=not has_errors,
+                        label="is_valid",
+                        metadata={
+                            "errors": MetadataValue.table(
+                                records=[
+                                    TableRecord(code="invalid-data-type", row=2, col="name"),
+                                ],
+                                schema=TableSchema(
+                                    columns=[
+                                        TableColumn(name="code", type="string"),
+                                        TableColumn(name="row", type="int"),
+                                        TableColumn(name="col", type="string"),
+                                    ]
+                                )
+                            ),
+                        },
+                    )
         """
         return TableMetadataValue(records, schema)
 
@@ -524,24 +534,25 @@ class MetadataValue(ABC, Generic[T_Packable]):
     ) -> "TableSchemaMetadataValue":
         """Static constructor for a metadata value wrapping a table schema as
         :py:class:`TableSchemaMetadataValue`. Can be used as the value type
-        for the `metadata` parameter for supported events. For example:
+        for the `metadata` parameter for supported events.
 
-        .. code-block:: python
+        Example:
+            .. code-block:: python
 
-            schema = TableSchema(
-                columns = [
-                    TableColumn(name="id", type="int"),
-                    TableColumn(name="status", type="bool"),
-                ]
-            )
+                schema = TableSchema(
+                    columns = [
+                        TableColumn(name="id", type="int"),
+                        TableColumn(name="status", type="bool"),
+                    ]
+                )
 
-            DagsterType(
-                type_check_fn=some_validation_fn,
-                name='MyTable',
-                metadata={
-                    'my_table_schema': MetadataValue.table_schema(schema),
-                }
-            )
+                DagsterType(
+                    type_check_fn=some_validation_fn,
+                    name='MyTable',
+                    metadata={
+                        'my_table_schema': MetadataValue.table_schema(schema),
+                    }
+                )
 
         Args:
             schema (TableSchema): The table schema for a metadata entry.

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -46,7 +46,9 @@ class TableSchema(
         ],
     )
 ):
-    """Representation of a schema for tabular data. Schema is composed of two parts:
+    """Representation of a schema for tabular data.
+
+    Schema is composed of two parts:
 
     - A required list of columns (`TableColumn`). Each column specifies a
       `name`, `type`, set of `constraints`, and (optional) `description`. `type`

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -610,7 +610,7 @@ class StaticPartitionMapping(
     @cached_method
     def _check_upstream(self, *, upstream_partitions_def: PartitionsDefinition):
         """
-        validate that the mapping from upstream to downstream is only defined on upstream keys
+        validate that the mapping from upstream to downstream is only defined on upstream keys.
         """
         check.inst(
             upstream_partitions_def,
@@ -627,7 +627,7 @@ class StaticPartitionMapping(
     @cached_method
     def _check_downstream(self, *, downstream_partitions_def: PartitionsDefinition):
         """
-        validate that the mapping from upstream to downstream only maps to downstream keys
+        validate that the mapping from upstream to downstream only maps to downstream keys.
         """
         check.inst(
             downstream_partitions_def,

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -393,7 +393,7 @@ def _process_and_validate_target(
     target: Union[GraphDefinition, PipelineDefinition, UnresolvedAssetJobDefinition],
 ):
     """
-    This function modifies the state of coerced_graphs, unresolved_jobs, and pipelines_or_jobs
+    This function modifies the state of coerced_graphs, unresolved_jobs, and pipelines_or_jobs.
     """
     targeter = (
         f"schedule '{schedule_or_sensor_def.name}'"

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -256,7 +256,7 @@ def submit_run_request(
     workspace: BaseWorkspaceRequestContext,
 ) -> None:
     """
-    Creates and submits a run for the given run request
+    Creates and submits a run for the given run request.
     """
     repo_handle = asset_graph.get_repository_handle(
         cast(Sequence[AssetKey], run_request.asset_selection)[0]

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -637,7 +637,7 @@ def build_input_context(
 
 
 class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
-    """For build_input_context when no PartitionsDefinition has been provided"""
+    """For build_input_context when no PartitionsDefinition has been provided."""
 
     def __init__(self, key_range: PartitionKeyRange):
         self._key_range = key_range

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -171,7 +171,7 @@ def submit_backfill_runs(
     backfill_job: PartitionBackfill,
     partition_names: Optional[Sequence[str]] = None,
 ) -> Iterable[Optional[str]]:
-    """Returns the run IDs of the submitted runs"""
+    """Returns the run IDs of the submitted runs."""
     origin = cast(ExternalPartitionSetOrigin, backfill_job.partition_set_origin)
 
     repository_origin = origin.external_repository_origin

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -431,7 +431,7 @@ class IWorkspaceProcessContext(ABC):
 
 class WorkspaceProcessContext(IWorkspaceProcessContext):
     """
-    This class is a process-scoped object that:
+    Process-scoped object that tracks the state of a workspace.
 
     1. Maintains an update-to-date dictionary of repository locations
     2. Creates a `WorkspaceRequestContext` to be the workspace for each request

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -152,8 +152,9 @@ def get_new_cursor(
     new_event_ids: Sequence[int],
 ) -> int:
     """
-    Return the new cursor value for an event type, or None if one shouldn't be persisted. The cursor
-    is guaranteed to be:
+    Return the new cursor value for an event type, or None if one shouldn't be persisted.
+
+    The cursor is guaranteed to be:
 
     - greater than or equal to any id in new_event_ids (otherwise we could process an event twice)
     - less than the id of any event of the desired type that hasn't been fetched yet (otherwise we

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -809,7 +809,7 @@ def copy_packed_set(
     as_type: Literal["__frozenset__", "__set__"],
 ) -> Mapping[str, Sequence[JsonSerializableValue]]:
     """
-    Returns a copy of the packed collection
+    Returns a copy of the packed collection.
     """
     if "__set__" in packed_set:
         return {as_type: packed_set["__set__"]}

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -62,7 +62,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def prefetch_asset_partition_counts(
         self, asset_keys: Sequence[AssetKey], after_cursor: Optional[int]
     ):
-        """For performance, batches together queries for selected assets"""
+        """For performance, batches together queries for selected assets."""
         self._asset_partition_count_cache[None] = dict(
             self.instance.get_materialization_count_by_partition(
                 asset_keys=asset_keys,
@@ -78,7 +78,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             )
 
     def prefetch_asset_records(self, asset_keys: Sequence[AssetKey]):
-        """For performance, batches together queries for selected assets"""
+        """For performance, batches together queries for selected assets."""
         # get all asset records for the selected assets
         asset_records = self.instance.get_asset_records(asset_keys)
         for asset_record in asset_records:

--- a/python_modules/dagster/dagster/_utils/tags.py
+++ b/python_modules/dagster/dagster/_utils/tags.py
@@ -6,7 +6,7 @@ from dagster import _check as check
 
 class TagConcurrencyLimitsCounter:
     """
-    Helper object that keeps track of when the tag concurrency limits are met
+    Helper object that keeps track of when the tag concurrency limits are met.
     """
 
     _key_limits: Dict[str, int]
@@ -46,7 +46,7 @@ class TagConcurrencyLimitsCounter:
 
     def is_blocked(self, item):
         """
-        True if there are in progress item which are blocking this item based on tag limits
+        True if there are in progress item which are blocking this item based on tag limits.
         """
         for key, value in item.tags.items():
             if key in self._key_limits and self._key_counts[key] >= self._key_limits[key]:
@@ -69,7 +69,7 @@ class TagConcurrencyLimitsCounter:
 
     def update_counters_with_launched_item(self, item):
         """
-        Add a new in progress item to the counters
+        Add a new in progress item to the counters.
         """
         for key, value in item.tags.items():
             if key in self._key_limits:

--- a/python_modules/dagster/dagster/_utils/timing.py
+++ b/python_modules/dagster/dagster/_utils/timing.py
@@ -56,17 +56,19 @@ class TimerResult:
 
 @contextmanager
 def time_execution_scope():
-    """Usage:
+    """Context manager that times the execution of a block of code.
 
-    from solid_util.timing import time_execution_scope
-    with time_execution_scope() as timer_result:
-        do_some_operation()
+    Example:
+    ..code-block::
+        from solid_util.timing import time_execution_scope
+        with time_execution_scope() as timer_result:
+            do_some_operation()
 
-    print(
-        'do_some_operation took {timer_result.millis} milliseconds'.format(
-            timer_result=timer_result
+        print(
+            'do_some_operation took {timer_result.millis} milliseconds'.format(
+                timer_result=timer_result
+            )
         )
-    )
     """
     timer_result = TimerResult()
     yield timer_result

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_group.py
@@ -76,6 +76,8 @@ def asset_aware_io_manager():
 
 def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
     """
+    Get a predefined set of assets definitions for testing.
+
     Dependencies:
         "upstream": {
             "start": set(),
@@ -436,10 +438,12 @@ def test_subset_does_not_respect_context():
 def test_subset_cycle_resolution_embed_assets_in_complex_graph():
     """
     This represents a single large multi-asset with two assets embedded inside of it.
+
     Ops:
         foo produces: a, b, c, d, e, f, g, h
         x produces: x
         y produces: y
+
     Upstream Assets:
         a: []
         b: []
@@ -450,7 +454,7 @@ def test_subset_cycle_resolution_embed_assets_in_complex_graph():
         g: [e]
         h: [g, y]
         x: [a]
-        y: [e, f]
+        y: [e, f].
     """
     io_manager_obj, io_manager_def = asset_aware_io_manager()
     for item in "abcdefghxy":
@@ -517,11 +521,14 @@ def test_subset_cycle_resolution_embed_assets_in_complex_graph():
 
 def test_subset_cycle_resolution_complex():
     """
+    Test cycle resolution.
+
     Ops:
         foo produces: a, b, c, d, e, f
         x produces: x
         y produces: y
         z produces: z
+
     Upstream Assets:
         a: []
         b: [x]
@@ -530,7 +537,7 @@ def test_subset_cycle_resolution_complex():
         e: [c]
         f: [d]
         x: [a]
-        y: [b, c]
+        y: [b, c].
     """
     io_manager_obj, io_manager_def = asset_aware_io_manager()
     for item in "abcdefxy":
@@ -590,7 +597,7 @@ def test_subset_cycle_resolution_basic():
         foo produces: a, b
         foo_prime produces: a', b'
     Assets:
-        s -> a -> a' -> b -> b'
+        s -> a -> a' -> b -> b'.
     """
     io_manager_obj, io_manager_def = asset_aware_io_manager()
     for item in "a,b,a_prime,b_prime".split(","):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -176,7 +176,7 @@ def test_prefix(prefix):
 )
 def test_load_assets_cacheable(load_fn, prefix):
     """
-    Tests the load-from-module and load-from-package-name functinos with cacheable assets
+    Tests the load-from-module and load-from-package-name functinos with cacheable assets.
     """
     from . import asset_package_with_cacheable
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -66,6 +66,8 @@ def asset_aware_io_manager():
 
 def _get_assets_defs(use_multi: bool = False, allow_subset: bool = False):
     """
+    Get a predefined set of assets for testing.
+
     Dependencies:
         "upstream": {
             "start": set(),

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -375,7 +375,7 @@ def test_basic_multi_asset():
         }
     )
     def assets():
-        """Some docstring for this operation"""
+        """Some docstring for this operation."""
         pass
 
     assets_job = build_assets_job("assets_job", [assets])

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -324,7 +324,7 @@ def test_io_manager_factory_class():
         a_config_value: str
 
         def create_io_manager(self, _) -> IOManager:
-            """Implement as one would implement a @io_manager decorator function"""
+            """Implement as one would implement a @io_manager decorator function."""
             return AnIOManagerImplementation(self.a_config_value)
 
     executed = {}

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -73,7 +73,7 @@ def test_repository_snap_definitions_resources_basic():
 
 def test_repository_snap_definitions_resources_complex():
     class MyStringResource(ConfigurableResource):
-        """my description"""
+        """My description."""
 
         my_string: str = "bar"
 
@@ -98,7 +98,7 @@ def test_repository_snap_definitions_resources_complex():
     assert external_repo_data.external_resource_data[0].resource_snapshot.name == "foo"
     assert (
         external_repo_data.external_resource_data[0].resource_snapshot.description
-        == "my description"
+        == "My description."
     )
 
     # Ensure we get config snaps for the resource's fields

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_descriptions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_descriptions.py
@@ -11,7 +11,7 @@ def test_new_config_descriptions_and_defaults():
 
     class AnOpConfig(Config):
         """
-        Config for my new op
+        Config for my new op.
         """
 
         a_string: str = Field(description="A string")
@@ -24,7 +24,7 @@ def test_new_config_descriptions_and_defaults():
     # test fields are inferred correctly
     assert a_new_config_op.config_schema.config_type.kind == ConfigTypeKind.STRICT_SHAPE
     assert list(a_new_config_op.config_schema.config_type.fields.keys()) == ["a_string", "nested"]
-    assert a_new_config_op.config_schema.description == "Config for my new op"
+    assert a_new_config_op.config_schema.description == "Config for my new op."
     assert a_new_config_op.config_schema.config_type.fields["a_string"].description == "A string"
     assert (
         a_new_config_op.config_schema.config_type.fields["nested"].description == "A nested config"

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor_perf.py
@@ -45,7 +45,7 @@ class RandomAssets(NamedTuple):
     def get_definitions(
         self, freshness_ids: AbstractSet[int] = frozenset()
     ) -> Tuple[Sequence[SourceAsset], Sequence[AssetsDefinition], AssetsDefinition]:
-        """Builds a random set of assets based on the given parameters"""
+        """Builds a random set of assets based on the given parameters."""
         random.seed(11235711)
 
         deps = {

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -111,7 +111,7 @@ def test_out():
         """
         Returns:
             int: some int
-        """
+        """  # noqa: D415
         return 1
 
     assert my_op.outs == {
@@ -144,10 +144,6 @@ def test_multi_out():
         }
     )
     def my_op() -> Tuple[int, str]:
-        """
-        Returns:
-            Tuple[int, str]: A tuple of values
-        """
         return 1, "q"
 
     assert len(my_op.output_defs) == 2

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -86,11 +86,11 @@ def test_schedule_decorators_sanity():
 
     @schedule(cron_schedule="* * * * *", job_name="foo_job")
     def foo_schedule():
-        """Fake doc block"""
+        """Fake doc block."""
         return {}
 
     # Ensure that schedule definition inherits properties from wrapped fxn
-    assert foo_schedule.__doc__ == """Fake doc block"""
+    assert foo_schedule.__doc__ == """Fake doc block."""
 
     assert not foo_schedule.execution_timezone
 

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_branching_io_manager.py
@@ -114,7 +114,7 @@ def test_write_alternative_branch_metadata_key():
 
 def test_basic_workflow():
     """
-    In this test we are going to iterate on an asset in the middle of a graph
+    In this test we are going to iterate on an asset in the middle of a graph.
 
     now_time --> now_time_plus_N --> now_time_plus_20_after_plus_N
 

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -17,7 +17,7 @@ from dagster._core.events import DagsterEventType
 
 class DefinitionsRunner:
     """Helper class for running asset-oriented tests. Handles threading
-    through the instance for you (this is easy to forget to do)
+    through the instance for you (this is easy to forget to do).
     """
 
     def __init__(self, defs: Definitions, instance: DagsterInstance):

--- a/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
@@ -417,7 +417,7 @@ def test_input_manager_with_assets():
 
 def test_input_manager_with_assets_no_default_io_manager():
     """Tests loading an upstream asset with an input manager when the downstream asset also uses a
-    custom io manager. Fixes a bug where dagster expected the io_manager key to be provided
+    custom io manager. Fixes a bug where dagster expected the io_manager key to be provided.
     """
 
     @asset
@@ -454,7 +454,7 @@ def test_input_manager_with_assets_no_default_io_manager():
 
 def test_input_manager_with_assets_and_config():
     """Tests that the correct config is passed to the io manager when using input_manager_key.
-    Fixes a bug when the config for the default io manager was passed to the input_manager_key io manager
+    Fixes a bug when the config for the default io manager was passed to the input_manager_key io manager.
     """
 
     @asset

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -26,7 +26,7 @@ def _build_asset_dependencies(
     task_ids_by_asset_key: Mapping[AssetKey, AbstractSet[str]],
     upstream_dependencies_by_asset_key: Mapping[AssetKey, AbstractSet[AssetKey]],
 ) -> Tuple[AbstractSet[OutputMapping], Mapping[str, AssetKey], Mapping[str, Set[AssetKey]]]:
-    """Builds the asset dependency graph for a given set of airflow task mappings and a dagster graph
+    """Builds the asset dependency graph for a given set of airflow task mappings and a dagster graph.
     """
     output_mappings = set()
     keys_by_output_name = {}
@@ -36,8 +36,8 @@ def _build_asset_dependencies(
     upstream_deps = set()
 
     def find_upstream_dependency(node_name: str) -> None:
-        """find_upstream_dependency uses Depth-Firs-Search to find all upstream asset dependencies
-        as described in task_ids_by_asset_key
+        """Uses Depth-Firs-Search to find all upstream asset dependencies
+        as described in task_ids_by_asset_key.
         """
         # node has been visited
         if visited_nodes[node_name]:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -262,6 +262,8 @@ def get_current_ecs_task_metadata() -> CurrentEcsTaskMetadata:
 
 def _container_metadata_uri():
     """
+    Get the metadata uri for the current ECS task.
+
     ECS injects an environment variable into each Fargate task. The value
     of this environment variable is a url that can be queried to introspect
     information about the current processes's running task:

--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -273,7 +273,9 @@ class FakeRedshiftResource(_BaseRedshiftResource):
 
 
 def define_redshift_config():
-    """Redshift configuration. See the Redshift documentation for reference:
+    """Redshift configuration.
+
+    See the Redshift documentation for reference:
 
     https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-to-cluster.html
     """

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/redshift_tests/test_resources.py
@@ -137,6 +137,8 @@ LIMIT 1;
 )
 def test_live_redshift(s3_bucket):
     """
+    Test live redshift instance.
+
     This test is based on:
 
     https://aws.amazon.com/premiumsupport/knowledge-center/redshift-stl-load-errors/

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -203,7 +203,12 @@ class DatabricksClient:
 
 
 class DatabricksJobRunner:
-    """Submits jobs created using Dagster config to Databricks, and monitors their progress."""
+    """Submits jobs created using Dagster config to Databricks, and monitors their progress.
+
+    Attributes:
+        host (str): Databricks host, e.g. https://uksouth.azuredatabricks.net
+        token (str): Databricks token
+    """
 
     def __init__(
         self,
@@ -212,11 +217,6 @@ class DatabricksJobRunner:
         poll_interval_sec: float = 5,
         max_wait_time_sec: int = DEFAULT_RUN_MAX_WAIT_TIME_SEC,
     ):
-        """Args:
-
-        host (str): Databricks host, e.g. https://uksouth.azuredatabricks.net
-        token (str): Databricks token
-        """
         self.host = check.str_param(host, "host")
         self.token = check.str_param(token, "token")
         self.poll_interval_sec = check.numeric_param(poll_interval_sec, "poll_interval_sec")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -105,8 +105,9 @@ def _can_stream_events(dbt_resource: DbtCliResource) -> bool:
 
 
 def _get_node_asset_key(node_info: Mapping[str, Any]) -> AssetKey:
-    """By default:
+    """Get the asset key for a dbt node.
 
+    By default:
         dbt sources: a dbt source's key is the union of its source name and its table name
         dbt models: a dbt model's key is the union of its model name and any schema configured on
     the model itself.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -19,8 +19,10 @@ from .utils import (
 
 class DbtCliResource(DbtResource):
     """
-    A resource that allows you to execute dbt cli commands. For the most up-to-date documentation on
-    the specific parameters available to you for each command, check out the dbt docs:
+    A resource that allows you to execute dbt cli commands.
+
+    For the most up-to-date documentation on the specific parameters available to you for each
+    command, check out the dbt docs:
 
     https://docs.getdbt.com/reference/commands/run
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_selection.py
@@ -10,7 +10,7 @@ from dagster_dbt.asset_defs import load_assets_from_dbt_manifest
 
 
 def get_previous_state_path():
-    """Make sure we're providing a compatible previous manifest.json object"""
+    """Make sure we're providing a compatible previous manifest.json object."""
     import dbt.version
     from packaging import version
 
@@ -102,7 +102,8 @@ def test_dbt_asset_selection(select, exclude, expected_asset_names):
 
 
 def test_dbt_asset_selection_with_state():
-    """Changes from previous state to sample_manifest.json:
+    """Changes from previous state to sample_manifest.json.
+
     - sort_cold_cereals_by_calories has an updated definition
     - added subdir/least_caloric
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -118,9 +118,10 @@ def _define_shared_fields():
 
 
 def define_bigquery_query_config():
-    """See:
+    """Config schema for BigQuery.
 
-    https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.job.QueryJobConfig.html
+    See:
+        https://googleapis.github.io/google-cloud-python/latest/bigquery/generated/google.cloud.bigquery.job.QueryJobConfig.html
     """
     sf = _define_shared_fields()
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -154,7 +154,7 @@ def build_bigquery_io_manager(
         }
     )
     def bigquery_io_manager(init_context):
-        """I/O Manager for storing outputs in a BigQuery database
+        """I/O Manager for storing outputs in a BigQuery database.
 
         Assets will be stored in the dataset and table name specified by their AssetKey.
         Subsequent materializations of an asset will overwrite previous materializations of that asset.

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -137,10 +137,12 @@ class DataprocResource:
 
     @contextmanager
     def cluster_context_manager(self):
-        """This context manager gives syntactic sugar so you can run:
+        """Context manager allowing execution with a dataproc cluster.
 
-        with context.resources.dataproc.cluster as cluster:
-            # do stuff...
+        Example:
+        .. code-block::
+            with context.resources.dataproc.cluster as cluster:
+                # do stuff...
         """
         self.create_cluster()
         try:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -632,7 +632,7 @@ def construct_dagster_k8s_job(
     labels: Optional[Mapping[str, str]] = None,
     env_vars: Optional[Sequence[Mapping[str, Any]]] = None,
 ) -> kubernetes.client.V1Job:
-    """Constructs a Kubernetes Job object
+    """Constructs a Kubernetes Job object.
 
     Args:
         job_config: Job configuration to use for constructing the Kubernetes

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/test.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/test.py
@@ -9,6 +9,7 @@ def wait_for_job_and_get_raw_logs(
     """
     Wait for a dagster-k8s job to complete, ensure it launched only one pod,
     and then grab the logs from the pod it launched.
+
     wait_timeout: default 5 minutes
     """
     client = DagsterKubernetesClient.production_client()

--- a/python_modules/libraries/dagster-spark/dagster_spark/utils.py
+++ b/python_modules/libraries/dagster-spark/dagster_spark/utils.py
@@ -28,7 +28,9 @@ def flatten_dict(d):
 
 
 def parse_spark_config(spark_conf):
-    """For each key-value pair in spark conf, we need to pass to CLI in format:
+    """Convert spark conf dict to list of CLI arguments.
+
+    For each key-value pair in spark conf, we need to pass to CLI in format:
 
     --conf "key=value"
     """

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -77,7 +77,7 @@ class Config(TypedDict):
 
 
 class WandbArtifactsIOManagerError(Exception):
-    """Represents an execution error of the W&B Artifacts IO Manager"""
+    """Represents an execution error of the W&B Artifacts IO Manager."""
 
     def __init__(self, message="A W&B Artifacts IO Manager error occurred."):
         self.message = message


### PR DESCRIPTION
## Summary & Motivation

Turns on Ruff `D415` docstring header punctuation (required by Google-style docstrings). This was supposed to be turned on in the past (see https://github.com/dagster-io/dagster/pull/11001) but I had not finished correcting the old violations in part because IIRC the autofix at the time was bugged for some cases. Autofix works well now so we can have this on, ensuring docstrings shown in docs and LSP service are well-formatted, with little-to-no additional effort required for devs.

In a few cases I had to add a suitable header docstring if the existing one wasn't a summary.

---

## How I Tested These Changes

BK
