### PR TITLE
Fix partitioned asset example

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -131,12 +131,21 @@ from dagster import (
 )
 
 
-@asset(partitions_def=HourlyPartitionsDefinition(start_date="2020-01-01-00:00"))
+hourly_partition_def = HourlyPartitionsDefinition(
+    start_date="2023-03-19-00:00"
+)
+
+
+@asset(partitions_def=hourly_partition_def)
 def hourly_asset():
     ...
 
 
-partitioned_asset_job = define_asset_job("partitioned_job", selection=[hourly_asset])
+partitioned_asset_job = define_asset_job(
+    "partitioned_job", 
+    selection=[hourly_asset],
+    partitions_def=hourly_partition_def,
+    )
 
 
 asset_partitioned_schedule = build_schedule_from_partitioned_job(


### PR DESCRIPTION
Without `partitions_def=...` in `define_asset_job`, I get the following errors:
* `dagster._core.errors.ScheduleExecutionError: Error occurred during the execution function for schedule partitioned_job_schedule`
* `dagster._check.CheckError: Failure condition: Called run_request_for_partition on a non-partitioned job`

## Summary & Motivation

This fixes the documentation error I was getting following the partitioned asset example.

## How I Tested These Changes

Running the above example with `dagster dev` using the following import and definitions:
```
from dagster import (
    HourlyPartitionsDefinition,
    asset,
    build_schedule_from_partitioned_job,
    define_asset_job,
)

defs = Definitions(
    assets=[hourly_asset],
    schedules=[asset_partitioned_schedule],
)
```

