### PR TITLE
Fix num static partitions to count unique partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -1,5 +1,6 @@
 import itertools
 from datetime import datetime
+from functools import reduce
 from typing import (
     Dict,
     Iterable,
@@ -437,6 +438,22 @@ class MultiPartitionsDefinition(PartitionsDefinition):
             )
             for partitions_tuple in itertools.product(*partition_sequences)
         ]
+
+    def get_num_partitions(
+        self,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> int:
+        # Static partitions definitions can contain duplicate keys (will throw error in 1.3.0)
+        # In the meantime, relying on get_num_partitions to handle duplicates to display
+        # correct counts in Dagit
+        dimension_counts = [
+            dim.partitions_def.get_num_partitions(
+                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+            )
+            for dim in self.partitions_defs
+        ]
+        return reduce(lambda x, y: x * y, dimension_counts, 1)
 
 
 class MultiPartitionsSubset(DefaultPartitionsSubset):

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -3,6 +3,7 @@ import hashlib
 import inspect
 import json
 from abc import ABC, abstractmethod
+from collections import Counter
 from datetime import (
     datetime,
     time,
@@ -400,6 +401,12 @@ class StaticPartitionsDefinition(
 
     def __init__(self, partition_keys: Sequence[str]):
         check.sequence_param(partition_keys, "partition_keys", of_type=str)
+
+        if len(partition_keys) != len(set(partition_keys)):
+            raise DagsterInvalidDefinitionError(
+                "Partition keys must be unique. Found duplicate keys: "
+                f"{[k for k, v in Counter(partition_keys).items() if v > 1]}"
+            )
 
         raise_error_on_invalid_partition_key_substring(partition_keys)
 

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -53,9 +53,8 @@ def test_invalid_partition_key():
         StaticPartitionsDefinition(["foo", "foo...bar"])
 
 
-def test_no_duplicate_static_partitions():
-    with pytest.raises(DagsterInvalidDefinitionError, match="Partition keys must be unique"):
-        StaticPartitionsDefinition(["foo", "foo"])
+def test_count_unique_static_partitions():
+    return StaticPartitionsDefinition(["foo", "foo"]).get_num_partitions() == 1
 
 
 @pytest.mark.parametrize(

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -53,6 +53,11 @@ def test_invalid_partition_key():
         StaticPartitionsDefinition(["foo", "foo...bar"])
 
 
+def test_no_duplicate_static_partitions():
+    with pytest.raises(DagsterInvalidDefinitionError, match="Partition keys must be unique"):
+        StaticPartitionsDefinition(["foo", "foo"])
+
+
 @pytest.mark.parametrize(
     argnames=["schedule_type", "start", "execution_day", "end", "error_message_regex"],
     ids=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -384,3 +384,29 @@ def test_keys_with_dimension_value():
             ("d", "2015-01-01"),
         ]
     ]
+
+
+def test_get_num_partitions():
+    static_keys = ["a", "b", "c", "d"]
+    daily_partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
+    multipartitions_def = MultiPartitionsDefinition(
+        {
+            "date": daily_partitions_def,
+            "static": StaticPartitionsDefinition(static_keys),
+        }
+    )
+    assert multipartitions_def.get_num_partitions() == len(
+        set(multipartitions_def.get_partition_keys())
+    )
+
+    static_keys = ["a", "a", "a"]
+    daily_partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
+    multipartitions_def = MultiPartitionsDefinition(
+        {
+            "date": daily_partitions_def,
+            "static": StaticPartitionsDefinition(static_keys),
+        }
+    )
+    assert multipartitions_def.get_num_partitions() == len(
+        set(multipartitions_def.get_partition_keys())
+    )


### PR DESCRIPTION
User reported an issue where partition counts were incorrect: https://elementl-workspace.slack.com/archives/C047XLJ0BRT/p1678716536609149

This was caused by duplicate static partition keys. In the next major release, we will raise an error for this. In the meantime, we'll change our partition counts logic to find the unique static partition keys.