### PR TITLE
Set stdin to DEVNULL when opening dagster subprocesses

### DIFF
--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -211,7 +211,13 @@ def open_ipc_subprocess(parts: Sequence[str], **kwargs: object) -> Popen[bytes]:
     else:
         # Works on all UNIX systems (but not WASI, see: https://docs.python.org/3/library/os.html#os.setpgrp)
         preexec_fn = os.setpgrp
-    return subprocess.Popen(parts, creationflags=creationflags, preexec_fn=preexec_fn, **kwargs)
+    return subprocess.Popen(
+        parts,
+        creationflags=creationflags,
+        preexec_fn=preexec_fn,
+        stdin=subprocess.DEVNULL,  # Prevent terminal signals from hanging the subprocess
+        **kwargs,
+    )
 
 
 def interrupt_ipc_subprocess(proc: Popen[bytes]) -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/import_readline.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/import_readline.py
@@ -1,0 +1,2 @@
+# This will hang if it is imported in a subprocess with stdin not equal to DEVNULL
+import readline  # noqa

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
@@ -223,6 +223,13 @@ def test_segfault_compute_log_tail(
                     wait_for_process(stderr_pid)
 
 
+def test_input_signal_hang():
+    please_dont_hang = open_ipc_subprocess(
+        [sys.executable, file_relative_path(__file__, "import_readline.py")],
+    )
+    please_dont_hang.communicate(timeout=10)
+
+
 def test_interrupt_compute_log_tail_grandchild(
     windows_legacy_stdio_env,
 ):


### PR DESCRIPTION
Summary:
To prevent terminal signals from hanging dagster code.

Test Plan: New test case that failed before

## Summary & Motivation

## How I Tested These Changes
