### PR TITLE
Update k8s repliacs docs

### DIFF
--- a/docs/content/deployment/overview.mdx
+++ b/docs/content/deployment/overview.mdx
@@ -82,8 +82,8 @@ Dagster requires three long-running services, which are outlined in the table be
       </td>
       <td>
         Code location servers serve metadata about the collection of its Dagster
-        definitions. You can have many code location servers; each server can
-        have one or more replicas.
+        definitions. You can have many code location servers, but currently each
+        code location can only have one replica for its server.
       </td>
       <td>Supported</td>
     </tr>


### PR DESCRIPTION
Summary:
Docs currently incorrectly say that user code deploymetns can have replicas - we could fix this (see https://github.com/dagster-io/dagster/issues/13016) - but it's not currently possible.

## Summary & Motivation

## How I Tested These Changes
