### PR TITLE
AssetSelection allow source assets, error for mixed

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -86,7 +86,7 @@ class AssetGraph:
 
     @staticmethod
     def from_assets(
-        all_assets: Sequence[Union[AssetsDefinition, SourceAsset]]
+        all_assets: Iterable[Union[AssetsDefinition, SourceAsset]]
     ) -> "InternalAssetGraph":
         assets_defs: List[AssetsDefinition] = []
         source_assets: List[SourceAsset] = []

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -8,6 +8,7 @@ from dagster._core.definitions import AssetKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.selector.subset_selector import parse_clause
+from dagster._utils.backcompat import deprecation_warning
 
 from .asset_layer import build_asset_selection_job
 from .config import ConfigMapping
@@ -191,7 +192,11 @@ class UnresolvedAssetJobDefinition(
                 check.failed(
                     "If asset_graph is not provided, must provide both assets and source_assets"
                 )
-
+            deprecation_warning(
+                "`assets` and `source_assets` arguments to `resolve`",
+                "1.3.0",
+                "Please use the `asset_graph` argument instead.",
+            )
             asset_graph = AssetGraph.from_assets([*assets, *source_assets])
 
         return build_asset_selection_job(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -1,20 +1,24 @@
 import operator
 from functools import reduce
+from typing import AbstractSet, Iterable, Union
 
 import pytest
 from dagster import (
     AssetIn,
-    DagsterInvalidSubsetError,
     DailyPartitionsDefinition,
     SourceAsset,
     TimeWindowPartitionMapping,
 )
 from dagster._core.definitions import AssetSelection, asset
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
+from typing_extensions import TypeAlias
+
+earth = SourceAsset("earth")
 
 
 @asset(group_name="ladies")
-def alice():
+def alice(earth):
     return "alice"
 
 
@@ -48,9 +52,13 @@ def george(bob, fiona):
     return "george"
 
 
+_AssetList: TypeAlias = Iterable[Union[AssetsDefinition, SourceAsset]]
+
+
 @pytest.fixture
-def all_assets():
+def all_assets() -> _AssetList:
     return [
+        earth,
         alice,
         bob,
         candace,
@@ -61,21 +69,24 @@ def all_assets():
     ]
 
 
-def _asset_keys_of(assets_defs):
-    return reduce(operator.or_, [assets_def.keys for assets_def in assets_defs])
+def _asset_keys_of(assets_defs: _AssetList) -> AbstractSet[AssetKey]:
+    return reduce(
+        operator.or_,
+        [item.keys if isinstance(item, AssetsDefinition) else {item.key} for item in assets_defs],
+    )
 
 
-def test_asset_selection_all(all_assets):
+def test_asset_selection_all(all_assets: _AssetList):
     sel = AssetSelection.all()
-    assert sel.resolve(all_assets) == _asset_keys_of(all_assets)
+    assert sel.resolve(all_assets) == _asset_keys_of(all_assets) - {earth.key}
 
 
-def test_asset_selection_and(all_assets):
+def test_asset_selection_and(all_assets: _AssetList):
     sel = AssetSelection.keys("alice", "bob") & AssetSelection.keys("bob", "candace")
     assert sel.resolve(all_assets) == _asset_keys_of({bob})
 
 
-def test_asset_selection_downstream(all_assets):
+def test_asset_selection_downstream(all_assets: _AssetList):
     sel_depth_inf = AssetSelection.keys("candace").downstream()
     assert sel_depth_inf.resolve(all_assets) == _asset_keys_of(
         {candace, danny, edgar, fiona, george}
@@ -85,12 +96,12 @@ def test_asset_selection_downstream(all_assets):
     assert sel_depth_1.resolve(all_assets) == _asset_keys_of({candace, danny})
 
 
-def test_asset_selection_groups(all_assets):
+def test_asset_selection_groups(all_assets: _AssetList):
     sel = AssetSelection.groups("ladies")
     assert sel.resolve(all_assets) == _asset_keys_of({alice, candace, fiona})
 
 
-def test_asset_selection_keys(all_assets):
+def test_asset_selection_keys(all_assets: _AssetList):
     sel = AssetSelection.keys(AssetKey("alice"), AssetKey("bob"))
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
 
@@ -98,17 +109,23 @@ def test_asset_selection_keys(all_assets):
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
 
 
-def test_asset_selection_assets(all_assets):
+def test_select_source_asset_keys():
+    a = SourceAsset("a")
+    selection = AssetSelection.keys(a.key)
+    assert selection.resolve([a]) == {a.key}
+
+
+def test_asset_selection_assets(all_assets: _AssetList):
     sel = AssetSelection.assets(alice, bob)
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
 
 
-def test_asset_selection_or(all_assets):
+def test_asset_selection_or(all_assets: _AssetList):
     sel = AssetSelection.keys("alice", "bob") | AssetSelection.keys("bob", "candace")
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob, candace})
 
 
-def test_asset_selection_subtraction(all_assets):
+def test_asset_selection_subtraction(all_assets: _AssetList):
     sel = AssetSelection.keys("alice", "bob") - AssetSelection.keys("bob", "candace")
     assert sel.resolve(all_assets) == _asset_keys_of({alice})
 
@@ -121,7 +138,7 @@ def test_asset_selection_subtraction(all_assets):
     assert sel.resolve(all_assets) == _asset_keys_of({bob})
 
 
-def test_asset_selection_nothing(all_assets):
+def test_asset_selection_nothing(all_assets: _AssetList):
     sel = AssetSelection.keys()
     assert sel.resolve(all_assets) == set()
 
@@ -132,7 +149,7 @@ def test_asset_selection_nothing(all_assets):
     assert sel.resolve(all_assets) == set()
 
 
-def test_asset_selection_sinks(all_assets):
+def test_asset_selection_sinks(all_assets: _AssetList):
     sel = AssetSelection.keys("alice", "bob").sinks()
     assert sel.resolve(all_assets) == _asset_keys_of({bob})
 
@@ -145,7 +162,7 @@ def test_asset_selection_sinks(all_assets):
     assert sel.resolve(all_assets) == _asset_keys_of({fiona})
 
 
-def test_asset_selection_upstream(all_assets):
+def test_asset_selection_upstream(all_assets: _AssetList):
     sel_depth_inf = AssetSelection.keys("george").upstream()
     assert sel_depth_inf.resolve(all_assets) == _asset_keys_of(
         {alice, bob, candace, danny, fiona, george}
@@ -155,17 +172,7 @@ def test_asset_selection_upstream(all_assets):
     assert sel_depth_1.resolve(all_assets) == _asset_keys_of({bob, fiona, george})
 
 
-def test_select_source_asset_keys():
-    a = SourceAsset("a")
-    selection = AssetSelection.keys(a.key)
-    with pytest.raises(
-        DagsterInvalidSubsetError,
-        match="these keys are supplied by SourceAsset objects, not AssetsDefinition objects",
-    ):
-        selection.resolve([a])
-
-
-def test_downstream_include_self(all_assets):
+def test_downstream_include_self(all_assets: _AssetList):
     selection = AssetSelection.keys("candace").downstream(include_self=False)
     assert selection.resolve(all_assets) == _asset_keys_of({danny, edgar, fiona, george})
 
@@ -176,7 +183,7 @@ def test_downstream_include_self(all_assets):
     assert selection.resolve(all_assets) == _asset_keys_of({george, danny, bob, edgar})
 
 
-def test_upstream_include_self(all_assets):
+def test_upstream_include_self(all_assets: _AssetList):
     selection = AssetSelection.keys("george").upstream(include_self=False)
     assert selection.resolve(all_assets) == _asset_keys_of({danny, fiona, alice, bob, candace})
 
@@ -185,6 +192,25 @@ def test_upstream_include_self(all_assets):
 
     selection = AssetSelection.groups("ladies").upstream(include_self=False)
     assert selection.resolve(all_assets) == _asset_keys_of({danny})
+
+
+def test_roots():
+    @asset
+    def a():
+        pass
+
+    @asset
+    def b(a):
+        pass
+
+    @asset
+    def c(b):
+        pass
+
+    assert AssetSelection.keys("a", "b", "c").roots().resolve([a, b, c]) == {a.key}
+    assert AssetSelection.keys("a", "c").roots().resolve([a, b, c]) == {a.key}
+    assert AssetSelection.keys("b", "c").roots().resolve([a, b, c]) == {b.key}
+    assert AssetSelection.keys("c").roots().resolve([a, b, c]) == {c.key}
 
 
 def test_sources():
@@ -200,10 +226,8 @@ def test_sources():
     def c(b):
         pass
 
-    assert AssetSelection.keys("a", "b", "c").sources().resolve([a, b, c]) == {a.key}
-    assert AssetSelection.keys("a", "c").sources().resolve([a, b, c]) == {a.key}
-    assert AssetSelection.keys("b", "c").sources().resolve([a, b, c]) == {b.key}
-    assert AssetSelection.keys("c").sources().resolve([a, b, c]) == {c.key}
+    with pytest.warns(DeprecationWarning):
+        assert AssetSelection.keys("a", "b", "c").sources().resolve([a, b, c]) == {a.key}
 
 
 def test_self_dep():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -33,6 +33,7 @@ from dagster import (
 )
 from dagster._config import StringSource
 from dagster._core.definitions import AssetGroup, AssetIn, SourceAsset, asset, build_assets_job
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets_job import get_base_asset_jobs
 from dagster._core.definitions.dependency import NodeHandle
@@ -65,6 +66,7 @@ def check_experimental_warnings():
                 "resource_defs" in w.message.args[0]
                 or "io_manager_def" in w.message.args[0]
                 or "build_assets_job" in w.message.args[0]
+                or "SQLALCHEMY" in w.message.args[0]  # SqlAlchemy 2.0 deprecation warnings
             ):
                 continue
             assert False, f"Unexpected warning: {w.message.args[0]}"
@@ -1358,11 +1360,12 @@ dbt_asset_def = AssetsDefinition(
 )
 
 my_job = define_asset_job("foo", selection=["a", "b", "c", "d", "e", "f"]).resolve(
-    with_resources(
-        [dbt_asset_def, fivetran_asset],
-        resource_defs={"my_resource": my_resource, "my_resource_2": my_resource_2},
-    ),
-    [],
+    asset_graph=AssetGraph.from_assets(
+        with_resources(
+            [dbt_asset_def, fivetran_asset],
+            resource_defs={"my_resource": my_resource, "my_resource_2": my_resource_2},
+        ),
+    )
 )
 
 
@@ -1424,7 +1427,7 @@ def test_job_preserved_with_asset_subset():
         },
         description="my cool job",
         tags={"yay": 1},
-    ).resolve([asset_one, two, three], [])
+    ).resolve(asset_graph=AssetGraph.from_assets([asset_one, two, three]))
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
     assert result.success
@@ -1448,7 +1451,9 @@ def test_job_default_config_preserved_with_asset_subset():
     def three(context, two):
         assert context.op_config["baz"] == 3
 
-    foo_job = define_asset_job("foo_job").resolve([asset_one, two, three], [])
+    foo_job = define_asset_job("foo_job").resolve(
+        asset_graph=AssetGraph.from_assets([asset_one, two, three])
+    )
 
     result = foo_job.execute_in_process(asset_selection=[AssetKey("one")])
     assert result.success
@@ -1466,7 +1471,9 @@ def test_empty_asset_job():
     empty_selection = AssetSelection.keys("a", "b") - AssetSelection.keys("a", "b")
     assert empty_selection.resolve([a, b]) == set()
 
-    empty_job = define_asset_job("empty_job", selection=empty_selection).resolve([a, b], [])
+    empty_job = define_asset_job("empty_job", selection=empty_selection).resolve(
+        asset_graph=AssetGraph.from_assets([a, b])
+    )
     assert empty_job.all_node_defs == []
 
     result = empty_job.execute_in_process()

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -441,7 +441,7 @@ def test_define_selection_job_assets_definition_selection():
     job1.execute_in_process()
 
 
-def test_source_asset_selection():
+def test_root_asset_selection():
     @asset
     def a(source):
         return source + 1
@@ -450,6 +450,7 @@ def test_source_asset_selection():
     def b(a):
         return a + 1
 
+    # Source asset should not be included in the job
     assert define_asset_job("job", selection="*b").resolve(
         assets=[a, b], source_assets=[SourceAsset("source")]
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
@@ -7,6 +7,1225 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['test_external_pipeline_data 1'] = '''{
+  "__class__": "ExternalPipelineData",
+  "active_presets": [
+    {
+      "__class__": "ExternalPresetData",
+      "mode": "mode_one",
+      "name": "kitchen_sink_preset",
+      "run_config": {
+        "foo": "bar"
+      },
+      "solid_selection": [
+        "a_solid"
+      ],
+      "tags": {}
+    },
+    {
+      "__class__": "ExternalPresetData",
+      "mode": "default",
+      "name": "plain_preset",
+      "run_config": {},
+      "solid_selection": null,
+      "tags": {}
+    }
+  ],
+  "is_job": false,
+  "name": "a_pipeline",
+  "parent_pipeline_snapshot": null,
+  "pipeline_snapshot": {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Array.Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d": {
+          "__class__": "ConfigTypeSnap",
+          "description": "List of Array.Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d",
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "Array.Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ARRAY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d"
+          ]
+        },
+        "Array.String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "List of Array.String",
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "Array.String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ARRAY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String"
+          ]
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "ScalarUnion.String-Shape.24ddf8da2b4484ca9c900e229e17286c1e1f6e85": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Shape.24ddf8da2b4484ca9c900e229e17286c1e1f6e85",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Shape.24ddf8da2b4484ca9c900e229e17286c1e1f6e85"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.1c1582f52086a27e6bcd0f36726fb599317b651c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"config\\": {\\"retries\\": {\\"enabled\\": {}}}}",
+              "description": null,
+              "is_required": false,
+              "name": "in_process",
+              "type_key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"config\\": {\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}}",
+              "description": null,
+              "is_required": false,
+              "name": "multiprocess",
+              "type_key": "Shape.92756569f6a8d8b0d744106fc51a929583a0419c"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1c1582f52086a27e6bcd0f36726fb599317b651c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.8318f5aff6cd0698a5c7fedfb9bdc75fd8006db8": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure the multiprocess executor to start subprocesses using `forkserver`.",
+              "is_required": false,
+              "name": "forkserver",
+              "type_key": "Shape.4b5c35afb20df31266eeee7e8c1060f1b490d054"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure the multiprocess executor to start subprocesses using `spawn`.",
+              "is_required": false,
+              "name": "spawn",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.8318f5aff6cd0698a5c7fedfb9bdc75fd8006db8",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\\"INFO\\"",
+              "description": "The logger\'s threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\\"dagster\\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.09d73f0755bf4752d3f121837669c8660dcf451e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"retries\\": {\\"enabled\\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.09d73f0755bf4752d3f121837669c8660dcf451e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "key",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "limit",
+              "type_key": "Int"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "value",
+              "type_key": "ScalarUnion.String-Shape.24ddf8da2b4484ca9c900e229e17286c1e1f6e85"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"log_level\\": \\"INFO\\", \\"name\\": \\"dagster\\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.17b6a168d89648299f5fa63c548ecef2405875ca": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "field_aliases": {
+            "solids": "ops"
+          },
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.17b6a168d89648299f5fa63c548ecef2405875ca",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.24ddf8da2b4484ca9c900e229e17286c1e1f6e85": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "applyLimitPerUniqueValue",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.24ddf8da2b4484ca9c900e229e17286c1e1f6e85",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"enabled\\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f24ac55059da1634e84af6c1bf7e0ed332251c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b5c35afb20df31266eeee7e8c1060f1b490d054": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Explicitly specify the modules to preload in the forkserver. Otherwise, there are two cases for default values if modules are not specified. If the Dagster job was loaded from a module, the same module will be preloaded. If not, the `dagster` module is preloaded.",
+              "is_required": false,
+              "name": "preload_modules",
+              "type_key": "Array.String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b5c35afb20df31266eeee7e8c1060f1b490d054",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.51de22a0beeb2c24796d84de27f258728bb7ede3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "field_aliases": {
+            "solids": "ops"
+          },
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"in_process\\": {}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Selector.1c1582f52086a27e6bcd0f36726fb599317b651c"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"io_manager\\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.95e096750f330490a26714025addb5f403b099e6"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"a_solid\\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "solids",
+              "type_key": "Shape.84b2f458a3dedc93b723ab8e48e6df374839d229"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.51de22a0beeb2c24796d84de27f258728bb7ede3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.60acefe08e1243b47034a632522b12985eb4acd1": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "0",
+              "description": "The number of processes that may run concurrently. By default, this is set to be the return value of `multiprocessing.cpu_count()`.",
+              "is_required": false,
+              "name": "max_concurrent",
+              "type_key": "Int"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"enabled\\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Select how subprocesses are created. By default, `spawn` is selected. See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods.",
+              "is_required": false,
+              "name": "start_method",
+              "type_key": "Selector.8318f5aff6cd0698a5c7fedfb9bdc75fd8006db8"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "A set of limits that are applied to steps with particular tags. If a value is set, the limit is applied to only that key-value pair. If no value is set, the limit is applied across all values of that key. If the value is set to a dict with `applyLimitPerUniqueValue: true`, the limit will apply to the number of unique values for that key. Note that these limits are per run, not global.",
+              "is_required": false,
+              "name": "tag_concurrency_limits",
+              "type_key": "Array.Shape.0c1ec89f38a496d79fd06df0e76cb61d9c5b7a8d"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.60acefe08e1243b47034a632522b12985eb4acd1",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.84b2f458a3dedc93b723ab8e48e6df374839d229": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "field_aliases": {
+            "solids": "ops"
+          },
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "a_solid",
+              "type_key": "Shape.17b6a168d89648299f5fa63c548ecef2405875ca"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.84b2f458a3dedc93b723ab8e48e6df374839d229",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.92756569f6a8d8b0d744106fc51a929583a0419c": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"max_concurrent\\": 0, \\"retries\\": {\\"enabled\\": {}}}",
+              "description": "Execute each step in an individual process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.60acefe08e1243b47034a632522b12985eb4acd1"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.92756569f6a8d8b0d744106fc51a929583a0419c",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.95e096750f330490a26714025addb5f403b099e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in IO manager that stores and retrieves values in memory.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.95e096750f330490a26714025addb5f403b099e6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "a_solid",
+          "solid_name": "a_solid",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "a_pipeline",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"log_level\\": \\"INFO\\", \\"name\\": \\"dagster\\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in IO manager that stores and retrieves values in memory.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.51de22a0beeb2c24796d84de27f258728bb7ede3"
+      },
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\\"log_level\\": \\"INFO\\", \\"name\\": \\"dagster\\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "mode_one",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in IO manager that stores and retrieves values in memory.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.51de22a0beeb2c24796d84de27f258728bb7ede3"
+      }
+    ],
+    "name": "a_pipeline",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "a_solid",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+}'''
+
 snapshots['test_external_repository_data 1'] = '''{
   "__class__": "ExternalRepositoryData",
   "external_asset_graph_data": [],

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -772,6 +772,7 @@ def test_build_multi_asset_sensor_context_asset_selection():
         bob,
         candace,
         danny,
+        earth,
         edgar,
         fiona,
         george,
@@ -785,7 +786,7 @@ def test_build_multi_asset_sensor_context_asset_selection():
 
     @repository
     def my_repo():
-        return [alice, bob, candace, danny, edgar, fiona, george, asset_selection_sensor]
+        return [earth, alice, bob, candace, danny, edgar, fiona, george, asset_selection_sensor]
 
     with instance_for_test() as instance:
         ctx = build_multi_asset_sensor_context(


### PR DESCRIPTION
## Summary & Motivation

Adjustments to `AssetSelection` and `define_asset_job`:

- `AssetSelection`
    - Allow source assets to be selected by `AssetSelection.keys`
    - Prevent `AssetSelection.upstream` from selecting source assets (previously it did, this was a bug)
    - Throw an error on resolution if selection includes both regular and mixed source assets
    - Rename `AssetSelection.sources` -> `roots`, with `sources` deprecated until 2.0. This is necessary because `sources` doesn't correspond to source assets.
- `UnresolvedAssetJob`
    - Add deprecation warning for 1.3 for passing `assets`/`source_assets` to `resolve` of `unresolved_asset_job`
    - Update internal uses of resolve to pass an `AssetGraph`

## How I Tested These Changes

- Updated some asset selection tests to operate in a context with `SourceAsset`
- Add test for `roots`
