### PR TITLE
[dagster-snowflake] config to determine how to handle timestamp data

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@ When new releases include breaking changes or deprecations, this document descri
 ### Breaking Changes
 
 #### Extension Libraries
-[dagster-snowflake-pandas] Prior to `dagster-snowflake` version `0.19.0` the Snowflake I/O manager converted all timestamp data to strings before loading the data in Snowflake, and did the opposite conversion when fetching a DataFrame from Snowflake. The I/O manager now ensures timestamp data has a timezone attached and stores the data as TIMESTAMP_NTZ(9) type. If you used the Snowflake I/O manager prior to version `0.19.0` you can set the `time_data_to_string=True` configuration value for the Snowflake I/O manager to continue storing time data as strings while you do table migrations.
+[dagster-snowflake-pandas] Prior to `dagster-snowflake` version `0.19.0` the Snowflake I/O manager converted all timestamp data to strings before loading the data in Snowflake, and did the opposite conversion when fetching a DataFrame from Snowflake. The I/O manager now ensures timestamp data has a timezone attached and stores the data as TIMESTAMP_NTZ(9) type. If you used the Snowflake I/O manager prior to version `0.19.0` you can set the `store_timestamps_as_strings=True` configuration value for the Snowflake I/O manager to continue storing time data as strings while you do table migrations.
 
 To migrate a table created prior to `0.19.0` to one with a TIMESTAMP_NTZ(9) type, you can run the follow SQL queries in Snowflake. In the example, our table is located at `database.schema.table` and the column we want to migrate is called `time`:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,11 +32,6 @@ RENAME COLUMN time_copy TO time
 
 ```
 
-<Note>
-The <code>time_data_to_string</code> configuration value will be deprecated in version X.Y.Z of the <code>dagster-snowflake</code> library. At that point, all timestamp data will be stored as TIMESTAMP_NTZ(9) type.
-</Note>
-
-
 ## Migrating to 1.2.0
 
 ### Database migration

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -332,34 +332,14 @@ In this example, the `iris_dataset` asset will be stored in the `IRIS` schema, a
 ---
 
 ## Storing timestamp data in Pandas DataFrames
-Due to a longstanding bug in the Snowflake Pandas connector, loading timestamp data from a Pandas DataFrame to Snowflake sometimes causes the data to be corrupted. Prior to `dagster-snowflake` version `0.19.0` we solved this issue by converting all timestamp data to strings before loading the data in Snowflake, and doing the opposite conversion when fetching a DataFrame from Snowflake. However, we can also avoid this issue by ensuring that all timestamp data has a timezone. This allows us to store the data as TIMESTAMP_NTZ(9) type in Snowflake.
-
-To specify how you would like timestamp data to be handled, use the `time_data_to_string` configuration value for the Snowflake I/O manager. If `True`, the I/O manager will convert timestamp data to a string before loading it into Snowflake. If `False` the I/O manager will ensure the data has a timezone (attaching the UTC timezone if necessary) before loading it into Snowflake.
-
-If you would like to migrate a table created prior to `0.19.0` to one with a TIMESTAMP_NTZ(9) type, you can run the follow SQL queries in Snowflake. In the example, our table is located at `database.schema.table` and the column we want to migrate is called `time`:
-
-```sql
-
-// Add a column of type TIMESTAMP_NTZ(9)
-ALTER TABLE database.schema.table
-ADD COLUMN time_copy TIMESTAMP_NTZ(9)
-
-// copy the data from time and convert to timestamp data
-UPDATE database.schema.table
-SET time_copy = to_timestamp_ntz(time)
-
-// drop the time column
-ALTER TABLE database.schema.table
-DROP COLUMN time
-
-// rename the time_copy column to time
-ALTER TABLER database.schema.table
-RENAME COLUMN time_copy TO time
-
-```
+Due to a longstanding [issue](https://github.com/snowflakedb/snowflake-connector-python/issues/319) with the Snowflake Pandas connector, loading timestamp data from a Pandas DataFrame to Snowflake sometimes causes the data to be corrupted. In order to store timestamp data properly, it must have a timezone attached. When storing a Pandas DataFrame with the Snowflake I/O manager, the I/O manager will check if timestamp data has a timezone attached, and if not, **it will assign the UTC timezone**. In Snowflake, you will see the timestamp data stored as the TIMESTAMP_NTZ(9) type, as this is the type assigned by the Snowflake Pandas connector.
 
 <Note>
-The <code>time_data_to_string</code> configuration value will be deprecated in version X.Y.Z of the <code>dagster-snowflake</code> library.
+Prior to `dagster-snowflake` version `0.19.0` the Snowflake I/O manager converted all timestamp data to strings before loading the data in Snowflake, and did the opposite conversion when fetching a DataFrame from Snowflake. If you have used a version of `dagster-snowflake` prior to version `0.19.0` please see the{" "}
+  <a href="/migration#extension-libraries">
+    Migration Guide
+  </a>{" "}
+for information about migrating you database tables.
 </Note>
 
 ---

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -11,6 +11,7 @@ This reference page provides information for working with [`dagster-snowflake`](
 - [Selecting specific columns in a downstream asset](#selecting-specific-columns-in-a-downstream-asset)
 - [Storing partitioned assets](#storing-partitioned-assets)
 - [Storing tables in multiple schemas](#storing-tables-in-multiple-schemas)
+- [Storing timestamp data in Pandas DataFrames](#storing-timestamp-data-in-pandas-dataframes)
 - [Using the Snowflake I/O manager with other I/O managers](#using-the-snowflake-io-manager-with-other-io-managers)
 - [Storing and loading PySpark DataFrames in Snowflake](#storing-and-loading-pyspark-dataframes-in-snowflake)
 - [Using Pandas and PySpark DataFrames with Snowflake](#using-pandas-and-pyspark-dataframes-with-snowflake)
@@ -326,6 +327,39 @@ In this example, the `iris_dataset` asset will be stored in the `IRIS` schema, a
   it via the asset key and vice versa. If no <code>schema</code> is provided,
   either from configuration or asset keys, the default schema{" "}
   <code>PUBLIC</code> will be used.
+</Note>
+
+---
+
+## Storing timestamp data in Pandas DataFrames
+Due to a longstanding bug in the Snowflake Pandas connector, loading timestamp data from a Pandas DataFrame to Snowflake sometimes causes the data to be corrupted. Prior to `dagster-snowflake` version `0.19.0` we solved this issue by converting all timestamp data to strings before loading the data in Snowflake, and doing the opposite conversion when fetching a DataFrame from Snowflake. However, we can also avoid this issue by ensuring that all timestamp data has a timezone. This allows us to store the data as TIMESTAMP_NTZ(9) type in Snowflake.
+
+To specify how you would like timestamp data to be handled, use the `time_data_to_string` configuration value for the Snowflake I/O manager. If `True`, the I/O manager will convert timestamp data to a string before loading it into Snowflake. If `False` the I/O manager will ensure the data has a timezone (attaching the UTC timezone if necessary) before loading it into Snowflake.
+
+If you would like to migrate a table created prior to `0.19.0` to one with a TIMESTAMP_NTZ(9) type, you can run the follow SQL queries in Snowflake. In the example, our table is located at `database.schema.table` and the column we want to migrate is called `time`:
+
+```sql
+
+// Add a column of type TIMESTAMP_NTZ(9)
+ALTER TABLE database.schema.table
+ADD COLUMN time_copy TIMESTAMP_NTZ(9)
+
+// copy the data from time and convert to timestamp data
+UPDATE database.schema.table
+SET time_copy = to_timestamp_ntz(time)
+
+// drop the time column
+ALTER TABLE database.schema.table
+DROP COLUMN time
+
+// rename the time_copy column to time
+ALTER TABLER database.schema.table
+RENAME COLUMN time_copy TO time
+
+```
+
+<Note>
+The <code>time_data_to_string</code> configuration value will be deprecated in version X.Y.Z of the <code>dagster-snowflake</code> library.
 </Note>
 
 ---

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -332,14 +332,16 @@ In this example, the `iris_dataset` asset will be stored in the `IRIS` schema, a
 ---
 
 ## Storing timestamp data in Pandas DataFrames
+
 Due to a longstanding [issue](https://github.com/snowflakedb/snowflake-connector-python/issues/319) with the Snowflake Pandas connector, loading timestamp data from a Pandas DataFrame to Snowflake sometimes causes the data to be corrupted. In order to store timestamp data properly, it must have a timezone attached. When storing a Pandas DataFrame with the Snowflake I/O manager, the I/O manager will check if timestamp data has a timezone attached, and if not, **it will assign the UTC timezone**. In Snowflake, you will see the timestamp data stored as the TIMESTAMP_NTZ(9) type, as this is the type assigned by the Snowflake Pandas connector.
 
 <Note>
-Prior to `dagster-snowflake` version `0.19.0` the Snowflake I/O manager converted all timestamp data to strings before loading the data in Snowflake, and did the opposite conversion when fetching a DataFrame from Snowflake. If you have used a version of `dagster-snowflake` prior to version `0.19.0` please see the{" "}
-  <a href="/migration#extension-libraries">
-    Migration Guide
-  </a>{" "}
-for information about migrating you database tables.
+  Prior to `dagster-snowflake` version `0.19.0` the Snowflake I/O manager
+  converted all timestamp data to strings before loading the data in Snowflake,
+  and did the opposite conversion when fetching a DataFrame from Snowflake. If
+  you have used a version of `dagster-snowflake` prior to version `0.19.0`
+  please see the <a href="/migration#extension-libraries">Migration Guide</a>{" "}
+  for information about migrating you database tables.
 </Note>
 
 ---

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -36,6 +36,11 @@ def _convert_string_to_timestamp(s: pd.Series) -> pd.Series:
         return s
 
 
+def _add_missing_timezone(s: pd.Series) -> pd.Series:
+    if pd_core_dtypes_common.is_datetime_or_timedelta_dtype(s):
+        pass
+
+
 class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     """Plugin for the Snowflake I/O Manager that can store and load Pandas DataFrames as Snowflake tables.
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -68,7 +68,7 @@ def _add_missing_timezone(
     s: pd.Series, column_types: Optional[Mapping[str, str]], table_name: str
 ) -> pd.Series:
     column_name = str(s.name)
-    if pd_core_dtypes_common.is_datetime_or_timedelta_dtype(s):
+    if pd_core_dtypes_common.is_datetime_or_timedelta_dtype(s):  # type: ignore  # (bad stubs)
         if column_types:
             if "VARCHAR" in column_types[column_name]:
                 raise DagsterInvariantViolationError(

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -2,25 +2,39 @@ from typing import Mapping, Optional, Sequence, Type
 
 import pandas as pd
 import pandas.core.dtypes.common as pd_core_dtypes_common
-from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
-from dagster._core.definitions.metadata import RawMetadataValue
-from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient, SnowflakeIOManager
 from snowflake.connector.pandas_tools import pd_writer
 
+from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
+from dagster._core.definitions.metadata import RawMetadataValue
+from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 
-def _convert_timestamp_to_string(s: pd.Series) -> pd.Series:
+
+def _table_exists(table_slice: TableSlice, connection):
+    tables = connection.execute(
+        f"SHOW TABLES LIKE '{table_slice.table}' IN DATABASE '{table_slice.database}' SCHEMA"
+        f" '{table_slice.schema}'"
+    ).fetchall()
+    return len(tables) > 0
+
+def _get_table_schema(table_slice: TableSlice, connection):
+    if _table_exists(table_slice, connection):
+        return connection.execute(f"DESCRIBE TABLE {table_slice.table}").fetchall()
+
+def _convert_timestamp_to_string(s: pd.Series, table_schema) -> pd.Series:
     """Converts columns of data of type pd.Timestamp to string so that it can be stored in
     snowflake.
     """
     if pd_core_dtypes_common.is_datetime_or_timedelta_dtype(s):  # type: ignore  # (bad stubs)
+        if table_schema:
+            pass
         return s.dt.strftime("%Y-%m-%d %H:%M:%S.%f %z")
     else:
         return s
 
 
-def _convert_string_to_timestamp(s: pd.Series) -> pd.Series:
+def _convert_string_to_timestamp(s: pd.Series, table_schema) -> pd.Series:
     """Converts columns of strings in Timestamp format to pd.Timestamp to undo the conversion in
     _convert_timestamp_to_string.
 
@@ -79,7 +93,15 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
 
         connector.paramstyle = "pyformat"
         with_uppercase_cols = obj.rename(str.upper, copy=False, axis="columns")
-        with_uppercase_cols = with_uppercase_cols.apply(_add_missing_timezone, axis="index")
+        table_schema = _get_table_schema(table_slice, connection)
+        if context.config["time_data_to_string"]:
+            with_uppercase_cols = with_uppercase_cols.apply(
+                _convert_timestamp_to_string, axis="index", args=(table_schema)
+            )
+        else:
+            with_uppercase_cols = with_uppercase_cols.apply(
+                _add_missing_timezone, axis="index", args=(table_schema)
+            )
         with_uppercase_cols.to_sql(
             table_slice.table,
             con=connection.engine,
@@ -108,7 +130,8 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
         result = pd.read_sql(
             sql=SnowflakeDbClient.get_select_statement(table_slice), con=connection
         )
-        # result = result.apply(_convert_string_to_timestamp, axis="index")
+        if context.config["time_data_to_string"]:
+            result = result.apply(_convert_string_to_timestamp, axis="index")
         result.columns = map(str.lower, result.columns)  # type: ignore  # (bad stubs)
         return result
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -293,7 +293,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
 
         with pytest.raises(
             DagsterInvariantViolationError,
-            match="is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9)",
+            match=r"is not of type VARCHAR, it is of type TIMESTAMP_NTZ\(9\)",
         ):
             io_manager_timestamp_as_string_test_job.execute_in_process()
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -293,13 +293,12 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
 
         with pytest.raises(
             DagsterInvariantViolationError,
-            match=(
-                "Snowflake I/O manager: Snowflake I/O manager configured to convert time data in"
-                " DataFrame column DATE to strings, but the corresponding DATE column in table"
-                f" {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set"
-                " store_timestamps_as_strings=False in the Snowflake I/O manager configuration to"
-                " store time data as TIMESTAMP types."
-            ),
+            match=f"""Snowflake I/O manager: Snowflake I/O manager configured to convert time data in
+                DataFrame column DATE to strings, but the corresponding DATE column in table
+                {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set
+                store_timestamps_as_strings=False in the Snowflake I/O manager configuration to
+                store time data as TIMESTAMP types.
+            """,
         ):
             io_manager_timestamp_as_string_test_job.execute_in_process()
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -149,7 +149,7 @@ def test_load_input():
 def test_type_conversions():
     # no timestamp data
     no_time = pandas.Series([1, 2, 3, 4, 5])
-    converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time, None))
+    converted = _convert_string_to_timestamp(_convert_timestamp_to_string(no_time, None, "foo"))
     assert (converted == no_time).all()
 
     # timestamp data
@@ -160,7 +160,9 @@ def test_type_conversions():
             pandas.Timestamp("2017-03-01T12:30:45.35"),
         ]
     )
-    time_converted = _convert_string_to_timestamp(_convert_timestamp_to_string(with_time, None))
+    time_converted = _convert_string_to_timestamp(
+        _convert_timestamp_to_string(with_time, None, "foo")
+    )
 
     assert (with_time == time_converted).all()
 
@@ -173,7 +175,7 @@ def test_type_conversions():
 def test_timezone_conversions():
     # no timestamp data
     no_time = pandas.Series([1, 2, 3, 4, 5])
-    converted = _add_missing_timezone(no_time, None)
+    converted = _add_missing_timezone(no_time, None, "foo")
     assert (converted == no_time).all()
 
     # timestamp data
@@ -184,7 +186,7 @@ def test_timezone_conversions():
             pandas.Timestamp("2017-03-01T12:30:45.35"),
         ]
     )
-    time_converted = _add_missing_timezone(with_time, None)
+    time_converted = _add_missing_timezone(with_time, None, "foo")
 
     assert (with_time.dt.tz_localize("UTC") == time_converted).all()
 
@@ -293,7 +295,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
             DagsterInvariantViolationError,
             match=(
                 "Snowflake I/O manager: Snowflake I/O manager configured to convert time data in"
-                " DataFrame column date to strings, but the corresponding DATE column in table"
+                " DataFrame column DATE to strings, but the corresponding DATE column in table"
                 f" {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set"
                 " store_timestamps_as_strings=False in the Snowflake I/O manager configuration to"
                 " store time data as TIMESTAMP types."

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -271,7 +271,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
                 "resources": {
                     "snowflake": {
                         "config": {
-                            "time_data_as_string": True,
+                            "store_timestamps_as_strings": True,
                         }
                     }
                 }

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -293,13 +293,7 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
 
         with pytest.raises(
             DagsterInvariantViolationError,
-            match=(
-                "Snowflake I/O manager: Snowflake I/O manager configured to convert time data in"
-                " DataFrame column DATE to strings, but the corresponding DATE column in table"
-                f" {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set"
-                " store_timestamps_as_strings=False in the Snowflake I/O manager configuration to"
-                " store time data as TIMESTAMP types."
-            ),
+            match="is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9)",
         ):
             io_manager_timestamp_as_string_test_job.execute_in_process()
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -289,7 +289,16 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
         def io_manager_timestamp_as_string_test_job():
             read_time_df(emit_time_df())
 
-        with pytest.raises(DagsterInvariantViolationError):
+        with pytest.raises(
+            DagsterInvariantViolationError,
+            match=(
+                "Snowflake I/O manager: Snowflake I/O manager configured to convert time data in"
+                " DataFrame column date to strings, but the corresponding DATE column in table"
+                f" {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set"
+                " store_timestamps_as_strings=False in the Snowflake I/O manager configuration to"
+                " store time data as TIMESTAMP types."
+            ),
+        ):
             io_manager_timestamp_as_string_test_job.execute_in_process()
 
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -293,12 +293,13 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
 
         with pytest.raises(
             DagsterInvariantViolationError,
-            match=f"""Snowflake I/O manager: Snowflake I/O manager configured to convert time data in
-                DataFrame column DATE to strings, but the corresponding DATE column in table
-                {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set
-                store_timestamps_as_strings=False in the Snowflake I/O manager configuration to
-                store time data as TIMESTAMP types.
-            """,
+            match=(
+                "Snowflake I/O manager: Snowflake I/O manager configured to convert time data in"
+                " DataFrame column DATE to strings, but the corresponding DATE column in table"
+                f" {table_name} is not of type VARCHAR, it is of type TIMESTAMP_NTZ(9). Please set"
+                " store_timestamps_as_strings=False in the Snowflake I/O manager configuration to"
+                " store time data as TIMESTAMP types."
+            ),
         ):
             io_manager_timestamp_as_string_test_job.execute_in_process()
 

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -230,7 +230,7 @@ def test_io_manager_with_snowflake_pandas(io_manager):
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 @pytest.mark.parametrize(
-    "io_manager", [(old_snowflake_io_manager), (pythonic_snowflake_io_manager)]
+    "io_manager", [(snowflake_pandas_io_manager), (SnowflakePandasIOManager.configure_at_launch())]
 )
 def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
     with temporary_snowflake_table(
@@ -258,6 +258,13 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
 
         @job(
             resource_defs={"snowflake": io_manager},
+            config={
+                "resources": {
+                    "snowflake": {
+                        "config": {**SHARED_BUILDKITE_SNOWFLAKE_CONF, "database": DATABASE}
+                    }
+                }
+            },
         )
         def io_manager_timestamp_test_job():
             read_time_df(emit_time_df())
@@ -271,6 +278,8 @@ def test_io_manager_with_snowflake_pandas_timestamp_data(io_manager):
                 "resources": {
                     "snowflake": {
                         "config": {
+                            **SHARED_BUILDKITE_SNOWFLAKE_CONF,
+                            "database": DATABASE,
                             "store_timestamps_as_strings": True,
                         }
                     }

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -94,7 +94,7 @@ def build_snowflake_io_manager(
 
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
-        if init_context.resource_config["store_timestamps_as_strings"]:
+        if init_context.resource_config.get("store_timestamps_as_strings", False):
             deprecation_warning(
                 "Snowflake I/O manager config store_timestamps_as_strings",
                 "2.0.0",
@@ -262,6 +262,15 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
         return None
 
     def create_io_manager(self, context) -> DbIOManager:
+        if self.store_timestamps_as_strings:
+            deprecation_warning(
+                "Snowflake I/O manager config store_timestamps_as_strings",
+                "2.0.0",
+                (
+                    "Convert existing tables to use timestamps and remove"
+                    " store_timestamps_as_strings configuration instead."
+                ),
+            )
         return DbIOManager(
             db_client=SnowflakeDbClient(),
             io_manager_name="SnowflakeIOManager",

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -14,9 +14,8 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
-from pydantic import Field
-from sqlalchemy.exc import ProgrammingError
 from dagster._utils.backcompat import deprecation_warning
+from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 
 from .resources import SnowflakeConnection
@@ -205,13 +204,13 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
             " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details."
         ),
     )
-    store_timestamps_as_strings: bool =  Field(
+    store_timestamps_as_strings: bool = Field(
         default=False,
         description=(
-            "If using Pandas DataFrames, whether to convert time data to strings. If True,"
-            " time data will be converted to strings when storing the DataFrame and"
-            " converted back to time data when loading the DataFrame. If False, time data"
-            " without a timezone will be set to UTC timezone to avoid a Snowflake bug. Defaults to False."
+            "If using Pandas DataFrames, whether to convert time data to strings. If True, time"
+            " data will be converted to strings when storing the DataFrame and converted back to"
+            " time data when loading the DataFrame. If False, time data without a timezone will be"
+            " set to UTC timezone to avoid a Snowflake bug. Defaults to False."
         ),
     )
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -17,6 +17,7 @@ from dagster._core.storage.db_io_manager import (
 from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 from dagster._utils.backcompat import deprecation_warning
+from sqlalchemy.exc import ProgrammingError
 
 from .resources import SnowflakeConnection
 
@@ -94,9 +95,14 @@ def build_snowflake_io_manager(
 
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
-        if init_context.config["time_data_to_string"]:
+        if init_context.resource_config["time_data_to_string"]:
             deprecation_warning(
-                "Snowflake I/O manager config time_data_to_string", "2.0.0", "Convert existing tables to use timestamps and remove time_data_to_string configuration instead."
+                "Snowflake I/O manager config time_data_to_string",
+                "2.0.0",
+                (
+                    "Convert existing tables to use timestamps and remove time_data_to_string"
+                    " configuration instead."
+                ),
             )
         return DbIOManager(
             type_handlers=type_handlers,

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -14,7 +14,6 @@ from dagster._core.storage.db_io_manager import (
     TablePartitionDimension,
     TableSlice,
 )
-from dagster._utils.backcompat import deprecation_warning
 from pydantic import Field
 from sqlalchemy.exc import ProgrammingError
 
@@ -94,15 +93,6 @@ def build_snowflake_io_manager(
 
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
-        if init_context.resource_config.get("store_timestamps_as_strings", False):
-            deprecation_warning(
-                "Snowflake I/O manager config store_timestamps_as_strings",
-                "2.0.0",
-                (
-                    "Convert existing tables to use timestamps and remove"
-                    " store_timestamps_as_strings configuration instead."
-                ),
-            )
         return DbIOManager(
             type_handlers=type_handlers,
             db_client=SnowflakeDbClient(),
@@ -262,15 +252,6 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
         return None
 
     def create_io_manager(self, context) -> DbIOManager:
-        if self.store_timestamps_as_strings:
-            deprecation_warning(
-                "Snowflake I/O manager config store_timestamps_as_strings",
-                "2.0.0",
-                (
-                    "Convert existing tables to use timestamps and remove"
-                    " store_timestamps_as_strings configuration instead."
-                ),
-            )
         return DbIOManager(
             db_client=SnowflakeDbClient(),
             io_manager_name="SnowflakeIOManager",

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -95,13 +95,13 @@ def build_snowflake_io_manager(
 
     @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
-        if init_context.resource_config["time_data_to_string"]:
+        if init_context.resource_config["store_timestamps_as_strings"]:
             deprecation_warning(
-                "Snowflake I/O manager config time_data_to_string",
+                "Snowflake I/O manager config store_timestamps_as_strings",
                 "2.0.0",
                 (
-                    "Convert existing tables to use timestamps and remove time_data_to_string"
-                    " configuration instead."
+                    "Convert existing tables to use timestamps and remove"
+                    " store_timestamps_as_strings configuration instead."
                 ),
             )
         return DbIOManager(
@@ -205,7 +205,7 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
             " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details."
         ),
     )
-    time_data_to_string: bool =  Field(
+    store_timestamps_as_strings: bool =  Field(
         default=False,
         description=(
             "If using Pandas DataFrames, whether to convert time data to strings. If True,"


### PR DESCRIPTION
## Summary & Motivation
There is an issue with storing pandas Timestamp values in snowflake where the year will get converted to a non-valid year (example 48399). In pr https://github.com/dagster-io/dagster/pull/8760 i got around this by storing pandas timestamps as strings, but i finally found this https://github.com/snowflakedb/snowflake-connector-python/issues/319 that indicates that the real fix is to include timezone information in your pandas timestamps https://github.com/snowflakedb/snowflake-connector-python/issues/319#issuecomment-764145625.

This PR adds a new configuration value to the snowflake io manager that allows the user to specify if they want to convert timestamp data to strings, or add a timezone to it. We also check the column types of the table to ensure that the chosen conversion aligns with the type of the corresponding table.

Right now I have deprecation warnings in place so that we can remove the string conversion at some point. I'm not sure what version to choose as the deprecation version, or if committing to deprecating makes sense right now. 

I also added documentation explaining the behavior of the configuration value and providing SQL commands that will allow a user to migrate a column from string to timestamp if they wish to move from converting timestamp data to strings to using timezones.

See https://github.com/dagster-io/dagster/pull/12190 for additional context

## How I Tested These Changes
