### PR TITLE
[ruff] Enable D207, D208, D209, over/under-indented docstring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,13 +172,6 @@ ignore = [
   "D205",  # (blank line after summary)
   "D417",  # (missing arg in docstring)
 
-  # (indent docstring rules) These rules should be enabled when ruff lands
-  # on/off style comments, which would allow turning them off for specific
-  # docstrings.
-  "D207", # (under-indented docstring)
-  "D208", # (over-indented docstring)
-  "D402", # (first line should not be the function's "signature")
-
 ]
 
 # Match black. Note that this also checks comment line length, but black does not format comments.

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -654,7 +654,7 @@ def process_is_alive(pid: int) -> bool:
 
 
 def compose(*args):
-    """Compose python functions args such that compose(f, g)(x) is equivalent to f(g(x))."""
+    """Compose python functions args such that compose(f, g)(x) is equivalent to f(g(x))."""  # noqa: D402
     # reduce using functional composition over all the arguments, with the identity function as
     # initializer
     return functools.reduce(lambda f, g: lambda x: f(g(x)), args, lambda x: x)

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -100,7 +100,7 @@ def test_failure_propagation():
     A                F (skipped)
      \\             //
       D (fails) == E (skipped).
-    """
+    """  # noqa: D208
     solid_a = create_root_success_solid("solid_a")
 
     @op


### PR DESCRIPTION
## Summary & Motivation

Enable Ruff D207, D208, D209. These were previously temporarily disabled due to difficulty of turning them off for individual multiline docstrings, but that functionality is now supported.

---

## How I Tested These Changes

BK
