### PR TITLE
[assets-defs] Update from_op/from_graph methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -266,13 +266,14 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
-        can_subset: bool = False,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from a GraphDefinition.
 
@@ -295,28 +296,31 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the graph.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
-            group_name (Optional[str]): A group name for the constructed asset. Assets without a
-                group name are assigned to a group called "default".
-            resource_defs (Optional[Mapping[str, ResourceDefinition]]):
-                (Experimental) A mapping of resource keys to resource definitions. These resources
-                will be initialized during execution, and can be accessed from the
-                body of ops in the graph during execution.
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
-            metadata_by_output_name (Optional[Mapping[str, MetadataUserInput]]): Defines metadata to
+            resource_defs (Optional[Mapping[str, ResourceDefinition]]):
+                (Experimental) A mapping of resource keys to resource definitions. These resources
+                will be initialized during execution, and can be accessed from the
+                body of ops in the graph during execution.
+            group_name (Optional[str]): A group name for the constructed asset. Assets without a
+                group name are assigned to a group called "default".
+            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
+                associated with some or all of the output assets for this node. Keys are names of the
+                outputs, and values are the group name. Cannot be used with the group_name argument.
+            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
+                associated with each of the output asstes for this graph.
+            metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
                 asset.
-            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, FreshnessPolicy]]): Defines a
+            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
-            descriptions_by_output_name (Optional[Mapping[str, str]]): Defines a description to be
-                associated with each of the output asstes for this graph.
         """
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
@@ -324,16 +328,17 @@ class AssetsDefinition(ResourceAddable):
             node_def=graph_def,
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
+            key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
-            group_name=group_name,
-            resource_defs=resource_defs,
             partition_mappings=partition_mappings,
+            resource_defs=resource_defs,
+            group_name=group_name,
+            group_names_by_output_name=group_names_by_output_name,
+            descriptions_by_output_name=descriptions_by_output_name,
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
-            key_prefix=key_prefix,
             can_subset=can_subset,
-            descriptions_by_output_name=descriptions_by_output_name,
         )
 
     @public
@@ -346,10 +351,13 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from an OpDefinition.
 
@@ -372,19 +380,24 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the op.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
-            group_name (Optional[str]): A group name for the constructed asset. Assets without a
-                group name are assigned to a group called "default".
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
-            metadata_by_output_name (Optional[Mapping[str, MetadataUserInput]]): Defines metadata to
+            group_name (Optional[str]): A group name for the constructed asset. Assets without a
+                group name are assigned to a group called "default".
+            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
+                associated with some or all of the output assets for this node. Keys are names of the
+                outputs, and values are the group name. Cannot be used with the group_name argument.
+            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
+                associated with each of the output asstes for this graph.
+            metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
                 asset.
-            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, FreshnessPolicy]]): Defines a
+            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
@@ -393,13 +406,16 @@ class AssetsDefinition(ResourceAddable):
             node_def=op_def,
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
+            key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
-            group_name=group_name,
             partition_mappings=partition_mappings,
+            group_name=group_name,
+            group_names_by_output_name=group_names_by_output_name,
+            descriptions_by_output_name=descriptions_by_output_name,
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
-            key_prefix=key_prefix,
+            can_subset=can_subset,
         )
 
     @staticmethod
@@ -408,16 +424,17 @@ class AssetsDefinition(ResourceAddable):
         *,
         keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
         keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
+        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
-        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-        can_subset: bool = False,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", NodeDefinition)
         keys_by_input_name = _infer_keys_by_input_names(
@@ -438,7 +455,6 @@ class AssetsDefinition(ResourceAddable):
         resource_defs = check.opt_mapping_param(
             resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition
         )
-
         transformed_internal_asset_deps: Dict[AssetKey, AbstractSet[AssetKey]] = {}
         if internal_asset_deps:
             for output_name, asset_keys in internal_asset_deps.items():
@@ -462,13 +478,24 @@ class AssetsDefinition(ResourceAddable):
             )
             keys_by_output_name_with_prefix[output_name] = key_with_key_prefix
 
-        # For graph backed assets, we assign all assets to the same group_name, if specified.
-        # To assign to different groups, use .with_prefix_or_groups.
-        group_names_by_key = (
-            {asset_key: group_name for asset_key in keys_by_output_name_with_prefix.values()}
-            if group_name
-            else None
+        check.param_invariant(
+            group_name is None or group_names_by_output_name is None,
+            "group_name",
+            "Cannot use both group_name and group_names_by_output_name",
         )
+
+        if group_name:
+            group_names_by_key = {
+                asset_key: group_name for asset_key in keys_by_output_name_with_prefix.values()
+            }
+        elif group_names_by_output_name:
+            group_names_by_key = {
+                keys_by_output_name_with_prefix[output_name]: group_name
+                for output_name, group_name in group_names_by_output_name.items()
+                if group_name is not None
+            }
+        else:
+            group_names_by_key = None
 
         return AssetsDefinition(
             keys_by_input_name=keys_by_input_name,
@@ -491,22 +518,25 @@ class AssetsDefinition(ResourceAddable):
             metadata_by_key={
                 keys_by_output_name[output_name]: metadata
                 for output_name, metadata in metadata_by_output_name.items()
+                if metadata is not None
             }
             if metadata_by_output_name
             else None,
             freshness_policies_by_key={
                 keys_by_output_name[output_name]: freshness_policy
                 for output_name, freshness_policy in freshness_policies_by_output_name.items()
+                if freshness_policy is not None
             }
             if freshness_policies_by_output_name
             else None,
-            can_subset=can_subset,
             descriptions_by_key={
                 keys_by_output_name[output_name]: description
                 for output_name, description in descriptions_by_output_name.items()
+                if description is not None
             }
             if descriptions_by_output_name
             else None,
+            can_subset=can_subset,
         )
 
     @public


### PR DESCRIPTION
## Summary & Motivation

Refactoring the from_op/from_graph stuff slightly. Changes:

1. Reorder the argument lists: we've been tacking new things into these functions over time, and the existing ordering felt a little ugly. These are keyword-only arguments so the order doesn't change anything for the user.
2. Add a `group_names_by_output_name` argument -- previously, the group name was all or nothing. Now, you have options
3. Loosen up the input types slightly. Previously, when supplying (e.g.) `freshness_policies_by_output_name`, you could not have `None` values in the dictionary (you would need to leave the entire key-value pair out). This seemed needlessly restrictive.
4. Let you pass "can_subset" through `from_op`. We already let you do this for `from_graph`.

## How I Tested These Changes
