### PR TITLE
[pythonic resources] Add docs on using resources with schedules and sensors

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -284,7 +284,7 @@ defs = Definitions(
 )
 ```
 
-For more information on resources, refer to the [Resources documentation](/concepts/resources).
+For more information on resources, refer to the [Resources documentation](/concepts/resources). To see how to test schedules with resources, refer to the section on [Testing schedules with resources](#testing-schedules-with-resources).
 
 ---
 

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -234,6 +234,59 @@ It's also possible to specify an execution time that exists twice on one day eve
 
 Hourly schedules will be unaffected by daylight savings time transitions - the schedule will continue to run exactly once every hour, even as the timezone changes. In the example above where the hour from 1:00 AM to 2:00 AM repeats, an hourly schedule running at 30 minutes past the hour would run at 12:30 AM, both instances of 1:30 AM, and then proceed normally from 2:30 AM on.
 
+### Using resources in schedules
+
+Dagster's [resources](/concepts/resources) system can be used with schedules to make it easier to interact with external systems or to make components of a schedule easier to plug in for testing purposes.
+
+To specify resource dependencies, annotate the resource as a parameter to the schedule's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
+
+Here, a resource is provided which helps a schedule generate run configuration for a job.
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_schedule endbefore=end_new_resource_on_schedule dedent=4
+from dagster import (
+    schedule,
+    ScheduleEvaluationContext,
+    ConfigurableResource,
+    job,
+    RunRequest,
+    RunConfig,
+    Definitions,
+)
+from datetime import datetime
+from typing import List
+
+class DateFormatter(ConfigurableResource):
+    format: str
+
+    def strftime(self, dt: datetime) -> str:
+        return dt.strftime(self.format)
+
+@job
+def process_data():
+    ...
+
+@schedule(job=process_data, cron_schedule="* * * * *")
+def process_data_schedule(
+    context: ScheduleEvaluationContext,
+    date_formatter: DateFormatter,
+):
+    formatted_date = date_formatter.strftime(context.scheduled_execution_time)
+
+    return RunRequest(
+        run_key=None,
+        run_config=RunConfig(ops={"fetch_data": {"date": formatted_date}}),
+        tags={},
+    )
+
+defs = Definitions(
+    jobs=[process_data],
+    schedules=[process_data_schedule],
+    resources={"date_formatter": DateFormatter(format="%Y-%m-%d")},
+)
+```
+
+For more information on resources, see the [resources](/concepts/resources#using-resources-with-schedules) concept page.
+
 ---
 
 ## Running the scheduler
@@ -335,6 +388,40 @@ def test_configurable_job_schedule():
 ```
 
 If your `@schedule`-decorated function doesn't have a context parameter, you don't need to provide one when invoking it.
+
+#### Testing schedules with resources
+
+For schedules which utilize [resources](/concepts/resources), you can provide the necessary resources when invoking the schedule function.
+
+Below is a test for the `process_data_schedule` that we defined [above](#using-resources-in-schedules) which uses the `date_formatter` resource.
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_test_resource_on_schedule endbefore=end_test_resource_on_schedule dedent=4
+from dagster import build_schedule_context, validate_run_config
+
+def test_process_data_schedule():
+    # You can build resources into the schedule context
+    context = build_schedule_context(
+        scheduled_execution_time=datetime.datetime(2020, 1, 1),
+        resources={"date_formatter": DateFormatter(format="%Y-%m-%d")},
+    )
+    run_request = process_data_schedule(context)
+    assert (
+        run_request.run_config["ops"]["fetch_data"]["config"]["date"]
+        == "2020-01-01"
+    )
+
+    # You can also supply resources as kwargs to the schedule function
+    context = build_schedule_context(
+        scheduled_execution_time=datetime.datetime(2020, 1, 1)
+    )
+    run_request = process_data_schedule(
+        context, date_formatter=DateFormatter(format="%Y-%m-%d")
+    )
+    assert (
+        run_request.run_config["ops"]["fetch_data"]["config"]["date"]
+        == "2020-01-01"
+    )
+```
 
 </TabItem>
 </TabGroup>

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -240,7 +240,7 @@ Dagster's [resources](/concepts/resources) system can be used with schedules to 
 
 To specify resource dependencies, annotate the resource as a parameter to the schedule's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
 
-Here, a resource is provided which helps a schedule generate run configuration for a job.
+Here, a resource is provided which helps a schedule generate a date string:
 
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_schedule endbefore=end_new_resource_on_schedule dedent=4
 from dagster import (
@@ -274,8 +274,7 @@ def process_data_schedule(
 
     return RunRequest(
         run_key=None,
-        run_config=RunConfig(ops={"fetch_data": {"date": formatted_date}}),
-        tags={},
+        tags={"date": formatted_date},
     )
 
 defs = Definitions(
@@ -285,7 +284,7 @@ defs = Definitions(
 )
 ```
 
-For more information on resources, see the [resources](/concepts/resources#using-resources-with-schedules) concept page.
+For more information on resources, refer to the [Resources documentation](/concepts/resources).
 
 ---
 
@@ -393,24 +392,12 @@ If your `@schedule`-decorated function doesn't have a context parameter, you don
 
 For schedules which utilize [resources](/concepts/resources), you can provide the necessary resources when invoking the schedule function.
 
-Below is a test for the `process_data_schedule` that we defined [above](#using-resources-in-schedules) which uses the `date_formatter` resource.
+Below is a test for the `process_data_schedule` that we defined in the [Using resources in schedules](#using-resources-in-schedules) section, which uses the `date_formatter` resource.
 
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_test_resource_on_schedule endbefore=end_test_resource_on_schedule dedent=4
 from dagster import build_schedule_context, validate_run_config
 
 def test_process_data_schedule():
-    # You can build resources into the schedule context
-    context = build_schedule_context(
-        scheduled_execution_time=datetime.datetime(2020, 1, 1),
-        resources={"date_formatter": DateFormatter(format="%Y-%m-%d")},
-    )
-    run_request = process_data_schedule(context)
-    assert (
-        run_request.run_config["ops"]["fetch_data"]["config"]["date"]
-        == "2020-01-01"
-    )
-
-    # You can also supply resources as kwargs to the schedule function
     context = build_schedule_context(
         scheduled_execution_time=datetime.datetime(2020, 1, 1)
     )

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -217,6 +217,66 @@ def my_directory_sensor_with_skip_reasons():
 
 ---
 
+## Using resources in sensors
+
+Dagster's [resources](/concepts/resources) system can be used with sensors to make it easier to call out to external systems and to make components of a sensor easier to plug in for testing purposes.
+
+To specify resource dependencies, annotate the resource as a parameter to the sensor's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
+
+Here, a resource is provided which provides access to an external API. The same resource could be used in the job that the sensor triggers.
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_sensor endbefore=end_new_resource_on_sensor dedent=4
+from dagster import (
+    sensor,
+    RunRequest,
+    SensorEvaluationContext,
+    ConfigurableResource,
+    job,
+    Definitions,
+    RunConfig,
+)
+import requests
+from typing import List
+
+class UsersAPI(ConfigurableResource):
+    url: str
+
+    def fetch_users(self) -> List[str]:
+        return requests.get(self.url).json()
+
+@job
+def process_user():
+    ...
+
+@sensor(job=process_user)
+def process_new_users_sensor(
+    context: SensorEvaluationContext,
+    users_api: UsersAPI,
+):
+    last_user = int(context.cursor) if context.cursor else 0
+    users = users_api.fetch_users()
+
+    num_users = len(users)
+    for user_id in users[last_user:]:
+        yield RunRequest(
+            run_key=user_id,
+            run_config=RunConfig(ops={"insert_user": {"user_id": user_id}}),
+            tags={},
+        )
+
+    context.update_cursor(str(num_users))
+
+defs = Definitions(
+    jobs=[process_user],
+    sensors=[process_new_users_sensor],
+    resources={"users_api": UsersAPI("https://my-api.com/users")},
+)
+```
+
+For more information on resources, see the [resources](/concepts/resources#using-resources-with-schedules) concept page.
+
+---
+
 ## Testing sensors
 
 <TabGroup>
@@ -332,6 +392,34 @@ def test_my_directory_sensor_cursor():
     context = build_sensor_context(cursor="0")
     for run_request in my_directory_sensor_cursor(context):
         assert validate_run_config(log_file_job, run_request.run_config)
+```
+
+#### Testing sensors with resources
+
+For sensors which utilize [resources](/concepts/resources), you can provide the necessary resources when invoking the sensor function.
+
+Below is a test for the `process_new_users_sensor` that we defined [above](#using-resources-in-sensors) which uses the `users_api` resource.
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_test_resource_on_sensor endbefore=end_test_resource_on_sensor dedent=4
+from dagster import build_sensor_context, validate_run_config
+
+def test_process_new_users_sensor():
+    class MockUsersAPI(ConfigurableResource):
+        def fetch_users(self) -> List[str]:
+            return ["1", "2", "3"]
+
+    # You can build resources into the sensor context
+    context = build_sensor_context(
+        resources={"users_api": MockUsersAPI()},
+    )
+    run_requests = process_new_users_sensor(context)
+    assert len(run_requests) == 3
+
+    # You can also supply resources as kwargs to the sensor function
+    context = build_sensor_context()
+    run_request = process_new_users_sensor(context, users_api=MockUsersAPI())
+    run_requests = process_new_users_sensor(context)
+    assert len(run_requests) == 3
 ```
 
 </TabItem>

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -272,9 +272,7 @@ defs = Definitions(
 )
 ```
 
-For more information on resources, refer to the [Resources documentation](/concepts/resources).
-
----
+## For more information on resources, refer to the [Resources documentation](/concepts/resources). To see how to test schedules with resources, refer to the section on [Testing sensors with resources](#testing-sensorss-with-resources).
 
 ## Testing sensors
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -272,7 +272,7 @@ defs = Definitions(
 )
 ```
 
-For more information on resources, refer to the [Resources documentation](/concepts/resources). To see how to test schedules with resources, refer to the section on [Testing sensors with resources](#testing-sensorss-with-resources).
+For more information on resources, refer to the [Resources documentation](/concepts/resources). To see how to test schedules with resources, refer to the section on [Testing sensors with resources](#testing-sensors-with-resources).
 
 ---
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -260,8 +260,7 @@ def process_new_users_sensor(
     for user_id in users[last_user:]:
         yield RunRequest(
             run_key=user_id,
-            run_config=RunConfig(ops={"insert_user": {"user_id": user_id}}),
-            tags={},
+            tags={"user_id": user_id},
         )
 
     context.update_cursor(str(num_users))
@@ -269,11 +268,11 @@ def process_new_users_sensor(
 defs = Definitions(
     jobs=[process_user],
     sensors=[process_new_users_sensor],
-    resources={"users_api": UsersAPI("https://my-api.com/users")},
+    resources={"users_api": UsersAPI(url="https://my-api.com/users")},
 )
 ```
 
-For more information on resources, see the [resources](/concepts/resources#using-resources-with-schedules) concept page.
+For more information on resources, refer to the [Resources documentation](/concepts/resources).
 
 ---
 
@@ -398,7 +397,7 @@ def test_my_directory_sensor_cursor():
 
 For sensors which utilize [resources](/concepts/resources), you can provide the necessary resources when invoking the sensor function.
 
-Below is a test for the `process_new_users_sensor` that we defined [above](#using-resources-in-sensors) which uses the `users_api` resource.
+Below is a test for the `process_new_users_sensor` that we defined in the [Using resources in sensors](#using-resources-in-sensors) section, which uses the `users_api` resource.
 
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_test_resource_on_sensor endbefore=end_test_resource_on_sensor dedent=4
 from dagster import build_sensor_context, validate_run_config
@@ -408,17 +407,8 @@ def test_process_new_users_sensor():
         def fetch_users(self) -> List[str]:
             return ["1", "2", "3"]
 
-    # You can build resources into the sensor context
-    context = build_sensor_context(
-        resources={"users_api": MockUsersAPI()},
-    )
-    run_requests = process_new_users_sensor(context)
-    assert len(run_requests) == 3
-
-    # You can also supply resources as kwargs to the sensor function
     context = build_sensor_context()
-    run_request = process_new_users_sensor(context, users_api=MockUsersAPI())
-    run_requests = process_new_users_sensor(context)
+    run_requests = process_new_users_sensor(context, users_api=MockUsersAPI())
     assert len(run_requests) == 3
 ```
 
@@ -778,27 +768,6 @@ def my_s3_sensor(context):
     context.update_cursor(last_key)
     return run_requests
 ```
-
-### Using resources in sensors
-
-If you want to use resources within your sensor, you can attach a set of `required_resource_keys` to the sensor decorator. This will ensure that the resources are initialized before the sensor is run. You can then access the resources in the sensor function using the context:
-
-```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_build_resources_example endbefore=end_build_resources_example
-from dagster import resource, sensor
-
-
-@resource
-def the_db_connection(init_context):
-    ...
-
-
-@sensor(job=the_job, required_resource_keys={"db_connection"})
-def uses_db_connection(context):
-    conn = context.resources.db_connection
-    ...
-```
-
-If a resource you want to initialize has dependencies on other resources, those can be included in the dictionary passed to <PyObject object="build_resources"/>.
 
 ---
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -403,12 +403,12 @@ Below is a test for the `process_new_users_sensor` that we defined in the [Using
 from dagster import build_sensor_context, validate_run_config
 
 def test_process_new_users_sensor():
-    class MockUsersAPI(ConfigurableResource):
+    class FakeUsersAPI:
         def fetch_users(self) -> List[str]:
             return ["1", "2", "3"]
 
     context = build_sensor_context()
-    run_requests = process_new_users_sensor(context, users_api=MockUsersAPI())
+    run_requests = process_new_users_sensor(context, users_api=FakeUsersAPI())
     assert len(run_requests) == 3
 ```
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -272,7 +272,9 @@ defs = Definitions(
 )
 ```
 
-## For more information on resources, refer to the [Resources documentation](/concepts/resources). To see how to test schedules with resources, refer to the section on [Testing sensors with resources](#testing-sensorss-with-resources).
+For more information on resources, refer to the [Resources documentation](/concepts/resources). To see how to test schedules with resources, refer to the section on [Testing sensors with resources](#testing-sensorss-with-resources).
+
+---
 
 ## Testing sensors
 

--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -693,29 +693,21 @@ def my_s3_sensor(context):
 
 ### Using resources in sensors
 
-If you want to use resources within your sensor, you can use the <PyObject object="build_resources"/> API to perform the initialization.
+If you want to use resources within your sensor, you can attach a set of `required_resource_keys` to the sensor decorator. This will ensure that the resources are initialized before the sensor is run. You can then access the resources in the sensor function using the context:
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_build_resources_example endbefore=end_build_resources_example
-from dagster import resource, build_resources, sensor
+from dagster import resource, sensor
 
 
 @resource
-def the_credentials():
+def the_db_connection(init_context):
     ...
 
 
-@resource(required_resource_keys={"credentials"})
-def the_db_connection(init_context):
-    get_the_db_connection(init_context.resources.credentials)
-
-
-@sensor(job=the_job)
-def uses_db_connection():
-    with build_resources(
-        {"db_connection": the_db_connection, "credentials": the_credentials}
-    ) as resources:
-        conn = resources.db_connection
-        ...
+@sensor(job=the_job, required_resource_keys={"db_connection"})
+def uses_db_connection(context):
+    conn = context.resources.db_connection
+    ...
 ```
 
 If a resource you want to initialize has dependencies on other resources, those can be included in the dictionary passed to <PyObject object="build_resources"/>.

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -129,108 +129,13 @@ There are many supported config types that can be used when defining resources. 
 
 [Sensors](/concepts/partitions-schedules-sensors/sensors) can use resources in the same way as ops and assets, which can be useful for querying external services for data.
 
-To specify resource dependencies, annotate the resource as a parameter to the sensor's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
-
-Here, a resource is provided which provides access to an external API. The same resource could be used in the job that the sensor triggers.
-
-```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_sensor endbefore=end_new_resource_on_sensor dedent=4
-from dagster import (
-    sensor,
-    RunRequest,
-    SensorEvaluationContext,
-    ConfigurableResource,
-    job,
-    Definitions,
-    RunConfig,
-)
-import requests
-from typing import List
-
-class UsersAPI(ConfigurableResource):
-    url: str
-
-    def fetch_users(self) -> List[str]:
-        return requests.get(self.url).json()
-
-@job
-def process_user():
-    ...
-
-@sensor(job=process_user)
-def process_new_users_sensor(
-    context: SensorEvaluationContext,
-    users_api: UsersAPI,
-):
-    last_user = int(context.cursor) if context.cursor else 0
-    users = users_api.fetch_users()
-
-    num_users = len(users)
-    for user_id in users[last_user:]:
-        yield RunRequest(
-            run_key=user_id,
-            run_config=RunConfig(ops={"insert_user": {"user_id": user_id}}),
-            tags={},
-        )
-
-    context.update_cursor(str(num_users))
-
-defs = Definitions(
-    jobs=[process_user],
-    sensors=[process_new_users_sensor],
-    resources={"users_api": UsersAPI("https://my-api.com/users")},
-)
-```
+To specify resource dependencies on a sensor, annotate the resource type as a parameter to the sensor's function. For more information and examples, refer to the [Sensors documentation](/concepts/partitions-schedules-sensors/sensors#using-resources-in-sensors).
 
 ### Using resources with schedules
 
-[Schedules](/concepts/partitions-schedules-sensors/schedules)can also use resources in case your schedule logic needs to interface with an external tool, or to make your schedule logic more testable.
+[Schedules](/concepts/partitions-schedules-sensors/schedules) can also use resources in case your schedule logic needs to interface with an external tool, or to make your schedule logic more testable.
 
-To specify resource dependencies, annotate the resource as a parameter to the schedule's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
-
-Here, a resource is provided which helps a schedule generate run configuration for a job.
-
-```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_schedule endbefore=end_new_resource_on_schedule dedent=4
-from dagster import (
-    schedule,
-    ScheduleEvaluationContext,
-    ConfigurableResource,
-    job,
-    RunRequest,
-    RunConfig,
-    Definitions,
-)
-from datetime import datetime
-from typing import List
-
-class DateFormatter(ConfigurableResource):
-    format: str
-
-    def strftime(self, dt: datetime) -> str:
-        return dt.strftime(self.format)
-
-@job
-def process_data():
-    ...
-
-@schedule(job=process_data, cron_schedule="* * * * *")
-def process_data_schedule(
-    context: ScheduleEvaluationContext,
-    date_formatter: DateFormatter,
-):
-    formatted_date = date_formatter.strftime(context.scheduled_execution_time)
-
-    return RunRequest(
-        run_key=None,
-        run_config=RunConfig(ops={"fetch_data": {"date": formatted_date}}),
-        tags={},
-    )
-
-defs = Definitions(
-    jobs=[process_data],
-    schedules=[process_data_schedule],
-    resources={"date_formatter": DateFormatter(format="%Y-%m-%d")},
-)
-```
+To specify resource dependencies on a schedule, annotate the resource type as a parameter to the schedule's function. For more information and examples, refer to the [Schedules documentation](/concepts/partitions-schedules-sensors/schedules#using-resources-in-schedules).
 
 ### Using environment variables with resources
 

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -125,6 +125,113 @@ defs = Definitions(
 
 There are many supported config types that can be used when defining resources. See the [advanced config types documentation](/concepts/configuration/advanced-config-types) for a more comprehensive overview on the available config types.
 
+### Using resources with sensors
+
+[Sensors](/concepts/partitions-schedules-sensors/sensors) can use resources in the same way as ops and assets, which can be useful for querying external services for data.
+
+To specify resource dependencies, annotate the resource as a parameter to the sensor's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
+
+Here, a resource is provided which provides access to an external API. The same resource could be used in the job that the sensor triggers.
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_sensor endbefore=end_new_resource_on_sensor dedent=4
+from dagster import (
+    sensor,
+    RunRequest,
+    SensorEvaluationContext,
+    ConfigurableResource,
+    job,
+    Definitions,
+    RunConfig,
+)
+import requests
+from typing import List
+
+class UsersAPI(ConfigurableResource):
+    url: str
+
+    def fetch_users(self) -> List[str]:
+        return requests.get(self.url).json()
+
+@job
+def process_user():
+    ...
+
+@sensor(job=process_user)
+def process_new_users_sensor(
+    context: SensorEvaluationContext,
+    users_api: UsersAPI,
+):
+    last_user = int(context.cursor) if context.cursor else 0
+    users = users_api.fetch_users()
+
+    num_users = len(users)
+    for user_id in users[last_user:]:
+        yield RunRequest(
+            run_key=user_id,
+            run_config=RunConfig(ops={"insert_user": {"user_id": user_id}}),
+            tags={},
+        )
+
+    context.update_cursor(str(num_users))
+
+defs = Definitions(
+    jobs=[process_user],
+    sensors=[process_new_users_sensor],
+    resources={"users_api": UsersAPI("https://my-api.com/users")},
+)
+```
+
+### Using resources with schedules
+
+[Schedules](/concepts/partitions-schedules-sensors/schedules)can also use resources in case your schedule logic needs to interface with an external tool, or to make your schedule logic more testable.
+
+To specify resource dependencies, annotate the resource as a parameter to the schedule's function. Resources are provided by attaching them to your <PyObject object="Definitions" /> call.
+
+Here, a resource is provided which helps a schedule generate run configuration for a job.
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_on_schedule endbefore=end_new_resource_on_schedule dedent=4
+from dagster import (
+    schedule,
+    ScheduleEvaluationContext,
+    ConfigurableResource,
+    job,
+    RunRequest,
+    RunConfig,
+    Definitions,
+)
+from datetime import datetime
+from typing import List
+
+class DateFormatter(ConfigurableResource):
+    format: str
+
+    def strftime(self, dt: datetime) -> str:
+        return dt.strftime(self.format)
+
+@job
+def process_data():
+    ...
+
+@schedule(job=process_data, cron_schedule="* * * * *")
+def process_data_schedule(
+    context: ScheduleEvaluationContext,
+    date_formatter: DateFormatter,
+):
+    formatted_date = date_formatter.strftime(context.scheduled_execution_time)
+
+    return RunRequest(
+        run_key=None,
+        run_config=RunConfig(ops={"fetch_data": {"date": formatted_date}}),
+        tags={},
+    )
+
+defs = Definitions(
+    jobs=[process_data],
+    schedules=[process_data_schedule],
+    resources={"date_formatter": DateFormatter(format="%Y-%m-%d")},
+)
+```
+
 ### Using environment variables with resources
 
 Resources can be configured using environment variables, which is useful for secrets or other environment-specific configuration. If you're using Dagster Cloud, environment variables can be [configured directly in the UI](/dagster-cloud/managing-deployments/environment-variables-and-secrets).

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -209,26 +209,18 @@ def get_the_db_connection(_):
 
 
 # start_build_resources_example
-from dagster import resource, build_resources, sensor
+from dagster import resource, sensor
 
 
 @resource
-def the_credentials():
+def the_db_connection(init_context):
     ...
 
 
-@resource(required_resource_keys={"credentials"})
-def the_db_connection(init_context):
-    get_the_db_connection(init_context.resources.credentials)
-
-
-@sensor(job=the_job)
-def uses_db_connection():
-    with build_resources(
-        {"db_connection": the_db_connection, "credentials": the_credentials}
-    ) as resources:
-        conn = resources.db_connection
-        ...
+@sensor(job=the_job, required_resource_keys={"db_connection"})
+def uses_db_connection(context):
+    conn = context.resources.db_connection
+    ...
 
 
 # end_build_resources_example

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -208,23 +208,6 @@ def get_the_db_connection(_):
     ...
 
 
-# start_build_resources_example
-from dagster import resource, sensor
-
-
-@resource
-def the_db_connection(init_context):
-    ...
-
-
-@sensor(job=the_job, required_resource_keys={"db_connection"})
-def uses_db_connection(context):
-    conn = context.resources.db_connection
-    ...
-
-
-# end_build_resources_example
-
 defs = Definitions(
     jobs=[my_job, log_file_job],
     sensors=[my_directory_sensor, sensor_A, sensor_B],

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -693,3 +693,98 @@ def new_resource_testing_with_state() -> None:
         assert my_asset(mocked_client_resource) == "my_result"
 
     # end_new_resource_testing_with_state
+
+
+def new_resource_on_sensor() -> None:
+    # start_new_resource_on_sensor
+    from dagster import (
+        sensor,
+        RunRequest,
+        SensorEvaluationContext,
+        ConfigurableResource,
+        job,
+        Definitions,
+        RunConfig,
+    )
+    import requests
+    from typing import List
+
+    class UsersAPI(ConfigurableResource):
+        url: str
+
+        def fetch_users(self) -> List[str]:
+            return requests.get(self.url).json()
+
+    @job
+    def process_user():
+        ...
+
+    @sensor(job=process_user)
+    def process_new_users_sensor(
+        context: SensorEvaluationContext,
+        users_api: UsersAPI,
+    ):
+        last_user = int(context.cursor) if context.cursor else 0
+        users = users_api.fetch_users()
+
+        num_users = len(users)
+        for user_id in users[last_user:]:
+            yield RunRequest(
+                run_key=user_id,
+                run_config=RunConfig(ops={"insert_user": {"user_id": user_id}}),  # type: ignore
+                tags={},
+            )
+
+        context.update_cursor(str(num_users))
+
+    defs = Definitions(
+        jobs=[process_user],
+        sensors=[process_new_users_sensor],
+        resources={"users_api": UsersAPI("https://my-api.com/users")},
+    )
+    # end_new_resource_on_sensor
+
+
+def new_resource_on_schedule() -> None:
+    # start_new_resource_on_schedule
+    from dagster import (
+        schedule,
+        ScheduleEvaluationContext,
+        ConfigurableResource,
+        job,
+        RunRequest,
+        RunConfig,
+        Definitions,
+    )
+    from datetime import datetime
+    from typing import List
+
+    class DateFormatter(ConfigurableResource):
+        format: str
+
+        def strftime(self, dt: datetime) -> str:
+            return dt.strftime(self.format)
+
+    @job
+    def process_data():
+        ...
+
+    @schedule(job=process_data, cron_schedule="* * * * *")
+    def process_data_schedule(
+        context: ScheduleEvaluationContext,
+        date_formatter: DateFormatter,
+    ):
+        formatted_date = date_formatter.strftime(context.scheduled_execution_time)
+
+        return RunRequest(
+            run_key=None,
+            run_config=RunConfig(ops={"fetch_data": {"date": formatted_date}}),  # type: ignore
+            tags={},
+        )
+
+    defs = Definitions(
+        jobs=[process_data],
+        schedules=[process_data_schedule],
+        resources={"date_formatter": DateFormatter(format="%Y-%m-%d")},
+    )
+    # end_new_resource_on_schedule

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -748,12 +748,12 @@ def new_resource_on_sensor() -> None:
     from dagster import build_sensor_context, validate_run_config
 
     def test_process_new_users_sensor():
-        class MockUsersAPI(ConfigurableResource):
+        class FakeUsersAPI:
             def fetch_users(self) -> List[str]:
                 return ["1", "2", "3"]
 
         context = build_sensor_context()
-        run_requests = process_new_users_sensor(context, users_api=MockUsersAPI())
+        run_requests = process_new_users_sensor(context, users_api=FakeUsersAPI())
         assert len(run_requests) == 3
 
         # end_test_resource_on_sensor

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_sensors.py
@@ -15,7 +15,6 @@ from docs_snippets.concepts.partitions_schedules_sensors.sensors.sensors import 
     sensor_B,
     test_my_directory_sensor_cursor,
     test_sensor,
-    uses_db_connection,
 )
 
 
@@ -67,10 +66,6 @@ def test_run_failure_sensor_def():
 def test_sensor_testing_example():
     test_sensor()
     test_my_directory_sensor_cursor()
-
-
-def test_resource_sensor_example():
-    uses_db_connection()
 
 
 def test_s3_sensor():


### PR DESCRIPTION
## Summary

Adds some examples of how to use schedules and sensors with resources. Preview: https://dagster-git-benpankow-docs-for-schedules-sensors-elementl.vercel.app/guides/dagster/pythonic-resources

