### PR TITLE
[dagit] Use pure-asset backfills instead of hidden asset job backfills

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -25,7 +25,11 @@ import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {usePermissionsForLocation} from '../app/Permissions';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {displayNameForAssetKey, itemWithAssetKey} from '../asset-graph/Utils';
+import {
+  displayNameForAssetKey,
+  isHiddenAssetGroupJob,
+  itemWithAssetKey,
+} from '../asset-graph/Utils';
 import {AssetKey} from '../assets/types';
 import {LaunchBackfillParams, PartitionDefinitionType} from '../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/BackfillUtils';
@@ -213,7 +217,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   const {useLaunchWithTelemetry} = useLaunchPadHooks();
   const launchWithTelemetry = useLaunchWithTelemetry();
   const launchAsBackfill =
-    target.type === 'pureAssetBackfill' || (!launchWithRangesAsTags && keysFiltered.length !== 1);
+    target.type === 'pureWithAnchorAsset' || (!launchWithRangesAsTags && keysFiltered.length !== 1);
 
   React.useEffect(() => {
     !canLaunchWithRangesAsTags && setLaunchWithRangesAsTags(false);
@@ -224,7 +228,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   }, [launchWithRangesAsTags]);
 
   React.useEffect(() => {
-    target.type === 'pureAssetBackfill' && setMissingFailedOnly(false);
+    target.type === 'pureWithAnchorAsset' && setMissingFailedOnly(false);
   }, [target]);
 
   const onLaunch = async () => {
@@ -333,7 +337,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
 
   const onLaunchAsBackfill = async () => {
     const selectorIfJobPage: LaunchBackfillParams['selector'] | undefined =
-      'jobName' in target
+      'jobName' in target && !isHiddenAssetGroupJob(target.jobName)
         ? {
             partitionSetName: target.partitionSetName,
             repositorySelector: {
@@ -412,7 +416,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
       <div data-testid={testId('choose-partitions-dialog')}>
         <Warnings
           launchAsBackfill={launchAsBackfill}
-          isPureAssetBackfill={target.type === 'pureAssetBackfill'}
+          isPureAssetBackfill={target.type === 'pureWithAnchorAsset'}
           upstreamAssetKeys={upstreamAssetKeys}
           selections={selections}
           setSelections={setSelections}
@@ -508,7 +512,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           isInitiallyOpen={true}
         >
           <Box padding={{vertical: 16, horizontal: 24}} flex={{direction: 'column', gap: 12}}>
-            {target.type === 'pureAssetBackfill' ? null : (
+            {target.type === 'pureWithAnchorAsset' ? null : (
               <Checkbox
                 data-testid={testId('missing-only-checkbox')}
                 label="Backfill only failed and missing partitions within selection"

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -42,7 +42,7 @@ import {
 
 export type LaunchAssetsChoosePartitionsTarget =
   | {type: 'job'; jobName: string; partitionSetName: string}
-  | {type: 'pureAssetBackfill'; anchorAssetKey: AssetKey};
+  | {type: 'pureWithAnchorAsset'; anchorAssetKey: AssetKey};
 
 type LaunchAssetsState =
   | {type: 'none'}
@@ -412,7 +412,7 @@ async function stateForLaunchingAssets(
     return {
       type: 'partitions',
       assets,
-      target: {type: 'pureAssetBackfill', anchorAssetKey: anchorAsset.assetKey},
+      target: {type: 'pureWithAnchorAsset', anchorAssetKey: anchorAsset.assetKey},
       upstreamAssetKeys: getUpstreamAssetKeys(assets),
       repoAddress,
     };


### PR DESCRIPTION
## Summary & Motivation

This change is based on this slack thread:
https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1678813493408879

The materialize button's behavior is as follows:

- on the asset job view, single runs and backfills should use the visible asset job
- on the asset group view, single runs should use the hidden asset jobs
- on the asset group view, all backfills should be pure asset backfills

Previously, we were using the hidden asset job for all backfills that did not REQUIRE the pure asset backfill machinery. Following this update, hidden asset jobs are only used for single runs.

## How I Tested These Changes

I manually tested and verified the GraphQL result of:

- launching a single partitioned asset from an asset group and from an asset job
- launching two same-partitioned assets from an asset group and from an asset job
- launching two partition-mapped assets from an asset group and from an asset job
- launching two unpartitioned assets from an asset group and from an asset job

I'm working on more automated tests for this in a small follow-up PR, but we may want to ship this tonight.