### PR TITLE
[for 1.3] change default job namespace of celery k8s run launcher to the release namespace instead of "default"

### DIFF
--- a/helm/dagster/schema/schema/utils/helm_template.py
+++ b/helm/dagster/schema/schema/utils/helm_template.py
@@ -28,6 +28,7 @@ class HelmTemplate:
     model: Optional[Any] = None
     release_name: str = "release-name"
     api_client: ApiClient = ApiClient()
+    namespace: str = "default"
 
     def render(
         self,
@@ -56,6 +57,8 @@ class HelmTemplate:
                 self.release_name,
                 helm_dir_path,
                 "--debug",
+                "--namespace",
+                self.namespace,
                 "--values",
                 tmp_file.name,
             ]

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -63,6 +63,7 @@ def helm_template() -> HelmTemplate:
         subchart_paths=["charts/dagster-user-deployments"],
         output="templates/configmap-instance.yaml",
         model=models.V1ConfigMap,
+        namespace="test-namespace",
     )
 
 
@@ -515,7 +516,7 @@ def test_celery_k8s_run_launcher_default_namespace(template: HelmTemplate):
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
     _check_valid_run_launcher_yaml(instance, instance_class=CeleryK8sRunLauncher)
     run_launcher_config = instance["run_launcher"]["config"]
-    assert "job_namespace" not in run_launcher_config
+    assert run_launcher_config["job_namespace"] == template.namespace
 
 
 def test_celery_k8s_run_launcher_set_namespace(template: HelmTemplate):

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -6,9 +6,7 @@ config:
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"
   postgres_password_secret: {{ include "dagster.postgresql.secretName" . | quote }}
-  {{- if $celeryK8sRunLauncherConfig.jobNamespace }}
-  job_namespace: {{ $celeryK8sRunLauncherConfig.jobNamespace }}
-  {{- end }}
+  job_namespace: {{ $celeryK8sRunLauncherConfig.jobNamespace | default .Release.Namespace }}
   broker:
     env: DAGSTER_CELERY_BROKER_URL
   backend:

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -469,7 +469,7 @@ runLauncher:
       #   tag: ""
       #   pullPolicy: Always
 
-      # The K8s namespace where new jobs will be launched.
+      # The Kubernetes namespace where new jobs will be launched.
       # By default, the release namespace is used.
       jobNamespace: ~
 
@@ -597,7 +597,7 @@ runLauncher:
         pullPolicy: Always
 
       # The Kubernetes namespace where new jobs will be launched.
-      # By default, the namespace "default" is used.
+      # By default, the release namespace is used.
       jobNamespace: ~
 
       # Support overriding the name prefix of Celery worker pods


### PR DESCRIPTION
Summary:
For consistency with the k8s run launcher config.

## Summary & Motivation

> **Does this pull request update the docs?** If so, please verify that the updates follow the [docs style checklist](https://github.com/dagster-io/dagster/blob/master/docs/DOC_CHECKLIST.md).

---

## How I Tested These Changes
