### PR TITLE
[ui] Click-to-copy code location image value

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
@@ -11,7 +11,10 @@ import {
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
 
+import {SharedToaster} from '../app/DomUtils';
+import {useCopyToClipboard} from '../app/browser';
 import {
   NO_RELOAD_PERMISSION_TEXT,
   ReloadRepositoryLocationButton,
@@ -106,20 +109,59 @@ export const CodeLocationRowSet: React.FC<Props> = ({locationNode}) => {
 };
 
 export const ImageName: React.FC<{metadata: WorkspaceDisplayMetadataFragment[]}> = ({metadata}) => {
+  const copy = useCopyToClipboard();
   const imageKV = metadata.find(({key}) => key === 'image');
+  const value = imageKV?.value || '';
+
+  const onClick = React.useCallback(() => {
+    copy(value);
+    SharedToaster.show({
+      intent: 'success',
+      icon: 'done',
+      message: 'Image string copied!',
+    });
+  }, [copy, value]);
+
   if (imageKV) {
     return (
-      <Box
-        flex={{direction: 'row', gap: 4}}
-        style={{width: '100%', color: Colors.Gray700, fontSize: 12}}
-      >
+      <ImageNameBox flex={{direction: 'row', gap: 4}}>
         <span style={{fontWeight: 500}}>image:</span>
-        <MiddleTruncate text={imageKV.value} />
-      </Box>
+        <Tooltip content="Click to copy" placement="top" display="block">
+          <button onClick={onClick}>
+            <MiddleTruncate text={imageKV.value} />
+          </button>
+        </Tooltip>
+      </ImageNameBox>
     );
   }
   return null;
 };
+
+const ImageNameBox = styled(Box)`
+  width: 100%;
+  color: ${Colors.Gray700};
+  font-size: 12px;
+
+  .bp3-popover2-target {
+    overflow: hidden;
+  }
+
+  button {
+    background: transparent;
+    border: none;
+    color: ${Colors.Gray700};
+    cursor: pointer;
+    font-size: 12px;
+    overflow: hidden;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+
+    :focus {
+      outline: none;
+    }
+  }
+`;
 
 export const ModuleOrPackageOrFile: React.FC<{metadata: WorkspaceDisplayMetadataFragment[]}> = ({
   metadata,


### PR DESCRIPTION
## Summary & Motivation

Add click-to-copy on image value strings in the Code Locations table. These strings are middle-truncated, and while the default behavior of selecting the string and copying it should actually already work, it's not intuitive, and this requires a little less understanding of the nuances of the rendered UI.

<img width="372" alt="Screenshot 2023-03-20 at 12 49 40 PM" src="https://user-images.githubusercontent.com/2823852/226425458-e8f3808f-3081-4d4a-b651-8a3e543270b1.png">
<img width="595" alt="Screenshot 2023-03-20 at 12 49 26 PM" src="https://user-images.githubusercontent.com/2823852/226425461-0ec4bf7b-4740-44ca-a0d5-333176e004fc.png">

## How I Tested These Changes

Force a long `image` string the Code Locations table. Verify correct middle truncation of string. Click to copy, verify correct tooltip, toaster, and copy behavior.

Force a short string with no middle truncation, verify same.
