### PR TITLE
[Multipartitions w/ dynamic dimension 2/2] Cache dynamic partitions status

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -16,12 +16,10 @@ from dagster._core.host_representation.external_data import (
     ExternalAssetDependency,
     ExternalAssetNode,
 )
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorType
 from dagster._core.storage.pipeline_run import JobBucket, RunRecord, RunsFilter, TagBucket
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG, SCHEDULE_NAME_TAG, SENSOR_NAME_TAG
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._utils.cached_method import cached_method
 
 
 class RepositoryDataType(Enum):
@@ -326,19 +324,6 @@ class BatchMaterializationLoader:
             record.asset_entry.asset_key: record.asset_entry.last_materialization
             for record in self._instance.get_asset_records(self._asset_keys)
         }
-
-
-class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
-    """A batch loader that caches the partition keys for a given dynamic partitions definition,
-    to avoid repeated calls to the database for the same partitions definition.
-    """
-
-    def __init__(self, instance: DagsterInstance):
-        self._instance = instance
-
-    @cached_method
-    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
-        return self._instance.get_dynamic_partitions(partitions_def_name)
 
 
 class CrossRepoAssetDependedByLoader:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -11,6 +11,7 @@ from dagster._core.definitions.data_version import (
     StaleStatus,
 )
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType
@@ -53,7 +54,6 @@ from ..implementation.fetch_assets import (
 )
 from ..implementation.loader import (
     BatchMaterializationLoader,
-    CachingDynamicPartitionsLoader,
     CrossRepoAssetDependedByLoader,
     StaleStatusLoader,
 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -7,6 +7,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.host_representation import (
     CodeLocation,
     ExternalRepository,
@@ -29,7 +30,6 @@ from dagster._core.workspace.workspace import (
 
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
 from dagster_graphql.implementation.loader import (
-    CachingDynamicPartitionsLoader,
     RepositoryScopedBatchLoader,
     StaleStatusLoader,
 )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -4,6 +4,7 @@ import dagster._check as check
 import graphene
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.selector import (
     InstigatorSelector,
     RepositorySelector,
@@ -64,7 +65,6 @@ from ...implementation.fetch_sensors import get_sensor_or_error, get_sensors_or_
 from ...implementation.fetch_solids import get_graph_or_error
 from ...implementation.loader import (
     BatchMaterializationLoader,
-    CachingDynamicPartitionsLoader,
     CrossRepoAssetDependedByLoader,
     StaleStatusLoader,
 )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -1886,11 +1886,14 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
             "dynamic_in_multipartitions_success_job",
             MultiPartitionKey({"dynamic": "1", "static": "a"}),
         )
+        traced_counter.set(Counter())
         result = execute_dagster_graphql(
             graphql_context,
             GET_2D_ASSET_PARTITIONS,
             variables={"pipelineSelector": selector},
         )
+        counts = traced_counter.get().counts()
+        assert counts.get("DagsterInstance.get_dynamic_partitions") == 1
 
         assert result.data
         assert result.data["assetNodes"]

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -70,14 +70,18 @@ class AssetGraphSubset:
                 partitions_subset is not None and asset_partition.partition_key in partitions_subset
             )
 
-    def to_storage_dict(self) -> Mapping[str, object]:
+    def to_storage_dict(
+        self, dynamic_partitions_store: DynamicPartitionsStore
+    ) -> Mapping[str, object]:
         return {
             "partitions_subsets_by_asset_key": {
                 key.to_user_string(): value.serialize()
                 for key, value in self.partitions_subsets_by_asset_key.items()
             },
             "serializable_partitions_def_ids_by_asset_key": {
-                key.to_user_string(): value.partitions_def.serializable_unique_identifier
+                key.to_user_string(): value.partitions_def.get_serializable_unique_identifier(
+                    dynamic_partitions_store=dynamic_partitions_store
+                )
                 for key, value in self.partitions_subsets_by_asset_key.items()
             },
             "partitions_def_class_names_by_asset_key": {

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -34,12 +34,13 @@ import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.target import ExecutableDefinition
-from dagster._core.instance import DynamicPartitionsStore
+from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._serdes import whitelist_for_serdes
 from dagster._seven.compat.pendulum import PendulumDateTime, to_timezone
 from dagster._utils import frozenlist
 from dagster._utils.backcompat import deprecation_warning, experimental_arg_warning
+from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 from dagster._utils.schedules import schedule_execution_time_iterator
 
@@ -347,9 +348,14 @@ class PartitionsDefinition(ABC, Generic[T_cov]):
             serialized_partitions_def_class_name,
         )
 
-    @property
-    def serializable_unique_identifier(self) -> str:
-        return hashlib.sha1(json.dumps(self.get_partition_keys()).encode("utf-8")).hexdigest()
+    def get_serializable_unique_identifier(
+        self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
+    ) -> str:
+        return hashlib.sha1(
+            json.dumps(
+                self.get_partition_keys(dynamic_partitions_store=dynamic_partitions_store)
+            ).encode("utf-8")
+        ).hexdigest()
 
     def get_tags_for_partition_key(self, partition_key: str) -> Mapping[str, str]:
         tags = {PARTITION_NAME_TAG: partition_key}
@@ -568,6 +574,19 @@ class ScheduleTimeBasedPartitionsDefinition(
             check.assert_never(self.schedule_type)
 
 
+class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
+    """A batch loader that caches the partition keys for a given dynamic partitions definition,
+    to avoid repeated calls to the database for the same partitions definition.
+    """
+
+    def __init__(self, instance: DagsterInstance):
+        self._instance = instance
+
+    @cached_method
+    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+        return self._instance.get_dynamic_partitions(partitions_def_name)
+
+
 class DynamicPartitionsDefinition(
     PartitionsDefinition,
     NamedTuple(
@@ -667,13 +686,6 @@ class DynamicPartitionsDefinition(
             return f'Dynamic partitions: "{self._validated_name()}"'
         else:
             return super().__str__()
-
-    @property
-    def serializable_unique_identifier(self) -> str:
-        if not self.name:
-            return super().serializable_unique_identifier
-
-        return hashlib.sha1(self.__repr__().encode("utf-8")).hexdigest()
 
     def get_partitions(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -683,8 +683,9 @@ class TimeWindowPartitionsDefinition(
         except ValueError:
             return False
 
-    @property
-    def serializable_unique_identifier(self) -> str:
+    def get_serializable_unique_identifier(
+        self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
+    ) -> str:
         return hashlib.sha1(self.__repr__().encode("utf-8")).hexdigest()
 
 
@@ -1461,7 +1462,8 @@ class TimeWindowPartitionsSubset(PartitionsSubset):
 
         if serialized_partitions_def_unique_id:
             return (
-                partitions_def.serializable_unique_identifier == serialized_partitions_def_unique_id
+                partitions_def.get_serializable_unique_identifier()
+                == serialized_partitions_def_unique_id
             )
 
         data = json.loads(serialized)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -186,14 +186,22 @@ class AssetBackfillData(NamedTuple):
 
         return cls.empty(target_subset)
 
-    def serialize(self) -> str:
+    def serialize(self, dynamic_partitions_store: DynamicPartitionsStore) -> str:
         storage_dict = {
             "requested_runs_for_target_roots": self.requested_runs_for_target_roots,
-            "serialized_target_subset": self.target_subset.to_storage_dict(),
+            "serialized_target_subset": self.target_subset.to_storage_dict(
+                dynamic_partitions_store=dynamic_partitions_store
+            ),
             "latest_storage_id": self.latest_storage_id,
-            "serialized_requested_subset": self.requested_subset.to_storage_dict(),
-            "serialized_materialized_subset": self.materialized_subset.to_storage_dict(),
-            "serialized_failed_subset": self.failed_and_downstream_subset.to_storage_dict(),
+            "serialized_requested_subset": self.requested_subset.to_storage_dict(
+                dynamic_partitions_store=dynamic_partitions_store
+            ),
+            "serialized_materialized_subset": self.materialized_subset.to_storage_dict(
+                dynamic_partitions_store=dynamic_partitions_store
+            ),
+            "serialized_failed_subset": self.failed_and_downstream_subset.to_storage_dict(
+                dynamic_partitions_store=dynamic_partitions_store
+            ),
         }
         return json.dumps(storage_dict)
 
@@ -233,7 +241,9 @@ def execute_asset_backfill_iteration(
             " AssetBackfillIterationResult"
         )
 
-    updated_backfill = backfill.with_asset_backfill_data(result.backfill_data)
+    updated_backfill = backfill.with_asset_backfill_data(
+        result.backfill_data, dynamic_partitions_store=instance
+    )
     if result.backfill_data.is_complete():
         updated_backfill = updated_backfill.with_status(BulkActionStatus.COMPLETED)
 

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -237,7 +237,9 @@ class PartitionBackfill(
         )
 
     def with_asset_backfill_data(
-        self, asset_backfill_data: AssetBackfillData
+        self,
+        asset_backfill_data: AssetBackfillData,
+        dynamic_partitions_store: DynamicPartitionsStore,
     ) -> "PartitionBackfill":
         return PartitionBackfill(
             status=self.status,
@@ -251,7 +253,9 @@ class PartitionBackfill(
             last_submitted_partition_name=self.last_submitted_partition_name,
             error=self.error,
             asset_selection=self.asset_selection,
-            serialized_asset_backfill_data=asset_backfill_data.serialize(),
+            serialized_asset_backfill_data=asset_backfill_data.serialize(
+                dynamic_partitions_store=dynamic_partitions_store
+            ),
         )
 
     @classmethod
@@ -285,5 +289,5 @@ class PartitionBackfill(
                 partition_names=partition_names,
                 asset_selection=asset_selection,
                 dynamic_partitions_store=dynamic_partitions_store,
-            ).serialize(),
+            ).serialize(dynamic_partitions_store=dynamic_partitions_store),
         )

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -34,16 +34,22 @@ CACHEABLE_PARTITION_TYPES = (
     TimeWindowPartitionsDefinition,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
+    DynamicPartitionsDefinition,
 )
 
 
-def can_cache_partition_type(partitions_def: PartitionsDefinition) -> bool:
-    return isinstance(partitions_def, CACHEABLE_PARTITION_TYPES) and (
-        not any(
-            isinstance(dim.partitions_def, DynamicPartitionsDefinition)
-            for dim in partitions_def.partitions_defs
+def is_cacheable_partition_type(partitions_def: PartitionsDefinition) -> bool:
+    check.inst_param(partitions_def, "partitions_def", PartitionsDefinition)
+    if not isinstance(partitions_def, CACHEABLE_PARTITION_TYPES):
+        return False
+    if isinstance(partitions_def, MultiPartitionsDefinition):
+        return all(
+            is_cacheable_partition_type(dimension_def.partitions_def)
+            for dimension_def in partitions_def.partitions_defs
         )
-        if isinstance(partitions_def, MultiPartitionsDefinition)
+    return (
+        partitions_def.name is not None
+        if isinstance(partitions_def, DynamicPartitionsDefinition)
         else True
     )
 
@@ -205,11 +211,12 @@ def _build_status_cache(
     asset_key: AssetKey,
     latest_storage_id: int,
     partitions_def: Optional[PartitionsDefinition],
+    dynamic_partitions_store: DynamicPartitionsStore,
 ) -> AssetStatusCacheValue:
     """This method refreshes the asset status cache for a given asset key. It recalculates
     the materialized partition subset for the asset key and updates the cache value.
     """
-    if not partitions_def or not can_cache_partition_type(partitions_def):
+    if not partitions_def or not is_cacheable_partition_type(partitions_def):
         return AssetStatusCacheValue(latest_storage_id=latest_storage_id)
 
     materialized_keys: Sequence[str]
@@ -228,15 +235,21 @@ def _build_status_cache(
 
     serialized_materialized_partition_subset = (
         serialized_materialized_partition_subset.with_partition_keys(
-            get_validated_partition_keys(instance, partitions_def, set(materialized_keys))
+            get_validated_partition_keys(
+                dynamic_partitions_store, partitions_def, set(materialized_keys)
+            )
         )
     )
 
-    failed_subset, cursor = _build_failed_partition_subset(instance, asset_key, partitions_def)
+    failed_subset, cursor = _build_failed_partition_subset(
+        instance, asset_key, partitions_def, dynamic_partitions_store
+    )
 
     return AssetStatusCacheValue(
         latest_storage_id=latest_storage_id,
-        partitions_def_id=partitions_def.serializable_unique_identifier,
+        partitions_def_id=partitions_def.get_serializable_unique_identifier(
+            dynamic_partitions_store=dynamic_partitions_store
+        ),
         serialized_materialized_partition_subset=serialized_materialized_partition_subset.serialize(),
         serialized_failed_partition_subset=failed_subset.serialize(),
         earliest_in_progress_materialization_event_id=cursor,
@@ -244,7 +257,10 @@ def _build_status_cache(
 
 
 def _build_failed_partition_subset(
-    instance: DagsterInstance, asset_key: AssetKey, partitions_def: PartitionsDefinition
+    instance: DagsterInstance,
+    asset_key: AssetKey,
+    partitions_def: PartitionsDefinition,
+    dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Tuple[PartitionsSubset, Optional[int]]:
     incomplete_materializations = instance.event_log_storage.get_latest_asset_partition_materialization_attempts_without_materializations(
         asset_key
@@ -277,7 +293,9 @@ def _build_failed_partition_subset(
 
     return (
         partitions_def.empty_subset().with_partition_keys(
-            get_validated_partition_keys(instance, partitions_def, new_failed_partitions)
+            get_validated_partition_keys(
+                dynamic_partitions_store, partitions_def, new_failed_partitions
+            )
         )
         if new_failed_partitions
         else partitions_def.empty_subset(),
@@ -291,6 +309,7 @@ def _get_updated_failed_partition_subset(
     partitions_def: PartitionsDefinition,
     current_cached_subset: PartitionsSubset,
     unevaluated_event_records: Sequence[EventLogRecord],
+    dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Tuple[PartitionsSubset, Optional[int]]:
     current_failed_partitions = set(current_cached_subset.get_partition_keys())
 
@@ -348,6 +367,7 @@ def _get_updated_status_cache(
     asset_key: AssetKey,
     current_status_cache_value: AssetStatusCacheValue,
     partitions_def: Optional[PartitionsDefinition],
+    dynamic_partitions_store: DynamicPartitionsStore,
 ) -> AssetStatusCacheValue:
     """This method accepts the current asset status cache value, and fetches unevaluated
     records from the event log. It then updates the cache value with the new materializations.
@@ -382,12 +402,14 @@ def _get_updated_status_cache(
     unevaluated_event_records.extend(list(unevaluated_materialization_event_records))
 
     latest_storage_id = max([record.storage_id for record in unevaluated_event_records])
-    if not partitions_def or not can_cache_partition_type(partitions_def):
+    if not partitions_def or not is_cacheable_partition_type(partitions_def):
         return AssetStatusCacheValue(latest_storage_id=latest_storage_id)
 
     check.invariant(
         current_status_cache_value.partitions_def_id
-        == partitions_def.serializable_unique_identifier
+        == partitions_def.get_serializable_unique_identifier(
+            dynamic_partitions_store=dynamic_partitions_store
+        )
     )
     materialized_subset: PartitionsSubset = (
         partitions_def.deserialize_subset(
@@ -410,7 +432,9 @@ def _get_updated_status_cache(
             check.failed("Expected materialization or materialization planned event")
 
     materialized_subset = materialized_subset.with_partition_keys(
-        get_validated_partition_keys(instance, partitions_def, newly_materialized_partitions)
+        get_validated_partition_keys(
+            dynamic_partitions_store, partitions_def, newly_materialized_partitions
+        )
     )
 
     failed_subset: PartitionsSubset = (
@@ -428,6 +452,7 @@ def _get_updated_status_cache(
         partitions_def,
         failed_subset,
         unevaluated_event_records,
+        dynamic_partitions_store=dynamic_partitions_store,
     )
 
     return AssetStatusCacheValue(
@@ -456,13 +481,18 @@ def _fetch_stored_asset_status_cache_value(
 def _get_fresh_asset_status_cache_value(
     instance: DagsterInstance,
     asset_key: AssetKey,
+    dynamic_partitions_store: DynamicPartitionsStore,
     partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Optional[AssetStatusCacheValue]:
     cached_status_data = _fetch_stored_asset_status_cache_value(instance, asset_key)
 
     updated_cache_value = None
     if cached_status_data is None or cached_status_data.partitions_def_id != (
-        partitions_def.serializable_unique_identifier if partitions_def else None
+        partitions_def.get_serializable_unique_identifier(
+            dynamic_partitions_store=dynamic_partitions_store
+        )
+        if partitions_def
+        else None
     ):
         planned_event_records = instance.get_event_records(
             event_records_filter=EventRecordsFilter(
@@ -491,6 +521,7 @@ def _get_fresh_asset_status_cache_value(
                 asset_key=asset_key,
                 partitions_def=partitions_def,
                 latest_storage_id=latest_storage_id,
+                dynamic_partitions_store=dynamic_partitions_store,
             )
     else:
         updated_cache_value = _get_updated_status_cache(
@@ -498,6 +529,7 @@ def _get_fresh_asset_status_cache_value(
             asset_key=asset_key,
             partitions_def=partitions_def,
             current_status_cache_value=cached_status_data,
+            dynamic_partitions_store=dynamic_partitions_store,
         )
 
     return updated_cache_value
@@ -507,8 +539,16 @@ def get_and_update_asset_status_cache_value(
     instance: DagsterInstance,
     asset_key: AssetKey,
     partitions_def: Optional[PartitionsDefinition] = None,
+    dynamic_partitions_loader: Optional[DynamicPartitionsStore] = None,
 ) -> Optional[AssetStatusCacheValue]:
-    updated_cache_value = _get_fresh_asset_status_cache_value(instance, asset_key, partitions_def)
+    updated_cache_value = _get_fresh_asset_status_cache_value(
+        instance=instance,
+        asset_key=asset_key,
+        partitions_def=partitions_def,
+        dynamic_partitions_store=dynamic_partitions_loader
+        if dynamic_partitions_loader
+        else instance,
+    )
     if updated_cache_value:
         instance.update_asset_cached_status_data(asset_key, updated_cache_value)
 

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -18,6 +18,7 @@ from dagster._core.definitions.partition import (
     ScheduleTimeBasedPartitionsDefinition,
     ScheduleType,
 )
+from dagster._core.test_utils import instance_for_test
 from dagster._seven.compat.pendulum import create_pendulum_time
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITH_TIMEZONE
 
@@ -771,13 +772,23 @@ def test_static_partition_keys_in_range():
 
 def test_unique_identifier():
     assert (
-        StaticPartitionsDefinition(["a", "b", "c"]).serializable_unique_identifier
-        != StaticPartitionsDefinition(["a", "b"]).serializable_unique_identifier
+        StaticPartitionsDefinition(["a", "b", "c"]).get_serializable_unique_identifier()
+        != StaticPartitionsDefinition(["a", "b"]).get_serializable_unique_identifier()
     )
     assert (
-        StaticPartitionsDefinition(["a", "b", "c"]).serializable_unique_identifier
-        == StaticPartitionsDefinition(["a", "b", "c"]).serializable_unique_identifier
+        StaticPartitionsDefinition(["a", "b", "c"]).get_serializable_unique_identifier()
+        == StaticPartitionsDefinition(["a", "b", "c"]).get_serializable_unique_identifier()
     )
+
+    with instance_for_test() as instance:
+        dynamic_def = DynamicPartitionsDefinition(name="foo")
+        identifier1 = dynamic_def.get_serializable_unique_identifier(
+            dynamic_partitions_store=instance
+        )
+        instance.add_dynamic_partitions(dynamic_def.name, ["bar"])
+        assert identifier1 != dynamic_def.get_serializable_unique_identifier(
+            dynamic_partitions_store=instance
+        )
 
 
 def test_static_partitions_subset():

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -105,7 +105,9 @@ class AssetReconciliationScenario(NamedTuple):
                     from_failure=False,
                     tags={},
                     backfill_timestamp=test_time.timestamp(),
-                    serialized_asset_backfill_data=asset_backfill_data.serialize(),
+                    serialized_asset_backfill_data=asset_backfill_data.serialize(
+                        dynamic_partitions_store=instance
+                    ),
                 )
                 instance.add_backfill(backfill)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -595,12 +595,12 @@ def test_time_window_partitions_contains():
 
 def test_unique_identifier():
     assert (
-        DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
-        != DailyPartitionsDefinition(start_date="2015-01-02").serializable_unique_identifier
+        DailyPartitionsDefinition(start_date="2015-01-01").get_serializable_unique_identifier()
+        != DailyPartitionsDefinition(start_date="2015-01-02").get_serializable_unique_identifier()
     )
     assert (
-        DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
-        == DailyPartitionsDefinition(start_date="2015-01-01").serializable_unique_identifier
+        DailyPartitionsDefinition(start_date="2015-01-01").get_serializable_unique_identifier()
+        == DailyPartitionsDefinition(start_date="2015-01-01").get_serializable_unique_identifier()
     )
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_status_cache.py
@@ -443,7 +443,8 @@ def test_failure_cache_added():
         created_instance.update_asset_cached_status_data(
             asset_key,
             AssetStatusCacheValue(
-                latest_storage_id=0, partitions_def_id=partitions_def.serializable_unique_identifier
+                latest_storage_id=0,
+                partitions_def_id=partitions_def.get_serializable_unique_identifier(),
             ),
         )
 


### PR DESCRIPTION
Part 1: https://github.com/dagster-io/dagster/pull/12894

This PR enables caching dynamic partitioned asset statuses in the asset status cache value. Since we now allow dynamic partitions defs to be dimensions of multipartitions defs and we cache multipartitions statuses, this PR brings the dynamic partitions status caching up to parity.

One side effect is that the serializable_unique_identifier we use to check whether a partitions definition has remained the same or not must be changed to a function that accepts a DynamicPartitionsStore, in order to build an identifier containing the dynamic partition keys. This enables rebuilding the partitions status cache when the partitions definition has been mutated.

Performance is expected to remain the same with this change. Dynamic partitions are serialized in default partitions subsets, which contain the set of selected partition keys, so querying the instance is not necessary to fetch the partition keys. We have a caching dynamic partitions loader that exists on all asset nodes, so when querying for partition statuses / partition keys for a set of assets we only query the instance once for the partition keys of a given dynamic partitions definition and return the cached value thereafter.