### PR TITLE
[dagster-io/ui] Make Suggest component a bit more flexible

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Suggest.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Suggest.tsx
@@ -48,16 +48,20 @@ export const GlobalSuggestStyle = createGlobalStyle`
 export const MENU_ITEM_HEIGHT = 32;
 
 const MENU_WIDTH = 250; // arbitrary, just looks nice
-const MENU_HEIGHT_MAX = MENU_ITEM_HEIGHT * 7.5;
+const VISIBLE_ITEMS = 7.5;
 
-export const Suggest = <T,>(props: React.PropsWithChildren<SuggestProps<T>>) => {
-  const popoverProps: Partial<IPopoverProps> = {
-    ...props.popoverProps,
+interface Props<T> extends React.PropsWithChildren<SuggestProps<T>> {
+  itemHeight?: number;
+  menuWidth?: number;
+}
+
+export const Suggest = <T,>(props: Props<T>) => {
+  const {popoverProps = {}, itemHeight = MENU_ITEM_HEIGHT, menuWidth = MENU_WIDTH, ...rest} = props;
+
+  const allPopoverProps: Partial<IPopoverProps> = {
+    ...popoverProps,
     minimal: true,
-    modifiers: deepmerge(
-      {offset: {enabled: true, offset: '0 8px'}},
-      props.popoverProps?.modifiers || {},
-    ),
+    modifiers: deepmerge({offset: {enabled: true, offset: '0, 8px'}}, popoverProps.modifiers || {}),
     popoverClassName: `dagit-popover ${props.popoverProps?.className || ''}`,
   };
 
@@ -68,7 +72,7 @@ export const Suggest = <T,>(props: React.PropsWithChildren<SuggestProps<T>>) => 
 
   return (
     <BlueprintSuggest<T>
-      {...props}
+      {...rest}
       inputProps={inputProps}
       itemListRenderer={(props) => (
         <List
@@ -79,17 +83,17 @@ export const Suggest = <T,>(props: React.PropsWithChildren<SuggestProps<T>>) => 
               ? props.filteredItems.indexOf(props.activeItem)
               : undefined
           }
-          rowHeight={MENU_ITEM_HEIGHT}
+          rowHeight={itemHeight}
           rowRenderer={(a) => (
             <div key={a.index} style={a.style}>
               {props.renderItem(props.filteredItems[a.index] as T, a.index)}
             </div>
           )}
-          width={MENU_WIDTH}
-          height={Math.min(props.filteredItems.length * MENU_ITEM_HEIGHT, MENU_HEIGHT_MAX)}
+          width={menuWidth}
+          height={Math.min(props.filteredItems.length * itemHeight, itemHeight * VISIBLE_ITEMS)}
         />
       )}
-      popoverProps={popoverProps}
+      popoverProps={allPopoverProps}
     />
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Make `Suggest` a little more flexible so that I can use it in more interesting ways for the Teams feature in Cloud.

## How I Tested These Changes

Sanity check the behavior of the existing Storybook example.

Use it in my cloud branch, verify that I have more customization control over how items render.
