### PR TITLE
[asset-reconciliation] Do not reconcile partitions involved in active asset backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -469,8 +469,11 @@ def determine_asset_partitions_to_reconcile(
             return False
 
         if any(
+            # do not reconcile assets if the freshness system will update them
             candidate in eventual_asset_partitions_to_reconcile_for_freshness
+            # do not reconcile assets if an active backfill will update them
             or candidate in backfill_target_asset_graph_subset
+            # do not reconcile assets if they are not in the target selection
             or candidate.asset_key not in target_asset_keys
             for candidate in candidates_unit
         ):

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -29,6 +29,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
 )
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 
 from .asset_selection import AssetGraph, AssetSelection
 from .decorators.sensor_decorator import sensor
@@ -203,9 +204,6 @@ class AssetReconciliationCursor(NamedTuple):
             )
         )
         return serialized
-
-
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 
 
 def get_active_backfill_target_asset_graph_subset(

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -22,6 +22,7 @@ import pendulum
 
 import dagster._check as check
 from dagster._annotations import experimental
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessConstraint
@@ -29,7 +30,6 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 
 from .asset_selection import AssetGraph, AssetSelection
 from .decorators.sensor_decorator import sensor

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -2,9 +2,6 @@ import contextlib
 import datetime
 import itertools
 from typing import Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, Union
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
-from dagster._core.execution.asset_backfill import AssetBackfillData
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 
 import mock
 import pendulum
@@ -34,6 +31,7 @@ from dagster import (
     multi_asset,
     repository,
 )
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_reconciliation_sensor import (
     AssetReconciliationCursor,
     reconcile,
@@ -48,6 +46,8 @@ from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
+from dagster._core.execution.asset_backfill import AssetBackfillData
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._seven.compat.pendulum import create_pendulum_time
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -2,6 +2,9 @@ import contextlib
 import datetime
 import itertools
 from typing import Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, Union
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.execution.asset_backfill import AssetBackfillData
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 
 import mock
 import pendulum
@@ -36,8 +39,15 @@ from dagster._core.definitions.asset_reconciliation_sensor import (
     reconcile,
 )
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.partition import DefaultPartitionsSubset, DynamicPartitionsDefinition
-from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
+from dagster._core.definitions.partition import (
+    DefaultPartitionsSubset,
+    DynamicPartitionsDefinition,
+    PartitionsSubset,
+)
+from dagster._core.definitions.time_window_partitions import (
+    HourlyPartitionsDefinition,
+    TimeWindowPartitionsSubset,
+)
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._seven.compat.pendulum import create_pendulum_time
 
@@ -56,6 +66,7 @@ class AssetReconciliationScenario(NamedTuple):
     cursor_from: Optional["AssetReconciliationScenario"] = None
     current_time: Optional[datetime.datetime] = None
     asset_selection: Optional[AssetSelection] = None
+    active_backfill_targets: Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]] = None
 
     expected_run_requests: Optional[Sequence[RunRequest]] = None
 
@@ -67,6 +78,36 @@ class AssetReconciliationScenario(NamedTuple):
             @repository
             def repo():
                 return self.assets
+
+            # add any backfills to the instance
+            for i, target in enumerate(self.active_backfill_targets or []):
+                target_subset = AssetGraphSubset(
+                    asset_graph=repo.asset_graph,
+                    partitions_subsets_by_asset_key=target,
+                    non_partitioned_asset_keys=set(),
+                )
+                empty_subset = AssetGraphSubset(
+                    asset_graph=repo.asset_graph,
+                    partitions_subsets_by_asset_key={},
+                    non_partitioned_asset_keys=set(),
+                )
+                asset_backfill_data = AssetBackfillData(
+                    latest_storage_id=0,
+                    target_subset=target_subset,
+                    requested_runs_for_target_roots=False,
+                    materialized_subset=empty_subset,
+                    requested_subset=empty_subset,
+                    failed_and_downstream_subset=empty_subset,
+                )
+                backfill = PartitionBackfill(
+                    backfill_id=f"backfill{i}",
+                    status=BulkActionStatus.REQUESTED,
+                    from_failure=False,
+                    tags={},
+                    backfill_timestamp=test_time.timestamp(),
+                    serialized_asset_backfill_data=asset_backfill_data.serialize(),
+                )
+                instance.add_backfill(backfill)
 
             if self.cursor_from is not None:
                 run_requests, cursor = self.cursor_from.do_scenario(instance)
@@ -807,6 +848,86 @@ scenarios = {
                 PartitionKeyRange(start="2013-01-07-00:00", end="2013-01-07-03:00")
             )
         ],
+    ),
+    "hourly_to_daily_partitions_with_active_backfill_independent": AssetReconciliationScenario(
+        assets=hourly_to_daily_partitions,
+        unevaluated_runs=[],
+        active_backfill_targets=[
+            {
+                AssetKey("daily"): TimeWindowPartitionsSubset(
+                    daily_partitions_def, num_partitions=1, included_partition_keys={"2013-01-06"}
+                )
+            },
+            {
+                AssetKey("hourly"): TimeWindowPartitionsSubset(
+                    hourly_partitions_def,
+                    num_partitions=3,
+                    included_partition_keys={
+                        "2013-01-06-01:00",
+                        "2013-01-06-02:00",
+                        "2013-01-06-03:00",
+                    },
+                )
+            },
+        ],
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        expected_run_requests=[
+            run_request(asset_keys=["hourly"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-06-04:00", end="2013-01-07-03:00")
+            )
+        ],
+    ),
+    "hourly_to_daily_partitions_with_active_backfill_intersecting": AssetReconciliationScenario(
+        assets=hourly_to_daily_partitions,
+        unevaluated_runs=[],
+        active_backfill_targets=[
+            {
+                AssetKey("hourly"): TimeWindowPartitionsSubset(
+                    hourly_partitions_def,
+                    num_partitions=3,
+                    included_partition_keys={
+                        "2013-01-06-04:00",
+                        "2013-01-06-05:00",
+                        "2013-01-06-06:00",
+                    },
+                )
+            },
+        ],
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        expected_run_requests=[
+            run_request(asset_keys=["hourly"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-06-07:00", end="2013-01-07-03:00")
+            )
+        ],
+    ),
+    "hourly_to_daily_partitions_with_active_backfill_superceding": AssetReconciliationScenario(
+        assets=hourly_to_daily_partitions,
+        unevaluated_runs=[],
+        active_backfill_targets=[
+            {
+                AssetKey("hourly"): TimeWindowPartitionsSubset(
+                    hourly_partitions_def,
+                    num_partitions=len(
+                        {
+                            partition_key
+                            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                                PartitionKeyRange(start="2013-01-06-00:00", end="2013-01-07-03:00")
+                            )
+                        },
+                    ),
+                    included_partition_keys={
+                        partition_key
+                        for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                            PartitionKeyRange(start="2013-01-06-00:00", end="2013-01-07-03:00")
+                        )
+                    },
+                )
+            },
+        ],
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        expected_run_requests=[],
     ),
     ################################################################################################
     # Exotic partition-mappings


### PR DESCRIPTION
## Summary & Motivation

resolves: https://github.com/dagster-io/dagster/issues/12885

## How I Tested These Changes

added a property to the AssetReconciliationScenario object which makes it possible to simulate the presence of asset backfills.

confirmed that two of the tests ("...with_backfill_intersecting" and "...with_backfill_superceding") failed before the changes, and now succeed. "..._with_backfill_independent" passes regardless of the changes by design.