### PR TITLE
[Dynamic partition requests 2/3] SensorResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -15,6 +15,7 @@ from ..multi_asset_sensor_definition import (
     MultiAssetMaterializationFunction,
     MultiAssetSensorDefinition,
 )
+from ..run_request import SensorResult
 from ..sensor_definition import (
     DefaultSensorStatus,
     RawSensorEvaluationFunction,
@@ -163,6 +164,21 @@ def asset_sensor(
                 for item in result:
                     yield item
             elif isinstance(result, (RunRequest, SkipReason)):
+                yield result
+
+            elif isinstance(result, SensorResult):
+                if result.cursor:
+                    raise DagsterInvariantViolationError(
+                        f"Error in asset sensor {sensor_name}: Sensor returned a SensorResult"
+                        " with a cursor value. The cursor is managed by the asset sensor and"
+                        " should not be modified by a user."
+                    )
+                if result.pipeline_run_reactions:
+                    raise DagsterInvariantViolationError(
+                        f"Error in asset sensor {sensor_name}: Sensor returned a SensorResult with"
+                        " pipeline run reactions. Should only return RunRequest or SkipReason"
+                        " objects within the returned SensorResult."
+                    )
                 yield result
 
             elif result is not None:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -173,12 +173,6 @@ def asset_sensor(
                         " with a cursor value. The cursor is managed by the asset sensor and"
                         " should not be modified by a user."
                     )
-                if result.pipeline_run_reactions:
-                    raise DagsterInvariantViolationError(
-                        f"Error in asset sensor {sensor_name}: Sensor returned a SensorResult with"
-                        " pipeline run reactions. Should only return RunRequest or SkipReason"
-                        " objects within the returned SensorResult."
-                    )
                 yield result
 
             elif result is not None:

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -33,7 +33,7 @@ from dagster._core.instance.ref import InstanceRef
 
 from ..decorator_utils import get_function_params
 from .events import AssetKey
-from .run_request import RunRequest, SkipReason
+from .run_request import RunRequest, SensorResult, SkipReason
 from .sensor_definition import (
     DefaultSensorStatus,
     SensorDefinition,
@@ -999,7 +999,12 @@ def build_multi_asset_sensor_context(
 
 
 AssetMaterializationFunctionReturn = Union[
-    Iterator[Union[RunRequest, SkipReason]], Sequence[RunRequest], RunRequest, SkipReason, None
+    Iterator[Union[RunRequest, SkipReason, SensorResult]],
+    Sequence[RunRequest],
+    RunRequest,
+    SkipReason,
+    None,
+    SensorResult,
 ]
 AssetMaterializationFunction = Callable[
     ["SensorEvaluationContext", "EventLogEntry"],
@@ -1058,6 +1063,13 @@ class MultiAssetSensorDefinition(SensorDefinition):
     ):
         def _wrap_asset_fn(materialization_fn):
             def _fn(context):
+                def _check_cursor_not_set(sensor_result: SensorResult):
+                    if sensor_result.cursor:
+                        raise DagsterInvariantViolationError(
+                            "Cannot set cursor in a multi_asset_sensor. Cursor is set automatically"
+                            " based on the latest materialization for each monitored asset."
+                        )
+
                 multi_asset_sensor_context = MultiAssetSensorEvaluationContext(
                     instance_ref=context.instance_ref,
                     last_completion_time=context.last_completion_time,
@@ -1081,6 +1093,10 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     for item in result:
                         if isinstance(item, RunRequest):
                             runs_yielded = True
+                        if isinstance(item, SensorResult):
+                            raise DagsterInvariantViolationError(
+                                "Cannot yield a SensorResult from a multi_asset_sensor. Instead return the SensorResult."
+                            )
                         yield item
                 elif isinstance(result, RunRequest):
                     runs_yielded = True
@@ -1088,11 +1104,13 @@ class MultiAssetSensorDefinition(SensorDefinition):
                 elif isinstance(result, SkipReason):
                     # if result is a SkipReason, we don't update the cursor, so don't set runs_yielded = True
                     yield result
+                elif isinstance(result, SensorResult):
+                    _check_cursor_not_set(result)
+                    if result.run_requests:
+                        runs_yielded = True
+                    yield result
 
-                if (
-                    runs_yielded
-                    and not multi_asset_sensor_context.cursor_updated  # pylint: disable=protected-access
-                ):
+                if runs_yielded and not multi_asset_sensor_context.cursor_updated:
                     raise DagsterInvalidDefinitionError(
                         "Asset materializations have been handled in this sensor, but the cursor"
                         " was not updated. This means the same materialization events will be"
@@ -1111,7 +1129,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
             name=check_valid_name(name),
             job_name=job_name,
             evaluation_fn=_wrap_asset_fn(
-                check.callable_param(asset_materialization_fn, "asset_materialization_fn"),
+                check.callable_param(asset_materialization_fn, "asset_materialization_fn")
             ),
             minimum_interval_seconds=minimum_interval_seconds,
             description=description,

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1095,7 +1095,8 @@ class MultiAssetSensorDefinition(SensorDefinition):
                             runs_yielded = True
                         if isinstance(item, SensorResult):
                             raise DagsterInvariantViolationError(
-                                "Cannot yield a SensorResult from a multi_asset_sensor. Instead return the SensorResult."
+                                "Cannot yield a SensorResult from a multi_asset_sensor. Instead"
+                                " return the SensorResult."
                             )
                         yield item
                 elif isinstance(result, RunRequest):

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -244,7 +244,6 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         # At the end of each tick, must call update_cursor_after_evaluation to update the serialized
         # cursor.
         self._unpacked_cursor = MultiAssetSensorContextCursor(cursor, self)
-        self._cursor_has_been_updated = False
         self._cursor_advance_state_mutation = MultiAssetSensorCursorAdvances()
 
         self._initial_unconsumed_events_by_id: Dict[int, EventLogRecord] = {}
@@ -730,7 +729,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
                 will not be updated.
         """
         self._cursor_advance_state_mutation.add_advanced_records(materialization_records_by_key)
-        self._cursor_has_been_updated = True
+        self._cursor_updated = True
 
     @public
     def advance_all_cursors(self):
@@ -743,7 +742,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
 
         self._cursor_advance_state_mutation.add_advanced_records(materializations_by_key)
         self._cursor_advance_state_mutation.advance_all_cursors_called = True
-        self._cursor_has_been_updated = True
+        self._cursor_updated = True
 
     @public
     @property
@@ -1092,7 +1091,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
 
                 if (
                     runs_yielded
-                    and not multi_asset_sensor_context._cursor_has_been_updated  # noqa: SLF001
+                    and not multi_asset_sensor_context.cursor_updated  # pylint: disable=protected-access
                 ):
                     raise DagsterInvalidDefinitionError(
                         "Asset materializations have been handled in this sensor, but the cursor"

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -227,7 +227,6 @@ class SensorResult(
         [
             ("run_requests", Optional[Sequence[RunRequest]]),
             ("skip_reason", Optional[SkipReason]),
-            ("pipeline_run_reactions", Optional[Sequence[PipelineRunReaction]]),
             ("cursor", Optional[str]),
         ],
     )
@@ -240,39 +239,23 @@ class SensorResult(
         skip_reason (Optional[SkipReason]): A skip message indicating why sensor evaluation was skipped.
         cursor (Optional[str]): The cursor value for this sensor, which will be provided on the
             context for the next sensor evaluation.
-        pipeline_run_reactions (Optional[PipelineRunReaction]): A list of pipeline run reactions to be evaluated.
     """
 
     def __new__(
         cls,
         run_requests: Optional[Sequence[RunRequest]] = None,
         skip_reason: Optional[SkipReason] = None,
-        pipeline_run_reactions: Optional[Sequence[PipelineRunReaction]] = None,
         cursor: Optional[str] = None,
     ):
-        if not run_requests and not skip_reason and not pipeline_run_reactions:
+        if skip_reason and len(run_requests if run_requests else []) > 0:
             check.failed(
-                "Must provide at least one of run_requests, skip_reason, or pipeline_run_reactions"
+                "Expected a single SkipReason or one or more RunRequests: received both "
+                "RunRequest and SkipReason"
             )
-
-        if skip_reason:
-            if len(run_requests if run_requests else []) > 0:
-                check.failed(
-                    "Expected a single SkipReason or one or more RunRequests: received both "
-                    "RunRequest and SkipReason"
-                )
-            elif pipeline_run_reactions:
-                check.failed(
-                    "Expected a single SkipReason or one or more PipelineRunReaction: "
-                    "received both PipelineRunReaction and SkipReason"
-                )
 
         return super(SensorResult, cls).__new__(
             cls,
             run_requests=check.opt_sequence_param(run_requests, "run_requests", RunRequest),
             skip_reason=check.opt_inst_param(skip_reason, "skip_reason", SkipReason),
-            pipeline_run_reactions=check.opt_sequence_param(
-                pipeline_run_reactions, "pipeline_run_reactions", PipelineRunReaction
-            ),
             cursor=check.opt_str_param(cursor, "cursor"),
         )

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -50,6 +50,7 @@ from .sensor_definition import (
     RunRequest,
     SensorDefinition,
     SensorEvaluationContext,
+    SensorTickResult,
     SensorType,
     SkipReason,
 )
@@ -482,7 +483,7 @@ class RunStatusSensorDefinition(SensorDefinition):
 
         def _wrapped_fn(
             context: SensorEvaluationContext,
-        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction]]:
+        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction, SensorTickResult]]:
             # initiate the cursor to (most recent event id, current timestamp) when:
             # * it's the first time starting the sensor
             # * or, the cursor isn't in valid format (backcompt)
@@ -636,7 +637,8 @@ class RunStatusSensorDefinition(SensorDefinition):
                             )
 
                             if isinstance(
-                                sensor_return, (RunRequest, SkipReason, PipelineRunReaction)
+                                sensor_return,
+                                (RunRequest, SkipReason, PipelineRunReaction, SensorTickResult),
                             ):
                                 yield sensor_return
                             else:

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -23,6 +23,7 @@ from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
+    DagsterInvariantViolationError,
     RunStatusSensorExecutionError,
     user_code_error_boundary,
 )
@@ -50,7 +51,7 @@ from .sensor_definition import (
     RunRequest,
     SensorDefinition,
     SensorEvaluationContext,
-    SensorTickResult,
+    SensorResult,
     SensorType,
     SkipReason,
 )
@@ -483,7 +484,7 @@ class RunStatusSensorDefinition(SensorDefinition):
 
         def _wrapped_fn(
             context: SensorEvaluationContext,
-        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction, SensorTickResult]]:
+        ) -> Iterator[Union[RunRequest, SkipReason, PipelineRunReaction, SensorResult]]:
             # initiate the cursor to (most recent event id, current timestamp) when:
             # * it's the first time starting the sensor
             # * or, the cursor isn't in valid format (backcompt)
@@ -636,9 +637,17 @@ class RunStatusSensorDefinition(SensorDefinition):
                                 ).to_json()
                             )
 
-                            if isinstance(
+                            if isinstance(sensor_return, SensorResult):
+                                if sensor_return.cursor:
+                                    raise DagsterInvariantViolationError(
+                                        f"Error in run status sensor {name}: Sensor returned a"
+                                        " SensorResult with a cursor value. The cursor is managed"
+                                        " by the sensor and should not be modified by a user."
+                                    )
+                                yield sensor_return
+                            elif isinstance(
                                 sensor_return,
-                                (RunRequest, SkipReason, PipelineRunReaction, SensorTickResult),
+                                (RunRequest, SkipReason, PipelineRunReaction),
                             ):
                                 yield sensor_return
                             else:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -583,11 +583,11 @@ class SensorDefinition:
 
             if isinstance(item, SensorResult):
                 run_requests = list(item.run_requests) if item.run_requests else []
-
-                pipeline_run_reactions = (
-                    list(item.pipeline_run_reactions) if item.pipeline_run_reactions else []
+                skip_message = (
+                    item.skip_reason.skip_message
+                    if item.skip_reason
+                    else (None if run_requests else "Sensor function returned an empty result")
                 )
-                skip_message = item.skip_reason.skip_message if item.skip_reason else None
 
                 if item.cursor and context.cursor_updated:
                     raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -53,7 +53,7 @@ from .pipeline_definition import PipelineDefinition
 from .run_request import (
     PipelineRunReaction,
     RunRequest,
-    SensorTickResult,
+    SensorResult,
     SkipReason,
 )
 from .target import DirectTarget, ExecutableDefinition, RepoRelativeTarget
@@ -299,12 +299,12 @@ class SensorEvaluationContext:
 
 
 RawSensorEvaluationFunctionReturn = Union[
-    Iterator[Union[SkipReason, RunRequest, PipelineRunReaction, SensorTickResult]],
+    Iterator[Union[SkipReason, RunRequest, PipelineRunReaction, SensorResult]],
     Sequence[RunRequest],
     SkipReason,
     RunRequest,
     PipelineRunReaction,
-    SensorTickResult,
+    SensorResult,
 ]
 RawSensorEvaluationFunction: TypeAlias = Callable[..., RawSensorEvaluationFunctionReturn]
 
@@ -579,20 +579,19 @@ class SensorDefinition:
             skip_message = "Sensor function returned an empty result"
         elif len(result) == 1:
             item = result[0]
-            check.inst(item, (SkipReason, RunRequest, PipelineRunReaction, SensorTickResult))
+            check.inst(item, (SkipReason, RunRequest, PipelineRunReaction, SensorResult))
 
-            if isinstance(item, SensorTickResult):
-                run_requests = [item] if isinstance(item, RunRequest) else []
+            if isinstance(item, SensorResult):
+                run_requests = list(item.run_requests) if item.run_requests else []
 
                 pipeline_run_reactions = (
-                    [item.pipeline_run_reaction] if item.pipeline_run_reaction else []
+                    list(item.pipeline_run_reactions) if item.pipeline_run_reactions else []
                 )
                 skip_message = item.skip_reason.skip_message if item.skip_reason else None
 
-                if item.cursor and context._cursor_updated:
+                if item.cursor and context.cursor_updated:
                     raise DagsterInvariantViolationError(
-                        "SensorTickResult.cursor cannot be set if context.update_cursor() was"
-                        " called."
+                        "SensorResult.cursor cannot be set if context.update_cursor() was called."
                     )
                 updated_cursor = item.cursor
 
@@ -609,9 +608,9 @@ class SensorDefinition:
             else:
                 check.failed(f"Unexpected type {type(item)} in sensor result")
         else:
-            if any(isinstance(item, SensorTickResult) for item in result):
+            if any(isinstance(item, SensorResult) for item in result):
                 check.failed(
-                    "When a SensorTickResult is returned from a sensor, it must be the only object"
+                    "When a SensorResult is returned from a sensor, it must be the only object"
                     " returned."
                 )
 
@@ -821,7 +820,7 @@ def wrap_sensor_evaluation(
         if inspect.isgenerator(result) or isinstance(result, list):
             for item in result:
                 yield item
-        elif isinstance(result, (SkipReason, RunRequest, SensorTickResult)):
+        elif isinstance(result, (SkipReason, RunRequest, SensorResult)):
             yield result
 
         elif result is not None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
@@ -1,0 +1,201 @@
+import pytest
+from dagster import (
+    AssetKey,
+    AssetMaterialization,
+    DagsterInvariantViolationError,
+    Output,
+    RunRequest,
+    SkipReason,
+    asset_sensor,
+    build_sensor_context,
+    job,
+    op,
+    sensor,
+)
+from dagster._check import CheckError
+from dagster._core.definitions.run_request import SensorResult
+from dagster._core.test_utils import instance_for_test
+
+
+@op
+def do_something():
+    pass
+
+
+@job
+def do_something_job():
+    do_something()
+
+
+def test_sensor_result_one_run_request():
+    @sensor(job=do_something_job)
+    def test_sensor(_):
+        return SensorResult(run_requests=[RunRequest(run_key="foo")])
+
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(
+            instance=instance,
+        )
+        sensor_data = test_sensor.evaluate_tick(ctx)
+        assert len(sensor_data.run_requests) == 1
+        assert sensor_data.run_requests[0].run_key == "foo"
+        assert not sensor_data.skip_message
+        assert not sensor_data.pipeline_run_reactions
+        assert not sensor_data.cursor
+
+
+def test_sensor_result_skip_reason():
+    skip_reason = SkipReason("I'm skipping")
+
+    @sensor(job=do_something_job)
+    def test_sensor(_):
+        return [
+            SensorResult(skip_reason=skip_reason),
+        ]
+
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(
+            instance=instance,
+        )
+        sensor_data = test_sensor.evaluate_tick(ctx)
+        assert not sensor_data.run_requests
+        assert sensor_data.skip_message == skip_reason.skip_message
+        assert not sensor_data.pipeline_run_reactions
+        assert not sensor_data.cursor
+
+
+def test_invalid_skip_reason_invocations():
+    @sensor(job=do_something_job)
+    def multiple_sensor_results(_):
+        return [
+            SensorResult(skip_reason=SkipReason("I'm skipping")),
+            SensorResult(skip_reason=SkipReason("I'm skipping")),
+        ]
+
+    @sensor(job=do_something_job)
+    def sensor_result_w_other_objects(_):
+        return [
+            SensorResult(run_requests=[RunRequest(run_key="foo")]),
+            RunRequest(run_key="foo"),
+        ]
+
+    @sensor(job=do_something_job)
+    def invalid_sensor_result(_):
+        return [
+            SensorResult(
+                run_requests=[RunRequest(run_key="foo")], skip_reason=SkipReason("aklsdj")
+            ),
+        ]
+
+    @sensor(job=do_something_job)
+    def empty_sensor_result(_):
+        return [
+            SensorResult(),
+        ]
+
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(
+            instance=instance,
+        )
+
+        with pytest.raises(
+            CheckError,
+            match=(
+                "When a SensorResult is returned from a sensor, it must be the only object"
+                " returned."
+            ),
+        ):
+            multiple_sensor_results.evaluate_tick(ctx)
+
+        with pytest.raises(
+            CheckError,
+            match=(
+                "When a SensorResult is returned from a sensor, it must be the only object"
+                " returned."
+            ),
+        ):
+            sensor_result_w_other_objects.evaluate_tick(ctx)
+
+        with pytest.raises(
+            CheckError,
+            match="Expected a single SkipReason or one or more RunRequests",
+        ):
+            invalid_sensor_result.evaluate_tick(ctx)
+
+        with pytest.raises(
+            CheckError,
+            match=(
+                "Must provide at least one of run_requests, skip_reason, or pipeline_run_reactions"
+            ),
+        ):
+            empty_sensor_result.evaluate_tick(ctx)
+
+
+def test_update_cursor():
+    @sensor(job=do_something_job)
+    def test_sensor(_):
+        return [
+            SensorResult([RunRequest("foo")], cursor="foo"),
+        ]
+
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(
+            instance=instance,
+        )
+        result = test_sensor.evaluate_tick(ctx)
+        assert result.cursor == "foo"
+
+
+def test_update_cursor_and_sensor_result_cursor():
+    @sensor(job=do_something_job)
+    def test_sensor(context):
+        context.update_cursor("bar")
+        return [
+            SensorResult([RunRequest("foo")], cursor="foo"),
+        ]
+
+    with instance_for_test() as instance:
+        ctx = build_sensor_context(
+            instance=instance,
+        )
+        with pytest.raises(
+            DagsterInvariantViolationError,
+            match=r"cannot be set if context.update_cursor()",
+        ):
+            test_sensor.evaluate_tick(ctx)
+
+
+def test_sensor_result_asset_sensor():
+    @op
+    def my_table_materialization():
+        yield AssetMaterialization("my_table")
+        yield Output(1)
+
+    @job
+    def my_table_job():
+        my_table_materialization()
+
+    @asset_sensor(asset_key=AssetKey("my_table"), job=do_something_job)
+    def my_asset_sensor(context, asset_event):
+        return SensorResult([RunRequest("foo")])
+
+    @asset_sensor(asset_key=AssetKey("my_table"), job=do_something_job)
+    def asset_sensor_set_cursor(context, asset_event):
+        return SensorResult([RunRequest("foo")], cursor="foo")
+
+    with instance_for_test() as instance:
+        my_table_job.execute_in_process(instance=instance)
+        with build_sensor_context(
+            instance=instance,
+        ) as ctx:
+            result = my_asset_sensor.evaluate_tick(ctx)
+            assert len(result.run_requests) == 1
+            assert result.run_requests[0].run_key == "foo"
+
+        with build_sensor_context(
+            instance=instance,
+        ) as ctx:
+            with pytest.raises(
+                DagsterInvariantViolationError, match="The cursor is managed by the asset sensor"
+            ):
+                asset_sensor_set_cursor.evaluate_tick(ctx)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
@@ -87,12 +87,6 @@ def test_invalid_skip_reason_invocations():
             ),
         ]
 
-    @sensor(job=do_something_job)
-    def empty_sensor_result(_):
-        return [
-            SensorResult(),
-        ]
-
     with instance_for_test() as instance:
         ctx = build_sensor_context(
             instance=instance,
@@ -121,14 +115,6 @@ def test_invalid_skip_reason_invocations():
             match="Expected a single SkipReason or one or more RunRequests",
         ):
             invalid_sensor_result.evaluate_tick(ctx)
-
-        with pytest.raises(
-            CheckError,
-            match=(
-                "Must provide at least one of run_requests, skip_reason, or pipeline_run_reactions"
-            ),
-        ):
-            empty_sensor_result.evaluate_tick(ctx)
 
 
 def test_update_cursor():


### PR DESCRIPTION
This PR introduces a `SensorResult` object that wraps all of the return objects from the sensor. This lays the groundwork for allowing users to return a dynamic partition request object that mutates a dynamic partitions definition as part of a `SensorResult`.

The `SensorResult` object allows for users to pass in:
- a cursor for the next time the sensor is evaluated
- and either a skip reason or a combination of run requests and pipeline run reactions. At least one of these objects must be provided.

However, the cursor update is only applied for regular sensors defined via `@sensor`. The other types of sensors (multi asset sensors, asset sensors, run status sensor) manage their cursors with dagster, so if a cursor update is attempted via a `SensorResult` an error is thrown.