### PR TITLE
Fix run monitoring for celery k8s run launcher

### DIFF
--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -945,6 +945,7 @@ def _base_helm_config(system_namespace, docker_image, enable_subchart=True):
                     "labels": {
                         "run_launcher_label_key": "run_launcher_label_value",
                     },
+                    "jobNamespace": system_namespace,
                 },
             },
         },

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
@@ -22,7 +22,7 @@ def log_run_events(instance, run_id):
         print(str(log) + "\n")  # noqa: T201
 
 
-def get_celery_job_engine_config(dagster_docker_image, job_namespace):
+def get_celery_job_engine_config(dagster_docker_image, job_namespace=None):
     return {
         "execution": {
             "config": merge_dicts(
@@ -33,8 +33,14 @@ def get_celery_job_engine_config(dagster_docker_image, job_namespace):
                     if dagster_docker_image
                     else {}
                 ),
+                (
+                    {
+                        "job_namespace": job_namespace,
+                    }
+                    if job_namespace
+                    else {}
+                ),
                 {
-                    "job_namespace": job_namespace,
                     "image_pull_policy": image_pull_policy(),
                 },
             )
@@ -74,9 +80,7 @@ def test_run_monitoring_fails_on_interrupt(
                 os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
             ]
         ),
-        get_celery_job_engine_config(
-            dagster_docker_image=dagster_docker_image, job_namespace=helm_namespace
-        ),
+        get_celery_job_engine_config(dagster_docker_image=dagster_docker_image),
     )
 
     pipeline_name = "demo_job_celery"

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -165,7 +165,7 @@ class CeleryK8sJobExecutor(Executor):
             dict(DEFAULT_CONFIG, **check.opt_dict_param(config_source, "config_source"))
         )
         self.job_config = check.inst_param(job_config, "job_config", DagsterK8sJobConfig)
-        self.job_namespace = check.opt_str_param(job_namespace, "job_namespace", default="default")
+        self.job_namespace = check.opt_str_param(job_namespace, "job_namespace")
 
         self.load_incluster_config = check.bool_param(
             load_incluster_config, "load_incluster_config"

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -345,7 +345,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         pipeline_run = self._instance.get_run_by_id(run_id)
         run_config = pipeline_run.run_config
         executor_config = _get_validated_celery_k8s_executor_config(run_config)
-        return executor_config.get("job_namespace")
+        return executor_config.get("job_namespace", self.job_namespace)
 
     @property
     def supports_check_run_worker_health(self):
@@ -353,7 +353,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
 
     def check_run_worker_health(self, run: DagsterRun):
         job_namespace = _get_validated_celery_k8s_executor_config(run.run_config).get(
-            "job_namespace"
+            "job_namespace", self.job_namespace
         )
         job_name = get_job_name_from_run_id(run.run_id)
         try:


### PR DESCRIPTION
Summary:
Missed a spot where the run launcher namespace needed to be set. Added a test case that specifically covers run monitoring when the namespace is set at the run launcher level.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
