### PR TITLE
Auto-infer partitions def for unresolved asset job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -34,7 +34,9 @@ class UnresolvedPartitionedAssetScheduleDefinition(NamedTuple):
     day_of_month: Optional[int]
     tags: Optional[Mapping[str, str]]
 
-    def resolve(self, asset_graph: InternalAssetGraph) -> ScheduleDefinition:
+    def resolve(
+        self, asset_graph: InternalAssetGraph, resolved_job: JobDefinition
+    ) -> ScheduleDefinition:
         selected_assets = self.job.selection.resolve(asset_graph)
         partitions_defs = {
             cast(PartitionsDefinition, asset_graph.get_partitions_def(asset_key))
@@ -59,9 +61,9 @@ class UnresolvedPartitionedAssetScheduleDefinition(NamedTuple):
         )
 
         return ScheduleDefinition(
-            job=self.job,
+            job=resolved_job,
             name=self.name,
-            execution_fn=_get_schedule_evaluation_fn(partitions_def, self.job, self.tags),
+            execution_fn=_get_schedule_evaluation_fn(partitions_def, resolved_job, self.tags),
             execution_timezone=partitions_def.timezone,
             cron_schedule=cron_schedule,
         )

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -1,9 +1,8 @@
-from typing import Callable, Mapping, NamedTuple, Optional, Union, cast
+from typing import Callable, Mapping, NamedTuple, Optional, Union
 
 import dagster._check as check
 from dagster._core.errors import DagsterInvalidDefinitionError
 
-from .asset_graph import InternalAssetGraph
 from .decorators.schedule_decorator import schedule
 from .job_definition import JobDefinition
 from .multi_dimensional_partitions import MultiPartitionsDefinition
@@ -38,8 +37,8 @@ class UnresolvedPartitionedAssetScheduleDefinition(NamedTuple):
         partitions_def = resolved_job.partitions_def
         if partitions_def is None:
             check.failed(
-                "A job provided to build_schedule_from_partitioned_job must contain partitioned"
-                " assets or a partitions definition."
+                f"Job '{resolved_job.name}' provided to build_schedule_from_partitioned_job must"
+                " contain partitioned assets or a partitions definition."
             )
 
         partitions_def = _check_valid_schedule_partitions_def(partitions_def)

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -266,8 +266,7 @@ def build_caching_repository_data_from_list(
                 unresolved_partitioned_asset_schedule.job,
             )
 
-    # resolve all the UnresolvedAssetJobDefinitions and
-    # UnresolvedPartitionedAssetScheduleDefinitions using the full set of assets
+    # resolve all the UnresolvedAssetJobDefinitions using the full set of assets
     if unresolved_jobs:
         for name, unresolved_job_def in unresolved_jobs.items():
             resolved_job = unresolved_job_def.resolve(
@@ -275,6 +274,8 @@ def build_caching_repository_data_from_list(
             )
             pipelines_or_jobs[name] = resolved_job
 
+    # resolve all the UnresolvedPartitionedAssetScheduleDefinitions using
+    # the resolved job containing the partitions def
     if unresolved_partitioned_asset_schedules:
         for (
             name,
@@ -282,7 +283,7 @@ def build_caching_repository_data_from_list(
         ) in unresolved_partitioned_asset_schedules.items():
             resolved_job = pipelines_or_jobs[unresolved_partitioned_asset_schedule.job.name]
             schedules[name] = unresolved_partitioned_asset_schedule.resolve(
-                asset_graph, cast(JobDefinition, resolved_job)
+                cast(JobDefinition, resolved_job)
             )
 
     for pipeline_or_job in pipelines_or_jobs.values():

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -31,6 +31,9 @@ from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.partition import PartitionSetDefinition
+from dagster._core.definitions.partitioned_schedule import (
+    UnresolvedPartitionedAssetScheduleDefinition,
+)
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
@@ -229,26 +232,6 @@ def build_caching_repository_data_from_list(
         source_assets_by_key = {}
         assets_defs_by_key = {}
 
-    asset_graph = AssetGraph.from_assets(
-        [*combined_asset_group.assets, *combined_asset_group.source_assets]
-        if combined_asset_group
-        else []
-    )
-
-    # resolve all the UnresolvedAssetJobDefinitions and
-    # UnresolvedPartitionedAssetScheduleDefinitions using the full set of assets
-    if unresolved_partitioned_asset_schedules:
-        for (
-            name,
-            unresolved_partitioned_asset_schedule,
-        ) in unresolved_partitioned_asset_schedules.items():
-            schedules[name] = unresolved_partitioned_asset_schedule.resolve(asset_graph)
-            if schedules[name].has_loadable_target():
-                target = schedules[name].load_target()
-                _process_and_validate_target(
-                    schedules[name], coerced_graphs, unresolved_jobs, pipelines_or_jobs, target
-                )
-
     for name, sensor_def in sensors.items():
         if sensor_def.has_loadable_targets():
             targets = sensor_def.load_targets()
@@ -264,12 +247,43 @@ def build_caching_repository_data_from_list(
                 schedule_def, coerced_graphs, unresolved_jobs, pipelines_or_jobs, target
             )
 
+    asset_graph = AssetGraph.from_assets(
+        [*combined_asset_group.assets, *combined_asset_group.source_assets]
+        if combined_asset_group
+        else []
+    )
+
+    if unresolved_partitioned_asset_schedules:
+        for (
+            name,
+            unresolved_partitioned_asset_schedule,
+        ) in unresolved_partitioned_asset_schedules.items():
+            _process_and_validate_target(
+                unresolved_partitioned_asset_schedule,
+                coerced_graphs,
+                unresolved_jobs,
+                pipelines_or_jobs,
+                unresolved_partitioned_asset_schedule.job,
+            )
+
+    # resolve all the UnresolvedAssetJobDefinitions and
+    # UnresolvedPartitionedAssetScheduleDefinitions using the full set of assets
     if unresolved_jobs:
         for name, unresolved_job_def in unresolved_jobs.items():
             resolved_job = unresolved_job_def.resolve(
                 asset_graph=asset_graph, default_executor_def=default_executor_def
             )
             pipelines_or_jobs[name] = resolved_job
+
+    if unresolved_partitioned_asset_schedules:
+        for (
+            name,
+            unresolved_partitioned_asset_schedule,
+        ) in unresolved_partitioned_asset_schedules.items():
+            resolved_job = pipelines_or_jobs[unresolved_partitioned_asset_schedule.job.name]
+            schedules[name] = unresolved_partitioned_asset_schedule.resolve(
+                asset_graph, cast(JobDefinition, resolved_job)
+            )
 
     for pipeline_or_job in pipelines_or_jobs.values():
         pipeline_or_job.validate_resource_requirements_satisfied()
@@ -384,7 +398,9 @@ def build_caching_repository_data_from_dict(
 
 
 def _process_and_validate_target(
-    schedule_or_sensor_def: Union[SensorDefinition, ScheduleDefinition],
+    schedule_or_sensor_def: Union[
+        SensorDefinition, ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition
+    ],
     coerced_graphs: Dict[str, JobDefinition],
     unresolved_jobs: Dict[str, UnresolvedAssetJobDefinition],
     pipelines_or_jobs: Dict[str, PipelineDefinition],

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -19,7 +19,6 @@ from dagster import (
     op,
     repository,
 )
-from dagster._check import CheckError
 from dagster._core.definitions import asset, multi_asset
 from dagster._core.definitions.load_assets_from_modules import prefix_assets
 from dagster._core.definitions.partition import (
@@ -626,7 +625,7 @@ def test_intersecting_partitions_on_repo_invalid():
     def d(c):
         return c
 
-    with pytest.raises(CheckError, match="partitions_def of Daily"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="must have the same partitions_def"):
 
         @repository
         def my_repo():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -625,7 +625,7 @@ def test_intersecting_partitions_on_repo_invalid():
     def d(c):
         return c
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="must have the same partitions_def"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="must have the same partitions def"):
 
         @repository
         def my_repo():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -545,7 +545,6 @@ def test_unresolved_partitioned_asset_schedule():
     assert defs_with_explicit_job.get_schedule_def("job1_schedule").cron_schedule == "0 0 * * *"
 
     defs_with_implicit_job = Definitions(schedules=[schedule1], assets=[asset1])
-    defs_with_implicit_job = Definitions(jobs=[job1], schedules=[schedule1], assets=[asset1])
     assert defs_with_implicit_job.get_job_def("job1").name == "job1"
     assert defs_with_implicit_job.get_job_def("job1").partitions_def == partitions_def
     assert defs_with_implicit_job.get_schedule_def("job1_schedule").cron_schedule == "0 0 * * *"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -439,3 +439,30 @@ def test_invalid_multipartitioned_job_schedule():
         build_schedule_from_partitioned_job(
             define_asset_job("multipartitions_job", [my_asset], partitions_def=multipartitions_def)
         )
+
+
+def test_unresolved_partitioned_schedule():
+    partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
+
+    @asset(partitions_def=partitions_def)
+    def asset1():
+        return 1
+
+    job1 = define_asset_job("job1")
+    schedule1 = build_schedule_from_partitioned_job(job1)
+
+    @repository
+    def my_repo():
+        return [asset1, job1, schedule1]
+
+    run_requests = (
+        my_repo.get_schedule_def("job1_schedule")
+        .evaluate_tick(
+            build_schedule_context(
+                scheduled_execution_time=datetime.strptime("2020-01-02", DATE_FORMAT)
+            )
+        )
+        .run_requests
+    )
+    assert len(run_requests) == 1
+    assert run_requests[0].partition_key == "2020-01-01"


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/12984

The cause of the error was that the unresolved partitioned schedule definition targeted an unresolved asset job that did not have a partitions definition, thus the call to `run_request_for_partition` threw an error.

In order to fix the issue above, this PR modifies unresolved asset jobs to determine their own partitions def based on the selected assets. Resolving an `UnresolvedPartitionedAssetScheduleDefinition` is now split into three steps:
- validating the target job
- resolving the target job into a `JobDefinition` and inferring its partitions def
- replacing the schedule's target job with the resolved `JobDefinition`
