### PR TITLE
[refactor] Replace StepOutputVersionData with custom serialization

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -76,7 +76,7 @@ from .inputs import (
     UnresolvedMappedStepInput,
 )
 from .outputs import StepOutput, StepOutputHandle, UnresolvedStepOutputHandle
-from .state import KnownExecutionState, StepOutputVersionData
+from .state import KnownExecutionState
 from .step import (
     ExecutionStep,
     IExecutionStep,
@@ -714,9 +714,7 @@ class ExecutionPlan(
 
     @property
     def step_output_versions(self) -> Mapping[StepOutputHandle, str]:
-        return StepOutputVersionData.get_version_dict_from_list(
-            self.known_state.step_output_versions if self.known_state else []
-        )
+        return self.known_state.step_output_versions if self.known_state else {}
 
     @property
     def step_keys_to_execute(self) -> Sequence[str]:
@@ -867,11 +865,10 @@ class ExecutionPlan(
         # If step output versions were provided when constructing the subset plan, add them to the
         # known state.
         if len(step_output_versions) > 0:
-            versions = StepOutputVersionData.get_version_list_from_dict(step_output_versions)  # type: ignore  # (possible none)
             if self.known_state:
-                known_state = self.known_state._replace(step_output_versions=versions)
+                known_state = self.known_state._replace(step_output_versions=step_output_versions)
             else:
-                known_state = KnownExecutionState(step_output_versions=versions)
+                known_state = KnownExecutionState(step_output_versions=step_output_versions)  # type: ignore  # (possible none)
         else:
             known_state = self.known_state
 

--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
+    Any,
     Dict,
     List,
     Mapping,
@@ -28,30 +29,16 @@ from dagster._core.execution.retries import RetryState
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.serdes import (
+    FieldSerializer,
+    UnknownSerdesValue,
+    UnpackContext,
+    WhitelistMap,
+    pack_value,
+)
 
 if TYPE_CHECKING:
     from dagster._core.execution.plan.plan import StepHandleUnion
-
-
-@whitelist_for_serdes
-class StepOutputVersionData(NamedTuple):
-    step_output_handle: StepOutputHandle
-    version: str
-
-    @staticmethod
-    def get_version_list_from_dict(
-        step_output_versions: Mapping[StepOutputHandle, str],
-    ) -> Sequence["StepOutputVersionData"]:
-        return [
-            StepOutputVersionData(step_output_handle=step_output_handle, version=version)
-            for step_output_handle, version in step_output_versions.items()
-        ]
-
-    @staticmethod
-    def get_version_dict_from_list(
-        step_output_versions: Sequence["StepOutputVersionData"],
-    ) -> Mapping[StepOutputHandle, str]:
-        return {data.step_output_handle: data.version for data in step_output_versions}
 
 
 @whitelist_for_serdes
@@ -87,7 +74,42 @@ class PastExecutionState(
         return cast(Optional[PastExecutionState], self.parent_state)
 
 
-@whitelist_for_serdes
+# Previously, step_output_versions was stored as a list of StepOutputVersionData objects. It
+# would have to be converted to a dict for use. The sole purpose of the `StepOutputVersion` objects
+# was to make the dict key-value pairs serializable. Using a custom field serializer allows us to
+# avoid this extra complexity.
+class StepOutputVersionSerializer(FieldSerializer):
+    def pack(
+        self, value: Mapping[StepOutputHandle, str], whitelist_map: WhitelistMap, descent_path: str
+    ) -> Sequence[Dict[str, Any]]:
+        return [
+            {
+                "__class__": "StepOutputVersionData",  # this class no longer exists
+                "step_output_handle": pack_value(
+                    k, whitelist_map, f"{descent_path}.{k.step_key}/{k.output_name}"
+                ),
+                "version": v,
+            }
+            for k, v in value.items()
+        ]
+
+    def unpack(
+        self,
+        value: Sequence[UnknownSerdesValue],
+        whitelist_map: WhitelistMap,
+        context: UnpackContext,
+    ) -> Mapping[StepOutputHandle, str]:
+        mapping: Dict[StepOutputHandle, str] = {}
+        for unknown_serdes_value in value:
+            item = unknown_serdes_value.value
+            step_output_handle = cast(StepOutputHandle, item["step_output_handle"])
+            version = cast(str, item["version"])
+            mapping[step_output_handle] = version
+            context.clear_ignored_unknown_values(unknown_serdes_value)
+        return mapping
+
+
+@whitelist_for_serdes(field_serializers={"step_output_versions": StepOutputVersionSerializer})
 class KnownExecutionState(
     NamedTuple(
         "_KnownExecutionState",
@@ -97,7 +119,7 @@ class KnownExecutionState(
             # step_key -> output_name -> mapping_keys
             ("dynamic_mappings", Mapping[str, Mapping[str, Optional[Sequence[str]]]]),
             # step_output_handle -> version
-            ("step_output_versions", Sequence[StepOutputVersionData]),
+            ("step_output_versions", Mapping[StepOutputHandle, str]),
             ("ready_outputs", Set[StepOutputHandle]),
             ("parent_state", Optional[PastExecutionState]),
         ],
@@ -112,7 +134,7 @@ class KnownExecutionState(
         cls,
         previous_retry_attempts: Optional[Mapping[str, int]] = None,
         dynamic_mappings: Optional[Mapping[str, Mapping[str, Optional[Sequence[str]]]]] = None,
-        step_output_versions: Optional[Sequence[StepOutputVersionData]] = None,
+        step_output_versions: Optional[Mapping[StepOutputHandle, str]] = None,
         ready_outputs: Optional[Set[StepOutputHandle]] = None,
         parent_state: Optional[PastExecutionState] = None,
     ):
@@ -134,8 +156,10 @@ class KnownExecutionState(
                 value_type=int,
             ),
             dynamic_mappings,
-            check.opt_sequence_param(
-                step_output_versions, "step_output_versions", of_type=StepOutputVersionData
+            check.opt_mapping_param(
+                step_output_versions,
+                "step_output_versions",
+                key_type=StepOutputHandle,
             ),
             check.opt_set_param(ready_outputs, "ready_outputs", StepOutputHandle),
             check.opt_inst_param(parent_state, "parent_state", PastExecutionState),

--- a/python_modules/dagster/dagster/_core/execution/resolve_versions.py
+++ b/python_modules/dagster/dagster/_core/execution/resolve_versions.py
@@ -173,7 +173,7 @@ def resolve_step_output_versions(
     pipeline_def: JobDefinition,
     execution_plan: "ExecutionPlan",
     resolved_run_config: ResolvedRunConfig,
-):
+) -> Mapping[StepOutputHandle, Optional[str]]:
     step_versions = resolve_step_versions(pipeline_def, execution_plan, resolved_run_config)
     return {
         StepOutputHandle(step.key, output_name): join_and_hash(output_name, step_versions[step.key])


### PR DESCRIPTION
## Summary & Motivation

`StepOutputVersionData` is a class that represents key-value pairs of`(StepOutputHandle, version)`. It's part of the old memoization system. The only reason it exists is to make a `Dict[StepOutputHandle, str]` serdes-friendly, since non-string keys fail the default serialization logic. Whenever we want to access the data encoded by a list of `StepOutputVersionData`, we convert it to a dictionary form.

This PR deletes `StepOutputVersionData` in favor of a custom field serializer (which option did not exist when `StepOutputVersionData` was written. This change allows a `Dict[StepOutputHandle, str]` to be serialized. While overall code volume is not reduced, it pushes serialization details to the serdes layer where they belong.

## How I Tested These Changes

New unit test.
