### PR TITLE
fixes to release sensor in dynamic partitions example

### DIFF
--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_release_sensor.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions_tests/test_release_sensor.py
@@ -1,0 +1,55 @@
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from assets_dynamic_partitions.release_sensor import release_sensor
+from dagster import DagsterInstance, RunRequest, SkipReason, build_sensor_context
+
+
+def test_release_sensor_no_new_releases():
+    old_environ = dict(os.environ)
+    os.environ.update({"GITHUB_USER_NAME": "username", "GITHUB_ACCESS_TOKEN": "token"})
+    try:
+        instance = DagsterInstance.ephemeral()
+        with patch("requests.get") as mock:
+            mock.return_value = MagicMock(ok=True, content=json.dumps([]))
+            assert release_sensor(build_sensor_context(instance=instance)) == SkipReason(
+                "No new releases"
+            )
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)
+
+
+def test_release_sensor_new_release():
+    old_environ = dict(os.environ)
+    os.environ.update({"GITHUB_USER_NAME": "username", "GITHUB_ACCESS_TOKEN": "token"})
+    try:
+        instance = DagsterInstance.ephemeral()
+        with patch("requests.get") as mock:
+            mock.return_value = MagicMock(ok=True, content=json.dumps([{"tag_name": "1.1.0"}]))
+            assert release_sensor(build_sensor_context(instance=instance)) == RunRequest(
+                tags={"dagster/partition": "1.1.0"}
+            )
+            assert instance.get_dynamic_partitions("releases") == ["1.1.0"]
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)
+
+
+def test_release_sensor_new_release_with_cursor():
+    old_environ = dict(os.environ)
+    os.environ.update({"GITHUB_USER_NAME": "username", "GITHUB_ACCESS_TOKEN": "token"})
+    try:
+        instance = DagsterInstance.ephemeral()
+        with patch("requests.get") as mock:
+            mock.return_value = MagicMock(
+                ok=True, content=json.dumps([{"tag_name": "1.1.0"}, {"tag_name": "1.2.0"}])
+            )
+            assert release_sensor(
+                build_sensor_context(instance=instance, cursor="1.1.0")
+            ) == RunRequest(tags={"dagster/partition": "1.2.0"})
+            assert instance.get_dynamic_partitions("releases") == ["1.2.0"]
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)


### PR DESCRIPTION
## Summary & Motivation

Prior to this fix:
- it wasn't updating the cursor
- it would request runs for old releases when there were no releases
- it would fail when there were no releases

## How I Tested These Changes
