### PR TITLE
[pythonic resources] Make direct invocation of ops/assets w/ resources easier

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -434,11 +434,6 @@ class OpDefinition(NodeDefinition):
                 if len(args) > 0 and isinstance(args[0], UnboundOpExecutionContext):
                     context = cast(UnboundOpExecutionContext, args[0])
                     args = args[1:]
-
-                    # raise DagsterInvalidInvocationError(
-                    #     f"Compute function of {node_label} '{self.name}' has no context argument,"
-                    #     " but context was provided when invoking."
-                    # )
                 return op_invocation_result(self, context, *args, **kwargs)
 
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -430,12 +430,16 @@ class OpDefinition(NodeDefinition):
                     return op_invocation_result(self, context, *args, **kwargs_sans_context)
 
             else:
+                context = None
                 if len(args) > 0 and isinstance(args[0], UnboundOpExecutionContext):
-                    raise DagsterInvalidInvocationError(
-                        f"Compute function of {node_label} '{self.name}' has no context argument,"
-                        " but context was provided when invoking."
-                    )
-                return op_invocation_result(self, None, *args, **kwargs)
+                    context = cast(UnboundOpExecutionContext, args[0])
+                    args = args[1:]
+
+                    # raise DagsterInvalidInvocationError(
+                    #     f"Compute function of {node_label} '{self.name}' has no context argument,"
+                    #     " but context was provided when invoking."
+                    # )
+                return op_invocation_result(self, context, *args, **kwargs)
 
 
 def _resolve_output_defs_from_outs(

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -61,16 +61,12 @@ def op_invocation_result(
             resource_args_from_kwargs[resource_arg] = kwargs[resource_arg]
             del kwargs[resource_arg]
 
-    resources_provided_in_multiple_places = list(
-        set(resource_args_from_kwargs.keys()).intersection(context.resource_keys)
-    )
+    resources_provided_in_multiple_places = (resource_args_from_kwargs) and (context.resource_keys)
     if resources_provided_in_multiple_places:
-        raise DagsterInvalidInvocationError(
-            "Cannot provide resources in both context and kwargs\n  Provided in both context and"
-            f" kwargs: {resources_provided_in_multiple_places}"
-        )
+        raise DagsterInvalidInvocationError("Cannot provide resources in both context and kwargs")
 
-    context = (context).with_resources(resource_args_from_kwargs)
+    if resource_args_from_kwargs:
+        context = context.replace_resources(resource_args_from_kwargs)
 
     bound_context = context.bind(op_def_or_invocation)
     input_dict = _resolve_inputs(op_def, args, kwargs, bound_context)

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -133,6 +133,10 @@ class UnboundOpExecutionContext(OpExecutionContext):
         return self._op_config
 
     @property
+    def resource_keys(self) -> AbstractSet[str]:
+        return self._resource_defs.keys()
+
+    @property
     def resources(self) -> Resources:
         if self._resources_contain_cm and not self._cm_scope_entered:
             raise DagsterInvariantViolationError(
@@ -319,6 +323,23 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
     def get_mapping_key(self) -> Optional[str]:
         return self._mapping_key
+
+    def with_resources(self, resources_dict: Mapping[str, Any]) -> "UnboundOpExecutionContext":
+        """Add resources to the context.
+
+        This method is intended to be used by the Dagster framework, and should not be called by user code.
+
+        Args:
+            resources (Mapping[str, Any]): The resources to add to the context.
+        """
+        return UnboundOpExecutionContext(
+            op_config=self._op_config,
+            resources_dict={**self._resource_defs, **resources_dict},
+            resources_config=self._resources_config,
+            instance=self._instance,
+            partition_key=self._partition_key,
+            mapping_key=self._mapping_key,
+        )
 
 
 def _validate_resource_requirements(

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -339,6 +339,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
             instance=self._instance,
             partition_key=self._partition_key,
             mapping_key=self._mapping_key,
+            assets_def=self._assets_def,
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -324,8 +324,8 @@ class UnboundOpExecutionContext(OpExecutionContext):
     def get_mapping_key(self) -> Optional[str]:
         return self._mapping_key
 
-    def with_resources(self, resources_dict: Mapping[str, Any]) -> "UnboundOpExecutionContext":
-        """Add resources to the context.
+    def replace_resources(self, resources_dict: Mapping[str, Any]) -> "UnboundOpExecutionContext":
+        """Replace the resources of this context.
 
         This method is intended to be used by the Dagster framework, and should not be called by user code.
 
@@ -334,7 +334,7 @@ class UnboundOpExecutionContext(OpExecutionContext):
         """
         return UnboundOpExecutionContext(
             op_config=self._op_config,
-            resources_dict={**self._resource_defs, **resources_dict},
+            resources_dict=resources_dict,
             resources_config=self._resources_config,
             instance=self._instance,
             partition_key=self._partition_key,

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -112,6 +112,7 @@ def invoke_compute_fn(
     if resource_args:
         for resource_name, arg_name in resource_args.items():
             args_to_pass[arg_name] = getattr(context.resources, resource_name)
+
     return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1926,7 +1926,7 @@ def test_direct_op_invocation() -> None:
     # Providing both context and resource is not ok, because we don't know which one to use
     with pytest.raises(
         DagsterInvalidInvocationError,
-        match="Provided in both context and kwargs: \\['my_resource'\\]",
+        match="Cannot provide resources in both context and kwargs",
     ):
         assert (
             my_op(
@@ -1969,7 +1969,7 @@ def test_direct_asset_invocation() -> None:
     # Providing both context and resource is not ok, because we don't know which one to use
     with pytest.raises(
         DagsterInvalidInvocationError,
-        match="Provided in both context and kwargs: \\['my_resource'\\]",
+        match="Cannot provide resources in both context and kwargs",
     ):
         assert (
             my_asset(

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -2026,6 +2026,59 @@ def test_direct_op_invocation_multiple_resources() -> None:
     )
 
 
+def test_direct_op_invocation_with_inputs() -> None:
+    class MyResource(ConfigurableResource):
+        z: int
+
+    @op
+    def my_wacky_addition_op(context, my_resource: MyResource, x: int, y: int) -> int:
+        return x + y + my_resource.z
+
+    # Just providing context is ok, we'll use the resource from the context
+    # We are successfully able to input x and y as args
+    assert (
+        my_wacky_addition_op(build_op_context(resources={"my_resource": MyResource(z=2)}), 4, 5)
+        == 11
+    )
+    # We can also input x and y as kwargs
+    assert (
+        my_wacky_addition_op(build_op_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2)
+        == 6
+    )
+
+    # Providing resource only as kwarg is ok, we'll use that (we still need a context though)
+    # We can input x and y as args
+    assert my_wacky_addition_op(build_op_context(), 10, 20, my_resource=MyResource(z=30)) == 60
+    # We can also input x and y as kwargs in this case
+    assert my_wacky_addition_op(build_op_context(), y=1, x=2, my_resource=MyResource(z=3)) == 6
+
+    @op
+    def my_wacky_addition_op_no_context(my_resource: MyResource, x: int, y: int) -> int:
+        return x + y + my_resource.z
+
+    # Providing context is ok, we just discard it and use the resource from the context
+    # We can input x and y as args
+    assert (
+        my_wacky_addition_op_no_context(
+            build_op_context(resources={"my_resource": MyResource(z=2)}), 4, 5
+        )
+        == 11
+    )
+    # We can also input x and y as kwargs
+    assert (
+        my_wacky_addition_op_no_context(
+            build_op_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
+        )
+        == 6
+    )
+
+    # Providing resource only as kwarg is ok, we'll use that
+    # We can input x and y as args
+    assert my_wacky_addition_op_no_context(10, 20, my_resource=MyResource(z=30)) == 60
+    # We can also input x and y as kwargs in this case
+    assert my_wacky_addition_op_no_context(y=1, x=2, my_resource=MyResource(z=3)) == 6
+
+
 def test_direct_asset_invocation() -> None:
     class MyResource(ConfigurableResource):
         a_str: str
@@ -2078,3 +2131,58 @@ def test_direct_asset_invocation() -> None:
 
     # Providing resource only as kwarg is ok, we'll use that
     assert my_asset_no_context(my_resource=MyResource(a_str="foo")) == "foo"
+
+
+def test_direct_asset_invocation_with_inputs() -> None:
+    class MyResource(ConfigurableResource):
+        z: int
+
+    @asset
+    def my_wacky_addition_asset(context, my_resource: MyResource, x: int, y: int) -> int:
+        return x + y + my_resource.z
+
+    # Just providing context is ok, we'll use the resource from the context
+    # We are successfully able to input x and y as args
+    assert (
+        my_wacky_addition_asset(build_op_context(resources={"my_resource": MyResource(z=2)}), 4, 5)
+        == 11
+    )
+    # We can also input x and y as kwargs
+    assert (
+        my_wacky_addition_asset(
+            build_op_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
+        )
+        == 6
+    )
+
+    # Providing resource only as kwarg is ok, we'll use that (we still need a context though)
+    # We can input x and y as args
+    assert my_wacky_addition_asset(build_op_context(), 10, 20, my_resource=MyResource(z=30)) == 60
+    # We can also input x and y as kwargs in this case
+    assert my_wacky_addition_asset(build_op_context(), y=1, x=2, my_resource=MyResource(z=3)) == 6
+
+    @asset
+    def my_wacky_addition_asset_no_context(my_resource: MyResource, x: int, y: int) -> int:
+        return x + y + my_resource.z
+
+    # Providing context is ok, we just discard it and use the resource from the context
+    # We can input x and y as args
+    assert (
+        my_wacky_addition_asset_no_context(
+            build_op_context(resources={"my_resource": MyResource(z=2)}), 4, 5
+        )
+        == 11
+    )
+    # We can also input x and y as kwargs
+    assert (
+        my_wacky_addition_asset_no_context(
+            build_op_context(resources={"my_resource": MyResource(z=3)}), y=1, x=2
+        )
+        == 6
+    )
+
+    # Providing resource only as kwarg is ok, we'll use that
+    # We can input x and y as args
+    assert my_wacky_addition_asset_no_context(10, 20, my_resource=MyResource(z=30)) == 60
+    # We can also input x and y as kwargs in this case
+    assert my_wacky_addition_asset_no_context(y=1, x=2, my_resource=MyResource(z=3)) == 6

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Optional
+from typing import List, Optional
 
 import dagster
 import pydantic
@@ -321,7 +321,7 @@ def test_nested_struct_config():
     assert executed["yes"]
 
 
-def test_direct_op_invocation():
+def test_direct_op_invocation() -> None:
     class MyBasicOpConfig(Config):
         foo: str
 
@@ -348,6 +348,48 @@ def test_direct_op_invocation():
 
     with pytest.raises(DagsterInvalidConfigError):
         basic_op_no_context(build_op_context(op_config={"baz": "qux"}))
+
+
+def test_direct_op_invocation_complex_config() -> None:
+    class MyBasicOpConfig(Config):
+        foo: str
+        bar: bool
+        baz: int
+        qux: List[str]
+
+    @op
+    def basic_op(context, config: MyBasicOpConfig):
+        assert config.foo == "bar"
+
+    basic_op(build_op_context(op_config={"foo": "bar", "bar": True, "baz": 1, "qux": ["a", "b"]}))
+
+    with pytest.raises(AssertionError):
+        basic_op(
+            build_op_context(op_config={"foo": "qux", "bar": True, "baz": 1, "qux": ["a", "b"]})
+        )
+
+    with pytest.raises(DagsterInvalidConfigError):
+        basic_op(
+            build_op_context(op_config={"foo": "bar", "bar": "true", "baz": 1, "qux": ["a", "b"]})
+        )
+
+    @op
+    def basic_op_no_context(config: MyBasicOpConfig):
+        assert config.foo == "bar"
+
+    basic_op_no_context(
+        build_op_context(op_config={"foo": "bar", "bar": True, "baz": 1, "qux": ["a", "b"]})
+    )
+
+    with pytest.raises(AssertionError):
+        basic_op_no_context(
+            build_op_context(op_config={"foo": "qux", "bar": True, "baz": 1, "qux": ["a", "b"]})
+        )
+
+    with pytest.raises(DagsterInvalidConfigError):
+        basic_op_no_context(
+            build_op_context(op_config={"foo": "bar", "bar": "true", "baz": 1, "qux": ["a", "b"]})
+        )
 
 
 def test_validate_run_config():

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -325,7 +325,6 @@ def test_direct_op_invocation():
     class MyBasicOpConfig(Config):
         foo: str
 
-    # Limitation: for now direct invocation still requires the op to have a context argument.
     @op
     def basic_op(context, config: MyBasicOpConfig):
         assert config.foo == "bar"
@@ -337,6 +336,18 @@ def test_direct_op_invocation():
 
     with pytest.raises(DagsterInvalidConfigError):
         basic_op(build_op_context(op_config={"baz": "qux"}))
+
+    @op
+    def basic_op_no_context(config: MyBasicOpConfig):
+        assert config.foo == "bar"
+
+    basic_op_no_context(build_op_context(op_config={"foo": "bar"}))
+
+    with pytest.raises(AssertionError):
+        basic_op_no_context(build_op_context(op_config={"foo": "qux"}))
+
+    with pytest.raises(DagsterInvalidConfigError):
+        basic_op_no_context(build_op_context(op_config={"baz": "qux"}))
 
 
 def test_validate_run_config():

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -51,24 +51,7 @@ def test_solid_invocation_no_arg():
     result = basic_solid()
     assert result == 5
 
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-        match=(
-            "Compute function of op 'basic_solid' has no context "
-            "argument, but context was provided when invoking."
-        ),
-    ):
-        basic_solid(build_op_context())
-
-    # Ensure alias is accounted for in error message
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-        match=(
-            "Compute function of op 'aliased_basic_solid' has no context "
-            "argument, but context was provided when invoking."
-        ),
-    ):
-        basic_solid.alias("aliased_basic_solid")(build_op_context())
+    basic_solid(build_op_context())
 
     with pytest.raises(
         DagsterInvalidInvocationError,


### PR DESCRIPTION
## Summary

Makes direct invocation of ops and assets which utilize resources via arguments easier.

Now, users can specify resources for these ops/assets through either the context or the resource kwarg. For example:

```python

@asset
def my_asset(my_resource: MyResource) -> str:
    assert my_resource.a_str == "foo"
    return my_resource.a_str

# valid (resource provided through context)
my_asset(build_op_context(resources={"my_resource": MyResource(a_str="foo")}))

# valid (resource provided through kwarg)
my_asset(my_resource=MyResource(a_str="foo"))

# invalid (resource provided in two places)
my_asset(build_op_context(resources={"my_resource": MyResource(a_str="foo")}), my_resource=MyResource(a_str="foo"))

```

Also loosens the context requirement for config, e.g. previously any directly invoked op/asset which had `config` as an argument had to also have `context` as an argument. Now, if `context` is missing from the function signature, we just discard the context.

## Test Plan

New unit tests.