### PR TITLE
Fix disabled state for launchpad button submenu

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -212,7 +212,7 @@ export const LaunchAssetExecutionButton: React.FC<{
                 onClick={(e: React.MouseEvent<any>) => {
                   onClick(firstOption.assetKeys, e, true);
                 }}
-                text="Open in lanchpad"
+                text="Open in launchpad"
               />
               {options.slice(1).map((option) => (
                 <MenuItem
@@ -230,7 +230,7 @@ export const LaunchAssetExecutionButton: React.FC<{
             role="button"
             style={{minWidth: 'initial', borderTopLeftRadius: 0, borderBottomLeftRadius: 0}}
             icon={<Icon name="arrow_drop_down" />}
-            disabled={options.slice(1).every((o) => o.assetKeys.length === 0)}
+            disabled={!firstOption.assetKeys.length}
             intent={intent}
           />
         </Popover>


### PR DESCRIPTION
## Summary & Motivation

The disabled state on the submenu  should match the disabled state of the button itself because the new "Open in launchpad" option will always be visible.

before:

<img width="269" alt="Screen Shot 2023-03-22 at 9 44 10 AM" src="https://user-images.githubusercontent.com/2286579/226923898-884c0945-657d-44e2-9c9d-527b1f5341b0.png">

after:

<img width="230" alt="Screen Shot 2023-03-22 at 9 48 24 AM" src="https://user-images.githubusercontent.com/2286579/226924548-6c3a70d4-e21b-4fd6-8927-51dfab7da0d0.png">
