### PR TITLE
[refactor] Make RepositoryDefinition.asset_defs_by_key public

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_different_io_managers.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_different_io_managers.py
@@ -2,7 +2,5 @@ from docs_snippets.concepts.assets.asset_different_io_managers import defs
 
 
 def test():
-    assets_defs_by_key = (
-        defs.get_repository_def()._assets_defs_by_key  # pylint: disable=protected-access
-    )
+    assets_defs_by_key = defs.get_repository_def().assets_defs_by_key
     assert len(assets_defs_by_key) == 2

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_io_manager.py
@@ -2,7 +2,5 @@ from docs_snippets.concepts.assets.asset_io_manager import defs
 
 
 def test():
-    assets_defs_by_key = (
-        defs.get_repository_def()._assets_defs_by_key  # pylint: disable=protected-access
-    )
+    assets_defs_by_key = defs.get_repository_def().assets_defs_by_key
     assert len(assets_defs_by_key) == 2

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_io_managers_prod_local.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_io_managers_prod_local.py
@@ -6,19 +6,9 @@ from docs_snippets.concepts.assets.asset_io_manager_prod_local import defs
 
 @mock.patch.dict(os.environ, {"ENV": "prod"})
 def test_prod_assets():
-    assert (
-        len(
-            defs.get_repository_def()._assets_defs_by_key.keys()  # pylint: disable=protected-access
-        )
-        == 2
-    )
+    assert len(defs.get_repository_def().assets_defs_by_key.keys()) == 2
 
 
 @mock.patch.dict(os.environ, {"ENV": "local"})
 def test_local_assets():
-    assert (
-        len(
-            defs.get_repository_def()._assets_defs_by_key.keys()  # pylint: disable=protected-access
-        )
-        == 2
-    )
+    assert len(defs.get_repository_def().assets_defs_by_key.keys()) == 2

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -46,7 +46,7 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
     repo_def = recon_repo.get_definition()
 
     asset_keys = parse_asset_selection(
-        assets_defs=list(repo_def._assets_defs_by_key.values()),
+        assets_defs=list(repo_def.assets_defs_by_key.values()),
         source_assets=list(repo_def.source_assets_by_key.values()),
         asset_selection=kwargs["select"].split(","),
     )
@@ -93,7 +93,7 @@ def asset_list_command(**kwargs):
     select = kwargs.get("select")
     if select is not None:
         asset_keys = parse_asset_selection(
-            assets_defs=list(repo_def._assets_defs_by_key.values()),
+            assets_defs=list(repo_def.assets_defs_by_key.values()),
             source_assets=list(repo_def.source_assets_by_key.values()),
             asset_selection=select.split(","),
             raise_on_clause_has_no_matches=False,
@@ -101,7 +101,7 @@ def asset_list_command(**kwargs):
     else:
         asset_keys = [
             asset_key
-            for assets_def in repo_def._assets_defs_by_key.values()
+            for assets_def in repo_def.assets_defs_by_key.values()
             for asset_key in assets_def.keys
         ]
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -221,7 +221,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         self._repository_def = repository_def
         self._monitored_asset_keys: Sequence[AssetKey]
         if isinstance(monitored_assets, AssetSelection):
-            repo_assets = self._repository_def._assets_defs_by_key.values()
+            repo_assets = self._repository_def.assets_defs_by_key.values()
             repo_source_assets = self._repository_def.source_assets_by_key.values()
             self._monitored_asset_keys = list(
                 monitored_assets.resolve([*repo_assets, *repo_source_assets])
@@ -231,11 +231,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
 
         self._assets_by_key: Dict[AssetKey, Optional[AssetsDefinition]] = {}
         for asset_key in self._monitored_asset_keys:
-            assets_def = (
-                self._repository_def._assets_defs_by_key.get(  # pylint:disable=protected-access
-                    asset_key
-                )
-            )
+            assets_def = self._repository_def.assets_defs_by_key.get(asset_key)
             self._assets_by_key[asset_key] = assets_def
 
         self._partitions_def_by_asset_key = {
@@ -647,7 +643,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         from dagster._core.definitions.repository_definition import RepositoryDefinition
 
         repo_def = cast(RepositoryDefinition, self._repository_def)
-        repository_assets = repo_def._assets_defs_by_key  # pylint:disable=protected-access
+        repository_assets = repo_def.assets_defs_by_key
         if asset_key in self._assets_by_key:
             asset_def = self._assets_by_key[asset_key]
             if asset_def is None:
@@ -983,13 +979,7 @@ def build_multi_asset_sensor_context(
             asset_keys = cast(
                 List[AssetKey],
                 list(
-                    monitored_assets.resolve(
-                        list(
-                            set(
-                                repository_def._assets_defs_by_key.values()  # pylint: disable=protected-access
-                            )
-                        )
-                    )
+                    monitored_assets.resolve(list(set(repository_def.assets_defs_by_key.values())))
                 ),
             )
         else:

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -252,7 +252,7 @@ class RepositoryDefinition:
         return self._repository_data.get_source_assets_by_key()
 
     @property
-    def _assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
+    def assets_defs_by_key(self) -> Mapping[AssetKey, "AssetsDefinition"]:
         return self._repository_data.get_assets_defs_by_key()
 
     def has_implicit_global_asset_job_def(self) -> bool:
@@ -354,7 +354,7 @@ class RepositoryDefinition:
         from dagster._core.storage.asset_value_loader import AssetValueLoader
 
         with AssetValueLoader(
-            self._assets_defs_by_key, self.source_assets_by_key, instance=instance
+            self.assets_defs_by_key, self.source_assets_by_key, instance=instance
         ) as loader:
             return loader.load_asset_value(
                 asset_key,
@@ -384,13 +384,13 @@ class RepositoryDefinition:
         from dagster._core.storage.asset_value_loader import AssetValueLoader
 
         return AssetValueLoader(
-            self._assets_defs_by_key, self.source_assets_by_key, instance=instance
+            self.assets_defs_by_key, self.source_assets_by_key, instance=instance
         )
 
     @property
     def asset_graph(self) -> InternalAssetGraph:
         return AssetGraph.from_assets(
-            [*set(self._assets_defs_by_key.values()), *self.source_assets_by_key.values()]
+            [*set(self.assets_defs_by_key.values()), *self.source_assets_by_key.values()]
         )
 
     # If definition comes from the @repository decorator, then the __call__ method will be

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -518,7 +518,7 @@ def log_repo_stats(
             num_pipelines_in_repo = len(repository.pipeline_names)
             num_schedules_in_repo = len(repository.schedule_defs)
             num_sensors_in_repo = len(repository.sensor_defs)
-            all_assets = list(repository._assets_defs_by_key.values())
+            all_assets = list(repository.assets_defs_by_key.values())
             num_assets_in_repo = len(all_assets)
         elif isinstance(repo, ReconstructableRepository):
             pipeline_name_hash = ""
@@ -527,7 +527,7 @@ def log_repo_stats(
             num_pipelines_in_repo = len(repository.pipeline_names)
             num_schedules_in_repo = len(repository.schedule_defs)
             num_sensors_in_repo = len(repository.sensor_defs)
-            all_assets = list(repository._assets_defs_by_key.values())
+            all_assets = list(repository.assets_defs_by_key.values())
             num_assets_in_repo = len(all_assets)
         else:
             pipeline_name_hash = hash_name(pipeline.get_definition().name)  # type: ignore

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -51,7 +51,7 @@ from dagster._core.test_utils import instance_for_test
 def get_all_assets_from_defs(defs: Definitions):
     # could not find public method on repository to do this
     repo = resolve_pending_repo_if_required(defs)
-    return list(repo._assets_defs_by_key.values())  # pylint: disable=protected-access
+    return list(repo.assets_defs_by_key.values())
 
 
 def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefinition:

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -31,9 +31,7 @@ class DefinitionsRunner:
             yield DefinitionsRunner(defs, instance)
 
     def materialize_all_assets(self, partition_key: Optional[str] = None) -> ExecuteInProcessResult:
-        all_keys = list(
-            self.defs.get_repository_def()._assets_defs_by_key.keys()  # pylint: disable=protected-access
-        )
+        all_keys = list(self.defs.get_repository_def().assets_defs_by_key.keys())
         job_def = self.defs.get_implicit_job_def_for_assets(all_keys)
         assert job_def
         return job_def.execute_in_process(instance=self.instance, partition_key=partition_key)


### PR DESCRIPTION
## Summary & Motivation

`RepositoryDefinition._asset_defs_by_key` was externally accessed in enough places that it made sense to just make it (internally public).

---

## How I Tested These Changes

BK
