### PR TITLE
[7/n][resources ui] Expose resource job/op dependencies in repo snapshot

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1944,8 +1944,8 @@ enum NestedResourceType {
 }
 
 type JobWithOps {
-  jobName: String!
-  ops: [String!]!
+  job: Job!
+  opsUsing: [SolidHandle!]!
 }
 
 type RepositoryConnection {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1918,6 +1918,7 @@ type ResourceDetails {
   parentResources: [NestedResourceEntry!]!
   resourceType: String!
   assetKeysUsing: [AssetKey!]!
+  jobsOpsUsing: [JobWithOps!]!
 }
 
 type ConfiguredValue {
@@ -1940,6 +1941,11 @@ type NestedResourceEntry {
 enum NestedResourceType {
   ANONYMOUS
   TOP_LEVEL
+}
+
+type JobWithOps {
+  jobName: String!
+  ops: [String!]!
 }
 
 type RepositoryConnection {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1746,6 +1746,12 @@ export type JobOrPipelineSelector = {
   solidSelection?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type JobWithOps = {
+  __typename: 'JobWithOps';
+  jobName: Scalars['String'];
+  ops: Array<Scalars['String']>;
+};
+
 export type JsonMetadataEntry = MetadataEntry & {
   __typename: 'JsonMetadataEntry';
   description: Maybe<Scalars['String']>;
@@ -2868,6 +2874,7 @@ export type ResourceDetails = {
   configuredValues: Array<ConfiguredValue>;
   description: Maybe<Scalars['String']>;
   isTopLevel: Scalars['Boolean'];
+  jobsOpsUsing: Array<JobWithOps>;
   name: Scalars['String'];
   nestedResources: Array<NestedResourceEntry>;
   parentResources: Array<NestedResourceEntry>;

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1748,8 +1748,8 @@ export type JobOrPipelineSelector = {
 
 export type JobWithOps = {
   __typename: 'JobWithOps';
-  jobName: Scalars['String'];
-  ops: Array<Scalars['String']>;
+  job: Job;
+  opsUsing: Array<SolidHandle>;
 };
 
 export type JsonMetadataEntry = MetadataEntry & {
@@ -7449,8 +7449,20 @@ export const buildJobWithOps = (
   relationshipsToOmit.add('JobWithOps');
   return {
     __typename: 'JobWithOps',
-    jobName: overrides && overrides.hasOwnProperty('jobName') ? overrides.jobName! : 'nihil',
-    ops: overrides && overrides.hasOwnProperty('ops') ? overrides.ops! : ['placeat'],
+    job:
+      overrides && overrides.hasOwnProperty('job')
+        ? overrides.job!
+        : relationshipsToOmit.has('Job')
+        ? ({} as Job)
+        : buildJob({}, relationshipsToOmit),
+    opsUsing:
+      overrides && overrides.hasOwnProperty('opsUsing')
+        ? overrides.opsUsing!
+        : [
+            relationshipsToOmit.has('SolidHandle')
+              ? ({} as SolidHandle)
+              : buildSolidHandle({}, relationshipsToOmit),
+          ],
   };
 };
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -7441,6 +7441,19 @@ export const buildJobOrPipelineSelector = (
   };
 };
 
+export const buildJobWithOps = (
+  overrides?: Partial<JobWithOps>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'JobWithOps'} & JobWithOps => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('JobWithOps');
+  return {
+    __typename: 'JobWithOps',
+    jobName: overrides && overrides.hasOwnProperty('jobName') ? overrides.jobName! : 'nihil',
+    ops: overrides && overrides.hasOwnProperty('ops') ? overrides.ops! : ['placeat'],
+  };
+};
+
 export const buildJsonMetadataEntry = (
   overrides?: Partial<JsonMetadataEntry>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -10290,6 +10303,14 @@ export const buildResourceDetails = (
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'laudantium',
     isTopLevel: overrides && overrides.hasOwnProperty('isTopLevel') ? overrides.isTopLevel! : false,
+    jobsOpsUsing:
+      overrides && overrides.hasOwnProperty('jobsOpsUsing')
+        ? overrides.jobsOpsUsing!
+        : [
+            relationshipsToOmit.has('JobWithOps')
+              ? ({} as JobWithOps)
+              : buildJobWithOps({}, relationshipsToOmit),
+          ],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'praesentium',
     nestedResources:
       overrides && overrides.hasOwnProperty('nestedResources')

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -61,6 +61,14 @@ class GrapheneNestedResourceEntry(graphene.ObjectType):
         name = "NestedResourceEntry"
 
 
+class GrapheneJobWithOps(graphene.ObjectType):
+    jobName = graphene.NonNull(graphene.String)
+    ops = graphene.Field(non_null_list(graphene.String))
+
+    class Meta:
+        name = "JobWithOps"
+
+
 class GrapheneResourceDetails(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     description = graphene.String()
@@ -86,6 +94,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
     )
     resourceType = graphene.NonNull(graphene.String)
     assetKeysUsing = graphene.Field(non_null_list(GrapheneAssetKey))
+    jobsOpsUsing = graphene.Field(non_null_list(GrapheneJobWithOps))
 
     class Meta:
         name = "ResourceDetails"
@@ -112,6 +121,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
         self._parent_resources = external_resource.parent_resources
         self.resourceType = external_resource.resource_type
         self._asset_keys_using = external_resource.asset_keys_using
+        self._job_ops_using = external_resource.job_ops_using
 
     def resolve_configFields(self, _graphene_info):
         return [
@@ -168,8 +178,14 @@ class GrapheneResourceDetails(graphene.ObjectType):
             for name, attribute in self._parent_resources.items()
         ]
 
-    def resolve_assetKeysUsing(self, _graphene_info):
+    def resolve_assetKeysUsing(self, _graphene_info) -> List[GrapheneAssetKey]:
         return [GrapheneAssetKey(path=asset_key.path) for asset_key in self._asset_keys_using]
+
+    def resolve_jobsOpsUsing(self, _graphene_info) -> List[GrapheneJobWithOps]:
+        return [
+            GrapheneJobWithOps(jobName=job_name, ops=ops)
+            for job_name, ops in self._job_ops_using.items()
+        ]
 
 
 class GrapheneResourceDetailsOrError(graphene.Union):

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -598,6 +598,10 @@ class ExternalResource:
     def asset_keys_using(self) -> List[AssetKey]:
         return self._external_resource_data.asset_keys_using
 
+    @property
+    def job_ops_using(self) -> Dict[str, List[str]]:
+        return self._external_resource_data.job_ops_using
+
 
 class ExternalSchedule:
     def __init__(self, external_schedule_data: ExternalScheduleData, handle: RepositoryHandle):

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -66,6 +66,7 @@ from .external_data import (
     ExternalSensorMetadata,
     ExternalTargetData,
     NestedResource,
+    ResourceJobUsageEntry,
 )
 from .handle import InstigatorHandle, JobHandle, PartitionSetHandle, RepositoryHandle
 from .pipeline_index import PipelineIndex
@@ -599,7 +600,7 @@ class ExternalResource:
         return self._external_resource_data.asset_keys_using
 
     @property
-    def job_ops_using(self) -> Dict[str, List[str]]:
+    def job_ops_using(self) -> List[ResourceJobUsageEntry]:
         return self._external_resource_data.job_ops_using
 
 

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -934,9 +934,7 @@ UNKNOWN_RESOURCE_TYPE = "Unknown"
 
 @whitelist_for_serdes
 class ResourceJobUsageEntry(NamedTuple):
-    """Stores information about where a resource is used in a job.
-
-    """
+    """Stores information about where a resource is used in a job."""
 
     job_name: str
     node_handles: List[NodeHandle]

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1174,7 +1174,7 @@ def _get_resource_job_usage(pipelines: Sequence[PipelineDefinition]) -> Resource
             continue
 
         resource_usage: List[NodeHandleResourceUse] = []
-        for solid in pipeline.solids_in_topological_order:
+        for solid in pipeline.nodes_in_topological_order:
             resource_usage += [use for use in _get_resource_usage_from_node(pipeline, solid)]
         node_use_by_key: Dict[str, List[NodeHandle]] = defaultdict(list)
         for use in resource_usage:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 from dagster import Definitions, asset, job, op, repository, resource
 from dagster._config.field_utils import EnvVar
 from dagster._config.structured_config import Config, ConfigurableResource
+from dagster._core.definitions.definitions_class import BindResourcesToJobs
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
@@ -434,3 +435,60 @@ def test_repository_snap_definitions_function_style_resources_assets_usage() -> 
         AssetKey("my_asset"),
         AssetKey("my_other_asset"),
     ]
+
+
+def test_repository_snap_definitions_resources_job_op_usage() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @op
+    def my_op(foo: MyResource):
+        pass
+
+    @op
+    def my_other_op(foo: MyResource, bar: MyResource):
+        pass
+
+    @op
+    def my_third_op():
+        pass
+
+    @op
+    def my_op_in_other_job(foo: MyResource):
+        pass
+
+    @job
+    def my_first_job() -> None:
+        my_op()
+        my_other_op()
+        my_third_op()
+
+    @job
+    def my_second_job() -> None:
+        my_op_in_other_job()
+
+    defs = Definitions(
+        jobs=BindResourcesToJobs([my_first_job, my_second_job]),
+        resources={"foo": MyResource(a_str="foo"), "bar": MyResource(a_str="bar")},
+    )
+
+    repo = resolve_pending_repo_if_required(defs)
+    external_repo_data = external_repository_data_from_def(repo)
+    assert external_repo_data.external_resource_data
+
+    assert len(external_repo_data.external_resource_data) == 2
+
+    foo = [data for data in external_repo_data.external_resource_data if data.name == "foo"]
+    assert len(foo) == 1
+
+    assert foo[0].job_ops_using == {
+        "my_first_job": ["my_op", "my_other_op"],
+        "my_second_job": ["my_op_in_other_job"],
+    }
+
+    bar = [data for data in external_repo_data.external_resource_data if data.name == "bar"]
+    assert len(bar) == 1
+
+    assert bar[0].job_ops_using == {
+        "my_first_job": ["my_other_op"],
+    }


### PR DESCRIPTION
## Summary

Locates the set of ops & their containing jobs that refer to a particular resource. Packages them up in the snapshot for display in the UI.

## Test Plan

New unit test.