### PR TITLE
[dagster-fivetran] Migrate to Pythonic resources

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -69,14 +69,13 @@ def _build_fivetran_assets(
             )
             for table, key in tracked_asset_keys.items()
         },
-        required_resource_keys={"fivetran"},
         compute_kind="fivetran",
         resource_defs=resource_defs,
         group_name=group_name,
         op_tags=op_tags,
     )
-    def _assets(context: OpExecutionContext) -> Any:
-        fivetran_output = context.resources.fivetran.sync_and_poll(
+    def _assets(context: OpExecutionContext, fivetran: FivetranResource) -> Any:
+        fivetran_output = fivetran.sync_and_poll(
             connector_id=connector_id,
             poll_interval=poll_interval,
             poll_timeout=poll_timeout,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -5,10 +5,8 @@ from dagster import (
     Config,
     In,
     Nothing,
-    OpExecutionContext,
     Out,
     Output,
-    Resource,
     op,
 )
 from pydantic import Field as PyField
@@ -69,9 +67,7 @@ class SyncConfig(Config):
     ),
     tags={"kind": "fivetran"},
 )
-def fivetran_sync_op(
-    context: OpExecutionContext, config: SyncConfig, fivetran: Resource["FivetranResource"]
-) -> Any:
+def fivetran_sync_op(config: SyncConfig, fivetran: "FivetranResource") -> Any:
     """Executes a Fivetran sync for a given ``connector_id``, and polls until that sync
     completes, raising an error if it is unsuccessful. It outputs a FivetranOutput which contains
     the details of the Fivetran connector after the sync successfully completes, as well as details
@@ -141,9 +137,8 @@ class FivetranResyncConfig(SyncConfig):
     tags={"kind": "fivetran"},
 )
 def fivetran_resync_op(
-    context: OpExecutionContext,
     config: FivetranResyncConfig,
-    fivetran: Resource["FivetranResource"],
+    fivetran: "FivetranResource",
 ) -> Any:
     """Executes a Fivetran historical resync for a given ``connector_id``, and polls until that resync
     completes, raising an error if it is unsuccessful. It outputs a FivetranOutput which contains

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -1,12 +1,62 @@
-from dagster import Array, AssetKey, Bool, Field, In, Noneable, Nothing, Out, Output, Permissive, op
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from dagster import (
+    AssetKey,
+    Config,
+    In,
+    Nothing,
+    OpExecutionContext,
+    Out,
+    Output,
+    Resource,
+    op,
+)
+from pydantic import Field as PyField
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL
 from dagster_fivetran.types import FivetranOutput
 from dagster_fivetran.utils import generate_materializations
 
+if TYPE_CHECKING:
+    from dagster_fivetran import FivetranResource
+
+
+class SyncConfig(Config):
+    connector_id: str = PyField(
+        ...,
+        description=(
+            "The Fivetran Connector ID that this op will sync. You can retrieve this "
+            'value from the "Setup" tab of a given connector in the Fivetran UI.'
+        ),
+    )
+    poll_interval: float = PyField(
+        DEFAULT_POLL_INTERVAL,
+        description="The time (in seconds) that will be waited between successive polls.",
+    )
+    poll_timeout: Optional[float] = PyField(
+        None,
+        description=(
+            "The maximum time that will waited before this operation is timed out. By "
+            "default, this will never time out."
+        ),
+    )
+    yield_materializations: bool = PyField(
+        True,
+        description=(
+            "If True, materializations corresponding to the results of the Fivetran sync will "
+            "be yielded when the op executes."
+        ),
+    )
+    asset_key_prefix: List[str] = PyField(
+        ["fivetran"],
+        description=(
+            "If provided and yield_materializations is True, these components will be used to "
+            "prefix the generated asset keys."
+        ),
+    )
+
 
 @op(
-    required_resource_keys={"fivetran"},
     ins={"start_after": In(Nothing)},
     out=Out(
         FivetranOutput,
@@ -17,48 +67,11 @@ from dagster_fivetran.utils import generate_materializations
             " detailed information on this response."
         ),
     ),
-    config_schema={
-        "connector_id": Field(
-            str,
-            is_required=True,
-            description=(
-                "The Fivetran Connector ID that this op will sync. You can retrieve this "
-                'value from the "Setup" tab of a given connector in the Fivetran UI.'
-            ),
-        ),
-        "poll_interval": Field(
-            float,
-            default_value=DEFAULT_POLL_INTERVAL,
-            description="The time (in seconds) that will be waited between successive polls.",
-        ),
-        "poll_timeout": Field(
-            Noneable(float),
-            default_value=None,
-            description=(
-                "The maximum time that will waited before this operation is timed out. By "
-                "default, this will never time out."
-            ),
-        ),
-        "yield_materializations": Field(
-            config=Bool,
-            default_value=True,
-            description=(
-                "If True, materializations corresponding to the results of the Fivetran sync will "
-                "be yielded when the op executes."
-            ),
-        ),
-        "asset_key_prefix": Field(
-            config=Array(str),
-            default_value=["fivetran"],
-            description=(
-                "If provided and yield_materializations is True, these components will be used to "
-                "prefix the generated asset keys."
-            ),
-        ),
-    },
     tags={"kind": "fivetran"},
 )
-def fivetran_sync_op(context):
+def fivetran_sync_op(
+    context: OpExecutionContext, config: SyncConfig, fivetran: Resource["FivetranResource"]
+) -> Any:
     """Executes a Fivetran sync for a given ``connector_id``, and polls until that sync
     completes, raising an error if it is unsuccessful. It outputs a FivetranOutput which contains
     the details of the Fivetran connector after the sync successfully completes, as well as details
@@ -91,20 +104,30 @@ def fivetran_sync_op(context):
                 final_foobar_state = sync_foobar(start_after=some_op())
                 other_op(final_foobar_state)
     """
-    fivetran_output = context.resources.fivetran.sync_and_poll(
-        connector_id=context.op_config["connector_id"],
-        poll_interval=context.op_config["poll_interval"],
-        poll_timeout=context.op_config["poll_timeout"],
+    fivetran_output = fivetran.sync_and_poll(
+        connector_id=config.connector_id,
+        poll_interval=config.poll_interval,
+        poll_timeout=config.poll_timeout,
     )
-    if context.op_config["yield_materializations"]:
+    if config.yield_materializations:
         yield from generate_materializations(
-            fivetran_output, asset_key_prefix=context.op_config["asset_key_prefix"]
+            fivetran_output, asset_key_prefix=config.asset_key_prefix
         )
     yield Output(fivetran_output)
 
 
+class FivetranResyncConfig(SyncConfig):
+    resync_parameters: Optional[Dict[str, Any]] = PyField(
+        None,
+        description=(
+            "Optional resync parameters to send in the payload to the Fivetran API. You can"
+            " find an example resync payload here:"
+            " https://fivetran.com/docs/rest-api/connectors#request_7"
+        ),
+    )
+
+
 @op(
-    required_resource_keys={"fivetran"},
     ins={"start_after": In(Nothing)},
     out=Out(
         FivetranOutput,
@@ -115,57 +138,13 @@ def fivetran_sync_op(context):
             " detailed information on this response."
         ),
     ),
-    config_schema={
-        "connector_id": Field(
-            str,
-            is_required=True,
-            description=(
-                "The Fivetran Connector ID that this op will sync. You can retrieve this "
-                'value from the "Setup" tab of a given connector in the Fivetran UI.'
-            ),
-        ),
-        "resync_parameters": Field(
-            Noneable(Permissive()),
-            default_value=None,
-            description=(
-                "Optional resync parameters to send in the payload to the Fivetran API. You can"
-                " find an example resync payload here:"
-                " https://fivetran.com/docs/rest-api/connectors#request_7"
-            ),
-        ),
-        "poll_interval": Field(
-            float,
-            default_value=DEFAULT_POLL_INTERVAL,
-            description="The time (in seconds) that will be waited between successive polls.",
-        ),
-        "poll_timeout": Field(
-            Noneable(float),
-            default_value=None,
-            description=(
-                "The maximum time that will waited before this operation is timed out. By "
-                "default, this will never time out."
-            ),
-        ),
-        "yield_materializations": Field(
-            config=Bool,
-            default_value=True,
-            description=(
-                "If True, materializations corresponding to the results of the Fivetran sync will "
-                "be yielded when the op executes."
-            ),
-        ),
-        "asset_key_prefix": Field(
-            config=Array(str),
-            default_value=["fivetran"],
-            description=(
-                "If provided and yield_materializations is True, these components will be used to "
-                "prefix the generated asset keys."
-            ),
-        ),
-    },
     tags={"kind": "fivetran"},
 )
-def fivetran_resync_op(context):
+def fivetran_resync_op(
+    context: OpExecutionContext,
+    config: FivetranResyncConfig,
+    fivetran: Resource["FivetranResource"],
+) -> Any:
     """Executes a Fivetran historical resync for a given ``connector_id``, and polls until that resync
     completes, raising an error if it is unsuccessful. It outputs a FivetranOutput which contains
     the details of the Fivetran connector after the resync successfully completes, as well as details
@@ -207,24 +186,24 @@ def fivetran_resync_op(context):
             final_foobar_state = sync_foobar(start_after=some_op())
             other_op(final_foobar_state)
     """
-    fivetran_output = context.resources.fivetran.resync_and_poll(
-        connector_id=context.op_config["connector_id"],
-        resync_parameters=context.op_config["resync_parameters"],
-        poll_interval=context.op_config["poll_interval"],
-        poll_timeout=context.op_config["poll_timeout"],
+    fivetran_output = fivetran.resync_and_poll(
+        connector_id=config.connector_id,
+        resync_parameters=config.resync_parameters,
+        poll_interval=config.poll_interval,
+        poll_timeout=config.poll_timeout,
     )
-    if context.op_config["yield_materializations"]:
+    if config.yield_materializations:
         asset_key_filter = (
             [
-                AssetKey(context.op_config["asset_key_prefix"] + [schema, table])
-                for schema, tables in context.op_config["resync_parameters"].items()
+                AssetKey(config.asset_key_prefix + [schema, table])
+                for schema, tables in config.resync_parameters.items()
                 for table in tables
             ]
-            if context.op_config["resync_parameters"] is not None
+            if config.resync_parameters is not None
             else None
         )
         for mat in generate_materializations(
-            fivetran_output, asset_key_prefix=context.op_config["asset_key_prefix"]
+            fivetran_output, asset_key_prefix=config.asset_key_prefix
         ):
             if asset_key_filter is None or mat.asset_key in asset_key_filter:
                 yield mat

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -9,7 +9,7 @@ from dagster import (
     Output,
     op,
 )
-from pydantic import Field as PyField
+from pydantic import Field
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
 from dagster_fivetran.types import FivetranOutput
@@ -17,33 +17,32 @@ from dagster_fivetran.utils import generate_materializations
 
 
 class SyncConfig(Config):
-    connector_id: str = PyField(
-        ...,
+    connector_id: str = Field(
         description=(
             "The Fivetran Connector ID that this op will sync. You can retrieve this "
             'value from the "Setup" tab of a given connector in the Fivetran UI.'
         ),
     )
-    poll_interval: float = PyField(
-        DEFAULT_POLL_INTERVAL,
+    poll_interval: float = Field(
+        default=DEFAULT_POLL_INTERVAL,
         description="The time (in seconds) that will be waited between successive polls.",
     )
-    poll_timeout: Optional[float] = PyField(
-        None,
+    poll_timeout: Optional[float] = Field(
+        default=None,
         description=(
             "The maximum time that will waited before this operation is timed out. By "
             "default, this will never time out."
         ),
     )
-    yield_materializations: bool = PyField(
-        True,
+    yield_materializations: bool = Field(
+        default=True,
         description=(
             "If True, materializations corresponding to the results of the Fivetran sync will "
             "be yielded when the op executes."
         ),
     )
-    asset_key_prefix: List[str] = PyField(
-        ["fivetran"],
+    asset_key_prefix: List[str] = Field(
+        default=["fivetran"],
         description=(
             "If provided and yield_materializations is True, these components will be used to "
             "prefix the generated asset keys."
@@ -110,7 +109,7 @@ def fivetran_sync_op(config: SyncConfig, fivetran: FivetranResource) -> Any:
 
 
 class FivetranResyncConfig(SyncConfig):
-    resync_parameters: Optional[Dict[str, Any]] = PyField(
+    resync_parameters: Optional[Dict[str, Any]] = Field(
         None,
         description=(
             "Optional resync parameters to send in the payload to the Fivetran API. You can"

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from dagster import (
     AssetKey,
@@ -11,12 +11,9 @@ from dagster import (
 )
 from pydantic import Field as PyField
 
-from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL
+from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
 from dagster_fivetran.types import FivetranOutput
 from dagster_fivetran.utils import generate_materializations
-
-if TYPE_CHECKING:
-    from dagster_fivetran import FivetranResource
 
 
 class SyncConfig(Config):
@@ -67,7 +64,7 @@ class SyncConfig(Config):
     ),
     tags={"kind": "fivetran"},
 )
-def fivetran_sync_op(config: SyncConfig, fivetran: "FivetranResource") -> Any:
+def fivetran_sync_op(config: SyncConfig, fivetran: FivetranResource) -> Any:
     """Executes a Fivetran sync for a given ``connector_id``, and polls until that sync
     completes, raising an error if it is unsuccessful. It outputs a FivetranOutput which contains
     the details of the Fivetran connector after the sync successfully completes, as well as details
@@ -138,7 +135,7 @@ class FivetranResyncConfig(SyncConfig):
 )
 def fivetran_resync_op(
     config: FivetranResyncConfig,
-    fivetran: "FivetranResource",
+    fivetran: FivetranResource,
 ) -> Any:
     """Executes a Fivetran historical resync for a given ``connector_id``, and polls until that resync
     completes, raising an error if it is unsuccessful. It outputs a FivetranOutput which contains

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -15,7 +15,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._config.structured_config import ConfigurableResource, infer_schema_from_config_class
+from dagster._config.structured_config import ConfigurableResource
 from dagster._utils.cached_method import cached_method
 from dateutil import parser
 from pydantic import Field
@@ -391,7 +391,7 @@ class FivetranResource(ConfigurableResource):
         return FivetranOutput(connector_details=final_details, schema_config=schema_config)
 
 
-@resource(config_schema=infer_schema_from_config_class(FivetranResource))
+@resource(config_schema=FivetranResource.to_config_schema())
 def fivetran_resource(context: InitResourceContext) -> FivetranResource:
     """This resource allows users to programatically interface with the Fivetran REST API to launch
     syncs and monitor their progress. This currently implements only a subset of the functionality
@@ -422,4 +422,4 @@ def fivetran_resource(context: InitResourceContext) -> FivetranResource:
             ...
 
     """
-    return FivetranResource(**context.resource_config).resource_fn(context)  # type: ignore
+    return FivetranResource.from_resource_context(context)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -16,8 +16,9 @@ from dagster import (
     resource,
 )
 from dagster._config.structured_config import ConfigurableResource, infer_schema_from_config_class
+from dagster._utils.cached_method import cached_method
 from dateutil import parser
-from pydantic import Field as PyField
+from pydantic import Field
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
@@ -35,24 +36,24 @@ DEFAULT_POLL_INTERVAL = 10
 class FivetranResource(ConfigurableResource):
     """This class exposes methods on top of the Fivetran REST API."""
 
-    api_key: str = PyField(..., description="The Fivetran API key to use for this resource.")
-    api_secret: str = PyField(..., description="The Fivetran API secret to use for this resource.")
-    disable_schedule_on_trigger: bool = PyField(
-        True,
+    api_key: str = Field(description="The Fivetran API key to use for this resource.")
+    api_secret: str = Field(description="The Fivetran API secret to use for this resource.")
+    disable_schedule_on_trigger: bool = Field(
+        default=True,
         description=(
             "Specifies if you would like any connector that is sync'd using this "
             "resource to be automatically taken off its Fivetran schedule."
         ),
     )
-    request_max_retries: int = PyField(
-        3,
+    request_max_retries: int = Field(
+        default=3,
         description=(
             "The maximum number of times requests to the Fivetran API should be retried "
             "before failing."
         ),
     )
-    request_retry_delay: float = PyField(
-        0.25,
+    request_retry_delay: float = Field(
+        default=0.25,
         description="Time (in seconds) to wait between each request retry.",
     )
 
@@ -61,6 +62,7 @@ class FivetranResource(ConfigurableResource):
         return HTTPBasicAuth(self.api_key, self.api_secret)
 
     @property
+    @cached_method
     def _log(self) -> logging.Logger:
         return get_dagster_logger()
 


### PR DESCRIPTION
## Summary

Converts the `dagster-fivetran` internals to use the new config and resource systems:

- Assets and ops now use Pythonic config rather than config_schema
- Assets and ops retrieve resource dependencies through params rather than the `context` / `required_resource_keys`
- `FivetranResource` is now a `ConfigurableResource`, holding its own config schema. The `fivetran_resource` function resource now wraps this class rather than holding the config.

## Test Plan

Existing unit tests.
