### PR TITLE
Add in progress subsets to the partition cache

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -63,6 +63,7 @@ class AssetStatusCacheValue(
             ("partitions_def_id", Optional[str]),
             ("serialized_materialized_partition_subset", Optional[str]),
             ("serialized_failed_partition_subset", Optional[str]),
+            ("serialized_in_progress_partition_subset", Optional[str]),
             ("earliest_in_progress_materialization_event_id", Optional[int]),
         ],
     )
@@ -80,6 +81,8 @@ class AssetStatusCacheValue(
             unpartitioned.
         serialized_failed_partition_subset (Optional(str)): The serialized representation of the failed
             partition subsets, up to the latest storage id. None if the asset is unpartitioned.
+        serialized_in_progress_partition_subset (Optional(str)): The serialized representation of the
+            in progress partition subsets, up to the latest storage id. None if the asset is unpartitioned.
         earliest_in_progress_materialization_event_id (Optional(int)): The event id of the earliest
             materialization planned event for a run that is still in progress. This is used to check
             on the status of runs that are still in progress.
@@ -91,17 +94,19 @@ class AssetStatusCacheValue(
         partitions_def_id: Optional[str] = None,
         serialized_materialized_partition_subset: Optional[str] = None,
         serialized_failed_partition_subset: Optional[str] = None,
+        serialized_in_progress_partition_subset: Optional[str] = None,
         earliest_in_progress_materialization_event_id: Optional[int] = None,
     ):
         check.int_param(latest_storage_id, "latest_storage_id")
         check.opt_str_param(partitions_def_id, "partitions_def_id")
-        check.opt_inst_param(
-            serialized_materialized_partition_subset,
-            "serialized_materialized_partition_subset",
-            str,
+        check.opt_str_param(
+            serialized_materialized_partition_subset, "serialized_materialized_partition_subset"
         )
-        check.opt_inst_param(
-            serialized_failed_partition_subset, "serialized_failed_partition_subset", str
+        check.opt_str_param(
+            serialized_failed_partition_subset, "serialized_failed_partition_subset"
+        )
+        check.opt_str_param(
+            serialized_in_progress_partition_subset, "serialized_in_progress_partition_subset"
         )
         return super(AssetStatusCacheValue, cls).__new__(
             cls,
@@ -109,6 +114,7 @@ class AssetStatusCacheValue(
             partitions_def_id,
             serialized_materialized_partition_subset,
             serialized_failed_partition_subset,
+            serialized_in_progress_partition_subset,
             earliest_in_progress_materialization_event_id,
         )
 
@@ -139,6 +145,14 @@ class AssetStatusCacheValue(
             return partitions_def.empty_subset()
 
         return partitions_def.deserialize_subset(self.serialized_failed_partition_subset)
+
+    def deserialize_in_progress_partition_subsets(
+        self, partitions_def: PartitionsDefinition
+    ) -> PartitionsSubset:
+        if not self.serialized_in_progress_partition_subset:
+            return partitions_def.empty_subset()
+
+        return partitions_def.deserialize_subset(self.serialized_in_progress_partition_subset)
 
 
 def get_materialized_multipartitions(
@@ -241,7 +255,7 @@ def _build_status_cache(
         )
     )
 
-    failed_subset, cursor = _build_failed_partition_subset(
+    failed_subset, in_progress_subset, cursor = _build_failed_and_in_progress_partition_subset(
         instance, asset_key, partitions_def, dynamic_partitions_store
     )
 
@@ -252,22 +266,23 @@ def _build_status_cache(
         ),
         serialized_materialized_partition_subset=serialized_materialized_partition_subset.serialize(),
         serialized_failed_partition_subset=failed_subset.serialize(),
+        serialized_in_progress_partition_subset=in_progress_subset.serialize(),
         earliest_in_progress_materialization_event_id=cursor,
     )
 
 
-def _build_failed_partition_subset(
+def _build_failed_and_in_progress_partition_subset(
     instance: DagsterInstance,
     asset_key: AssetKey,
     partitions_def: PartitionsDefinition,
     dynamic_partitions_store: DynamicPartitionsStore,
-) -> Tuple[PartitionsSubset, Optional[int]]:
+) -> Tuple[PartitionsSubset, PartitionsSubset, Optional[int]]:
     incomplete_materializations = instance.event_log_storage.get_latest_asset_partition_materialization_attempts_without_materializations(
         asset_key
     )
 
     if not incomplete_materializations:
-        return partitions_def.empty_subset(), None
+        return partitions_def.empty_subset(), partitions_def.empty_subset(), None
 
     finished_runs = {
         r.run_id: r.status
@@ -280,6 +295,7 @@ def _build_failed_partition_subset(
     }
 
     new_failed_partitions = set()
+    in_progress_partitions = set()
     cursor = None
     for partition, (run_id, event_id) in incomplete_materializations.items():
         if run_id in finished_runs:
@@ -287,6 +303,7 @@ def _build_failed_partition_subset(
             if status == DagsterRunStatus.FAILURE:
                 new_failed_partitions.add(partition)
         else:
+            in_progress_partitions.add(partition)
             # If the run is not finished, keep track of the event id so we can check on it next time
             if cursor is None or event_id < cursor:
                 cursor = event_id
@@ -299,18 +316,23 @@ def _build_failed_partition_subset(
         )
         if new_failed_partitions
         else partitions_def.empty_subset(),
+        partitions_def.empty_subset().with_partition_keys(
+            get_validated_partition_keys(instance, partitions_def, in_progress_partitions)
+        )
+        if in_progress_partitions
+        else partitions_def.empty_subset(),
         cursor,
     )
 
 
-def _get_updated_failed_partition_subset(
+def _get_updated_failed_and_in_progress_partition_subset(
     instance: DagsterInstance,
     asset_key: AssetKey,
     partitions_def: PartitionsDefinition,
     current_cached_subset: PartitionsSubset,
     unevaluated_event_records: Sequence[EventLogRecord],
     dynamic_partitions_store: DynamicPartitionsStore,
-) -> Tuple[PartitionsSubset, Optional[int]]:
+) -> Tuple[PartitionsSubset, PartitionsSubset, Optional[int]]:
     current_failed_partitions = set(current_cached_subset.get_partition_keys())
 
     cursor = None
@@ -330,6 +352,7 @@ def _get_updated_failed_partition_subset(
                 current_failed_partitions.discard(event.partition)
 
     new_failed_partitions = set()
+    in_progress_partitions = set()
     if incomplete_materialization_records:
         finished_runs = {
             r.run_id: r.status
@@ -348,6 +371,7 @@ def _get_updated_failed_partition_subset(
                 if finished_runs[record.run_id] == DagsterRunStatus.FAILURE:
                     new_failed_partitions.add(partition)
             else:
+                in_progress_partitions.add(partition)
                 if cursor is None or record.storage_id <= cursor:
                     # If the run is not finished, keep track of the event id so we can check on it next time
                     cursor = record.storage_id
@@ -357,6 +381,9 @@ def _get_updated_failed_partition_subset(
             get_validated_partition_keys(
                 instance, partitions_def, new_failed_partitions | current_failed_partitions
             )
+        ),
+        partitions_def.empty_subset().with_partition_keys(
+            get_validated_partition_keys(instance, partitions_def, in_progress_partitions)
         ),
         cursor,
     )
@@ -446,7 +473,11 @@ def _get_updated_status_cache(
         else partitions_def.empty_subset()
     )
 
-    failed_subset, new_cursor = _get_updated_failed_partition_subset(
+    (
+        failed_subset,
+        in_progress_subset,
+        new_cursor,
+    ) = _get_updated_failed_and_in_progress_partition_subset(
         instance,
         asset_key,
         partitions_def,
@@ -460,6 +491,7 @@ def _get_updated_status_cache(
         partitions_def_id=current_status_cache_value.partitions_def_id,
         serialized_materialized_partition_subset=materialized_subset.serialize(),
         serialized_failed_partition_subset=failed_subset.serialize(),
+        serialized_in_progress_partition_subset=in_progress_subset.serialize(),
         earliest_in_progress_materialization_event_id=new_cursor,
     )
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_partition_status_cache.py
@@ -360,6 +360,12 @@ def test_failure_cache():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail1"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
 
         asset_job.execute_in_process(
             instance=created_instance, partition_key="good1", raise_on_error=False
@@ -375,6 +381,12 @@ def test_failure_cache():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail1", "fail2"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
 
         run_1 = create_run_for_test(created_instance)
         created_instance.event_log_storage.store_event(
@@ -401,6 +413,12 @@ def test_failure_cache():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail2"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
 
         run_2 = create_run_for_test(created_instance)
         created_instance.event_log_storage.store_event(
@@ -425,6 +443,9 @@ def test_failure_cache():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail2"}
+        assert cached_status.deserialize_in_progress_partition_subsets(
+            partitions_def
+        ).get_partition_keys() == {"good2"}
 
 
 def test_failure_cache_added():
@@ -501,9 +522,15 @@ def test_failure_cache_in_progress_runs():
         cached_status = get_and_update_asset_status_cache_value(
             created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
         )
-        assert partitions_def.deserialize_subset(
-            cached_status.serialized_failed_partition_subset
+        assert cached_status.deserialize_failed_partition_subsets(
+            partitions_def
         ).get_partition_keys() == {"fail1"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
 
         run_2 = create_run_for_test(created_instance, status=DagsterRunStatus.STARTED)
         created_instance.event_log_storage.store_event(
@@ -526,18 +553,27 @@ def test_failure_cache_in_progress_runs():
         cached_status = get_and_update_asset_status_cache_value(
             created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
         )
-        assert partitions_def.deserialize_subset(
-            cached_status.serialized_failed_partition_subset
+        assert cached_status.deserialize_failed_partition_subsets(
+            partitions_def
         ).get_partition_keys() == {"fail1"}
+        assert cached_status.deserialize_in_progress_partition_subsets(
+            partitions_def
+        ).get_partition_keys() == {"fail2"}
 
         created_instance.report_run_failed(run_2)
 
         cached_status = get_and_update_asset_status_cache_value(
             created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
         )
-        assert partitions_def.deserialize_subset(
-            cached_status.serialized_failed_partition_subset
+        assert cached_status.deserialize_failed_partition_subsets(
+            partitions_def
         ).get_partition_keys() == {"fail1", "fail2"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
 
 
 def test_cache_cancelled_runs():
@@ -575,6 +611,9 @@ def test_cache_cancelled_runs():
             created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
         )
         early_id = cached_status.earliest_in_progress_materialization_event_id
+        assert cached_status.deserialize_in_progress_partition_subsets(
+            partitions_def
+        ).get_partition_keys() == {"fail1"}
 
         run_2 = create_run_for_test(created_instance, status=DagsterRunStatus.STARTED)
         created_instance.event_log_storage.store_event(
@@ -603,6 +642,9 @@ def test_cache_cancelled_runs():
             ).get_partition_keys()
             == set()
         )
+        assert cached_status.deserialize_in_progress_partition_subsets(
+            partitions_def
+        ).get_partition_keys() == {"fail1", "fail2"}
         assert cached_status.earliest_in_progress_materialization_event_id == early_id
 
         created_instance.report_run_failed(run_2)
@@ -613,6 +655,9 @@ def test_cache_cancelled_runs():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail2"}
+        assert cached_status.deserialize_in_progress_partition_subsets(
+            partitions_def
+        ).get_partition_keys() == {"fail1"}
         assert cached_status.earliest_in_progress_materialization_event_id == early_id
 
         created_instance.report_run_canceled(run_1)
@@ -623,6 +668,12 @@ def test_cache_cancelled_runs():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail2"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
         assert cached_status.earliest_in_progress_materialization_event_id is None
 
 
@@ -678,6 +729,9 @@ def test_failure_cache_concurrent_materializations():
         cached_status = get_and_update_asset_status_cache_value(
             created_instance, asset_key, asset_graph.get_partitions_def(asset_key)
         )
+        assert cached_status.deserialize_in_progress_partition_subsets(
+            partitions_def
+        ).get_partition_keys() == {"fail1"}
         assert cached_status.earliest_in_progress_materialization_event_id is not None
 
         created_instance.report_run_failed(run_2)
@@ -688,5 +742,11 @@ def test_failure_cache_concurrent_materializations():
         assert partitions_def.deserialize_subset(
             cached_status.serialized_failed_partition_subset
         ).get_partition_keys() == {"fail1"}
+        assert (
+            cached_status.deserialize_in_progress_partition_subsets(
+                partitions_def
+            ).get_partition_keys()
+            == set()
+        )
         # run_1 is still in progress, but run_2 started after and failed, so we move on
         assert cached_status.earliest_in_progress_materialization_event_id is None


### PR DESCRIPTION
While computing failed materializations we were filtering out in progress. Now we'll actually keep track of them