### PR TITLE
CeleryK8sRunLauncher - Add run_k8s_config to configuration and helm chart

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -13,6 +13,17 @@ class RunLauncherType(str, Enum):
     CUSTOM = "CustomRunLauncher"
 
 
+class RunK8sConfig(BaseModel):
+    containerConfig: Optional[Dict[str, Any]]
+    podSpecConfig: Optional[Dict[str, Any]]
+    podTemplateSpecMetadata: Optional[Dict[str, Any]]
+    jobSpecConfig: Optional[Dict[str, Any]]
+    jobMetadata: Optional[Dict[str, Any]]
+
+    class Config:
+        extra = Extra.forbid
+
+
 class CeleryWorkerQueue(BaseModel):
     replicaCount: int = Field(gt=0)
     name: str
@@ -41,6 +52,7 @@ class CeleryK8sRunLauncherConfig(BaseModel):
     podSecurityContext: kubernetes.PodSecurityContext
     securityContext: kubernetes.SecurityContext
     resources: kubernetes.Resources
+    runK8sConfig: Optional[RunK8sConfig]
     livenessProbe: kubernetes.LivenessProbe
     volumeMounts: List[kubernetes.VolumeMount]
     volumes: List[kubernetes.Volume]
@@ -52,16 +64,6 @@ class CeleryK8sRunLauncherConfig(BaseModel):
     class Config:
         extra = Extra.forbid
 
-
-class RunK8sConfig(BaseModel):
-    containerConfig: Optional[Dict[str, Any]]
-    podSpecConfig: Optional[Dict[str, Any]]
-    podTemplateSpecMetadata: Optional[Dict[str, Any]]
-    jobSpecConfig: Optional[Dict[str, Any]]
-    jobMetadata: Optional[Dict[str, Any]]
-
-    class Config:
-        extra = Extra.forbid
 
 
 class K8sRunLauncherConfig(BaseModel):

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -9,6 +9,24 @@ config:
   {{- if $celeryK8sRunLauncherConfig.jobNamespace }}
   job_namespace: {{ $celeryK8sRunLauncherConfig.jobNamespace }}
   {{- end }}
+  {{- if $celeryK8sRunLauncherConfig.runK8sConfig }}
+  run_k8s_config:
+    {{- if $celeryK8sRunLauncherConfig.runK8sConfig.containerConfig }}
+    container_config: {{- $celeryK8sRunLauncherConfig.runK8sConfig.containerConfig | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $celeryK8sRunLauncherConfig.runK8sConfig.podSpecConfig }}
+    pod_spec_config: {{- $celeryK8sRunLauncherConfig.runK8sConfig.podSpecConfig | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $celeryK8sRunLauncherConfig.runK8sConfig.podTemplateSpecMetadata }}
+    pod_template_spec_metadata: {{- $celeryK8sRunLauncherConfig.runK8sConfig.podTemplateSpecMetadata | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $celeryK8sRunLauncherConfig.runK8sConfig.jobSpecConfig }}
+    job_spec_config: {{- $celeryK8sRunLauncherConfig.runK8sConfig.jobSpecConfig | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $celeryK8sRunLauncherConfig.runK8sConfig.jobMetadata }}
+    job_metadata: {{- $celeryK8sRunLauncherConfig.runK8sConfig.jobMetadata | toYaml | nindent 6 }}
+    {{- end }}
+  {{- end }}
   broker:
     env: DAGSTER_CELERY_BROKER_URL
   backend:

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1926,6 +1926,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "runK8sConfig": {
+                    "title": "RunK8sConfig",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RunK8sConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -597,6 +597,10 @@ runLauncher:
       # By default, the namespace "default" is used.
       jobNamespace: ~
 
+      # Raw k8s configuration for the Kubernetes Job and Pod created for the run.
+      # See: https://docs.dagster.io/deployment/guides/kubernetes/customizing-your-deployment
+      runK8sConfig: { }
+
       # Support overriding the name prefix of Celery worker pods
       nameOverride: "celery-workers"
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -84,6 +84,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         labels=None,
         fail_pod_on_run_failure=None,
         job_namespace=None,
+        run_k8s_config=None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
 
@@ -136,6 +137,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             fail_pod_on_run_failure, "fail_pod_on_run_failure"
         )
         self.job_namespace = check.opt_str_param(job_namespace, "job_namespace", default="default")
+        self._run_k8s_config = check.opt_dict_param(run_k8s_config, "run_k8s_config")
 
         super().__init__()
 


### PR DESCRIPTION
## Summary & Motivation

We are using `dagster-celery-k8s` in our dagster installation. While dagster-k8s allows us to define a `run_k8s_config` in the helm chart, it looks like the same option is not available for the celeryK8sRunLauncher. This leads to our code being filled with:

```
@op(
    tags={
        "dagster-k8s/config": {
            "container_config": {
                "resources": {
                    "limits": {"memory": "512Mi"},
                    "requests": {"cpu": "256m", "memory": "512Mi"},
                }
            },
            "pod_spec_config": {
                "node_selector": {"appgroup": "dagster"},
                "tolerations": [
                    {
                        "key": "appgroup",
                        "operator": "Equal",
                        "effect": "NoExecute",
                        "value": "dagster",
                    }
                ],
            }
        }
)
``` 

We would love to move this configuration on the infra side and avoid writing these tags for every op/job/asset in our codebase.

This PR would allow us to define a `run_k8s_config` for CeleryK8sRunLauncher`. The PR is still incomplete, and I haven't had the chance to test it on a real cluster yet. It would be nice to have some initial feedback and push in the right direction.
