### PR TITLE
[pythonic config] Add support for enums

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -1,9 +1,11 @@
 import inspect
+from enum import Enum
 from typing import (
     AbstractSet,
     Any,
     Dict,
     Generic,
+    Iterable,
     Mapping,
     NamedTuple,
     Optional,
@@ -17,8 +19,9 @@ from typing import (
 from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr
 from typing_extensions import TypeAlias
 
+from dagster import Enum as DagEnum
 from dagster._annotations import experimental
-from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType, Noneable
+from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType, EnumValue, Noneable
 from dagster._config.field_utils import config_dictionary_from_values
 from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
@@ -769,6 +772,15 @@ def _config_type_for_type_on_pydantic_field(potential_dagster_type: Any) -> Conf
         potential_dagster_type = float
     elif safe_is_subclass(potential_dagster_type, ConstrainedInt):
         return IntSource
+
+    if safe_is_subclass(potential_dagster_type, Enum):
+        return DagEnum(
+            potential_dagster_type.__name__,
+            [
+                EnumValue(v.name, python_value=v.value)
+                for v in cast(Iterable[Enum], potential_dagster_type)
+            ],
+        )
 
     # special case raw python literals to their source equivalents
     if potential_dagster_type is str:

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Any, Dict, List, Mapping, Optional, Type, Union
 
 import pytest
@@ -524,3 +525,33 @@ def test_struct_config_optional_array() -> None:
         a_job.execute_in_process(
             {"ops": {"a_struct_config_op": {"config": {"a_string_list": ["foo", "bar", 3]}}}}
         )
+
+
+def test_str_enum_value() -> None:
+    class MyEnum(enum.Enum):
+        FOO = "foo"
+        BAR = "bar"
+
+    class AnOpConfig(Config):
+        an_enum: MyEnum
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: AnOpConfig):
+        assert config.an_enum == MyEnum.FOO
+        executed["yes"] = True
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    a_job.execute_in_process({"ops": {"a_struct_config_op": {"config": {"an_enum": "FOO"}}}})
+    assert executed["yes"]
+
+    with pytest.raises(DagsterInvalidConfigError):
+        a_job.execute_in_process({"ops": {"a_struct_config_op": {"config": {"an_enum": "BAZ"}}}})
+
+    # must pass enum name, not value
+    with pytest.raises(DagsterInvalidConfigError):
+        a_job.execute_in_process({"ops": {"a_struct_config_op": {"config": {"an_enum": "foo"}}}})


### PR DESCRIPTION
## Summary

Adds support for enums to Pydantic config, e.g.

```python
class MyEnum(enum.Enum):
    FOO = "foo"
    BAR = "bar"

class AnOpConfig(Config):
    an_enum: MyEnum
```

## Test Plan

new unit tests
