### PR TITLE
[9/n][resources ui] Link to resources page from op, asset sidebar

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -124,6 +124,7 @@ export type SidebarAssetFragment = {
     name: string;
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
   };
+  requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
   configField: {
     __typename: 'ConfigTypeField';
     name: string;
@@ -15671,6 +15672,7 @@ export type SidebarAssetQuery = {
           name: string;
           location: {__typename: 'RepositoryLocation'; id: string; name: string};
         };
+        requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
         configField: {
           __typename: 'ConfigTypeField';
           name: string;

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
+import {useFeatureFlags} from '../app/Flags';
 import {breakOnUnderscores} from '../app/Util';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -12,6 +13,7 @@ import {pluginForMetadata} from '../plugins';
 import {CONFIG_TYPE_SCHEMA_FRAGMENT} from '../typeexplorer/ConfigTypeSchema';
 import {DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT, TypeWithTooltip} from '../typeexplorer/TypeWithTooltip';
 import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 import {Description} from './Description';
 import {
@@ -45,6 +47,9 @@ const DEFAULT_INVOCATIONS_SHOWN = 20;
 
 export const SidebarOpDefinition: React.FC<SidebarOpDefinitionProps> = (props) => {
   const {definition, getInvocations, showingSubgraph, onClickInvocation, repoAddress} = props;
+
+  const {flagSidebarResources} = useFeatureFlags();
+
   const Plugin = pluginForMetadata(definition.metadata);
   const isComposite = definition.__typename === 'CompositeSolidDefinition';
   const configField = definition.__typename === 'SolidDefinition' ? definition.configField : null;
@@ -113,7 +118,18 @@ export const SidebarOpDefinition: React.FC<SidebarOpDefinitionProps> = (props) =
             {[...requiredResources].sort().map((requirement) => (
               <ResourceContainer key={requirement.resourceKey}>
                 <Icon name="resource" color={Colors.Gray700} />
-                <ResourceHeader>{requirement.resourceKey}</ResourceHeader>
+                {flagSidebarResources && repoAddress ? (
+                  <Link
+                    to={workspacePathFromAddress(
+                      repoAddress,
+                      `/resources/${requirement.resourceKey}`,
+                    )}
+                  >
+                    <ResourceHeader>{requirement.resourceKey}</ResourceHeader>
+                  </Link>
+                ) : (
+                  <ResourceHeader>{requirement.resourceKey}</ResourceHeader>
+                )}
               </ResourceContainer>
             ))}
           </Box>


### PR DESCRIPTION
## Summary

Adds a link to the resource page from the existing op resource requirements sidebar section. Adds a corresponding section to the asset sidebar, with links.

![Screen Shot 2023-03-20 at 2 26 40 PM](https://user-images.githubusercontent.com/10215173/226470112-e236a63e-b8be-4792-ba50-7561cd0158e3.png)
![Screen Shot 2023-03-20 at 2 26 33 PM](https://user-images.githubusercontent.com/10215173/226470117-f0d4e9ae-9d3c-4626-895f-cc7d63f1fce6.png)


## Test Plan

Tested locally.
