### PR TITLE
[dagstermill] Migrate dagstermill to Pythonic config + resources

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -848,7 +848,7 @@ class ConfigurableResourceFactory(
                 return MyResource.from_resource_context(context)
 
         """
-        return cls(**context.resource_config or {}).create_resource(context)
+        return cls(**context.resource_config or {})._create_object_fn(context) # noqa: SLF001
 
 
 class ConfigurableResource(ConfigurableResourceFactory[TResValue]):

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -848,7 +848,7 @@ class ConfigurableResourceFactory(
                 return MyResource.from_resource_context(context)
 
         """
-        return cls(**context.resource_config or {})._create_object_fn(context) # noqa: SLF001
+        return cls(**context.resource_config or {})._create_object_fn(context)  # noqa: SLF001
 
 
 class ConfigurableResource(ConfigurableResourceFactory[TResValue]):

--- a/python_modules/libraries/dagstermill/dagstermill/__init__.py
+++ b/python_modules/libraries/dagstermill/dagstermill/__init__.py
@@ -4,7 +4,10 @@ from .asset_factory import define_dagstermill_asset as define_dagstermill_asset
 from .context import DagstermillExecutionContext as DagstermillExecutionContext
 from .errors import DagstermillError as DagstermillError
 from .factory import define_dagstermill_op as define_dagstermill_op
-from .io_managers import local_output_notebook_io_manager as local_output_notebook_io_manager
+from .io_managers import (
+    ConfigurableLocalOutputNotebookIOManager as ConfigurableLocalOutputNotebookIOManager,
+    local_output_notebook_io_manager as local_output_notebook_io_manager,
+)
 from .manager import MANAGER_FOR_NOTEBOOK_INSTANCE as _MANAGER_FOR_NOTEBOOK_INSTANCE
 from .version import __version__ as __version__
 

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -1,6 +1,6 @@
 import pickle
 import tempfile
-from typing import Any, Callable, Iterable, Mapping, Optional, Set, Union
+from typing import Any, Callable, Iterable, Mapping, Optional, Set, Type, Union, cast
 
 import dagster._check as check
 from dagster import (
@@ -15,6 +15,8 @@ from dagster import (
     RetryRequested,
     asset,
 )
+from dagster._config.structured_config import Config, infer_schema_from_config_class
+from dagster._config.structured_config.utils import safe_is_subclass
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.utils import validate_tags
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -184,6 +186,9 @@ def define_dagstermill_asset(
         )
 
     default_tags = {"notebook_path": _clean_path_for_windows(notebook_path), "kind": "ipynb"}
+
+    if safe_is_subclass(config_schema, Config):
+        config_schema = infer_schema_from_config_class(cast(Type[Config], config_schema))
 
     return asset(
         name=name,

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -15,8 +15,8 @@ from dagster import (
     RetryRequested,
     asset,
 )
-from dagster._config.structured_config import Config, infer_schema_from_config_class
-from dagster._config.structured_config.utils import safe_is_subclass
+from dagster._config.pythonic_config import Config, infer_schema_from_config_class
+from dagster._config.pythonic_config.utils import safe_is_subclass
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
 from dagster._core.definitions.utils import validate_tags
 from dagster._core.execution.context.compute import OpExecutionContext

--- a/python_modules/libraries/dagstermill/dagstermill/examples/notebooks/hello_world_config_struct.ipynb
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/notebooks/hello_world_config_struct.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dagstermill"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "context = dagstermill.get_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "您好\n"
+     ]
+    }
+   ],
+   "source": [
+    "dagstermill.yield_result(context.op_config[\"greeting\"])"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "dagster",
+   "language": "python",
+   "name": "dagster"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -7,7 +7,6 @@ from dagster import (
     AssetSelection,
     Field,
     In,
-    Int,
     List,
     Out,
     ResourceDefinition,

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -150,7 +150,7 @@ class HelloWorldConfig(Config):
     greeting: str = "hello"
 
 
-hello_world_config_struct = test_nb_op("hello_world_config", config_schema=HelloWorldConfig)
+hello_world_config_struct = test_nb_op("hello_world_config_struct", config_schema=HelloWorldConfig)
 
 
 class GoodbyeConfig(Config):
@@ -158,7 +158,7 @@ class GoodbyeConfig(Config):
 
 
 goodbye_config_struct = test_nb_op(
-    name="goodbye_config",
+    name="goodbye_config_struct",
     path=nb_test_path("print_dagstermill_context_op_config"),
     output_notebook_name="notebook",
     config_schema=GoodbyeConfig,

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -22,12 +22,15 @@ from dagster import (
     resource,
     with_resources,
 )
-from dagster._config.structured_config import Config
+from dagster._config.pythonic_config import Config
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._utils import PICKLE_PROTOCOL, file_relative_path
 
 import dagstermill
-from dagstermill.io_managers import LocalOutputNotebookIOManager, local_output_notebook_io_manager
+from dagstermill.io_managers import (
+    ConfigurableLocalOutputNotebookIOManager,
+    local_output_notebook_io_manager,
+)
 
 try:
     from dagster_pandas import DataFrame
@@ -92,7 +95,7 @@ def hello_world_job():
 
 @job(
     resource_defs={
-        "output_notebook_io_manager": LocalOutputNotebookIOManager.configure_at_launch(),
+        "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager.configure_at_launch(),
         "io_manager": fs_io_manager,
     }
 )

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -4,7 +4,9 @@ import pickle
 import sys
 import tempfile
 import uuid
-from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Set, Union, cast
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Set, Type, Union, cast
+from dagster._config.structured_config import Config, infer_schema_from_config_class
+from dagster._config.structured_config.utils import safe_is_subclass
 
 import nbformat
 import papermill
@@ -429,6 +431,9 @@ def define_dagstermill_op(
             ),
         )
     default_tags = {"notebook_path": _clean_path_for_windows(notebook_path), "kind": "ipynb"}
+
+    if safe_is_subclass(config_schema, Config):
+        config_schema = infer_schema_from_config_class(cast(Type[Config], config_schema))
 
     return OpDefinition(
         name=name,

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -5,8 +5,6 @@ import sys
 import tempfile
 import uuid
 from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Set, Type, Union, cast
-from dagster._config.structured_config import Config, infer_schema_from_config_class
-from dagster._config.structured_config.utils import safe_is_subclass
 
 import nbformat
 import papermill
@@ -18,6 +16,8 @@ from dagster import (
     _check as check,
     _seven,
 )
+from dagster._config.structured_config import Config, infer_schema_from_config_class
+from dagster._config.structured_config.utils import safe_is_subclass
 from dagster._core.definitions.events import AssetMaterialization, Failure, RetryRequested
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructablePipeline

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -16,8 +16,8 @@ from dagster import (
     _check as check,
     _seven,
 )
-from dagster._config.structured_config import Config, infer_schema_from_config_class
-from dagster._config.structured_config.utils import safe_is_subclass
+from dagster._config.pythonic_config import Config, infer_schema_from_config_class
+from dagster._config.pythonic_config.utils import safe_is_subclass
 from dagster._core.definitions.events import AssetMaterialization, Failure, RetryRequested
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructablePipeline

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -1,19 +1,18 @@
 import os
 from pathlib import Path
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Optional
 
 import dagster._check as check
 from dagster import AssetKey, AssetMaterialization, ConfigurableIOManager
-from dagster._config import Field
 from dagster._config.structured_config import infer_schema_from_config_class
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.storage.io_manager import IOManager, io_manager
+from dagster._core.storage.io_manager import io_manager
 from dagster._utils import mkdir_p
+from pydantic import Field as PyField
 
 from dagstermill.factory import _clean_path_for_windows
-from pydantic import Field as PyField
 
 
 class OutputNotebookIOManager(ConfigurableIOManager):

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -85,8 +85,20 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
 class ConfigurableLocalOutputNotebookIOManager(ConfigurableIOManagerFactory):
     """Built-in IO Manager for handling output notebook."""
 
-    base_dir: Optional[str] = Field(None)
-    asset_key_prefix: List[str] = Field([])
+    base_dir: Optional[str] = Field(
+        default=None,
+        description=(
+            "Base directory to use for output notebooks. Defaults to the Dagster instance storage"
+            " directory if not provided."
+        ),
+    )
+    asset_key_prefix: List[str] = Field(
+        [],
+        description=(
+            "Asset key prefix to apply to assets materialized for output notebooks. Defaults to no"
+            " prefix."
+        ),
+    )
 
     def create_io_manager(self, context: InitResourceContext) -> "LocalOutputNotebookIOManager":
         return LocalOutputNotebookIOManager(

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -31,10 +31,6 @@ class OutputNotebookIOManager(IOManager):
         raise NotImplementedError
 
 
-WRITE_MODE = "wb"
-READ_MODE = "rb"
-
-
 class LocalOutputNotebookIOManager(OutputNotebookIOManager):
     def __init__(self, base_dir: str, asset_key_prefix: Optional[Sequence[str]] = None):
         super(LocalOutputNotebookIOManager, self).__init__(asset_key_prefix=asset_key_prefix)
@@ -57,7 +53,7 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         # the output notebook itself is stored at output_file_path
         output_notebook_path = self._get_path(context)
         mkdir_p(os.path.dirname(output_notebook_path))
-        with open(output_notebook_path, WRITE_MODE) as dest_file_obj:
+        with open(output_notebook_path, self.write_mode) as dest_file_obj:
             dest_file_obj.write(obj)
 
         metadata = {
@@ -82,7 +78,7 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         check.inst_param(context, "context", InputContext)
         # pass output notebook to downstream ops as File Object
         output_context = check.not_none(context.upstream_output)
-        with open(self._get_path(output_context), READ_MODE) as file_obj:
+        with open(self._get_path(output_context), self.read_mode) as file_obj:
             return file_obj.read()
 
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
@@ -14,7 +14,10 @@ from dagster import (
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import safe_tempfile_path
 from dagstermill.examples.repository import hello_logging
-from dagstermill.io_managers import LocalOutputNotebookIOManager, local_output_notebook_io_manager
+from dagstermill.io_managers import (
+    ConfigurableLocalOutputNotebookIOManager,
+    local_output_notebook_io_manager,
+)
 
 
 class LogTestFileHandler(logging.Handler):
@@ -62,7 +65,7 @@ def hello_logging_pipeline():
         "critical": test_file_logger,
     },
     resource_defs={
-        "output_notebook_io_manager": LocalOutputNotebookIOManager.configure_at_launch(),
+        "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager.configure_at_launch(),
     },
 )
 def hello_logging_pipeline_pythonic():

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_logging.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 
+import pytest
 from dagster import (
     String,
     _seven as seven,
@@ -13,7 +14,7 @@ from dagster import (
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import safe_tempfile_path
 from dagstermill.examples.repository import hello_logging
-from dagstermill.io_managers import local_output_notebook_io_manager
+from dagstermill.io_managers import LocalOutputNotebookIOManager, local_output_notebook_io_manager
 
 
 class LogTestFileHandler(logging.Handler):
@@ -55,12 +56,33 @@ def hello_logging_pipeline():
     hello_logging()
 
 
-def test_logging():
+@job(
+    logger_defs={
+        "test": test_file_logger,
+        "critical": test_file_logger,
+    },
+    resource_defs={
+        "output_notebook_io_manager": LocalOutputNotebookIOManager.configure_at_launch(),
+    },
+)
+def hello_logging_pipeline_pythonic():
+    hello_logging()
+
+
+@pytest.fixture(name="hello_logging_pipeline_type", params=[True, False])
+def hello_logging_pipeline_type_fixture(request):
+    if request.param:
+        return hello_logging_pipeline
+    else:
+        return hello_logging_pipeline_pythonic
+
+
+def test_logging(hello_logging_pipeline_type) -> None:
     with safe_tempfile_path() as test_file_path:
         with safe_tempfile_path() as critical_file_path:
             with instance_for_test() as instance:
                 execute_job(
-                    reconstructable(hello_logging_pipeline),
+                    reconstructable(hello_logging_pipeline_type),
                     run_config={
                         "loggers": {
                             "test": {

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -88,6 +88,13 @@ def test_hello_world_with_config():
 
 
 @pytest.mark.notebook_test
+def test_hello_world_with_struct_config() -> None:
+    with exec_for_test("hello_world_config_job_struct") as result:
+        assert result.success
+        assert result.output_for_node("hello_world_config_struct") == "hello"
+
+
+@pytest.mark.notebook_test
 def test_hello_world_with_config_escape():
     with exec_for_test(
         "hello_world_config_job",

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -69,6 +69,12 @@ def test_hello_world():
 
 
 @pytest.mark.notebook_test
+def test_hello_world_struct_resource() -> None:
+    with exec_for_test("hello_world_job_struct_resource") as result:
+        assert result.success
+
+
+@pytest.mark.notebook_test
 def test_hello_world_job():
     with exec_for_test("hello_world_job") as result:
         assert result.success


### PR DESCRIPTION
## Summary

Migrates `dagstermill` IO manager to use `ConfigurableIOManager` and allow the op/asset factories to use `Config` for config schemas rather than config dicts.


## Test Plan

New examples testing the config path and new IO manager construction.
