### PR TITLE
[typing] make storage classes return sequences

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -48,7 +48,6 @@ from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
 from dagster._core.utils import toposort
 from dagster._serdes import create_snapshot_id
-from dagster._utils import iter_to_list
 from dagster._utils.cached_method import cached_method
 from dagster._utils.schedules import schedule_execution_time_iterator
 
@@ -143,7 +142,7 @@ class ExternalRepository:
         return self._external_schedules[schedule_name]
 
     def get_external_schedules(self) -> Sequence[ExternalSchedule]:
-        return iter_to_list(self._external_schedules.values())
+        return list(self._external_schedules.values())
 
     @property
     @cached_method
@@ -186,7 +185,7 @@ class ExternalRepository:
         return self._external_sensors[sensor_name]
 
     def get_external_sensors(self) -> Sequence[ExternalSensor]:
-        return iter_to_list(self._external_sensors.values())
+        return list(self._external_sensors.values())
 
     @property
     @cached_method
@@ -205,7 +204,7 @@ class ExternalRepository:
         return self._external_partition_sets[partition_set_name]
 
     def get_external_partition_sets(self) -> Sequence[ExternalPartitionSet]:
-        return iter_to_list(self._external_partition_sets.values())
+        return list(self._external_partition_sets.values())
 
     def has_external_job(self, job_name: str) -> bool:
         return job_name in self._job_map

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -19,7 +19,6 @@ from typing import (
     Callable,
     Dict,
     Generic,
-    Iterable,
     List,
     Mapping,
     Optional,
@@ -933,7 +932,7 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._run_storage.get_run_tag_keys()
 
     @traced
-    def get_run_group(self, run_id: str) -> Optional[Tuple[str, Iterable[DagsterRun]]]:
+    def get_run_group(self, run_id: str) -> Optional[Tuple[str, Sequence[DagsterRun]]]:
         return self._run_storage.get_run_group(run_id)
 
     def create_run_for_pipeline(
@@ -1568,7 +1567,7 @@ class DagsterInstance(DynamicPartitionsStore):
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
-    ) -> Iterable[DagsterRun]:
+    ) -> Sequence[DagsterRun]:
         return self._run_storage.get_runs(filters, cursor, limit, bucket_by)
 
     @traced
@@ -1683,7 +1682,7 @@ class DagsterInstance(DynamicPartitionsStore):
         self._event_storage.update_asset_cached_status_data(asset_key, cache_values)
 
     @traced
-    def all_asset_keys(self) -> Iterable[AssetKey]:
+    def all_asset_keys(self) -> Sequence[AssetKey]:
         return self._event_storage.all_asset_keys()
 
     @public
@@ -1693,7 +1692,7 @@ class DagsterInstance(DynamicPartitionsStore):
         prefix: Optional[str] = None,
         limit: Optional[int] = None,
         cursor: Optional[str] = None,
-    ) -> Iterable[AssetKey]:
+    ) -> Sequence[AssetKey]:
         return self._event_storage.get_asset_keys(prefix=prefix, limit=limit, cursor=cursor)
 
     @public
@@ -1719,7 +1718,7 @@ class DagsterInstance(DynamicPartitionsStore):
         event_records_filter: "EventRecordsFilter",
         limit: Optional[int] = None,
         ascending: bool = False,
-    ) -> Iterable["EventLogRecord"]:
+    ) -> Sequence["EventLogRecord"]:
         """Return a list of event records stored in the event log storage.
 
         Args:
@@ -1738,7 +1737,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
-    ) -> Iterable["AssetRecord"]:
+    ) -> Sequence["AssetRecord"]:
         return self._event_storage.get_asset_records(asset_keys)
 
     @traced
@@ -1763,7 +1762,7 @@ class DagsterInstance(DynamicPartitionsStore):
         return self._event_storage.get_event_tags_for_asset(asset_key, filter_tags, filter_event_id)
 
     @traced
-    def run_ids_for_asset_key(self, asset_key: AssetKey) -> Iterable[str]:
+    def run_ids_for_asset_key(self, asset_key: AssetKey) -> Sequence[str]:
         check.inst_param(asset_key, "asset_key", AssetKey)
         return self._event_storage.get_asset_run_ids(asset_key)
 
@@ -2337,7 +2336,7 @@ class DagsterInstance(DynamicPartitionsStore):
         selector_ids: Sequence[str],
         limit: Optional[int] = None,
         statuses: Optional[Sequence["TickStatus"]] = None,
-    ) -> Mapping[str, Iterable["InstigatorTick"]]:
+    ) -> Mapping[str, Sequence["InstigatorTick"]]:
         if not self._schedule_storage:
             return {}
         return self._schedule_storage.get_batch_ticks(selector_ids, limit, statuses)
@@ -2349,7 +2348,7 @@ class DagsterInstance(DynamicPartitionsStore):
         matches = self._schedule_storage.get_ticks(  # type: ignore  # (possible none)
             origin_id, selector_id, before=timestamp + 1, after=timestamp - 1, limit=1
         )
-        return matches[0] if len(matches) else None  # type: ignore  # (iterable getitem)
+        return matches[0] if len(matches) else None
 
     @traced
     def get_ticks(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
-    Iterable,
     Mapping,
     NamedTuple,
     Optional,
@@ -262,7 +261,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
-    ) -> Iterable[EventLogRecord]:
+    ) -> Sequence[EventLogRecord]:
         pass
 
     def supports_event_consumer_queries(self) -> bool:
@@ -289,7 +288,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
-    ) -> Iterable[AssetRecord]:
+    ) -> Sequence[AssetRecord]:
         pass
 
     @abstractmethod
@@ -297,7 +296,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
-    def all_asset_keys(self) -> Iterable[AssetKey]:
+    def all_asset_keys(self) -> Sequence[AssetKey]:
         pass
 
     @abstractmethod
@@ -311,7 +310,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         prefix: Optional[Sequence[str]] = None,
         limit: Optional[int] = None,
         cursor: Optional[str] = None,
-    ) -> Iterable[AssetKey]:
+    ) -> Sequence[AssetKey]:
         # base implementation of get_asset_keys, using the existing `all_asset_keys` and doing the
         # filtering in-memory
         asset_keys = sorted(self.all_asset_keys(), key=str)
@@ -356,7 +355,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
-    def get_asset_run_ids(self, asset_key: AssetKey) -> Iterable[str]:
+    def get_asset_run_ids(self, asset_key: AssetKey) -> Sequence[str]:
         pass
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -870,7 +870,7 @@ class SqlEventLogStorage(EventLogStorage):
         event_records_filter: EventRecordsFilter,
         limit: Optional[int] = None,
         ascending: bool = False,
-    ) -> Iterable[EventLogRecord]:
+    ) -> Sequence[EventLogRecord]:
         """Returns a list of (record_id, record)."""
         check.inst_param(event_records_filter, "event_records_filter", EventRecordsFilter)
         check.opt_int_param(limit, "limit")
@@ -1100,7 +1100,7 @@ class SqlEventLogStorage(EventLogStorage):
 
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
-    ) -> Iterable[AssetRecord]:
+    ) -> Sequence[AssetRecord]:
         rows = self._fetch_asset_rows(asset_keys=asset_keys)
         latest_materialization_records = self._get_latest_materialization_records(rows)
         can_cache_asset_status_data = self.can_cache_asset_status_data()
@@ -1134,7 +1134,7 @@ class SqlEventLogStorage(EventLogStorage):
         prefix: Optional[Sequence[str]] = None,
         limit: Optional[int] = None,
         cursor: Optional[str] = None,
-    ) -> Iterable[AssetKey]:
+    ) -> Sequence[AssetKey]:
         rows = self._fetch_asset_rows(prefix=prefix, limit=limit, cursor=cursor)
         asset_keys = [AssetKey.from_db_string(row[1]) for row in sorted(rows, key=lambda x: x[1])]
         return [asset_key for asset_key in asset_keys if asset_key]

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Set, Tuple, Union
 
 from typing_extensions import TypedDict
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 class RunGroupInfo(TypedDict):
     count: int
-    runs: Iterable[DagsterRun]
+    runs: Sequence[DagsterRun]
 
 
 class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
@@ -67,7 +67,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         bucket_by: Optional[Union[JobBucket, TagBucket]] = None,
-    ) -> Iterable[DagsterRun]:
+    ) -> Sequence[DagsterRun]:
         """Return all the runs present in the storage that match the given filters.
 
         Args:
@@ -95,7 +95,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """
 
     @abstractmethod
-    def get_run_group(self, run_id: str) -> Optional[Tuple[str, Iterable[DagsterRun]]]:
+    def get_run_group(self, run_id: str) -> Optional[Tuple[str, Sequence[DagsterRun]]]:
         """Get the run group to which a given run belongs.
 
         Args:

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -62,14 +62,14 @@ def chunked_run_iterator(
 
         while has_more:
             chunk = storage.get_runs(cursor=cursor, limit=chunk_size)
-            has_more = chunk_size and len(chunk) >= chunk_size  # type: ignore
+            has_more = chunk_size and len(chunk) >= chunk_size
 
             for run in chunk:
                 cursor = run.run_id
                 yield run
 
             if progress:
-                progress.update(len(chunk))  # type: ignore
+                progress.update(len(chunk))
 
 
 def chunked_run_records_iterator(

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -603,7 +603,7 @@ class SqlRunStorage(RunStorage):
                     [dict(run_id=run_id, key=tag, value=new_tags[tag]) for tag in added_tags],
                 )
 
-    def get_run_group(self, run_id: str) -> Tuple[str, Iterable[DagsterRun]]:
+    def get_run_group(self, run_id: str) -> Tuple[str, Sequence[DagsterRun]]:
         check.str_param(run_id, "run_id")
         pipeline_run = self._get_run_by_id(run_id)
         if not pipeline_run:

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Iterable, Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence
 
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
@@ -26,7 +26,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
-    ) -> Iterable[InstigatorState]:
+    ) -> Sequence[InstigatorState]:
         """Return all InstigationStates present in storage.
 
         Args:
@@ -78,7 +78,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         selector_ids: Sequence[str],
         limit: Optional[int] = None,
         statuses: Optional[Sequence[TickStatus]] = None,
-    ) -> Mapping[str, Iterable[InstigatorTick]]:
+    ) -> Mapping[str, Sequence[InstigatorTick]]:
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -90,7 +90,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         after: Optional[float] = None,
         limit: Optional[int] = None,
         statuses: Optional[Sequence[TickStatus]] = None,
-    ) -> Iterable[InstigatorTick]:
+    ) -> Sequence[InstigatorTick]:
         """Get the ticks for a given instigator.
 
         Args:

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -5,7 +5,6 @@ from typing import (
     Any,
     Callable,
     ContextManager,
-    Iterable,
     Mapping,
     NamedTuple,
     Optional,
@@ -270,7 +269,7 @@ class SqlScheduleStorage(ScheduleStorage):
         selector_ids: Sequence[str],
         limit: Optional[int] = None,
         statuses: Optional[Sequence[TickStatus]] = None,
-    ) -> Mapping[str, Iterable[InstigatorTick]]:
+    ) -> Mapping[str, Sequence[InstigatorTick]]:
         check.sequence_param(selector_ids, "selector_ids", of_type=str)
         check.opt_int_param(limit, "limit")
         check.opt_sequence_param(statuses, "statuses", of_type=TickStatus)

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -28,7 +28,6 @@ from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._daemon.daemon import DaemonIterator, IntervalDaemon
-from dagster._utils import len_iter
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.tags import TagConcurrencyLimitsCounter
 
@@ -194,13 +193,13 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         in_progress_runs = self._get_in_progress_runs(instance)
 
         max_concurrent_runs_enabled = max_concurrent_runs != -1  # setting to -1 disables the limit
-        max_runs_to_launch = max_concurrent_runs - len_iter(in_progress_runs)
+        max_runs_to_launch = max_concurrent_runs - len(in_progress_runs)
         if max_concurrent_runs_enabled:
             # Possibly under 0 if runs were launched without queuing
             if max_runs_to_launch <= 0:
                 self._logger.info(
                     "{} runs are currently in progress. Maximum is {}, won't launch more.".format(
-                        len_iter(in_progress_runs), max_concurrent_runs
+                        len(in_progress_runs), max_concurrent_runs
                     )
                 )
                 return []
@@ -263,7 +262,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         runs = instance.get_runs(filters=queued_runs_filter)[::-1]
         return runs
 
-    def _get_in_progress_runs(self, instance: DagsterInstance) -> Iterable[DagsterRun]:
+    def _get_in_progress_runs(self, instance: DagsterInstance) -> Sequence[DagsterRun]:
         return instance.get_runs(filters=RunsFilter(statuses=IN_PROGRESS_RUN_STATUSES))
 
     def _priority_sort(self, runs: Iterable[DagsterRun]) -> Sequence[DagsterRun]:

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -26,14 +26,12 @@ from typing import (
     Dict,
     Generator,
     Generic,
-    Iterable,
     Iterator,
     List,
     Mapping,
     NamedTuple,
     Optional,
     Sequence,
-    Sized,
     Tuple,
     Type,
     TypeVar,
@@ -725,18 +723,6 @@ def get_run_crash_explanation(prefix: str, exit_code: int):
         exit_clause = f"unexpectedly exited with code {exit_code}."
 
     return prefix + " " + exit_clause
-
-
-def len_iter(iterable: Iterable[object]) -> int:
-    if isinstance(iterable, Sized):
-        return len(iterable)
-    return sum(1 for _ in iterable)
-
-
-def iter_to_list(iterable: Iterable[T]) -> List[T]:
-    if isinstance(iterable, List):
-        return iterable
-    return list(iterable)
 
 
 def last_file_comp(path: str) -> str:

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -45,7 +45,7 @@ from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.backfill import execute_backfill_iteration
 from dagster._legacy import ModeDefinition, pipeline
 from dagster._seven import IS_WINDOWS, get_system_temp_directory
-from dagster._utils import len_iter, touch_file
+from dagster._utils import touch_file
 from dagster._utils.error import SerializableErrorInfo
 
 default_mode_def = ModeDefinition(resource_defs={"io_manager": fs_io_manager})
@@ -703,10 +703,10 @@ def test_backfill_with_asset_selection(
         assert step_succeeded(instance, run, "bar")
     # selected
     for asset_key in asset_selection:
-        assert len_iter(instance.run_ids_for_asset_key(asset_key)) == 3
+        assert len(instance.run_ids_for_asset_key(asset_key)) == 3
     # not selected
     for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
-        assert len_iter(instance.run_ids_for_asset_key(asset_key)) == 0
+        assert len(instance.run_ids_for_asset_key(asset_key)) == 0
 
 
 def test_pure_asset_backfill(
@@ -752,10 +752,10 @@ def test_pure_asset_backfill(
         assert step_succeeded(instance, run, "bar")
     # selected
     for asset_key in asset_selection:
-        assert len_iter(instance.run_ids_for_asset_key(asset_key)) == 3
+        assert len(instance.run_ids_for_asset_key(asset_key)) == 3
     # not selected
     for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
-        assert len_iter(instance.run_ids_for_asset_key(asset_key)) == 0
+        assert len(instance.run_ids_for_asset_key(asset_key)) == 0
 
     backfill = instance.get_backfill("backfill_with_asset_selection")
     assert backfill

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
@@ -26,7 +26,7 @@ from dagster._legacy import (
     ModeDefinition,
     pipeline,
 )
-from dagster._utils import file_relative_path, len_iter
+from dagster._utils import file_relative_path
 from dagster._utils.test import copy_directory
 
 
@@ -241,7 +241,7 @@ def test_execution_plan_snapshot_backcompat():
 if __name__ == "__main__":
     with DagsterInstance.get() as gen_instance:
         empty_runs = gen_instance.get_runs()
-        assert len_iter(empty_runs) == 0
+        assert len(empty_runs) == 0
         gen_instance.create_run_for_pipeline(
             pipeline_def=dynamic_pipeline,
             run_config={"solids": {"emit": {"inputs": {"range_input": 5}}}},


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5215

Several storage and `DagsterInstance` methods like `get_runs` were annotated with `Iterable` returns, despite the fact that many callsites assume a `Sequence` and all implementations are returning lists. This updates the annotations to `Sequence` and in the process eliminates many type errors.

I also deleted two utility functions (`len_iter`, `iter_to_list`) that existed to work around the issues with the old annotations.

Confirmed with @prha that these annotations are erroneous and don't actually support some other instance/storage implementation somewhere: https://elementl-workspace.slack.com/archives/C03A0D72A6T/p1679081865061649

## How I Tested These Changes

Existing test suite.
