### PR TITLE
[dagster-airbyte] Add namespace to connection metadata

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -363,6 +363,7 @@ class AirbyteConnectionMetadata(
         "_AirbyteConnectionMetadata",
         [
             ("name", str),
+            ("namespace", str),
             ("stream_prefix", str),
             ("has_basic_normalization", bool),
             ("stream_data", List[Mapping[str, Any]]),
@@ -386,6 +387,7 @@ class AirbyteConnectionMetadata(
         return cls(
             name=contents["name"],
             stream_prefix=contents.get("prefix", ""),
+            namespace=contents.get("namespaceFormat", ""),
             has_basic_normalization=any(
                 is_basic_normalization_operation(op.get("operatorConfiguration", {}))
                 for op in operations.get("operations", [])
@@ -403,6 +405,7 @@ class AirbyteConnectionMetadata(
         return cls(
             name=contents["resource_name"],
             stream_prefix=config_contents.get("prefix", ""),
+            namespace=config_contents.get("namespace_format", ""),
             has_basic_normalization=any(
                 is_basic_normalization_operation(op.get("operator_configuration", {}))
                 for op in config_contents.get("operations", [])

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -157,7 +157,7 @@ def test_load_from_instance(
         tables = {
             connection_to_asset_key_fn(
                 AirbyteConnectionMetadata(
-                    "Github <> snowflake-ben", "", use_normalization_tables, []
+                    "Github <> snowflake-ben", "", "", use_normalization_tables, []
                 ),
                 t,
             ).path[0]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
@@ -76,7 +76,7 @@ def test_load_from_project(
         tables = {
             connection_to_asset_key_fn(
                 AirbyteConnectionMetadata(
-                    "Github <> snowflake-ben", "", use_normalization_tables, []
+                    "Github <> snowflake-ben", "", "", use_normalization_tables, []
                 ),
                 t,
             ).path[0]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -432,6 +432,8 @@ def get_instance_connections_json():
                 "connectionId": "87b7fe85-a22c-420e-8d74-b30e7ede77df",
                 "name": "GitHub <> snowflake-ben",
                 "prefix": "dagster_",
+                "namespaceDefinition": "source",
+                "namespaceFormat": "${SOURCE_NAMESPACE}",
                 "sourceId": "4b8fc3cc-efce-41d7-8654-05c3fc03485e",
                 "destinationId": "028fc82d-3a27-4fef-94a6-a22fbd45bac4",
                 "operationIds": ["f39dbcd0-a6dc-4319-9ae4-28937997b48a"],
@@ -692,6 +694,7 @@ def get_instance_operations_json():
             {
                 "workspaceId": "b49ed3cd-7bb4-4f11-b8ba-95b4a5f7bc75",
                 "operationId": "f39dbcd0-a6dc-4319-9ae4-28937997b48a",
+                "namespace_format": "${SOURCE_NAMESPACE}",
                 "name": "Normalization",
                 "operatorConfiguration": {
                     "operatorType": "normalization",


### PR DESCRIPTION
## Summary & Motivation

Add `namespace` information to the `AirbyteConnectionMetadata` class so it can be used to construct `AssetKey`s.

## How I Tested These Changes
* Local tests
* Unit tests