### PR TITLE
[Asset Partitions] Show latest date partition first + Allow sorting of partitions

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -412,7 +412,7 @@ const ConfigEditorConfigGeneratorPicker: React.FC<ConfigEditorConfigGeneratorPic
   },
 );
 
-const SortButton = styled.button`
+export const SortButton = styled.button`
   border: 0;
   cursor: pointer;
   padding: 4px;
@@ -421,11 +421,11 @@ const SortButton = styled.button`
   border-radius: 4px;
   transition: background-color 100ms;
 
-  :hover,
   :focus {
     background-color: ${Colors.Gray100};
     outline: none;
-
+  }
+  :hover {
     ${IconWrapper} {
       background-color: ${Colors.Gray700};
     }


### PR DESCRIPTION
## Summary & Motivation

Currently partitions show up in the UI in the order that they're created. This means the oldest partition always shows up first.

For time based partitions this is undesirable so for time based partitions we reverse the default sorting so that the latest partition appears first.

We also add a button that users can use to reverse the sort.

## How I Tested These Changes

<img width="482" alt="Screen Shot 2023-03-15 at 3 22 04 PM" src="https://user-images.githubusercontent.com/2286579/225420440-7870d090-bd95-43e7-837c-ec9e8e945f2e.png">
<img width="527" alt="Screen Shot 2023-03-15 at 3 21 56 PM" src="https://user-images.githubusercontent.com/2286579/225420444-131f3e85-084d-41f0-8c03-0c675399682e.png">
