### PR TITLE
Deprecate environment_vars argument to `ScheduleDefinition`, `@schedule`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -106,8 +106,6 @@ def schedule(
             schedule execution time to determine whether a schedule should execute or skip. Takes a
             :py:class:`~dagster.ScheduleEvaluationContext` and returns a boolean (``True`` if the
             schedule should execute). Defaults to a function that always returns ``True``.
-        environment_vars (Optional[Dict[str, str]]): Any environment variables to set when executing
-            the schedule.
         execution_timezone (Optional[str]): Timezone in which the schedule should run.
             Supported strings for timezones are the ones provided by the
             `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".

--- a/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_deprecations.py
@@ -8,6 +8,7 @@ from dagster._core.definitions.events import Output
 from dagster._core.definitions.input import InputDefinition
 from dagster._core.definitions.metadata import MetadataEntry, MetadataValue
 from dagster._core.definitions.output import OutputDefinition
+from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster._core.types.dagster_type import DagsterType
 
 # ########################
@@ -38,3 +39,18 @@ def test_arbitrary_metadata():
 def test_metadata_entry_description():
     with pytest.warns(DeprecationWarning, match=re.escape('"description" attribute')):
         MetadataEntry("foo", "bar", MetadataValue.text("baz"))
+
+
+# ########################
+# ##### SCHEDULE ENV VARS
+# ########################
+
+
+def test_schedule_environment_vars():
+    with pytest.warns(DeprecationWarning, match=re.escape("environment_vars")):
+        ScheduleDefinition(
+            name="foo",
+            cron_schedule="@daily",
+            job_name="bar",
+            environment_vars={"foo": "bar"},
+        )


### PR DESCRIPTION
## Summary & Motivation

Deprecate `environment_vars` argument to `ScheduleDefinition` for removal in 1.3. It is a no-op and should've been removed in the past.

## How I Tested These Changes

Existing test suite.
