### PR TITLE
Add docs for source asset observation jobs/schedules

### DIFF
--- a/docs/content/concepts/assets/asset-observations.mdx
+++ b/docs/content/concepts/assets/asset-observations.mdx
@@ -116,13 +116,14 @@ used in staleness calculations for downstream assets.
 
 The <PyObject object="observable_source_asset" /> decorator provides a convenient way to define source assets with observation functions. The below observable source asset takes a file hash and returns it as the data version. Every time you run the observation function, a new observation will be generated with this hash set as its data version.
 
-```python file=/concepts/assets/observable_source_assets.py startafter=start_marker endbefore=end_marker
+```python file=/concepts/assets/observable_source_assets.py startafter=start_plain endbefore=end_plain
 from hashlib import sha256
+
 from dagster import DataVersion, observable_source_asset
 
 
 @observable_source_asset
-def foo_source_asset(_context):
+def foo_source_asset():
     content = read_some_file()
     hash_sig = sha256()
     hash_sig.update(bytearray(content, "utf8"))
@@ -139,3 +140,34 @@ src="/images/concepts/assets/observe-sources.png"
 width={1768}
 height={1282}
 />
+
+Source asset observations can also be run as part of an asset job. This allows you to run source asset observations on a schedule:
+
+```python file=/concepts/assets/observable_source_assets.py startafter=start_schedule endbefore=end_schedule
+from dagster import (
+    DataVersion,
+    ScheduleDefinition,
+    define_asset_job,
+    observable_source_asset,
+)
+
+
+@observable_source_asset
+def foo_source_asset():
+    content = read_some_file()
+    hash_sig = sha256()
+    hash_sig.update(bytearray(content, "utf8"))
+    return DataVersion(hash_sig.hexdigest())
+
+
+observation_job = define_asset_job("observation_job", [foo_source_asset])
+
+# schedule that will run the observation on foo_source_asset every day
+observation_schedule = ScheduleDefinition(
+    name="observation_schedule",
+    cron_schedule="@daily",
+    job=observation_job,
+)
+```
+
+**NOTE**: Currently, source asset observations cannot be run as part of a standard asset job that materializes assets. The `selection` argument to <PyObject object="define_asset_job" /> must target only observable source assets-- an error will be thrown if a mix of regular assets and observable source assets is selected.

--- a/docs/next/util/codeBlockTransformer.ts
+++ b/docs/next/util/codeBlockTransformer.ts
@@ -81,8 +81,8 @@ export default ({setCodeBlockStats: setCodeBlockStats}: CodeTransformerOptions) 
         );
 
         // remove pragmas
-        contentWithLimit = contentWithLimit.replace(/^\s*# (type|noqa):.*$/g, '');
-        contentWithLimit = contentWithLimit.replace(/  # (type|noqa):.*$/g, '');
+        contentWithLimit = contentWithLimit.replace(/^\s*# (type|ruff|isort|noqa):.*$/g, '');
+        contentWithLimit = contentWithLimit.replace(/  # (type|ruff|isort|noqa):.*$/g, '');
 
         if (metaOptions.trim) {
           contentWithLimit = contentWithLimit.trim();

--- a/examples/docs_snippets/docs_snippets/concepts/assets/observable_source_assets.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/observable_source_assets.py
@@ -1,21 +1,48 @@
-# isort: off
-
-
 def read_some_file():
     return "foo"
 
 
-# start_marker
+# isort: split
+# start_plain
 from hashlib import sha256
+
 from dagster import DataVersion, observable_source_asset
 
 
 @observable_source_asset
-def foo_source_asset(_context):
+def foo_source_asset():  # type: ignore  # (didactic)
     content = read_some_file()
     hash_sig = sha256()
     hash_sig.update(bytearray(content, "utf8"))
     return DataVersion(hash_sig.hexdigest())
 
 
-# end_marker
+# end_plain
+
+# isort: split
+# start_schedule
+from dagster import (
+    DataVersion,
+    ScheduleDefinition,
+    define_asset_job,
+    observable_source_asset,
+)
+
+
+@observable_source_asset
+def foo_source_asset():
+    content = read_some_file()
+    hash_sig = sha256()
+    hash_sig.update(bytearray(content, "utf8"))
+    return DataVersion(hash_sig.hexdigest())
+
+
+observation_job = define_asset_job("observation_job", [foo_source_asset])
+
+# schedule that will run the observation on foo_source_asset every day
+observation_schedule = ScheduleDefinition(
+    name="observation_schedule",
+    cron_schedule="@daily",
+    job=observation_job,
+)
+# end_schedule

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
@@ -1,6 +1,13 @@
 from dagster import repository
 from dagster._core.definitions.assets_job import build_assets_job
-from docs_snippets.concepts.assets.observable_source_assets import foo_source_asset
+from dagster._core.definitions.data_version import extract_data_version_from_entry
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.instance_for_test import instance_for_test
+from docs_snippets.concepts.assets.observable_source_assets import (
+    foo_source_asset,
+    observation_job,
+    observation_schedule,
+)
 
 
 def test_observable_source_asset():
@@ -11,3 +18,22 @@ def test_observable_source_asset():
     job_def = build_assets_job("test_job", [], [foo_source_asset])
     result = job_def.execute_in_process()
     assert result.success
+
+
+def test_observable_source_asset_job():
+    with instance_for_test() as instance:
+        Definitions(
+            assets=[foo_source_asset],
+            jobs=[observation_job],
+        ).get_job_def(
+            "observation_job"
+        ).execute_in_process(instance=instance)
+
+        record = instance.get_latest_data_version_record(foo_source_asset.key)
+        assert record
+        assert extract_data_version_from_entry(record.event_log_entry)
+
+
+def test_observable_source_asset_schedule():
+    assert observation_schedule.name == "observation_schedule"
+    assert observation_schedule.cron_schedule == "@daily"


### PR DESCRIPTION
## Summary & Motivation

Add some docs for ability to run observable source assets on jobs and in schedules.

## How I Tested These Changes

New unit tests.
