### PR TITLE
[dbt-assets][2/n] DbtExecutionContext

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -18,6 +18,7 @@ from dagster import (
     AssetMaterialization,
     AssetObservation,
     MetadataValue,
+    OpExecutionContext,
     Output,
     _check as check,
 )
@@ -165,6 +166,77 @@ def result_to_events(
                     "Test ID": result["unique_id"],
                     "Test Status": status,
                     "Test Message": result.get("message") or "",
+                },
+            )
+
+
+def structured_json_line_to_events(
+    json_line: Mapping[str, Any],
+    context: OpExecutionContext,
+    node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey],
+    runtime_metadata_fn: Optional[
+        Callable[[OpExecutionContext, Mapping[str, Any]], Mapping[str, RawMetadataValue]]
+    ],
+    manifest_json: Mapping[str, Any],
+) -> Iterator[Union[AssetObservation, Output]]:
+    """Parses a json line into a Dagster event. Attempts to replicate the behavior of result_to_events
+    as closely as possible.
+    """
+    runtime_node_info = json_line.get("data", {}).get("node_info", {})
+    if not runtime_node_info:
+        return
+
+    node_resource_type = runtime_node_info.get("resource_type")
+    node_status = runtime_node_info.get("node_status")
+    unique_id = runtime_node_info.get("unique_id")
+
+    if not node_resource_type or not unique_id:
+        return
+
+    compiled_node_info = manifest_json["nodes"][unique_id]
+
+    if node_resource_type in ASSET_RESOURCE_TYPES and node_status == "success":
+        metadata = dict(
+            runtime_metadata_fn(context, compiled_node_info) if runtime_metadata_fn else {}
+        )
+        started_at_str = runtime_node_info.get("node_started_at")
+        finished_at_str = runtime_node_info.get("node_finished_at")
+        if started_at_str is None or finished_at_str is None:
+            return
+
+        started_at = dateutil.parser.isoparse(started_at_str)  # type: ignore
+        completed_at = dateutil.parser.isoparse(finished_at_str)  # type: ignore
+        duration = completed_at - started_at
+        metadata.update(
+            {
+                "Execution Started At": started_at.isoformat(timespec="seconds"),
+                "Execution Completed At": completed_at.isoformat(timespec="seconds"),
+                "Execution Duration": duration.total_seconds(),
+            }
+        )
+        yield Output(
+            value=None,
+            output_name=_get_output_name(compiled_node_info),
+            metadata=metadata,
+        )
+    elif node_resource_type == "test" and runtime_node_info.get("node_finished_at") is not None:
+        upstream_unique_ids = (
+            manifest_json["nodes"][unique_id].get("depends_on", {}).get("nodes", [])
+        )
+        # tests can apply to multiple asset keys
+        for upstream_id in upstream_unique_ids:
+            # the upstream id can reference a node or a source
+            upstream_node_info = manifest_json["nodes"].get(upstream_id) or manifest_json[
+                "sources"
+            ].get(upstream_id)
+            if upstream_node_info is None:
+                continue
+            upstream_asset_key = node_info_to_asset_key(upstream_node_info)
+            yield AssetObservation(
+                asset_key=upstream_asset_key,
+                metadata={
+                    "Test ID": unique_id,
+                    "Test Status": node_status,
                 },
             )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -10,7 +10,7 @@ from dagster._utils.test.postgres_instance import TestPostgresInstance
 # ======= CONFIG ========
 DBT_EXECUTABLE = "dbt"
 TEST_PROJECT_DIR = file_relative_path(__file__, "dagster_dbt_test_project")
-DBT_CONFIG_DIR = os.path.join(TEST_PROJECT_DIR, "dbt_config")
+TEST_PROFILES_DIR = os.path.join(TEST_PROJECT_DIR, "dbt_config")
 TEST_DBT_TARGET_DIR = os.path.join(TEST_PROJECT_DIR, "target_test")
 
 TEST_PYTHON_PROJECT_DIR = file_relative_path(__file__, "dagster_dbt_python_test_project")
@@ -25,8 +25,14 @@ def test_project_dir():
 
 
 @pytest.fixture(scope="session")
+def test_profiles_dir():
+    return TEST_PROFILES_DIR
+
+
+@pytest.fixture(scope="session")
 def dbt_config_dir():
-    return DBT_CONFIG_DIR
+    # temporary backcompat
+    return TEST_PROFILES_DIR
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary & Motivation

Stack got a little messed up so don't mind the DbtAssetResource stuff, and moving the structured_json_line_to_events. Creates a DbtExecutionContext that wraps the OpExecutionContext and provides some convenient methods that people/resources can call when executing dbt assets. The most important one being `get_dbt_selection_kwargs`

## How I Tested These Changes
