### PR TITLE
[tech][templates] moving the scaffold project's asset loader outside of the defs

### DIFF
--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/__init__.py
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/__init__.py
@@ -5,5 +5,5 @@ from . import assets
 all_assets = load_assets_from_modules([assets])
 
 defs = Definitions(
-    assets=all_assets
+    assets=all_assets,
 )

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/__init__.py
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/__init__.py
@@ -2,4 +2,8 @@ from dagster import Definitions, load_assets_from_modules
 
 from . import assets
 
-defs = Definitions(assets=load_assets_from_modules([assets]))
+all_assets = load_assets_from_modules([assets])
+
+defs = Definitions(
+    assets=all_assets
+)


### PR DESCRIPTION
## Summary & Motivation

Separating the `load_assets_from_module` call from it getting passed as an argument into `Definitions`. Mainly for readability/consistency since the tutorial/guides and other things all define things outside of the `Definitions`

## How I Tested These Changes
