### PR TITLE
[dagit] Add 18 more tests for the Materialize button

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -435,6 +435,12 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
               }}
               padding={{vertical: 12, horizontal: 24}}
             >
+              {target.type === 'pureWithAnchorAsset' && (
+                <Box flex={{gap: 8}} data-testid={testId('anchor-asset-label')}>
+                  <Icon name="asset" size={20} />
+                  <Subheading>{displayNameForAssetKey(target.anchorAssetKey)}</Subheading>
+                </Box>
+              )}
               <Box as={Subheading} flex={{alignItems: 'center', gap: 8}}>
                 <Icon name="partition" />
                 {range.dimension.name}
@@ -511,8 +517,8 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
           title={<Subheading data-testid={testId('backfill-options')}>Backfill options</Subheading>}
           isInitiallyOpen={true}
         >
-          <Box padding={{vertical: 16, horizontal: 24}} flex={{direction: 'column', gap: 12}}>
-            {target.type === 'pureWithAnchorAsset' ? null : (
+          {target.type === 'job' && (
+            <Box padding={{vertical: 16, horizontal: 24}} flex={{direction: 'column', gap: 12}}>
               <Checkbox
                 data-testid={testId('missing-only-checkbox')}
                 label="Backfill only failed and missing partitions within selection"
@@ -520,42 +526,42 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                 disabled={launchWithRangesAsTags}
                 onChange={() => setMissingFailedOnly(!missingFailedOnly)}
               />
-            )}
-            <RadioContainer>
-              <Subheading>Launch as...</Subheading>
-              <Radio
-                name="grant"
-                checked={canLaunchWithRangesAsTags && launchWithRangesAsTags}
-                disabled={!canLaunchWithRangesAsTags}
-                onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
-              >
-                <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                  <span>Single run</span>
-                  <Tooltip
-                    targetTagName="div"
-                    position="top-left"
-                    content={
-                      <div style={{maxWidth: 300}}>
-                        This option requires that your assets are written to operate on a partition
-                        key range via context.asset_partition_key_range_for_output or
-                        context.asset_partitions_time_window_for_output.
-                      </div>
-                    }
-                  >
-                    <Icon name="info" color={Colors.Gray500} />
-                  </Tooltip>
-                </Box>
-              </Radio>
-              <Radio
-                name="grant"
-                checked={!canLaunchWithRangesAsTags || !launchWithRangesAsTags}
-                disabled={!canLaunchWithRangesAsTags}
-                onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
-              >
-                Multiple runs (One per selected partition)
-              </Radio>
-            </RadioContainer>
-          </Box>
+              <RadioContainer>
+                <Subheading>Launch as...</Subheading>
+                <Radio
+                  data-testid={testId('ranges-as-tags-true-radio')}
+                  checked={canLaunchWithRangesAsTags && launchWithRangesAsTags}
+                  disabled={!canLaunchWithRangesAsTags}
+                  onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
+                >
+                  <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                    <span>Single run</span>
+                    <Tooltip
+                      targetTagName="div"
+                      position="top-left"
+                      content={
+                        <div style={{maxWidth: 300}}>
+                          This option requires that your assets are written to operate on a
+                          partition key range via context.asset_partition_key_range_for_output or
+                          context.asset_partitions_time_window_for_output.
+                        </div>
+                      }
+                    >
+                      <Icon name="info" color={Colors.Gray500} />
+                    </Tooltip>
+                  </Box>
+                </Radio>
+                <Radio
+                  data-testid={testId('ranges-as-tags-false-radio')}
+                  checked={!canLaunchWithRangesAsTags || !launchWithRangesAsTags}
+                  disabled={!canLaunchWithRangesAsTags}
+                  onChange={() => setLaunchWithRangesAsTags(!launchWithRangesAsTags)}
+                >
+                  Multiple runs (One per selected partition)
+                </Radio>
+              </RadioContainer>
+            </Box>
+          )}
         </ToggleableSection>
 
         <Box padding={{horizontal: 24}}>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -753,7 +753,7 @@ export const LAUNCH_ASSET_LOADER_RESOURCE_QUERY = gql`
   ${CONFIG_TYPE_SCHEMA_FRAGMENT}
 `;
 
-const LAUNCH_ASSET_CHECK_UPSTREAM_QUERY = gql`
+export const LAUNCH_ASSET_CHECK_UPSTREAM_QUERY = gql`
   query LaunchAssetCheckUpstreamQuery($assetKeys: [AssetKeyInput!]!) {
     assetNodes(assetKeys: $assetKeys, loadMaterializations: true) {
       id

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.mocks.ts
@@ -1,15 +1,98 @@
 import {MockedResponse} from '@apollo/client/testing';
 
+import {tokenForAssetKey} from '../../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../../asset-graph/types/useAssetGraphData.types';
-import {PartitionDefinitionType, PartitionRangeStatus} from '../../graphql/types';
+import {LaunchPipelineExecutionMutationVariables} from '../../graphql/graphql';
+import {
+  AssetKeyInput,
+  LaunchBackfillParams,
+  PartitionDefinitionType,
+  PartitionRangeStatus,
+} from '../../graphql/types';
+import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/BackfillUtils';
+import {LaunchPartitionBackfillMutation} from '../../instance/types/BackfillUtils.types';
+import {CONFIG_PARTITION_SELECTION_QUERY} from '../../launchpad/ConfigEditorConfigPicker';
+import {ConfigPartitionSelectionQuery} from '../../launchpad/types/ConfigEditorConfigPicker.types';
+import {LAUNCH_PIPELINE_EXECUTION_MUTATION} from '../../runs/RunUtils';
+import {LaunchPipelineExecutionMutation} from '../../runs/types/RunUtils.types';
 import {LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY} from '../LaunchAssetChoosePartitionsDialog';
-import {LAUNCH_ASSET_LOADER_QUERY} from '../LaunchAssetExecutionButton';
+import {
+  LAUNCH_ASSET_CHECK_UPSTREAM_QUERY,
+  LAUNCH_ASSET_LOADER_QUERY,
+  LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
+} from '../LaunchAssetExecutionButton';
 import {LaunchAssetChoosePartitionsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
-import {LaunchAssetLoaderQuery} from '../types/LaunchAssetExecutionButton.types';
+import {
+  LaunchAssetCheckUpstreamQuery,
+  LaunchAssetLoaderQuery,
+  LaunchAssetLoaderResourceQuery,
+} from '../types/LaunchAssetExecutionButton.types';
 import {PartitionHealthQuery} from '../types/usePartitionHealthData.types';
 import {PARTITION_HEALTH_QUERY} from '../usePartitionHealthData';
 
 import {generateDailyTimePartitions} from './PartitionHealthSummary.mocks';
+
+export const UNPARTITIONED_ASSET: AssetNodeForGraphQueryFragment = {
+  __typename: 'AssetNode',
+  id: 'test.py.repo.["unpartitioned_asset"]',
+  groupName: 'mapped',
+  hasMaterializePermission: true,
+  repository: {
+    __typename: 'Repository',
+    id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
+    name: 'repo',
+    location: {
+      __typename: 'RepositoryLocation',
+      id: 'test.py',
+      name: 'test.py',
+    },
+  },
+  dependencyKeys: [],
+  dependedByKeys: [],
+  graphName: null,
+  jobNames: ['__ASSET_JOB_7', 'my_asset_job'],
+  opNames: ['unpartitioned_asset'],
+  opVersion: null,
+  description: null,
+  computeKind: null,
+  isPartitioned: false,
+  isObservable: false,
+  isSource: false,
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['unpartitioned_asset'],
+  },
+};
+
+export const UNPARTITIONED_ASSET_OTHER_REPO: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["unpartitioned_asset_other_repo"]',
+  opNames: ['unpartitioned_asset_other_repo'],
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['unpartitioned_asset_other_repo'],
+  },
+  repository: {
+    __typename: 'Repository',
+    id: '000000000000000000000000000000000000000',
+    name: 'other-repo',
+    location: {
+      __typename: 'RepositoryLocation',
+      id: 'other-location.py',
+      name: 'other-location.py',
+    },
+  },
+};
+
+export const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG: AssetNodeForGraphQueryFragment = {
+  ...UNPARTITIONED_ASSET,
+  id: 'test.py.repo.["unpartitioned_asset_with_required_config"]',
+  opNames: ['unpartitioned_asset_with_required_config'],
+  assetKey: {
+    __typename: 'AssetKey',
+    path: ['unpartitioned_asset_with_required_config'],
+  },
+};
 
 export const ASSET_DAILY_PARTITION_KEYS = generateDailyTimePartitions(
   new Date('2020-01-01'),
@@ -39,7 +122,7 @@ export const ASSET_DAILY: AssetNodeForGraphQueryFragment = {
     },
   ],
   graphName: null,
-  jobNames: ['__ASSET_JOB_7'],
+  jobNames: ['__ASSET_JOB_7', 'my_asset_job'],
   opNames: ['asset_daily'],
   opVersion: null,
   description: null,
@@ -267,6 +350,253 @@ export const PartitionHealthAssetWeeklyRootMock: MockedResponse<PartitionHealthQ
   },
 };
 
+export const LaunchAssetLoaderResourceJob7Mock: MockedResponse<LaunchAssetLoaderResourceQuery> = {
+  request: {
+    query: LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
+    variables: {
+      pipelineName: '__ASSET_JOB_7',
+      repositoryLocationName: 'test.py',
+      repositoryName: 'repo',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionSetsOrError: {
+        results: [
+          {
+            id: '5b10aae97b738c48a4262b1eca530f89b13e9afc',
+            name: '__ASSET_JOB_7_partition_set',
+            __typename: 'PartitionSet',
+          },
+        ],
+        __typename: 'PartitionSets',
+      },
+      pipelineOrError: {
+        id: '8e2d3f9597c4a45bb52fe9ab5656419f4329d4fb',
+        modes: [
+          {
+            id: 'da3055161c528f4c839339deb4a362ec1be4f079-default',
+            resources: [
+              {
+                name: 'io_manager',
+                description:
+                  'Built-in filesystem IO manager that stores and retrieves values using pickling.',
+                configField: {
+                  name: 'config',
+                  isRequired: false,
+                  configType: {
+                    __typename: 'CompositeConfigType',
+                    key: 'Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851',
+                    description: null,
+                    isSelector: false,
+                    typeParamKeys: [],
+                    fields: [
+                      {
+                        name: 'base_dir',
+                        description: null,
+                        isRequired: false,
+                        configTypeKey: 'StringSourceType',
+                        defaultValueAsJson: null,
+                        __typename: 'ConfigTypeField',
+                      },
+                    ],
+                    recursiveConfigTypes: [
+                      {
+                        __typename: 'CompositeConfigType',
+                        key: 'Selector.2571019f1a5201853d11032145ac3e534067f214',
+                        description: null,
+                        isSelector: true,
+                        typeParamKeys: [],
+                        fields: [
+                          {
+                            name: 'env',
+                            description: null,
+                            isRequired: true,
+                            configTypeKey: 'String',
+                            defaultValueAsJson: null,
+                            __typename: 'ConfigTypeField',
+                          },
+                        ],
+                      },
+                      {
+                        __typename: 'RegularConfigType',
+                        givenName: 'String',
+                        key: 'String',
+                        description: '',
+                        isSelector: false,
+                        typeParamKeys: [],
+                      },
+                      {
+                        __typename: 'ScalarUnionConfigType',
+                        key: 'StringSourceType',
+                        description: null,
+                        isSelector: false,
+                        typeParamKeys: [
+                          'String',
+                          'Selector.2571019f1a5201853d11032145ac3e534067f214',
+                        ],
+                        scalarTypeKey: 'String',
+                        nonScalarTypeKey: 'Selector.2571019f1a5201853d11032145ac3e534067f214',
+                      },
+                    ],
+                  },
+                  __typename: 'ConfigTypeField',
+                },
+                __typename: 'Resource',
+              },
+            ],
+            __typename: 'Mode',
+          },
+        ],
+        __typename: 'Pipeline',
+      },
+    },
+  },
+};
+
+export const LaunchAssetLoaderResourceJob8Mock: MockedResponse<LaunchAssetLoaderResourceQuery> = {
+  request: {
+    query: LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
+    variables: {
+      pipelineName: '__ASSET_JOB_8',
+      repositoryLocationName: 'test.py',
+      repositoryName: 'repo',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionSetsOrError: {
+        results: [
+          {
+            id: '129179973a9144278c2429d3ba680bf0f809a59b',
+            name: '__ASSET_JOB_8_partition_set',
+            __typename: 'PartitionSet',
+          },
+        ],
+        __typename: 'PartitionSets',
+      },
+      pipelineOrError: {
+        id: '8689a9dcd052f769b73d73dfe57e89065dac369d',
+        modes: [
+          {
+            id: '719d9b2c592b98ae0f4a7ec570cae0a06667db31-default',
+            resources: [
+              {
+                name: 'io_manager',
+                description:
+                  'Built-in filesystem IO manager that stores and retrieves values using pickling.',
+                configField: {
+                  name: 'config',
+                  isRequired: false,
+                  configType: {
+                    __typename: 'CompositeConfigType',
+                    key: 'Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851',
+                    description: null,
+                    isSelector: false,
+                    typeParamKeys: [],
+                    fields: [
+                      {
+                        name: 'base_dir',
+                        description: null,
+                        isRequired: false,
+                        configTypeKey: 'StringSourceType',
+                        defaultValueAsJson: null,
+                        __typename: 'ConfigTypeField',
+                      },
+                    ],
+                    recursiveConfigTypes: [
+                      {
+                        __typename: 'CompositeConfigType',
+                        key: 'Selector.2571019f1a5201853d11032145ac3e534067f214',
+                        description: null,
+                        isSelector: true,
+                        typeParamKeys: [],
+                        fields: [
+                          {
+                            name: 'env',
+                            description: null,
+                            isRequired: true,
+                            configTypeKey: 'String',
+                            defaultValueAsJson: null,
+                            __typename: 'ConfigTypeField',
+                          },
+                        ],
+                      },
+                      {
+                        __typename: 'RegularConfigType',
+                        givenName: 'String',
+                        key: 'String',
+                        description: '',
+                        isSelector: false,
+                        typeParamKeys: [],
+                      },
+                      {
+                        __typename: 'ScalarUnionConfigType',
+                        key: 'StringSourceType',
+                        description: null,
+                        isSelector: false,
+                        typeParamKeys: [
+                          'String',
+                          'Selector.2571019f1a5201853d11032145ac3e534067f214',
+                        ],
+                        scalarTypeKey: 'String',
+                        nonScalarTypeKey: 'Selector.2571019f1a5201853d11032145ac3e534067f214',
+                      },
+                    ],
+                  },
+                  __typename: 'ConfigTypeField',
+                },
+                __typename: 'Resource',
+              },
+            ],
+            __typename: 'Mode',
+          },
+        ],
+        __typename: 'Pipeline',
+      },
+    },
+  },
+};
+
+export const LaunchAssetLoaderResourceMyAssetJobMock: MockedResponse<LaunchAssetLoaderResourceQuery> = {
+  request: {
+    query: LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
+    variables: {
+      pipelineName: 'my_asset_job',
+      repositoryLocationName: 'test.py',
+      repositoryName: 'repo',
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      partitionSetsOrError: {
+        results: [
+          {
+            id: '129179973a9144278c2429d3ba680bf0f809a59b',
+            name: 'my_asset_job_partition_set',
+            __typename: 'PartitionSet',
+          },
+        ],
+        __typename: 'PartitionSets',
+      },
+      pipelineOrError: {
+        id: '8689a9dcd052f769b73d73dfe57e89065dac369d',
+        modes: [
+          {
+            __typename: 'Mode',
+            id: '719d9b2c592b98ae0f4a7ec570cae0a06667db31-default',
+            resources: [],
+          },
+        ],
+        __typename: 'Pipeline',
+      },
+    },
+  },
+};
+
 export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLoaderQuery> = {
   request: {
     query: LAUNCH_ASSET_LOADER_QUERY,
@@ -336,11 +666,11 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
   },
 };
 
-export const LaunchAssetLoaderAssetDailyWeeklyRootsDifferentPartitioningMock: MockedResponse<LaunchAssetLoaderQuery> = {
+export const LaunchAssetCheckUpstreamWeeklyRootMock: MockedResponse<LaunchAssetCheckUpstreamQuery> = {
   request: {
-    query: LAUNCH_ASSET_LOADER_QUERY,
+    query: LAUNCH_ASSET_CHECK_UPSTREAM_QUERY,
     variables: {
-      assetKeys: [{path: ['asset_daily']}, {path: ['asset_weekly']}, {path: ['asset_weekly_root']}],
+      assetKeys: [{path: ['asset_weekly_root']}],
     },
   },
   result: {
@@ -348,92 +678,311 @@ export const LaunchAssetLoaderAssetDailyWeeklyRootsDifferentPartitioningMock: Mo
       __typename: 'DagitQuery',
       assetNodes: [
         {
-          ...ASSET_DAILY,
-          requiredResources: [],
-          partitionDefinition: {
-            name: 'Foo',
-            type: PartitionDefinitionType.TIME_WINDOW,
-            description: 'Daily, starting 2020-01-01 UTC.',
-            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
-            __typename: 'PartitionDefinition',
+          id: 'test.py.repo.["asset_weekly_root"]',
+          assetKey: {
+            path: ['asset_weekly_root'],
+            __typename: 'AssetKey',
           },
-          configField: {
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType',
-              givenName: 'Any',
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              recursiveConfigTypes: [],
-            },
-            __typename: 'ConfigTypeField',
-          },
-          __typename: 'AssetNode',
-        },
-        {
-          ...ASSET_WEEKLY,
-          requiredResources: [],
-          partitionDefinition: {
-            name: 'Foo',
-            type: PartitionDefinitionType.TIME_WINDOW,
-            description: 'Weekly, starting 2020-01-01 UTC.',
-            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
-            __typename: 'PartitionDefinition',
-          },
-
-          dependencyKeys: [
+          isSource: false,
+          opNames: ['asset_weekly_root'],
+          graphName: null,
+          assetMaterializations: [
             {
-              __typename: 'AssetKey',
-              path: ['asset_daily', 'asset_weekly_root'],
+              runId: '8fec6fcd-7a05-4f1c-8cf8-4bfd6965eeba',
+              __typename: 'MaterializationEvent',
             },
           ],
-          configField: {
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType',
-              givenName: 'Any',
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              recursiveConfigTypes: [],
-            },
-            __typename: 'ConfigTypeField',
-          },
-          __typename: 'AssetNode',
-        },
-        {
-          ...ASSET_WEEKLY_ROOT,
-          requiredResources: [],
-          partitionDefinition: {
-            name: 'Foo',
-            type: PartitionDefinitionType.TIME_WINDOW,
-            description: 'Weekly, starting 2020-01-01 UTC.',
-            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
-            __typename: 'PartitionDefinition',
-          },
-          configField: {
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType',
-              givenName: 'Any',
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              recursiveConfigTypes: [],
-            },
-            __typename: 'ConfigTypeField',
-          },
           __typename: 'AssetNode',
         },
       ],
-      assetNodeDefinitionCollisions: [],
     },
   },
 };
+
+export function buildConfigPartitionSelectionLatestPartitionMock(
+  partitionName: string,
+  partitionSetName: string,
+): MockedResponse<ConfigPartitionSelectionQuery> {
+  return {
+    request: {
+      query: CONFIG_PARTITION_SELECTION_QUERY,
+      variables: {
+        partitionName,
+        partitionSetName,
+        repositorySelector: {
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        partitionSetOrError: {
+          __typename: 'PartitionSet',
+          id: '5b10aae97b738c48a4262b1eca530f89b13e9afc',
+          partition: {
+            name: '2023-03-14',
+            solidSelection: null,
+            runConfigOrError: {
+              yaml: '{}\n',
+              __typename: 'PartitionRunConfig',
+            },
+            mode: 'default',
+            tagsOrError: {
+              results: [
+                {
+                  key: 'dagster/partition',
+                  value: partitionName,
+                  __typename: 'PipelineTag',
+                },
+                {
+                  key: 'dagster/partition_set',
+                  value: partitionSetName,
+                  __typename: 'PipelineTag',
+                },
+              ],
+              __typename: 'PartitionTags',
+            },
+            __typename: 'Partition',
+          },
+        },
+      },
+    },
+  };
+}
+
+type LaunchAssetLoaderQueryAssetNode = LaunchAssetLoaderQuery['assetNodes'][0];
+
+const ASSET_DAILY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...ASSET_DAILY,
+  requiredResources: [],
+  partitionDefinition: {
+    name: 'Foo',
+    type: PartitionDefinitionType.TIME_WINDOW,
+    description: 'Daily, starting 2020-01-01 UTC.',
+    dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+    __typename: 'PartitionDefinition',
+  },
+  configField: {
+    name: 'config',
+    isRequired: false,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+
+const ASSET_WEEKLY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...ASSET_WEEKLY,
+  requiredResources: [],
+  partitionDefinition: {
+    name: 'Foo',
+    type: PartitionDefinitionType.TIME_WINDOW,
+    description: 'Weekly, starting 2020-01-01 UTC.',
+    dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+    __typename: 'PartitionDefinition',
+  },
+
+  dependencyKeys: [
+    {
+      __typename: 'AssetKey',
+      path: ['asset_daily'],
+    },
+    {
+      __typename: 'AssetKey',
+      path: ['asset_weekly_root'],
+    },
+  ],
+  configField: {
+    name: 'config',
+    isRequired: false,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+
+const ASSET_WEEKLY_ROOT_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...ASSET_WEEKLY_ROOT,
+  requiredResources: [],
+  partitionDefinition: {
+    name: 'Foo',
+    type: PartitionDefinitionType.TIME_WINDOW,
+    description: 'Weekly, starting 2020-01-01 UTC.',
+    dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+    __typename: 'PartitionDefinition',
+  },
+  configField: {
+    name: 'config',
+    isRequired: false,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+
+const UNPARTITIONED_ASSET_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...UNPARTITIONED_ASSET,
+  requiredResources: [],
+  partitionDefinition: null,
+  configField: {
+    name: 'config',
+    isRequired: false,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+const UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...UNPARTITIONED_ASSET_OTHER_REPO,
+  requiredResources: [],
+  partitionDefinition: null,
+  configField: {
+    name: 'config',
+    isRequired: false,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+
+const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
+  ...UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
+  requiredResources: [],
+  partitionDefinition: null,
+  configField: {
+    name: 'config',
+    isRequired: true,
+    configType: {
+      __typename: 'RegularConfigType',
+      givenName: 'Any',
+      key: 'Any',
+      description: null,
+      isSelector: false,
+      typeParamKeys: [],
+      recursiveConfigTypes: [],
+    },
+    __typename: 'ConfigTypeField',
+  },
+  __typename: 'AssetNode',
+};
+
+export const LOADER_RESULTS = [
+  ASSET_DAILY_LOADER_RESULT,
+  ASSET_WEEKLY_LOADER_RESULT,
+  ASSET_WEEKLY_ROOT_LOADER_RESULT,
+  UNPARTITIONED_ASSET_LOADER_RESULT,
+  UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG_LOADER_RESULT,
+  UNPARTITIONED_ASSET_OTHER_REPO_LOADER_RESULT,
+];
+
+export const PartitionHealthAssetMocks = [
+  PartitionHealthAssetWeeklyRootMock,
+  PartitionHealthAssetWeeklyMock,
+  PartitionHealthAssetDailyMock,
+];
+
+export function buildLaunchAssetLoaderMock(
+  assetKeys: AssetKeyInput[],
+): MockedResponse<LaunchAssetLoaderQuery> {
+  return {
+    request: {
+      query: LAUNCH_ASSET_LOADER_QUERY,
+      variables: {
+        assetKeys: assetKeys.map((a) => ({path: a.path})),
+      },
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        assetNodeDefinitionCollisions: [],
+        assetNodes: LOADER_RESULTS.filter((a) =>
+          assetKeys.some((k) => tokenForAssetKey(k) === tokenForAssetKey(a.assetKey)),
+        ),
+      },
+    },
+  };
+}
+
+export function buildExpectedLaunchBackfillMutation(
+  backfillParams: LaunchBackfillParams,
+): MockedResponse<LaunchPartitionBackfillMutation> {
+  return {
+    request: {
+      query: LAUNCH_PARTITION_BACKFILL_MUTATION,
+      variables: {backfillParams},
+    },
+    result: jest.fn(() => ({
+      data: {
+        __typename: 'DagitMutation',
+        launchPartitionBackfill: {__typename: 'LaunchBackfillSuccess', backfillId: 'backfillid'},
+      },
+    })),
+  };
+}
+
+export function buildExpectedLaunchSingleRunMutation(
+  executionParams: LaunchPipelineExecutionMutationVariables['executionParams'],
+): MockedResponse<LaunchPipelineExecutionMutation> {
+  return {
+    request: {
+      query: LAUNCH_PIPELINE_EXECUTION_MUTATION,
+      variables: {executionParams},
+    },
+    result: jest.fn(() => ({
+      data: {
+        __typename: 'DagitMutation',
+        launchPipelineExecution: {
+          __typename: 'LaunchRunSuccess',
+          run: {
+            __typename: 'Run',
+            runId: 'RUN_ID',
+            id: 'RUN_ID',
+            pipelineName: executionParams['selector']['pipelineName']!,
+          },
+        },
+      },
+    })),
+  };
+}

--- a/js_modules/dagit/packages/core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -1,13 +1,14 @@
+/* eslint-disable jest/expect-expect */
 import {MockedProvider, MockedResponse} from '@apollo/client/testing';
 import {act, render, screen, waitFor} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import {CustomAlertProvider} from '../../app/CustomAlertProvider';
-import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/BackfillUtils';
 import {LaunchPartitionBackfillMutation} from '../../instance/types/BackfillUtils.types';
+import {LaunchPipelineExecutionMutation} from '../../runs/types/RunUtils.types';
 import {TestProvider} from '../../testing/TestProvider';
 import {
+  AssetsInScope,
   ERROR_INVALID_ASSET_SELECTION,
   LaunchAssetExecutionButton,
 } from '../LaunchAssetExecutionButton';
@@ -16,123 +17,395 @@ import {
   ASSET_DAILY_PARTITION_KEYS,
   ASSET_WEEKLY,
   ASSET_WEEKLY_ROOT,
+  buildConfigPartitionSelectionLatestPartitionMock,
+  buildExpectedLaunchBackfillMutation,
+  buildExpectedLaunchSingleRunMutation,
+  buildLaunchAssetLoaderMock,
+  LaunchAssetCheckUpstreamWeeklyRootMock,
   LaunchAssetChoosePartitionsMock,
-  LaunchAssetLoaderAssetDailyWeeklyMock,
-  LaunchAssetLoaderAssetDailyWeeklyRootsDifferentPartitioningMock,
-  PartitionHealthAssetDailyMock,
-  PartitionHealthAssetWeeklyMock,
-  PartitionHealthAssetWeeklyRootMock,
+  LaunchAssetLoaderResourceJob7Mock,
+  LaunchAssetLoaderResourceJob8Mock,
+  LaunchAssetLoaderResourceMyAssetJobMock,
+  PartitionHealthAssetMocks,
+  UNPARTITIONED_ASSET,
+  UNPARTITIONED_ASSET_OTHER_REPO,
+  UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
 } from '../__fixtures__/LaunchAssetExecutionButton.mocks';
 
 // This file must be mocked because Jest can't handle `import.meta.url`.
 jest.mock('../../graph/asyncGraphLayout', () => ({}));
 
 describe('LaunchAssetExecutionButton', () => {
-  it('should show the partition dialog with an anchor asset', async () => {
-    const LaunchMutationMock: MockedResponse<LaunchPartitionBackfillMutation> = {
-      request: {
-        query: LAUNCH_PARTITION_BACKFILL_MUTATION,
-        variables: {
-          backfillParams: {
-            selector: undefined,
-            assetSelection: [{path: ['asset_daily']}, {path: ['asset_weekly']}],
-            partitionNames: ASSET_DAILY_PARTITION_KEYS,
-            fromFailure: false,
-            tags: [],
-          },
-        },
-      },
-      result: jest.fn(() => ({
-        data: {
-          __typename: 'DagitMutation',
-          launchPartitionBackfill: {__typename: 'LaunchBackfillSuccess', backfillId: 'vlpmimsl'},
-        },
-      })),
-    };
-
-    await act(async () => {
-      render(
-        <TestProvider>
-          <CustomAlertProvider />
-          <MockedProvider
-            mocks={[
-              LaunchAssetChoosePartitionsMock,
-              LaunchAssetLoaderAssetDailyWeeklyMock,
-              PartitionHealthAssetDailyMock,
-              PartitionHealthAssetWeeklyMock,
-              LaunchMutationMock,
-            ]}
-          >
-            <LaunchAssetExecutionButton scope={{all: [ASSET_DAILY, ASSET_WEEKLY]}} />
-          </MockedProvider>
-        </TestProvider>,
+  describe('labeling', () => {
+    it('should say "Materialize all" for an `all` scope', async () => {
+      await renderButton({scope: {all: [UNPARTITIONED_ASSET, UNPARTITIONED_ASSET_OTHER_REPO]}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual(
+        'Materialize all',
       );
     });
 
-    // click Materialize
-    const materializeButton = await screen.findByTestId('materialize-button');
-    expect(materializeButton).toBeVisible();
-    materializeButton.click();
-
-    // expect the dialog to be displayed
-    await waitFor(async () => {
-      await screen.findByTestId('choose-partitions-dialog');
+    it('should say "Materialize all…" for an `all` scope if assets are partitioned', async () => {
+      await renderButton({scope: {all: [UNPARTITIONED_ASSET, ASSET_DAILY]}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual(
+        'Materialize all…',
+      );
     });
 
-    userEvent.click(screen.getByTestId('backfill-options'));
-
-    expect(await screen.queryByTestId('missing-only-checkbox')).toBeNull();
-    expect(await screen.queryByTestId('ranges-as-tags-checkbox')).toBeNull();
-
-    const launchButton = await screen.findByTestId('launch-button');
-    expect(launchButton.textContent).toEqual('Launch backfill');
-    await launchButton.click();
-
-    // expect that it triggers the mutation (variables checked by mock matching)
-    await waitFor(async () => {
-      expect(LaunchMutationMock.result).toHaveBeenCalled();
+    it('should say "Materialize" for an `all` scope if skipAllTerm is passed', async () => {
+      await renderButton({scope: {all: [UNPARTITIONED_ASSET], skipAllTerm: true}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual('Materialize');
     });
 
-    // expect the dialog to close
-    await waitFor(async () => {
-      expect(await screen.queryByTestId('choose-partitions-dialog')).toBeNull();
+    it('should say "Materialize…" for an `all` scope if assets are partitioned and skipAllTerm is passed', async () => {
+      await renderButton({scope: {all: [UNPARTITIONED_ASSET, ASSET_DAILY], skipAllTerm: true}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual('Materialize…');
+    });
+
+    it('should say "Materialize selected" for an `selected` scope', async () => {
+      await renderButton({scope: {selected: [UNPARTITIONED_ASSET]}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual(
+        'Materialize selected',
+      );
+    });
+
+    it('should say "Materialize selected…" for an `selected` scope with a partitioned asset', async () => {
+      await renderButton({scope: {selected: [ASSET_DAILY]}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual(
+        'Materialize selected…',
+      );
+    });
+
+    it('should say "Materialize selected (2)…" for an `selected` scope with two items', async () => {
+      await renderButton({scope: {selected: [UNPARTITIONED_ASSET, ASSET_DAILY]}});
+      expect((await screen.findByTestId('materialize-button')).textContent).toEqual(
+        'Materialize selected (2)…',
+      );
     });
   });
 
-  it('should show an error if two roots have different partition defintions', async () => {
-    await act(async () => {
-      render(
-        <TestProvider>
-          <CustomAlertProvider />
-          <MockedProvider
-            mocks={[
-              LaunchAssetChoosePartitionsMock,
-              LaunchAssetLoaderAssetDailyWeeklyRootsDifferentPartitioningMock,
-              PartitionHealthAssetDailyMock,
-              PartitionHealthAssetWeeklyMock,
-              PartitionHealthAssetWeeklyRootMock,
-            ]}
-          >
-            <LaunchAssetExecutionButton
-              scope={{all: [ASSET_DAILY, ASSET_WEEKLY, ASSET_WEEKLY_ROOT]}}
-            />
-          </MockedProvider>
-        </TestProvider>,
-      );
+  describe('unpartitioned assets', () => {
+    it('should directly launch via the in-context asset job', async () => {
+      const launchMock = buildExpectedLaunchSingleRunMutation({
+        mode: 'default',
+        executionMetadata: {
+          tags: [{key: 'dagster/step_selection', value: 'unpartitioned_asset'}],
+        },
+        runConfigData: '{}',
+        selector: {
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+          pipelineName: 'my_asset_job',
+          assetSelection: [{path: ['unpartitioned_asset']}],
+        },
+      });
+      await renderButton({
+        scope: {all: [UNPARTITIONED_ASSET]},
+        preferredJobName: 'my_asset_job',
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
     });
 
-    // click Materialize
-    const materializeButton = await screen.findByTestId('materialize-button');
-    expect(materializeButton).toBeVisible();
-    materializeButton.click();
-
-    // expect an error to be displayed
-    await waitFor(async () => {
-      await screen.findByTestId('alert-body');
+    it('should directly launch via the hidden job if no job is in context', async () => {
+      const launchMock = buildExpectedLaunchSingleRunMutation({
+        mode: 'default',
+        executionMetadata: {
+          tags: [{key: 'dagster/step_selection', value: 'unpartitioned_asset'}],
+        },
+        runConfigData: '{}',
+        selector: {
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+          pipelineName: '__ASSET_JOB_7',
+          assetSelection: [{path: ['unpartitioned_asset']}],
+        },
+      });
+      await renderButton({
+        scope: {all: [UNPARTITIONED_ASSET]},
+        preferredJobName: undefined,
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
     });
 
-    expect(await screen.findByTestId('alert-body')).toHaveTextContent(
-      ERROR_INVALID_ASSET_SELECTION,
-    );
+    it('should show the launchpad if an asset or resource requires config', async () => {
+      await renderButton({
+        scope: {all: [UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG]},
+        preferredJobName: undefined,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => expect(screen.getByText('Launchpad (configure assets)')).toBeVisible());
+    });
+
+    it('should show an error if the assets do not share a code location', async () => {
+      await renderButton({
+        scope: {all: [UNPARTITIONED_ASSET, UNPARTITIONED_ASSET_OTHER_REPO]},
+        preferredJobName: undefined,
+      });
+      await clickMaterializeButton();
+      await expectErrorShown(ERROR_INVALID_ASSET_SELECTION);
+    });
+  });
+
+  describe('partitioned assets', () => {
+    it('should show the partition dialog', async () => {
+      await renderButton({scope: {all: [ASSET_DAILY]}});
+      await clickMaterializeButton();
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+    });
+
+    it('should launch single runs using the job in context if specified', async () => {
+      const launchMock = buildExpectedLaunchSingleRunMutation({
+        executionMetadata: {
+          tags: [
+            {key: 'dagster/partition', value: '2023-02-22'},
+            {key: 'dagster/partition_set', value: 'my_asset_job_partition_set'},
+            {key: 'dagster/step_selection', value: 'asset_daily'},
+          ],
+        },
+        mode: 'default',
+        runConfigData: '{}\n',
+        selector: {
+          assetSelection: [{path: ['asset_daily']}],
+          pipelineName: 'my_asset_job',
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+        },
+      });
+      await renderButton({
+        scope: {all: [ASSET_DAILY]},
+        preferredJobName: 'my_asset_job',
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+      await (await screen.findByTestId('latest-partition-button')).click();
+
+      await expectLaunchExecutesMutationAndCloses('Launch 1 run', launchMock);
+    });
+
+    it('should launch backfills using the job in context if specified', async () => {
+      const launchMock = buildExpectedLaunchBackfillMutation({
+        selector: {
+          partitionSetName: 'my_asset_job_partition_set',
+          repositorySelector: {repositoryLocationName: 'test.py', repositoryName: 'repo'},
+        },
+        assetSelection: [{path: ['asset_daily']}],
+        partitionNames: ASSET_DAILY_PARTITION_KEYS,
+        fromFailure: false,
+        tags: [],
+      });
+      await renderButton({
+        scope: {all: [ASSET_DAILY]},
+        preferredJobName: 'my_asset_job',
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+
+      // uncheck missing only
+      await (await screen.getByTestId('missing-only-checkbox')).click();
+
+      await expectLaunchExecutesMutationAndCloses('Launch 1148-run backfill', launchMock);
+    });
+
+    it('should launch single runs via the hidden job if no job is in context', async () => {
+      const launchMock = buildExpectedLaunchSingleRunMutation({
+        executionMetadata: {
+          tags: [
+            {key: 'dagster/partition', value: '2023-02-22'},
+            {key: 'dagster/partition_set', value: '__ASSET_JOB_7_partition_set'},
+            {key: 'dagster/step_selection', value: 'asset_daily'},
+          ],
+        },
+        mode: 'default',
+        runConfigData: '{}\n',
+        selector: {
+          assetSelection: [{path: ['asset_daily']}],
+          pipelineName: '__ASSET_JOB_7',
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+        },
+      });
+      await renderButton({
+        scope: {all: [ASSET_DAILY]},
+        preferredJobName: undefined,
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+      await (await screen.findByTestId('latest-partition-button')).click();
+      await expectLaunchExecutesMutationAndCloses('Launch 1 run', launchMock);
+    });
+
+    it('should launch backfills as pure-asset backfills if no job is in context', async () => {
+      const launchMock = buildExpectedLaunchBackfillMutation({
+        selector: undefined,
+        assetSelection: [{path: ['asset_daily']}],
+        partitionNames: ASSET_DAILY_PARTITION_KEYS,
+        fromFailure: false,
+        tags: [],
+      });
+      await renderButton({
+        scope: {all: [ASSET_DAILY]},
+        preferredJobName: undefined,
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+
+      // missing-and-failed only option is available
+      await (await screen.getByTestId('missing-only-checkbox')).click();
+      // ranges-as-tags option is available
+      const rangesAsTags = await screen.getByTestId('ranges-as-tags-true-radio');
+      await waitFor(async () => expect(rangesAsTags).toBeEnabled());
+
+      await expectLaunchExecutesMutationAndCloses('Launch 1148-run backfill', launchMock);
+    });
+
+    it('should launch a single run if you choose to pass the partition range using tags', async () => {
+      const launchMock = buildExpectedLaunchSingleRunMutation({
+        mode: 'default',
+        executionMetadata: {
+          tags: [
+            {key: 'dagster/asset_partition_range_start', value: '2020-01-02'},
+            {key: 'dagster/asset_partition_range_end', value: '2023-02-22'},
+            {key: 'dagster/step_selection', value: 'asset_daily'},
+          ],
+        },
+        runConfigData: '{}\n',
+        selector: {
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+          pipelineName: 'my_asset_job',
+          assetSelection: [{path: ['asset_daily']}],
+        },
+      });
+      await renderButton({
+        scope: {all: [ASSET_DAILY]},
+        preferredJobName: 'my_asset_job',
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+
+      const rangesAsTags = await screen.getByTestId('ranges-as-tags-true-radio');
+      await waitFor(async () => expect(rangesAsTags).toBeEnabled());
+      await rangesAsTags.click();
+      await expectLaunchExecutesMutationAndCloses('Launch 1 run', launchMock);
+    });
+  });
+
+  describe('partition mapped assets', () => {
+    it('should show the partition dialog with an anchor asset', async () => {
+      const LaunchMutationMock = buildExpectedLaunchBackfillMutation({
+        selector: undefined,
+        assetSelection: [{path: ['asset_daily']}, {path: ['asset_weekly']}],
+        partitionNames: ASSET_DAILY_PARTITION_KEYS,
+        fromFailure: false,
+        tags: [],
+      });
+
+      await renderButton({
+        scope: {all: [ASSET_DAILY, ASSET_WEEKLY]},
+        launchMock: LaunchMutationMock,
+      });
+
+      await clickMaterializeButton();
+
+      // expect the dialog to be displayed
+      await waitFor(() => screen.findByTestId('choose-partitions-dialog'));
+
+      // expect the anchor asset to be labeled
+      expect(await screen.getByTestId('anchor-asset-label')).toHaveTextContent('asset_daily');
+
+      // backfill options for run as tags, missing only are not available
+      expect(await screen.queryByTestId('missing-only-checkbox')).toBeNull();
+      expect(await screen.queryByTestId('ranges-as-tags-true-radio')).toBeNull();
+
+      await expectLaunchExecutesMutationAndCloses('Launch backfill', LaunchMutationMock);
+    });
+
+    it('should show an error if two roots have different partition defintions', async () => {
+      await renderButton({
+        scope: {all: [ASSET_DAILY, ASSET_WEEKLY, ASSET_WEEKLY_ROOT]},
+      });
+      await clickMaterializeButton();
+      await expectErrorShown(ERROR_INVALID_ASSET_SELECTION);
+    });
   });
 });
+
+// Helpers to make tests more concise
+
+async function renderButton({
+  scope,
+  launchMock,
+  preferredJobName,
+}: {
+  scope: AssetsInScope;
+  launchMock?: MockedResponse<Record<string, any>>;
+  preferredJobName?: string;
+}) {
+  const assetKeys = ('all' in scope ? scope.all : scope.selected).map((s) => s.assetKey);
+
+  const mocks: MockedResponse<Record<string, any>>[] = [
+    LaunchAssetChoosePartitionsMock,
+    LaunchAssetLoaderResourceJob7Mock,
+    LaunchAssetLoaderResourceJob8Mock,
+    LaunchAssetLoaderResourceMyAssetJobMock,
+    LaunchAssetCheckUpstreamWeeklyRootMock,
+    ...PartitionHealthAssetMocks,
+    buildConfigPartitionSelectionLatestPartitionMock('2020-01-02', 'my_asset_job_partition_set'),
+    buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', 'my_asset_job_partition_set'),
+    buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', '__ASSET_JOB_7_partition_set'),
+    buildLaunchAssetLoaderMock(assetKeys),
+    ...(launchMock ? [launchMock] : []),
+  ];
+
+  await act(async () => {
+    render(
+      <TestProvider>
+        <CustomAlertProvider />
+        <MockedProvider mocks={mocks}>
+          <LaunchAssetExecutionButton scope={scope} preferredJobName={preferredJobName} />
+        </MockedProvider>
+      </TestProvider>,
+    );
+  });
+}
+
+async function clickMaterializeButton() {
+  const materializeButton = await screen.findByTestId('materialize-button');
+  expect(materializeButton).toBeVisible();
+  materializeButton.click();
+}
+
+async function expectErrorShown(msg: string) {
+  // expect an error to be displayed
+  await waitFor(async () => {
+    await screen.findByTestId('alert-body');
+  });
+  expect(await screen.findByTestId('alert-body')).toHaveTextContent(msg);
+}
+
+async function expectLaunchExecutesMutationAndCloses(
+  label: string,
+  mutation:
+    | MockedResponse<LaunchPartitionBackfillMutation>
+    | MockedResponse<LaunchPipelineExecutionMutation>,
+) {
+  const launchButton = await screen.findByTestId('launch-button');
+  expect(launchButton.textContent).toEqual(label);
+  await launchButton.click();
+
+  // expect that it triggers the mutation (variables checked by mock matching)
+  await waitFor(() => expect(mutation.result).toHaveBeenCalled());
+
+  // expect the dialog to close
+  await waitFor(async () => {
+    expect(await screen.queryByTestId('choose-partitions-dialog')).toBeNull();
+  });
+}

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -16,6 +16,7 @@ import styled from 'styled-components/macro';
 import {StateDot} from '../assets/AssetPartitionList';
 import {partitionStateAtIndex, Range} from '../assets/usePartitionHealthData';
 import {PartitionDefinitionType} from '../graphql/types';
+import {testId} from '../testing/testId';
 import {RepoAddress} from '../workspace/types';
 
 import {CreatePartitionDialog} from './CreatePartitionDialog';
@@ -69,7 +70,11 @@ export const DimensionRangeWizard: React.FC<{
           )}
         </Box>
         {isTimeseries && (
-          <Button small={true} onClick={() => setSelected(partitionKeys.slice(-1))}>
+          <Button
+            small={true}
+            onClick={() => setSelected(partitionKeys.slice(-1))}
+            data-testid={testId('latest-partition-button')}
+          >
             Latest
           </Button>
         )}


### PR DESCRIPTION
## Summary & Motivation

The Materialize button and the partition selection modal are complicated and I'd like to be able to refactor things like `stateForLaunchingAssets` with more confidence. This PR adds 18 more tests for clicking "Materialize" with different combinations of assets and verifying that the mutations triggered and options displayed in the partitions modal are correct.

These are very high level tests (assets in, launch mutation out) because I want to be able to refactor everything inside this flow in the future and use the tests to verify correctness.

New Tests:

```
  LaunchAssetExecutionButton
    labeling
      ✓ should say "Materialize all" for an `all` scope (183 ms)
      ✓ should say "Materialize all…" for an `all` scope if assets are partitioned (131 ms)
      ✓ should say "Materialize" for an `all` scope if skipAllTerm is passed (113 ms)
      ✓ should say "Materialize…" for an `all` scope if assets are partitioned and skipAllTerm is passed (107 ms)
      ✓ should say "Materialize selected" for an `selected` scope (103 ms)
      ✓ should say "Materialize selected…" for an `selected` scope with a partitioned asset (97 ms)
      ✓ should say "Materialize selected (2)…" for an `selected` scope with two items (101 ms)
    unpartitioned assets
      ✓ should directly launch via the in-context asset job (179 ms)
      ✓ should directly launch via the hidden job if no job is in context (141 ms)
      ✓ should show the launchpad if an asset or resource requires config (169 ms)
      ✓ should show an error if the assets do not share a code location (136 ms)
    partitioned assets
      ✓ should show the partition dialog (356 ms)
      ✓ should launch single runs using the job in context if specified (272 ms)
      ✓ should launch backfills using the job in context if specified (185 ms)
      ✓ should launch single runs via the hidden job if no job is in context (139 ms)
      ✓ should launch backfills as pure-asset backfills (130 ms)
      ✓ should launch a single run if you are on a job page and choose to pass the partition range using tags (120 ms)
    partition mapped assets
      ✓ should show the partition dialog with an anchor asset (140 ms)
      ✓ should show an error if two roots have different partition defintions (89 ms)

```

UI Tweaks:

- This PR hides the "launch as one run" in the partition-mapped backfill case, because that feature requires a hidden asset job in common.
- This PR puts back the "anchor asset" label