### PR TITLE
[dbt-assets][1/n] Basic decorator

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -267,9 +267,15 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+<<<<<<< HEAD
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+=======
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
+>>>>>>> 32fcffe614 (wip)
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
@@ -352,12 +358,17 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+<<<<<<< HEAD
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
+=======
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+>>>>>>> 32fcffe614 (wip)
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from an OpDefinition.
 
@@ -428,9 +439,16 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+<<<<<<< HEAD
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+=======
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+        can_subset: bool = False,
+>>>>>>> 32fcffe614 (wip)
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -266,13 +266,14 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
-        can_subset: bool = False,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from a GraphDefinition.
 
@@ -295,28 +296,31 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the graph.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
-            group_name (Optional[str]): A group name for the constructed asset. Assets without a
-                group name are assigned to a group called "default".
-            resource_defs (Optional[Mapping[str, ResourceDefinition]]):
-                (Experimental) A mapping of resource keys to resource definitions. These resources
-                will be initialized during execution, and can be accessed from the
-                body of ops in the graph during execution.
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
-            metadata_by_output_name (Optional[Mapping[str, MetadataUserInput]]): Defines metadata to
+            resource_defs (Optional[Mapping[str, ResourceDefinition]]):
+                (Experimental) A mapping of resource keys to resource definitions. These resources
+                will be initialized during execution, and can be accessed from the
+                body of ops in the graph during execution.
+            group_name (Optional[str]): A group name for the constructed asset. Assets without a
+                group name are assigned to a group called "default".
+            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
+                associated with some or all of the output assets for this node. Keys are names of the
+                outputs, and values are the group name. Cannot be used with the group_name argument.
+            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
+                associated with each of the output asstes for this graph.
+            metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
                 asset.
-            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, FreshnessPolicy]]): Defines a
+            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
-            descriptions_by_output_name (Optional[Mapping[str, str]]): Defines a description to be
-                associated with each of the output asstes for this graph.
         """
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
@@ -324,16 +328,17 @@ class AssetsDefinition(ResourceAddable):
             node_def=graph_def,
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
+            key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
-            group_name=group_name,
-            resource_defs=resource_defs,
             partition_mappings=partition_mappings,
+            resource_defs=resource_defs,
+            group_name=group_name,
+            group_names_by_output_name=group_names_by_output_name,
+            descriptions_by_output_name=descriptions_by_output_name,
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
-            key_prefix=key_prefix,
             can_subset=can_subset,
-            descriptions_by_output_name=descriptions_by_output_name,
         )
 
     @public
@@ -346,10 +351,13 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from an OpDefinition.
 
@@ -372,19 +380,24 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the op.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
-            group_name (Optional[str]): A group name for the constructed asset. Assets without a
-                group name are assigned to a group called "default".
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
-            metadata_by_output_name (Optional[Mapping[str, MetadataUserInput]]): Defines metadata to
+            group_name (Optional[str]): A group name for the constructed asset. Assets without a
+                group name are assigned to a group called "default".
+            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
+                associated with some or all of the output assets for this node. Keys are names of the
+                outputs, and values are the group name. Cannot be used with the group_name argument.
+            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
+                associated with each of the output asstes for this graph.
+            metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
                 asset.
-            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, FreshnessPolicy]]): Defines a
+            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
@@ -393,13 +406,16 @@ class AssetsDefinition(ResourceAddable):
             node_def=op_def,
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
+            key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
-            group_name=group_name,
             partition_mappings=partition_mappings,
+            group_name=group_name,
+            group_names_by_output_name=group_names_by_output_name,
+            descriptions_by_output_name=descriptions_by_output_name,
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
-            key_prefix=key_prefix,
+            can_subset=can_subset,
         )
 
     @staticmethod
@@ -408,16 +424,17 @@ class AssetsDefinition(ResourceAddable):
         *,
         keys_by_input_name: Optional[Mapping[str, AssetKey]] = None,
         keys_by_output_name: Optional[Mapping[str, AssetKey]] = None,
+        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-        group_name: Optional[str] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-        metadata_by_output_name: Optional[Mapping[str, MetadataUserInput]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
-        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-        can_subset: bool = False,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", NodeDefinition)
         keys_by_input_name = _infer_keys_by_input_names(
@@ -438,7 +455,6 @@ class AssetsDefinition(ResourceAddable):
         resource_defs = check.opt_mapping_param(
             resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition
         )
-
         transformed_internal_asset_deps: Dict[AssetKey, AbstractSet[AssetKey]] = {}
         if internal_asset_deps:
             for output_name, asset_keys in internal_asset_deps.items():
@@ -462,13 +478,24 @@ class AssetsDefinition(ResourceAddable):
             )
             keys_by_output_name_with_prefix[output_name] = key_with_key_prefix
 
-        # For graph backed assets, we assign all assets to the same group_name, if specified.
-        # To assign to different groups, use .with_prefix_or_groups.
-        group_names_by_key = (
-            {asset_key: group_name for asset_key in keys_by_output_name_with_prefix.values()}
-            if group_name
-            else None
+        check.param_invariant(
+            group_name is None or group_names_by_output_name is None,
+            "group_name",
+            "Cannot use both group_name and group_names_by_output_name",
         )
+
+        if group_name:
+            group_names_by_key = {
+                asset_key: group_name for asset_key in keys_by_output_name_with_prefix.values()
+            }
+        elif group_names_by_output_name:
+            group_names_by_key = {
+                keys_by_output_name_with_prefix[output_name]: group_name
+                for output_name, group_name in group_names_by_output_name.items()
+                if group_name is not None
+            }
+        else:
+            group_names_by_key = None
 
         return AssetsDefinition(
             keys_by_input_name=keys_by_input_name,
@@ -491,22 +518,25 @@ class AssetsDefinition(ResourceAddable):
             metadata_by_key={
                 keys_by_output_name[output_name]: metadata
                 for output_name, metadata in metadata_by_output_name.items()
+                if metadata is not None
             }
             if metadata_by_output_name
             else None,
             freshness_policies_by_key={
                 keys_by_output_name[output_name]: freshness_policy
                 for output_name, freshness_policy in freshness_policies_by_output_name.items()
+                if freshness_policy is not None
             }
             if freshness_policies_by_output_name
             else None,
-            can_subset=can_subset,
             descriptions_by_key={
                 keys_by_output_name[output_name]: description
                 for output_name, description in descriptions_by_output_name.items()
+                if description is not None
             }
             if descriptions_by_output_name
             else None,
+            can_subset=can_subset,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -266,28 +266,6 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        group_name: Optional[str] = None,
-        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
->>>>>>> af003fa331 (wip)
-        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-<<<<<<< HEAD
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-        group_name: Optional[str] = None,
-        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-=======
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
-        can_subset: bool = False,
->>>>>>> 32fcffe614 (wip)
-        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
-        can_subset: bool = False,
-=======
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         group_name: Optional[str] = None,
@@ -296,7 +274,6 @@ class AssetsDefinition(ResourceAddable):
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
->>>>>>> a85d147ed7 (reorder)
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from a GraphDefinition.
 
@@ -319,31 +296,12 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the graph.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            group_name (Optional[str]): A group name for the constructed asset. Assets without a
-                group name are assigned to a group called "default".
-            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
-                associated with some or all of the output assets for this node. Keys are names of the
-                outputs, and values are the group name. Cannot be used with the group_name argument.
-            resource_defs (Optional[Mapping[str, ResourceDefinition]]):
-                (Experimental) A mapping of resource keys to resource definitions. These resources
-                will be initialized during execution, and can be accessed from the
-                body of ops in the graph during execution.
->>>>>>> af003fa331 (wip)
-=======
->>>>>>> a85d147ed7 (reorder)
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> a85d147ed7 (reorder)
             resource_defs (Optional[Mapping[str, ResourceDefinition]]):
                 (Experimental) A mapping of resource keys to resource definitions. These resources
                 will be initialized during execution, and can be accessed from the
@@ -355,11 +313,6 @@ class AssetsDefinition(ResourceAddable):
                 outputs, and values are the group name. Cannot be used with the group_name argument.
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
-<<<<<<< HEAD
-=======
->>>>>>> af003fa331 (wip)
-=======
->>>>>>> a85d147ed7 (reorder)
             metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
@@ -368,14 +321,6 @@ class AssetsDefinition(ResourceAddable):
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
-                associated with each of the output asstes for this graph.
->>>>>>> af003fa331 (wip)
-=======
->>>>>>> a85d147ed7 (reorder)
         """
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
@@ -406,37 +351,13 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        group_name: Optional[str] = None,
-        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
->>>>>>> af003fa331 (wip)
-        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-<<<<<<< HEAD
-        group_name: Optional[str] = None,
-        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
-<<<<<<< HEAD
-        can_subset: bool = False,
-=======
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
->>>>>>> 32fcffe614 (wip)
-=======
-        descriptions_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-=======
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
->>>>>>> a85d147ed7 (reorder)
         can_subset: bool = False,
->>>>>>> af003fa331 (wip)
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from an OpDefinition.
 
@@ -459,27 +380,12 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the op.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            group_name (Optional[str]): A group name for the constructed asset. Assets without a
-                group name are assigned to a group called "default".
-            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
-                associated with some or all of the output assets for this node. Keys are names of the
-                outputs, and values are the group name. Cannot be used with the group_name argument.
->>>>>>> af003fa331 (wip)
-=======
->>>>>>> a85d147ed7 (reorder)
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> a85d147ed7 (reorder)
             group_name (Optional[str]): A group name for the constructed asset. Assets without a
                 group name are assigned to a group called "default".
             group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
@@ -487,11 +393,6 @@ class AssetsDefinition(ResourceAddable):
                 outputs, and values are the group name. Cannot be used with the group_name argument.
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
-<<<<<<< HEAD
-=======
->>>>>>> af003fa331 (wip)
-=======
->>>>>>> a85d147ed7 (reorder)
             metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
@@ -508,26 +409,6 @@ class AssetsDefinition(ResourceAddable):
             key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-            group_name=group_name,
-            group_names_by_output_name=group_names_by_output_name,
->>>>>>> af003fa331 (wip)
-            partition_mappings=partition_mappings,
-            group_name=group_name,
-            group_names_by_output_name=group_names_by_output_name,
-            descriptions_by_output_name=descriptions_by_output_name,
-            metadata_by_output_name=metadata_by_output_name,
-            freshness_policies_by_output_name=freshness_policies_by_output_name,
-<<<<<<< HEAD
-            can_subset=can_subset,
-=======
-            descriptions_by_output_name=descriptions_by_output_name,
-            can_subset=can_subset,
-            key_prefix=key_prefix,
->>>>>>> af003fa331 (wip)
-=======
             partition_mappings=partition_mappings,
             group_name=group_name,
             group_names_by_output_name=group_names_by_output_name,
@@ -535,7 +416,6 @@ class AssetsDefinition(ResourceAddable):
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
             can_subset=can_subset,
->>>>>>> a85d147ed7 (reorder)
         )
 
     @staticmethod
@@ -547,37 +427,14 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        group_name: Optional[str] = None,
-        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
->>>>>>> af003fa331 (wip)
-        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
-<<<<<<< HEAD
-        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
-        group_name: Optional[str] = None,
-        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-=======
-=======
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
->>>>>>> a85d147ed7 (reorder)
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
-<<<<<<< HEAD
->>>>>>> 32fcffe614 (wip)
-        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
-        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
-        can_subset: bool = False,
-=======
->>>>>>> af003fa331 (wip)
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", NodeDefinition)
         keys_by_input_name = _infer_keys_by_input_names(

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -266,6 +266,12 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
+<<<<<<< HEAD
+=======
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+>>>>>>> af003fa331 (wip)
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
 <<<<<<< HEAD
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -302,12 +308,25 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the graph.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
+<<<<<<< HEAD
+=======
+            group_name (Optional[str]): A group name for the constructed asset. Assets without a
+                group name are assigned to a group called "default".
+            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
+                associated with some or all of the output assets for this node. Keys are names of the
+                outputs, and values are the group name. Cannot be used with the group_name argument.
+            resource_defs (Optional[Mapping[str, ResourceDefinition]]):
+                (Experimental) A mapping of resource keys to resource definitions. These resources
+                will be initialized during execution, and can be accessed from the
+                body of ops in the graph during execution.
+>>>>>>> af003fa331 (wip)
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
+<<<<<<< HEAD
             resource_defs (Optional[Mapping[str, ResourceDefinition]]):
                 (Experimental) A mapping of resource keys to resource definitions. These resources
                 will be initialized during execution, and can be accessed from the
@@ -319,6 +338,8 @@ class AssetsDefinition(ResourceAddable):
                 outputs, and values are the group name. Cannot be used with the group_name argument.
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
+=======
+>>>>>>> af003fa331 (wip)
             metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
@@ -327,6 +348,11 @@ class AssetsDefinition(ResourceAddable):
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
+<<<<<<< HEAD
+=======
+            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
+                associated with each of the output asstes for this graph.
+>>>>>>> af003fa331 (wip)
         """
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
@@ -357,6 +383,11 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
+<<<<<<< HEAD
+=======
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+>>>>>>> af003fa331 (wip)
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
 <<<<<<< HEAD
         group_name: Optional[str] = None,
@@ -364,11 +395,16 @@ class AssetsDefinition(ResourceAddable):
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+<<<<<<< HEAD
         can_subset: bool = False,
 =======
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
 >>>>>>> 32fcffe614 (wip)
+=======
+        descriptions_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        can_subset: bool = False,
+>>>>>>> af003fa331 (wip)
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from an OpDefinition.
 
@@ -391,12 +427,21 @@ class AssetsDefinition(ResourceAddable):
                 either used as input to the asset or produced within the op.
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
+<<<<<<< HEAD
+=======
+            group_name (Optional[str]): A group name for the constructed asset. Assets without a
+                group name are assigned to a group called "default".
+            group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
+                associated with some or all of the output assets for this node. Keys are names of the
+                outputs, and values are the group name. Cannot be used with the group_name argument.
+>>>>>>> af003fa331 (wip)
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
                 If no entry is provided for a particular asset dependency, the partition mapping defaults
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
+<<<<<<< HEAD
             group_name (Optional[str]): A group name for the constructed asset. Assets without a
                 group name are assigned to a group called "default".
             group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
@@ -404,6 +449,8 @@ class AssetsDefinition(ResourceAddable):
                 outputs, and values are the group name. Cannot be used with the group_name argument.
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
+=======
+>>>>>>> af003fa331 (wip)
             metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
@@ -412,6 +459,8 @@ class AssetsDefinition(ResourceAddable):
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
+            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
+                associated with each of the output asstes for this graph.
         """
         return AssetsDefinition._from_node(
             node_def=op_def,
@@ -420,13 +469,24 @@ class AssetsDefinition(ResourceAddable):
             key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
+<<<<<<< HEAD
+=======
+            group_name=group_name,
+            group_names_by_output_name=group_names_by_output_name,
+>>>>>>> af003fa331 (wip)
             partition_mappings=partition_mappings,
             group_name=group_name,
             group_names_by_output_name=group_names_by_output_name,
             descriptions_by_output_name=descriptions_by_output_name,
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
+<<<<<<< HEAD
             can_subset=can_subset,
+=======
+            descriptions_by_output_name=descriptions_by_output_name,
+            can_subset=can_subset,
+            key_prefix=key_prefix,
+>>>>>>> af003fa331 (wip)
         )
 
     @staticmethod
@@ -438,6 +498,12 @@ class AssetsDefinition(ResourceAddable):
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
+<<<<<<< HEAD
+=======
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+>>>>>>> af003fa331 (wip)
         partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
 <<<<<<< HEAD
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -446,13 +512,17 @@ class AssetsDefinition(ResourceAddable):
 =======
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        descriptions_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         can_subset: bool = False,
+<<<<<<< HEAD
 >>>>>>> 32fcffe614 (wip)
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
+=======
+>>>>>>> af003fa331 (wip)
     ) -> "AssetsDefinition":
         node_def = check.inst_param(node_def, "node_def", NodeDefinition)
         keys_by_input_name = _infer_keys_by_input_names(

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -267,6 +267,7 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
@@ -286,6 +287,16 @@ class AssetsDefinition(ResourceAddable):
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
         can_subset: bool = False,
+=======
+        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        can_subset: bool = False,
+>>>>>>> a85d147ed7 (reorder)
     ) -> "AssetsDefinition":
         """Constructs an AssetsDefinition from a GraphDefinition.
 
@@ -309,6 +320,7 @@ class AssetsDefinition(ResourceAddable):
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
             group_name (Optional[str]): A group name for the constructed asset. Assets without a
                 group name are assigned to a group called "default".
@@ -320,6 +332,8 @@ class AssetsDefinition(ResourceAddable):
                 will be initialized during execution, and can be accessed from the
                 body of ops in the graph during execution.
 >>>>>>> af003fa331 (wip)
+=======
+>>>>>>> a85d147ed7 (reorder)
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
@@ -327,6 +341,9 @@ class AssetsDefinition(ResourceAddable):
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a85d147ed7 (reorder)
             resource_defs (Optional[Mapping[str, ResourceDefinition]]):
                 (Experimental) A mapping of resource keys to resource definitions. These resources
                 will be initialized during execution, and can be accessed from the
@@ -338,8 +355,11 @@ class AssetsDefinition(ResourceAddable):
                 outputs, and values are the group name. Cannot be used with the group_name argument.
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
+<<<<<<< HEAD
 =======
 >>>>>>> af003fa331 (wip)
+=======
+>>>>>>> a85d147ed7 (reorder)
             metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
@@ -349,10 +369,13 @@ class AssetsDefinition(ResourceAddable):
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
 >>>>>>> af003fa331 (wip)
+=======
+>>>>>>> a85d147ed7 (reorder)
         """
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "AssetsDefinition.from_graph")
@@ -384,6 +407,7 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
@@ -403,6 +427,14 @@ class AssetsDefinition(ResourceAddable):
 >>>>>>> 32fcffe614 (wip)
 =======
         descriptions_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+=======
+        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+        metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+>>>>>>> a85d147ed7 (reorder)
         can_subset: bool = False,
 >>>>>>> af003fa331 (wip)
     ) -> "AssetsDefinition":
@@ -428,6 +460,7 @@ class AssetsDefinition(ResourceAddable):
             partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
                 compose the assets.
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
             group_name (Optional[str]): A group name for the constructed asset. Assets without a
                 group name are assigned to a group called "default".
@@ -435,6 +468,8 @@ class AssetsDefinition(ResourceAddable):
                 associated with some or all of the output assets for this node. Keys are names of the
                 outputs, and values are the group name. Cannot be used with the group_name argument.
 >>>>>>> af003fa331 (wip)
+=======
+>>>>>>> a85d147ed7 (reorder)
             partition_mappings (Optional[Mapping[str, PartitionMapping]]): Defines how to map partition
                 keys for this asset to partition keys of upstream assets. Each key in the dictionary
                 correponds to one of the input assets, and each value is a PartitionMapping.
@@ -442,6 +477,9 @@ class AssetsDefinition(ResourceAddable):
                 to the default partition mapping for the partitions definition, which is typically maps
                 partition keys to the same partition keys in upstream assets.
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a85d147ed7 (reorder)
             group_name (Optional[str]): A group name for the constructed asset. Assets without a
                 group name are assigned to a group called "default".
             group_names_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a group name to be
@@ -449,8 +487,11 @@ class AssetsDefinition(ResourceAddable):
                 outputs, and values are the group name. Cannot be used with the group_name argument.
             descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
                 associated with each of the output asstes for this graph.
+<<<<<<< HEAD
 =======
 >>>>>>> af003fa331 (wip)
+=======
+>>>>>>> a85d147ed7 (reorder)
             metadata_by_output_name (Optional[Mapping[str, Optional[MetadataUserInput]]]): Defines metadata to
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
@@ -459,8 +500,6 @@ class AssetsDefinition(ResourceAddable):
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
-            descriptions_by_output_name (Optional[Mapping[str, Optional[str]]]): Defines a description to be
-                associated with each of the output asstes for this graph.
         """
         return AssetsDefinition._from_node(
             node_def=op_def,
@@ -469,6 +508,7 @@ class AssetsDefinition(ResourceAddable):
             key_prefix=key_prefix,
             internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
             group_name=group_name,
@@ -487,6 +527,15 @@ class AssetsDefinition(ResourceAddable):
             can_subset=can_subset,
             key_prefix=key_prefix,
 >>>>>>> af003fa331 (wip)
+=======
+            partition_mappings=partition_mappings,
+            group_name=group_name,
+            group_names_by_output_name=group_names_by_output_name,
+            descriptions_by_output_name=descriptions_by_output_name,
+            metadata_by_output_name=metadata_by_output_name,
+            freshness_policies_by_output_name=freshness_policies_by_output_name,
+            can_subset=can_subset,
+>>>>>>> a85d147ed7 (reorder)
         )
 
     @staticmethod
@@ -499,6 +548,7 @@ class AssetsDefinition(ResourceAddable):
         internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
@@ -510,10 +560,15 @@ class AssetsDefinition(ResourceAddable):
         group_name: Optional[str] = None,
         group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
 =======
+=======
+        partition_mappings: Optional[Mapping[str, PartitionMapping]] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+        group_name: Optional[str] = None,
+        group_names_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
+        descriptions_by_output_name: Optional[Mapping[str, str]] = None,
+>>>>>>> a85d147ed7 (reorder)
         metadata_by_output_name: Optional[Mapping[str, Optional[MetadataUserInput]]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
-        descriptions_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
-        key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         can_subset: bool = False,
 <<<<<<< HEAD
 >>>>>>> 32fcffe614 (wip)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorators.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorators.py
@@ -1,87 +1,22 @@
 from functools import wraps
-from typing import (
-    Any,
-    Callable,
-    Generator,
-    Iterator,
-    Mapping,
-    NamedTuple,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
-from dagster import (
-    op,
-    AssetsDefinition,
-    OpExecutionContext,
-    ConfigurableResource,
-    AssetObservation,
-    Output,
-    Out,
-    In,
-    Nothing,
-    asset,
-    materialize_to_memory,
-)
-from typing_extensions import ParamSpec
-import dagster._check as check
-from dagster._core.decorator_utils import get_function_params
-from dagster._core.definitions.decorators.op_decorator import is_context_provided
+from typing import Any, Callable, Mapping, Optional, Set
+
+from dagster import AssetsDefinition, In, Nothing, Out, op
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.input import In
 from dagster._core.definitions.metadata import MetadataUserInput
-from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
-from dagster._core.execution.context.invocation import build_op_context
-from dagster_dbt.utils import select_unique_ids_from_manifest, default_node_info_to_asset_key
-from dagster_dbt.asset_defs import _get_deps, _get_node_description
-
 from dbt.contracts.graph.manifest import WritableManifest
 
-
-class DbtExecutionContext(OpExecutionContext):
-    def __init__(
-        self,
-        op_context: OpExecutionContext,
-        manifest: WritableManifest,
-        base_select: str,
-        base_exclude: Optional[str],
-        key_by_unique_id: Mapping[str, AssetKey],
-    ):
-        super().__init__(op_context._step_execution_context)
-        self._manifest = manifest
-        self._base_select = base_select
-        self._base_exclude = base_exclude
-        self._key_by_unique_id = key_by_unique_id
-        self._unique_id_by_key = {v: k for k, v in key_by_unique_id.items()}
-
-    @property
-    def all_selected(self) -> bool:
-        return self.selected_output_names == len(self.op_def.output_defs)
-
-    @property
-    def dbt_select(self) -> str:
-        explicit_select = " ".join(self.fqn_for_key(key) for key in self.selected_asset_keys)
-        return self._base_select if self.all_selected else explicit_select
-
-    @property
-    def dbt_exclude(self) -> Optional[str]:
-        return self._base_exclude if self.all_selected else None
-
-    def key_for_unique_id(self, unique_id: str) -> AssetKey:
-        return self._key_by_unique_id[unique_id]
-
-    def unique_id_for_key(self, key: AssetKey) -> str:
-        return self._unique_id_by_key[key]
-
-    def node_info_for_key(self, key: AssetKey) -> Mapping[str, Any]:
-        return self._manifest.nodes[self.unique_id_for_key(key)]
-
-    def fqn_for_key(self, key: AssetKey) -> str:
-        return ".".join(self.node_info_for_key(key)["fqn"])
+from dagster_dbt.asset_utils import (
+    default_asset_key_fn,
+    default_description_fn,
+    default_freshness_policy_fn,
+    default_group_fn,
+    default_metadata_fn,
+    get_deps,
+)
+from dagster_dbt.utils import select_unique_ids_from_manifest
 
 
 def manifest_to_node_dict(manifest: WritableManifest) -> Mapping[str, Any]:
@@ -103,29 +38,36 @@ def dbt_assets(
     manifest_path: str,
     select: str = "*",
     exclude: Optional[str] = None,
+    models_only: bool = True,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
-    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    asset_key_fn: Callable[[Mapping[str, Any]], AssetKey] = default_node_info_to_asset_key,
-    freshness_policy_fn: Optional[Callable[[Mapping[str, Any]], Optional[FreshnessPolicy]]] = None,
-    metadata_fn: Optional[Callable[[Mapping[str, Any]], Optional[MetadataUserInput]]] = None,
+    asset_key_fn: Callable[[Mapping[str, Any]], AssetKey] = default_asset_key_fn,
+    freshness_policy_fn: Callable[
+        [Mapping[str, Any]], Optional[FreshnessPolicy]
+    ] = default_freshness_policy_fn,
+    metadata_fn: Callable[[Mapping[str, Any]], Optional[MetadataUserInput]] = default_metadata_fn,
+    group_fn: Callable[[Mapping[str, Any]], Optional[str]] = default_group_fn,
     op_name: Optional[str] = None,
     io_manager_key: Optional[str] = None,
+    required_resource_keys: Optional[Set[str]] = None,
 ) -> Callable[..., AssetsDefinition]:
     manifest: WritableManifest = WritableManifest.read_and_check_versions(manifest_path)
     unique_ids = select_unique_ids_from_manifest(
         select=select, exclude=exclude or "", manifest_parsed=manifest
     )
     manifest_dict = manifest_to_node_dict(manifest)
-    key_by_unique_id = {uid: asset_key_fn(manifest_dict[uid]) for uid in unique_ids}
 
-    deps = _get_deps(
+    deps = get_deps(
         manifest_dict,
         selected_unique_ids=unique_ids,
-        asset_resource_types=["model", "seed", "snapshot"],
+        asset_resource_types=["model"] if models_only else ["model", "seed", "snapshot"],
     )
     output_unique_ids = set(deps.keys())
-    input_unique_ids = unique_ids - output_unique_ids
+    input_unique_ids = set().union(*deps.values()) - output_unique_ids
+
+    key_by_unique_id = {
+        uid: asset_key_fn(manifest_dict[uid]) for uid in {*input_unique_ids, *output_unique_ids}
+    }
 
     def inner(fn) -> AssetsDefinition:
         @op(
@@ -135,55 +77,43 @@ def dbt_assets(
             out={
                 _chop(uid): Out(
                     dagster_type=Nothing,
-                    description=_get_node_description(
-                        manifest_dict[uid],
-                        display_raw_sql=len(unique_ids) > 200,
-                    ),
                     io_manager_key=io_manager_key,
                     is_required=False,
                 )
                 for uid in output_unique_ids
             },
+            required_resource_keys=required_resource_keys,
         )
         @wraps(fn)
         def _op(*args, **kwargs):
-            if is_context_provided(get_function_params(fn)):
-                # convert the OpExecutionContext into a DbtExecutionContext, which has
-                # additional context related to dbt
-                return fn(
-                    DbtExecutionContext(
-                        cast(OpExecutionContext, args[0]),
-                        manifest=manifest,
-                        base_select=select,
-                        base_exclude=exclude,
-                        key_by_unique_id=key_by_unique_id,
-                    ),
-                    *args[1:],
-                    **kwargs,
-                )
-            else:
-                return fn(*args, **kwargs)
+            return fn(*args, **kwargs)
 
         return AssetsDefinition.from_op(
             _op,
             keys_by_input_name={_chop(uid): key_by_unique_id[uid] for uid in input_unique_ids},
             keys_by_output_name={_chop(uid): key_by_unique_id[uid] for uid in output_unique_ids},
             key_prefix=key_prefix,
+            partitions_def=partitions_def,
             internal_asset_deps={
                 _chop(uid): {key_by_unique_id[parent_uid] for parent_uid in parent_uids}
                 for uid, parent_uids in deps.items()
             },
-            partitions_def=partitions_def,
             metadata_by_output_name={
                 _chop(uid): metadata_fn(manifest_dict[uid]) for uid in output_unique_ids
-            }
-            if metadata_fn
-            else None,
+            },
             freshness_policies_by_output_name={
                 _chop(uid): freshness_policy_fn(manifest_dict[uid]) for uid in output_unique_ids
-            }
-            if freshness_policy_fn
-            else None,
+            },
+            group_names_by_output_name={
+                _chop(uid): group_fn(manifest_dict[uid]) for uid in output_unique_ids
+            },
+            descriptions_by_output_name={
+                _chop(uid): default_description_fn(
+                    manifest_dict[uid], display_raw_sql=len(output_unique_ids) < 500
+                )
+                for uid in output_unique_ids
+            },
+            can_subset=True,
         )
 
     return inner

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorators.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorators.py
@@ -1,0 +1,136 @@
+from functools import wraps
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Iterator,
+    Mapping,
+    NamedTuple,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
+from dagster import (
+    op,
+    AssetsDefinition,
+    OpExecutionContext,
+    ConfigurableResource,
+    AssetObservation,
+    Output,
+    Out,
+    asset,
+    materialize_to_memory,
+)
+from typing_extensions import ParamSpec
+import dagster._check as check
+from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.decorators.op_decorator import is_context_provided
+from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.execution.context.invocation import build_op_context
+from torch import ExcludeDispatchKeyGuard
+
+
+class DbtExecutionContext(OpExecutionContext):
+    def __init__(
+        self,
+        op_context: OpExecutionContext,
+        manifest_path: str,
+        base_select: str,
+        base_exclude: Optional[str],
+    ):
+        super().__init__(op_context._step_execution_context)
+        self.manifest_path = manifest_path
+        self.base_select = base_select
+        self.base_exclude = base_exclude
+
+    @property
+    def all_selected(self) -> bool:
+        return self.selected_output_names == len(self.op_def.output_defs)
+
+    @property
+    def dbt_select(self) -> str:
+        return self.base_select if self.all_selected else "fqn stuff"
+
+    @property
+    def dbt_exclude(self) -> Optional[str]:
+        return self.base_exclude if self.all_selected else None
+
+
+class DbtAssetResource(ConfigurableResource):
+    project_dir: str
+    profiles_dir: str
+    json_log_format: bool = True
+
+    def _event_iterator(self, command: str, **kwargs):
+        pass
+
+    def cli(self, command: str, **kwargs):
+        pass
+
+    def run(
+        self, context: DbtExecutionContext, **kwargs
+    ) -> Iterator[Union[AssetObservation, Output]]:
+        yield from self._event_iterator(
+            "run", select=context.dbt_select, exclude=context.dbt_exclude, **kwargs
+        )
+
+
+def dbt_assets(
+    *,
+    manifest_path: str,
+    select: Optional[str] = None,
+    exclude: Optional[str] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
+    op_name: Optional[str] = None,
+    node_info_to_asset_properties_fn: Optional[
+        Callable[[Mapping[str, Any]], Mapping[str, Any]]
+    ] = None,
+) -> Callable[..., AssetsDefinition]:
+    def inner(fn) -> AssetsDefinition:
+        @op(
+            name=op_name,
+            tags={"kind": "dbt"},
+            out={"a": Out(), "b": Out()},
+        )
+        @wraps(fn)
+        def _op(*args, **kwargs):
+            if is_context_provided(get_function_params(fn)):
+                # convert the OpExecutionContext into a DbtExecutionContext, which has
+                # additional context related to dbt
+                return fn(
+                    DbtExecutionContext(cast(OpExecutionContext, args[0]), manifest_path),
+                    *args[1:],
+                    **kwargs,
+                )
+            else:
+                return fn(*args, **kwargs)
+
+        return AssetsDefinition(
+            node_def=_op,
+        )
+
+    return inner
+
+
+@dbt_assets(manifest_path="manifest.json")
+def dbt_run_assets(
+    context: DbtExecutionContext, dbt: DbtAssetResource
+):  # , dbt: DbtAssetResource):
+    print("hi")
+    print(dbt.project_dir)
+    assert isinstance(context, DbtExecutionContext)
+    assert isinstance(context, OpExecutionContext)
+    return 1, 2
+
+
+print(dbt_run_assets)
+
+materialize_to_memory(
+    [dbt_run_assets],
+    resources={
+        "dbt": DbtAssetResource(project_dir="foo", profiles_dir="bar", json_log_format=True)
+    },
+)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorators.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorators.py
@@ -20,6 +20,8 @@ from dagster import (
     AssetObservation,
     Output,
     Out,
+    In,
+    Nothing,
     asset,
     materialize_to_memory,
 )
@@ -27,24 +29,34 @@ from typing_extensions import ParamSpec
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.decorators.op_decorator import is_context_provided
+from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
+from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.input import In
+from dagster._core.definitions.metadata import MetadataUserInput
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.execution.context.invocation import build_op_context
-from torch import ExcludeDispatchKeyGuard
+from dagster_dbt.utils import select_unique_ids_from_manifest, default_node_info_to_asset_key
+from dagster_dbt.asset_defs import _get_deps, _get_node_description
+
+from dbt.contracts.graph.manifest import WritableManifest
 
 
 class DbtExecutionContext(OpExecutionContext):
     def __init__(
         self,
         op_context: OpExecutionContext,
-        manifest_path: str,
+        manifest: WritableManifest,
         base_select: str,
         base_exclude: Optional[str],
+        key_by_unique_id: Mapping[str, AssetKey],
     ):
         super().__init__(op_context._step_execution_context)
-        self.manifest_path = manifest_path
-        self.base_select = base_select
-        self.base_exclude = base_exclude
+        self._manifest = manifest
+        self._base_select = base_select
+        self._base_exclude = base_exclude
+        self._key_by_unique_id = key_by_unique_id
+        self._unique_id_by_key = {v: k for k, v in key_by_unique_id.items()}
 
     @property
     def all_selected(self) -> bool:
@@ -52,48 +64,86 @@ class DbtExecutionContext(OpExecutionContext):
 
     @property
     def dbt_select(self) -> str:
-        return self.base_select if self.all_selected else "fqn stuff"
+        explicit_select = " ".join(self.fqn_for_key(key) for key in self.selected_asset_keys)
+        return self._base_select if self.all_selected else explicit_select
 
     @property
     def dbt_exclude(self) -> Optional[str]:
-        return self.base_exclude if self.all_selected else None
+        return self._base_exclude if self.all_selected else None
+
+    def key_for_unique_id(self, unique_id: str) -> AssetKey:
+        return self._key_by_unique_id[unique_id]
+
+    def unique_id_for_key(self, key: AssetKey) -> str:
+        return self._unique_id_by_key[key]
+
+    def node_info_for_key(self, key: AssetKey) -> Mapping[str, Any]:
+        return self._manifest.nodes[self.unique_id_for_key(key)]
+
+    def fqn_for_key(self, key: AssetKey) -> str:
+        return ".".join(self.node_info_for_key(key)["fqn"])
 
 
-class DbtAssetResource(ConfigurableResource):
-    project_dir: str
-    profiles_dir: str
-    json_log_format: bool = True
+def manifest_to_node_dict(manifest: WritableManifest) -> Mapping[str, Any]:
+    raw_dict = manifest.to_dict()
+    return {
+        **raw_dict["nodes"],
+        **raw_dict["sources"],
+        **raw_dict["exposures"],
+        **raw_dict["metrics"],
+    }
 
-    def _event_iterator(self, command: str, **kwargs):
-        pass
 
-    def cli(self, command: str, **kwargs):
-        pass
-
-    def run(
-        self, context: DbtExecutionContext, **kwargs
-    ) -> Iterator[Union[AssetObservation, Output]]:
-        yield from self._event_iterator(
-            "run", select=context.dbt_select, exclude=context.dbt_exclude, **kwargs
-        )
+def _chop(unique_id: str) -> str:
+    return unique_id.split(".")[-1]
 
 
 def dbt_assets(
     *,
     manifest_path: str,
-    select: Optional[str] = None,
+    select: str = "*",
     exclude: Optional[str] = None,
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
+    asset_key_fn: Callable[[Mapping[str, Any]], AssetKey] = default_node_info_to_asset_key,
+    freshness_policy_fn: Optional[Callable[[Mapping[str, Any]], Optional[FreshnessPolicy]]] = None,
+    metadata_fn: Optional[Callable[[Mapping[str, Any]], Optional[MetadataUserInput]]] = None,
     op_name: Optional[str] = None,
-    node_info_to_asset_properties_fn: Optional[
-        Callable[[Mapping[str, Any]], Mapping[str, Any]]
-    ] = None,
+    io_manager_key: Optional[str] = None,
 ) -> Callable[..., AssetsDefinition]:
+    manifest: WritableManifest = WritableManifest.read_and_check_versions(manifest_path)
+    unique_ids = select_unique_ids_from_manifest(
+        select=select, exclude=exclude or "", manifest_parsed=manifest
+    )
+    manifest_dict = manifest_to_node_dict(manifest)
+    key_by_unique_id = {uid: asset_key_fn(manifest_dict[uid]) for uid in unique_ids}
+
+    deps = _get_deps(
+        manifest_dict,
+        selected_unique_ids=unique_ids,
+        asset_resource_types=["model", "seed", "snapshot"],
+    )
+    output_unique_ids = set(deps.keys())
+    input_unique_ids = unique_ids - output_unique_ids
+
     def inner(fn) -> AssetsDefinition:
         @op(
             name=op_name,
             tags={"kind": "dbt"},
-            out={"a": Out(), "b": Out()},
+            ins={_chop(uid): In(Nothing) for uid in input_unique_ids},
+            out={
+                _chop(uid): Out(
+                    dagster_type=Nothing,
+                    description=_get_node_description(
+                        manifest_dict[uid],
+                        display_raw_sql=len(unique_ids) > 200,
+                    ),
+                    io_manager_key=io_manager_key,
+                    is_required=False,
+                )
+                for uid in output_unique_ids
+            },
         )
         @wraps(fn)
         def _op(*args, **kwargs):
@@ -101,36 +151,39 @@ def dbt_assets(
                 # convert the OpExecutionContext into a DbtExecutionContext, which has
                 # additional context related to dbt
                 return fn(
-                    DbtExecutionContext(cast(OpExecutionContext, args[0]), manifest_path),
+                    DbtExecutionContext(
+                        cast(OpExecutionContext, args[0]),
+                        manifest=manifest,
+                        base_select=select,
+                        base_exclude=exclude,
+                        key_by_unique_id=key_by_unique_id,
+                    ),
                     *args[1:],
                     **kwargs,
                 )
             else:
                 return fn(*args, **kwargs)
 
-        return AssetsDefinition(
-            node_def=_op,
+        return AssetsDefinition.from_op(
+            _op,
+            keys_by_input_name={_chop(uid): key_by_unique_id[uid] for uid in input_unique_ids},
+            keys_by_output_name={_chop(uid): key_by_unique_id[uid] for uid in output_unique_ids},
+            key_prefix=key_prefix,
+            internal_asset_deps={
+                _chop(uid): {key_by_unique_id[parent_uid] for parent_uid in parent_uids}
+                for uid, parent_uids in deps.items()
+            },
+            partitions_def=partitions_def,
+            metadata_by_output_name={
+                _chop(uid): metadata_fn(manifest_dict[uid]) for uid in output_unique_ids
+            }
+            if metadata_fn
+            else None,
+            freshness_policies_by_output_name={
+                _chop(uid): freshness_policy_fn(manifest_dict[uid]) for uid in output_unique_ids
+            }
+            if freshness_policy_fn
+            else None,
         )
 
     return inner
-
-
-@dbt_assets(manifest_path="manifest.json")
-def dbt_run_assets(
-    context: DbtExecutionContext, dbt: DbtAssetResource
-):  # , dbt: DbtAssetResource):
-    print("hi")
-    print(dbt.project_dir)
-    assert isinstance(context, DbtExecutionContext)
-    assert isinstance(context, OpExecutionContext)
-    return 1, 2
-
-
-print(dbt_run_assets)
-
-materialize_to_memory(
-    [dbt_run_assets],
-    resources={
-        "dbt": DbtAssetResource(project_dir="foo", profiles_dir="bar", json_log_format=True)
-    },
-)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_selection.py
@@ -6,9 +6,9 @@ from dagster import AssetKey, AssetSelection
 from dagster._annotations import experimental
 from dagster._core.definitions.asset_graph import AssetGraph
 
-from dagster_dbt.asset_defs import (
-    _get_node_asset_key,
-    _is_non_asset_node,
+from dagster_dbt.asset_utils import (
+    default_asset_key_fn,
+    is_non_asset_node,
 )
 from dagster_dbt.utils import select_unique_ids_from_manifest
 
@@ -61,7 +61,7 @@ class DbtManifestAssetSelection(AssetSelection):
         select: str = "*",
         exclude: str = "",
         resource_types: Optional[Sequence[str]] = None,
-        node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
+        node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = default_asset_key_fn,
         manifest_json_path: Optional[str] = None,
         state_path: Optional[str] = None,
     ):
@@ -115,7 +115,7 @@ class DbtManifestAssetSelection(AssetSelection):
             manifest_json=self.manifest_json,
         ):
             node_info = dbt_nodes[unique_id]
-            if node_info["resource_type"] in self.resource_types and not _is_non_asset_node(
+            if node_info["resource_type"] in self.resource_types and not is_non_asset_node(
                 node_info
             ):
                 keys.add(self.node_info_to_asset_key(node_info))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -1,0 +1,142 @@
+import textwrap
+from typing import AbstractSet, Any, Dict, FrozenSet, List, Mapping, Optional, Set
+
+from dagster import AssetKey, FreshnessPolicy, MetadataValue, TableColumn, TableSchema
+
+###################
+# DEFAULT FUNCTIONS
+###################
+
+
+def default_asset_key_fn(node_info: Mapping[str, Any]) -> AssetKey:
+    """Get the asset key for a dbt node.
+
+    By default:
+        dbt sources: a dbt source's key is the union of its source name and its table name
+        dbt models: a dbt model's key is the union of its model name and any schema configured on
+    the model itself.
+    """
+    if node_info["resource_type"] == "source":
+        components = [node_info["source_name"], node_info["name"]]
+    else:
+        configured_schema = node_info["config"].get("schema")
+        if configured_schema is not None:
+            components = [configured_schema, node_info["name"]]
+        else:
+            components = [node_info["name"]]
+
+    return AssetKey(components)
+
+
+def default_metadata_fn(node_info: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata: Dict[str, Any] = {}
+    columns = node_info.get("columns", {})
+    if len(columns) > 0:
+        metadata["table_schema"] = MetadataValue.table_schema(
+            TableSchema(
+                columns=[
+                    TableColumn(
+                        name=column_name,
+                        type=column_info.get("data_type") or "?",
+                        description=column_info.get("description"),
+                    )
+                    for column_name, column_info in columns.items()
+                ]
+            )
+        )
+    return metadata
+
+
+def default_group_fn(node_info: Mapping[str, Any]) -> Optional[str]:
+    """A node's group name is subdirectory that it resides in."""
+    fqn = node_info.get("fqn", [])
+    # the first component is the package name, and the last component is the model name
+    if len(fqn) < 3:
+        return None
+    return fqn[1]
+
+
+def default_freshness_policy_fn(node_info: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
+    freshness_policy_config = node_info["config"].get("dagster_freshness_policy")
+    if freshness_policy_config:
+        return FreshnessPolicy(
+            maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
+            cron_schedule=freshness_policy_config.get("cron_schedule"),
+            cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),
+        )
+    return None
+
+
+def default_description_fn(node_info: Mapping[str, Any], display_raw_sql: bool = True):
+    code_block = textwrap.indent(node_info.get("raw_sql") or node_info.get("raw_code", ""), "    ")
+    description_sections = [
+        node_info["description"] or f"dbt {node_info['resource_type']} {node_info['name']}",
+    ]
+    if display_raw_sql:
+        description_sections.append(f"#### Raw SQL:\n```\n{code_block}\n```")
+    return "\n\n".join(filter(None, description_sections))
+
+
+###################
+# DEPENDENCIES
+###################
+
+
+def is_non_asset_node(node_info: Mapping[str, Any]):
+    # some nodes exist inside the dbt graph but are not assets
+    resource_type = node_info["resource_type"]
+    if resource_type == "metric":
+        return True
+    if resource_type == "model" and node_info.get("config", {}).get("materialized") == "ephemeral":
+        return True
+    return False
+
+
+def get_deps(
+    dbt_nodes: Mapping[str, Any],
+    selected_unique_ids: AbstractSet[str],
+    asset_resource_types: List[str],
+) -> Mapping[str, FrozenSet[str]]:
+    def _valid_parent_node(node_info):
+        # sources are valid parents, but not assets
+        return node_info["resource_type"] in asset_resource_types + ["source"]
+
+    asset_deps: Dict[str, Set[str]] = {}
+    for unique_id in selected_unique_ids:
+        node_info = dbt_nodes[unique_id]
+        node_resource_type = node_info["resource_type"]
+
+        # skip non-assets, such as metrics, tests, and ephemeral models
+        if is_non_asset_node(node_info) or node_resource_type not in asset_resource_types:
+            continue
+
+        asset_deps[unique_id] = set()
+        for parent_unique_id in node_info.get("depends_on", {}).get("nodes", []):
+            parent_node_info = dbt_nodes[parent_unique_id]
+            # for metrics or ephemeral dbt models, BFS to find valid parents
+            if is_non_asset_node(parent_node_info):
+                visited = set()
+                replaced_parent_ids = set()
+                queue = parent_node_info.get("depends_on", {}).get("nodes", [])
+                while queue:
+                    candidate_parent_id = queue.pop()
+                    if candidate_parent_id in visited:
+                        continue
+                    visited.add(candidate_parent_id)
+
+                    candidate_parent_info = dbt_nodes[candidate_parent_id]
+                    if is_non_asset_node(candidate_parent_info):
+                        queue.extend(candidate_parent_info.get("depends_on", {}).get("nodes", []))
+                    elif _valid_parent_node(candidate_parent_info):
+                        replaced_parent_ids.add(candidate_parent_id)
+
+                asset_deps[unique_id] |= replaced_parent_ids
+            # ignore nodes which are not assets / sources
+            elif _valid_parent_node(parent_node_info):
+                asset_deps[unique_id].add(parent_unique_id)
+
+    frozen_asset_deps = {
+        unique_id: frozenset(parent_ids) for unique_id, parent_ids in asset_deps.items()
+    }
+
+    return frozen_asset_deps

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -40,11 +40,13 @@ from dbt.main import parse_args as dbt_parse_args
 
 from ..asset_defs import (
     _get_asset_deps,
-    _get_deps,
-    _get_node_asset_key,
-    _get_node_freshness_policy,
-    _get_node_group_name,
-    _get_node_metadata,
+)
+from ..asset_utils import (
+    default_asset_key_fn,
+    default_freshness_policy_fn,
+    default_group_fn,
+    default_metadata_fn,
+    get_deps,
 )
 from ..errors import DagsterDbtCloudJobInvariantViolationError
 from ..utils import ASSET_RESOURCE_TYPES, result_to_events
@@ -290,7 +292,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             )
 
         # Generate the dependency structure for the executed nodes.
-        dbt_dependencies = _get_deps(
+        dbt_dependencies = get_deps(
             dbt_nodes=dbt_nodes,
             selected_unique_ids=executed_node_ids,
             asset_resource_types=ASSET_RESOURCE_TYPES,
@@ -319,7 +321,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             node_info_to_group_fn=self._node_info_to_group_fn,
             node_info_to_freshness_policy_fn=self._node_info_to_freshness_policy_fn,
             # TODO: In the future, allow this function to be specified
-            node_info_to_definition_metadata_fn=_get_node_metadata,
+            node_info_to_definition_metadata_fn=default_metadata_fn,
             # TODO: In the future, allow the IO manager to be specified.
             io_manager_key=None,
             # We shouldn't display the raw sql. Instead, inspect if dbt docs were generated,
@@ -522,11 +524,11 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
 def load_assets_from_dbt_cloud_job(
     dbt_cloud: ResourceDefinition,
     job_id: int,
-    node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = _get_node_asset_key,
-    node_info_to_group_fn: Callable[[Mapping[str, Any]], Optional[str]] = _get_node_group_name,
+    node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey] = default_asset_key_fn,
+    node_info_to_group_fn: Callable[[Mapping[str, Any]], Optional[str]] = default_group_fn,
     node_info_to_freshness_policy_fn: Callable[
         [Mapping[str, Any]], Optional[FreshnessPolicy]
-    ] = _get_node_freshness_policy,
+    ] = default_freshness_policy_fn,
     partitions_def: Optional[PartitionsDefinition] = None,
     partition_key_to_vars_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
 ) -> CacheableAssetsDefinition:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -245,6 +245,7 @@ def select_unique_ids_from_manifest(
     state_path: Optional[str] = None,
     manifest_json_path: Optional[str] = None,
     manifest_json: Optional[Mapping[str, Any]] = None,
+    manifest_parsed: Optional[Any] = None,
 ) -> AbstractSet[str]:
     """Method to apply a selection string to an existing manifest.json file."""
     try:
@@ -274,7 +275,7 @@ def select_unique_ids_from_manifest(
         previous_state = None
 
     if manifest_json_path is not None:
-        manifest = WritableManifest.read_and_check_versions(manifest_json_path)
+        manifest: WritableManifest = WritableManifest.read_and_check_versions(manifest_json_path)
         child_map = manifest.child_map
     elif manifest_json is not None:
 
@@ -302,8 +303,11 @@ def select_unique_ids_from_manifest(
             },
         )
         child_map = manifest_json["child_map"]
+    elif manifest_parsed is not None:
+        manifest = manifest_parsed
+        child_map = manifest.child_map
     else:
-        check.failed("Must provide either a manifest_json_path or manifest_json.")
+        check.failed("Must provide either a manifest_json_path, manifest_json, or manifest_parsed.")
     graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
 
     # create a parsed selection from the select string

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -96,7 +96,7 @@ def test_runtime_metadata_fn(
     dbt_assets = load_assets_from_dbt_manifest(
         manifest_json=manifest_json, runtime_metadata_fn=runtime_metadata_fn
     )
-    assert_assets_match_project(dbt_assets)
+    assert_assets_match_project(dbt_assets, has_non_argument_dependencies=True)
 
     assets_job = build_assets_job(
         "assets_job",


### PR DESCRIPTION
## Summary & Motivation

This adds support for a basic `@dbt_assets` decorator. Essentially, this decorator lets you decorate an arbitrary asset execution function. The decorator will create all the asset dependencies based off of a selection of assets from a dbt manifest file.

This also moves a lot of the default node_info_to... functions into a separate asset_utils file, as both asset_defs and asset_decorators depend on these functions.

## How I Tested These Changes
