### PR TITLE
Include much more k8s debug info when run monitoring fails

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ template "dagster.fullname" . }}-role
   labels: {{ include "dagster.labels" . | nindent 4 }}
 
-# Allow the Dagster service account to read and write Kubernetes jobs and pods.
+# Allow the Dagster service account to read and write Kubernetes jobs, deployments, pods, and events.
 rules:
   - apiGroups: ["batch"]
     resources: ["jobs", "jobs/status"]
     verbs: ["*"]
   # The empty arg "" corresponds to the core API group
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "pods/status"]
+    resources: ["pods", "pods/log", "pods/status", "events"]
     verbs: ["*"]
 {{- end -}}

--- a/helm/dagster/templates/role.yaml
+++ b/helm/dagster/templates/role.yaml
@@ -9,13 +9,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 
-# Allow the Dagster service account to read and write Kubernetes jobs and pods.
+# Allow the Dagster service account to read and write Kubernetes jobs, deployments, pods, and events.
 rules:
   - apiGroups: ["batch"]
     resources: ["jobs", "jobs/status"]
     verbs: ["*"]
   # The empty arg "" corresponds to the core API group
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "pods/status"]
+    resources: ["pods", "pods/log", "pods/status", "events"]
     verbs: ["*"]
 {{- end -}}

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/helm.py
@@ -749,7 +749,7 @@ def helm_chart_for_k8s_run_launcher(
                 "runMonitoring": {
                     "enabled": True,
                     "pollIntervalSeconds": 5,
-                    "startTimeoutSeconds": 180,
+                    "startTimeoutSeconds": 60,
                     "maxResumeRunAttempts": 3,
                 }
                 if run_monitoring

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -147,7 +147,9 @@ def launch_run_over_graphql(
     code_location_name="user-code-deployment-1",
     mode="default",
     solid_selection=None,
+    tags=None,
 ):
+    tags = tags or {}
     variables = json.dumps(
         {
             "executionParams": {
@@ -159,6 +161,9 @@ def launch_run_over_graphql(
                 },
                 "runConfigData": run_config,
                 "mode": mode,
+                "executionMetadata": {
+                    "tags": [{"key": key, "value": value} for key, value in tags.items()]
+                },
             }
         }
     )

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
@@ -7,29 +7,36 @@ from dagster_k8s.client import DagsterK8sError, DagsterKubernetesClient, WaitFor
 pytest_plugins = ["dagster_k8s_test_infra.helm"]
 
 
-def construct_pod_spec(name, cmd):
+def construct_pod_spec(name, cmd, image="busybox", container_kwargs=None):
     return kubernetes.client.V1PodSpec(
         restart_policy="Never",
         containers=[
-            kubernetes.client.V1Container(name=name, image="busybox", args=["/bin/sh", "-c", cmd])
+            kubernetes.client.V1Container(
+                name=name,
+                image=image,
+                args=["/bin/sh", "-c", cmd],
+                **(container_kwargs or {}),
+            )
         ],
     )
 
 
-def construct_pod_manifest(name, cmd):
+def construct_pod_manifest(name, cmd, image="busybox", container_kwargs=None):
     return kubernetes.client.V1Pod(
         metadata=kubernetes.client.V1ObjectMeta(name=name),
-        spec=construct_pod_spec(name, cmd),
+        spec=construct_pod_spec(name, cmd, image=image, container_kwargs=container_kwargs),
     )
 
 
-def construct_job_manifest(name, cmd):
+def construct_job_manifest(name, cmd, image="busybox", container_kwargs=None):
     return kubernetes.client.V1Job(
         api_version="batch/v1",
         kind="Job",
         metadata=kubernetes.client.V1ObjectMeta(name=name),
         spec=kubernetes.client.V1JobSpec(
-            template=kubernetes.client.V1PodTemplateSpec(spec=construct_pod_spec(name, cmd)),
+            template=kubernetes.client.V1PodTemplateSpec(
+                spec=construct_pod_spec(name, cmd, image=image, container_kwargs=container_kwargs)
+            ),
         ),
     )
 
@@ -91,7 +98,264 @@ def test_wait_for_pod(cluster_provider, namespace):
 
 
 @pytest.mark.default
-def test_wait_for_job(cluster_provider, namespace):
+def test_pod_debug_info_failure(cluster_provider, namespace, should_cleanup):
+    time.sleep(5)
+    api_client = DagsterKubernetesClient.production_client()
+
+    try:
+        # test case where the pod can't be scheduled due to an unworkable resource request
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest(
+                "resourcelimit",
+                'echo "hello world"',
+                container_kwargs={
+                    "resources": kubernetes.client.V1ResourceRequirements(
+                        requests={"memory": "4000000M"}, limits={"memory": "4000000M"}
+                    ),
+                },
+            ),
+            namespace=namespace,
+        )
+        api_client.wait_for_job("resourcelimit", namespace=namespace)
+
+        pod_names = api_client.get_pod_names_in_job("resourcelimit", namespace=namespace)
+
+        pod_debug_info = api_client.get_pod_debug_info(
+            pod_names[0], namespace=namespace, container_name="resourcelimit"
+        )
+
+        print(str(pod_debug_info))  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Pending
+Warning events for pod:
+FailedScheduling: 0/1 nodes are available: 1 Insufficient memory."""
+        )
+
+        # Test case where the pod is still running
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest(
+                "waitforever", 'echo "time for sleep"; sleep 3600; echo "hello world"'
+            ),
+            namespace=namespace,
+        )
+        api_client.wait_for_job("waitforever", namespace=namespace)
+
+        start_time = time.time()
+        while True:
+            if time.time() - start_time > 60:
+                raise Exception("No error state after 60 seconds")
+
+            pod_names = api_client.get_pod_names_in_job("waitforever", namespace=namespace)
+            if pod_names:
+                pod_debug_info = api_client.get_pod_debug_info(
+                    pod_names[0], namespace=namespace, container_name="waitforever"
+                )
+                if "time for sleep" in pod_debug_info:
+                    break
+
+            time.sleep(5)
+
+        print(str(pod_debug_info))  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Running
+Container 'waitforever' status: Ready
+Last 25 log lines:"""
+        )
+
+        assert "No warning events for pod." in pod_debug_info
+
+        # Test case where logs have an exec format error (simulated)
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest(
+                "execformaterror", 'echo "exec /usr/local/bin/dagster: exec format error"; exit 1'
+            ),
+            namespace=namespace,
+        )
+
+        with pytest.raises(
+            DagsterK8sError,
+            match="Encountered failed job pods for job execformaterror with status:",
+        ):
+            api_client.wait_for_job_success("execformaterror", namespace=namespace)
+
+        pod_names = api_client.get_pod_names_in_job("execformaterror", namespace=namespace)
+
+        pod_debug_info = api_client.get_pod_debug_info(
+            pod_names[0], namespace=namespace, container_name="execformaterror"
+        )
+
+        print(str(pod_debug_info))  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Failed
+Container 'execformaterror' status: Terminated with exit code 1: Error
+Pod logs contained `exec format error`, which usually means that your Docker image was built using the wrong architecture.
+Try rebuilding your docker image with the `--platform linux/amd64` flag set.
+Last 25 log lines:
+"""
+        )
+
+        assert "exec /usr/local/bin/dagster: exec format error" in pod_debug_info
+        assert "No warning events for pod." in pod_debug_info
+
+        # Test case where a non-existant secret is used
+        bad_secret_config = [
+            kubernetes.client.V1EnvFromSource(
+                secret_ref=kubernetes.client.V1SecretEnvSource(name="missing-secret")
+            )
+        ]
+
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest(
+                "missingsecret",
+                'echo "hello world"',
+                container_kwargs={"env_from": bad_secret_config},
+            ),
+            namespace=namespace,
+        )
+
+        api_client.wait_for_job("missingsecret", namespace=namespace)
+
+        start_time = time.time()
+        while True:
+            if time.time() - start_time > 60:
+                raise Exception("No error state after 60 seconds")
+
+            pod_names = api_client.get_pod_names_in_job("missingsecret", namespace=namespace)
+
+            if pod_names:
+                pod_debug_info = api_client.get_pod_debug_info(
+                    pod_names[0], namespace=namespace, container_name="missingsecret"
+                )
+                if "CreateContainerConfigError" in pod_debug_info:
+                    break
+
+            time.sleep(5)
+
+        pod_debug_info = api_client.get_pod_debug_info(
+            pod_names[0], namespace=namespace, container_name="missingsecret"
+        )
+
+        print(str(pod_debug_info))  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Pending
+Container 'missingsecret' status: Waiting: CreateContainerConfigError: secret "missing-secret" not found
+Warning events for pod:"""
+        )
+
+        # Test case where an unpullable image is used
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest("pullfail", 'echo "should not reach"', image="fakeimage"),
+            namespace=namespace,
+        )
+
+        api_client.wait_for_job("pullfail", namespace=namespace)
+
+        start_time = time.time()
+        while True:
+            if time.time() - start_time > 60:
+                raise Exception("No error state after 60 seconds")
+
+            pod_names = api_client.get_pod_names_in_job("pullfail", namespace=namespace)
+
+            if pod_names:
+                pod_debug_info = api_client.get_pod_debug_info(
+                    pod_names[0], namespace=namespace, container_name="pullfail"
+                )
+                if "ImagePullBackOff" in pod_debug_info:
+                    break
+
+            time.sleep(5)
+
+        print(str(pod_debug_info))  # noqa
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Pending
+Container 'pullfail' status: Waiting: ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/fakeimage:latest": failed to resolve reference "docker.io/library/fakeimage:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
+Warning events for pod:"""
+        )
+        assert "Failed: Error: ErrImagePull" in pod_debug_info
+        assert "Failed: Error: ImagePullBackOff" in pod_debug_info
+
+        # Test case where the pod unexpectedly terminates
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest("fail", 'echo "whoops!"; exit 1'),
+            namespace=namespace,
+        )
+
+        with pytest.raises(
+            DagsterK8sError,
+            match="Encountered failed job pods for job fail with status:",
+        ):
+            api_client.wait_for_job_success("fail", namespace=namespace)
+
+        pod_names = api_client.get_pod_names_in_job("fail", namespace=namespace)
+
+        pod_debug_info = api_client.get_pod_debug_info(
+            pod_names[0], namespace=namespace, container_name="fail"
+        )
+
+        print(pod_debug_info)  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Failed
+Container 'fail' status: Terminated with exit code 1: Error
+Last 25 log lines:"""
+        )
+        assert " whoops!\n" in pod_debug_info
+        assert pod_debug_info.endswith("No warning events for pod.")
+
+        # Test case where the pod completes successfully
+        api_client.batch_api.create_namespaced_job(
+            body=construct_job_manifest("sayhi1", 'echo "hello world"'), namespace=namespace
+        )
+        api_client.wait_for_job_success("sayhi1", namespace=namespace)
+
+        pod_names = api_client.get_pod_names_in_job("sayhi1", namespace=namespace)
+
+        pod_debug_info = api_client.get_pod_debug_info(
+            pod_names[0], namespace=namespace, container_name="sayhi1"
+        )
+        print(pod_debug_info)  # noqa
+
+        assert pod_debug_info.startswith(
+            f"""Debug information for pod {pod_names[0]}:
+Pod status: Succeeded
+Container 'sayhi1' status: Terminated with exit code 0: Completed
+Last 25 log lines:"""
+        )
+        assert "hello world" in pod_debug_info
+        assert "No warning events for pod." in pod_debug_info
+
+    finally:
+        if should_cleanup:
+            for job in [
+                "fail",
+                "pullfail",
+                "missingsecret",
+                "sayhi1",
+                "waitforever",
+                "execformaterror",
+                "resourcelimit",
+            ]:
+                try:
+                    api_client.batch_api.delete_namespaced_job(
+                        job, namespace=namespace, propagation_policy="Foreground"
+                    )
+                except kubernetes.client.rest.ApiException:
+                    pass
+
+
+@pytest.mark.default
+def test_wait_for_job(cluster_provider, namespace, should_cleanup):
     # Without this sleep, we get the following error on kind:
     # HTTP response body:
     # {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"No API
@@ -129,10 +393,11 @@ def test_wait_for_job(cluster_provider, namespace):
             api_client.wait_for_job_success("fail", namespace=namespace)
 
     finally:
-        for job in ["sayhi1", "sayhi2", "fail"]:
-            try:
-                api_client.batch_api.delete_namespaced_job(
-                    job, namespace=namespace, propagation_policy="Foreground"
-                )
-            except kubernetes.client.rest.ApiException:
-                pass
+        if should_cleanup:
+            for job in ["sayhi1", "sayhi2", "fail"]:
+                try:
+                    api_client.batch_api.delete_namespaced_job(
+                        job, namespace=namespace, propagation_policy="Foreground"
+                    )
+                except kubernetes.client.rest.ApiException:
+                    pass

--- a/python_modules/dagster/dagster/_core/launcher/base.py
+++ b/python_modules/dagster/dagster/_core/launcher/base.py
@@ -94,6 +94,9 @@ class RunLauncher(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             "This run launcher does not support run monitoring. Please disable it on your instance."
         )
 
+    def get_run_worker_debug_info(self, run: DagsterRun) -> Optional[str]:
+        return None
+
     @property
     def supports_resume_run(self) -> bool:
         """Whether the run launcher supports resume_run."""

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import time
 from enum import Enum
-from typing import Callable, Optional, TypeVar
+from typing import Callable, List, Optional, TypeVar
 
 import kubernetes.client
 import kubernetes.client.rest
@@ -11,7 +11,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.storage.pipeline_run import DagsterRunStatus
-from kubernetes.client.models import V1JobStatus
+from kubernetes.client.models import EventsV1Event, V1JobStatus
 
 T = TypeVar("T")
 
@@ -144,10 +144,10 @@ class DagsterKubernetesClient:
         self.timer = timer
 
     @staticmethod
-    def production_client(batch_api_override=None):
+    def production_client(batch_api_override=None, core_api_override=None):
         return DagsterKubernetesClient(
             batch_api=batch_api_override or kubernetes.client.BatchV1Api(),
-            core_api=kubernetes.client.CoreV1Api(),
+            core_api=core_api_override or kubernetes.client.CoreV1Api(),
             logger=logging.info,
             sleeper=time.sleep,
             timer=time.time,
@@ -578,7 +578,11 @@ class DagsterKubernetesClient:
                 raise DagsterK8sError("Should not get here, unknown pod state")
 
     def retrieve_pod_logs(
-        self, pod_name: str, namespace: str, container_name: Optional[str] = None
+        self,
+        pod_name: str,
+        namespace: str,
+        container_name: Optional[str] = None,
+        **kwargs,
     ) -> str:
         """Retrieves the raw pod logs for the pod named `pod_name` from Kubernetes.
 
@@ -598,5 +602,124 @@ class DagsterKubernetesClient:
         #
         # https://github.com/kubernetes-client/python/issues/811
         return self.core_api.read_namespaced_pod_log(
-            name=pod_name, namespace=namespace, container=container_name, _preload_content=False
+            name=pod_name,
+            namespace=namespace,
+            container=container_name,
+            _preload_content=False,
+            **kwargs,
         ).data.decode("utf-8")
+
+    def _get_container_status_str(self, container_status):
+        state = container_status.state
+        # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1ContainerState.md
+        if state.running:
+            return "Ready" if container_status.ready else "Running but not ready"
+        elif state.terminated:
+            return f"Terminated with exit code {state.terminated.exit_code}: " + (
+                f"{state.terminated.reason}: {state.terminated.message}"
+                if state.terminated.message
+                else f"{state.terminated.reason}"
+            )
+        elif state.waiting:
+            return (
+                f"Waiting: {state.waiting.reason}: {state.waiting.message}"
+                if state.waiting.message
+                else f"Waiting: {state.waiting.reason}"
+            )
+
+    def _get_pod_status_str(self, pod):
+        if not pod.status:
+            return "Could not determine pod status."
+
+        pod_status = [
+            f"Pod status: {pod.status.phase}"
+            + (f": {pod.status.message}" if pod.status.message else "")
+        ]
+
+        if pod.status.container_statuses:
+            pod_status.extend(
+                [
+                    f"Container '{status.name}' status: {self._get_container_status_str(status)}"
+                    for status in pod.status.container_statuses
+                ]
+            )
+        return "\n".join(pod_status)
+
+    def retrieve_pod_events(
+        self,
+        pod_name: str,
+        namespace: str,
+    ) -> List[EventsV1Event]:
+        # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/EventsV1Event.md
+        field_selector = f"involvedObject.name={pod_name}"
+        return self.core_api.list_namespaced_event(namespace, field_selector=field_selector).items
+
+    def get_pod_debug_info(self, pod_name, namespace, container_name: Optional[str] = None) -> str:
+        pods = self.core_api.list_namespaced_pod(
+            namespace=namespace, field_selector="metadata.name=%s" % pod_name
+        ).items
+        pod = pods[0] if pods else None
+
+        pod_status_str = self._get_pod_status_str(pod) if pod else f"Could not find pod {pod_name}"
+
+        specific_warning = ""
+
+        log_str = ""
+        if (
+            pod is not None
+            and pod.status
+            and pod.status.container_statuses
+            and any(
+                [
+                    container_status.name == container_name
+                    and container_status.state.running
+                    or container_status.state.terminated
+                    for container_status in pod.status.container_statuses
+                ]
+            )
+        ):
+            try:
+                pod_logs = self.retrieve_pod_logs(
+                    pod_name,
+                    namespace,
+                    container_name,
+                    tail_lines=25,
+                    timestamps=True,
+                )
+                # Remove trailing newline if present
+                pod_logs = pod_logs[:-1] if pod_logs.endswith("\n") else pod_logs
+
+                if "exec format error" in pod_logs:
+                    specific_warning = (
+                        "Pod logs contained `exec format error`, which usually means that your"
+                        " Docker image was built using the wrong architecture.\nTry rebuilding your"
+                        " docker image with the `--platform linux/amd64` flag set."
+                    )
+                log_str = f"Last 25 log lines:\n{pod_logs}" if pod_logs else "No logs in pod."
+
+            except kubernetes.client.rest.ApiException as e:
+                log_str = f"Failure fetching pod logs: {str(e)}"
+
+        try:
+            pod_events = self.retrieve_pod_events(pod_name, namespace)
+            warning_events = [event for event in pod_events if event.type == "Warning"]
+
+            if not warning_events:
+                warning_str = "No warning events for pod."
+            else:
+                event_strs = []
+                for event in warning_events:
+                    count_str = f" (x{event.count})" if event.count > 1 else ""
+                    event_strs.append(f"{event.reason}: {event.message}{count_str}")
+                warning_str = "Warning events for pod:\n" + "\n".join(event_strs)
+
+        except kubernetes.client.rest.ApiException as e:
+            warning_str = f"Failure fetching pod events: {str(e)}"
+
+        return (
+            f"Debug information for pod {pod_name}:"
+            + f"\n{pod_status_str}"
+            + (f"\n{specific_warning}" if specific_warning else "")
+            + (f"\n{log_str}" if log_str else "")
+            + f"\n{warning_str}"
+        )


### PR DESCRIPTION
Summary:
Like we already have with the EcsRunLauncher, when a k8s job crashes or fails to start, include:
- the last 10 logs from the pod
- the status of the containers in the pod
- any warning events in the pod

## Summary & Motivation

## How I Tested These Changes
