### PR TITLE
[dagster-airflow] don't require setting uri ENV for persistent db, fixup schedule resource defs

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -208,7 +208,9 @@ def make_schedules_and_jobs_from_airflow_dag_bag(
             continue
         if _is_dag_is_schedule(dag):
             schedule_defs.append(
-                make_dagster_schedule_from_airflow_dag(dag=dag, tags=None, connections=connections)
+                make_dagster_schedule_from_airflow_dag(
+                    dag=dag, tags=None, connections=connections, resource_defs=resource_defs
+                )
             )
         else:
             job_defs.append(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -1,6 +1,6 @@
 import importlib
 import os
-from typing import List, Optional
+from typing import List
 
 import airflow
 from airflow.models.connection import Connection
@@ -52,7 +52,7 @@ class AirflowPersistentDatabase(AirflowDatabase):
 
 
 def make_persistent_airflow_db_resource(
-    uri: Optional[str] = "", connections: List[Connection] = []
+    uri: str = "", connections: List[Connection] = []
 ) -> ResourceDefinition:
     """Creates a Dagster resource that provides an persistent Airflow database.
 
@@ -80,6 +80,11 @@ def make_persistent_airflow_db_resource(
         ResourceDefinition: The persistent Airflow DB resource
 
     """
+    if is_airflow_2_loaded_in_environment():
+        os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = uri
+    else:
+        os.environ["AIRFLOW__CORE__SQL_ALCHEMY_CONN"] = uri
+
     serialized_connections = serialize_connections(connections)
     airflow_db_resource_def = ResourceDefinition(
         resource_fn=AirflowPersistentDatabase.from_resource_context,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/conftest.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/conftest.py
@@ -72,4 +72,4 @@ def postgres_airflow_db(
                     "Waiting for Airflow postgres database to start and initialize"
                     + "." * (3 + (now - start_time).seconds // RETRY_DELAY_SEC)
                 )
-            yield uri
+        yield uri


### PR DESCRIPTION
## Summary & Motivation

this pr fixes two bugs for the persistent db feature released in 1.2.0
1. resource_defs for airflow database definitions are passed to schedule definitions now
2. users no longer need to set the URI env for a persistent db to be used

## How I Tested These Changes

- updated unit tests to not use uri ENVS