### PR TITLE
Allow setting the job_namespace for the celery k8s run launcher

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -47,6 +47,7 @@ class CeleryK8sRunLauncherConfig(BaseModel):
     labels: Optional[Dict[str, str]]
     failPodOnRunFailure: Optional[bool]
     schedulerName: Optional[str]
+    jobNamespace: Optional[str]
 
     class Config:
         extra = Extra.forbid

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -12,6 +12,8 @@ deps =
   -e ../../../python_modules/libraries/dagster-azure
   -e ../../../python_modules/libraries/dagster-gcp
   -e ../../../python_modules/libraries/dagster-k8s
+  -e ../../../python_modules/libraries/dagster-celery
+  -e ../../../python_modules/libraries/dagster-celery-k8s
   pyparsing<3.0.0 # Hint to nudge pypi to avoid a conflict between various dagster deps
   -e .[test]
 allowlist_externals =

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -6,6 +6,9 @@ config:
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"
   postgres_password_secret: {{ include "dagster.postgresql.secretName" . | quote }}
+  {{- if $celeryK8sRunLauncherConfig.jobNamespace }}
+  job_namespace: {{ $celeryK8sRunLauncherConfig.jobNamespace }}
+  {{- end }}
   broker:
     env: DAGSTER_CELERY_BROKER_URL
   backend:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1915,6 +1915,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "jobNamespace": {
+                    "title": "Jobnamespace",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -592,6 +592,10 @@ runLauncher:
         tag: ~
         pullPolicy: Always
 
+      # The Kubernetes namespace where new jobs will be launched.
+      # By default, the namespace "default" is used.
+      jobNamespace: ~
+
       # Support overriding the name prefix of Celery worker pods
       nameOverride: "celery-workers"
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
@@ -31,7 +31,6 @@ def celery_k8s_executor_config():
         "job_namespace": Field(
             StringSource,
             is_required=False,
-            default_value="default",
             description=(
                 "The namespace into which to launch new jobs. Note that any "
                 "other Kubernetes resources the Job requires (such as the service account) must be "

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -126,7 +126,7 @@ def celery_k8s_job_executor(init_context):
         include=include,
         retries=retries,
         job_config=job_config,
-        job_namespace=exc_cfg.get("job_namespace"),
+        job_namespace=exc_cfg.get("job_namespace", run_launcher.job_namespace),
         load_incluster_config=exc_cfg.get("load_incluster_config"),
         kubeconfig_file=exc_cfg.get("kubeconfig_file"),
         repo_location_name=exc_cfg.get("repo_location_name"),

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -83,6 +83,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         image_pull_secrets=None,
         labels=None,
         fail_pod_on_run_failure=None,
+        job_namespace=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
@@ -134,6 +135,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         self._fail_pod_on_run_failure = check.opt_bool_param(
             fail_pod_on_run_failure, "fail_pod_on_run_failure"
         )
+        self.job_namespace = check.opt_str_param(job_namespace, "job_namespace", default="default")
 
         super().__init__()
 
@@ -223,7 +225,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             env_vars=[{"name": "DAGSTER_RUN_JOB_NAME", "value": pipeline_origin.pipeline_name}],
         )
 
-        job_namespace = exc_config.get("job_namespace")
+        job_namespace = exc_config.get("job_namespace", self.job_namespace)
 
         self._instance.report_engine_event(
             "Creating Kubernetes run worker job",

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -38,7 +38,6 @@ def test_empty_celery_config():
         "volume_mounts": [],
         "volumes": [],
         "load_incluster_config": True,
-        "job_namespace": "default",
         "repo_location_name": "<<in_process>>",
         "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
     }
@@ -54,7 +53,6 @@ def test_get_validated_celery_k8s_executor_config():
         "retries": {"enabled": {}},
         "job_image": "foo",
         "load_incluster_config": True,
-        "job_namespace": "default",
         "repo_location_name": "<<in_process>>",
         "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
         "volume_mounts": [],
@@ -71,7 +69,7 @@ def test_get_validated_celery_k8s_executor_config():
 
     with environ(
         {
-            "DAGSTER_K8S_PIPELINE_RUN_NAMESPACE": "default",
+            "DAGSTER_K8S_PIPELINE_RUN_NAMESPACE": "my-namespace",
             "DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP": "config-pipeline-env",
         }
     ):
@@ -82,7 +80,7 @@ def test_get_validated_celery_k8s_executor_config():
             "retries": {"enabled": {}},
             "env_config_maps": ["config-pipeline-env"],
             "load_incluster_config": True,
-            "job_namespace": "default",
+            "job_namespace": "my-namespace",
             "repo_location_name": "<<in_process>>",
             "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
             "volume_mounts": [],
@@ -92,7 +90,7 @@ def test_get_validated_celery_k8s_executor_config():
     # Test setting all possible config fields
     with environ(
         {
-            "TEST_PIPELINE_RUN_NAMESPACE": "default",
+            "TEST_PIPELINE_RUN_NAMESPACE": "my-namespace",
             "TEST_CELERY_BROKER": "redis://some-redis-host:6379/0",
             "TEST_CELERY_BACKEND": "redis://some-redis-host:6379/0",
             "TEST_PIPELINE_RUN_IMAGE": "foo",
@@ -138,9 +136,9 @@ def test_get_validated_celery_k8s_executor_config():
             "repo_location_name": "<<in_process>>",
             "load_incluster_config": False,
             "kubeconfig_file": "/some/kubeconfig/file",
-            "job_namespace": "default",
             "backend": "redis://some-redis-host:6379/0",
             "broker": "redis://some-redis-host:6379/0",
+            "job_namespace": "my-namespace",
             "include": ["dagster", "dagit"],
             "config_source": {"task_annotations": """{'*': {'on_failure': my_on_failure}}"""},
             "retries": {"disabled": {}},
@@ -164,7 +162,6 @@ def test_get_validated_celery_k8s_executor_config_for_job():
         "retries": {"enabled": {}},
         "job_image": "foo",
         "load_incluster_config": True,
-        "job_namespace": "default",
         "repo_location_name": "<<in_process>>",
         "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
         "volume_mounts": [],
@@ -179,7 +176,7 @@ def test_get_validated_celery_k8s_executor_config_for_job():
 
     with environ(
         {
-            "DAGSTER_K8S_PIPELINE_RUN_NAMESPACE": "default",
+            "DAGSTER_K8S_PIPELINE_RUN_NAMESPACE": "my-namespace",
             "DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP": "config-pipeline-env",
         }
     ):
@@ -190,7 +187,7 @@ def test_get_validated_celery_k8s_executor_config_for_job():
             "retries": {"enabled": {}},
             "env_config_maps": ["config-pipeline-env"],
             "load_incluster_config": True,
-            "job_namespace": "default",
+            "job_namespace": "my-namespace",
             "repo_location_name": "<<in_process>>",
             "job_wait_timeout": DEFAULT_WAIT_TIMEOUT,
             "volume_mounts": [],
@@ -200,7 +197,7 @@ def test_get_validated_celery_k8s_executor_config_for_job():
     # Test setting all possible config fields
     with environ(
         {
-            "TEST_PIPELINE_RUN_NAMESPACE": "default",
+            "TEST_PIPELINE_RUN_NAMESPACE": "my-namespace",
             "TEST_CELERY_BROKER": "redis://some-redis-host:6379/0",
             "TEST_CELERY_BACKEND": "redis://some-redis-host:6379/0",
             "TEST_PIPELINE_RUN_IMAGE": "foo",
@@ -249,7 +246,7 @@ def test_get_validated_celery_k8s_executor_config_for_job():
             "repo_location_name": "<<in_process>>",
             "load_incluster_config": False,
             "kubeconfig_file": "/some/kubeconfig/file",
-            "job_namespace": "default",
+            "job_namespace": "my-namespace",
             "backend": "redis://some-redis-host:6379/0",
             "broker": "redis://some-redis-host:6379/0",
             "include": ["dagster", "dagit"],

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -390,6 +390,7 @@ class DagsterK8sJobConfig(
                     is_required=False,
                     description="Raw Kubernetes configuration for launched runs.",
                 ),
+                "job_namespace": Field(StringSource, is_required=False, default_value="default"),
             },
         )
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -3,9 +3,7 @@ from typing import Any, Mapping, Optional, Sequence
 
 import kubernetes
 from dagster import (
-    Field,
     MetadataEntry,
-    StringSource,
     _check as check,
 )
 from dagster._cli.api import ExecuteRunArgs
@@ -17,7 +15,6 @@ from dagster._core.storage.tags import DOCKER_IMAGE_TAG
 from dagster._grpc.types import ResumeRunArgs
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils.error import serializable_error_info_from_exc_info
-from dagster._utils.merger import merge_dicts
 
 from .client import DagsterKubernetesClient
 from .container_context import K8sContainerContext
@@ -188,12 +185,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         """Include all arguments required for DagsterK8sJobConfig along with additional arguments
         needed for the RunLauncher itself.
         """
-        job_cfg = DagsterK8sJobConfig.config_type_run_launcher()
-
-        run_launcher_extra_cfg = {
-            "job_namespace": Field(StringSource, is_required=False, default_value="default"),
-        }
-        return merge_dicts(job_cfg, run_launcher_extra_cfg)
+        return DagsterK8sJobConfig.config_type_run_launcher()
 
     @classmethod
     def from_config_value(cls, inst_data, config_value):


### PR DESCRIPTION
Summary:
Inspired by https://github.com/dagster-io/dagster/pull/9235/files by @gmontanola.

For 1.3 we can also change the default behavior to be in the release namespace rather than the default namespace, but for now to avoid a breaking change just allow it to be configurable.

Test Plan: BK

## Summary & Motivation

> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md).

---

## How I Tested These Changes
