### PR TITLE
[refactor] Remove DagsterRun, DagsterRunStatus from dagster._legacy

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -6,7 +6,7 @@ from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
 from dagster._core.snap import snapshot_from_execution_plan
-from dagster._core.storage.pipeline_run import RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import MAX_RETRIES_TAG, RETRY_STRATEGY_TAG
 from dagster._core.test_utils import create_run_for_test, instance_for_test
 from dagster._daemon.auto_run_reexecution.auto_run_reexecution import (
@@ -15,7 +15,6 @@ from dagster._daemon.auto_run_reexecution.auto_run_reexecution import (
     get_reexecution_strategy,
 )
 from dagster._daemon.auto_run_reexecution.event_log_consumer import EventLogConsumerDaemon
-from dagster._legacy import DagsterRunStatus
 
 from .utils import foo, get_foo_job_handle
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -21,9 +21,8 @@ from dagster import (
 from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.errors import DagsterRunNotFoundError
 from dagster._core.execution.stats import RunStepKeyStatsSnapshot, StepEventStatus
-from dagster._core.storage.pipeline_run import RunRecord, RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunRecord, RunsFilter
 from dagster._core.storage.tags import TagType, get_tag_type
-from dagster._legacy import DagsterRunStatus
 
 from .external import ensure_valid_config, get_external_pipeline_or_raise
 from .utils import capture_error

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -17,8 +17,8 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test, poll_for_finished_run
-from dagster._legacy import DagsterRunStatus
 from dagster._utils import Counter, safe_tempfile_path, traced_counter
 from dagster_graphql.client.query import (
     LAUNCH_PIPELINE_EXECUTION_MUTATION,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -2,9 +2,8 @@ import json
 import time
 import uuid
 
-from dagster._core.storage.pipeline_run import RunsFilter
+from dagster._core.storage.pipeline_run import DagsterRunStatus, RunsFilter
 from dagster._core.test_utils import wait_for_runs_to_finish
-from dagster._legacy import DagsterRunStatus
 from dagster._utils import file_relative_path
 from dagster_graphql.client.query import (
     LAUNCH_PIPELINE_EXECUTION_MUTATION,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -4,10 +4,10 @@ from typing import List, Tuple
 
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.host_representation.origin import ExternalPartitionSetOrigin
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import create_run_for_test
 from dagster._core.utils import make_new_backfill_id
-from dagster._legacy import DagsterRun, DagsterRunStatus
 from dagster._seven import get_system_temp_directory
 from dagster_graphql.client.query import LAUNCH_PARTITION_BACKFILL_MUTATION
 from dagster_graphql.test.utils import (

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, 
 from typing_extensions import Protocol
 
 import dagster._check as check
+from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.utils import coerce_valid_log_level, make_new_run_id
 from dagster._utils.log import get_dagster_logger
 
 if TYPE_CHECKING:
     from dagster import DagsterInstance
     from dagster._core.events import DagsterEvent
-    from dagster._legacy import DagsterRun
 
 DAGSTER_META_KEY = "dagster_meta"
 

--- a/python_modules/dagster/dagster/_legacy/__init__.py
+++ b/python_modules/dagster/dagster/_legacy/__init__.py
@@ -31,10 +31,6 @@ from dagster._core.storage.fs_io_manager import (
     custom_path_fs_io_manager as custom_path_fs_io_manager,
     fs_io_manager as fs_io_manager,
 )
-from dagster._core.storage.pipeline_run import (
-    DagsterRun as DagsterRun,
-    DagsterRunStatus as DagsterRunStatus,
-)
 from dagster._utils.partitions import (
     create_offset_partition_selector as create_offset_partition_selector,
     date_partition_range as date_partition_range,

--- a/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_retries.py
@@ -27,9 +27,9 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.retries import RetryMode
+from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
 from dagster._legacy import (
-    DagsterRun,
     execute_pipeline,
     execute_pipeline_iterator,
     pipeline,

--- a/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_logging.py
@@ -20,8 +20,9 @@ from dagster._core.execution.context.logger import InitLoggerContext
 from dagster._core.execution.plan.objects import StepFailureData
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.log_manager import DagsterLogManager
+from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import DagsterRun, ModeDefinition, execute_pipeline, execute_solid, pipeline
+from dagster._legacy import ModeDefinition, execute_pipeline, execute_solid, pipeline
 from dagster._loggers import colored_console_logger, default_system_loggers, json_console_logger
 from dagster._utils.error import SerializableErrorInfo
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -23,11 +23,10 @@ from dagster._core.launcher import DefaultRunLauncher
 from dagster._core.run_coordinator import DefaultRunCoordinator
 from dagster._core.storage.event_log import SqliteEventLogStorage
 from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
-from dagster._core.storage.pipeline_run import DagsterRunStatus
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import environ
-from dagster._legacy import DagsterRun
 
 
 def test_fs_stores():

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -25,10 +25,13 @@ from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import execute_plan
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.plan import ExecutionPlan
+from dagster._core.storage.pipeline_run import (
+    DagsterRun as DagsterRun,
+)
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._core.utils import make_new_run_id
-from dagster._legacy import AssetGroup, DagsterRun
+from dagster._legacy import AssetGroup
 from dagster_gcp.gcs import FakeGCSClient
 from dagster_gcp.gcs.io_manager import PickledObjectGCSIOManager, gcs_pickle_io_manager
 from dagster_gcp.gcs.resources import gcs_resource

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/data_frame.py
@@ -127,8 +127,7 @@ def create_dagster_pandas_dataframe_description(description, columns):
 def create_table_schema_metadata_from_dataframe(
     pandas_df: pd.DataFrame,
 ) -> TableSchemaMetadataValue:
-    """
-    This function takes a pandas DataFrame and returns its metadata as a Dagster TableSchema.
+    """This function takes a pandas DataFrame and returns its metadata as a Dagster TableSchema.
 
     Args:
         pandas_df (pandas.DataFrame): A pandas DataFrame for which to create metadata.


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5221

These classes are mistakenly in `dagster._legacy` as the result of an earlier rename of `PipelineRun(Status)` -> `DagsterRun(Status)`.

## How I Tested These Changes

Existing test suite.
