### PR TITLE
[8/n][resources ui] Display resource job/op dependencies in resource UI

### DIFF
--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -433,7 +433,7 @@ const ResourceUses: React.FC<{
             <tbody>
               {resourceDetails.jobsOpsUsing.map((jobOps) => {
                 return (
-                  <tr key={jobOps.jobName}>
+                  <tr key={jobOps.job.name}>
                     <td>
                       <Box
                         flex={{
@@ -446,8 +446,10 @@ const ResourceUses: React.FC<{
                       >
                         <Icon name="job" color={Colors.Gray400} />
 
-                        <Link to={workspacePathFromAddress(repoAddress, `/jobs/${jobOps.jobName}`)}>
-                          <MiddleTruncate text={jobOps.jobName} />
+                        <Link
+                          to={workspacePathFromAddress(repoAddress, `/jobs/${jobOps.job.name}`)}
+                        >
+                          <MiddleTruncate text={jobOps.job.name} />
                         </Link>
                       </Box>
                     </td>
@@ -461,7 +463,7 @@ const ResourceUses: React.FC<{
                         }}
                         style={{maxWidth: '100%'}}
                       >
-                        {jobOps.ops.map((op) => (
+                        {jobOps.opsUsing.map((op) => (
                           <Box
                             flex={{
                               direction: 'row',
@@ -470,17 +472,17 @@ const ResourceUses: React.FC<{
                               gap: 8,
                             }}
                             style={{maxWidth: '100%'}}
-                            key={op}
+                            key={op.handleID}
                           >
                             <Icon name="op" color={Colors.Gray400} />
 
                             <Link
                               to={workspacePathFromAddress(
                                 repoAddress,
-                                `/jobs/${jobOps.jobName}/${op}`,
+                                `/jobs/${jobOps.job.name}/${op.handleID.split('.').join('/')}`,
                               )}
                             >
-                              <MiddleTruncate text={op} />
+                              <MiddleTruncate text={op.solid.name} />
                             </Link>
                           </Box>
                         ))}
@@ -575,8 +577,15 @@ export const RESOURCE_DETAILS_FRAGMENT = gql`
       path
     }
     jobsOpsUsing {
-      jobName
-      ops
+      job {
+        name
+      }
+      opsUsing {
+        handleID
+        solid {
+          name
+        }
+      }
     }
     resourceType
   }

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -110,7 +110,8 @@ export const ResourceRoot: React.FC<Props> = (props) => {
   const numUses =
     queryResult.data?.topLevelResourceDetailsOrError.__typename === 'ResourceDetails'
       ? queryResult.data.topLevelResourceDetailsOrError.parentResources.length +
-        queryResult.data.topLevelResourceDetailsOrError.assetKeysUsing.length
+        queryResult.data.topLevelResourceDetailsOrError.assetKeysUsing.length +
+        queryResult.data.topLevelResourceDetailsOrError.jobsOpsUsing.length
       : 0;
 
   const tab = useRouteMatch<{tab?: string}>(['/locations/:repoPath/resources/:name/:tab?'])?.params
@@ -417,6 +418,81 @@ const ResourceUses: React.FC<{
           </Table>
         </Box>
       )}
+      {resourceDetails.jobsOpsUsing.length > 0 && (
+        <Box>
+          <SectionHeader>
+            <Subheading>Jobs</Subheading>
+          </SectionHeader>
+          <Table>
+            <thead>
+              <tr>
+                <th>Job name</th>
+                <th>Ops</th>
+              </tr>
+            </thead>
+            <tbody>
+              {resourceDetails.jobsOpsUsing.map((jobOps) => {
+                return (
+                  <tr key={jobOps.jobName}>
+                    <td>
+                      <Box
+                        flex={{
+                          direction: 'row',
+                          alignItems: 'center',
+                          display: 'inline-flex',
+                          gap: 8,
+                        }}
+                        style={{maxWidth: '100%'}}
+                      >
+                        <Icon name="job" color={Colors.Gray400} />
+
+                        <Link to={workspacePathFromAddress(repoAddress, `/jobs/${jobOps.jobName}`)}>
+                          <MiddleTruncate text={jobOps.jobName} />
+                        </Link>
+                      </Box>
+                    </td>
+                    <td>
+                      <Box
+                        flex={{
+                          direction: 'row',
+                          alignItems: 'center',
+                          display: 'inline-flex',
+                          gap: 8,
+                        }}
+                        style={{maxWidth: '100%'}}
+                      >
+                        {jobOps.ops.map((op) => (
+                          <Box
+                            flex={{
+                              direction: 'row',
+                              alignItems: 'center',
+                              display: 'inline-flex',
+                              gap: 8,
+                            }}
+                            style={{maxWidth: '100%'}}
+                            key={op}
+                          >
+                            <Icon name="op" color={Colors.Gray400} />
+
+                            <Link
+                              to={workspacePathFromAddress(
+                                repoAddress,
+                                `/jobs/${jobOps.jobName}/${op}`,
+                              )}
+                            >
+                              <MiddleTruncate text={op} />
+                            </Link>
+                          </Box>
+                        ))}
+                      </Box>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </Box>
+      )}
     </>
   );
 };
@@ -497,6 +573,10 @@ export const RESOURCE_DETAILS_FRAGMENT = gql`
     }
     assetKeysUsing {
       path
+    }
+    jobsOpsUsing {
+      jobName
+      ops
     }
     resourceType
   }

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -242,7 +242,7 @@ const ResourceConfig: React.FC<{
           <SectionHeader>
             <Subheading>Resource dependencies</Subheading>
           </SectionHeader>
-          <Table>
+          <Table $monospaceFont={false}>
             <thead>
               <tr>
                 <th style={{width: 120}}>Key</th>
@@ -367,7 +367,7 @@ const ResourceUses: React.FC<{
           <SectionHeader>
             <Subheading>Parent resources</Subheading>
           </SectionHeader>
-          <Table>
+          <Table $monospaceFont={false}>
             <thead>
               <tr>
                 <th>Resource</th>
@@ -398,7 +398,7 @@ const ResourceUses: React.FC<{
           <SectionHeader>
             <Subheading>Assets</Subheading>
           </SectionHeader>
-          <Table>
+          <Table $monospaceFont={false}>
             <thead>
               <tr>
                 <th>Asset key</th>
@@ -423,7 +423,7 @@ const ResourceUses: React.FC<{
           <SectionHeader>
             <Subheading>Jobs</Subheading>
           </SectionHeader>
-          <Table>
+          <Table $monospaceFont={false}>
             <thead>
               <tr>
                 <th>Job name</th>

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -578,6 +578,7 @@ export const RESOURCE_DETAILS_FRAGMENT = gql`
     }
     jobsOpsUsing {
       job {
+        id
         name
       }
       opsUsing {

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -43,7 +43,15 @@ export type ResourceDetailsFragment = {
     } | null;
   }>;
   assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
-  jobsOpsUsing: Array<{__typename: 'JobWithOps'; jobName: string; ops: Array<string>}>;
+  jobsOpsUsing: Array<{
+    __typename: 'JobWithOps';
+    job: {__typename: 'Job'; name: string};
+    opsUsing: Array<{
+      __typename: 'SolidHandle';
+      handleID: string;
+      solid: {__typename: 'Solid'; name: string};
+    }>;
+  }>;
 };
 
 export type ResourceRootQueryVariables = Types.Exact<{
@@ -104,7 +112,15 @@ export type ResourceRootQuery = {
           } | null;
         }>;
         assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
-        jobsOpsUsing: Array<{__typename: 'JobWithOps'; jobName: string; ops: Array<string>}>;
+        jobsOpsUsing: Array<{
+          __typename: 'JobWithOps';
+          job: {__typename: 'Job'; name: string};
+          opsUsing: Array<{
+            __typename: 'SolidHandle';
+            handleID: string;
+            solid: {__typename: 'Solid'; name: string};
+          }>;
+        }>;
       }
     | {__typename: 'ResourceNotFoundError'};
 };

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -43,6 +43,7 @@ export type ResourceDetailsFragment = {
     } | null;
   }>;
   assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+  jobsOpsUsing: Array<{__typename: 'JobWithOps'; jobName: string; ops: Array<string>}>;
 };
 
 export type ResourceRootQueryVariables = Types.Exact<{
@@ -103,6 +104,7 @@ export type ResourceRootQuery = {
           } | null;
         }>;
         assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+        jobsOpsUsing: Array<{__typename: 'JobWithOps'; jobName: string; ops: Array<string>}>;
       }
     | {__typename: 'ResourceNotFoundError'};
 };

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -45,7 +45,7 @@ export type ResourceDetailsFragment = {
   assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
   jobsOpsUsing: Array<{
     __typename: 'JobWithOps';
-    job: {__typename: 'Job'; name: string};
+    job: {__typename: 'Job'; id: string; name: string};
     opsUsing: Array<{
       __typename: 'SolidHandle';
       handleID: string;
@@ -114,7 +114,7 @@ export type ResourceRootQuery = {
         assetKeysUsing: Array<{__typename: 'AssetKey'; path: Array<string>}>;
         jobsOpsUsing: Array<{
           __typename: 'JobWithOps';
-          job: {__typename: 'Job'; name: string};
+          job: {__typename: 'Job'; id: string; name: string};
           opsUsing: Array<{
             __typename: 'SolidHandle';
             handleID: string;


### PR DESCRIPTION
## Summary

Adds job/op dependencies as a section to the uses page on the resources UI.



![Screen Shot 2023-03-20 at 1 59 34 PM](https://user-images.githubusercontent.com/10215173/226470036-293b196b-f5df-409b-9672-50cb2f3c401c.png)

## Test Plan

tested locally