### PR TITLE
ExitStack.pop_all -> close

### DIFF
--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -57,7 +57,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
 
     def __exit__(self, _exception_type, _exception_value, _traceback):
         self._executor = None
-        self._exit_stack.pop_all()
+        self._exit_stack.close()
         super().__exit__(_exception_type, _exception_value, _traceback)
 
     @classmethod

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -2106,7 +2106,7 @@ def test_grpc_server_down(instance, executor):
         server_up_ctx = workspace_context.copy_for_test_instance(instance)
 
         # shut down the server
-        stack.pop_all()
+        stack.close()
 
         # Server is no longer running, ticks fail but indicate it will resume once it is reachable
         for _trial in range(3):


### PR DESCRIPTION
The current call sites appear to believe this is equivalent to close even though it is not quite. Clearer to use the correct method.
 
> pop_all()
> Transfers the callback stack to a fresh ExitStack instance and returns it. No callbacks are invoked by this operation - instead, they will now be invoked when the new stack is closed (either explicitly or implicitly at the end of a with statement).


## How I Tested These Changes

bk