### PR TITLE
[resource verification][1/n] Add ConfigVerifiable interface for resources

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -109,6 +109,11 @@ from dagster._config.structured_config import (
     PermissiveConfig as PermissiveConfig,
     ResourceDependency as ResourceDependency,
 )
+from dagster._config.structured_config.resource_verification import (
+    ConfigVerifiable as ConfigVerifiable,
+    VerificationResult as VerificationResult,
+    VerificationStatus as VerificationStatus,
+)
 from dagster._core.definitions.asset_in import AssetIn as AssetIn
 from dagster._core.definitions.asset_out import AssetOut as AssetOut
 from dagster._core.definitions.asset_reconciliation_sensor import (

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -109,10 +109,10 @@ from dagster._config.structured_config import (
     PermissiveConfig as PermissiveConfig,
     ResourceDependency as ResourceDependency,
 )
-from dagster._config.structured_config.resource_verification import (
-    ConfigVerifiable as ConfigVerifiable,
-    VerificationResult as VerificationResult,
-    VerificationStatus as VerificationStatus,
+from dagster._config.structured_config.readiness_check import (
+    ReadinessCheckedResource as ReadinessCheckedResource,
+    ReadinessCheckResult as ReadinessCheckResult,
+    ReadinessCheckStatus as ReadinessCheckStatus,
 )
 from dagster._core.definitions.asset_in import AssetIn as AssetIn
 from dagster._core.definitions.asset_out import AssetOut as AssetOut

--- a/python_modules/dagster/dagster/_config/structured_config/readiness_check.py
+++ b/python_modules/dagster/dagster/_config/structured_config/readiness_check.py
@@ -5,29 +5,27 @@ from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-class VerificationStatus(Enum):
+class ReadinessCheckStatus(Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
 
 
 @whitelist_for_serdes
-class VerificationResult(NamedTuple):
-    status: VerificationStatus
+class ReadinessCheckResult(NamedTuple):
+    status: ReadinessCheckStatus
     message: Optional[str]
 
     @classmethod
     def success(cls, message: Optional[str] = None):
-        """Create a successful verification result.
-        """
-        return cls(VerificationStatus.SUCCESS, message)
+        """Create a successful readiness check result."""
+        return cls(ReadinessCheckStatus.SUCCESS, message)
 
     @classmethod
     def failure(cls, message: Optional[str] = None):
-        """Create a failed verification result.
-        """
-        return cls(VerificationStatus.FAILURE, message)
+        """Create a failed readiness check result."""
+        return cls(ReadinessCheckStatus.FAILURE, message)
 
 
-class ConfigVerifiable:
-    def verify_config(self) -> VerificationResult:
+class ReadinessCheckedResource:
+    def readiness_check(self) -> ReadinessCheckResult:
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_config/structured_config/resource_verification.py
+++ b/python_modules/dagster/dagster/_config/structured_config/resource_verification.py
@@ -1,0 +1,21 @@
+from enum import Enum
+from typing import NamedTuple, Optional
+
+from dagster._serdes.serdes import whitelist_for_serdes
+
+
+@whitelist_for_serdes
+class VerificationStatus(Enum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+
+@whitelist_for_serdes
+class VerificationResult(NamedTuple):
+    status: VerificationStatus
+    message: Optional[str]
+
+
+class ConfigVerifiable:
+    def verify_config(self) -> VerificationResult:
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/_config/structured_config/resource_verification.py
+++ b/python_modules/dagster/dagster/_config/structured_config/resource_verification.py
@@ -15,6 +15,18 @@ class VerificationResult(NamedTuple):
     status: VerificationStatus
     message: Optional[str]
 
+    @classmethod
+    def success(cls, message: Optional[str] = None):
+        """Create a successful verification result.
+        """
+        return cls(VerificationStatus.SUCCESS, message)
+
+    @classmethod
+    def failure(cls, message: Optional[str] = None):
+        """Create a failed verification result.
+        """
+        return cls(VerificationStatus.FAILURE, message)
+
 
 class ConfigVerifiable:
     def verify_config(self) -> VerificationResult:


### PR DESCRIPTION
## Summary

Adds a new `ConfigVerifiable` interface which resources can implement so that they can be validated in the Dagster UI (and perhaps at code location load time). Subsequent PRs will interface with this.

This is meant as an experimental proof of concept API, something we can ship and let users toy with to proof out the usefulness of verification.

## Test Plan

n/a