### PR TITLE
Allow making a run status sensor with no context parameter

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -613,16 +613,20 @@ class RunStatusSensorDefinition(SensorDefinition):
                         RunStatusSensorExecutionError,
                         lambda: f'Error occurred during the execution sensor "{name}".',
                     ):
-                        # one user code invocation maps to one failure event
-                        sensor_return = run_status_sensor_fn(
-                            RunStatusSensorContext(  # type: ignore
-                                sensor_name=name,
-                                dagster_run=pipeline_run,
-                                dagster_event=event_log_entry.dagster_event,
-                                instance=context.instance,
-                                context=context,
+                        if has_at_least_one_parameter(run_status_sensor_fn):
+                            # one user code invocation maps to one failure event
+                            sensor_return = run_status_sensor_fn(
+                                RunStatusSensorContext(
+                                    sensor_name=name,
+                                    dagster_run=pipeline_run,
+                                    dagster_event=event_log_entry.dagster_event,
+                                    instance=context.instance,
+                                    context=context,
+                                )
                             )
-                        )
+                        else:
+                            sensor_return = run_status_sensor_fn()  # type: ignore
+
                         if sensor_return is not None:
                             context.update_cursor(
                                 RunStatusSensorCursor(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -481,7 +481,7 @@ def request_list_sensor(_ctx):
     run_status=DagsterRunStatus.SUCCESS,
     request_job=the_job,
 )
-def cross_repo_job_sensor(_ctx):
+def cross_repo_job_sensor():
     from time import time
 
     return RunRequest(run_key=str(time()))
@@ -504,8 +504,8 @@ def cross_repo_sensor(context):
     monitor_all_repositories=True,
     run_status=DagsterRunStatus.SUCCESS,
 )
-def instance_sensor(context):
-    assert isinstance(context.instance, DagsterInstance)
+def instance_sensor():
+    pass
 
 
 @sensor(job=the_job)


### PR DESCRIPTION
Summary:
We check this during direct invocation, but not during the actual sensor evaluation. Make them match up.

Test Plan:
BK (test cases now include sensors w/no context args)

## Summary & Motivation

## How I Tested These Changes
