### PR TITLE
[pythonic config] Fix using RunConfig with optional config fields

### DIFF
--- a/docs/content/guides/dagster/pythonic-config.mdx
+++ b/docs/content/guides/dagster/pythonic-config.mdx
@@ -126,6 +126,31 @@ class MyMetadataConfig(Config):
 MyMetadataConfig(person_name="Alice", age=200)
 ```
 
+### Defaults and optional config fields
+
+Config fields can be marked as optional by specifying a default value. For example, we can mark the `greeting_phrase` field as optional by specifying a default of `hello`. Optional fields, such as `person_name`, can be specified a default value of `None`.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_optional_config endbefore=end_optional_config dedent=4
+from typing import Optional
+from dagster import asset, Config, materialize, RunConfig
+
+class MyAssetConfig(Config):
+    person_name: Optional[str] = None
+    greeting_phrase: str = "hello"
+
+@asset
+def greeting(config: MyAssetConfig) -> str:
+    if config.person_name:
+        return f"{config.greeting_phrase} {config.person_name}"
+    else:
+        return config.greeting_phrase
+
+asset_result = materialize(
+    [greeting],
+    run_config=RunConfig({"greeting": MyAssetConfig()}),
+)
+```
+
 ### Basic data structures
 
 Many basic Python data structures can be used in your config schemas, including lists and mappings.

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -189,3 +189,28 @@ def metadata_config() -> None:
     MyMetadataConfig(person_name="Alice", age=200)
 
     # end_metadata_config
+
+
+def optional_config() -> None:
+    # start_optional_config
+
+    from typing import Optional
+    from dagster import asset, Config, materialize, RunConfig
+
+    class MyAssetConfig(Config):
+        person_name: Optional[str] = None
+        greeting_phrase: str = "hello"
+
+    @asset
+    def greeting(config: MyAssetConfig) -> str:
+        if config.person_name:
+            return f"{config.greeting_phrase} {config.person_name}"
+        else:
+            return config.greeting_phrase
+
+    asset_result = materialize(
+        [greeting],
+        run_config=RunConfig({"greeting": MyAssetConfig()}),
+    )
+
+    # end_optional_config

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -130,7 +130,15 @@ class Config(MakeConfigCacheable):
         Returns a dictionary representation of this config object,
         ignoring any private fields.
         """
-        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+        output = {}
+        for key, value in self.__dict__.items():
+            if key.startswith("_"):
+                continue
+            field = self.__fields__.get(key)
+            if field and value is None and not _is_pydantic_field_required(field):
+                continue
+            output[key] = value
+        return output
 
 
 @experimental


### PR DESCRIPTION
## Summary

Updates the Pythonic config class to config dict conversion code to drop optional entries with `None` values, to satisfy Dagster's internal type checking.

Previously, this lead to errors with optional fields using `RunConfig`:

```python
class AssetConfig(Config):
    baz: Optional[str] = None


@asset
def foo(config: AssetConfig) -> str:
    ...

# would error, since underlying Dagster config is passed `{"baz": None}` rather than `{}`
materialize([foo], run_config=RunConfig({"foo": AssetConfig()}))
```

Surfaced here: https://dagster.slack.com/archives/C01U5LFUZJS/p1678621110892759

Also adds some new documentation to describe how to set defaults & optional values.

## Test Plan

new unit tests
