### PR TITLE
[fix] Fix behavior of BindResourcesToJobs when jobs have config specified

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -110,6 +110,7 @@ class JobDefinition(PipelineDefinition):
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
+        _did_user_provide_resources: bool = False,
     ):
         from dagster._core.definitions.run_config import RunConfig, convert_config_input
         from dagster._loggers import default_loggers
@@ -172,7 +173,11 @@ class JobDefinition(PipelineDefinition):
             _preset_defs, "preset_defs", of_type=PresetDefinition
         )
 
-        did_user_provide_resources = bool(resource_defs)
+        did_user_provide_resources = (
+            bool(resource_defs)
+            if _did_user_provide_resources is None
+            else _did_user_provide_resources
+        )
         if resource_defs and DEFAULT_IO_MANAGER_KEY in resource_defs:
             resource_defs_with_defaults = resource_defs
         else:
@@ -210,6 +215,7 @@ class JobDefinition(PipelineDefinition):
                         executor_def,
                         logger_defs,
                         asset_layer,
+                        did_user_provide_resources=did_user_provide_resources,
                     ),
                     config,
                     name,
@@ -1041,6 +1047,7 @@ def get_run_config_schema_for_job(
     executor_def: "ExecutorDefinition",
     logger_defs: Mapping[str, LoggerDefinition],
     asset_layer: Optional[AssetLayer],
+    did_user_provide_resources: bool = False,
 ) -> ConfigType:
     return (
         JobDefinition(
@@ -1050,6 +1057,7 @@ def get_run_config_schema_for_job(
             executor_def=executor_def,
             logger_defs=logger_defs,
             asset_layer=asset_layer,
+            _did_user_provide_resources=did_user_provide_resources,
         )
         .get_run_config_schema("default")
         .run_config_schema_type

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -110,7 +110,7 @@ class JobDefinition(PipelineDefinition):
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
-        _did_user_provide_resources: Optional[bool] = None,
+        _was_explicitly_provided_resources: Optional[bool] = None,
     ):
         from dagster._core.definitions.run_config import RunConfig, convert_config_input
         from dagster._loggers import default_loggers
@@ -173,10 +173,10 @@ class JobDefinition(PipelineDefinition):
             _preset_defs, "preset_defs", of_type=PresetDefinition
         )
 
-        did_user_provide_resources = (
+        was_provided_resources = (
             bool(resource_defs)
-            if _did_user_provide_resources is None
-            else _did_user_provide_resources
+            if _was_explicitly_provided_resources is None
+            else _was_explicitly_provided_resources
         )
         if resource_defs and DEFAULT_IO_MANAGER_KEY in resource_defs:
             resource_defs_with_defaults = resource_defs
@@ -215,7 +215,7 @@ class JobDefinition(PipelineDefinition):
                         executor_def,
                         logger_defs,
                         asset_layer,
-                        did_user_provide_resources=did_user_provide_resources,
+                        was_explicitly_provided_resources=was_provided_resources,
                     ),
                     config,
                     name,
@@ -258,7 +258,7 @@ class JobDefinition(PipelineDefinition):
             graph_def=graph_def,
             version_strategy=version_strategy,
             asset_layer=asset_layer or _infer_asset_layer_from_source_asset_deps(graph_def),
-            _should_validate_resource_requirements=did_user_provide_resources,
+            _should_validate_resource_requirements=was_provided_resources,
         )
 
     @property
@@ -1047,7 +1047,7 @@ def get_run_config_schema_for_job(
     executor_def: "ExecutorDefinition",
     logger_defs: Mapping[str, LoggerDefinition],
     asset_layer: Optional[AssetLayer],
-    did_user_provide_resources: bool = False,
+    was_explicitly_provided_resources: bool = False,
 ) -> ConfigType:
     return (
         JobDefinition(
@@ -1057,7 +1057,7 @@ def get_run_config_schema_for_job(
             executor_def=executor_def,
             logger_defs=logger_defs,
             asset_layer=asset_layer,
-            _did_user_provide_resources=did_user_provide_resources,
+            _was_explicitly_provided_resources=was_explicitly_provided_resources,
         )
         .get_run_config_schema("default")
         .run_config_schema_type

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -110,7 +110,7 @@ class JobDefinition(PipelineDefinition):
         _executor_def_specified: Optional[bool] = None,
         _logger_defs_specified: Optional[bool] = None,
         _preset_defs: Optional[Sequence[PresetDefinition]] = None,
-        _did_user_provide_resources: bool = False,
+        _did_user_provide_resources: Optional[bool] = None,
     ):
         from dagster._core.definitions.run_config import RunConfig, convert_config_input
         from dagster._loggers import default_loggers

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1551,6 +1551,15 @@ def test_bind_resource_to_job_with_job_config() -> None:
     assert defs.get_job_def("hello_earth_job").execute_in_process().success
     assert out_txt == ["msg: hello, earth!"]
 
+    # Validate that we correctly error
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="resource with key 'writer' required by op 'hello_world_op' was not provided",
+    ):
+        Definitions(
+            jobs=BindResourcesToJobs([hello_world_job]),
+        )
+
 
 def test_execute_in_process() -> None:
     out_txt = []

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1513,6 +1513,45 @@ def test_bind_resource_to_job_at_defn_time() -> None:
     assert out_txt == ["msg: hello, world!"]
 
 
+def test_bind_resource_to_job_with_job_config() -> None:
+    out_txt = []
+
+    class WriterResource(ConfigurableResource):
+        prefix: str
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix}{text}")
+
+    class OpConfig(Config):
+        message: str = "hello, world!"
+
+    @op
+    def hello_world_op(writer: WriterResource, config: OpConfig):
+        writer.output(config.message)
+
+    @job(config={})
+    def hello_world_job() -> None:
+        hello_world_op()
+
+    @job(config={"ops": {"hello_world_op": {"config": {"message": "hello, earth!"}}}})
+    def hello_earth_job() -> None:
+        hello_world_op()
+
+    defs = Definitions(
+        jobs=BindResourcesToJobs([hello_world_job, hello_earth_job]),
+        resources={
+            "writer": WriterResource(prefix="msg: "),
+        },
+    )
+
+    assert defs.get_job_def("hello_world_job").execute_in_process().success
+    assert out_txt == ["msg: hello, world!"]
+    out_txt.clear()
+
+    assert defs.get_job_def("hello_earth_job").execute_in_process().success
+    assert out_txt == ["msg: hello, earth!"]
+
+
 def test_execute_in_process() -> None:
     out_txt = []
 


### PR DESCRIPTION
## Summary

Addresses #13022. Jobs which have config bound would cause issues when trying to late-bind resources because the job would be validated early, since we construct new `JobDefinition` objects as part of processing this config.

This PR passes through resource-binding status to these nested `JobDefinitions` to ensure that their resources are resolved late.

## Test Plan

new unit test
