### PR TITLE
[ui] Fix date demarcations in timeline for non-en-US

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -329,7 +329,7 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
 };
 
 const dateTimeOptionsWithTimezone: Intl.DateTimeFormatOptions = {
-  month: 'numeric',
+  month: 'short',
   day: 'numeric',
   year: 'numeric',
   timeZoneName: 'short',
@@ -347,7 +347,11 @@ const TimeDividers = (props: TimeDividersProps) => {
   const dateMarkers: DateMarker[] = React.useMemo(() => {
     const totalTime = end - start;
     const startDate = new Date(start);
-    const startDateStringWithTimezone = formatDateTime(startDate, dateTimeOptionsWithTimezone);
+    const startDateStringWithTimezone = formatDateTime(
+      startDate,
+      dateTimeOptionsWithTimezone,
+      'en-US',
+    );
 
     const dayBoundaries = [];
 

--- a/js_modules/dagit/packages/core/src/ui/useFormatDateTime.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useFormatDateTime.test.tsx
@@ -15,11 +15,12 @@ describe('useFormatDateTime', () => {
   interface Props {
     date: Date;
     options: Intl.DateTimeFormatOptions;
+    language?: string;
   }
 
-  const Test: React.FC<Props> = ({date, options}) => {
+  const Test: React.FC<Props> = ({date, options, language}) => {
     const formatDateTime = useFormatDateTime();
-    return <div>{formatDateTime(date, options)}</div>;
+    return <div>{formatDateTime(date, options, language)}</div>;
   };
 
   afterEach(() => {
@@ -129,6 +130,42 @@ describe('useFormatDateTime', () => {
         </TimezoneProvider>,
       );
       expect(screen.getByText(/^7:00 AM GMT\+1/)).toBeVisible();
+    });
+  });
+
+  describe('Manual language setting', () => {
+    beforeEach(() => {
+      const languageGetter = jest.spyOn(window.navigator, 'language', 'get');
+      languageGetter.mockReturnValue('de-DE');
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('uses navigator.language by default (de-DE)', () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{month: 'short', day: 'numeric', year: 'numeric', timeZoneName: 'short'}}
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/31\. Dez\. 2022, GMT-10/)).toBeVisible();
+    });
+
+    it('uses allows passing a custom language (pt-PT overrides de-DE)', () => {
+      render(
+        <TimezoneProvider>
+          <Test
+            date={new Date(NYD_2023_CST)}
+            options={{month: 'short', day: 'numeric', year: 'numeric', timeZoneName: 'short'}}
+            language="pt-PT"
+          />
+        </TimezoneProvider>,
+      );
+      expect(screen.getByText(/31\/12\/2022, GMT-10/)).toBeVisible();
     });
   });
 });

--- a/js_modules/dagit/packages/core/src/ui/useFormatDateTime.tsx
+++ b/js_modules/dagit/packages/core/src/ui/useFormatDateTime.tsx
@@ -13,8 +13,8 @@ export const useFormatDateTime = () => {
   const [storedTimezone] = React.useContext(TimezoneContext);
   const timeZone = storedTimezone === 'Automatic' ? browserTimezone() : storedTimezone;
   return React.useCallback(
-    (date: Date, options: Intl.DateTimeFormatOptions) => {
-      return Intl.DateTimeFormat(navigator.language, {timeZone, ...options}).format(date);
+    (date: Date, options: Intl.DateTimeFormatOptions, language = navigator.language) => {
+      return Intl.DateTimeFormat(language, {timeZone, ...options}).format(date);
     },
     [timeZone],
   );


### PR DESCRIPTION
## Summary & Motivation

A bug report from a user (https://dagster.slack.com/archives/C01U5LFUZJS/p1678711831120359) noted that the date demarcations on the Jobs timeline were missing. Some investigation led to an issue with parsing dates from formatted date strings.

Namely, when we produce a date string to represent a midnight timestamp for a specific date at a specific time zone, the string must be parseable by `new Date()`. In cases where the user's locale (navigator.language) produced a date that could not be parsed, an `Invalid Date` is produced, and we can't bucket the timeline segments by date at all.

To fix this, allow a `language` string to be passed to the date formatter, and in this situation *always* use `en-US` to ensure that a valid date string can be created.

## How I Tested These Changes

Added some jest specs to verify `language` argument behavior.

Screenshots with different navigator.language values:

en-US:

<img width="1212" alt="Screenshot 2023-03-14 at 1 39 10 PM" src="https://user-images.githubusercontent.com/2823852/225109361-f4776386-af29-4e35-9f66-1976d2b3d7c5.png">

de-DE:

<img width="1213" alt="Screenshot 2023-03-14 at 1 38 59 PM" src="https://user-images.githubusercontent.com/2823852/225109364-802deb7d-cc8b-48f8-9653-ef26128faf78.png">

hu:

<img width="1212" alt="Screenshot 2023-03-14 at 1 38 48 PM" src="https://user-images.githubusercontent.com/2823852/225109365-12d37e8c-ab76-4bfb-bd57-0ae07aee9506.png">

zh:

<img width="1216" alt="Screenshot 2023-03-14 at 1 38 38 PM" src="https://user-images.githubusercontent.com/2823852/225109367-4e01f31f-8b61-4dbc-b436-1527f298ac58.png">

en-GB:

<img width="1213" alt="Screenshot 2023-03-14 at 1 38 27 PM" src="https://user-images.githubusercontent.com/2823852/225109369-8bde6f39-cdcd-499e-b39d-ca1eb0685663.png">

