### PR TITLE
MultiPartitionMapping

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -267,7 +267,7 @@ from dagster._core.definitions.partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
-    MultiPartitionsMapping as MultiPartitionsMapping,
+    MultiPartitionMapping as MultiPartitionMapping,
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
     SpecificPartitionsPartitionMapping as SpecificPartitionsPartitionMapping,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -267,6 +267,7 @@ from dagster._core.definitions.partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
+    MultiPartitionsMapping as MultiPartitionsMapping,
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
     SpecificPartitionsPartitionMapping as SpecificPartitionsPartitionMapping,

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -164,6 +164,7 @@ from .partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
+    MultiPartitionsMapping as MultiPartitionsMapping,
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
 )

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -164,7 +164,7 @@ from .partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
-    MultiPartitionsMapping as MultiPartitionsMapping,
+    MultiPartitionMapping as MultiPartitionMapping,
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
     PartitionMapping as PartitionMapping,
 )

--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -224,6 +224,12 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     def partitions_defs(self) -> Sequence[PartitionDimensionDefinition]:
         return self._partitions_defs
 
+    def get_partitions_def_for_dimension(self, dimension_name: str) -> PartitionsDefinition:
+        for dim_def in self._partitions_defs:
+            if dim_def.name == dimension_name:
+                return dim_def.partitions_def
+        check.failed(f"Invalid dimension name {dimension_name}")
+
     def get_partition(
         self,
         partition_key: str,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -16,7 +16,7 @@ from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import (
     DimensionMapping,
-    MultiPartitionsMapping,
+    MultiPartitionMapping,
     MultiToSingleDimensionPartitionMapping,
 )
 
@@ -234,19 +234,16 @@ upstream_and_downstream_tests = [
                 "weekly": WeeklyPartitionsDefinition("2023-01-01"),
             }
         ),
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "abc",
-                    "abc",
-                    IdentityPartitionMapping(),
+        MultiPartitionMapping(
+            {
+                "abc": DimensionMapping(
+                    downstream_dimension_name="abc", partition_mapping=IdentityPartitionMapping()
                 ),
-                DimensionMapping(
-                    "daily",
-                    "weekly",
-                    TimeWindowPartitionMapping(),
+                "daily": DimensionMapping(
+                    downstream_dimension_name="weekly",
+                    partition_mapping=TimeWindowPartitionMapping(),
                 ),
-            ]
+            }
         ),
         [
             MultiPartitionKey({"abc": values[0], "daily": values[1]})
@@ -275,19 +272,16 @@ upstream_and_downstream_tests = [
                 "weekly": WeeklyPartitionsDefinition("2023-01-01"),
             }
         ),
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "abc",
-                    "abc",
-                    IdentityPartitionMapping(),
+        MultiPartitionMapping(
+            {
+                "abc": DimensionMapping(
+                    downstream_dimension_name="abc", partition_mapping=IdentityPartitionMapping()
                 ),
-                DimensionMapping(
-                    "daily",
-                    "weekly",
-                    TimeWindowPartitionMapping(),
+                "daily": DimensionMapping(
+                    downstream_dimension_name="weekly",
+                    partition_mapping=TimeWindowPartitionMapping(),
                 ),
-            ]
+            },
         ),
         [
             MultiPartitionKey({"abc": values[0], "daily": values[1]})
@@ -332,19 +326,17 @@ upstream_only_tests = [
                 "daily": DailyPartitionsDefinition("2023-01-01"),
             }
         ),
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "abc",
-                    "123",
-                    SpecificPartitionsPartitionMapping(["c"]),
+        MultiPartitionMapping(
+            {
+                "abc": DimensionMapping(
+                    downstream_dimension_name="123",
+                    partition_mapping=SpecificPartitionsPartitionMapping(["c"]),
                 ),
-                DimensionMapping(
-                    "weekly",
-                    "daily",
-                    TimeWindowPartitionMapping(),
+                "weekly": DimensionMapping(
+                    downstream_dimension_name="daily",
+                    partition_mapping=TimeWindowPartitionMapping(),
                 ),
-            ]
+            },
         ),
         [
             MultiPartitionKey({"abc": values[0], "daily": values[1]})
@@ -373,19 +365,17 @@ upstream_only_tests = [
                 "daily": DailyPartitionsDefinition("2023-01-01"),
             }
         ),
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "abc",
-                    "123",
-                    SpecificPartitionsPartitionMapping(["c"]),
+        MultiPartitionMapping(
+            {
+                "abc": DimensionMapping(
+                    downstream_dimension_name="123",
+                    partition_mapping=SpecificPartitionsPartitionMapping(["c"]),
                 ),
-                DimensionMapping(
-                    "weekly",
-                    "daily",
-                    TimeWindowPartitionMapping(),
+                "weekly": DimensionMapping(
+                    downstream_dimension_name="daily",
+                    partition_mapping=TimeWindowPartitionMapping(),
                 ),
-            ]
+            }
         ),
         [
             MultiPartitionKey({"abc": values[0], "daily": values[1]})
@@ -427,19 +417,15 @@ upstream_only_tests = [
                 "daily": DailyPartitionsDefinition("2023-01-01"),
             }
         ),
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "abc",
-                    "123",
-                    AllPartitionMapping(),
+        MultiPartitionMapping(
+            {
+                "abc": DimensionMapping(
+                    downstream_dimension_name="123", partition_mapping=AllPartitionMapping()
                 ),
-                DimensionMapping(
-                    "daily",
-                    "daily",
-                    IdentityPartitionMapping(),
+                "daily": DimensionMapping(
+                    downstream_dimension_name="daily", partition_mapping=IdentityPartitionMapping()
                 ),
-            ]
+            }
         ),
         [
             MultiPartitionKey({"abc": values[0], "daily": values[1]})
@@ -473,19 +459,17 @@ downstream_only_tests = [
                 "daily": DailyPartitionsDefinition("2023-01-01"),
             }
         ),
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "abc",
-                    "123",
-                    StaticPartitionMapping({"a": "1", "b": "2", "c": "3"}),
+        MultiPartitionMapping(
+            {
+                "abc": DimensionMapping(
+                    downstream_dimension_name="123",
+                    partition_mapping=StaticPartitionMapping({"a": "1", "b": "2", "c": "3"}),
                 ),
-                DimensionMapping(
-                    "weekly",
-                    "daily",
-                    TimeWindowPartitionMapping(),
+                "weekly": DimensionMapping(
+                    downstream_dimension_name="daily",
+                    partition_mapping=TimeWindowPartitionMapping(),
                 ),
-            ]
+            }
         ),
         [
             MultiPartitionKey({"abc": values[0], "daily": values[1]})
@@ -572,39 +556,35 @@ def test_error_multipartitions_mapping():
     )
 
     with pytest.raises(CheckError, match="dimensions that are not mapped"):
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "123",
-                    "abc",
-                    SpecificPartitionsPartitionMapping(["c"]),
+        MultiPartitionMapping(
+            {
+                "123": DimensionMapping(
+                    downstream_dimension_name="abc",
+                    partition_mapping=SpecificPartitionsPartitionMapping(["c"]),
                 )
-            ]
+            }
         ).get_upstream_partitions_for_partitions(weekly_abc.empty_subset(), daily_123)
 
     with pytest.raises(
         CheckError, match="upstream dimension name that is not in the upstream partitions def"
     ):
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "nonexistent dimension",
-                    "other nonexistent dimension",
-                    SpecificPartitionsPartitionMapping(["c"]),
+        MultiPartitionMapping(
+            {
+                "nonexistent dimension": DimensionMapping(
+                    "other nonexistent dimension", SpecificPartitionsPartitionMapping(["c"])
                 )
-            ]
+            }
         ).get_upstream_partitions_for_partitions(weekly_abc.empty_subset(), daily_123)
 
     with pytest.raises(ValueError):
-        MultiPartitionsMapping(
-            [
-                DimensionMapping(
-                    "123",
+        MultiPartitionMapping(
+            {
+                "123": DimensionMapping(
                     "abc",
                     StaticPartitionMapping({"1": "a", "2": "b", "3": "c"}),
                 ),
-                DimensionMapping("daily", "weekly", IdentityPartitionMapping()),  # Invalid
-            ]
+                "daily": DimensionMapping("weekly", IdentityPartitionMapping()),  # Invalid
+            }
         ).get_upstream_partitions_for_partitions(
             weekly_abc.empty_subset().with_partition_keys(
                 MultiPartitionKey({"abc": "a", "weekly": "2023-01-01"})


### PR DESCRIPTION
Requested by multiple users, primarily for the use case of defining multipartitions dependencies for different time intervals: https://github.com/dagster-io/dagster/issues/12905

Introduces a new `MultiPartitionsMapping` partition mapping that allows for defining partition mapping relationships per-dimension. For example, the below partition mapping would map `a|2023-01-01` in `weekly_abc` would map to `1|2023-01-01`... `1|2023-01-07`.
```
weekly_abc = MultiPartitionsDefinition(
    {
        "abc": StaticPartitionsDefinition(["a", "b", "c"]),
        "weekly": WeeklyPartitionsDefinition("2023-01-01"),
    }
)
daily_123 = MultiPartitionsDefinition(
    {
        "123": StaticPartitionsDefinition(["1", "2", "3"]),
        "daily": DailyPartitionsDefinition("2023-01-01"),
    }
)

MultiPartitionsMapping(
    {
      "abc": DimensionMapping(
          downstream_dimension_name="123",
          partition_mapping=StaticPartitionMapping({"a": "1", "b": "2", "c": "3"}),
      ),
      "weekly": DimensionMapping(
            downstream_dimension_name="daily",
            partition_mapping=TimeWindowPartitionMapping(),
       )
    }
)
```
The `MultiPartitionsMapping` object checks that the selected dimensions in the dimension mapping objects are existent, relying on the partition mapping per-dimension to perform type checks and calculate the mapped partitions. Each dimension in the upstream partitions definition must be mapped 1:1 with a dimension in the downstream partitions definition.

In the situation where a user only wants to define a dependency relationship between one dimension of the upstream and downstream multipartitions defs, they could do something like the below example. In this case, `a|2023-01-01` would map to `1|2023-01-01`, `2|2023-01-01`, and `3|2023-01-01`.
```
MultiPartitionsDefinition(
    {
        "abc": StaticPartitionsDefinition(["a", "b", "c"]),
        "daily": DailyPartitionsDefinition("2023-01-01"),
    }
),
MultiPartitionsDefinition(
    {
        "123": StaticPartitionsDefinition(["1", "2", "3"]),
        "daily": DailyPartitionsDefinition("2023-01-01"),
    }
),
MultiPartitionsMapping(
    {
        "abc": DimensionMapping(
            "123",
            AllPartitionMapping(),
        ),
        "daily": DimensionMapping(
            "daily",
            IdentityPartitionMapping(),
        ),
    }
)
```
I'm very open to API changes. My intent here was to make this partition mapping generic, so it can handle any number of dimensions in the future.