### PR TITLE
[ruff] enable W605 invalid-escape-sequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ select = [
   # (pyflakes) use all pyflakes rules
   "F",
 
+
   # (isort) detect improperly sorted imports
   "I001",
 
@@ -226,6 +227,8 @@ select = [
   # (disallow print statements) keep debugging statements out of the codebase
   "T",
 
+  # (invalid escape sequence) flag errant backslashes
+  "W605",
 ]
 
 # Fail if Ruff is not running this version.

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -706,7 +706,7 @@ def test_sanitize_labels():
         [],
         "job456",
         labels={
-            "dagster/op": "-get_f\o.o[bar-0]-",  # pylint: disable=anomalous-backslash-in-string
+            "dagster/op": r"-get_f\o.o[bar-0]-",
             "my_label": "_WhatsUP",
         },
     ).to_dict()

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -600,7 +600,7 @@ class ArtifactsIOManager(IOManager):
                 "Unique ID for this run, used for resuming. It must be unique in the project, and"
                 " if you delete a run you can't reuse the ID. Use the name field for a short"
                 " descriptive name, or config for saving hyperparameters to compare across runs."
-                " The ID cannot contain the following special characters: /\#?%:.. You need to set"
+                r" The ID cannot contain the following special characters: /\#?%:.. You need to set"
                 " the Run ID when you are doing experiment tracking inside Dagster to allow the IO"
                 " Manager to resume the run. By default it`s set to the Dagster Run ID e.g "
                 " 7e4df022-1bf2-44b5-a383-bb852df4077e."

--- a/scripts/gen_airbyte_classes.py
+++ b/scripts/gen_airbyte_classes.py
@@ -30,7 +30,7 @@ def _capitalize(s: str) -> str:
 
 
 def _to_class_name(name: str) -> str:
-    class_name = "".join([_capitalize(_remove_invalid_chars(x)) for x in re.split("\W+", name)])
+    class_name = "".join([_capitalize(_remove_invalid_chars(x)) for x in re.split(r"\W+", name)])
     if class_name in KEYWORDS:
         class_name += "_"
     return class_name
@@ -87,7 +87,6 @@ class SchemaType(ABC):
         self.description = description.replace("\n", " ")
 
     def get_doc_desc(self, name: str, scope: Optional[str] = None) -> Optional[str]:
-
         if not self.description:
             return None
         formatted_desc = (
@@ -162,7 +161,9 @@ class OptType(SchemaType):
     def annotation(
         self, scope: Optional[str] = None, quote: bool = False, hide_default: bool = False
     ):
-        return f"Optional[{self.inner.annotation(scope, quote, hide_default)}]{' = None' if not hide_default else ''}"
+        return (
+            f"Optional[{self.inner.annotation(scope, quote, hide_default)}]{' = None' if not hide_default else ''}"
+        )
 
     def get_check(self, name: str, scope: Optional[str] = None):
         inner_check = self.inner.get_check(name, scope)
@@ -480,7 +481,7 @@ def airbyte_repo_path(airbyte_repo_root: Optional[str], tag: str):
         subprocess.call(["git", "clone", "--depth", "1", "--branch", "master", AIRBYTE_REPO_URL])
         os.chdir("./airbyte")
         subprocess.call(["git", "fetch", "--all", "--tags"])
-        subprocess.call(["git", "checkout", "-b" f"tags/{tag}", f"tags/{tag}"])
+        subprocess.call(["git", "checkout", f"-btags/{tag}", f"tags/{tag}"])
 
         yield os.path.join(str(build_dir), "airbyte")
 
@@ -508,7 +509,7 @@ def gen_airbyte_classes(airbyte_repo_root, airbyte_tag):
     with airbyte_repo_path(airbyte_repo_root, airbyte_tag) as airbyte_dir:
         connectors_root = os.path.join(airbyte_dir, "airbyte-integrations/connectors")
 
-        for (title, prefix, out_file, imp, is_source) in [
+        for title, prefix, out_file, imp, is_source in [
             ("Source", "source-", SOURCE_OUT_FILE, "GeneratedAirbyteSource", True),
             ("Destination", "destination-", DEST_OUT_FILE, "GeneratedAirbyteDestination", False),
         ]:
@@ -555,7 +556,6 @@ from dagster._annotations import public
                     )
                     for root, file in files:
                         if file == "spec.json" or file == "spec.yml" or file == "spec.yaml":
-
                             # First, attempt to load the spec file and generate
                             # the class definition
                             new_out = out


### PR DESCRIPTION
## Summary & Motivation

Enable ruff W605 `invalid-escape-sequence`. Replaces previously-enabled pylint rule.

---

## How I Tested These Changes

BK
