### PR TITLE
[dagster-twilio] Migrate to Pythonic resources

### DIFF
--- a/python_modules/libraries/dagster-twilio/dagster_twilio/__init__.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/__init__.py
@@ -1,6 +1,9 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from .resources import twilio_resource
+from .resources import (
+    TwilioResource as TwilioResource,
+    twilio_resource as twilio_resource,
+)
 from .version import __version__
 
 DagsterLibraryRegistry.register("dagster-twilio", __version__)

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -1,13 +1,34 @@
-from dagster import Field, StringSource, resource
+from dagster import ConfigurableResourceFactory, resource
+from dagster._config.structured_config import infer_schema_from_config_class
+from dagster._core.execution.context.init import InitResourceContext
+from pydantic import Field
 from twilio.rest import Client
 
 
+class TwilioResource(ConfigurableResourceFactory[Client]):
+    """This resource is for connecting to Twilio."""
+
+    account_sid: str = Field(
+        description=(
+            "Twilio Account SID, created with yout Twilio account. This can be found on your Twilio"
+            " dashboard, see"
+            " https://www.twilio.com/blog/twilio-access-tokens-python"
+        ),
+    )
+    auth_token: str = Field(
+        description=(
+            "Twilio Authentication Token, created with yout Twilio account. This can be found on"
+            " your Twilio dashboard, see https://www.twilio.com/blog/twilio-access-tokens-python"
+        ),
+    )
+
+    def create_resource(self, context) -> Client:
+        return Client(self.account_sid, self.auth_token)
+
+
 @resource(
-    {
-        "account_sid": Field(StringSource, description="Twilio Account SID"),
-        "auth_token": Field(StringSource, description="Twilio Auth Token"),
-    },
+    config_schema=infer_schema_from_config_class(TwilioResource),
     description="This resource is for connecting to Twilio",
 )
-def twilio_resource(context):
-    return Client(context.resource_config["account_sid"], context.resource_config["auth_token"])
+def twilio_resource(context: InitResourceContext) -> Client:
+    return TwilioResource(**context.resource_config).create_resource(context=context)

--- a/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio/resources.py
@@ -1,5 +1,4 @@
 from dagster import ConfigurableResourceFactory, resource
-from dagster._config.structured_config import infer_schema_from_config_class
 from dagster._core.execution.context.init import InitResourceContext
 from pydantic import Field
 from twilio.rest import Client
@@ -27,8 +26,8 @@ class TwilioResource(ConfigurableResourceFactory[Client]):
 
 
 @resource(
-    config_schema=infer_schema_from_config_class(TwilioResource),
+    config_schema=TwilioResource.to_config_schema(),
     description="This resource is for connecting to Twilio",
 )
 def twilio_resource(context: InitResourceContext) -> Client:
-    return TwilioResource(**context.resource_config).create_resource(context=context)
+    return TwilioResource.from_resource_context(context)

--- a/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
@@ -5,7 +5,6 @@ from dagster import Resource, op
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_twilio import TwilioResource, twilio_resource
-from dagster_twilio.resources import TwilioResource
 from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client
 

--- a/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
@@ -1,40 +1,44 @@
 import os
 
 import pytest
-from dagster import op
+from dagster import Resource, op
+from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._utils.test import wrap_op_in_graph_and_execute
-from dagster_twilio import twilio_resource
+from dagster_twilio import TwilioResource, twilio_resource
 from twilio.base.exceptions import TwilioRestException
+from twilio.rest import Client
 
 
-def test_twilio_resource():
+@pytest.fixture(name="twilio_resource_option", params=[True, False])
+def twilio_resource_option_fixture(request) -> ResourceDefinition:
+    if request.param:
+        return twilio_resource
+    else:
+        return TwilioResource.configure_at_launch()
+
+
+def test_twilio_resource(twilio_resource_option) -> None:
     account_sid = os.environ.get("TWILIO_TEST_ACCOUNT_SID")
     auth_token = os.environ.get("TWILIO_TEST_AUTH_TOKEN")
 
-    @op(required_resource_keys={"twilio"})
-    def twilio_solid(context):
-        assert context.resources.twilio
-
+    @op
+    def twilio_op(twilio: Resource[Client]):
         # These tests are against the live SMS APIs using test creds/numbers; see
         # https://www.twilio.com/docs/iam/test-credentials#test-sms-messages
 
-        context.resources.twilio.messages.create(
-            body="test message", from_="+15005550006", to="+15005550006"
-        )
+        twilio.messages.create(body="test message", from_="+15005550006", to="+15005550006")
 
         with pytest.raises(TwilioRestException) as exc_info:
-            context.resources.twilio.messages.create(
-                body="test message", from_="+15005550006", to="+15005550001"
-            )
+            twilio.messages.create(body="test message", from_="+15005550006", to="+15005550001")
         assert "The 'To' number +15005550001 is not a valid phone number" in str(exc_info.value)
 
     result = wrap_op_in_graph_and_execute(
-        twilio_solid,
+        twilio_op,
         run_config={
             "resources": {
                 "twilio": {"config": {"account_sid": account_sid, "auth_token": auth_token}}
             }
         },
-        resources={"twilio": twilio_resource},
+        resources={"twilio": twilio_resource_option},
     )
     assert result.success

--- a/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
@@ -5,6 +5,7 @@ from dagster import Resource, op
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_twilio import TwilioResource, twilio_resource
+from dagster_twilio.resources import TwilioResource
 from twilio.base.exceptions import TwilioRestException
 from twilio.rest import Client
 
@@ -20,6 +21,9 @@ def twilio_resource_option_fixture(request) -> ResourceDefinition:
 def test_twilio_resource(twilio_resource_option) -> None:
     account_sid = os.environ.get("TWILIO_TEST_ACCOUNT_SID")
     auth_token = os.environ.get("TWILIO_TEST_AUTH_TOKEN")
+
+    assert account_sid, "TWILIO_TEST_ACCOUNT_SID not set"
+    assert auth_token, "TWILIO_TEST_AUTH_TOKEN not set"
 
     @op
     def twilio_op(twilio: Resource[Client]):


### PR DESCRIPTION
## Summary

Migrates the `dagster-twilio` resource to be a Pythonic resource, existing factory method continues to work.
