### PR TITLE
[ui] Use DefaultLogLevels when there is no level state stored

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/useQueryPersistedLogFilter.ts
+++ b/js_modules/dagit/packages/core/src/runs/useQueryPersistedLogFilter.ts
@@ -80,7 +80,7 @@ export const EnabledRunLogLevelsKey = 'EnabledRunLogLevels';
 
 export const validateLogLevels = (json: any) => {
   if (json === undefined || !Array.isArray(json)) {
-    return [];
+    return null;
   }
 
   const validLevels = new Set(Object.keys(LogLevel));
@@ -95,7 +95,8 @@ export function useQueryPersistedLogFilter(): [LogFilter, (updates: LogFilter) =
   const [storedLogLevels] = useStateWithStorage(EnabledRunLogLevelsKey, validateLogLevels);
 
   const defaults = React.useMemo(() => {
-    return {...DefaultQuerystring, levels: levelsToQuery(storedLogLevels || DefaultLogLevels)};
+    const levels = storedLogLevels ?? DefaultLogLevels;
+    return {...DefaultQuerystring, levels: levelsToQuery(levels)};
   }, [storedLogLevels]);
 
   return useQueryPersistedState<LogFilter>({


### PR DESCRIPTION
## Summary & Motivation

In the recent change to `useQueryPersistedLogFilter`, I didn't correctly check the empty state of the persisted log levels value. If it's undefined, we shouldn't treat that as an empty array -- we should treat it as falling back to the current `DefaultLogLevels` array.

## How I Tested These Changes

Clear the `EnabledRunLogLevels` localStorage key. Load a run, verify that the default five levels are selected.

Make a change in the level selector show only `event` logs, reload the run with the `levels` query parameter removed (to make sure it uses the persisted value). Verify that my change is reflected in the selector, and sanity check that the localStorage value has updated with my change as well.

Manually modify the `localStorage` value to an empty array, reload the run without the query parameter. Verify that the selector has zero levels selected, correctly matching the empty array.

Manually modify the `localStorage` value to `["EVENT"]`, reload the run. Verify that the selector loads with just `event` selected.
