### PR TITLE
feat(helm): add path-prefix to dagit command

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/dagit.py
@@ -22,6 +22,7 @@ class Dagit(BaseModel):
     replicaCount: int
     image: kubernetes.Image
     nameOverride: str
+    pathPrefix: Optional[str]
     service: kubernetes.Service
     workspace: Workspace
     env: Union[Dict[str, str], List[kubernetes.EnvVar]]

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -179,6 +179,18 @@ def test_dagit_name_override(deployment_template, name_override):
     assert deployment_name == f"{deployment_template.release_name}-{name_override}"
 
 
+@pytest.mark.parametrize("path_prefix", ["dagit", "some-path"])
+def test_dagit_path_prefix(deployment_template, path_prefix):
+    helm_values = DagsterHelmValues.construct(dagit=Dagit.construct(pathPrefix=path_prefix))
+    dagit_deployments = deployment_template.render(helm_values)
+
+    assert len(dagit_deployments) == 1
+
+    command = " ".join(dagit_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--path-prefix {path_prefix}" in command
+
+
 def test_dagit_service(service_template):
     helm_values = DagsterHelmValues.construct()
     dagit_template = service_template.render(helm_values)

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -45,6 +45,7 @@ dagit -h 0.0.0.0 -p {{ .Values.dagit.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
 {{- with .Values.dagit.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with .Values.dagit.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
+{{- if .Values.dagit.pathPrefix }} --path-prefix {{ .Values.dagit.pathPrefix }} {{- end -}}
 {{- with .Values.dagit.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .dagitReadOnly }} --read-only {{- end -}}
 {{- end -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -334,6 +334,17 @@
                     "title": "Nameoverride",
                     "type": "string"
                 },
+                "pathPrefix": {
+                    "title": "Pathprefix",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "service": {
                     "$ref": "#/definitions/schema__charts__utils__kubernetes__Service"
                 },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -41,6 +41,9 @@ dagit:
   # Support overriding the name prefix of the Dagit pods
   nameOverride: "dagit"
 
+  # Support path prefix (i.e. /dagster)
+  pathPrefix: ~
+
   service:
     type: ClusterIP
     # Defines the port where Dagit will serve requests; if changed, don't forget to update the


### PR DESCRIPTION
## Summary & Motivation

partially fixes #3637 by allowing the --path-prefix argument to be supplied via the Helm chart.

## How I Tested These Changes

These changes have been unit tested using the helm schema tests