### PR TITLE
Add assets def to op context

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1141,6 +1141,7 @@ def _build_invocation_context_with_included_resources(
             instance=context._instance,  # noqa: SLF001
             partition_key=context._partition_key,  # noqa: SLF001
             mapping_key=context._mapping_key,  # noqa: SLF001
+            _assets_def=assets_def,
         )
     else:
         # If user is mocking OpExecutionContext, send it through (we don't know

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -5,6 +5,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import experimental, public
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
     DataProvenance,
     extract_data_provenance_from_entry,
@@ -25,7 +26,10 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.definitions.time_window_partitions import TimeWindow
-from dagster._core.errors import DagsterInvalidPropertyError, DagsterInvariantViolationError
+from dagster._core.errors import (
+    DagsterInvalidPropertyError,
+    DagsterInvariantViolationError,
+)
 from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
@@ -266,6 +270,16 @@ class OpExecutionContext(AbstractComputeExecutionContext):
     def op_def(self) -> OpDefinition:
         """OpDefinition: The current op definition."""
         return cast(OpDefinition, self.op.definition)
+
+    @public
+    @property
+    def assets_def(self) -> AssetsDefinition:
+        assets_def = self.job_def.asset_layer.assets_def_for_node(self.solid_handle)
+        if assets_def is None:
+            raise DagsterInvalidPropertyError(
+                f"Op '{self.op.name}' does not have an assets definition."
+            )
+        return assets_def
 
     @public
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_invocation.py
@@ -1193,6 +1193,24 @@ def test_required_resource_keys_no_context_invocation():
         uses_resource_no_context(None)
 
 
+def test_assets_def_invocation():
+    @asset()
+    def my_asset(context):
+        assert context.assets_def == my_asset
+
+    @op
+    def non_asset_op(context):
+        context.assets_def
+
+    with build_op_context(
+        partition_key="2023-02-02",
+    ) as context:
+        my_asset(context)
+
+        with pytest.raises(DagsterInvalidPropertyError, match="does not have an assets definition"):
+            non_asset_op(context)
+
+
 def test_partitions_time_window_asset_invocation():
     partitions_def = DailyPartitionsDefinition(start_date=datetime(2023, 1, 1))
 


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/12039

Assets that are directly invoked for testing can't access fields on the assets def, i.e. the partitions def. This PR adds the assets def to the context to enable accessing these fields.