### PR TITLE
Add dynamic partitions name resolver to dimension type

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -777,6 +777,7 @@ type DimensionDefinitionType {
   description: String!
   type: PartitionDefinitionType!
   isPrimaryDimension: Boolean!
+  dynamicPartitionsDefinitionName: String
 }
 
 type TimePartitionsDefinitionMetadata {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -980,6 +980,7 @@ export type DeleteRunMutation = {
 export type DimensionDefinitionType = {
   __typename: 'DimensionDefinitionType';
   description: Scalars['String'];
+  dynamicPartitionsDefinitionName: Maybe<Scalars['String']>;
   isPrimaryDimension: Scalars['Boolean'];
   name: Scalars['String'];
   type: PartitionDefinitionType;
@@ -5524,6 +5525,10 @@ export const buildDimensionDefinitionType = (
     __typename: 'DimensionDefinitionType',
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'aut',
+    dynamicPartitionsDefinitionName:
+      overrides && overrides.hasOwnProperty('dynamicPartitionsDefinitionName')
+        ? overrides.dynamicPartitionsDefinitionName!
+        : 'qui',
     isPrimaryDimension:
       overrides && overrides.hasOwnProperty('isPrimaryDimension')
         ? overrides.isPrimaryDimension!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -362,6 +362,7 @@ class GrapheneDimensionDefinitionType(graphene.ObjectType):
     description = graphene.NonNull(graphene.String)
     type = graphene.NonNull(GraphenePartitionDefinitionType)
     isPrimaryDimension = graphene.NonNull(graphene.Boolean)
+    dynamicPartitionsDefinitionName = graphene.Field(graphene.String)
 
     class Meta:
         name = "DimensionDefinitionType"
@@ -418,6 +419,11 @@ class GraphenePartitionDefinition(graphene.ObjectType):
                     == cast(
                         MultiPartitionsDefinition, partition_def_data.get_partitions_definition()
                     ).primary_dimension.name,
+                    dynamicPartitionsDefinitionName=dim.external_partitions_def_data.name
+                    if isinstance(
+                        dim.external_partitions_def_data, ExternalDynamicPartitionsDefinitionData
+                    )
+                    else None,
                 )
                 for dim in partition_def_data.external_partition_dimension_definitions
             ]
@@ -430,6 +436,9 @@ class GraphenePartitionDefinition(graphene.ObjectType):
                         partition_def_data
                     ),
                     isPrimaryDimension=True,
+                    dynamicPartitionsDefinitionName=partition_def_data.name
+                    if isinstance(partition_def_data, ExternalDynamicPartitionsDefinitionData)
+                    else None,
                 )
             ],
             timeWindowMetadata=_get_time_partitions_metadata(partition_def_data)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -355,6 +355,13 @@ GET_2D_ASSET_PARTITIONS = """
                     }
                 }
             }
+            partitionDefinition {
+                name
+                dimensionTypes {
+                    dynamicPartitionsDefinitionName
+                    name
+                }
+            }
         }
     }
 """
@@ -1897,6 +1904,14 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result.data
         assert result.data["assetNodes"]
+
+        assert result.data["assetNodes"][0]["partitionDefinition"] == {
+            "dimensionTypes": [
+                {"dynamicPartitionsDefinitionName": "dynamic", "name": "dynamic"},
+                {"dynamicPartitionsDefinitionName": None, "name": "static"},
+            ],
+            "name": None,
+        }
 
         # success asset contains 1 materialized range
         success_asset_result = result.data["assetNodes"][1]


### PR DESCRIPTION
Currently the Dagit view to add a partition to a multipartitions def containing a dynamic dimension is broken and throws a "you do not have permission" error. The cause of this issue is that the name of the multipartitions def (which is `null`) is being passed into the add partitions mutation, so no matching partitions defs are found.

This PR adds a `dynamicPartitionsName` resolver to the partition dimension gql object, to fetch the name of nested dynamic partitions defs within multipartitions defs. This resolver is not to be confused with the `name` resolver, which represents the dimension name (though longer term we should refactor these objects to be cleaner). 

In addition, modifies the permission check to also detect when a matching partitions def is found that is a dimension a multipartitions def.