### PR TITLE
[resource verification][4/n] Add basic frontend for ConfigVerifiable resources

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1958,6 +1958,7 @@ type ResourceVerificationResult {
 enum VerificationStatus {
   SUCCESS
   FAILURE
+  NOT_RUN
 }
 
 type RepositoryConnection {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3871,6 +3871,7 @@ export type UsedSolid = {
 
 export enum VerificationStatus {
   FAILURE = 'FAILURE',
+  NOT_RUN = 'NOT_RUN',
   SUCCESS = 'SUCCESS',
 }
 

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -262,23 +262,34 @@ export const ResourceRoot: React.FC<Props> = (props) => {
                             padding={{vertical: 16, horizontal: 24}}
                             flex={{direction: 'column', gap: 8}}
                           >
-                            <Box flex={{direction: 'row', gap: 8}}>
+                            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
                               <Button onClick={() => verify()}>Launch verification</Button>
                               {verificationResult && (
-                                <Tag
-                                  intent={
-                                    verificationResult.status === VerificationStatus.SUCCESS
-                                      ? 'success'
-                                      : 'danger'
+                                <Tooltip
+                                  content={<>{verificationResult?.message}</>}
+                                  canShow={
+                                    verificationResult?.message !== null &&
+                                    verificationResult.message.length > 0
                                   }
                                 >
-                                  {verificationResult.status === VerificationStatus.SUCCESS
-                                    ? 'Success'
-                                    : 'Failure'}
-                                </Tag>
+                                  <Tag
+                                    intent={
+                                      verificationResult.status === VerificationStatus.SUCCESS
+                                        ? 'success'
+                                        : verificationResult.status === VerificationStatus.NOT_RUN
+                                        ? 'none'
+                                        : 'danger'
+                                    }
+                                  >
+                                    {verificationResult.status === VerificationStatus.SUCCESS
+                                      ? 'Success'
+                                      : verificationResult.status === VerificationStatus.NOT_RUN
+                                      ? 'Not yet run'
+                                      : 'Failure'}
+                                  </Tag>
+                                </Tooltip>
                               )}
                             </Box>
-                            <CaptionMono>{verificationResult?.message}</CaptionMono>
                           </Box>
                         </SidebarSection>
                       ) : null}

--- a/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/resources/ResourceRoot.tsx
@@ -677,21 +677,6 @@ const RESOURCE_ROOT_QUERY = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
-// const SECTION_HEADER_HEIGHT = 48;
-// const SectionHeader = styled.div`
-//   background-color: ${Colors.Gray50};
-//   border: 0;
-//   box-shadow: inset 0px -1px 0 ${Colors.KeylineGray}, inset 0px 1px 0 ${Colors.KeylineGray};
-//   cursor: pointer;
-//   display: block;
-//   width: 100%;
-//   margin: 0;
-//   height: ${SECTION_HEADER_HEIGHT}px;
-//   line-height: ${SECTION_HEADER_HEIGHT}px;
-//   text-align: left;
-//   padding-left: 24px;
-//   font-weight: bold;
-// `;
 const VERIFY_MUTATION = gql`
   mutation Verification(
     $repositoryName: String!

--- a/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/resources/types/ResourceRoot.types.ts
@@ -6,6 +6,7 @@ export type ResourceDetailsFragment = {
   __typename: 'ResourceDetails';
   name: string;
   description: string | null;
+  supportsVerification: boolean;
   resourceType: string;
   configFields: Array<{
     __typename: 'ConfigTypeField';
@@ -52,6 +53,11 @@ export type ResourceDetailsFragment = {
       solid: {__typename: 'Solid'; name: string};
     }>;
   }>;
+  verificationResult: {
+    __typename: 'ResourceVerificationResult';
+    status: Types.VerificationStatus;
+    message: string;
+  } | null;
 };
 
 export type ResourceRootQueryVariables = Types.Exact<{
@@ -75,6 +81,7 @@ export type ResourceRootQuery = {
         __typename: 'ResourceDetails';
         name: string;
         description: string | null;
+        supportsVerification: boolean;
         resourceType: string;
         configFields: Array<{
           __typename: 'ConfigTypeField';
@@ -121,6 +128,35 @@ export type ResourceRootQuery = {
             solid: {__typename: 'Solid'; name: string};
           }>;
         }>;
+        verificationResult: {
+          __typename: 'ResourceVerificationResult';
+          status: Types.VerificationStatus;
+          message: string;
+        } | null;
       }
     | {__typename: 'ResourceNotFoundError'};
+};
+
+export type VerificationMutationVariables = Types.Exact<{
+  repositoryName: Types.Scalars['String'];
+  repositoryLocationName: Types.Scalars['String'];
+  resourceName: Types.Scalars['String'];
+}>;
+
+export type VerificationMutation = {
+  __typename: 'DagitMutation';
+  launchResourceVerification:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {__typename: 'RepositoryLocationNotFound'}
+    | {__typename: 'ResourceVerificationResult'; status: Types.VerificationStatus; message: string}
+    | {__typename: 'UnauthorizedError'};
 };


### PR DESCRIPTION
## Summary 

Adds a very minimal  user-facing frontend for the verifiable resource system which allows users to trigger verification and view the result.

<img width="1390" alt="Screen Shot 2023-03-27 at 3 49 40 PM" src="https://user-images.githubusercontent.com/10215173/228084241-8454a2e4-9e9a-462b-8d97-6f22e0c8e178.png">

## Test Plan

Tested locally.