### PR TITLE
Ensure pyright venvs use statically legible editable installs

### DIFF
--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -284,6 +284,11 @@ def normalize_env(env: str, rebuild: bool, update_pins: bool) -> None:
                         "install",
                         "-r",
                         dest_requirements_path,
+                        # editable-mode=compat ensures dagster-internal editable installs are done
+                        # in a way that is legible to pyright (i.e. not using import hooks). See:
+                        #  https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md#editable-installs
+                        "--config-settings",
+                        "editable-mode=compat",
                         *extra_pip_install_args,
                     ]
                 ),


### PR DESCRIPTION
## Summary & Motivation

Newer versions of `setuptools` perform editable installs using "import hooks", which is illegible to static analysis. This PR ensures that pyright venvs are built in "compat" mode, which ensures statically legible editable installs.

## How I Tested These Changes

Had @brad-alexander run `make rebuild_pyright` with this branch to ensure his pyright venvs started working in (he first surfaced above-described issue).
