### PR TITLE
Add an instance property to hook context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/hook_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/hook_invocation.py
@@ -17,7 +17,7 @@ def hook_invocation_result(
 ):
     if not hook_context:
         hook_context = UnboundHookContext(
-            resources={}, op=None, run_id=None, job_name=None, op_exception=None
+            resources={}, op=None, run_id=None, job_name=None, op_exception=None, instance=None
         )
 
     # Validate that all required resources are provided in the context
@@ -34,6 +34,7 @@ def hook_invocation_result(
         run_id=hook_context._run_id,  # noqa: SLF001
         job_name=hook_context._job_name,  # noqa: SLF001
         op_exception=hook_context._op_exception,  # noqa: SLF001
+        instance=hook_context._instance,  # noqa: SLF001
     )
 
     decorated_fn = check.not_none(hook_def.decorated_fn)

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -20,6 +20,7 @@ from dagster._core.definitions.decorators.hook_decorator import event_list_hook
 from dagster._core.definitions.events import HookExecutionResult
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvalidDefinitionError
+from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import instance_for_test
 
 
@@ -219,6 +220,7 @@ def test_failure_hook():
 
     @failure_hook
     def a_failure_hook(context):
+        assert isinstance(context.instance, DagsterInstance)
         called_hook_to_solids[context.hook_def.name].append(context.op.name)
 
     @failure_hook(name="a_named_failure_hook")


### PR DESCRIPTION
Summary:
Allows you to reference the DagsterInstance within a hook.

Test Plan:
New Test case

## Summary & Motivation

## How I Tested These Changes
