### PR TITLE
[toy] user-computed data versions

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/__init__.py
@@ -1,0 +1,164 @@
+"""Models a case where Dagster is used purely for orchestration and not data transformation.
+
+In this scenario, both the structure of the asset graph and the compute logic for assets are
+defined externally to Dagster. The asset graph is specified in a schema, and an external system
+knows how to compute each asset listed in this schema.
+
+We integrate the system with Dagster by using an asset factory to construct Dagster
+`AssetsDefinition` objects for each node in the asset graph. Dagster forwards materialization
+requests to the external system. We pass an asset specification together with provenance information
+for the last materialization of the asset on record. The external system is responsible for
+correctly processing this information-- if the provenance of the last materialization is stale
+(different from the current state of the asset), then it should recompute the asset and overwrite
+the existing value. Otherwise, it should simply use the existing stored value of the asset.
+
+The materialization endpoint of the external system returns a data version string and a flag
+indicating whether a memoized value was used. This information is passed to the Dagster framework by
+returning a `Nothing` `Output`.
+"""
+import warnings
+from typing import Sequence, cast
+
+from dagster import (
+    AssetKey,
+    AssetsDefinition,
+    AssetSelection,
+    DataProvenance,
+    DataVersion,
+    Definitions,
+    ExperimentalWarning,
+    In,
+    Nothing,
+    OpDefinition,
+    OpExecutionContext,
+    Out,
+    Output,
+    SourceAsset,
+    define_asset_job,
+)
+from typing_extensions import TypedDict
+
+from .external_system import AssetSpec, ExternalSystem, ProvenanceSpec, SourceAssetSpec
+
+warnings.filterwarnings("ignore", category=ExperimentalWarning)
+
+
+def external_asset(asset_spec: AssetSpec):
+    """Factory to build an `AssetsDefinition` object to represent an asset externally defined by an
+    `AssetSpec`.
+
+    The op attached to the `AssetsDefinition` forwards materialization requests to the external
+    system, sending an asset key and provenance info for the last recorded materialization of the
+    asset. The external system responds with a data version and a flag indicating whether a memoized
+    value was used for the materialization (i.e. whether recomputation occurred). This is passed to
+    the dagster framework by packaging it on a returned `Output` object. The `Output` returns
+    `Nothing` because Dagster is not handling passing data in between ops in this scenario.
+
+    Args:
+        asset_spec (AssetSpec):
+            A dictionary containing the metadata that defines the asset.
+
+    Returns (AssetsDefinition):
+        An `AssetsDefinition` instance representing the asset in the external system.
+    """
+    key = AssetKey([asset_spec["key"]])
+    code_version = asset_spec["code_version"]
+    dependencies = {AssetKey([dep]) for dep in asset_spec["dependencies"]}
+
+    def fn(context: OpExecutionContext, *args):
+        external_system = ExternalSystem(context.instance.storage_directory())
+
+        provenance = context.get_asset_provenance(key)
+        provenance_spec = provenance_to_dict(provenance) if provenance else None
+        result = external_system.materialize(
+            asset_spec,
+            provenance_spec,
+        )
+        if result["is_memoized"]:
+            context.log.info(f"Used memoized value for {key.to_user_string()}")
+        yield Output(
+            None,
+            data_version=DataVersion(result["data_version"]),
+            metadata={"is_memoized": result["is_memoized"]},
+        )
+
+    keys_by_input_name = {k.path[-1]: k for k in dependencies}
+    keys_by_output_name = {"result": key}
+    op_def = OpDefinition(
+        name=key.path[-1],
+        ins={k.to_user_string(): In(cast(type, Nothing)) for k in dependencies},
+        outs={"result": Out(Nothing)},
+        code_version=code_version,
+        compute_fn=fn,
+    )
+    return AssetsDefinition(
+        keys_by_input_name=keys_by_input_name,
+        keys_by_output_name=keys_by_output_name,
+        node_def=op_def,
+    )
+
+
+def external_source_asset(source_asset_spec: SourceAssetSpec) -> SourceAsset:
+    """Factory to build a `SourceAsset` object to represent a source asset externally defined by a `SourceAssetSpec`.
+
+    The op attached to the `SourceAsset` forwards observation requests to the external system. The
+    external system responds with the current data version of the asset.
+
+    Args:
+        source_asset_spec (SourceAssetSpec):
+            A dictionary containing the metadata that defines the source asset.
+
+    Returns (SourceAsset):
+        A `SourceAsset` instance representing the source asset in the external system.
+    """
+    key = AssetKey([source_asset_spec["key"]])
+
+    def fn(context) -> DataVersion:
+        external_system = ExternalSystem(context.instance.storage_directory())
+        result = external_system.observe(source_asset_spec)
+        return DataVersion(result["data_version"])
+
+    return SourceAsset(key, observe_fn=fn)
+
+
+def provenance_to_dict(provenance: DataProvenance) -> ProvenanceSpec:
+    return {
+        "code_version": provenance.code_version,
+        "input_data_versions": {
+            key.to_user_string(): version.value
+            for key, version in provenance.input_data_versions.items()
+        },
+    }
+
+
+# ########################
+# ##### DEFINITIONS
+# ########################
+
+
+class Schema(TypedDict):
+    assets: Sequence[AssetSpec]
+    source_assets: Sequence[SourceAssetSpec]
+
+
+SCHEMA: Schema = {
+    "assets": [
+        {"key": "alpha", "code_version": "lib/v1", "dependencies": set()},
+        {"key": "beta", "code_version": "lib/v1", "dependencies": {"alpha"}},
+        {"key": "epsilon", "code_version": "lib/v1", "dependencies": {"delta"}},
+    ],
+    "source_assets": [
+        {"key": "delta"},
+    ],
+}
+
+assets = [external_asset(asset_spec) for asset_spec in SCHEMA["assets"]]
+source_assets = [
+    external_source_asset(source_asset_spec) for source_asset_spec in SCHEMA["source_assets"]
+]
+
+
+defs = Definitions(
+    assets=[*assets, *source_assets],
+    jobs=[define_asset_job("external_system_job", AssetSelection.keys("alpha", "beta"))],
+)

--- a/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/external_system.py
+++ b/python_modules/dagster-test/dagster_test/toys/user_computed_data_versions/external_system.py
@@ -1,0 +1,162 @@
+import json
+import os
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from time import sleep
+from typing import AbstractSet, Any, Mapping, Optional, Union
+
+from typing_extensions import TypedDict
+
+# For source assets
+_DUMMY_VALUE = 100
+
+# ExternalSystem simulates source assets outside of Dagster's control by idempotently creating a set
+# of them using dummy data whenever it is constructed.
+_SOURCE_ASSETS: Mapping[str, Any] = {
+    "delta": _DUMMY_VALUE,
+}
+
+
+class AssetSpec(TypedDict):
+    key: str
+    code_version: str
+    dependencies: AbstractSet[str]
+
+
+class SourceAssetSpec(TypedDict):
+    key: str
+
+
+class ProvenanceSpec(TypedDict):
+    code_version: str
+    input_data_versions: Mapping[str, str]
+
+
+class MaterializeResult(TypedDict):
+    data_version: str
+    is_memoized: bool
+
+
+class ObserveResult(TypedDict):
+    data_version: str
+
+
+class ExternalSystem:
+    def __init__(self, storage_path: str):
+        self._db = _Database(storage_path)
+
+    def materialize(
+        self, asset_spec: AssetSpec, provenance_spec: Optional[ProvenanceSpec]
+    ) -> MaterializeResult:
+        """Recompute an asset if its provenance is missing or stale.
+
+        Receives asset provenance info from Dagster representing the last materialization on record.
+        The provenance is compared to the specified code version and current data versions of
+        dependencies to determine whether something has changed and the asset should be recomputed.
+
+        Args:
+            asset_spec (AssetSpec):
+                A dictionary containing an asset key, code version, and data dependencies.
+            provenance_spec (ProvenanceSpec):
+                A dictionary containing provenance info for the last materialization of the
+                specified asset. `None` if there is no materialization on record for the asset.
+
+        Returns (MaterializeResult):
+            A dictionary containing the data version for the asset and a boolean flag indicating
+            whether the data version corresponds to a memoized value (true) or a freshly computed
+            value (false).
+        """
+        key = asset_spec["key"]
+        if (
+            not self._db.has(key)
+            or provenance_spec is None
+            or self._is_provenance_stale(asset_spec, provenance_spec)
+        ):
+            inputs = {dep: self._db.get(dep).value for dep in asset_spec["dependencies"]}
+            value = _compute_value(key, inputs, asset_spec["code_version"])
+            data_version = _get_hash(value)
+            record = _DatabaseRecord(value, data_version)
+            self._db.set(key, record)
+            is_memoized = False
+        else:
+            record = self._db.get(key)
+            is_memoized = True
+        return {"data_version": record.data_version, "is_memoized": is_memoized}
+
+    def observe(self, asset_spec: Union[AssetSpec, SourceAssetSpec]) -> ObserveResult:
+        """Observe an asset or source asset, returning its current data version.
+
+        Args:
+            asset_spec (Union[AssetSpec, SourceAssetSpec]):
+                A dictionary containing an asset key.
+
+        Returns (ObserveResult):
+            A dictionary containing the current data version of the asset.
+        """
+        return {"data_version": self._db.get(asset_spec["key"]).data_version}
+
+    def _is_provenance_stale(self, asset_spec: AssetSpec, provenance_spec: ProvenanceSpec) -> bool:
+        # did code change?
+        if provenance_spec["code_version"] != asset_spec["code_version"]:
+            return True
+        # was a dependency added or removed?
+        if set(provenance_spec["input_data_versions"].keys()) != asset_spec["dependencies"]:
+            return True
+        # did the version of a dependency change?
+        for dep_key, version in provenance_spec["input_data_versions"].items():
+            if self._db.get(dep_key).data_version != version:
+                return True
+        return False
+
+
+def _compute_value(key: str, inputs: Mapping[str, Any], code_version: str) -> Any:
+    if code_version != "lib/v1":
+        raise Exception(f"Unknown code version {code_version}. Cannot compute.")
+    if key == "alpha":
+        return 1
+    elif key == "beta":
+        sleep(10)
+        value = inputs["alpha"] + 1
+        return value
+    elif key == "epsilon":
+        sleep(10)
+        return inputs["delta"] * 5
+
+
+def _get_hash(value: Any) -> str:
+    hash_sig = sha256()
+    hash_sig.update(bytearray(str(value), "utf8"))
+    return hash_sig.hexdigest()[:6]
+
+
+@dataclass
+class _DatabaseRecord:
+    value: Any
+    data_version: str
+
+
+class _Database:
+    def __init__(self, storage_path: str):
+        self.storage_path = storage_path
+        if not os.path.exists(self.storage_path):
+            os.mkdir(self.storage_path)
+        for k, v in _SOURCE_ASSETS.items():
+            path = self.asset_path(k)
+            if not os.path.exists(path):
+                with open(self.asset_path(k), "w") as fd:  # source asset
+                    record = _DatabaseRecord(v, _get_hash(v))
+                    fd.write(json.dumps(asdict(record)))
+
+    def asset_path(self, key: str) -> str:
+        return f"{self.storage_path}/{key}.json"
+
+    def get(self, key: str) -> _DatabaseRecord:
+        with open(self.asset_path(key), "r") as fd:
+            return _DatabaseRecord(**json.load(fd))
+
+    def has(self, key: str) -> bool:
+        return os.path.exists(self.asset_path(key))
+
+    def set(self, key: str, record: _DatabaseRecord) -> None:
+        with open(self.asset_path(key), "w") as fd:
+            fd.write(json.dumps(asdict(record)))


### PR DESCRIPTION
## Summary & Motivation

Adds a toy modeling a scenario where:

- An asset graph resides in an external system
- An asset factory is used to build a representation of the external system's graph
- Dagster forwards materialization requests to the external system, passing an asset key and provenance
- The external system decides whether to actually recompute the asset based on the provenance
- The external system reports back a data version and whether it represents a memoized value
- This information is fed into Dagster by being attached to a Nothing `Output`

## How I Tested These Changes

- `dagit -m external_system_assets` (from `python_modules/dagster_test/toys`
- materialize `alpha`
- materialize `beta` -- it should take ~10 seconds
- materialize `beta` again-- it should be fast because `beta` is memoized
- observe `delta`
- materialize `epsilon`-- it should take ~10 seconds
- materialize `epsilon` again-- it should be fast because `epsilon` is memoized
