### PR TITLE
[asset-reconciliation][perf] more efficient is_reconciled function for partitioned assets

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -423,10 +423,10 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             if asset_graph.is_source(parent.asset_key):
                 continue
 
-            # For performance, we want to avoid querying for the latest materialization record for
-            # each partition of a partitioned asset, so we reverse the order of the logic as
-            # necessary to avoid this.
-            if asset_partition.partition_key is None and parent.partition_key is not None:
+            # For performance, we try to only call get_latest_materialization on unpartitioned
+            # assets. To do so, we reverse the order of operations based on the partitioning of
+            # the current asset.
+            if asset_partition.partition_key is None:
                 latest_materialization_record = self.get_latest_materialization_record(
                     asset_partition, None
                 )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -406,6 +406,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def is_reconciled(
         self, *, asset_partition: AssetKeyPartitionKey, asset_graph: AssetGraph
     ) -> bool:
+        """Returns a boolean representing if the given `asset_partition` is currently reconciled.
+        An asset (partition) is considered unreconciled if any of:
+        - It has never been materialized
+        - One of its parents has been updated more recently than it has
+        - One of its parents is unreconciled.
+        """
         if not self.materialization_exists(asset_partition):
             return False
 


### PR DESCRIPTION
## Summary & Motivation

This specifically helps when:
- you have a partitions definition with lots of materialized partitions (e.g. 1000)
- you have an unpartitioned asset upstream of this asset

The `should_reconcile` function tells our filtered BFS of the asset partition graph which nodes to explore. If we detect that the unpartitioned asset has been newly materialized, we need to look at all of its children to see if any of them need to be updated as well. In order to do this, we use the `is_reconciled` function, which detects if a given (asset_key, partition_key) has been updated more recently than all of its parents (in which case it is reconciled) or if it hasn't (in which case it is unreconciled).

So, we need to call this `is_reconciled` function 1001 times (once for the unpartitioned asset, then once for all of its children partitions).

Previously, each call would require getting the latest materialization record for the (asset_key, partition_key). From there, we would look for the latest materialization record of its parent (asset_key, partition_key)s that happened after that latest materialization record. If this record was None (meaning no materializations of our parents happened after us), then we're good, otherwise we're not.

This PR introduces a faster way to check if a given (asset_key, partition_key) has a materialization after a given cursor, in cases where we expect to make the same query for many partitions of the same asset key (with the same after_cursor). It does this by just doing a single query to get the count  of materializations per partition after the given cursor. After this, future queries for if another partition for that same asset key after the same cursor will not require a round trip to the database.

We then use this inside is_reconciled.

## How I Tested These Changes

The current reconciliation performance tests do not currently capture a scenario where this would make a large difference, as it only tests TimeWindowPartitionsDefinitions. However, I did some manual testing and it indeed works as expected, eliminating the need for a bunch of individual queries.