### PR TITLE
Use dynamic partition definition name for dimension of multipartition definition

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -413,8 +413,6 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     );
   };
 
-  console.log({selections, assets, target});
-
   return (
     <>
       <div data-testid={testId('choose-partitions-dialog')}>

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -164,10 +164,12 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     return assetHealth.find(itemWithAssetKey(target.anchorAssetKey)) || mergedAssetHealth([]);
   }, [assetHealth, assetHealthLoading, target]);
 
-  const displayedPartitionDefinition =
+  const displayedBaseAsset =
     target.type === 'job'
-      ? partitionedAssets[0].partitionDefinition
-      : partitionedAssets.find(itemWithAssetKey(target.anchorAssetKey))?.partitionDefinition;
+      ? partitionedAssets[0]
+      : partitionedAssets.find(itemWithAssetKey(target.anchorAssetKey));
+
+  const displayedPartitionDefinition = displayedBaseAsset?.partitionDefinition;
 
   const knownDimensions = partitionedAssets[0].partitionDefinition?.dimensionTypes || [];
   const [missingFailedOnly, setMissingFailedOnly] = React.useState(true);
@@ -411,6 +413,8 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     );
   };
 
+  console.log({selections, assets, target});
+
   return (
     <>
       <div data-testid={testId('choose-partitions-dialog')}>
@@ -468,7 +472,12 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
                     ),
                   )
                 }
-                partitionDefinitionName={displayedPartitionDefinition?.name}
+                partitionDefinitionName={
+                  displayedPartitionDefinition?.name ||
+                  displayedBaseAsset?.partitionDefinition?.dimensionTypes.find(
+                    (d) => d.name === range.dimension.name,
+                  )?.dynamicPartitionsDefinitionName
+                }
                 repoAddress={repoAddress}
                 refetch={refetch}
               />

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -654,6 +654,7 @@ export const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
     name
     dimensionTypes {
       name
+      dynamicPartitionsDefinitionName
     }
   }
 

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsDialog.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsDialog.fixtures.tsx
@@ -1,7 +1,7 @@
-import {ReleasesWorkspace_RAW} from './LaunchAssetLoaderQuery.fixtures';
+import {assetNodes} from './LaunchAssetLoaderQuery.fixtures';
 
 export const ReleasesJobProps = {
-  assets: ReleasesWorkspace_RAW.result.data.assetNodes,
+  assets: assetNodes,
   upstreamAssetKeys: [],
   repoAddress: {
     name: '__repository__',

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.mocks.ts
@@ -8,6 +8,7 @@ import {
   LaunchBackfillParams,
   PartitionDefinitionType,
   PartitionRangeStatus,
+  buildDimensionDefinitionType,
 } from '../../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/BackfillUtils';
 import {LaunchPartitionBackfillMutation} from '../../instance/types/BackfillUtils.types';
@@ -615,7 +616,7 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
             name: 'Foo',
             type: PartitionDefinitionType.TIME_WINDOW,
             description: 'Daily, starting 2020-01-01 UTC.',
-            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
             __typename: 'PartitionDefinition',
           },
           configField: {
@@ -641,7 +642,7 @@ export const LaunchAssetLoaderAssetDailyWeeklyMock: MockedResponse<LaunchAssetLo
             name: 'Foo',
             type: PartitionDefinitionType.TIME_WINDOW,
             description: 'Weekly, starting 2020-01-01 UTC.',
-            dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+            dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
             __typename: 'PartitionDefinition',
           },
           configField: {
@@ -761,7 +762,7 @@ const ASSET_DAILY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
     name: 'Foo',
     type: PartitionDefinitionType.TIME_WINDOW,
     description: 'Daily, starting 2020-01-01 UTC.',
-    dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
     __typename: 'PartitionDefinition',
   },
   configField: {
@@ -788,7 +789,7 @@ const ASSET_WEEKLY_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
     name: 'Foo',
     type: PartitionDefinitionType.TIME_WINDOW,
     description: 'Weekly, starting 2020-01-01 UTC.',
-    dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
     __typename: 'PartitionDefinition',
   },
 
@@ -826,7 +827,7 @@ const ASSET_WEEKLY_ROOT_LOADER_RESULT: LaunchAssetLoaderQueryAssetNode = {
     name: 'Foo',
     type: PartitionDefinitionType.TIME_WINDOW,
     description: 'Weekly, starting 2020-01-01 UTC.',
-    dimensionTypes: [{name: 'default', __typename: 'DimensionDefinitionType'}],
+    dimensionTypes: [buildDimensionDefinitionType({name: 'default'})],
     __typename: 'PartitionDefinition',
   },
   configField: {

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetLoaderQuery.fixtures.tsx
@@ -1,10 +1,254 @@
 import {MockedResponse} from '@apollo/client/testing';
 
-import {PartitionDefinitionType} from '../../graphql/types';
+import {
+  AssetNode,
+  PartitionDefinitionType,
+  buildAssetKey,
+  buildAssetNode,
+  buildConfigTypeField,
+  buildDimensionDefinitionType,
+  buildPartitionDefinition,
+  buildRegularConfigType,
+  buildRepository,
+  buildRepositoryLocation,
+} from '../../graphql/types';
 import {LAUNCH_ASSET_LOADER_QUERY} from '../LaunchAssetExecutionButton';
 import {LaunchAssetLoaderQuery} from '../types/LaunchAssetExecutionButton.types';
 
-export const ReleasesWorkspace_RAW = {
+export const assetNodes: AssetNode[] = [
+  buildAssetNode({
+    id: 'assets_dynamic_partitions.__repository__.["release_files"]',
+    opNames: ['release_files'],
+    jobNames: ['__ASSET_JOB_0'],
+    graphName: null,
+    hasMaterializePermission: true,
+    partitionDefinition: buildPartitionDefinition({
+      type: PartitionDefinitionType.DYNAMIC,
+      name: 'Foo',
+      description: 'Dynamic partitions definition releases',
+      dimensionTypes: [
+        buildDimensionDefinitionType({
+          name: 'default',
+        }),
+      ],
+    }),
+    isObservable: false,
+    isSource: false,
+    assetKey: buildAssetKey({
+      path: ['release_files'],
+    }),
+    dependencyKeys: [
+      buildAssetKey({
+        path: ['release_zips'],
+      }),
+    ],
+    repository: buildRepository({
+      id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
+      name: '__repository__',
+      location: buildRepositoryLocation({
+        id: 'assets_dynamic_partitions',
+        name: 'assets_dynamic_partitions',
+      }),
+    }),
+    requiredResources: [],
+    configField: buildConfigTypeField({
+      name: 'config',
+      isRequired: false,
+      configType: buildRegularConfigType({
+        recursiveConfigTypes: [],
+        key: 'Any',
+        description: null,
+        isSelector: false,
+        typeParamKeys: [],
+        givenName: 'Any',
+      }),
+    }),
+  }),
+  buildAssetNode({
+    id: 'assets_dynamic_partitions.__repository__.["release_files_metadata"]',
+    opNames: ['release_files_metadata'],
+    jobNames: ['__ASSET_JOB_0'],
+    graphName: null,
+    hasMaterializePermission: true,
+    partitionDefinition: buildPartitionDefinition({
+      type: PartitionDefinitionType.DYNAMIC,
+      name: 'Foo',
+      description: 'Dynamic partitions definition releases',
+      dimensionTypes: [
+        buildDimensionDefinitionType({
+          name: 'default',
+        }),
+      ],
+    }),
+    isObservable: false,
+    isSource: false,
+    assetKey: buildAssetKey({
+      path: ['release_files_metadata'],
+    }),
+    dependencyKeys: [
+      buildAssetKey({
+        path: ['release_files'],
+      }),
+    ],
+    repository: buildRepository({
+      id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
+      name: '__repository__',
+      location: buildRepositoryLocation({
+        id: 'assets_dynamic_partitions',
+        name: 'assets_dynamic_partitions',
+      }),
+    }),
+    requiredResources: [],
+    configField: buildConfigTypeField({
+      name: 'config',
+      isRequired: false,
+      configType: buildRegularConfigType({
+        recursiveConfigTypes: [],
+        key: 'Any',
+        description: null,
+        isSelector: false,
+        typeParamKeys: [],
+        givenName: 'Any',
+      }),
+    }),
+  }),
+  buildAssetNode({
+    id: 'assets_dynamic_partitions.__repository__.["release_zips"]',
+    opNames: ['release_zips'],
+    jobNames: ['__ASSET_JOB_0'],
+    graphName: null,
+    hasMaterializePermission: true,
+    partitionDefinition: buildPartitionDefinition({
+      type: PartitionDefinitionType.DYNAMIC,
+      name: 'Foo',
+      description: 'Dynamic partitions definition releases',
+      dimensionTypes: [
+        buildDimensionDefinitionType({
+          name: 'default',
+        }),
+      ],
+    }),
+    isObservable: false,
+    isSource: false,
+    assetKey: buildAssetKey({
+      path: ['release_zips'],
+    }),
+    dependencyKeys: [
+      buildAssetKey({
+        path: ['releases_metadata'],
+      }),
+    ],
+    repository: buildRepository({
+      id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
+      name: '__repository__',
+      location: buildRepositoryLocation({
+        id: 'assets_dynamic_partitions',
+        name: 'assets_dynamic_partitions',
+      }),
+    }),
+    requiredResources: [],
+    configField: buildConfigTypeField({
+      name: 'config',
+      isRequired: false,
+      configType: buildRegularConfigType({
+        recursiveConfigTypes: [],
+        key: 'Any',
+        description: null,
+        isSelector: false,
+        typeParamKeys: [],
+        givenName: 'Any',
+      }),
+    }),
+  }),
+  buildAssetNode({
+    id: 'assets_dynamic_partitions.__repository__.["releases_metadata"]',
+    opNames: ['releases_metadata'],
+    jobNames: ['__ASSET_JOB_0'],
+    graphName: null,
+    hasMaterializePermission: true,
+    partitionDefinition: buildPartitionDefinition({
+      type: PartitionDefinitionType.DYNAMIC,
+      name: 'Foo',
+      description: 'Dynamic partitions definition releases',
+      dimensionTypes: [
+        buildDimensionDefinitionType({
+          name: 'default',
+        }),
+      ],
+    }),
+    isObservable: false,
+    isSource: false,
+    assetKey: buildAssetKey({
+      path: ['releases_metadata'],
+    }),
+    dependencyKeys: [],
+    repository: buildRepository({
+      id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
+      name: '__repository__',
+      location: buildRepositoryLocation({
+        id: 'assets_dynamic_partitions',
+        name: 'assets_dynamic_partitions',
+      }),
+    }),
+    requiredResources: [],
+    configField: buildConfigTypeField({
+      name: 'config',
+      isRequired: false,
+      configType: buildRegularConfigType({
+        recursiveConfigTypes: [],
+        key: 'Any',
+        description: null,
+        isSelector: false,
+        typeParamKeys: [],
+        givenName: 'Any',
+      }),
+    }),
+  }),
+  buildAssetNode({
+    id: 'assets_dynamic_partitions.__repository__.["releases_summary"]',
+    opNames: ['releases_summary'],
+    jobNames: ['__ASSET_JOB_0'],
+    graphName: null,
+    hasMaterializePermission: true,
+    partitionDefinition: null,
+    isObservable: false,
+    isSource: false,
+    assetKey: buildAssetKey({
+      path: ['releases_summary'],
+    }),
+    dependencyKeys: [
+      buildAssetKey({
+        path: ['releases_metadata'],
+      }),
+      buildAssetKey({
+        path: ['release_files_metadata'],
+      }),
+    ],
+    repository: buildRepository({
+      id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
+      name: '__repository__',
+      location: buildRepositoryLocation({
+        id: 'assets_dynamic_partitions',
+        name: 'assets_dynamic_partitions',
+      }),
+    }),
+    requiredResources: [],
+    configField: buildConfigTypeField({
+      name: 'config',
+      isRequired: false,
+      configType: buildRegularConfigType({
+        recursiveConfigTypes: [],
+        key: 'Any',
+        description: null,
+        isSelector: false,
+        typeParamKeys: [],
+        givenName: 'Any',
+      }),
+    }),
+  }),
+];
+
+export const ReleasesWorkspace: MockedResponse<LaunchAssetLoaderQuery> = {
   request: {
     query: LAUNCH_ASSET_LOADER_QUERY,
     variables: {
@@ -30,284 +274,8 @@ export const ReleasesWorkspace_RAW = {
   result: {
     data: {
       __typename: 'DagitQuery' as const,
-      assetNodes: [
-        {
-          __typename: 'AssetNode' as const,
-          id: 'assets_dynamic_partitions.__repository__.["release_files"]',
-          opNames: ['release_files'],
-          jobNames: ['__ASSET_JOB_0'],
-          graphName: null,
-          hasMaterializePermission: true,
-          partitionDefinition: {
-            type: PartitionDefinitionType.DYNAMIC,
-            name: 'Foo',
-            __typename: 'PartitionDefinition' as const,
-            description: 'Dynamic partitions definition releases',
-            dimensionTypes: [
-              {
-                __typename: 'DimensionDefinitionType' as const,
-                name: 'default',
-              },
-            ],
-          },
-          isObservable: false,
-          isSource: false,
-          assetKey: {
-            __typename: 'AssetKey' as const,
-            path: ['release_files'],
-          },
-          dependencyKeys: [
-            {
-              __typename: 'AssetKey' as const,
-              path: ['release_zips'],
-            },
-          ],
-          repository: {
-            __typename: 'Repository' as const,
-            id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
-            name: '__repository__',
-            location: {
-              __typename: 'RepositoryLocation' as const,
-              id: 'assets_dynamic_partitions',
-              name: 'assets_dynamic_partitions',
-            },
-          },
-          requiredResources: [],
-          configField: {
-            __typename: 'ConfigTypeField' as const,
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType' as const,
-              recursiveConfigTypes: [],
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              givenName: 'Any',
-            },
-          },
-        },
-        {
-          __typename: 'AssetNode' as const,
-          id: 'assets_dynamic_partitions.__repository__.["release_files_metadata"]',
-          opNames: ['release_files_metadata'],
-          jobNames: ['__ASSET_JOB_0'],
-          graphName: null,
-          hasMaterializePermission: true,
-          partitionDefinition: {
-            type: PartitionDefinitionType.DYNAMIC,
-            name: 'Foo',
-            __typename: 'PartitionDefinition' as const,
-            description: 'Dynamic partitions definition releases',
-            dimensionTypes: [
-              {
-                __typename: 'DimensionDefinitionType' as const,
-                name: 'default',
-              },
-            ],
-          },
-          isObservable: false,
-          isSource: false,
-          assetKey: {
-            __typename: 'AssetKey' as const,
-            path: ['release_files_metadata'],
-          },
-          dependencyKeys: [
-            {
-              __typename: 'AssetKey' as const,
-              path: ['release_files'],
-            },
-          ],
-          repository: {
-            __typename: 'Repository' as const,
-            id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
-            name: '__repository__',
-            location: {
-              __typename: 'RepositoryLocation' as const,
-              id: 'assets_dynamic_partitions',
-              name: 'assets_dynamic_partitions',
-            },
-          },
-          requiredResources: [],
-          configField: {
-            __typename: 'ConfigTypeField' as const,
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType' as const,
-              recursiveConfigTypes: [],
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              givenName: 'Any',
-            },
-          },
-        },
-        {
-          __typename: 'AssetNode' as const,
-          id: 'assets_dynamic_partitions.__repository__.["release_zips"]',
-          opNames: ['release_zips'],
-          jobNames: ['__ASSET_JOB_0'],
-          graphName: null,
-          hasMaterializePermission: true,
-          partitionDefinition: {
-            type: PartitionDefinitionType.DYNAMIC,
-            name: 'Foo',
-            __typename: 'PartitionDefinition' as const,
-            description: 'Dynamic partitions definition releases',
-            dimensionTypes: [
-              {
-                __typename: 'DimensionDefinitionType' as const,
-                name: 'default',
-              },
-            ],
-          },
-          isObservable: false,
-          isSource: false,
-          assetKey: {
-            __typename: 'AssetKey' as const,
-            path: ['release_zips'],
-          },
-          dependencyKeys: [
-            {
-              __typename: 'AssetKey' as const,
-              path: ['releases_metadata'],
-            },
-          ],
-          repository: {
-            __typename: 'Repository' as const,
-            id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
-            name: '__repository__',
-            location: {
-              __typename: 'RepositoryLocation' as const,
-              id: 'assets_dynamic_partitions',
-              name: 'assets_dynamic_partitions',
-            },
-          },
-          requiredResources: [],
-          configField: {
-            __typename: 'ConfigTypeField' as const,
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType' as const,
-              recursiveConfigTypes: [],
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              givenName: 'Any',
-            },
-          },
-        },
-        {
-          __typename: 'AssetNode' as const,
-          id: 'assets_dynamic_partitions.__repository__.["releases_metadata"]',
-          opNames: ['releases_metadata'],
-          jobNames: ['__ASSET_JOB_0'],
-          graphName: null,
-          hasMaterializePermission: true,
-          partitionDefinition: {
-            type: PartitionDefinitionType.DYNAMIC,
-            name: 'Foo',
-            __typename: 'PartitionDefinition' as const,
-            description: 'Dynamic partitions definition releases',
-            dimensionTypes: [
-              {
-                __typename: 'DimensionDefinitionType' as const,
-                name: 'default',
-              },
-            ],
-          },
-          isObservable: false,
-          isSource: false,
-          assetKey: {
-            __typename: 'AssetKey' as const,
-            path: ['releases_metadata'],
-          },
-          dependencyKeys: [],
-          repository: {
-            __typename: 'Repository' as const,
-            id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
-            name: '__repository__',
-            location: {
-              __typename: 'RepositoryLocation' as const,
-              id: 'assets_dynamic_partitions',
-              name: 'assets_dynamic_partitions',
-            },
-          },
-          requiredResources: [],
-          configField: {
-            __typename: 'ConfigTypeField' as const,
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType' as const,
-              recursiveConfigTypes: [],
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              givenName: 'Any',
-            },
-          },
-        },
-        {
-          __typename: 'AssetNode' as const,
-          id: 'assets_dynamic_partitions.__repository__.["releases_summary"]',
-          opNames: ['releases_summary'],
-          jobNames: ['__ASSET_JOB_0'],
-          graphName: null,
-          hasMaterializePermission: true,
-          partitionDefinition: null,
-          isObservable: false,
-          isSource: false,
-          assetKey: {
-            __typename: 'AssetKey' as const,
-            path: ['releases_summary'],
-          },
-          dependencyKeys: [
-            {
-              __typename: 'AssetKey' as const,
-              path: ['releases_metadata'],
-            },
-            {
-              __typename: 'AssetKey' as const,
-              path: ['release_files_metadata'],
-            },
-          ],
-          repository: {
-            __typename: 'Repository' as const,
-            id: 'd2e5e8b7989e1da5fd8f505e6a968a03b24d40f4',
-            name: '__repository__',
-            location: {
-              __typename: 'RepositoryLocation' as const,
-              id: 'assets_dynamic_partitions',
-              name: 'assets_dynamic_partitions',
-            },
-          },
-          requiredResources: [],
-          configField: {
-            __typename: 'ConfigTypeField' as const,
-            name: 'config',
-            isRequired: false,
-            configType: {
-              __typename: 'RegularConfigType' as const,
-              recursiveConfigTypes: [],
-              key: 'Any',
-              description: null,
-              isSelector: false,
-              typeParamKeys: [],
-              givenName: 'Any',
-            },
-          },
-        },
-      ],
+      assetNodes: assetNodes as any[],
       assetNodeDefinitionCollisions: [],
     },
   },
 };
-
-export const ReleasesWorkspace: MockedResponse<LaunchAssetLoaderQuery> = ReleasesWorkspace_RAW;

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthQuery.fixtures.tsx
@@ -1,6 +1,11 @@
 import {MockedResponse} from '@apollo/client/testing';
 
-import {PartitionDefinitionType} from '../../graphql/types';
+import {
+  PartitionDefinitionType,
+  buildAssetNode,
+  buildDefaultPartitions,
+  buildDimensionPartitionKeys,
+} from '../../graphql/types';
 import {PartitionHealthQuery} from '../types/usePartitionHealthData.types';
 import {PARTITION_HEALTH_QUERY} from '../usePartitionHealthData';
 
@@ -19,23 +24,20 @@ export const buildPartitionHealthMock = (
   result: {
     data: {
       __typename: 'DagitQuery',
-      assetNodeOrError: {
+      assetNodeOrError: buildAssetNode({
         id: `assets_dynamic_partitions.__repository__.["${assetKey}"]`,
         partitionKeysByDimension: [
-          {
+          buildDimensionPartitionKeys({
             name: 'default',
             partitionKeys: empty ? [] : ['test1', 'test2'],
             type: PartitionDefinitionType.DYNAMIC,
-            __typename: 'DimensionPartitionKeys',
-          },
+          }),
         ],
-        assetPartitionStatuses: {
+        assetPartitionStatuses: buildDefaultPartitions({
           materializedPartitions: ['test1'],
           failedPartitions: [],
-          __typename: 'DefaultPartitions',
-        },
-        __typename: 'AssetNode',
-      },
+        }),
+      }),
     },
   },
 });

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -16,7 +16,11 @@ export type LaunchAssetExecutionAssetNodeFragment = {
     description: string;
     type: Types.PartitionDefinitionType;
     name: string | null;
-    dimensionTypes: Array<{__typename: 'DimensionDefinitionType'; name: string}>;
+    dimensionTypes: Array<{
+      __typename: 'DimensionDefinitionType';
+      name: string;
+      dynamicPartitionsDefinitionName: string | null;
+    }>;
   } | null;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   dependencyKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
@@ -586,7 +590,11 @@ export type PartitionDefinitionForLaunchAssetFragment = {
   description: string;
   type: Types.PartitionDefinitionType;
   name: string | null;
-  dimensionTypes: Array<{__typename: 'DimensionDefinitionType'; name: string}>;
+  dimensionTypes: Array<{
+    __typename: 'DimensionDefinitionType';
+    name: string;
+    dynamicPartitionsDefinitionName: string | null;
+  }>;
 };
 
 export type LaunchAssetLoaderQueryVariables = Types.Exact<{
@@ -609,7 +617,11 @@ export type LaunchAssetLoaderQuery = {
       description: string;
       type: Types.PartitionDefinitionType;
       name: string | null;
-      dimensionTypes: Array<{__typename: 'DimensionDefinitionType'; name: string}>;
+      dimensionTypes: Array<{
+        __typename: 'DimensionDefinitionType';
+        name: string;
+        dynamicPartitionsDefinitionName: string | null;
+      }>;
     } | null;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     dependencyKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/single_partitions_to_multi.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/single_partitions_to_multi.py
@@ -1,7 +1,7 @@
 from dagster import (
+    DynamicPartitionsDefinition,
     MultiPartitionsDefinition,
     StaticPartitionsDefinition,
-    DynamicPartitionsDefinition,
     asset,
 )
 

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/single_partitions_to_multi.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/single_partitions_to_multi.py
@@ -1,4 +1,9 @@
-from dagster import MultiPartitionsDefinition, StaticPartitionsDefinition, asset
+from dagster import (
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    asset,
+)
 
 abc_def = StaticPartitionsDefinition(["a", "b", "c"])
 
@@ -10,6 +15,14 @@ composite = MultiPartitionsDefinition(
 )
 
 
+composite2 = MultiPartitionsDefinition(
+    {
+        "abc": abc_def,
+        "123": DynamicPartitionsDefinition(name="testing123"),
+    }
+)
+
+
 @asset(partitions_def=abc_def)
 def single_partitions(context):
     return 1
@@ -17,4 +30,9 @@ def single_partitions(context):
 
 @asset(partitions_def=composite)
 def multi_partitions(single_partitions):
+    return 1
+
+
+@asset(partitions_def=composite2)
+def multi_partitions_dynamic(single_partitions):
     return 1


### PR DESCRIPTION
## Summary & Motivation

Multipartition definitions don't have names, instead the partitions they compose have names, so we should be using those in the create partition dialog.

## How I Tested These Changes

Definition:
```
MultiPartitionsDefinition(
    {
        "abc": abc_def,
        "123": DynamicPartitionsDefinition(name="testing123"),
    }
)
```

You can see in the dialog the label is still "123".
In the CreatePartitionDialog we see the "testing123"

I successfully added the partition "hello1234"

<img width="921" alt="Screen Shot 2023-03-22 at 1 18 49 PM" src="https://user-images.githubusercontent.com/2286579/226986057-e9028402-3165-4ef1-86a7-6ac621a2fbbd.png">
