### PR TITLE
[pythonic config] Treat Optional as both not-required and Noneable

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -18,7 +18,7 @@ from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr
 from typing_extensions import TypeAlias
 
 from dagster._annotations import experimental
-from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType
+from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType, Noneable
 from dagster._config.field_utils import config_dictionary_from_values
 from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
@@ -744,6 +744,8 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
         wrapped_config_type = _wrap_config_type(
             shape_type=pydantic_field.shape, config_type=config_type, key_type=key_type
         )
+        if pydantic_field.allow_none:
+            wrapped_config_type = Noneable(wrapped_config_type)
         return Field(
             config=wrapped_config_type,
             description=pydantic_field.field_info.description,

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -15,7 +15,7 @@ from dagster import (
     op,
     validate_run_config,
 )
-from dagster._config.config_type import ConfigTypeKind
+from dagster._config.config_type import ConfigTypeKind, Noneable
 from dagster._config.field_utils import convert_potential_field
 from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.structured_config import Config, infer_schema_from_config_class
@@ -518,12 +518,12 @@ def test_int_source_default():
     )
 
 
-def test_optional_string_source_default():
+def test_optional_string_source_default() -> None:
     class RawStringConfigSchema(Config):
         a_str: Optional[str]
 
     assert print_config_type_to_string(
-        {"a_str": dagster.Field(StringSource, is_required=False)}
+        {"a_str": dagster.Field(Noneable(StringSource))}
     ) == print_config_type_to_string(
         infer_schema_from_config_class(RawStringConfigSchema).config_type
     )
@@ -531,12 +531,12 @@ def test_optional_string_source_default():
     assert RawStringConfigSchema(a_str=None).a_str is None
 
 
-def test_optional_string_source_with_default_none():
+def test_optional_string_source_with_default_none() -> None:
     class RawStringConfigSchema(Config):
         a_str: Optional[str] = None
 
     assert print_config_type_to_string(
-        {"a_str": dagster.Field(StringSource, is_required=False)}
+        {"a_str": dagster.Field(Noneable(StringSource))}
     ) == print_config_type_to_string(
         infer_schema_from_config_class(RawStringConfigSchema).config_type
     )
@@ -545,23 +545,23 @@ def test_optional_string_source_with_default_none():
     assert RawStringConfigSchema(a_str=None).a_str is None
 
 
-def test_optional_bool_source_default():
+def test_optional_bool_source_default() -> None:
     class RawBoolConfigSchema(Config):
         a_bool: Optional[bool]
 
     assert print_config_type_to_string(
-        {"a_bool": dagster.Field(BoolSource, is_required=False)}
+        {"a_bool": dagster.Field(Noneable(BoolSource))}
     ) == print_config_type_to_string(
         infer_schema_from_config_class(RawBoolConfigSchema).config_type
     )
 
 
-def test_optional_int_source_default():
+def test_optional_int_source_default() -> None:
     class OptionalInt(Config):
         an_int: Optional[int]
 
     assert print_config_type_to_string(
-        {"an_int": dagster.Field(IntSource, is_required=False)}
+        {"an_int": dagster.Field(Noneable(IntSource))}
     ) == print_config_type_to_string(infer_schema_from_config_class(OptionalInt).config_type)
 
 


### PR DESCRIPTION
## Summary

Ensures that `Optional` fields are treated as both (1) noneable and (2) optional, so that config for these fields can be dropped (filling in `None`) or explicitly provided with `None`. Previously, this would cause issues with e.g. `Optional[Dict[...]]` fields which wouldn't accept `None` as an input (only default to `None` if not provided).

## Test Plan

Add two previously-failing unit tests.
