### PR TITLE
[10/n][resources ui] Display resource requirements on asset catalog

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -3,6 +3,7 @@ import {Body, Box, Caption, Colors, ConfigTypeSchema, Icon, Mono, Subheading} fr
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
+import {useFeatureFlags} from '../app/Flags';
 import {ASSET_NODE_FRAGMENT} from '../asset-graph/AssetNode';
 import {
   displayNameForAssetKey,
@@ -40,6 +41,7 @@ export const AssetNodeDefinition: React.FC<{
   dependsOnSelf: boolean;
 }> = ({assetNode, upstream, downstream, liveDataByNode, dependsOnSelf}) => {
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
+  const {flagSidebarResources} = useFeatureFlags();
   const liveDataForNode = liveDataByNode[toGraphId(assetNode.assetKey)];
 
   const assetConfigSchema = assetNode.configField?.configType;
@@ -162,7 +164,7 @@ export const AssetNodeDefinition: React.FC<{
                   {assetNode.requiredResources.map((resource) => (
                     <ResourceContainer key={resource.resourceKey}>
                       <Icon name="resource" color={Colors.Gray700} />
-                      {true && repoAddress ? (
+                      {flagSidebarResources && repoAddress ? (
                         <Link
                           to={workspacePathFromAddress(
                             repoAddress,

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -14,6 +14,7 @@ import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraph
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {Description} from '../pipelines/Description';
 import {PipelineReference} from '../pipelines/PipelineReference';
+import {ResourceContainer, ResourceHeader} from '../pipelines/SidebarOpHelpers';
 import {Version} from '../versions/Version';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
@@ -140,24 +141,60 @@ export const AssetNodeDefinition: React.FC<{
           {/** Ensures the line between the left and right columns goes to the bottom of the page */}
           <div style={{flex: 1}} />
         </Box>
-        {assetConfigSchema ? (
+        {assetConfigSchema || assetNode.requiredResources.length > 0 ? (
           <Box
             border={{side: 'vertical', width: 1, color: Colors.KeylineGray}}
             style={{flex: 0.5, minWidth: 0}}
             flex={{direction: 'column'}}
           >
-            <Box
-              padding={{vertical: 16, horizontal: 24}}
-              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-            >
-              <Subheading>Config</Subheading>
-            </Box>
-            <Box padding={{vertical: 16, horizontal: 24}}>
-              <ConfigTypeSchema
-                type={assetConfigSchema}
-                typesInScope={assetConfigSchema.recursiveConfigTypes}
-              />
-            </Box>
+            {assetNode.requiredResources.length > 0 && (
+              <>
+                <Box
+                  padding={{vertical: 16, horizontal: 24}}
+                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                >
+                  <Subheading>Required Resources</Subheading>
+                </Box>
+                <Box
+                  padding={{vertical: 16, horizontal: 24}}
+                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                >
+                  {assetNode.requiredResources.map((resource) => (
+                    <ResourceContainer key={resource.resourceKey}>
+                      <Icon name="resource" color={Colors.Gray700} />
+                      {true && repoAddress ? (
+                        <Link
+                          to={workspacePathFromAddress(
+                            repoAddress,
+                            `/resources/${resource.resourceKey}`,
+                          )}
+                        >
+                          <ResourceHeader>{resource.resourceKey}</ResourceHeader>
+                        </Link>
+                      ) : (
+                        <ResourceHeader>{resource.resourceKey}</ResourceHeader>
+                      )}
+                    </ResourceContainer>
+                  ))}
+                </Box>
+              </>
+            )}
+            {assetConfigSchema && (
+              <>
+                <Box
+                  padding={{vertical: 16, horizontal: 24}}
+                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+                >
+                  <Subheading>Config</Subheading>
+                </Box>
+                <Box padding={{vertical: 16, horizontal: 24}}>
+                  <ConfigTypeSchema
+                    type={assetConfigSchema}
+                    typesInScope={assetConfigSchema.recursiveConfigTypes}
+                  />
+                </Box>
+              </>
+            )}
           </Box>
         ) : null}
 
@@ -286,6 +323,10 @@ export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
         name
       }
     }
+    requiredResources {
+      resourceKey
+    }
+
     ...AssetNodeConfigFragment
     ...AssetNodeFragment
     ...AssetNodeOpMetadataFragment

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetViewDefinition.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetViewDefinition.mocks.ts
@@ -100,6 +100,12 @@ export const AssetViewDefinitionSourceAsset: MockedResponse<AssetViewDefinitionQ
           },
           metadataEntries: [],
           type: null,
+          requiredResources: [
+            {
+              __typename: 'ResourceRequirement',
+              resourceKey: 'foo',
+            },
+          ],
         },
         __typename: 'Asset',
       },
@@ -158,6 +164,12 @@ export const AssetViewDefinitionSDA: MockedResponse<AssetViewDefinitionQuery> = 
           },
           metadataEntries: [],
           type: null,
+          requiredResources: [
+            {
+              __typename: 'ResourceRequirement',
+              resourceKey: 'foo',
+            },
+          ],
         },
         __typename: 'Asset',
       },

--- a/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetNodeDefinition.types.ts
@@ -22,6 +22,7 @@ export type AssetNodeDefinitionFragment = {
     name: string;
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
   };
+  requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
   configField: {
     __typename: 'ConfigTypeField';
     name: string;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
@@ -66,6 +66,7 @@ export type AssetViewDefinitionQuery = {
               };
             }>;
           }>;
+          requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
           configField: {
             __typename: 'ConfigTypeField';
             name: string;
@@ -15766,6 +15767,7 @@ export type AssetViewDefinitionNodeFragment = {
       };
     }>;
   }>;
+  requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
   configField: {
     __typename: 'ConfigTypeField';
     name: string;


### PR DESCRIPTION
## Summary

Adds assets' required resources to the asset catalog page.

<img width="1459" alt="Screen Shot 2023-03-21 at 3 08 49 PM" src="https://user-images.githubusercontent.com/10215173/226753791-324c00c3-3768-49c2-b73e-fc31dab05d9e.png">


## Test Plan

tested locally
