### PR TITLE
Expand scope of try/catch blocks in grpc impl functions

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from contextlib import ExitStack
 from typing import Generator, Optional, Sequence, Union
 
 import pendulum
@@ -257,12 +256,14 @@ def get_external_pipeline_subset_result(
             op_selection=solid_selection,
             asset_selection=frozenset(asset_selection) if asset_selection else None,
         )
+        external_pipeline_data = external_pipeline_data_from_def(definition)
+        return ExternalPipelineSubsetResult(
+            success=True, external_pipeline_data=external_pipeline_data
+        )
     except Exception:
         return ExternalPipelineSubsetResult(
             success=False, error=serializable_error_info_from_exc_info(sys.exc_info())
         )
-    external_pipeline_data = external_pipeline_data_from_def(definition)
-    return ExternalPipelineSubsetResult(success=True, external_pipeline_data=external_pipeline_data)
 
 
 def get_external_schedule_execution(
@@ -274,42 +275,46 @@ def get_external_schedule_execution(
 ):
     from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 
-    schedule_def = repo_def.get_schedule_def(schedule_name)
-    scheduled_execution_time = (
-        pendulum.from_timestamp(
-            scheduled_execution_timestamp,
-            tz=check.not_none(scheduled_execution_timezone),
-        )
-        if scheduled_execution_timestamp
-        else None
-    )
-
-    required_resource_keys = get_transitive_required_resource_keys(
-        schedule_def.required_resource_keys, repo_def.get_top_level_resources()
-    )
-    resources_to_build = {
-        k: v for k, v in repo_def.get_top_level_resources().items() if k in required_resource_keys
-    }
-
-    with ScheduleEvaluationContext(
-        instance_ref,
-        scheduled_execution_time,
-        repo_def.name,
-        schedule_name,
-        resources=resources_to_build,
-    ) as schedule_context:
-        try:
-            with user_code_error_boundary(
-                ScheduleExecutionError,
-                lambda: "Error occurred during the execution function for schedule {schedule_name}".format(
-                    schedule_name=schedule_def.name
-                ),
-            ):
-                return schedule_def.evaluate_tick(schedule_context)
-        except Exception:
-            return ExternalScheduleExecutionErrorData(
-                serializable_error_info_from_exc_info(sys.exc_info())
+    try:
+        schedule_def = repo_def.get_schedule_def(schedule_name)
+        scheduled_execution_time = (
+            pendulum.from_timestamp(
+                scheduled_execution_timestamp,
+                tz=check.not_none(scheduled_execution_timezone),
             )
+            if scheduled_execution_timestamp
+            else None
+        )
+
+        required_resource_keys = get_transitive_required_resource_keys(
+            schedule_def.required_resource_keys, repo_def.get_top_level_resources()
+        )
+        resources_to_build = {
+            k: v
+            for k, v in repo_def.get_top_level_resources().items()
+            if k in required_resource_keys
+        }
+
+        # User code boundary includes creating the context since it may involve
+        # instantiating resources
+        with user_code_error_boundary(
+            ScheduleExecutionError,
+            lambda: "Error occurred during the execution function for schedule {schedule_name}".format(
+                schedule_name=schedule_def.name
+            ),
+        ):
+            with ScheduleEvaluationContext(
+                instance_ref,
+                scheduled_execution_time,
+                repo_def.name,
+                schedule_name,
+                resources=resources_to_build,
+            ) as schedule_context:
+                return schedule_def.evaluate_tick(schedule_context)
+    except Exception:
+        return ExternalScheduleExecutionErrorData(
+            serializable_error_info_from_exc_info(sys.exc_info())
+        )
 
 
 def get_external_sensor_execution(
@@ -322,9 +327,9 @@ def get_external_sensor_execution(
 ):
     from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 
-    sensor_def = repo_def.get_sensor_def(sensor_name)
+    try:
+        sensor_def = repo_def.get_sensor_def(sensor_name)
 
-    with ExitStack() as stack:
         required_resource_keys = get_transitive_required_resource_keys(
             sensor_def.required_resource_keys, repo_def.get_top_level_resources()
         )
@@ -333,8 +338,16 @@ def get_external_sensor_execution(
             for k, v in repo_def.get_top_level_resources().items()
             if k in required_resource_keys
         }
-        sensor_context = stack.enter_context(
-            SensorEvaluationContext(
+
+        # User code boundary includes creating the context since it may involve
+        # instantiating resources
+        with user_code_error_boundary(
+            SensorExecutionError,
+            lambda: "Error occurred during the execution of evaluation_fn for sensor {sensor_name}".format(
+                sensor_name=sensor_def.name
+            ),
+        ):
+            with SensorEvaluationContext(
                 instance_ref,
                 last_completion_time=last_completion_timestamp,
                 last_run_key=last_run_key,
@@ -343,21 +356,12 @@ def get_external_sensor_execution(
                 repository_def=repo_def,
                 sensor_name=sensor_name,
                 resources=resources_to_build,
-            )
-        )
-
-        try:
-            with user_code_error_boundary(
-                SensorExecutionError,
-                lambda: "Error occurred during the execution of evaluation_fn for sensor {sensor_name}".format(
-                    sensor_name=sensor_def.name
-                ),
-            ):
+            ) as sensor_context:
                 return sensor_def.evaluate_tick(sensor_context)
-        except Exception:
-            return ExternalSensorExecutionErrorData(
-                serializable_error_info_from_exc_info(sys.exc_info())
-            )
+    except Exception:
+        return ExternalSensorExecutionErrorData(
+            serializable_error_info_from_exc_info(sys.exc_info())
+        )
 
 
 def _partitions_def_contains_dynamic_partitions_def(partitions_def: PartitionsDefinition) -> bool:
@@ -377,19 +381,23 @@ def get_partition_config(
     partition_name: str,
     instance_ref: Optional[InstanceRef] = None,
 ):
-    partition_set_def = repo_def.get_partition_set_def(partition_set_name)
-
-    # Certain gRPC servers do not have access to the instance, so we only attempt to instantiate
-    # the instance when necessary for dynamic partitions: https://github.com/dagster-io/dagster/issues/12440
-    if _partitions_def_contains_dynamic_partitions_def(partition_set_def.partitions_def):
-        with DagsterInstance.from_ref(instance_ref) if instance_ref else nullcontext() as instance:
-            partition = partition_set_def.get_partition(
-                partition_name, dynamic_partitions_store=instance
-            )
-    else:
-        partition = partition_set_def.get_partition(partition_name, dynamic_partitions_store=None)
-
     try:
+        partition_set_def = repo_def.get_partition_set_def(partition_set_name)
+
+        # Certain gRPC servers do not have access to the instance, so we only attempt to instantiate
+        # the instance when necessary for dynamic partitions: https://github.com/dagster-io/dagster/issues/12440
+        if _partitions_def_contains_dynamic_partitions_def(partition_set_def.partitions_def):
+            with DagsterInstance.from_ref(
+                instance_ref
+            ) if instance_ref else nullcontext() as instance:
+                partition = partition_set_def.get_partition(
+                    partition_name, dynamic_partitions_store=instance
+                )
+        else:
+            partition = partition_set_def.get_partition(
+                partition_name, dynamic_partitions_store=None
+            )
+
         with user_code_error_boundary(
             PartitionExecutionError,
             lambda: "Error occurred during the evaluation of the `run_config_for_partition` function for partition set {partition_set_name}".format(
@@ -415,8 +423,9 @@ def get_partition_names(
     repo_def: RepositoryDefinition,
     partition_set_name: str,
 ):
-    partition_set_def = repo_def.get_partition_set_def(partition_set_name)
     try:
+        partition_set_def = repo_def.get_partition_set_def(partition_set_name)
+
         with user_code_error_boundary(
             PartitionExecutionError,
             lambda: f"Error occurred during the execution of the partition generation function for {_get_target_for_partition_execution_error(partition_set_def)}",
@@ -436,18 +445,22 @@ def get_partition_tags(
     partition_name: str,
     instance_ref: Optional[InstanceRef] = None,
 ):
-    partition_set_def = repo_def.get_partition_set_def(partition_set_name)
-
-    # Certain gRPC servers do not have access to the instance, so we only attempt to instantiate
-    # the instance when necessary for dynamic partitions: https://github.com/dagster-io/dagster/issues/12440
-    if _partitions_def_contains_dynamic_partitions_def(partition_set_def.partitions_def):
-        with DagsterInstance.from_ref(instance_ref) if instance_ref else nullcontext() as instance:
-            partition = partition_set_def.get_partition(
-                partition_name, dynamic_partitions_store=instance
-            )
-    else:
-        partition = partition_set_def.get_partition(partition_name, dynamic_partitions_store=None)
     try:
+        partition_set_def = repo_def.get_partition_set_def(partition_set_name)
+
+        # Certain gRPC servers do not have access to the instance, so we only attempt to instantiate
+        # the instance when necessary for dynamic partitions: https://github.com/dagster-io/dagster/issues/12440
+        if _partitions_def_contains_dynamic_partitions_def(partition_set_def.partitions_def):
+            with DagsterInstance.from_ref(
+                instance_ref
+            ) if instance_ref else nullcontext() as instance:
+                partition = partition_set_def.get_partition(
+                    partition_name, dynamic_partitions_store=instance
+                )
+        else:
+            partition = partition_set_def.get_partition(
+                partition_name, dynamic_partitions_store=None
+            )
         with user_code_error_boundary(
             PartitionExecutionError,
             lambda: f"Error occurred during the evaluation of the `tags_for_partition` function for {_get_target_for_partition_execution_error(partition_set_def)}",


### PR DESCRIPTION
Summary:
Two problems here we observed:
- the try/catch doesn't catch issues that come up while cleaning up the Sensor/Schedule execution context
- There is 'user code' when creating a schedule/sensor context (creating resources) that is not wrapped in a user code error boundary. This is less important since it mostly determines which exception gets raised, but is still worth fixing?

This fixes those issues by moving the try/catch to the very beginning of the gRPC execution function for all grpc calls, so errors will always bubble up as structured error messages instead of cryptic grpc errors with no stack traces.

## Summary & Motivation

## How I Tested These Changes
Existing tests cover gRPC errors in general - testing a failure in the specific new callsites that are newly inside a try/catch block here may not be worth the additional effort? There's also a test flake that hopefully now includes a clearer exception 