### PR TITLE
[refactor] *Solid*Snap renames

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -25,7 +25,7 @@ from dagster._core.host_representation.external_data import (
     ExternalStaticPartitionsDefinitionData,
     ExternalTimeWindowPartitionsDefinitionData,
 )
-from dagster._core.snap.solid import GraphDefSnap, OpDefSnap
+from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 from dagster._core.workspace.permissions import Permissions
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -410,7 +410,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Sequence[str]:
         if isinstance(node_def_snap, CompositeSolidDefSnap):
             constituent_node_names = [
-                inv.solid_def_name
+                inv.node_def_name
                 for inv in node_def_snap.dep_structure_snapshot.solid_invocation_snaps
             ]
             external_pipeline = self.get_external_pipeline()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -25,7 +25,7 @@ from dagster._core.host_representation.external_data import (
     ExternalStaticPartitionsDefinitionData,
     ExternalTimeWindowPartitionsDefinitionData,
 )
-from dagster._core.snap.solid import CompositeSolidDefSnap, SolidDefSnap
+from dagster._core.snap.solid import CompositeSolidDefSnap, OpDefSnap
 from dagster._core.workspace.permissions import Permissions
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -168,7 +168,7 @@ class GrapheneMaterializationUpstreamDataVersion(graphene.ObjectType):
 class GrapheneAssetNode(graphene.ObjectType):
     _depended_by_loader: Optional[CrossRepoAssetDependedByLoader]
     _external_asset_node: ExternalAssetNode
-    _node_definition_snap: Optional[Union[CompositeSolidDefSnap, SolidDefSnap]]
+    _node_definition_snap: Optional[Union[CompositeSolidDefSnap, OpDefSnap]]
     _external_pipeline: Optional[ExternalPipeline]
     _external_repository: ExternalRepository
     _latest_materialization_loader: Optional[BatchMaterializationLoader]
@@ -323,7 +323,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def get_node_definition_snap(
         self,
-    ) -> Union[CompositeSolidDefSnap, SolidDefSnap]:
+    ) -> Union[CompositeSolidDefSnap, OpDefSnap]:
         if self._node_definition_snap is None and len(self._external_asset_node.job_names) > 0:
             node_key = check.not_none(
                 self._external_asset_node.node_definition_name
@@ -400,13 +400,13 @@ class GrapheneAssetNode(graphene.ObjectType):
         )
 
     def get_required_resource_keys(
-        self, node_def_snap: Union[CompositeSolidDefSnap, SolidDefSnap]
+        self, node_def_snap: Union[CompositeSolidDefSnap, OpDefSnap]
     ) -> Sequence[str]:
         all_keys = self.get_required_resource_keys_rec(node_def_snap)
         return list(set(all_keys))
 
     def get_required_resource_keys_rec(
-        self, node_def_snap: Union[CompositeSolidDefSnap, SolidDefSnap]
+        self, node_def_snap: Union[CompositeSolidDefSnap, OpDefSnap]
     ) -> Sequence[str]:
         if isinstance(node_def_snap, CompositeSolidDefSnap):
             constituent_node_names = [
@@ -862,7 +862,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             return None
         external_pipeline = self.get_external_pipeline()
         node_def_snap = self.get_node_definition_snap()
-        if isinstance(node_def_snap, SolidDefSnap):
+        if isinstance(node_def_snap, OpDefSnap):
             return GrapheneSolidDefinition(external_pipeline, node_def_snap.name)
 
         if isinstance(node_def_snap, CompositeSolidDefSnap):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -411,7 +411,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         if isinstance(node_def_snap, GraphDefSnap):
             constituent_node_names = [
                 inv.node_def_name
-                for inv in node_def_snap.dep_structure_snapshot.solid_invocation_snaps
+                for inv in node_def_snap.dep_structure_snapshot.node_invocation_snaps
             ]
             external_pipeline = self.get_external_pipeline()
             constituent_resource_key_sets = [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -258,7 +258,7 @@ class GrapheneInputMapping(graphene.ObjectType):
         return GrapheneInput(
             self._represented_pipeline,
             self._current_dep_index,
-            self._input_mapping_snap.mapped_solid_name,
+            self._input_mapping_snap.mapped_node_name,
             self._input_mapping_snap.mapped_input_name,
         )
 
@@ -300,7 +300,7 @@ class GrapheneOutputMapping(graphene.ObjectType):
         return GrapheneOutput(
             self._represented_pipeline,
             self._current_dep_index,
-            self._output_mapping_snap.mapped_solid_name,
+            self._output_mapping_snap.mapped_node_name,
             self._output_mapping_snap.mapped_output_name,
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -7,8 +7,8 @@ from dagster._core.definitions import NodeHandle
 from dagster._core.host_representation import RepresentedPipeline
 from dagster._core.host_representation.external import ExternalPipeline
 from dagster._core.host_representation.historical import HistoricalPipeline
-from dagster._core.snap import DependencyStructureIndex, GraphDefSnap, NodeDefSnap
-from dagster._core.snap.solid import InputMappingSnap, OutputMappingSnap
+from dagster._core.snap import DependencyStructureIndex, GraphDefSnap, OpDefSnap
+from dagster._core.snap.node import InputMappingSnap, OutputMappingSnap
 from dagster._core.storage.pipeline_run import RunsFilter
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -196,7 +196,7 @@ class GrapheneOutput(graphene.ObjectType):
         self._output_name = check.str_param(output_name, "output_name")
         self._solid_invocation_snap = current_dep_structure.get_invocation(solid_name)
         self._solid_def_snap = represented_pipeline.get_node_def_snap(
-            self._solid_invocation_snap.solid_def_name
+            self._solid_invocation_snap.node_def_name
         )
         self._output_def_snap = self._solid_def_snap.get_output_snap(output_name)
         super().__init__()
@@ -459,7 +459,7 @@ class GrapheneSolidDefinition(graphene.ObjectType, ISolidDefinitionMixin):
     def __init__(self, represented_pipeline: RepresentedPipeline, solid_def_name: str):
         check.inst_param(represented_pipeline, "represented_pipeline", RepresentedPipeline)
         _solid_def_snap = represented_pipeline.get_node_def_snap(solid_def_name)
-        if not isinstance(_solid_def_snap, NodeDefSnap):
+        if not isinstance(_solid_def_snap, OpDefSnap):
             check.failed("Expected SolidDefSnap")
         self._solid_def_snap = _solid_def_snap
         super().__init__(name=solid_def_name, description=self._solid_def_snap.description)
@@ -741,7 +741,7 @@ def build_solid_definition(
 
     solid_def_snap = represented_pipeline.get_node_def_snap(solid_def_name)
 
-    if isinstance(solid_def_snap, NodeDefSnap):
+    if isinstance(solid_def_snap, OpDefSnap):
         return GrapheneSolidDefinition(represented_pipeline, solid_def_snap.name)
 
     if isinstance(solid_def_snap, GraphDefSnap):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -7,7 +7,7 @@ from dagster._core.definitions import NodeHandle
 from dagster._core.host_representation import RepresentedPipeline
 from dagster._core.host_representation.external import ExternalPipeline
 from dagster._core.host_representation.historical import HistoricalPipeline
-from dagster._core.snap import CompositeSolidDefSnap, DependencyStructureIndex, SolidDefSnap
+from dagster._core.snap import CompositeSolidDefSnap, DependencyStructureIndex, NodeDefSnap
 from dagster._core.snap.solid import InputMappingSnap, OutputMappingSnap
 from dagster._core.storage.pipeline_run import RunsFilter
 
@@ -459,7 +459,7 @@ class GrapheneSolidDefinition(graphene.ObjectType, ISolidDefinitionMixin):
     def __init__(self, represented_pipeline: RepresentedPipeline, solid_def_name: str):
         check.inst_param(represented_pipeline, "represented_pipeline", RepresentedPipeline)
         _solid_def_snap = represented_pipeline.get_node_def_snap(solid_def_name)
-        if not isinstance(_solid_def_snap, SolidDefSnap):
+        if not isinstance(_solid_def_snap, NodeDefSnap):
             check.failed("Expected SolidDefSnap")
         self._solid_def_snap = _solid_def_snap
         super().__init__(name=solid_def_name, description=self._solid_def_snap.description)
@@ -741,7 +741,7 @@ def build_solid_definition(
 
     solid_def_snap = represented_pipeline.get_node_def_snap(solid_def_name)
 
-    if isinstance(solid_def_snap, SolidDefSnap):
+    if isinstance(solid_def_snap, NodeDefSnap):
         return GrapheneSolidDefinition(represented_pipeline, solid_def_snap.name)
 
     if isinstance(solid_def_snap, CompositeSolidDefSnap):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -344,7 +344,7 @@ def _build_solid_handles(
     check.opt_inst_param(parent, "parent", GrapheneSolidHandle)
     all_handle: List[GrapheneSolidHandle] = []
     for solid_invocation in current_dep_index.solid_invocations:
-        solid_name, solid_def_name = solid_invocation.solid_name, solid_invocation.solid_def_name
+        solid_name, solid_def_name = solid_invocation.node_name, solid_invocation.solid_def_name
         handle = GrapheneSolidHandle(
             solid=GrapheneSolid(represented_pipeline, solid_name, current_dep_index),
             handle=NodeHandle(solid_name, parent.handleID if parent else None),
@@ -562,7 +562,7 @@ class GrapheneSolid(graphene.ObjectType):
             GrapheneInput(
                 self._represented_pipeline,
                 self._current_dep_structure,
-                self._solid_invocation_snap.solid_name,
+                self._solid_invocation_snap.node_name,
                 input_def_snap.name,
             )
             for input_def_snap in self._solid_def_snap.input_def_snaps
@@ -573,7 +573,7 @@ class GrapheneSolid(graphene.ObjectType):
             GrapheneOutput(
                 self._represented_pipeline,
                 self._current_dep_structure,
-                self._solid_invocation_snap.solid_name,
+                self._solid_invocation_snap.node_name,
                 output_def_snap.name,
             )
             for output_def_snap in self._solid_def_snap.output_def_snaps

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -142,7 +142,7 @@ class GrapheneInput(graphene.ObjectType):
         self._input_name = check.str_param(input_name, "input_name")
         self._solid_invocation_snap = current_dep_structure.get_invocation(solid_name)
         self._solid_def_snap = represented_pipeline.get_node_def_snap(
-            self._solid_invocation_snap.solid_def_name
+            self._solid_invocation_snap.node_def_name
         )
         self._input_def_snap = self._solid_def_snap.get_input_snap(input_name)
 
@@ -344,7 +344,7 @@ def _build_solid_handles(
     check.opt_inst_param(parent, "parent", GrapheneSolidHandle)
     all_handle: List[GrapheneSolidHandle] = []
     for solid_invocation in current_dep_index.solid_invocations:
-        solid_name, solid_def_name = solid_invocation.node_name, solid_invocation.solid_def_name
+        solid_name, solid_def_name = solid_invocation.node_name, solid_invocation.node_def_name
         handle = GrapheneSolidHandle(
             solid=GrapheneSolid(represented_pipeline, solid_name, current_dep_index),
             handle=NodeHandle(solid_name, parent.handleID if parent else None),
@@ -531,7 +531,7 @@ class GrapheneSolid(graphene.ObjectType):
         )
         self._solid_invocation_snap = current_dep_structure.get_invocation(solid_name)
         self._solid_def_snap = represented_pipeline.get_node_def_snap(
-            self._solid_invocation_snap.solid_def_name
+            self._solid_invocation_snap.node_def_name
         )
         super().__init__(name=solid_name)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -165,7 +165,7 @@ class GrapheneInput(graphene.ObjectType):
             GrapheneOutput(
                 self._represented_pipeline,
                 self._current_dep_structure,
-                output_handle_snap.solid_name,
+                output_handle_snap.node_name,
                 output_handle_snap.output_name,
             )
             for output_handle_snap in self._current_dep_structure.get_upstream_outputs(
@@ -219,7 +219,7 @@ class GrapheneOutput(graphene.ObjectType):
             GrapheneInput(
                 self._represented_pipeline,
                 self._current_dep_structure,
-                input_handle_snap.solid_name,
+                input_handle_snap.node_name,
                 input_handle_snap.input_name,
             )
             for input_handle_snap in self._current_dep_structure.get_downstream_inputs(
@@ -329,7 +329,7 @@ def build_solids(represented_pipeline, current_dep_index):
     return sorted(
         [
             GrapheneSolid(represented_pipeline, solid_name, current_dep_index)
-            for solid_name in current_dep_index.solid_invocation_names
+            for solid_name in current_dep_index.node_invocation_names
         ],
         key=lambda solid: solid.name,
     )
@@ -343,7 +343,7 @@ def _build_solid_handles(
     check.inst_param(represented_pipeline, "represented_pipeline", RepresentedPipeline)
     check.opt_inst_param(parent, "parent", GrapheneSolidHandle)
     all_handle: List[GrapheneSolidHandle] = []
-    for solid_invocation in current_dep_index.solid_invocations:
+    for solid_invocation in current_dep_index.node_invocations:
         solid_name, solid_def_name = solid_invocation.node_name, solid_invocation.node_def_name
         handle = GrapheneSolidHandle(
             solid=GrapheneSolid(represented_pipeline, solid_name, current_dep_index),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -411,7 +411,7 @@ def hello_world_with_tags():
 
 
 @op(name="solid_with_list", config_schema=[int], out={})
-def solid_def(_):
+def op_def(_):
     return None
 
 
@@ -429,7 +429,7 @@ def pipeline_with_input_output_metadata():
 
 @pipeline
 def pipeline_with_list():
-    solid_def()
+    op_def()
 
 
 @pipeline(mode_defs=[default_mode_def_for_test])

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -46,7 +46,7 @@ from dagster._core.host_representation.external_data import (
     ExternalPartitionSetExecutionParamData,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.snap import PipelineSnapshot, SolidInvocationSnap
+from dagster._core.snap import NodeInvocationSnap, PipelineSnapshot
 from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
 from dagster._core.telemetry import log_external_repo_stats, telemetry_wrapper
@@ -220,10 +220,10 @@ def format_description(desc: str, indent: str):
 def print_op(
     printer: IndentingPrinter,
     pipeline_snapshot: PipelineSnapshot,
-    solid_invocation_snap: SolidInvocationSnap,
+    solid_invocation_snap: NodeInvocationSnap,
 ) -> None:
     check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
-    check.inst_param(solid_invocation_snap, "solid_invocation_snap", SolidInvocationSnap)
+    check.inst_param(solid_invocation_snap, "solid_invocation_snap", NodeInvocationSnap)
     printer.line(f"Op: {solid_invocation_snap.solid_name}")
     with printer.with_indent():
         printer.line("Inputs:")

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -233,7 +233,7 @@ def print_op(
 
         printer.line("Outputs:")
         for output_def_snap in pipeline_snapshot.get_node_def_snap(
-            solid_invocation_snap.solid_def_name
+            solid_invocation_snap.node_def_name
         ).output_def_snaps:
             printer.line(output_def_snap.name)
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -180,7 +180,7 @@ def print_ops(
     printer.line("Ops")
     for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
         with printer.with_indent():
-            printer.line(f"Op: {solid.solid_name}")
+            printer.line(f"Op: {solid.node_name}")
 
 
 def print_job(
@@ -224,7 +224,7 @@ def print_op(
 ) -> None:
     check.inst_param(pipeline_snapshot, "pipeline_snapshot", PipelineSnapshot)
     check.inst_param(solid_invocation_snap, "solid_invocation_snap", NodeInvocationSnap)
-    printer.line(f"Op: {solid_invocation_snap.solid_name}")
+    printer.line(f"Op: {solid_invocation_snap.node_name}")
     with printer.with_indent():
         printer.line("Inputs:")
         for input_dep_snap in solid_invocation_snap.input_dep_snaps:

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -110,7 +110,7 @@ def execute_list_command(cli_args, print_fn):
                     print_fn("Description:")
                     print_fn(format_description(job.description, indent=" " * 4))
                 print_fn("Ops: (Execution Order)")
-                for solid_name in job.pipeline_snapshot.solid_names_in_topological_order:
+                for solid_name in job.pipeline_snapshot.node_names_in_topological_order:
                     print_fn("    " + solid_name)
 
 
@@ -178,7 +178,7 @@ def print_ops(
     printer.line(f"Job: {pipeline_snapshot.name}")
 
     printer.line("Ops")
-    for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
+    for solid in pipeline_snapshot.dep_structure_snapshot.node_invocation_snaps:
         with printer.with_indent():
             printer.line(f"Op: {solid.node_name}")
 
@@ -194,7 +194,7 @@ def print_job(
     print_description(printer, pipeline_snapshot.description)
 
     printer.line("Ops")
-    for solid in pipeline_snapshot.dep_structure_snapshot.solid_invocation_snaps:
+    for solid in pipeline_snapshot.dep_structure_snapshot.node_invocation_snaps:
         with printer.with_indent():
             print_op(printer, pipeline_snapshot, solid)
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -23,6 +23,7 @@ from dagster._config.config_schema import UserConfigSchema
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.dependency import NodeHandle, NodeInputHandle
 from dagster._core.definitions.node_definition import NodeDefinition
+from dagster._core.definitions.op_invocation import op_invocation_result
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_requirement import (
     InputManagerRequirement,
@@ -30,7 +31,6 @@ from dagster._core.definitions.resource_requirement import (
     OutputManagerRequirement,
     ResourceRequirement,
 )
-from dagster._core.definitions.solid_invocation import op_invocation_result
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster._utils.backcompat import canonicalize_backcompat_args, deprecation_warning

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -346,7 +346,7 @@ class ExternalPipeline(RepresentedPipeline):
 
     @property
     def solid_names_in_topological_order(self):
-        return self._pipeline_index.pipeline_snapshot.solid_names_in_topological_order
+        return self._pipeline_index.pipeline_snapshot.node_names_in_topological_order
 
     @property
     def external_pipeline_data(self):
@@ -365,7 +365,7 @@ class ExternalPipeline(RepresentedPipeline):
     @property
     def solid_selection(self) -> Optional[Sequence[str]]:
         return (
-            self._pipeline_index.pipeline_snapshot.lineage_snapshot.solid_selection
+            self._pipeline_index.pipeline_snapshot.lineage_snapshot.node_selection
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
             else None
         )
@@ -373,7 +373,7 @@ class ExternalPipeline(RepresentedPipeline):
     @property
     def solids_to_execute(self) -> Optional[AbstractSet[str]]:
         return (
-            self._pipeline_index.pipeline_snapshot.lineage_snapshot.solids_to_execute
+            self._pipeline_index.pipeline_snapshot.lineage_snapshot.nodes_to_execute
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
             else None
         )
@@ -392,7 +392,7 @@ class ExternalPipeline(RepresentedPipeline):
 
     @property
     def solid_names(self) -> Sequence[str]:
-        return self._pipeline_index.pipeline_snapshot.solid_names
+        return self._pipeline_index.pipeline_snapshot.node_names
 
     def has_solid_invocation(self, solid_name: str):
         check.str_param(solid_name, "solid_name")

--- a/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
@@ -10,13 +10,13 @@ from dagster._core.snap import (
 )
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ModeDefSnap
-from dagster._core.snap.solid import CompositeSolidDefSnap, NodeDefSnap
+from dagster._core.snap.solid import GraphDefSnap, NodeDefSnap
 
 
 class PipelineIndex:
     pipeline_snapshot: PipelineSnapshot
     parent_pipeline_snapshot: Optional[PipelineSnapshot]
-    _node_defs_snaps_index: Mapping[str, Union[NodeDefSnap, CompositeSolidDefSnap]]
+    _node_defs_snaps_index: Mapping[str, Union[NodeDefSnap, GraphDefSnap]]
     _dagster_type_snaps_by_name_index: Mapping[str, DagsterTypeSnap]
     dep_structure_index: DependencyStructureIndex
     _comp_dep_structures: Mapping[str, DependencyStructureIndex]
@@ -43,7 +43,7 @@ class PipelineIndex:
                 ),
             )
 
-        node_def_snaps: Sequence[Union[NodeDefSnap, CompositeSolidDefSnap]] = [
+        node_def_snaps: Sequence[Union[NodeDefSnap, GraphDefSnap]] = [
             *pipeline_snapshot.solid_definitions_snapshot.solid_def_snaps,
             *pipeline_snapshot.solid_definitions_snapshot.composite_solid_def_snaps,
         ]
@@ -96,7 +96,7 @@ class PipelineIndex:
     def get_dagster_type_from_name(self, type_name: str) -> DagsterTypeSnap:
         return self._dagster_type_snaps_by_name_index[type_name]
 
-    def get_node_def_snap(self, node_def_name: str) -> Union[NodeDefSnap, CompositeSolidDefSnap]:
+    def get_node_def_snap(self, node_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
         check.str_param(node_def_name, "node_def_name")
         return self._node_defs_snaps_index[node_def_name]
 

--- a/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
@@ -10,13 +10,13 @@ from dagster._core.snap import (
 )
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ModeDefSnap
-from dagster._core.snap.solid import GraphDefSnap, NodeDefSnap
+from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 
 
 class PipelineIndex:
     pipeline_snapshot: PipelineSnapshot
     parent_pipeline_snapshot: Optional[PipelineSnapshot]
-    _node_defs_snaps_index: Mapping[str, Union[NodeDefSnap, GraphDefSnap]]
+    _node_defs_snaps_index: Mapping[str, Union[OpDefSnap, GraphDefSnap]]
     _dagster_type_snaps_by_name_index: Mapping[str, DagsterTypeSnap]
     dep_structure_index: DependencyStructureIndex
     _comp_dep_structures: Mapping[str, DependencyStructureIndex]
@@ -43,7 +43,7 @@ class PipelineIndex:
                 ),
             )
 
-        node_def_snaps: Sequence[Union[NodeDefSnap, GraphDefSnap]] = [
+        node_def_snaps: Sequence[Union[OpDefSnap, GraphDefSnap]] = [
             *pipeline_snapshot.solid_definitions_snapshot.op_def_snaps,
             *pipeline_snapshot.solid_definitions_snapshot.graph_def_snaps,
         ]
@@ -96,7 +96,7 @@ class PipelineIndex:
     def get_dagster_type_from_name(self, type_name: str) -> DagsterTypeSnap:
         return self._dagster_type_snaps_by_name_index[type_name]
 
-    def get_node_def_snap(self, node_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
+    def get_node_def_snap(self, node_def_name: str) -> Union[OpDefSnap, GraphDefSnap]:
         check.str_param(node_def_name, "node_def_name")
         return self._node_defs_snaps_index[node_def_name]
 

--- a/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
@@ -44,8 +44,8 @@ class PipelineIndex:
             )
 
         node_def_snaps: Sequence[Union[NodeDefSnap, GraphDefSnap]] = [
-            *pipeline_snapshot.solid_definitions_snapshot.solid_def_snaps,
-            *pipeline_snapshot.solid_definitions_snapshot.composite_solid_def_snaps,
+            *pipeline_snapshot.solid_definitions_snapshot.op_def_snaps,
+            *pipeline_snapshot.solid_definitions_snapshot.graph_def_snaps,
         ]
         self._node_defs_snaps_index = {sd.name: sd for sd in node_def_snaps}
 
@@ -61,7 +61,7 @@ class PipelineIndex:
 
         self._comp_dep_structures = {
             comp_snap.name: DependencyStructureIndex(comp_snap.dep_structure_snapshot)
-            for comp_snap in pipeline_snapshot.solid_definitions_snapshot.composite_solid_def_snaps
+            for comp_snap in pipeline_snapshot.solid_definitions_snapshot.graph_def_snaps
         }
 
         self._memo_lock = Lock()

--- a/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
@@ -10,13 +10,13 @@ from dagster._core.snap import (
 )
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ModeDefSnap
-from dagster._core.snap.solid import CompositeSolidDefSnap, SolidDefSnap
+from dagster._core.snap.solid import CompositeSolidDefSnap, NodeDefSnap
 
 
 class PipelineIndex:
     pipeline_snapshot: PipelineSnapshot
     parent_pipeline_snapshot: Optional[PipelineSnapshot]
-    _node_defs_snaps_index: Mapping[str, Union[SolidDefSnap, CompositeSolidDefSnap]]
+    _node_defs_snaps_index: Mapping[str, Union[NodeDefSnap, CompositeSolidDefSnap]]
     _dagster_type_snaps_by_name_index: Mapping[str, DagsterTypeSnap]
     dep_structure_index: DependencyStructureIndex
     _comp_dep_structures: Mapping[str, DependencyStructureIndex]
@@ -43,7 +43,7 @@ class PipelineIndex:
                 ),
             )
 
-        node_def_snaps: Sequence[Union[SolidDefSnap, CompositeSolidDefSnap]] = [
+        node_def_snaps: Sequence[Union[NodeDefSnap, CompositeSolidDefSnap]] = [
             *pipeline_snapshot.solid_definitions_snapshot.solid_def_snaps,
             *pipeline_snapshot.solid_definitions_snapshot.composite_solid_def_snaps,
         ]
@@ -96,7 +96,7 @@ class PipelineIndex:
     def get_dagster_type_from_name(self, type_name: str) -> DagsterTypeSnap:
         return self._dagster_type_snaps_by_name_index[type_name]
 
-    def get_node_def_snap(self, node_def_name: str) -> Union[SolidDefSnap, CompositeSolidDefSnap]:
+    def get_node_def_snap(self, node_def_name: str) -> Union[NodeDefSnap, CompositeSolidDefSnap]:
         check.str_param(node_def_name, "node_def_name")
         return self._node_defs_snaps_index[node_def_name]
 

--- a/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
+++ b/python_modules/dagster/dagster/_core/host_representation/pipeline_index.py
@@ -44,8 +44,8 @@ class PipelineIndex:
             )
 
         node_def_snaps: Sequence[Union[OpDefSnap, GraphDefSnap]] = [
-            *pipeline_snapshot.solid_definitions_snapshot.op_def_snaps,
-            *pipeline_snapshot.solid_definitions_snapshot.graph_def_snaps,
+            *pipeline_snapshot.node_defs_snapshot.op_def_snaps,
+            *pipeline_snapshot.node_defs_snapshot.graph_def_snaps,
         ]
         self._node_defs_snaps_index = {sd.name: sd for sd in node_def_snaps}
 
@@ -61,7 +61,7 @@ class PipelineIndex:
 
         self._comp_dep_structures = {
             comp_snap.name: DependencyStructureIndex(comp_snap.dep_structure_snapshot)
-            for comp_snap in pipeline_snapshot.solid_definitions_snapshot.graph_def_snaps
+            for comp_snap in pipeline_snapshot.node_defs_snapshot.graph_def_snaps
         }
 
         self._memo_lock = Lock()

--- a/python_modules/dagster/dagster/_core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/host_representation/represented.py
@@ -6,8 +6,8 @@ from dagster._config import ConfigSchemaSnapshot
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.dep_snapshot import DependencyStructureIndex
 from dagster._core.snap.mode import ModeDefSnap
+from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 from dagster._core.snap.pipeline_snapshot import PipelineSnapshot
-from dagster._core.snap.solid import GraphDefSnap, NodeDefSnap
 
 from .pipeline_index import PipelineIndex
 
@@ -103,7 +103,7 @@ class RepresentedPipeline(ABC):
         return self._pipeline_index.dep_structure_index
 
     # Solids
-    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
+    def get_node_def_snap(self, solid_def_name: str) -> Union[OpDefSnap, GraphDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
         return self._pipeline_index.get_node_def_snap(solid_def_name)
 

--- a/python_modules/dagster/dagster/_core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/host_representation/represented.py
@@ -7,7 +7,7 @@ from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.dep_snapshot import DependencyStructureIndex
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._core.snap.pipeline_snapshot import PipelineSnapshot
-from dagster._core.snap.solid import CompositeSolidDefSnap, SolidDefSnap
+from dagster._core.snap.solid import CompositeSolidDefSnap, NodeDefSnap
 
 from .pipeline_index import PipelineIndex
 
@@ -103,7 +103,7 @@ class RepresentedPipeline(ABC):
         return self._pipeline_index.dep_structure_index
 
     # Solids
-    def get_node_def_snap(self, solid_def_name: str) -> Union[SolidDefSnap, CompositeSolidDefSnap]:
+    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, CompositeSolidDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
         return self._pipeline_index.get_node_def_snap(solid_def_name)
 

--- a/python_modules/dagster/dagster/_core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/host_representation/represented.py
@@ -7,7 +7,7 @@ from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.dep_snapshot import DependencyStructureIndex
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._core.snap.pipeline_snapshot import PipelineSnapshot
-from dagster._core.snap.solid import CompositeSolidDefSnap, NodeDefSnap
+from dagster._core.snap.solid import GraphDefSnap, NodeDefSnap
 
 from .pipeline_index import PipelineIndex
 
@@ -103,7 +103,7 @@ class RepresentedPipeline(ABC):
         return self._pipeline_index.dep_structure_index
 
     # Solids
-    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, CompositeSolidDefSnap]:
+    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
         return self._pipeline_index.get_node_def_snap(solid_def_name)
 

--- a/python_modules/dagster/dagster/_core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/host_representation/represented.py
@@ -56,7 +56,7 @@ class RepresentedPipeline(ABC):
     @property
     def solid_selection(self) -> Optional[Sequence[str]]:
         return (
-            self._pipeline_index.pipeline_snapshot.lineage_snapshot.solid_selection
+            self._pipeline_index.pipeline_snapshot.lineage_snapshot.node_selection
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
             else None
         )
@@ -64,7 +64,7 @@ class RepresentedPipeline(ABC):
     @property
     def solids_to_execute(self) -> Optional[AbstractSet[str]]:
         return (
-            self._pipeline_index.pipeline_snapshot.lineage_snapshot.solids_to_execute
+            self._pipeline_index.pipeline_snapshot.lineage_snapshot.nodes_to_execute
             if self._pipeline_index.pipeline_snapshot.lineage_snapshot
             else None
         )

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -43,7 +43,7 @@ from .dagster_types import (
 )
 from .dep_snapshot import (
     DependencyStructureIndex as DependencyStructureIndex,
-    SolidInvocationSnap as SolidInvocationSnap,
+    NodeInvocationSnap as NodeInvocationSnap,
 )
 from .execution_plan_snapshot import (
     ExecutionPlanSnapshot as ExecutionPlanSnapshot,

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -63,7 +63,7 @@ from .pipeline_snapshot import (
     create_pipeline_snapshot_id as create_pipeline_snapshot_id,
 )
 from .solid import (
-    CompositeSolidDefSnap as CompositeSolidDefSnap,
+    GraphDefSnap as GraphDefSnap,
     NodeDefSnap as NodeDefSnap,
     build_composite_solid_def_snap as build_composite_solid_def_snap,
 )

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -64,6 +64,6 @@ from .pipeline_snapshot import (
 )
 from .solid import (
     CompositeSolidDefSnap as CompositeSolidDefSnap,
-    SolidDefSnap as SolidDefSnap,
+    NodeDefSnap as NodeDefSnap,
     build_composite_solid_def_snap as build_composite_solid_def_snap,
 )

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -58,12 +58,12 @@ from .mode import (
     ModeDefSnap as ModeDefSnap,
     ResourceDefSnap as ResourceDefSnap,
 )
+from .node import (
+    GraphDefSnap as GraphDefSnap,
+    OpDefSnap as OpDefSnap,
+    build_graph_def_snap as build_graph_def_snap,
+)
 from .pipeline_snapshot import (
     PipelineSnapshot as PipelineSnapshot,
     create_pipeline_snapshot_id as create_pipeline_snapshot_id,
-)
-from .solid import (
-    GraphDefSnap as GraphDefSnap,
-    NodeDefSnap as NodeDefSnap,
-    build_graph_def_snap as build_graph_def_snap,
 )

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -65,5 +65,5 @@ from .pipeline_snapshot import (
 from .solid import (
     GraphDefSnap as GraphDefSnap,
     NodeDefSnap as NodeDefSnap,
-    build_composite_solid_def_snap as build_composite_solid_def_snap,
+    build_graph_def_snap as build_graph_def_snap,
 )

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -33,8 +33,8 @@ def build_solid_invocation_snap(
         )
 
     return NodeInvocationSnap(
-        solid_name=solid.name,
-        solid_def_name=solid.definition.name,
+        node_name=solid.name,
+        node_def_name=solid.definition.name,
         tags=solid.tags,
         input_dep_snaps=input_def_snaps,
         is_dynamic_mapped=dep_structure.is_dynamic_mapped(solid.name),

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -115,7 +115,7 @@ class DependencyStructureIndex:
                         output_dep_snap.output_name
                     ].append(
                         InputHandle(
-                            solid_def_name=invocation.solid_def_name,
+                            solid_def_name=invocation.node_def_name,
                             solid_name=invocation.node_name,
                             input_name=input_dep_snap.input_name,
                         )
@@ -210,16 +210,17 @@ class InputDependencySnap(
         )
 
 
-# Use old name as storage for backcompat
+# Use old names in storage for backcompat
 @whitelist_for_serdes(
-    storage_name="SolidInvocationSnap", storage_field_names={"node_name": "solid_name"}
+    storage_name="SolidInvocationSnap",
+    storage_field_names={"node_name": "solid_name", "node_def_name": "solid_def_name"},
 )
 class NodeInvocationSnap(
     NamedTuple(
         "_NodeInvocationSnap",
         [
             ("node_name", str),
-            ("solid_def_name", str),
+            ("node_def_name", str),
             ("tags", Mapping[str, str]),
             ("input_dep_snaps", Sequence[InputDependencySnap]),
             ("is_dynamic_mapped", bool),
@@ -229,7 +230,7 @@ class NodeInvocationSnap(
     def __new__(
         cls,
         node_name: str,
-        solid_def_name: str,
+        node_def_name: str,
         tags: Mapping[str, str],
         input_dep_snaps: Sequence[InputDependencySnap],
         is_dynamic_mapped: bool = False,
@@ -237,7 +238,7 @@ class NodeInvocationSnap(
         return super(NodeInvocationSnap, cls).__new__(
             cls,
             node_name=check.str_param(node_name, "node_name"),
-            solid_def_name=check.str_param(solid_def_name, "solid_def_name"),
+            node_def_name=check.str_param(node_def_name, "node_def_name"),
             tags=check.mapping_param(tags, "tags", key_type=str, value_type=str),
             input_dep_snaps=check.sequence_param(
                 input_dep_snaps, "input_dep_snaps", of_type=InputDependencySnap

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -41,13 +41,13 @@ def build_solid_invocation_snap(
     )
 
 
-def build_dep_structure_snapshot_from_icontains_solids(
-    icontains_solids: GraphDefinition,
+def build_dep_structure_snapshot_from_graph_def(
+    graph_def: GraphDefinition,
 ) -> "DependencyStructureSnapshot":
-    check.inst_param(icontains_solids, "icontains_solids", GraphDefinition)
+    check.inst_param(graph_def, "graph_def", GraphDefinition)
     return DependencyStructureSnapshot(
         solid_invocation_snaps=[
-            build_solid_invocation_snap(icontains_solids, solid) for solid in icontains_solids.nodes
+            build_solid_invocation_snap(graph_def, node) for node in graph_def.nodes
         ]
     )
 

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -66,7 +66,7 @@ class DependencyStructureSnapshot(
                 check.sequence_param(
                     solid_invocation_snaps, "solid_invocation_snaps", of_type=NodeInvocationSnap
                 ),
-                key=lambda si: si.solid_name,
+                key=lambda si: si.node_name,
             ),
         )
 
@@ -96,7 +96,7 @@ class DependencyStructureIndex:
             dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot
         )
         self._invocations_dict = {
-            si.solid_name: si for si in dep_structure_snapshot.solid_invocation_snaps
+            si.node_name: si for si in dep_structure_snapshot.solid_invocation_snaps
         }
         self._output_to_upstream_index = self._build_index(
             dep_structure_snapshot.solid_invocation_snaps
@@ -116,7 +116,7 @@ class DependencyStructureIndex:
                     ].append(
                         InputHandle(
                             solid_def_name=invocation.solid_def_name,
-                            solid_name=invocation.solid_name,
+                            solid_name=invocation.node_name,
                             input_name=input_dep_snap.input_name,
                         )
                     )
@@ -211,12 +211,14 @@ class InputDependencySnap(
 
 
 # Use old name as storage for backcompat
-@whitelist_for_serdes(storage_name="SolidInvocationSnap")
+@whitelist_for_serdes(
+    storage_name="SolidInvocationSnap", storage_field_names={"node_name": "solid_name"}
+)
 class NodeInvocationSnap(
     NamedTuple(
         "_NodeInvocationSnap",
         [
-            ("solid_name", str),
+            ("node_name", str),
             ("solid_def_name", str),
             ("tags", Mapping[str, str]),
             ("input_dep_snaps", Sequence[InputDependencySnap]),
@@ -226,7 +228,7 @@ class NodeInvocationSnap(
 ):
     def __new__(
         cls,
-        solid_name: str,
+        node_name: str,
         solid_def_name: str,
         tags: Mapping[str, str],
         input_dep_snaps: Sequence[InputDependencySnap],
@@ -234,7 +236,7 @@ class NodeInvocationSnap(
     ):
         return super(NodeInvocationSnap, cls).__new__(
             cls,
-            solid_name=check.str_param(solid_name, "solid_name"),
+            node_name=check.str_param(node_name, "node_name"),
             solid_def_name=check.str_param(solid_def_name, "solid_def_name"),
             tags=check.mapping_param(tags, "tags", key_type=str, value_type=str),
             input_dep_snaps=check.sequence_param(

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -7,19 +7,17 @@ from dagster._core.definitions.dependency import DependencyType, Node, NodeInput
 from dagster._serdes import whitelist_for_serdes
 
 
-def build_solid_invocation_snap(
-    icontains_solids: GraphDefinition, solid: Node
-) -> "NodeInvocationSnap":
-    check.inst_param(solid, "solid", Node)
-    check.inst_param(icontains_solids, "icontains_solids", GraphDefinition)
-    dep_structure = icontains_solids.dependency_structure
+def build_node_invocation_snap(graph_def: GraphDefinition, node: Node) -> "NodeInvocationSnap":
+    check.inst_param(node, "node", Node)
+    check.inst_param(graph_def, "graph_def", GraphDefinition)
+    dep_structure = graph_def.dependency_structure
 
     input_def_snaps = []
 
-    input_to_outputs_map = dep_structure.input_to_upstream_outputs_for_node(solid.name)
+    input_to_outputs_map = dep_structure.input_to_upstream_outputs_for_node(node.name)
 
-    for input_def in solid.definition.input_defs:
-        node_input = NodeInput(solid, input_def)
+    for input_def in node.definition.input_defs:
+        node_input = NodeInput(node, input_def)
         input_def_snaps.append(
             InputDependencySnap(
                 input_def.name,
@@ -33,11 +31,11 @@ def build_solid_invocation_snap(
         )
 
     return NodeInvocationSnap(
-        node_name=solid.name,
-        node_def_name=solid.definition.name,
-        tags=solid.tags,
+        node_name=node.name,
+        node_def_name=node.definition.name,
+        tags=node.tags,
         input_dep_snaps=input_def_snaps,
-        is_dynamic_mapped=dep_structure.is_dynamic_mapped(solid.name),
+        is_dynamic_mapped=dep_structure.is_dynamic_mapped(node.name),
     )
 
 
@@ -46,25 +44,25 @@ def build_dep_structure_snapshot_from_graph_def(
 ) -> "DependencyStructureSnapshot":
     check.inst_param(graph_def, "graph_def", GraphDefinition)
     return DependencyStructureSnapshot(
-        solid_invocation_snaps=[
-            build_solid_invocation_snap(graph_def, node) for node in graph_def.nodes
+        node_invocation_snaps=[
+            build_node_invocation_snap(graph_def, node) for node in graph_def.nodes
         ]
     )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_field_names={"node_invocation_snaps": "solid_invocation_snaps"})
 class DependencyStructureSnapshot(
     NamedTuple(
         "_DependencyStructureSnapshot",
-        [("solid_invocation_snaps", Sequence["NodeInvocationSnap"])],
+        [("node_invocation_snaps", Sequence["NodeInvocationSnap"])],
     )
 ):
-    def __new__(cls, solid_invocation_snaps: Sequence["NodeInvocationSnap"]):
+    def __new__(cls, node_invocation_snaps: Sequence["NodeInvocationSnap"]):
         return super(DependencyStructureSnapshot, cls).__new__(
             cls,
             sorted(
                 check.sequence_param(
-                    solid_invocation_snaps, "solid_invocation_snaps", of_type=NodeInvocationSnap
+                    node_invocation_snaps, "node_invocation_snaps", of_type=NodeInvocationSnap
                 ),
                 key=lambda si: si.node_name,
             ),
@@ -73,20 +71,20 @@ class DependencyStructureSnapshot(
 
 # Not actually serialized. Used within the dependency index
 class InputHandle(
-    NamedTuple("_InputHandle", [("solid_def_name", str), ("solid_name", str), ("input_name", str)])
+    NamedTuple("_InputHandle", [("node_def_name", str), ("node_name", str), ("input_name", str)])
 ):
-    def __new__(cls, solid_def_name: str, solid_name: str, input_name: str):
+    def __new__(cls, node_def_name: str, node_name: str, input_name: str):
         return super(InputHandle, cls).__new__(
             cls,
-            solid_def_name=check.str_param(solid_def_name, "solid_def_name"),
-            solid_name=check.str_param(solid_name, "solid_name"),
+            node_def_name=check.str_param(node_def_name, "node_def_name"),
+            node_name=check.str_param(node_name, "node_name"),
             input_name=check.str_param(input_name, "input_name"),
         )
 
 
 # This class contains all the dependency information
 # for a given "level" in a pipeline. So either the pipelines
-# or within a composite solid
+# or within a graph
 class DependencyStructureIndex:
     _invocations_dict: Dict[str, "NodeInvocationSnap"]
     _output_to_upstream_index: Mapping[str, Mapping[str, Sequence[InputHandle]]]
@@ -96,27 +94,27 @@ class DependencyStructureIndex:
             dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot
         )
         self._invocations_dict = {
-            si.node_name: si for si in dep_structure_snapshot.solid_invocation_snaps
+            si.node_name: si for si in dep_structure_snapshot.node_invocation_snaps
         }
         self._output_to_upstream_index = self._build_index(
-            dep_structure_snapshot.solid_invocation_snaps
+            dep_structure_snapshot.node_invocation_snaps
         )
 
     def _build_index(
-        self, solid_invocation_snaps: Sequence["NodeInvocationSnap"]
+        self, node_invocation_snaps: Sequence["NodeInvocationSnap"]
     ) -> Mapping[str, Mapping[str, Sequence[InputHandle]]]:
         output_to_upstream_index: DefaultDict[str, Mapping[str, List[InputHandle]]] = defaultdict(
             lambda: defaultdict(list)
         )
-        for invocation in solid_invocation_snaps:
+        for invocation in node_invocation_snaps:
             for input_dep_snap in invocation.input_dep_snaps:
                 for output_dep_snap in input_dep_snap.upstream_output_snaps:
-                    output_to_upstream_index[output_dep_snap.solid_name][
+                    output_to_upstream_index[output_dep_snap.node_name][
                         output_dep_snap.output_name
                     ].append(
                         InputHandle(
-                            solid_def_name=invocation.node_def_name,
-                            solid_name=invocation.node_name,
+                            node_def_name=invocation.node_def_name,
+                            node_name=invocation.node_name,
                             input_name=input_dep_snap.input_name,
                         )
                     )
@@ -124,59 +122,55 @@ class DependencyStructureIndex:
         return output_to_upstream_index
 
     @property
-    def solid_invocation_names(self) -> Sequence[str]:
+    def node_invocation_names(self) -> Sequence[str]:
         return list(self._invocations_dict.keys())
 
     @property
-    def solid_invocations(self) -> Sequence["NodeInvocationSnap"]:
+    def node_invocations(self) -> Sequence["NodeInvocationSnap"]:
         return list(self._invocations_dict.values())
 
-    def get_invocation(self, solid_name: str) -> "NodeInvocationSnap":
-        check.str_param(solid_name, "solid_name")
-        return self._invocations_dict[solid_name]
+    def get_invocation(self, node_name: str) -> "NodeInvocationSnap":
+        check.str_param(node_name, "node_name")
+        return self._invocations_dict[node_name]
 
-    def has_invocation(self, solid_name: str) -> bool:
-        return solid_name in self._invocations_dict
+    def has_invocation(self, node_name: str) -> bool:
+        return node_name in self._invocations_dict
 
-    def get_upstream_outputs(
-        self, solid_name: str, input_name: str
-    ) -> Sequence["OutputHandleSnap"]:
-        check.str_param(solid_name, "solid_name")
+    def get_upstream_outputs(self, node_name: str, input_name: str) -> Sequence["OutputHandleSnap"]:
+        check.str_param(node_name, "node_name")
         check.str_param(input_name, "input_name")
 
-        for input_dep_snap in self.get_invocation(solid_name).input_dep_snaps:
+        for input_dep_snap in self.get_invocation(node_name).input_dep_snaps:
             if input_dep_snap.input_name == input_name:
                 return input_dep_snap.upstream_output_snaps
 
         check.failed(
-            "Input {input_name} not found for solid {solid_name}".format(
+            "Input {input_name} not found for node {node_name}".format(
                 input_name=input_name,
-                solid_name=solid_name,
+                node_name=node_name,
             )
         )
 
-    def get_upstream_output(self, solid_name: str, input_name: str) -> "OutputHandleSnap":
-        check.str_param(solid_name, "solid_name")
+    def get_upstream_output(self, node_name: str, input_name: str) -> "OutputHandleSnap":
+        check.str_param(node_name, "node_name")
         check.str_param(input_name, "input_name")
 
-        outputs = self.get_upstream_outputs(solid_name, input_name)
+        outputs = self.get_upstream_outputs(node_name, input_name)
         check.invariant(len(outputs) == 1)
         return outputs[0]
 
-    def get_downstream_inputs(self, solid_name: str, output_name: str) -> Sequence[InputHandle]:
-        check.str_param(solid_name, "solid_name")
+    def get_downstream_inputs(self, node_name: str, output_name: str) -> Sequence[InputHandle]:
+        check.str_param(node_name, "node_name")
         check.str_param(output_name, "output_name")
-        return self._output_to_upstream_index[solid_name][output_name]
+        return self._output_to_upstream_index[node_name][output_name]
 
 
-@whitelist_for_serdes
-class OutputHandleSnap(
-    NamedTuple("_OutputHandleSnap", [("solid_name", str), ("output_name", str)])
-):
-    def __new__(cls, solid_name: str, output_name: str):
+@whitelist_for_serdes(storage_field_names={"node_name": "solid_name"})
+class OutputHandleSnap(NamedTuple("_OutputHandleSnap", [("node_name", str), ("output_name", str)])):
+    def __new__(cls, node_name: str, output_name: str):
         return super(OutputHandleSnap, cls).__new__(
             cls,
-            solid_name=check.str_param(solid_name, "solid_name"),
+            node_name=check.str_param(node_name, "node_name"),
             output_name=check.str_param(output_name, "output_name"),
         )
 

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -88,12 +88,12 @@ class OutputDefSnap(
         )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_field_names={"mapped_node_name": "mapped_solid_name"})
 class OutputMappingSnap(
     NamedTuple(
         "_OutputMappingSnap",
         [
-            ("mapped_solid_name", str),
+            ("mapped_node_name", str),
             ("mapped_output_name", str),
             ("external_output_name", str),
         ],
@@ -101,13 +101,13 @@ class OutputMappingSnap(
 ):
     def __new__(
         cls,
-        mapped_solid_name: str,
+        mapped_node_name: str,
         mapped_output_name: str,
         external_output_name: str,
     ):
         return super(OutputMappingSnap, cls).__new__(
             cls,
-            mapped_solid_name=check.str_param(mapped_solid_name, "mapped_solid_name"),
+            mapped_node_name=check.str_param(mapped_node_name, "mapped_node_name"),
             mapped_output_name=check.str_param(mapped_output_name, "mapped_output_name"),
             external_output_name=check.str_param(external_output_name, "external_output_name"),
         )
@@ -115,7 +115,7 @@ class OutputMappingSnap(
 
 def build_output_mapping_snap(output_mapping: OutputMapping) -> OutputMappingSnap:
     return OutputMappingSnap(
-        mapped_solid_name=output_mapping.maps_from.node_name,
+        mapped_node_name=output_mapping.maps_from.node_name,
         mapped_output_name=output_mapping.maps_from.output_name,
         external_output_name=output_mapping.graph_output_name,
     )

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -385,7 +385,7 @@ def build_op_def_snap(op_def: OpDefinition) -> OpDefSnap:
         description=op_def.description,
         tags=op_def.tags,
         required_resource_keys=sorted(list(op_def.required_resource_keys)),
-        config_field_snap=snap_from_field("config", op_def.config_field)
+        config_field_snap=snap_from_field("config", op_def.config_field)  # type: ignore  # (possible none)
         if op_def.has_config_field
         else None,
     )

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -45,10 +45,10 @@ from .dep_snapshot import (
     build_dep_structure_snapshot_from_graph_def,
 )
 from .mode import ModeDefSnap, build_mode_def_snap
-from .solid import (
+from .node import (
     GraphDefSnap,
-    NodeDefSnap,
     NodeDefsSnap,
+    OpDefSnap,
     build_node_defs_snap,
 )
 
@@ -190,7 +190,7 @@ class PipelineSnapshot(
             graph_def_name=pipeline_def.graph.name,
         )
 
-    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
+    def get_node_def_snap(self, solid_def_name: str) -> Union[OpDefSnap, GraphDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
         for solid_def_snap in self.solid_definitions_snapshot.op_def_snaps:
             if solid_def_snap.name == solid_def_name:
@@ -211,9 +211,9 @@ class PipelineSnapshot(
 
     def get_config_type_from_solid_def_snap(
         self,
-        solid_def_snap: Union[NodeDefSnap, GraphDefSnap],
+        solid_def_snap: Union[OpDefSnap, GraphDefSnap],
     ) -> Optional[ConfigType]:
-        check.inst_param(solid_def_snap, "solid_def_snap", (NodeDefSnap, GraphDefSnap))
+        check.inst_param(solid_def_snap, "solid_def_snap", (OpDefSnap, GraphDefSnap))
         if solid_def_snap.config_field_snap:
             config_type_key = solid_def_snap.config_field_snap.type_key
             if self.config_schema_snapshot.has_config_snap(config_type_key):

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -49,7 +49,7 @@ from .solid import (
     GraphDefSnap,
     NodeDefinitionsSnapshot,
     NodeDefSnap,
-    build_solid_definitions_snapshot,
+    build_node_definitions_snapshot,
 )
 
 
@@ -180,7 +180,7 @@ class PipelineSnapshot(
             metadata=pipeline_def.metadata,
             config_schema_snapshot=build_config_schema_snapshot(pipeline_def),
             dagster_type_namespace_snapshot=build_dagster_type_namespace_snapshot(pipeline_def),
-            solid_definitions_snapshot=build_solid_definitions_snapshot(pipeline_def),
+            solid_definitions_snapshot=build_node_definitions_snapshot(pipeline_def),
             dep_structure_snapshot=build_dep_structure_snapshot_from_icontains_solids(
                 pipeline_def.graph
             ),

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -46,7 +46,7 @@ from .dep_snapshot import (
 )
 from .mode import ModeDefSnap, build_mode_def_snap
 from .solid import (
-    CompositeSolidDefSnap,
+    GraphDefSnap,
     NodeDefSnap,
     SolidDefinitionsSnapshot,
     build_solid_definitions_snapshot,
@@ -192,7 +192,7 @@ class PipelineSnapshot(
             graph_def_name=pipeline_def.graph.name,
         )
 
-    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, CompositeSolidDefSnap]:
+    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
         for solid_def_snap in self.solid_definitions_snapshot.solid_def_snaps:
             if solid_def_snap.name == solid_def_name:
@@ -213,9 +213,9 @@ class PipelineSnapshot(
 
     def get_config_type_from_solid_def_snap(
         self,
-        solid_def_snap: Union[NodeDefSnap, CompositeSolidDefSnap],
+        solid_def_snap: Union[NodeDefSnap, GraphDefSnap],
     ) -> Optional[ConfigType]:
-        check.inst_param(solid_def_snap, "solid_def_snap", (NodeDefSnap, CompositeSolidDefSnap))
+        check.inst_param(solid_def_snap, "solid_def_snap", (NodeDefSnap, GraphDefSnap))
         if solid_def_snap.config_field_snap:
             config_type_key = solid_def_snap.config_field_snap.type_key
             if self.config_schema_snapshot.has_config_snap(config_type_key):

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -207,7 +207,7 @@ class PipelineSnapshot(
     def has_solid_name(self, solid_name: str) -> bool:
         check.str_param(solid_name, "solid_name")
         for solid_snap in self.dep_structure_snapshot.solid_invocation_snaps:
-            if solid_snap.solid_name == solid_name:
+            if solid_snap.node_name == solid_name:
                 return True
         return False
 
@@ -227,14 +227,14 @@ class PipelineSnapshot(
 
     @property
     def solid_names(self) -> Sequence[str]:
-        return [ss.solid_name for ss in self.dep_structure_snapshot.solid_invocation_snaps]
+        return [ss.node_name for ss in self.dep_structure_snapshot.solid_invocation_snaps]
 
     @property
     def solid_names_in_topological_order(self) -> Sequence[str]:
         upstream_outputs = {}
 
         for solid_invocation_snap in self.dep_structure_snapshot.solid_invocation_snaps:
-            solid_name = solid_invocation_snap.solid_name
+            solid_name = solid_invocation_snap.node_name
             upstream_outputs[solid_name] = {
                 upstream_output_snap.solid_name
                 for input_dep_snap in solid_invocation_snap.input_dep_snaps

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -42,7 +42,7 @@ from .config_types import build_config_schema_snapshot
 from .dagster_types import DagsterTypeNamespaceSnapshot, build_dagster_type_namespace_snapshot
 from .dep_snapshot import (
     DependencyStructureSnapshot,
-    build_dep_structure_snapshot_from_icontains_solids,
+    build_dep_structure_snapshot_from_graph_def,
 )
 from .mode import ModeDefSnap, build_mode_def_snap
 from .solid import (
@@ -181,9 +181,7 @@ class PipelineSnapshot(
             config_schema_snapshot=build_config_schema_snapshot(pipeline_def),
             dagster_type_namespace_snapshot=build_dagster_type_namespace_snapshot(pipeline_def),
             solid_definitions_snapshot=build_node_definitions_snapshot(pipeline_def),
-            dep_structure_snapshot=build_dep_structure_snapshot_from_icontains_solids(
-                pipeline_def.graph
-            ),
+            dep_structure_snapshot=build_dep_structure_snapshot_from_graph_def(pipeline_def.graph),
             mode_def_snaps=[
                 build_mode_def_snap(md, pipeline_def.get_run_config_schema(md.name).config_type.key)
                 for md in pipeline_def.mode_definitions

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -47,8 +47,8 @@ from .dep_snapshot import (
 from .mode import ModeDefSnap, build_mode_def_snap
 from .solid import (
     CompositeSolidDefSnap,
+    NodeDefSnap,
     SolidDefinitionsSnapshot,
-    SolidDefSnap,
     build_solid_definitions_snapshot,
 )
 
@@ -192,7 +192,7 @@ class PipelineSnapshot(
             graph_def_name=pipeline_def.graph.name,
         )
 
-    def get_node_def_snap(self, solid_def_name: str) -> Union[SolidDefSnap, CompositeSolidDefSnap]:
+    def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, CompositeSolidDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
         for solid_def_snap in self.solid_definitions_snapshot.solid_def_snaps:
             if solid_def_snap.name == solid_def_name:
@@ -213,9 +213,9 @@ class PipelineSnapshot(
 
     def get_config_type_from_solid_def_snap(
         self,
-        solid_def_snap: Union[SolidDefSnap, CompositeSolidDefSnap],
+        solid_def_snap: Union[NodeDefSnap, CompositeSolidDefSnap],
     ) -> Optional[ConfigType]:
-        check.inst_param(solid_def_snap, "solid_def_snap", (SolidDefSnap, CompositeSolidDefSnap))
+        check.inst_param(solid_def_snap, "solid_def_snap", (NodeDefSnap, CompositeSolidDefSnap))
         if solid_def_snap.config_field_snap:
             config_type_key = solid_def_snap.config_field_snap.type_key
             if self.config_schema_snapshot.has_config_snap(config_type_key):

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -49,7 +49,7 @@ from .solid import (
     GraphDefSnap,
     NodeDefSnap,
     NodeDefsSnap,
-    build_node_definitions_snapshot,
+    build_node_defs_snap,
 )
 
 
@@ -180,7 +180,7 @@ class PipelineSnapshot(
             metadata=pipeline_def.metadata,
             config_schema_snapshot=build_config_schema_snapshot(pipeline_def),
             dagster_type_namespace_snapshot=build_dagster_type_namespace_snapshot(pipeline_def),
-            solid_definitions_snapshot=build_node_definitions_snapshot(pipeline_def),
+            solid_definitions_snapshot=build_node_defs_snap(pipeline_def),
             dep_structure_snapshot=build_dep_structure_snapshot_from_graph_def(pipeline_def.graph),
             mode_def_snaps=[
                 build_mode_def_snap(md, pipeline_def.get_run_config_schema(md.name).config_type.key)

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -47,8 +47,8 @@ from .dep_snapshot import (
 from .mode import ModeDefSnap, build_mode_def_snap
 from .solid import (
     GraphDefSnap,
-    NodeDefinitionsSnapshot,
     NodeDefSnap,
+    NodeDefsSnap,
     build_node_definitions_snapshot,
 )
 
@@ -93,7 +93,7 @@ class PipelineSnapshot(
             ("tags", Mapping[str, Any]),
             ("config_schema_snapshot", ConfigSchemaSnapshot),
             ("dagster_type_namespace_snapshot", DagsterTypeNamespaceSnapshot),
-            ("solid_definitions_snapshot", NodeDefinitionsSnapshot),
+            ("solid_definitions_snapshot", NodeDefsSnap),
             ("dep_structure_snapshot", DependencyStructureSnapshot),
             ("mode_def_snaps", Sequence[ModeDefSnap]),
             ("lineage_snapshot", Optional["PipelineSnapshotLineage"]),
@@ -109,7 +109,7 @@ class PipelineSnapshot(
         tags: Optional[Mapping[str, Any]],
         config_schema_snapshot: ConfigSchemaSnapshot,
         dagster_type_namespace_snapshot: DagsterTypeNamespaceSnapshot,
-        solid_definitions_snapshot: NodeDefinitionsSnapshot,
+        solid_definitions_snapshot: NodeDefsSnap,
         dep_structure_snapshot: DependencyStructureSnapshot,
         mode_def_snaps: Sequence[ModeDefSnap],
         lineage_snapshot: Optional["PipelineSnapshotLineage"],
@@ -130,7 +130,7 @@ class PipelineSnapshot(
                 DagsterTypeNamespaceSnapshot,
             ),
             solid_definitions_snapshot=check.inst_param(
-                solid_definitions_snapshot, "solid_definitions_snapshot", NodeDefinitionsSnapshot
+                solid_definitions_snapshot, "solid_definitions_snapshot", NodeDefsSnap
             ),
             dep_structure_snapshot=check.inst_param(
                 dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -47,8 +47,8 @@ from .dep_snapshot import (
 from .mode import ModeDefSnap, build_mode_def_snap
 from .solid import (
     GraphDefSnap,
+    NodeDefinitionsSnapshot,
     NodeDefSnap,
-    SolidDefinitionsSnapshot,
     build_solid_definitions_snapshot,
 )
 
@@ -93,7 +93,7 @@ class PipelineSnapshot(
             ("tags", Mapping[str, Any]),
             ("config_schema_snapshot", ConfigSchemaSnapshot),
             ("dagster_type_namespace_snapshot", DagsterTypeNamespaceSnapshot),
-            ("solid_definitions_snapshot", SolidDefinitionsSnapshot),
+            ("solid_definitions_snapshot", NodeDefinitionsSnapshot),
             ("dep_structure_snapshot", DependencyStructureSnapshot),
             ("mode_def_snaps", Sequence[ModeDefSnap]),
             ("lineage_snapshot", Optional["PipelineSnapshotLineage"]),
@@ -109,7 +109,7 @@ class PipelineSnapshot(
         tags: Optional[Mapping[str, Any]],
         config_schema_snapshot: ConfigSchemaSnapshot,
         dagster_type_namespace_snapshot: DagsterTypeNamespaceSnapshot,
-        solid_definitions_snapshot: SolidDefinitionsSnapshot,
+        solid_definitions_snapshot: NodeDefinitionsSnapshot,
         dep_structure_snapshot: DependencyStructureSnapshot,
         mode_def_snaps: Sequence[ModeDefSnap],
         lineage_snapshot: Optional["PipelineSnapshotLineage"],
@@ -130,7 +130,7 @@ class PipelineSnapshot(
                 DagsterTypeNamespaceSnapshot,
             ),
             solid_definitions_snapshot=check.inst_param(
-                solid_definitions_snapshot, "solid_definitions_snapshot", SolidDefinitionsSnapshot
+                solid_definitions_snapshot, "solid_definitions_snapshot", NodeDefinitionsSnapshot
             ),
             dep_structure_snapshot=check.inst_param(
                 dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot
@@ -194,11 +194,11 @@ class PipelineSnapshot(
 
     def get_node_def_snap(self, solid_def_name: str) -> Union[NodeDefSnap, GraphDefSnap]:
         check.str_param(solid_def_name, "solid_def_name")
-        for solid_def_snap in self.solid_definitions_snapshot.solid_def_snaps:
+        for solid_def_snap in self.solid_definitions_snapshot.op_def_snaps:
             if solid_def_snap.name == solid_def_name:
                 return solid_def_snap
 
-        for comp_solid_def_snap in self.solid_definitions_snapshot.composite_solid_def_snaps:
+        for comp_solid_def_snap in self.solid_definitions_snapshot.graph_def_snaps:
             if comp_solid_def_snap.name == solid_def_name:
                 return comp_solid_def_snap
 

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -336,7 +336,7 @@ class NodeDefinitionsSnapshot(
         )
 
 
-def build_solid_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDefinitionsSnapshot:
+def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDefinitionsSnapshot:
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     solid_def_snaps = []
     graph_def_snaps = []

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -344,7 +344,7 @@ def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDef
         if isinstance(node_def, OpDefinition):
             solid_def_snaps.append(build_core_solid_def_snap(node_def))
         elif isinstance(node_def, GraphDefinition):
-            graph_def_snaps.append(build_composite_solid_def_snap(node_def))
+            graph_def_snaps.append(build_graph_def_snap(node_def))
         else:
             check.failed(f"Unexpected NodeDefinition type {node_def}")
 
@@ -355,24 +355,24 @@ def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDef
     )
 
 
-def build_composite_solid_def_snap(comp_solid_def):
-    check.inst_param(comp_solid_def, "comp_solid_def", GraphDefinition)
+def build_graph_def_snap(graph_def):
+    check.inst_param(graph_def, "comp_solid_def", GraphDefinition)
     return GraphDefSnap(
-        name=comp_solid_def.name,
-        input_def_snaps=list(map(build_input_def_snap, comp_solid_def.input_defs)),
-        output_def_snaps=list(map(build_output_def_snap, comp_solid_def.output_defs)),
-        description=comp_solid_def.description,
-        tags=comp_solid_def.tags,
+        name=graph_def.name,
+        input_def_snaps=list(map(build_input_def_snap, graph_def.input_defs)),
+        output_def_snaps=list(map(build_output_def_snap, graph_def.output_defs)),
+        description=graph_def.description,
+        tags=graph_def.tags,
         config_field_snap=snap_from_field(
-            "config", comp_solid_def.config_mapping.config_schema.as_field()
+            "config", graph_def.config_mapping.config_schema.as_field()
         )
-        if comp_solid_def.config_mapping
-        and comp_solid_def.config_mapping.config_schema
-        and comp_solid_def.config_mapping.config_schema.as_field()
+        if graph_def.config_mapping
+        and graph_def.config_mapping.config_schema
+        and graph_def.config_mapping.config_schema.as_field()
         else None,
-        dep_structure_snapshot=build_dep_structure_snapshot_from_icontains_solids(comp_solid_def),
-        input_mapping_snaps=list(map(build_input_mapping_snap, comp_solid_def.input_mappings)),
-        output_mapping_snaps=list(map(build_output_mapping_snap, comp_solid_def.output_mappings)),
+        dep_structure_snapshot=build_dep_structure_snapshot_from_icontains_solids(graph_def),
+        input_mapping_snaps=list(map(build_input_mapping_snap, graph_def.input_mappings)),
+        output_mapping_snaps=list(map(build_output_mapping_snap, graph_def.output_mappings)),
     )
 
 

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -342,7 +342,7 @@ def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDef
     graph_def_snaps = []
     for node_def in pipeline_def.all_node_defs:
         if isinstance(node_def, OpDefinition):
-            solid_def_snaps.append(build_core_solid_def_snap(node_def))
+            solid_def_snaps.append(build_op_def_snap(node_def))
         elif isinstance(node_def, GraphDefinition):
             graph_def_snaps.append(build_graph_def_snap(node_def))
         else:
@@ -376,17 +376,17 @@ def build_graph_def_snap(graph_def):
     )
 
 
-def build_core_solid_def_snap(solid_def):
-    check.inst_param(solid_def, "solid_def", OpDefinition)
+def build_op_def_snap(op_def):
+    check.inst_param(op_def, "solid_def", OpDefinition)
     return OpDefSnap(
-        name=solid_def.name,
-        input_def_snaps=list(map(build_input_def_snap, solid_def.input_defs)),
-        output_def_snaps=list(map(build_output_def_snap, solid_def.output_defs)),
-        description=solid_def.description,
-        tags=solid_def.tags,
-        required_resource_keys=sorted(list(solid_def.required_resource_keys)),
-        config_field_snap=snap_from_field("config", solid_def.config_field)
-        if solid_def.has_config_field
+        name=op_def.name,
+        input_def_snaps=list(map(build_input_def_snap, op_def.input_defs)),
+        output_def_snaps=list(map(build_output_def_snap, op_def.output_defs)),
+        description=op_def.description,
+        tags=op_def.tags,
+        required_resource_keys=sorted(list(op_def.required_resource_keys)),
+        config_field_snap=snap_from_field("config", op_def.config_field)
+        if op_def.has_config_field
         else None,
     )
 

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -298,31 +298,37 @@ class OpDefSnap(
         return _get_output_snap(self, name)
 
 
-@whitelist_for_serdes
-class SolidDefinitionsSnapshot(
+@whitelist_for_serdes(
+    storage_name="SolidDefinitionsSnapshot",
+    storage_field_names={
+        "op_def_snaps": "solid_def_snaps",
+        "graph_def_snaps": "composite_solid_def_snaps",
+    },
+)
+class NodeDefinitionsSnapshot(
     NamedTuple(
-        "_SolidDefinitionsSnapshot",
+        "_NodeDefinitionsSnapshot",
         [
-            ("solid_def_snaps", Sequence[OpDefSnap]),
-            ("composite_solid_def_snaps", Sequence[GraphDefSnap]),
+            ("op_def_snaps", Sequence[OpDefSnap]),
+            ("graph_def_snaps", Sequence[GraphDefSnap]),
         ],
     )
 ):
     def __new__(
         cls,
-        solid_def_snaps: Sequence[OpDefSnap],
-        composite_solid_def_snaps: Sequence[GraphDefSnap],
+        op_def_snaps: Sequence[OpDefSnap],
+        graph_def_snaps: Sequence[GraphDefSnap],
     ):
-        return super(SolidDefinitionsSnapshot, cls).__new__(
+        return super(NodeDefinitionsSnapshot, cls).__new__(
             cls,
-            solid_def_snaps=sorted(
-                check.sequence_param(solid_def_snaps, "solid_def_snaps", of_type=OpDefSnap),
+            op_def_snaps=sorted(
+                check.sequence_param(op_def_snaps, "op_def_snaps", of_type=OpDefSnap),
                 key=lambda solid_def: solid_def.name,
             ),
-            composite_solid_def_snaps=sorted(
+            graph_def_snaps=sorted(
                 check.sequence_param(
-                    composite_solid_def_snaps,
-                    "composite_solid_def_snaps",
+                    graph_def_snaps,
+                    "graph_def_snaps",
                     of_type=GraphDefSnap,
                 ),
                 key=lambda comp_def: comp_def.name,
@@ -330,7 +336,7 @@ class SolidDefinitionsSnapshot(
         )
 
 
-def build_solid_definitions_snapshot(pipeline_def: PipelineDefinition) -> SolidDefinitionsSnapshot:
+def build_solid_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDefinitionsSnapshot:
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     solid_def_snaps = []
     graph_def_snaps = []
@@ -342,7 +348,7 @@ def build_solid_definitions_snapshot(pipeline_def: PipelineDefinition) -> SolidD
         else:
             check.failed(f"Unexpected NodeDefinition type {node_def}")
 
-    return SolidDefinitionsSnapshot(
+    return NodeDefinitionsSnapshot(
         solid_def_snaps=solid_def_snaps,
         # update when snapshot renames happen
         composite_solid_def_snaps=graph_def_snaps,

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -251,10 +251,10 @@ class CompositeSolidDefSnap(
         return _get_output_snap(self, name)
 
 
-@whitelist_for_serdes
-class SolidDefSnap(
+@whitelist_for_serdes(storage_name="SolidDefSnap")
+class OpDefSnap(
     NamedTuple(
-        "_SolidDefMeta",
+        "_OpDefSnap",
         [
             ("name", str),
             ("input_def_snaps", Sequence[InputDefSnap]),
@@ -276,7 +276,7 @@ class SolidDefSnap(
         required_resource_keys: Sequence[str],
         config_field_snap: Optional[ConfigFieldSnap],
     ):
-        return super(SolidDefSnap, cls).__new__(
+        return super(OpDefSnap, cls).__new__(
             cls,
             required_resource_keys=check.sequence_param(
                 required_resource_keys, "required_resource_keys", str
@@ -303,20 +303,20 @@ class SolidDefinitionsSnapshot(
     NamedTuple(
         "_SolidDefinitionsSnapshot",
         [
-            ("solid_def_snaps", Sequence[SolidDefSnap]),
+            ("solid_def_snaps", Sequence[OpDefSnap]),
             ("composite_solid_def_snaps", Sequence[CompositeSolidDefSnap]),
         ],
     )
 ):
     def __new__(
         cls,
-        solid_def_snaps: Sequence[SolidDefSnap],
+        solid_def_snaps: Sequence[OpDefSnap],
         composite_solid_def_snaps: Sequence[CompositeSolidDefSnap],
     ):
         return super(SolidDefinitionsSnapshot, cls).__new__(
             cls,
             solid_def_snaps=sorted(
-                check.sequence_param(solid_def_snaps, "solid_def_snaps", of_type=SolidDefSnap),
+                check.sequence_param(solid_def_snaps, "solid_def_snaps", of_type=OpDefSnap),
                 key=lambda solid_def: solid_def.name,
             ),
             composite_solid_def_snaps=sorted(
@@ -372,7 +372,7 @@ def build_composite_solid_def_snap(comp_solid_def):
 
 def build_core_solid_def_snap(solid_def):
     check.inst_param(solid_def, "solid_def", OpDefinition)
-    return SolidDefSnap(
+    return OpDefSnap(
         name=solid_def.name,
         input_def_snaps=list(map(build_input_def_snap, solid_def.input_defs)),
         output_def_snaps=list(map(build_output_def_snap, solid_def.output_defs)),
@@ -386,9 +386,7 @@ def build_core_solid_def_snap(solid_def):
 
 
 # shared impl for CompositeSolidDefSnap and SolidDefSnap
-def _get_input_snap(
-    solid_def: Union[CompositeSolidDefSnap, SolidDefSnap], name: str
-) -> InputDefSnap:
+def _get_input_snap(solid_def: Union[CompositeSolidDefSnap, OpDefSnap], name: str) -> InputDefSnap:
     check.str_param(name, "name")
     for inp in solid_def.input_def_snaps:
         if inp.name == name:
@@ -403,7 +401,7 @@ def _get_input_snap(
 
 # shared impl for CompositeSolidDefSnap and SolidDefSnap
 def _get_output_snap(
-    solid_def: Union[CompositeSolidDefSnap, SolidDefSnap], name: str
+    solid_def: Union[CompositeSolidDefSnap, OpDefSnap], name: str
 ) -> OutputDefSnap:
     check.str_param(name, "name")
     for out in solid_def.output_def_snaps:

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -194,10 +194,10 @@ def _check_solid_def_header_args(
     )
 
 
-@whitelist_for_serdes
-class CompositeSolidDefSnap(
+@whitelist_for_serdes(storage_name="CompositeSolidDefSnap")
+class GraphDefSnap(
     NamedTuple(
-        "_CompositeSolidDefSnap",
+        "_GraphDefSnap",
         [
             ("name", str),
             ("input_def_snaps", Sequence[InputDefSnap]),
@@ -223,7 +223,7 @@ class CompositeSolidDefSnap(
         input_mapping_snaps: Sequence[InputMappingSnap],
         output_mapping_snaps: Sequence[OutputMappingSnap],
     ):
-        return super(CompositeSolidDefSnap, cls).__new__(
+        return super(GraphDefSnap, cls).__new__(
             cls,
             dep_structure_snapshot=check.inst_param(
                 dep_structure_snapshot, "dep_structure_snapshot", DependencyStructureSnapshot
@@ -304,14 +304,14 @@ class SolidDefinitionsSnapshot(
         "_SolidDefinitionsSnapshot",
         [
             ("solid_def_snaps", Sequence[OpDefSnap]),
-            ("composite_solid_def_snaps", Sequence[CompositeSolidDefSnap]),
+            ("composite_solid_def_snaps", Sequence[GraphDefSnap]),
         ],
     )
 ):
     def __new__(
         cls,
         solid_def_snaps: Sequence[OpDefSnap],
-        composite_solid_def_snaps: Sequence[CompositeSolidDefSnap],
+        composite_solid_def_snaps: Sequence[GraphDefSnap],
     ):
         return super(SolidDefinitionsSnapshot, cls).__new__(
             cls,
@@ -323,7 +323,7 @@ class SolidDefinitionsSnapshot(
                 check.sequence_param(
                     composite_solid_def_snaps,
                     "composite_solid_def_snaps",
-                    of_type=CompositeSolidDefSnap,
+                    of_type=GraphDefSnap,
                 ),
                 key=lambda comp_def: comp_def.name,
             ),
@@ -351,7 +351,7 @@ def build_solid_definitions_snapshot(pipeline_def: PipelineDefinition) -> SolidD
 
 def build_composite_solid_def_snap(comp_solid_def):
     check.inst_param(comp_solid_def, "comp_solid_def", GraphDefinition)
-    return CompositeSolidDefSnap(
+    return GraphDefSnap(
         name=comp_solid_def.name,
         input_def_snaps=list(map(build_input_def_snap, comp_solid_def.input_defs)),
         output_def_snaps=list(map(build_output_def_snap, comp_solid_def.output_defs)),
@@ -386,7 +386,7 @@ def build_core_solid_def_snap(solid_def):
 
 
 # shared impl for CompositeSolidDefSnap and SolidDefSnap
-def _get_input_snap(solid_def: Union[CompositeSolidDefSnap, OpDefSnap], name: str) -> InputDefSnap:
+def _get_input_snap(solid_def: Union[GraphDefSnap, OpDefSnap], name: str) -> InputDefSnap:
     check.str_param(name, "name")
     for inp in solid_def.input_def_snaps:
         if inp.name == name:
@@ -400,9 +400,7 @@ def _get_input_snap(solid_def: Union[CompositeSolidDefSnap, OpDefSnap], name: st
 
 
 # shared impl for CompositeSolidDefSnap and SolidDefSnap
-def _get_output_snap(
-    solid_def: Union[CompositeSolidDefSnap, OpDefSnap], name: str
-) -> OutputDefSnap:
+def _get_output_snap(solid_def: Union[GraphDefSnap, OpDefSnap], name: str) -> OutputDefSnap:
     check.str_param(name, "name")
     for out in solid_def.output_def_snaps:
         if out.name == name:

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -336,7 +336,7 @@ class NodeDefsSnap(
         )
 
 
-def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDefsSnap:
+def build_node_defs_snap(pipeline_def: PipelineDefinition) -> NodeDefsSnap:
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     solid_def_snaps = []
     graph_def_snaps = []

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -305,9 +305,9 @@ class OpDefSnap(
         "graph_def_snaps": "composite_solid_def_snaps",
     },
 )
-class NodeDefinitionsSnapshot(
+class NodeDefsSnap(
     NamedTuple(
-        "_NodeDefinitionsSnapshot",
+        "_NodeDefsSnapshot",
         [
             ("op_def_snaps", Sequence[OpDefSnap]),
             ("graph_def_snaps", Sequence[GraphDefSnap]),
@@ -319,7 +319,7 @@ class NodeDefinitionsSnapshot(
         op_def_snaps: Sequence[OpDefSnap],
         graph_def_snaps: Sequence[GraphDefSnap],
     ):
-        return super(NodeDefinitionsSnapshot, cls).__new__(
+        return super(NodeDefsSnap, cls).__new__(
             cls,
             op_def_snaps=sorted(
                 check.sequence_param(op_def_snaps, "op_def_snaps", of_type=OpDefSnap),
@@ -336,7 +336,7 @@ class NodeDefinitionsSnapshot(
         )
 
 
-def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDefinitionsSnapshot:
+def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDefsSnap:
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
     solid_def_snaps = []
     graph_def_snaps = []
@@ -348,7 +348,7 @@ def build_node_definitions_snapshot(pipeline_def: PipelineDefinition) -> NodeDef
         else:
             check.failed(f"Unexpected NodeDefinition type {node_def}")
 
-    return NodeDefinitionsSnapshot(
+    return NodeDefsSnap(
         op_def_snaps=solid_def_snaps,
         # update when snapshot renames happen
         graph_def_snaps=graph_def_snaps,

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -18,7 +18,7 @@ from dagster._serdes import whitelist_for_serdes
 
 from .dep_snapshot import (
     DependencyStructureSnapshot,
-    build_dep_structure_snapshot_from_icontains_solids,
+    build_dep_structure_snapshot_from_graph_def,
 )
 
 
@@ -370,7 +370,7 @@ def build_graph_def_snap(graph_def: GraphDefinition) -> GraphDefSnap:
         and graph_def.config_mapping.config_schema
         and graph_def.config_mapping.config_schema.as_field()
         else None,
-        dep_structure_snapshot=build_dep_structure_snapshot_from_icontains_solids(graph_def),
+        dep_structure_snapshot=build_dep_structure_snapshot_from_graph_def(graph_def),
         input_mapping_snaps=list(map(build_input_mapping_snap, graph_def.input_mappings)),
         output_mapping_snaps=list(map(build_output_mapping_snap, graph_def.output_mappings)),
     )

--- a/python_modules/dagster/dagster/_core/snap/solid.py
+++ b/python_modules/dagster/dagster/_core/snap/solid.py
@@ -121,21 +121,21 @@ def build_output_mapping_snap(output_mapping: OutputMapping) -> OutputMappingSna
     )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_field_names={"mapped_node_name": "mapped_solid_name"})
 class InputMappingSnap(
     NamedTuple(
         "_InputMappingSnap",
         [
-            ("mapped_solid_name", str),
+            ("mapped_node_name", str),
             ("mapped_input_name", str),
             ("external_input_name", str),
         ],
     )
 ):
-    def __new__(cls, mapped_solid_name: str, mapped_input_name: str, external_input_name: str):
+    def __new__(cls, mapped_node_name: str, mapped_input_name: str, external_input_name: str):
         return super(InputMappingSnap, cls).__new__(
             cls,
-            mapped_solid_name=check.str_param(mapped_solid_name, "mapped_solid_name"),
+            mapped_node_name=check.str_param(mapped_node_name, "mapped_node_name"),
             mapped_input_name=check.str_param(mapped_input_name, "mapped_input_name"),
             external_input_name=check.str_param(external_input_name, "external_input_name"),
         )
@@ -143,7 +143,7 @@ class InputMappingSnap(
 
 def build_input_mapping_snap(input_mapping: InputMapping) -> InputMappingSnap:
     return InputMappingSnap(
-        mapped_solid_name=input_mapping.maps_to.node_name,
+        mapped_node_name=input_mapping.maps_to.node_name,
         mapped_input_name=input_mapping.maps_to.input_name,
         external_input_name=input_mapping.graph_input_name,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -43,7 +43,7 @@ from dagster._core.execution.api import execute_pipeline, execute_run_iterator
 from dagster._core.snap import DependencyStructureIndex
 from dagster._core.snap.dep_snapshot import (
     OutputHandleSnap,
-    build_dep_structure_snapshot_from_icontains_solids,
+    build_dep_structure_snapshot_from_graph_def,
 )
 from dagster._core.storage.event_log.base import EventRecordsFilter
 from dagster._core.test_utils import instance_for_test
@@ -395,7 +395,7 @@ def test_multiple_non_argument_deps():
 
     job = build_assets_job("a", [foo, bar, baz, qux])
 
-    dep_structure_snapshot = build_dep_structure_snapshot_from_icontains_solids(job.graph)
+    dep_structure_snapshot = build_dep_structure_snapshot_from_graph_def(job.graph)
     index = DependencyStructureIndex(dep_structure_snapshot)
 
     assert index.get_invocation("foo")

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
@@ -1,7 +1,7 @@
 from dagster import graph, op
 from dagster._core.snap import (
-    CompositeSolidDefSnap,
     DependencyStructureIndex,
+    GraphDefSnap,
     build_composite_solid_def_snap,
 )
 from dagster._serdes import serialize_value
@@ -19,11 +19,8 @@ def test_noop_comp_solid_definition():
 
     comp_solid_meta = build_composite_solid_def_snap(comp_graph)
 
-    assert isinstance(comp_solid_meta, CompositeSolidDefSnap)
-    assert (
-        deserialize_value(serialize_value(comp_solid_meta), CompositeSolidDefSnap)
-        == comp_solid_meta
-    )
+    assert isinstance(comp_solid_meta, GraphDefSnap)
+    assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta
 
 
 def test_basic_comp_solid_definition():
@@ -41,11 +38,8 @@ def test_basic_comp_solid_definition():
 
     comp_solid_meta = build_composite_solid_def_snap(comp_graph)
 
-    assert isinstance(comp_solid_meta, CompositeSolidDefSnap)
-    assert (
-        deserialize_value(serialize_value(comp_solid_meta), CompositeSolidDefSnap)
-        == comp_solid_meta
-    )
+    assert isinstance(comp_solid_meta, GraphDefSnap)
+    assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta
 
     index = DependencyStructureIndex(comp_solid_meta.dep_structure_snapshot)
     assert index.get_invocation("return_one")
@@ -69,11 +63,8 @@ def test_complex_comp_solid_definition():
 
     comp_solid_meta = build_composite_solid_def_snap(comp_graph)
 
-    assert isinstance(comp_solid_meta, CompositeSolidDefSnap)
-    assert (
-        deserialize_value(serialize_value(comp_solid_meta), CompositeSolidDefSnap)
-        == comp_solid_meta
-    )
+    assert isinstance(comp_solid_meta, GraphDefSnap)
+    assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta
 
     index = DependencyStructureIndex(comp_solid_meta.dep_structure_snapshot)
     assert index.get_invocation("return_one")

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
@@ -2,7 +2,7 @@ from dagster import graph, op
 from dagster._core.snap import (
     DependencyStructureIndex,
     GraphDefSnap,
-    build_composite_solid_def_snap,
+    build_graph_def_snap,
 )
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
@@ -17,7 +17,7 @@ def test_noop_comp_solid_definition():
     def comp_graph():
         noop_op()
 
-    comp_solid_meta = build_composite_solid_def_snap(comp_graph)
+    comp_solid_meta = build_graph_def_snap(comp_graph)
 
     assert isinstance(comp_solid_meta, GraphDefSnap)
     assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta
@@ -36,7 +36,7 @@ def test_basic_comp_solid_definition():
     def comp_graph():
         take_one(return_one())
 
-    comp_solid_meta = build_composite_solid_def_snap(comp_graph)
+    comp_solid_meta = build_graph_def_snap(comp_graph)
 
     assert isinstance(comp_solid_meta, GraphDefSnap)
     assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta
@@ -61,7 +61,7 @@ def test_complex_comp_solid_definition():
     def comp_graph(this_number):
         take_many([return_one(), this_number, return_one.alias("return_one_also")()])
 
-    comp_solid_meta = build_composite_solid_def_snap(comp_graph)
+    comp_solid_meta = build_graph_def_snap(comp_graph)
 
     assert isinstance(comp_solid_meta, GraphDefSnap)
     assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_composite_solid_def_snap.py
@@ -44,7 +44,7 @@ def test_basic_comp_solid_definition():
     index = DependencyStructureIndex(comp_solid_meta.dep_structure_snapshot)
     assert index.get_invocation("return_one")
     assert index.get_invocation("take_one")
-    assert index.get_upstream_output("take_one", "one").solid_name == "return_one"
+    assert index.get_upstream_output("take_one", "one").node_name == "return_one"
     assert index.get_upstream_output("take_one", "one").output_name == "result"
 
 
@@ -69,5 +69,5 @@ def test_complex_comp_solid_definition():
     index = DependencyStructureIndex(comp_solid_meta.dep_structure_snapshot)
     assert index.get_invocation("return_one")
     assert index.get_invocation("take_many")
-    assert index.get_upstream_outputs("take_many", "items")[0].solid_name == "return_one"
-    assert index.get_upstream_outputs("take_many", "items")[1].solid_name == "return_one_also"
+    assert index.get_upstream_outputs("take_many", "items")[0].node_name == "return_one"
+    assert index.get_upstream_outputs("take_many", "items")[1].node_name == "return_one_also"

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -5,8 +5,8 @@ from dagster import Field, In, Map, Nothing, Out, Permissive, Selector, Shape, j
 from dagster._config import Array, Bool, Enum, EnumValue, Float, Int, Noneable, String
 from dagster._core.snap import (
     DependencyStructureIndex,
+    NodeInvocationSnap,
     PipelineSnapshot,
-    SolidInvocationSnap,
     create_pipeline_snapshot_id,
     snap_from_config_type,
 )
@@ -91,7 +91,7 @@ def test_noop_deps_snap():
         noop_job.graph
     ).solid_invocation_snaps
     assert len(invocations) == 1
-    assert isinstance(invocations[0], SolidInvocationSnap)
+    assert isinstance(invocations[0], NodeInvocationSnap)
 
 
 def test_two_invocations_deps_snap(snapshot):

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -14,7 +14,7 @@ from dagster._core.snap.dep_snapshot import (
     DependencyStructureSnapshot,
     InputHandle,
     OutputHandleSnap,
-    build_dep_structure_snapshot_from_icontains_solids,
+    build_dep_structure_snapshot_from_graph_def,
 )
 from dagster._legacy import pipeline
 from dagster._serdes import (
@@ -87,9 +87,7 @@ def test_noop_deps_snap():
     def noop_job():
         noop_op()
 
-    invocations = build_dep_structure_snapshot_from_icontains_solids(
-        noop_job.graph
-    ).solid_invocation_snaps
+    invocations = build_dep_structure_snapshot_from_graph_def(noop_job.graph).solid_invocation_snaps
     assert len(invocations) == 1
     assert isinstance(invocations[0], NodeInvocationSnap)
 
@@ -105,7 +103,7 @@ def test_two_invocations_deps_snap(snapshot):
         noop_op.alias("two")()
 
     index = DependencyStructureIndex(
-        build_dep_structure_snapshot_from_icontains_solids(two_solid_job.graph)
+        build_dep_structure_snapshot_from_graph_def(two_solid_job.graph)
     )
     assert index.get_invocation("one")
     assert index.get_invocation("two")
@@ -131,7 +129,7 @@ def test_basic_dep():
         passthrough(return_one())
 
     index = DependencyStructureIndex(
-        build_dep_structure_snapshot_from_icontains_solids(single_dep_job.graph)
+        build_dep_structure_snapshot_from_graph_def(single_dep_job.graph)
     )
 
     assert index.get_invocation("return_one")
@@ -158,9 +156,7 @@ def test_basic_dep_fan_out(snapshot):
         passthrough.alias("passone")(return_one_result)
         passthrough.alias("passtwo")(return_one_result)
 
-    dep_structure_snapshot = build_dep_structure_snapshot_from_icontains_solids(
-        single_dep_job.graph
-    )
+    dep_structure_snapshot = build_dep_structure_snapshot_from_graph_def(single_dep_job.graph)
     index = DependencyStructureIndex(dep_structure_snapshot)
 
     assert index.get_invocation("return_one")
@@ -207,7 +203,7 @@ def test_basic_fan_in(snapshot):
             ]
         )
 
-    dep_structure_snapshot = build_dep_structure_snapshot_from_icontains_solids(fan_in_test.graph)
+    dep_structure_snapshot = build_dep_structure_snapshot_from_graph_def(fan_in_test.graph)
     index = DependencyStructureIndex(dep_structure_snapshot)
 
     assert index.get_invocation("nothing_one")

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_pipeline_snap.py
@@ -87,7 +87,7 @@ def test_noop_deps_snap():
     def noop_job():
         noop_op()
 
-    invocations = build_dep_structure_snapshot_from_graph_def(noop_job.graph).solid_invocation_snaps
+    invocations = build_dep_structure_snapshot_from_graph_def(noop_job.graph).node_invocation_snaps
     assert len(invocations) == 1
     assert isinstance(invocations[0], NodeInvocationSnap)
 
@@ -137,7 +137,7 @@ def test_basic_dep():
 
     outputs = index.get_upstream_outputs("passthrough", "value")
     assert len(outputs) == 1
-    assert outputs[0].solid_name == "return_one"
+    assert outputs[0].node_name == "return_one"
     assert outputs[0].output_name == "result"
 
 
@@ -262,7 +262,7 @@ def test_deserialize_solid_def_snaps_default_field():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Shape)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     assert isinstance(recevied_config_type.fields["bar"].config_type, String)
@@ -289,7 +289,7 @@ def test_deserialize_solid_def_snaps_enum():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Enum)
     assert recevied_config_type.given_name == "CowboyType"
     assert all(
@@ -309,7 +309,7 @@ def test_deserialize_solid_def_snaps_strict_shape():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Shape)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     assert isinstance(recevied_config_type.fields["bar"].config_type, String)
@@ -331,7 +331,7 @@ def test_deserialize_solid_def_snaps_selector():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Selector)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     assert isinstance(recevied_config_type.fields["bar"].config_type, Int)
@@ -352,7 +352,7 @@ def test_deserialize_solid_def_snaps_permissive():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Permissive)
     assert isinstance(recevied_config_type.fields["foo"].config_type, String)
     _dict_has_stable_hashes(
@@ -372,7 +372,7 @@ def test_deserialize_solid_def_snaps_array():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Array)
     assert isinstance(recevied_config_type.inner_type, String)
     _array_has_stable_hashes(
@@ -392,7 +392,7 @@ def test_deserialize_solid_def_snaps_map():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Map)
     assert isinstance(recevied_config_type.key_type, String)
     assert isinstance(recevied_config_type.inner_type, String)
@@ -413,7 +413,7 @@ def test_deserialize_solid_def_snaps_map_with_name():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Map)
     assert isinstance(recevied_config_type.key_type, Bool)
     assert isinstance(recevied_config_type.inner_type, Float)
@@ -435,7 +435,7 @@ def test_deserialize_solid_def_snaps_noneable():
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("noop_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     assert isinstance(recevied_config_type, Noneable)
     assert isinstance(recevied_config_type.inner_type, String)
 
@@ -477,7 +477,7 @@ def test_deserialize_solid_def_snaps_multi_type_config(snapshot):
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("fancy_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _dict_has_stable_hashes(
         recevied_config_type,
@@ -497,7 +497,7 @@ def test_multi_type_config_array_dict_fields(dict_config_type, snapshot):
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("fancy_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _array_has_stable_hashes(
         recevied_config_type,
@@ -516,7 +516,7 @@ def test_multi_type_config_array_map(snapshot):
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("fancy_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _array_has_stable_hashes(
         recevied_config_type,
@@ -541,7 +541,7 @@ def test_multi_type_config_nested_dicts(nested_dict_types, snapshot):
 
     pipeline_snapshot = PipelineSnapshot.from_pipeline_def(noop_job)
     solid_def_snap = pipeline_snapshot.get_node_def_snap("fancy_op")
-    recevied_config_type = pipeline_snapshot.get_config_type_from_solid_def_snap(solid_def_snap)
+    recevied_config_type = pipeline_snapshot.get_config_type_from_node_def_snap(solid_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
     _dict_has_stable_hashes(
         recevied_config_type,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
@@ -1,5 +1,5 @@
 from dagster import In, Out, op
-from dagster._core.snap.solid import OpDefSnap, build_op_def_snap
+from dagster._core.snap.node import OpDefSnap, build_op_def_snap
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
@@ -1,5 +1,5 @@
 from dagster import In, Out, op
-from dagster._core.snap.solid import SolidDefSnap, build_core_solid_def_snap
+from dagster._core.snap.solid import OpDefSnap, build_core_solid_def_snap
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 
@@ -12,7 +12,7 @@ def test_basic_solid_definition():
     solid_snap = build_core_solid_def_snap(noop_op)
 
     assert solid_snap
-    assert deserialize_value(serialize_value(solid_snap), SolidDefSnap) == solid_snap
+    assert deserialize_value(serialize_value(solid_snap), OpDefSnap) == solid_snap
 
 
 def test_solid_definition_kitchen_sink():
@@ -73,6 +73,6 @@ def test_solid_definition_kitchen_sink():
     assert kitchen_sink_op.positional_inputs == ["arg_two", "arg_one"]
 
     assert (
-        deserialize_value(serialize_value(kitchen_sink_solid_snap), SolidDefSnap)
+        deserialize_value(serialize_value(kitchen_sink_solid_snap), OpDefSnap)
         == kitchen_sink_solid_snap
     )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_solid_def_snap.py
@@ -1,5 +1,5 @@
 from dagster import In, Out, op
-from dagster._core.snap.solid import OpDefSnap, build_core_solid_def_snap
+from dagster._core.snap.solid import OpDefSnap, build_op_def_snap
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 
@@ -9,7 +9,7 @@ def test_basic_solid_definition():
     def noop_op(_):
         pass
 
-    solid_snap = build_core_solid_def_snap(noop_op)
+    solid_snap = build_op_def_snap(noop_op)
 
     assert solid_snap
     assert deserialize_value(serialize_value(solid_snap), OpDefSnap) == solid_snap
@@ -36,7 +36,7 @@ def test_solid_definition_kitchen_sink():
         assert arg_two
         raise Exception("should not execute")
 
-    kitchen_sink_solid_snap = build_core_solid_def_snap(kitchen_sink_op)
+    kitchen_sink_solid_snap = build_op_def_snap(kitchen_sink_op)
 
     assert kitchen_sink_solid_snap
     assert kitchen_sink_solid_snap.name == "kitchen_sink_op"


### PR DESCRIPTION
## Summary & Motivation

Rename (mostly) `*Snap` classes and fields to eliminate "solid".  Where classes are serdes-whitelisted, use `storage_name`/`storage_field_names` to keep the serialized name the same for backcompat. Also includes local variable renames.

- assorted local variables
- DependencyStructureIndex.solid_names -> node_names
- DependencyStructureIndex.solid_invocation_names -> node_invocation_names
- DependencyStructureIndex.solid_invocations -> node_invocations
- DependencyStructureSnapshot.solid_invocation_snaps -> node_invocation_snaps
- PipelineSnapshot.solid_defs_snapshot -> node_defs_snapshot
- PipelineSnapshot.solid_names_in_topological_order -> node_names_in_topological_order
- PipelineLineageSnapshot.solid_selection -> node_selection
- PipelineLineageSnapshot.solids_to_execute -> nodes_to_execute
- PipelineSnaphot.solid_names -> node_names
- PipelineSnaphot.solid_definitions_snapshot -> node_defs_snapshot
- build_solid_invocation_snap -> build_node_invocation_snap
- InputHandle.solid_def_name -> node_def_name
- InputHandle.solid_name -> node_name
- OutputHandleSnap.solid_name -> node_name
- OutputHandleSnap.solid_name -> node_name
- CompleteCompositionContext.solid_defs -> node_defs
- DynamicFanIn.solid_name -> node_name
- InvokedNodeOutputHandle.solid_name -> node_name
- InvokedNodeDynamicOutputWrapper.solid_name -> node_name
- _core.snap.solid -> node (module)
- _core.definitions.solid_invocation -> op_invocation (module)
- build_dep_structure_snapshot_from_icontains_solids -> build_dep_structure_snapshot_from_graph_def
- OutputMappingSnap.mapped_solid_name -> mapped_node_name
- InputMappingSnap.mapped_solid_name -> mapped_node_name
- build_core_solid_def_snap -> build_op_def_snap
- build_composite_solid_def_snap -> build_graph_def_snap
- build_solid_definitions_snapshot -> build_node_defs_snap
- SolidDefinitionsSnapshot -> NodeDefsSnapshot
- CompositeSolidDefSnap -> GraphDefSnap
- SolidDefSnap -> OpDefSnap
- NodeInvocationSnap.solid_def_name -> node_def_name
- NodeInvocationSnap.solid_name -> node_name
- SolidInvocationSnap -> NodeInvocationSnap

## How I Tested These Changes

Existing test suite.