### PR TITLE
[5/n][resources ui] Expose resource-asset dependencies in repo snapshot

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1917,6 +1917,7 @@ type ResourceDetails {
   nestedResources: [NestedResourceEntry!]!
   parentResources: [NestedResourceEntry!]!
   resourceType: String!
+  assetKeysUsing: [AssetKey!]!
 }
 
 type ConfiguredValue {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -10205,6 +10205,14 @@ export const buildResourceDetails = (
   relationshipsToOmit.add('ResourceDetails');
   return {
     __typename: 'ResourceDetails',
+    assetKeysUsing:
+      overrides && overrides.hasOwnProperty('assetKeysUsing')
+        ? overrides.assetKeysUsing!
+        : [
+            relationshipsToOmit.has('AssetKey')
+              ? ({} as AssetKey)
+              : buildAssetKey({}, relationshipsToOmit),
+          ],
     configFields:
       overrides && overrides.hasOwnProperty('configFields')
         ? overrides.configFields!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2853,6 +2853,7 @@ export type Resource = {
 
 export type ResourceDetails = {
   __typename: 'ResourceDetails';
+  assetKeysUsing: Array<AssetKey>;
   configFields: Array<ConfigTypeField>;
   configuredValues: Array<ConfiguredValue>;
   description: Maybe<Scalars['String']>;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -10,6 +10,7 @@ from dagster._core.host_representation.external_data import (
     NestedResourceType,
 )
 
+from dagster_graphql.schema.asset_key import GrapheneAssetKey
 from dagster_graphql.schema.errors import (
     GraphenePythonError,
     GrapheneRepositoryNotFoundError,
@@ -84,6 +85,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
         description="List of parent resources for the given resource",
     )
     resourceType = graphene.NonNull(graphene.String)
+    assetKeysUsing = graphene.Field(non_null_list(GrapheneAssetKey))
 
     class Meta:
         name = "ResourceDetails"
@@ -109,6 +111,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
         self._nested_resources = external_resource.nested_resources
         self._parent_resources = external_resource.parent_resources
         self.resourceType = external_resource.resource_type
+        self._asset_keys_using = external_resource.asset_keys_using
 
     def resolve_configFields(self, _graphene_info):
         return [
@@ -164,6 +167,9 @@ class GrapheneResourceDetails(graphene.ObjectType):
             )
             for name, attribute in self._parent_resources.items()
         ]
+
+    def resolve_assetKeysUsing(self, _graphene_info):
+        return [GrapheneAssetKey(path=asset_key.path) for asset_key in self._asset_keys_using]
 
 
 class GrapheneResourceDetailsOrError(graphene.Union):

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -594,6 +594,10 @@ class ExternalResource:
     def is_top_level(self) -> bool:
         return self._external_resource_data.is_top_level
 
+    @property
+    def asset_keys_using(self) -> List[AssetKey]:
+        return self._external_resource_data.asset_keys_using
+
 
 class ExternalSchedule:
     def __init__(self, external_schedule_data: ExternalScheduleData, handle: RepositoryHandle):

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1131,7 +1131,6 @@ def external_repository_data_from_def(
     asset_graph = external_asset_graph_from_defs(
         pipelines,
         source_assets_by_key=repository_def.source_assets_by_key,
-        resource_key_mapping=repository_def.get_resource_key_mapping(),
     )
 
     nested_resource_map = _get_nested_resources_map(
@@ -1204,7 +1203,6 @@ def external_repository_data_from_def(
 def external_asset_graph_from_defs(
     pipelines: Sequence[PipelineDefinition],
     source_assets_by_key: Mapping[AssetKey, SourceAsset],
-    resource_key_mapping: Mapping[int, str],
 ) -> Sequence[ExternalAssetNode]:
     node_defs_by_asset_key: Dict[
         AssetKey, List[Tuple[NodeOutputHandle, PipelineDefinition]]

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -57,6 +57,7 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import MetadataEntry, MetadataUserInput, normalize_metadata
 from dagster._core.definitions.mode import DEFAULT_MODE_NAME
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import (
     DynamicPartitionsDefinition,
     ScheduleType,
@@ -930,6 +931,7 @@ class ExternalResourceData(
             ("parent_resources", Dict[str, str]),
             ("resource_type", str),
             ("is_top_level", bool),
+            ("asset_keys_using", List[AssetKey]),
         ],
     )
 ):
@@ -949,6 +951,7 @@ class ExternalResourceData(
         parent_resources: Mapping[str, str],
         resource_type: str,
         is_top_level: bool = True,
+        asset_keys_using: Optional[Sequence[AssetKey]] = None,
     ):
         return super(ExternalResourceData, cls).__new__(
             cls,
@@ -982,6 +985,10 @@ class ExternalResourceData(
             ),
             is_top_level=check.bool_param(is_top_level, "is_top_level"),
             resource_type=check.str_param(resource_type, "resource_type"),
+            asset_keys_using=list(
+                check.opt_sequence_param(asset_keys_using, "asset_keys_using", of_type=AssetKey)
+            )
+            or [],
         )
 
 
@@ -1015,6 +1022,7 @@ class ExternalAssetNode(
             # have the same atomic_execution_unit_id. This ID should be stable across reloads and
             # unique deployment-wide.
             ("atomic_execution_unit_id", Optional[str]),
+            ("required_top_level_resources", Optional[Sequence[str]]),
         ],
     )
 ):
@@ -1045,6 +1053,7 @@ class ExternalAssetNode(
         is_source: Optional[bool] = None,
         is_observable: bool = False,
         atomic_execution_unit_id: Optional[str] = None,
+        required_top_level_resources: Optional[Sequence[str]] = None,
     ):
         # backcompat logic to handle ExternalAssetNodes serialized without op_names/graph_name
         if not op_names:
@@ -1092,6 +1101,9 @@ class ExternalAssetNode(
             atomic_execution_unit_id=check.opt_str_param(
                 atomic_execution_unit_id, "atomic_execution_unit_id"
             ),
+            required_top_level_resources=check.opt_sequence_param(
+                required_top_level_resources, "required_top_level_resources", of_type=str
+            ),
         )
 
 
@@ -1116,6 +1128,11 @@ def external_repository_data_from_def(
         job_refs = None
 
     resource_datas = repository_def.get_top_level_resources()
+    asset_graph = external_asset_graph_from_defs(
+        pipelines,
+        source_assets_by_key=repository_def.source_assets_by_key,
+        resource_key_mapping=repository_def.get_resource_key_mapping(),
+    )
 
     nested_resource_map = _get_nested_resources_map(
         resource_datas, repository_def.get_resource_key_mapping()
@@ -1125,6 +1142,12 @@ def external_repository_data_from_def(
         for attribute, nested_resource in nested_resources.items():
             if nested_resource.type == NestedResourceType.TOP_LEVEL:
                 inverted_nested_resources_map[nested_resource.name][resource_key] = attribute
+
+    resource_asset_usage_map = defaultdict(list)
+    for asset in asset_graph:
+        if asset.required_top_level_resources:
+            for resource_key in asset.required_top_level_resources:
+                resource_asset_usage_map[resource_key].append(asset.asset_key)
 
     return ExternalRepositoryData(
         name=repository_def.name,
@@ -1152,9 +1175,7 @@ def external_repository_data_from_def(
             ],
             key=lambda sd: sd.name,
         ),
-        external_asset_graph_data=external_asset_graph_from_defs(
-            pipelines, source_assets_by_key=repository_def.source_assets_by_key
-        ),
+        external_asset_graph_data=asset_graph,
         external_pipeline_datas=pipeline_datas,
         external_job_refs=job_refs,
         external_resource_data=sorted(
@@ -1164,6 +1185,7 @@ def external_repository_data_from_def(
                     res_data,
                     nested_resource_map[res_name],
                     inverted_nested_resources_map[res_name],
+                    resource_asset_usage_map,
                 )
                 for res_name, res_data in resource_datas.items()
             ],
@@ -1180,7 +1202,9 @@ def external_repository_data_from_def(
 
 
 def external_asset_graph_from_defs(
-    pipelines: Sequence[PipelineDefinition], source_assets_by_key: Mapping[AssetKey, SourceAsset]
+    pipelines: Sequence[PipelineDefinition],
+    source_assets_by_key: Mapping[AssetKey, SourceAsset],
+    resource_key_mapping: Mapping[int, str],
 ) -> Sequence[ExternalAssetNode]:
     node_defs_by_asset_key: Dict[
         AssetKey, List[Tuple[NodeOutputHandle, PipelineDefinition]]
@@ -1295,6 +1319,10 @@ def external_asset_graph_from_defs(
 
         asset_info = asset_info_by_asset_key[asset_key]
 
+        required_top_level_resources: List[str] = []
+        if isinstance(node_def, OpDefinition):
+            required_top_level_resources = list(node_def.required_resource_keys)
+
         asset_metadata_entries = (
             cast(
                 Sequence,
@@ -1348,6 +1376,7 @@ def external_asset_graph_from_defs(
                 group_name=group_name_by_asset_key.get(asset_key, DEFAULT_GROUP_NAME),
                 freshness_policy=freshness_policy_by_asset_key.get(asset_key),
                 atomic_execution_unit_id=atomic_execution_unit_ids_by_asset_key.get(asset_key),
+                required_top_level_resources=required_top_level_resources,
             )
         )
 
@@ -1436,6 +1465,7 @@ def external_resource_data_from_def(
     resource_def: ResourceDefinition,
     nested_resources: Mapping[str, NestedResource],
     parent_resources: Mapping[str, str],
+    resource_asset_usage_map: Mapping[str, List[AssetKey]],
 ) -> ExternalResourceData:
     check.inst_param(resource_def, "resource_def", ResourceDefinition)
 
@@ -1480,6 +1510,7 @@ def external_resource_data_from_def(
         nested_resources=nested_resources,
         parent_resources=parent_resources,
         is_top_level=True,
+        asset_keys_using=resource_asset_usage_map.get(name, []),
         resource_type=resource_type,
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -366,7 +366,11 @@ def test_repository_snap_definitions_resources_assets_usage() -> None:
 
     defs = Definitions(
         assets=[my_asset, my_other_asset, my_third_asset],
-        resources={"foo": MyResource(a_str="foo"), "bar": MyResource(a_str="bar")},
+        resources={
+            "foo": MyResource(a_str="foo"),
+            "bar": MyResource(a_str="bar"),
+            "baz": MyResource(a_str="baz"),
+        },
     )
 
     repo = resolve_pending_repo_if_required(defs)
@@ -389,6 +393,11 @@ def test_repository_snap_definitions_resources_assets_usage() -> None:
     assert bar[0].asset_keys_using == [
         AssetKey("my_other_asset"),
     ]
+
+    baz = [data for data in external_repo_data.external_resource_data if data.name == "baz"]
+    assert len(baz) == 1
+
+    assert baz[0].asset_keys_using == []
 
 
 def test_repository_snap_definitions_function_style_resources_assets_usage() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -377,7 +377,7 @@ def test_repository_snap_definitions_resources_assets_usage() -> None:
     external_repo_data = external_repository_data_from_def(repo)
     assert external_repo_data.external_resource_data
 
-    assert len(external_repo_data.external_resource_data) == 2
+    assert len(external_repo_data.external_resource_data) == 3
 
     foo = [data for data in external_repo_data.external_resource_data if data.name == "foo"]
     assert len(foo) == 1


### PR DESCRIPTION
## Summary

Walks assets defined in a repo and builds a list of the resources they depend on, binding this info to the resources so we can surface it in the UI in the 'uses' page:

```python
class MyResource(ConfigurableResource):
    a_str: str

@asset
def my_asset(foo: MyResource):
    pass

@asset
def my_other_asset(foo: MyResource):
    pass

defs = Definitions(
    assets=[my_asset, my_other_asset],
    resources={"foo": MyResource(a_str="foo")}
)
```

Here, the `asset_keys_using` attribute of `foo` will have the asset keys for `my_asset`, `my_other_asset`.

See the stacked PR for the UI impl.

## Test Plan

Unit test.
