### PR TITLE
[Dynamic partition requests 1/3] Validate run request partition in sensor eval

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -174,8 +174,7 @@ def image_sensor(context):
     context.instance.add_dynamic_partitions(images_partitions_def.name, new_images)
 
     run_requests = [
-        images_job.run_request_for_partition(img_filename, instance=context.instance)
-        for img_filename in new_images
+        RunRequest(partition_key=img_filename) for img_filename in new_images
     ]
     return run_requests
 ```

--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions/release_sensor.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions/release_sensor.py
@@ -50,6 +50,6 @@ def release_sensor(context):
         # first time the sensor turns on. This means that you might need to manually backfill earlier
         # releases.
         context.update_cursor(new_releases[-1])
-        return RunRequest(tags={"dagster/partition": new_releases[-1]})
+        return RunRequest(partition_key=new_releases[-1])
     else:
         return SkipReason("No new releases")

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/dynamic_partitioned_asset.py
@@ -4,6 +4,7 @@ from dagster import (
     AssetSelection,
     Definitions,
     DynamicPartitionsDefinition,
+    RunRequest,
     asset,
     define_asset_job,
     sensor,
@@ -41,8 +42,7 @@ def image_sensor(context):
     context.instance.add_dynamic_partitions(images_partitions_def.name, new_images)
 
     run_requests = [
-        images_job.run_request_for_partition(img_filename, instance=context.instance)
-        for img_filename in new_images
+        RunRequest(partition_key=img_filename) for img_filename in new_images
     ]
     return run_requests
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -785,9 +785,10 @@ def build_run_requests(
                 check.failed("Partition key provided for unpartitioned asset")
             tags.update({**partitions_def.get_tags_for_partition_key(partition_key)})
 
-        # Normally the run request would have to be resolved with the partitions def, but
-        # we have already confirmed that the partition key exists. Performing another check
-        # in the run request resolution would be redundant and costly to fetch all partition keys.
+        # Do not call run_request.with_resolved_tags_and_config as the partition key is
+        # valid and there is no config.
+        # Calling with_resolved_tags_and_config is costly in asset reconciliation as it
+        # checks for valid partition keys.
         run_requests.append(
             RunRequest(
                 asset_selection=list(asset_keys),

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -785,9 +785,13 @@ def build_run_requests(
                 check.failed("Partition key provided for unpartitioned asset")
             tags.update({**partitions_def.get_tags_for_partition_key(partition_key)})
 
+        # Normally the run request would have to be resolved with the partitions def, but
+        # we have already confirmed that the partition key exists. Performing another check
+        # in the run request resolution would be redundant and costly to fetch all partition keys.
         run_requests.append(
             RunRequest(
                 asset_selection=list(asset_keys),
+                partition_key=partition_key,
                 tags=tags,
             )
         )

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -585,6 +585,7 @@ class JobDefinition(PipelineDefinition):
         instance: Optional["DagsterInstance"] = None,
         current_time: Optional[datetime] = None,
     ) -> RunRequest:
+        # TODO deprecate this function?
         """Creates a RunRequest object for a run that processes the given partition.
 
         Args:
@@ -620,13 +621,16 @@ class JobDefinition(PipelineDefinition):
             run_config
             if run_config is not None
             else self.partitioned_config.get_run_config_for_partition_key(
-                partition.name, instance=instance, current_time=current_time
+                partition.name, dynamic_partitions_store=instance, current_time=current_time
             )
         )
         run_request_tags = {
             **(tags or {}),
             **self.partitioned_config.get_tags_for_partition_key(
-                partition_key, instance=instance, current_time=current_time, job_name=self.name
+                partition_key,
+                dynamic_partitions_store=instance,
+                current_time=current_time,
+                job_name=self.name,
             ),
         }
 
@@ -636,6 +640,7 @@ class JobDefinition(PipelineDefinition):
             tags=run_request_tags,
             job_name=self.name,
             asset_selection=asset_selection,
+            partition_key=partition_key,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -56,6 +56,7 @@ from dagster._core.selector.subset_selector import (
 )
 from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
 from dagster._core.utils import str_format_set
+from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.merger import merge_dicts
 
 from .asset_layer import AssetLayer, build_asset_selection_job
@@ -585,7 +586,6 @@ class JobDefinition(PipelineDefinition):
         instance: Optional["DagsterInstance"] = None,
         current_time: Optional[datetime] = None,
     ) -> RunRequest:
-        # TODO deprecate this function?
         """Creates a RunRequest object for a run that processes the given partition.
 
         Args:
@@ -605,6 +605,12 @@ class JobDefinition(PipelineDefinition):
         Returns:
             RunRequest: an object that requests a run to process the given partition.
         """
+        deprecation_warning(
+            "JobDefinition.run_request_for_partition",
+            "2.0.0",
+            additional_warn_txt="Directly instantiate `RunRequest(partition_key=...)` instead.",
+        )
+
         if not (self.partitions_def and self.partitioned_config):
             check.failed("Called run_request_for_partition on a non-partitioned job")
 

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -730,7 +730,7 @@ class PartitionedConfig(Generic[T_cov]):
     def get_run_config_for_partition_key(
         self,
         partition_key: str,
-        instance: Optional[DagsterInstance] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
         current_time: Optional[datetime] = None,
     ) -> Mapping[str, Any]:
         """Generates the run config corresponding to a partition key.
@@ -738,13 +738,13 @@ class PartitionedConfig(Generic[T_cov]):
         Args:
             partition_key (str): the key for a partition that should be used to generate a run config.
         """
-        partition = self._key_to_partition(partition_key, current_time, instance)
+        partition = self._key_to_partition(partition_key, current_time, dynamic_partitions_store)
         return copy.deepcopy(self.run_config_for_partition_fn(partition))
 
     def get_tags_for_partition_key(
         self,
         partition_key: str,
-        instance: Optional[DagsterInstance] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
         current_time: Optional[datetime] = None,
         job_name: Optional[str] = None,
     ) -> Mapping[str, str]:
@@ -752,7 +752,7 @@ class PartitionedConfig(Generic[T_cov]):
             external_partition_set_name_for_job_name,
         )
 
-        partition = self._key_to_partition(partition_key, current_time, instance)
+        partition = self._key_to_partition(partition_key, current_time, dynamic_partitions_store)
         user_tags = (
             validate_tags(self._tags_for_partition_fn(partition), allow_reserved_tags=False)
             if self._tags_for_partition_fn
@@ -774,12 +774,12 @@ class PartitionedConfig(Generic[T_cov]):
         self,
         partition_key: str,
         current_time: Optional[datetime],
-        instance: Optional[DagsterInstance],
+        dynamic_partitions_store: Optional[DynamicPartitionsStore],
     ) -> Partition[T_cov]:
         matches = [
             p
             for p in self.partitions_def.get_partitions(
-                current_time=current_time, dynamic_partitions_store=instance
+                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
             )
             if p.name == partition_key
         ]

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -110,7 +110,7 @@ class RunRequest(
                 fields[k] = kwargs[k]
         return RunRequest(**fields)
 
-    def with_resolved_partition(
+    def with_resolved_tags_and_config(
         self,
         target_definition: Union["JobDefinition", "UnresolvedAssetJobDefinition"],
         current_time: Optional[datetime] = None,
@@ -126,7 +126,10 @@ class RunRequest(
         partitions_def = target_definition.partitions_def
         if partitions_def is None:
             check.failed(
-                "Cannot resolve partition for run request without partitions_def",
+                (
+                    "Cannot resolve partition for run request when target job"
+                    f" '{target_definition.name}' is unpartitioned."
+                ),
             )
         partitions_def = cast(PartitionsDefinition, partitions_def)
 
@@ -177,7 +180,7 @@ class RunRequest(
             tags=get_run_request_tags(partition.name),
         )
 
-    def has_resolved_partition_run_request(self) -> bool:
+    def has_resolved_partition(self) -> bool:
         # Backcompat run requests yielded via `run_request_for_partition` already have resolved
         # partitioning
         return self.tags.get(PARTITION_NAME_TAG) is not None if self.partition_key else True

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -1,13 +1,22 @@
+from datetime import datetime
 from enum import Enum
-from typing import Any, Mapping, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.partition import PartitionedConfig, PartitionsDefinition
+from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.job_definition import JobDefinition
+    from dagster._core.definitions.unresolved_asset_job_definition import (
+        UnresolvedAssetJobDefinition,
+    )
 
 
 @whitelist_for_serdes(old_storage_names={"JobType"})
@@ -44,22 +53,21 @@ class RunRequest(
             ("job_name", PublicAttr[Optional[str]]),
             ("asset_selection", PublicAttr[Optional[Sequence[AssetKey]]]),
             ("stale_assets_only", PublicAttr[bool]),
+            ("partition_key", PublicAttr[Optional[str]]),
         ],
     )
 ):
     """Represents all the information required to launch a single run.  Must be returned by a
     SensorDefinition or ScheduleDefinition's evaluation function for a run to be launched.
 
-    To build a run request for a particular partitition, use
-    :py:func:`~JobDefinition.run_request_for_partition`.
-
     Attributes:
         run_key (Optional[str]): A string key to identify this launched run. For sensors, ensures that
             only one run is created per run key across all sensor evaluations.  For schedules,
             ensures that one run is created per tick, across failure recoveries. Passing in a `None`
             value means that a run will always be launched per evaluation.
-        run_config (Optional[Dict]): The config that parameterizes the run execution to
-            be launched, as a dict.
+        run_config (Optional[Mapping[str, Any]]: Configuration for the run. If the job has
+            a :py:class:`PartitionedConfig`, this value will override replace the config
+            provided by it.
         tags (Optional[Dict[str, str]]): A dictionary of tags (string key-value pairs) to attach
             to the launched run.
         job_name (Optional[str]): (Experimental) The name of the job this run request will launch.
@@ -69,6 +77,7 @@ class RunRequest(
         stale_assets_only (Optional[Sequence[AssetKey]]): Set to true to further narrow the asset
             selection to stale assets. If passed without an asset selection, all stale assets in the
             job will be materialized. If the job does not materialize assets, this flag is ignored.
+        partition_key (Optional[str]): The partition key for this run request.
     """
 
     def __new__(
@@ -79,6 +88,7 @@ class RunRequest(
         job_name: Optional[str] = None,
         asset_selection: Optional[Sequence[AssetKey]] = None,
         stale_assets_only: bool = False,
+        partition_key: Optional[str] = None,
     ):
         return super(RunRequest, cls).__new__(
             cls,
@@ -90,11 +100,8 @@ class RunRequest(
                 asset_selection, "asset_selection", of_type=AssetKey
             ),
             stale_assets_only=check.bool_param(stale_assets_only, "stale_assets_only"),
+            partition_key=check.opt_str_param(partition_key, "partition_key"),
         )
-
-    @property
-    def partition_key(self) -> Optional[str]:
-        return self.tags.get(PARTITION_NAME_TAG)
 
     def with_replaced_attrs(self, **kwargs: Any) -> "RunRequest":
         fields = self._asdict()
@@ -102,6 +109,78 @@ class RunRequest(
             if k in kwargs:
                 fields[k] = kwargs[k]
         return RunRequest(**fields)
+
+    def with_resolved_partition(
+        self,
+        target_definition: Union["JobDefinition", "UnresolvedAssetJobDefinition"],
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> "RunRequest":
+        from dagster._core.definitions.job_definition import JobDefinition
+
+        if self.partition_key is None:
+            check.failed(
+                "Cannot resolve partition for run request without partition key",
+            )
+
+        partitions_def = target_definition.partitions_def
+        if partitions_def is None:
+            check.failed(
+                "Cannot resolve partition for run request without partitions_def",
+            )
+        partitions_def = cast(PartitionsDefinition, partitions_def)
+
+        partitioned_config = (
+            target_definition.partitioned_config
+            if isinstance(target_definition, JobDefinition)
+            else PartitionedConfig.from_flexible_config(target_definition.config, partitions_def)
+        )
+        if partitioned_config is None:
+            check.failed(
+                "Cannot resolve partition for run request on unpartitioned job",
+            )
+
+        # Relies on the partitions def to throw an error if the partition does not exist
+        partition = partitions_def.get_partition(
+            self.partition_key,
+            current_time=current_time,
+            dynamic_partitions_store=dynamic_partitions_store,
+        )
+
+        get_run_request_tags = lambda partition: (
+            {
+                **self.tags,
+                **partitioned_config.get_tags_for_partition_key(
+                    partition,
+                    dynamic_partitions_store=dynamic_partitions_store,
+                    current_time=current_time,
+                    job_name=target_definition.name,
+                ),
+            }
+            if self.tags
+            else partitioned_config.get_tags_for_partition_key(
+                partition,
+                dynamic_partitions_store=dynamic_partitions_store,
+                current_time=current_time,
+                job_name=target_definition.name,
+            )
+        )
+
+        return self.with_replaced_attrs(
+            run_config=self.run_config
+            if self.run_config
+            else partitioned_config.get_run_config_for_partition_key(
+                partition.name,
+                dynamic_partitions_store=dynamic_partitions_store,
+                current_time=current_time,
+            ),
+            tags=get_run_request_tags(partition.name),
+        )
+
+    def has_resolved_partition_run_request(self) -> bool:
+        # Backcompat run requests yielded via `run_request_for_partition` already have resolved
+        # partitioning
+        return self.tags.get(PARTITION_NAME_TAG) is not None if self.partition_key else True
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -25,6 +25,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.instigation_logger import InstigationLogger
+from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import (
     Resources,
@@ -44,9 +45,14 @@ from ..decorator_utils import (
 )
 from .asset_selection import AssetSelection
 from .graph_definition import GraphDefinition
+from .job_definition import JobDefinition
 from .mode import DEFAULT_MODE_NAME
 from .pipeline_definition import PipelineDefinition
-from .run_request import PipelineRunReaction, RunRequest, SkipReason
+from .run_request import (
+    PipelineRunReaction,
+    RunRequest,
+    SkipReason,
+)
 from .target import DirectTarget, ExecutableDefinition, RepoRelativeTarget
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from .utils import check_valid_name
@@ -592,15 +598,12 @@ class SensorDefinition:
                 else:
                     check.failed("Expected a single SkipReason: received multiple SkipReasons")
 
-        self.check_valid_run_requests(run_requests)
-
-        if self._asset_selection:
-            run_requests = [
-                *_run_requests_with_base_asset_jobs(run_requests, context, self._asset_selection)
-            ]
+        resolved_run_requests = self.resolve_run_requests(
+            run_requests, context, self._asset_selection
+        )
 
         return SensorExecutionData(
-            run_requests,
+            resolved_run_requests,
             skip_message,
             context.cursor,
             pipeline_run_reactions,
@@ -615,18 +618,34 @@ class SensorDefinition:
 
     def load_targets(
         self,
-    ) -> Sequence[Union[PipelineDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]:
+    ) -> Sequence[Union[JobDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]:
+        """Returns job/graph definitions that have been directly passed into the sensor definition.
+        Any jobs or graphs that are referenced by name will not be loaded.
+        """
         targets = []
         for target in self._targets:
             if isinstance(target, DirectTarget):
                 targets.append(target.load())
         return targets
 
-    def check_valid_run_requests(self, run_requests: Sequence[RunRequest]):
+    def resolve_run_requests(
+        self,
+        run_requests: Sequence[RunRequest],
+        context: SensorEvaluationContext,
+        asset_selection: Optional[AssetSelection],
+    ) -> Sequence[RunRequest]:
+        def _get_repo_job_by_name(context: SensorEvaluationContext, job_name: str) -> JobDefinition:
+            if context.repository_def is None:
+                raise DagsterInvariantViolationError(
+                    "Must provide repository def to build_sensor_context when yielding partitioned"
+                    " run requests"
+                )
+            return context.repository_def.get_job(job_name)
+
         has_multiple_targets = len(self._targets) > 1
         target_names = [target.pipeline_name for target in self._targets]
 
-        if run_requests and not self._targets and not self._asset_selection:
+        if run_requests and len(self._targets) == 0 and not self._asset_selection:
             raise Exception(
                 f"Error in sensor {self._name}: Sensor evaluation function returned a RunRequest "
                 "for a sensor lacking a specified target (job_name, job, or jobs). Targets "
@@ -634,17 +653,68 @@ class SensorDefinition:
                 "decorator."
             )
 
+        # Run requests may contain an invalid target, or a partition key that does not exist.
+        # We will resolve these run requests, applying the target and partition config/tags.
+        resolved_run_requests = []
+
         for run_request in run_requests:
             if run_request.job_name is None and has_multiple_targets:
                 raise Exception(
-                    f"Error in sensor {self._name}: Sensor returned a RunRequest that did not "
-                    f"specify job_name for the requested run. Expected one of: {target_names}"
+                    f"Error in sensor {self._name}: Sensor returned a RunRequest that did not"
+                    " specify job_name for the requested run. Expected one of:"
+                    f" {target_names}"
                 )
             elif run_request.job_name and run_request.job_name not in target_names:
                 raise Exception(
                     f"Error in sensor {self._name}: Sensor returned a RunRequest with job_name "
                     f"{run_request.job_name}. Expected one of: {target_names}"
                 )
+
+            if run_request.partition_key and not run_request.has_resolved_partition_run_request():
+                selected_job = _get_repo_job_by_name(
+                    context, run_request.job_name if run_request.job_name else target_names[0]
+                )
+
+                if isinstance(selected_job, GraphDefinition):
+                    raise Exception(
+                        f"Error in sensor {self._name}: Sensor returned a partitioned RunRequest, "
+                        "but the target is a graph with no partitions definition."
+                    )
+
+                partitions_def = selected_job.partitions_def
+                if not partitions_def:
+                    raise Exception(
+                        f"Error in sensor {self._name}: Sensor returned a partitioned RunRequest, "
+                        "but the target job has no partitions definition."
+                    )
+
+                dynamic_partitions_store = None
+                if isinstance(partitions_def, DynamicPartitionsDefinition):
+                    # Instance also needs to be provided when partitions def is a multipartitions
+                    # def with dynamic dimension
+                    if context.instance_ref is None:
+                        raise DagsterInvalidInvocationError(
+                            "Instance must be provided in build_sensor_context when yielding run"
+                            " requests for dynamic partitions."
+                        )
+                    dynamic_partitions_store = context.instance
+
+                resolved_run_requests.append(
+                    run_request.with_resolved_partition(
+                        target_definition=selected_job,
+                        current_time=None,
+                        dynamic_partitions_store=dynamic_partitions_store,
+                    )
+                )
+            else:
+                resolved_run_requests.append(run_request)
+
+        if asset_selection:
+            resolved_run_requests = [
+                *_run_requests_with_base_asset_jobs(resolved_run_requests, context, asset_selection)
+            ]
+
+        return resolved_run_requests
 
     @property
     def _target(self) -> Optional[Union[DirectTarget, RepoRelativeTarget]]:

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -83,6 +83,7 @@ class UnresolvedAssetJobDefinition(
         instance: Optional[DagsterInstance] = None,
         current_time: Optional[datetime] = None,
     ) -> RunRequest:
+        # TODO deprecate this function?
         """Creates a RunRequest object for a run that processes the given partition.
 
         Args:
@@ -127,7 +128,7 @@ class UnresolvedAssetJobDefinition(
             run_config
             if run_config is not None
             else partitioned_config.get_run_config_for_partition_key(
-                partition.name, instance=instance, current_time=current_time
+                partition.name, dynamic_partitions_store=instance, current_time=current_time
             )
         )
         run_request_tags = {
@@ -143,6 +144,7 @@ class UnresolvedAssetJobDefinition(
             run_config=run_config,
             tags=run_request_tags,
             asset_selection=asset_selection,
+            partition_key=partition_key,
         )
 
     def resolve(

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -83,7 +83,6 @@ class UnresolvedAssetJobDefinition(
         instance: Optional[DagsterInstance] = None,
         current_time: Optional[datetime] = None,
     ) -> RunRequest:
-        # TODO deprecate this function?
         """Creates a RunRequest object for a run that processes the given partition.
 
         Args:
@@ -106,6 +105,12 @@ class UnresolvedAssetJobDefinition(
         from dagster._core.definitions.partition import (
             DynamicPartitionsDefinition,
             PartitionedConfig,
+        )
+
+        deprecation_warning(
+            "UnresolvedAssetJobDefinition.run_request_for_partition",
+            "2.0.0",
+            additional_warn_txt="Directly instantiate `RunRequest(partition_key=...)` instead.",
         )
 
         if not self.partitions_def:

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -48,7 +48,6 @@ from dagster._core.definitions.time_window_partitions import (
 )
 from dagster._core.execution.asset_backfill import AssetBackfillData
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._seven.compat.pendulum import create_pendulum_time
 
 
@@ -233,7 +232,7 @@ def run(
 def run_request(asset_keys: List[str], partition_key: Optional[str] = None) -> RunRequest:
     return RunRequest(
         asset_selection=[AssetKey(key) for key in asset_keys],
-        tags={PARTITION_NAME_TAG: partition_key} if partition_key else None,
+        partition_key=partition_key,
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -403,12 +403,17 @@ def test_multipartitioned_job_schedule():
     def my_asset():
         return 1
 
-    my_schedule = build_schedule_from_partitioned_job(
-        define_asset_job("multipartitions_job", [my_asset], partitions_def=multipartitions_def)
-    )
+    my_job = define_asset_job("multipartitions_job", [my_asset], partitions_def=multipartitions_def)
+    my_schedule = build_schedule_from_partitioned_job(my_job)
+
+    @repository
+    def my_repo():
+        return [my_asset, my_schedule, my_job]
+
     run_requests = my_schedule.evaluate_tick(
         build_schedule_context(
-            scheduled_execution_time=datetime.strptime("2020-01-02", DATE_FORMAT)
+            scheduled_execution_time=datetime.strptime("2020-01-02", DATE_FORMAT),
+            repository_def=my_repo,
         )
     ).run_requests
     assert len(run_requests) == 4

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -12,6 +12,7 @@ from dagster import (
     DagsterInstance,
     DagsterInvariantViolationError,
     DagsterRunStatus,
+    DagsterUnknownPartitionError,
     DailyPartitionsDefinition,
     EventRecordsFilter,
     FreshnessPolicy,
@@ -39,12 +40,14 @@ from dagster import (
     run_failure_sensor,
     run_status_sensor,
     sensor,
+    static_partitioned_config,
 )
 from dagster._config.structured_config import ConfigurableResource
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.resource_annotation import Resource
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import instance_for_test
 
 
@@ -194,22 +197,110 @@ def test_instance_access_with_mock():
 def test_sensor_w_no_job():
     @sensor()
     def no_job_sensor():
-        pass
+        return RunRequest(
+            run_key=None,
+            run_config=None,
+            tags=None,
+        )
 
     with pytest.raises(
         Exception,
         match=r".* Sensor evaluation function returned a RunRequest for a sensor lacking a "
         r"specified target .*",
     ):
-        no_job_sensor.check_valid_run_requests(
-            [
-                RunRequest(
-                    run_key=None,
-                    run_config=None,
-                    tags=None,
-                )
-            ]
-        )
+        with build_sensor_context() as context:
+            no_job_sensor.evaluate_tick(context)
+
+
+def test_validated_partitions():
+    @job(partitions_def=StaticPartitionsDefinition(["foo", "bar"]))
+    def my_job():
+        pass
+
+    @sensor(job=my_job)
+    def invalid_req_sensor():
+        return RunRequest(partition_key="nonexistent")
+
+    @sensor(job=my_job)
+    def valid_req_sensor():
+        return RunRequest(partition_key="foo", tags={"yay": "yay!"})
+
+    @repository
+    def my_repo():
+        return [my_job, invalid_req_sensor, valid_req_sensor]
+
+    with pytest.raises(DagsterInvariantViolationError, match="Must provide repository def"):
+        with build_sensor_context() as context:
+            invalid_req_sensor.evaluate_tick(context)
+
+    with pytest.raises(DagsterUnknownPartitionError, match="Could not find a partition"):
+        with build_sensor_context(repository_def=my_repo) as context:
+            invalid_req_sensor.evaluate_tick(context)
+
+    with build_sensor_context(repository_def=my_repo) as context:
+        run_requests = valid_req_sensor.evaluate_tick(context).run_requests
+        assert len(run_requests) == 1
+        run_request = run_requests[0]
+        assert run_request.partition_key == "foo"
+        assert run_request.run_config == {}
+        assert run_request.tags.get(PARTITION_NAME_TAG) == "foo"
+        assert run_request.tags.get("yay") == "yay!"
+
+
+def test_partitioned_config_run_request():
+    def partition_fn(partition_key: str):
+        return {"ops": {"my_op": {"config": {"partition": partition_key}}}}
+
+    @static_partitioned_config(partition_keys=["a", "b", "c", "d"])
+    def my_partitioned_config(partition_key: str):
+        return partition_fn(partition_key)
+
+    @op
+    def my_op():
+        pass
+
+    @job(config=my_partitioned_config)
+    def my_job():
+        my_op()
+
+    @sensor(job=my_job)
+    def valid_req_sensor():
+        return RunRequest(partition_key="a", tags={"yay": "yay!"})
+
+    @sensor(job=my_job)
+    def invalid_req_sensor():
+        return RunRequest(partition_key="nonexistent")
+
+    @sensor(job_name="my_job")
+    def job_str_target_sensor():
+        return RunRequest(partition_key="a", tags={"yay": "yay!"})
+
+    @sensor(job_name="my_job")
+    def invalid_job_str_target_sensor():
+        return RunRequest(partition_key="invalid")
+
+    @repository
+    def my_repo():
+        return [
+            my_job,
+            valid_req_sensor,
+            invalid_req_sensor,
+            job_str_target_sensor,
+            invalid_job_str_target_sensor,
+        ]
+
+    with build_sensor_context(repository_def=my_repo) as context:
+        for valid_sensor in [valid_req_sensor, job_str_target_sensor]:
+            run_requests = valid_sensor.evaluate_tick(context).run_requests
+            assert len(run_requests) == 1
+            run_request = run_requests[0]
+            assert run_request.run_config == partition_fn("a")
+            assert run_request.tags.get(PARTITION_NAME_TAG) == "a"
+            assert run_request.tags.get("yay") == "yay!"
+
+        for invalid_sensor in [invalid_req_sensor, invalid_job_str_target_sensor]:
+            with pytest.raises(DagsterUnknownPartitionError, match="Could not find a partition"):
+                run_requests = invalid_sensor.evaluate_tick(context).run_requests
 
 
 def test_run_status_sensor():
@@ -506,7 +597,9 @@ def test_partitions_multi_asset_sensor_context():
         "yay", selection="daily_partitions_asset", partitions_def=daily_partitions_def
     )
 
-    @multi_asset_sensor(monitored_assets=[daily_partitions_asset.key, daily_partitions_asset_2.key])
+    @multi_asset_sensor(
+        monitored_assets=[daily_partitions_asset.key, daily_partitions_asset_2.key], job=asset_job
+    )
     def two_asset_sensor(context):
         partition_1 = next(
             iter(
@@ -538,8 +631,15 @@ def test_partitions_multi_asset_sensor_context():
             instance=instance,
             repository_def=my_repo,
         )
-        assert two_asset_sensor(ctx).tags["dagster/partition"] == "2022-08-01"
-        assert ctx.get_cursor_partition(AssetKey("daily_partitions_asset")) == "2022-08-01"
+        sensor_data = two_asset_sensor.evaluate_tick(ctx)
+        assert len(sensor_data.run_requests) == 1
+        assert sensor_data.run_requests[0].partition_key == "2022-08-01"
+        assert sensor_data.run_requests[0].tags["dagster/partition"] == "2022-08-01"
+        assert (
+            ctx.cursor
+            == '{"AssetKey([\'daily_partitions_asset\'])": ["2022-08-01", 3, {}],'
+            ' "AssetKey([\'daily_partitions_asset_2\'])": ["2022-08-01", 4, {}]}'
+        )
 
 
 @asset(partitions_def=DailyPartitionsDefinition("2022-07-01"))
@@ -1305,7 +1405,7 @@ def test_dynamic_partitions_sensor():
     @sensor(job=my_job)
     def test_sensor(context):
         context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["apple"])
-        return my_job.run_request_for_partition("apple", instance=context.instance)
+        return RunRequest(partition_key="apple")
 
     with instance_for_test() as instance:
         ctx = build_sensor_context(


### PR DESCRIPTION
The proposed dynamic partitions sensor behavior requires users being able to yield run requests for partitions that do not exist yet in sensors/schedules. This PR bumps the validation into sensor/schedule evaluation, where we also raise errors for invalid job names / asset selections.

This enables yielding partitioned run requests from sensors/schedules that have invalid partition keys, via `RunRequest(partition_key=...)`.

Consequences of bumping the validation of partition keys into sensor evaluation:
- In order to evaluate directly instantiated partition run requests (`RunRequest(partition_key=...)`) methods like `build_sensor_context` and `build_schedule_context` have to accept a repository def so we can fetch the partition set of the target job. 
- Users who have written custom tests that evaluate run request objects will receive a different run request object from direct instantiation versus `run_request_for_partition`. The latter will return back a resolved run request with partition tags/config.

In order to prevent breaking user code in the situations above above, `run_request_for_partition` retains its current behavior in returning a resolved run request. We can optionally deprecate this method a designate direct instantiation as the new way forward.