### PR TITLE
Fix black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,21 @@
 repos:
 - repo: https://github.com/psf/black
   rev: refs/tags/22.12.0:refs/tags/22.12.0
+
+  # We need two instances of the black pre-commit hook because black can only run with a single
+  # config, but we need different configs for docs_snippets and the rest of the repo due to
+  # differing line lengths.
   hooks:
     - id: black-jupyter
-      # Make sure black reads its config from root `pyproject.toml`
+      exclude: "examples/docs_snippets|snapshots/"
+      # Make sure black reads its config from root `pyproject.toml`. This is necessary for commits
+      # where all files share a common root with a pyproject.toml file. Black config will by default
+      # resolve to this pyproject.toml, which will cause use of default line-length instead of the
+      # length specified in the root config.
       args: ["--config", "pyproject.toml"]
+    - id: black-jupyter
+      name: black-jupyter [docs-snippets]
+      files: "^examples/docs_snippets/.*.py"
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.241
   hooks:


### PR DESCRIPTION
## Summary & Motivation

Fixes the annoying behavior of the `black` pre-commit hook where docs_snippets files get formatted with line-length 100, causing disagreement with `make black`/CI. This should bring pre-commit fully into alignment with `make black`.

---

## How I Tested These Changes

Tried changing files in and out of `examples/docs_snippets` and commiting to ensure the correct hook fired or was skipped.
