### PR TITLE
CLI for wiping asset cached status data

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -158,3 +158,61 @@ def asset_wipe_command(key, **cli_args):
             click.echo("Removed asset indexes from event logs")
         else:
             click.echo("Exiting without removing asset indexes")
+
+
+@asset_cli.command(name="wipe-cache")
+@click.argument("key", nargs=-1)
+@click.option("--all", is_flag=True, help="Wipe partitions status cache of all asset keys")
+@click.option("--noprompt", is_flag=True)
+def asset_wipe_cache_command(key, **cli_args):
+    r"""Clears the asset partition status cache.
+
+    Warning: Cannot be undone.
+
+    \b
+    Usage:
+      dagster asset wipe-cache --all
+      dagster asset wipe-cache <unstructured_asset_key_name>
+      dagster asset wipe-cache <json_string_of_structured_asset_key>
+    """
+    if not cli_args.get("all") and len(key) == 0:
+        raise click.UsageError(
+            "Error, you must specify an asset key or use `--all` to clear the partitions status"
+            " cache of all asset keys."
+        )
+
+    if cli_args.get("all") and len(key) > 0:
+        raise click.UsageError("Error, cannot use more than one of: asset key, `--all`.")
+
+    noprompt = cli_args.get("noprompt")
+
+    with DagsterInstance.get() as instance:
+        if instance.can_cache_asset_status_data() is False:
+            raise click.UsageError(
+                "Error, the instance does not support caching asset status. Wiping the cache is not"
+                " supported."
+            )
+
+        if len(key) > 0:
+            asset_keys = [AssetKey.from_db_string(key_string) for key_string in key]
+            prompt = (
+                "Are you sure you want to wipe the partitions status cache for these"
+                f" keys {asset_keys} from the event logs? Type DELETE"
+            )
+        else:
+            asset_keys = instance.all_asset_keys()
+            prompt = (
+                "Are you sure you want to wipe the partitions status cache for all asset keys?"
+                " Type DELETE"
+            )
+
+        if noprompt:
+            confirmation = "DELETE"
+        else:
+            confirmation = click.prompt(prompt)
+
+        if confirmation == "DELETE":
+            instance.wipe_asset_cached_status(asset_keys)
+            click.echo("Cleared the partitions status cache")
+        else:
+            click.echo("Exiting without wiping the partitions status cache")

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -160,14 +160,14 @@ def asset_wipe_command(key, **cli_args):
             click.echo("Exiting without removing asset indexes")
 
 
-@asset_cli.command(name="wipe-cache")
+@asset_cli.command(name="wipe-partitions-status-cache")
 @click.argument("key", nargs=-1)
 @click.option("--all", is_flag=True, help="Wipe partitions status cache of all asset keys")
 @click.option("--noprompt", is_flag=True)
 def asset_wipe_cache_command(key, **cli_args):
-    r"""Clears the asset partition status cache.
-
-    Warning: Cannot be undone.
+    r"""Clears the asset partitions status cache, which is used by Dagit to load partition
+    pages more quickly. The cache will be rebuilt the next time the partition pages are loaded,
+    if caching is enabled.
 
     \b
     Usage:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1682,6 +1682,12 @@ class DagsterInstance(DynamicPartitionsStore):
         self._event_storage.update_asset_cached_status_data(asset_key, cache_values)
 
     @traced
+    def wipe_asset_cached_status(self, asset_keys: Sequence[AssetKey]) -> None:
+        check.list_param(asset_keys, "asset_keys", of_type=AssetKey)
+        for asset_key in asset_keys:
+            self._event_storage.wipe_asset_cached_status(asset_key)
+
+    @traced
     def all_asset_keys(self) -> Sequence[AssetKey]:
         return self._event_storage.all_asset_keys()
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -286,6 +286,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
+    def wipe_asset_cached_status(self, asset_key: AssetKey) -> None:
+        pass
+
+    @abstractmethod
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
     ) -> Sequence[AssetRecord]:

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1098,6 +1098,18 @@ class SqlEventLogStorage(EventLogStorage):
     def can_cache_asset_status_data(self) -> bool:
         return self.has_asset_key_col("cached_status_data")
 
+    def wipe_asset_cached_status(self, asset_key: AssetKey) -> None:
+        if self.can_cache_asset_status_data():
+            check.inst_param(asset_key, "asset_key", AssetKey)
+            with self.index_connection() as conn:
+                conn.execute(
+                    AssetKeyTable.update()
+                    .values(dict(cached_status_data=None))
+                    .where(
+                        AssetKeyTable.c.asset_key == asset_key.to_string(),
+                    )
+                )
+
     def get_asset_records(
         self, asset_keys: Optional[Sequence[AssetKey]] = None
     ) -> Sequence[AssetRecord]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -515,6 +515,9 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def can_cache_asset_status_data(self) -> bool:
         return self._storage.event_log_storage.can_cache_asset_status_data()
 
+    def wipe_asset_cached_status(self, asset_key: "AssetKey") -> None:
+        return self._storage.event_log_storage.wipe_asset_cached_status(asset_key)
+
     def update_asset_cached_status_data(
         self, asset_key: "AssetKey", cache_values: "AssetStatusCacheValue"
     ) -> None:

--- a/python_modules/dagster/dagster_tests/cli_tests/test_asset_wipe_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_asset_wipe_command.py
@@ -3,8 +3,9 @@ import tempfile
 import pytest
 from click.testing import CliRunner
 from dagster import AssetKey, AssetMaterialization, Output
-from dagster._cli.asset import asset_wipe_command
+from dagster._cli.asset import asset_wipe_cache_command, asset_wipe_command
 from dagster._core.definitions import op
+from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import execute_pipeline, pipeline
 from dagster._seven import json
@@ -51,25 +52,30 @@ def pipeline_two():
     solid_two()
 
 
-def test_asset_wipe_errors(instance_runner):
+@pytest.mark.parametrize("command", [asset_wipe_command, asset_wipe_cache_command])
+def test_asset_wipe_errors(instance_runner, command):
     _, runner = instance_runner
-    result = runner.invoke(asset_wipe_command)
+    result = runner.invoke(command)
     assert result.exit_code == 2
-    assert (
-        "Error, you must specify an asset key or use `--all` to wipe all asset keys."
-        in result.output
-    )
+    assert "Error, you must specify an asset key or use `--all`" in result.output
 
-    result = runner.invoke(asset_wipe_command, ["--all", json.dumps(["path", "to", "asset_key"])])
+    result = runner.invoke(command, ["--all", json.dumps(["path", "to", "asset_key"])])
     assert result.exit_code == 2
     assert "Error, cannot use more than one of: asset key, `--all`." in result.output
 
 
-def test_asset_exit(instance_runner):
+@pytest.mark.parametrize(
+    "command, message",
+    [
+        (asset_wipe_command, "Exiting without removing asset indexes"),
+        (asset_wipe_cache_command, "Exiting without wiping the partitions status cache"),
+    ],
+)
+def test_asset_exit(instance_runner, command, message):
     _, runner = instance_runner
-    result = runner.invoke(asset_wipe_command, ["--all"], input="NOT_DELETE\n")
+    result = runner.invoke(command, ["--all"], input="NOT_DELETE\n")
     assert result.exit_code == 0
-    assert "Exiting without removing asset indexes" in result.output
+    assert message in result.output
 
 
 def test_asset_single_wipe(instance_runner):
@@ -142,3 +148,75 @@ def test_asset_single_wipe_noprompt(instance_runner):
 
     asset_keys = instance.all_asset_keys()
     assert len(asset_keys) == 3
+
+
+def _get_cached_status_for_asset(instance, asset_key):
+    asset_records = list(instance.get_asset_records([asset_key]))
+    assert len(asset_records) == 1
+    return asset_records[0].asset_entry.cached_status
+
+
+def test_asset_single_wipe_cache(instance_runner):
+    instance, runner = instance_runner
+    execute_pipeline(pipeline_one, instance=instance)
+    execute_pipeline(pipeline_two, instance=instance)
+    asset_1 = AssetKey("asset_1")
+    asset_2 = AssetKey("asset_2")
+
+    dummy_cache_value = AssetStatusCacheValue(1, "foo", "bar")
+    for key in [asset_1, asset_2]:
+        instance.update_asset_cached_status_data(key, dummy_cache_value)
+        assert _get_cached_status_for_asset(instance, key) == dummy_cache_value
+
+    result = runner.invoke(asset_wipe_cache_command, [json.dumps(asset_1.path)], input="DELETE\n")
+    assert result.exit_code == 0
+    assert "Cleared the partitions status cache" in result.output
+
+    assert _get_cached_status_for_asset(instance, asset_1) is None
+    assert _get_cached_status_for_asset(instance, asset_2) == dummy_cache_value
+
+
+def test_asset_multi_wipe_cache(instance_runner):
+    instance, runner = instance_runner
+    execute_pipeline(pipeline_one, instance=instance)
+    execute_pipeline(pipeline_two, instance=instance)
+    asset_1 = AssetKey("asset_1")
+    asset_2 = AssetKey("asset_2")
+    asset_3 = AssetKey(["path", "to", "asset_3"])
+
+    dummy_cache_value = AssetStatusCacheValue(1, "foo", "bar")
+    for key in [asset_1, asset_2, asset_3]:
+        instance.update_asset_cached_status_data(key, dummy_cache_value)
+        assert _get_cached_status_for_asset(instance, key) == dummy_cache_value
+
+    result = runner.invoke(
+        asset_wipe_cache_command,
+        [json.dumps(asset_3.path), json.dumps(asset_1.path)],
+        input="DELETE\n",
+    )
+    assert result.exit_code == 0
+    assert "Cleared the partitions status cache" in result.output
+
+    for key in [asset_1, asset_3]:
+        assert _get_cached_status_for_asset(instance, key) is None
+    assert _get_cached_status_for_asset(instance, asset_2) == dummy_cache_value
+
+
+def test_asset_wipe_all_cache_status_values(instance_runner):
+    instance, runner = instance_runner
+    execute_pipeline(pipeline_two, instance=instance)
+    asset_2 = AssetKey("asset_2")
+    asset_3 = AssetKey(["path", "to", "asset_3"])
+
+    dummy_cache_value = AssetStatusCacheValue(1, "foo", "bar")
+    for key in [asset_2, asset_3]:
+        instance.update_asset_cached_status_data(key, dummy_cache_value)
+        assert _get_cached_status_for_asset(instance, key) == dummy_cache_value
+
+    result = runner.invoke(asset_wipe_cache_command, ["--all"], input="DELETE\n")
+    assert result.exit_code == 0
+    assert "Cleared the partitions status cache" in result.output
+
+    records = list(instance.get_asset_records())
+    for record in records:
+        assert record.asset_entry.cached_status is None

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3171,6 +3171,25 @@ class TestEventLogStorage:
             assert _get_cached_status_for_asset(storage, asset_key) == cache_value
 
             if self.can_wipe():
+                cache_value = AssetStatusCacheValue(
+                    latest_storage_id=1,
+                    partitions_def_id=None,
+                    serialized_materialized_partition_subset=None,
+                )
+                storage.update_asset_cached_status_data(
+                    asset_key=asset_key, cache_values=cache_value
+                )
+                assert _get_cached_status_for_asset(storage, asset_key) == cache_value
+                record = storage.get_asset_records([asset_key])[0]
+                storage.wipe_asset_cached_status(asset_key)
+                assert _get_cached_status_for_asset(storage, asset_key) is None
+                post_wipe_record = storage.get_asset_records([asset_key])[0]
+                assert (
+                    record.asset_entry.last_materialization_record
+                    == post_wipe_record.asset_entry.last_materialization_record
+                )
+                assert record.asset_entry.last_run_id == post_wipe_record.asset_entry.last_run_id
+
                 storage.wipe_asset(asset_key)
                 assert storage.get_asset_records() == []
 


### PR DESCRIPTION
Second part for fixing https://github.com/dagster-io/dagster/pull/12944

After an incorrect value is serialized into the asset status cache, we want to create an escape hatch for users to clear and rebuild their caches. This PR introduces a CLI command that will clear the cache for a selection of assets, or all assets.

Corresponding internal PR: https://github.com/dagster-io/internal/pull/5227