### PR TITLE
Support FIPs environments

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -975,7 +975,7 @@ class AssetsDefinition(ResourceAddable):
     @property
     def unique_id(self) -> str:
         """A unique identifier for the AssetsDefinition that's stable across processes."""
-        return hashlib.md5((json.dumps(sorted(self.keys))).encode("utf-8")).hexdigest()
+        return hashlib.md5((json.dumps(sorted(self.keys))).encode("utf-8"), usedforsecurity=False).hexdigest()
 
     def with_resources(self, resource_defs: Mapping[str, ResourceDefinition]) -> "AssetsDefinition":
         from dagster._core.execution.resources_init import get_transitive_required_resource_keys


### PR DESCRIPTION
Set the flag that says that this is not used for security purposes (as I don't believe that it is). This will allow this code to run in FIPs environments (currently it fails saying that MD5 is not allowed to be used)

Summary & Motivation
Currently, this code fails in FIPs environments because md5 is not allowed to be used for security purposes there, and by default, that is what python assumes that it is being used for. This changes makes it clear that it is not the case so the code will work

How I Tested These Changes
I made the changes on our systems and it works.