### PR TITLE
[freshness-refactor][4/n] Simplify scheduling algorithm

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -379,6 +379,7 @@ class AssetGraph:
             *(
                 self.get_downstream_freshness_policies(asset_key=child_key)
                 for child_key in self.get_children(asset_key)
+                if child_key != asset_key
             )
         )
         current_policy = self.freshness_policies_by_key.get(asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -371,6 +371,22 @@ class AssetGraph:
             {key for key in level} for level in toposort.toposort(self._asset_dep_graph["upstream"])
         ]
 
+    @cached_method
+    def get_downstream_freshness_policies(
+        self, *, asset_key: AssetKey
+    ) -> AbstractSet[FreshnessPolicy]:
+        downstream_policies = set().union(
+            *(
+                self.get_downstream_freshness_policies(asset_key=child_key)
+                for child_key in self.get_children(asset_key)
+            )
+        )
+        current_policy = self.freshness_policies_by_key.get(asset_key)
+        if current_policy is not None:
+            downstream_policies.add(current_policy)
+
+        return downstream_policies
+
     def has_self_dependency(self, asset_key: AssetKey) -> bool:
         return asset_key in self.get_parents(asset_key)
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -383,7 +383,7 @@ class AssetGraph:
             )
         )
         current_policy = self.freshness_policies_by_key.get(asset_key)
-        if current_policy is not None:
+        if self.get_partitions_def(asset_key) is None and current_policy is not None:
             downstream_policies.add(current_policy)
 
         return downstream_policies

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -563,21 +563,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
     eventually_materialize: Set[AssetKeyPartitionKey] = set()
     expected_data_time_by_key: Dict[AssetKey, Optional[datetime.datetime]] = {}
 
-    # EXPERIMENT: handle the root data assets
-    levels = asset_graph.toposort_asset_keys()
-    for key in levels[0]:
-        """get a mapping from downstream asset key to downstream freshness policy
-
-        for each asset_key,freshness policy pair, get the execution period for that policy
-
-        do the execution period thing, keeping track of which downstream assets have freshness
-        policies that made it into the merge
-
-        * somehow we want to optimize for the minimum number of runs across all root assets
-        """
-        pass
-
-    for level in levels[1:]:
+    for level in asset_graph.toposort_asset_keys():
         for key in level:
             if asset_graph.is_source(key) or not asset_graph.get_downstream_freshness_policies(
                 asset_key=key

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -23,7 +23,7 @@ from dagster._annotations import experimental
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.freshness_policy import FreshnessConstraint, FreshnessPolicy
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import AbstractSet, FrozenSet, NamedTuple, Optional
+from typing import AbstractSet, FrozenSet, NamedTuple, Optional, Tuple
 
 import pendulum
 
@@ -148,6 +148,14 @@ class FreshnessPolicy(
     @property
     def maximum_lag_delta(self) -> datetime.timedelta:
         return datetime.timedelta(minutes=self.maximum_lag_minutes)
+
+    def get_execution_window(
+        self,
+        data_time: Optional[datetime.datetime],
+        evaluation_time: datetime.datetime,
+    ) -> Tuple[datetime.datetime, datetime.datetime]:
+        if data_time is None:
+            return (evaluation_time, evaluation_time)
 
     def constraints_for_time_window(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -149,68 +149,6 @@ class FreshnessPolicy(
     def maximum_lag_delta(self) -> datetime.timedelta:
         return datetime.timedelta(minutes=self.maximum_lag_minutes)
 
-    def get_execution_window(
-        self,
-        data_time: Optional[datetime.datetime],
-        evaluation_time: datetime.datetime,
-    ) -> Tuple[datetime.datetime, datetime.datetime]:
-        if data_time is None:
-            return (evaluation_time, evaluation_time)
-
-    def constraints_for_time_window(
-        self,
-        window_start: datetime.datetime,
-        window_end: datetime.datetime,
-        upstream_keys: FrozenSet[AssetKey],
-    ) -> AbstractSet[FreshnessConstraint]:
-        """For a given time window, calculate a set of FreshnessConstraints that this asset must
-        satisfy.
-
-        Args:
-            window_start (datetime): The start time of the window that constraints will be
-                calculated for. Generally, this is the current time.
-            window_start (datetime): The end time of the window that constraints will be
-                calculated for.
-            upstream_keys (FrozenSet[AssetKey]): The relevant upstream keys for this policy.
-        """
-        constraints = set()
-
-        # get an iterator of times to evaluate these constraints at
-        if self.cron_schedule:
-            constraint_ticks = cron_string_iterator(
-                start_timestamp=window_start.timestamp(),
-                cron_string=self.cron_schedule,
-                execution_timezone=self.cron_schedule_timezone,
-            )
-        else:
-            # this constraint must be satisfied at all points in time, so generate a series of
-            # many constraints (10 per maximum lag window)
-            period = pendulum.period(pendulum.instance(window_start), pendulum.instance(window_end))
-            # old versions of pendulum return a list, so ensure this is an iterator
-            constraint_ticks = iter(
-                period.range("minutes", (self.maximum_lag_minutes / 10.0) + 0.1)
-            )
-
-        # iterate over each schedule tick in the provided time window
-        evaluation_tick = next(constraint_ticks, None)
-        while evaluation_tick is not None and evaluation_tick < window_end:
-            required_data_time = evaluation_tick - self.maximum_lag_delta
-            required_by_time = evaluation_tick
-
-            constraints.add(
-                FreshnessConstraint(
-                    asset_keys=upstream_keys,
-                    required_data_time=required_data_time,
-                    required_by_time=required_by_time,
-                )
-            )
-
-            evaluation_tick = next(constraint_ticks, None)
-            # fallback if the user selects a very small maximum_lag_minutes value
-            if len(constraints) > 100:
-                break
-        return constraints
-
     def minutes_late(
         self,
         data_time: Optional[datetime.datetime],

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import AbstractSet, FrozenSet, NamedTuple, Optional, Tuple
+from typing import AbstractSet, NamedTuple, Optional
 
 import pendulum
 
@@ -8,7 +8,6 @@ from dagster._annotations import experimental
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.schedules import (
-    cron_string_iterator,
     is_valid_cron_schedule,
     reverse_cron_string_iterator,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -1319,6 +1319,7 @@ def test_reconciliation(scenario):
     instance = DagsterInstance.ephemeral()
     run_requests, _ = scenario.do_scenario(instance)
 
+    print(run_requests)
     assert len(run_requests) == len(scenario.expected_run_requests)
 
     def sort_run_request_key_fn(run_request):


### PR DESCRIPTION
## Summary & Motivation

further simplifies the freshness-based scheduling logic.

completely removes the concept of "constraint propagation", in favor of just informing nodes what their downstream freshness policies are, then using those freshness policies to create time windows where it's valid to execute the asset.

## How I Tested These Changes
