### PR TITLE
Fix valid start time check for time partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -109,8 +109,11 @@ class TimeWindowPartitionsDefinition(
         day_offset: Optional[int] = None,
         cron_schedule: Optional[str] = None,
     ):
+        check.opt_str_param(timezone, "timezone")
+        timezone = timezone or "UTC"
+
         if isinstance(start, datetime):
-            start_dt = start
+            start_dt = pendulum.instance(start, tz=timezone)
         else:
             start_dt = pendulum.instance(datetime.strptime(start, fmt), tz=timezone)
 
@@ -139,7 +142,7 @@ class TimeWindowPartitionsDefinition(
             )
 
         return super(TimeWindowPartitionsDefinition, cls).__new__(
-            cls, start_dt, timezone or "UTC", fmt, end_offset, cron_schedule  # type: ignore  # (pyright bug)
+            cls, start_dt, timezone, fmt, end_offset, cron_schedule  # type: ignore  # (pyright bug)
         )
 
     def get_current_timestamp(self, current_time: Optional[datetime] = None) -> float:
@@ -682,7 +685,7 @@ class TimeWindowPartitionsDefinition(
             partition_time = pendulum.instance(
                 datetime.strptime(partition_key, self.fmt), tz=self.timezone
             )
-            return partition_time.timestamp() >= self.start.timestamp()
+            return partition_time >= self.start
         except ValueError:
             return False
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -112,7 +112,7 @@ class TimeWindowPartitionsDefinition(
         if isinstance(start, datetime):
             start_dt = start
         else:
-            start_dt = datetime.strptime(start, fmt)
+            start_dt = pendulum.instance(datetime.strptime(start, fmt), tz=timezone)
 
         if cron_schedule is not None:
             check.invariant(
@@ -679,8 +679,10 @@ class TimeWindowPartitionsDefinition(
 
     def is_valid_partition_key(self, partition_key: str) -> bool:
         try:
-            time_obj = datetime.strptime(partition_key, self.fmt)
-            return time_obj.timestamp() >= self.start.timestamp()
+            partition_time = pendulum.instance(
+                datetime.strptime(partition_key, self.fmt), tz=self.timezone
+            )
+            return partition_time.timestamp() >= self.start.timestamp()
         except ValueError:
             return False
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -8,6 +8,7 @@ from dagster import (
     AssetsDefinition,
     DailyPartitionsDefinition,
     GraphOut,
+    HourlyPartitionsDefinition,
     Out,
     StaticPartitionsDefinition,
     define_asset_job,
@@ -1051,3 +1052,15 @@ def test_graph_multi_asset_description():
     }
     assert external_asset_nodes[AssetKey("asset1")].op_description == "bar"
     assert external_asset_nodes[AssetKey("asset2")].op_description == "baz"
+
+
+def test_external_time_window_valid_partition_key():
+    hourly_partition = HourlyPartitionsDefinition(start_date="2023-03-11-15:00")
+
+    external_partitions_def = external_time_window_partitions_definition_from_def(hourly_partition)
+    assert (
+        external_partitions_def.get_partitions_definition().is_valid_partition_key(
+            "2023-03-11-15:00"
+        )
+        is True
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1064,3 +1064,9 @@ def test_external_time_window_valid_partition_key():
         )
         is True
     )
+    assert (
+        external_partitions_def.get_partitions_definition().start.timestamp()
+        == pendulum.instance(
+            datetime.strptime("2023-03-11-15:00", "%Y-%m-%d-%H:%M"), tz="UTC"
+        ).timestamp()
+    )


### PR DESCRIPTION
Reported by a user: https://dagster.slack.com/archives/C01U954MEER/p1678304642514719

Fixes an error where the first partition in the partition health bar always displays as unmaterialized despite a materialization existing for this partition. This error occurs when the running OS timezone is ahead of the partitions def timezone (by default UTC).

The cause of this issue was a partition key validation check that relied on a `datetime.strptime` object which is not timezone aware (so defaults to the running OS timezone). Because the external time window partitions def creates a start time object that is timezone aware, certain valid partition keys would be considered invalid as they were set to an earlier timezone and thus were considered to be "before" the valid start time.