### PR TITLE
enable setting freshness policies when loading assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -103,7 +103,7 @@ class AssetsDefinition(ResourceAddable):
         metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
         freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]] = None,
         descriptions_by_key: Optional[Mapping[AssetKey, str]] = None,
-        # if adding new fields, make sure to handle them in the with_prefix_or_group
+        # if adding new fields, make sure to handle them in the with_attributes
         # and from_graph methods
     ):
         from .graph_definition import GraphDefinition
@@ -696,11 +696,14 @@ class AssetsDefinition(ResourceAddable):
         output_name = self.get_output_name_for_asset_key(key)
         return self.node_def.resolve_output_to_origin_op_def(output_name)
 
-    def with_prefix_or_group(
+    def with_attributes(
         self,
         output_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         input_asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
+        freshness_policy: Optional[
+            Union[FreshnessPolicy, Mapping[AssetKey, FreshnessPolicy]]
+        ] = None,
     ) -> "AssetsDefinition":
         output_asset_key_replacements = check.opt_mapping_param(
             output_asset_key_replacements,
@@ -718,26 +721,49 @@ class AssetsDefinition(ResourceAddable):
             group_names_by_key, "group_names_by_key", key_type=AssetKey, value_type=str
         )
 
-        defined_group_names = [
-            asset_key.to_user_string()
-            for asset_key in group_names_by_key
-            if asset_key in self.group_names_by_key
-            and self.group_names_by_key[asset_key] != DEFAULT_GROUP_NAME
-        ]
-        if defined_group_names:
-            raise DagsterInvalidDefinitionError(
-                f"Group name already exists on assets {', '.join(defined_group_names)}"
-            )
+        if group_names_by_key:
+            group_name_conflicts = [
+                asset_key
+                for asset_key in group_names_by_key
+                if asset_key in self.group_names_by_key
+                and self.group_names_by_key[asset_key] != DEFAULT_GROUP_NAME
+            ]
+            if group_name_conflicts:
+                raise DagsterInvalidDefinitionError(
+                    "Group name already exists on assets"
+                    f" {', '.join(asset_key.to_user_string() for asset_key in group_name_conflicts)}"
+                )
 
         replaced_group_names_by_key = {
             output_asset_key_replacements.get(key, key): group_name
             for key, group_name in self.group_names_by_key.items()
         }
 
-        replaced_freshness_policies_by_key = {
-            output_asset_key_replacements.get(key, key): policy
-            for key, policy in self._freshness_policies_by_key.items()
-        }
+        if freshness_policy:
+            freshness_policy_conflicts = (
+                self.freshness_policies_by_key.keys()
+                if isinstance(freshness_policy, FreshnessPolicy)
+                else (freshness_policy.keys() & self.freshness_policies_by_key.keys())
+            )
+            if freshness_policy_conflicts:
+                raise DagsterInvalidDefinitionError(
+                    "FreshnessPolicy already exists on assets"
+                    f" {', '.join(key.to_string() for key in freshness_policy_conflicts)}"
+                )
+
+        replaced_freshness_policies_by_key = {}
+        for key in self.keys:
+            if isinstance(freshness_policy, FreshnessPolicy):
+                replaced_freshness_policy = freshness_policy
+            elif freshness_policy:
+                replaced_freshness_policy = freshness_policy.get(key)
+            else:
+                replaced_freshness_policy = self.freshness_policies_by_key.get(key)
+
+            if replaced_freshness_policy:
+                replaced_freshness_policies_by_key[
+                    output_asset_key_replacements.get(key, key)
+                ] = replaced_freshness_policy
 
         replaced_descriptions_by_key = {
             output_asset_key_replacements.get(key, key): description

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -188,6 +188,21 @@ CoercibleToAssetKey = Union[AssetKey, str, Sequence[str]]
 CoercibleToAssetKeyPrefix = Union[str, Sequence[str]]
 
 
+def check_opt_coercible_to_asset_key_prefix_param(
+    prefix: Optional[CoercibleToAssetKeyPrefix], param_name: str
+) -> Optional[Sequence[str]]:
+    if prefix is None:
+        return prefix
+    elif isinstance(prefix, str):
+        return [prefix]
+    elif isinstance(prefix, list):
+        return prefix
+    else:
+        raise check.ParameterCheckError(
+            f'Param "{param_name}" is not a string or a sequence of strings'
+        )
+
+
 DynamicAssetKey = Callable[["OutputContext"], Optional[AssetKey]]
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -49,7 +49,7 @@ def test_with_replaced_asset_keys():
         assert input1
         assert input2
 
-    replaced = asset1.with_prefix_or_group(
+    replaced = asset1.with_attributes(
         output_asset_key_replacements={
             AssetKey(["asset1"]): AssetKey(["prefix1", "asset1_changed"])
         },
@@ -114,7 +114,7 @@ def test_retain_group():
     def bar():
         pass
 
-    replaced = bar.with_prefix_or_group(
+    replaced = bar.with_attributes(
         output_asset_key_replacements={AssetKey(["bar"]): AssetKey(["baz"])}
     )
     assert replaced.group_names_by_key[AssetKey("baz")] == "foo"
@@ -127,7 +127,7 @@ def test_retain_freshness_policy():
     def bar():
         pass
 
-    replaced = bar.with_prefix_or_group(
+    replaced = bar.with_attributes(
         output_asset_key_replacements={AssetKey(["bar"]): AssetKey(["baz"])}
     )
     assert (
@@ -159,7 +159,7 @@ def test_graph_backed_retain_freshness_policy():
         my_graph, freshness_policies_by_output_name={"a": fpa, "b": fpb}
     )
 
-    replaced = my_graph_asset.with_prefix_or_group(
+    replaced = my_graph_asset.with_attributes(
         output_asset_key_replacements={
             AssetKey("a"): AssetKey("aa"),
             AssetKey("b"): AssetKey("bb"),
@@ -183,7 +183,7 @@ def test_retain_metadata_graph():
     md = {"foo": "bar", "baz": 12.5}
     original = AssetsDefinition.from_graph(bar, metadata_by_output_name={"result": md})
 
-    replaced = original.with_prefix_or_group(
+    replaced = original.with_attributes(
         output_asset_key_replacements={AssetKey(["bar"]): AssetKey(["baz"])}
     )
     assert (
@@ -218,7 +218,7 @@ def test_retain_partition_mappings():
 
     assert isinstance(bar_.get_partition_mapping(AssetKey(["input_last"])), LastPartitionMapping)
 
-    replaced = bar_.with_prefix_or_group(
+    replaced = bar_.with_attributes(
         input_asset_key_replacements={
             AssetKey(["input_last"]): AssetKey(["input_last2"]),
         }
@@ -242,7 +242,7 @@ def test_chain_replace_and_subset_for():
     def abc_(context, in1, in2, in3):
         pass
 
-    replaced_1 = abc_.with_prefix_or_group(
+    replaced_1 = abc_.with_attributes(
         output_asset_key_replacements={AssetKey(["a"]): AssetKey(["foo", "foo_a"])},
         input_asset_key_replacements={AssetKey(["in1"]): AssetKey(["foo", "bar_in1"])},
     )
@@ -264,7 +264,7 @@ def test_chain_replace_and_subset_for():
     )
     assert subbed_1.keys == {AssetKey(["foo", "foo_a"]), AssetKey("b")}
 
-    replaced_2 = subbed_1.with_prefix_or_group(
+    replaced_2 = subbed_1.with_attributes(
         output_asset_key_replacements={
             AssetKey(["foo", "foo_a"]): AssetKey(["again", "foo", "foo_a"]),
             AssetKey(["b"]): AssetKey(["something", "bar_b"]),

--- a/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
@@ -220,7 +220,7 @@ def test_resolve_with_resources():
 
 
 def test_group_cached_assets():
-    """Test that with_prefix_or_group works properly on cacheable assets."""
+    """Test that with_attributes works properly on cacheable assets."""
 
     class MyCacheableAssets(CacheableAssetsDefinition):
         def compute_cacheable_data(self):
@@ -244,7 +244,7 @@ def test_group_cached_assets():
                 for cd in data
             ]
 
-    my_cacheable_assets_cool = MyCacheableAssets("foo").with_prefix_or_group(
+    my_cacheable_assets_cool = MyCacheableAssets("foo").with_attributes(
         group_names_by_key={AssetKey("foo"): "my_cool_group"}
     )
 
@@ -274,7 +274,7 @@ def test_group_cached_assets():
 
 
 def test_multiple_wrapped_cached_assets():
-    """Test that multiple wrappers (with_prefix_or_group, with_resources) work properly on cacheable assets.
+    """Test that multiple wrappers (with_attributes, with_resources) work properly on cacheable assets.
     """
 
     @resource
@@ -282,16 +282,14 @@ def test_multiple_wrapped_cached_assets():
         return 3
 
     my_cacheable_assets_with_group_and_asset = [
-        x.with_prefix_or_group(
+        x.with_attributes(
             output_asset_key_replacements={
                 AssetKey("res_downstream"): AssetKey("res_downstream_too")
             }
         )
         for x in with_resources(
             [
-                x.with_prefix_or_group(
-                    group_names_by_key={AssetKey("res_midstream"): "my_cool_group"}
-                )
+                x.with_attributes(group_names_by_key={AssetKey("res_midstream"): "my_cool_group"})
                 for x in define_resource_dependent_cacheable_and_uncacheable_assets()
             ],
             {"foo": foo_resource},

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -892,7 +892,7 @@ def load_assets_from_dbt_manifest(
             for input_key in dbt_assets_def.keys_by_input_name.values()
         }
         dbt_assets = [
-            dbt_assets_def.with_prefix_or_group(input_asset_key_replacements=input_key_replacements)
+            dbt_assets_def.with_attributes(input_asset_key_replacements=input_key_replacements)
         ]
     else:
         dbt_assets = [dbt_assets_def]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -20,7 +20,6 @@ from dagster._core.definitions.cacheable_assets import (
     CacheableAssetsDefinition,
 )
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
-from dagster._core.definitions.load_assets_from_modules import with_group
 from dagster._core.definitions.metadata import MetadataUserInput
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterStepOutputNotFoundError
@@ -282,23 +281,21 @@ def _build_fivetran_assets_from_metadata(
     connector_id = cast(str, metadata["connector_id"])
     io_manager_key = cast(Optional[str], metadata["io_manager_key"])
 
-    return with_group(
-        _build_fivetran_assets(
-            connector_id=connector_id,
-            destination_tables=list(
-                assets_defn_meta.keys_by_output_name.keys()
-                if assets_defn_meta.keys_by_output_name
-                else []
-            ),
-            asset_key_prefix=list(assets_defn_meta.key_prefix or []),
-            metadata_by_table_name=cast(
-                Dict[str, MetadataUserInput], assets_defn_meta.metadata_by_output_name
-            ),
-            io_manager_key=io_manager_key,
-            table_to_asset_key_map=assets_defn_meta.keys_by_output_name,
-            resource_defs=resource_defs,
+    return _build_fivetran_assets(
+        connector_id=connector_id,
+        destination_tables=list(
+            assets_defn_meta.keys_by_output_name.keys()
+            if assets_defn_meta.keys_by_output_name
+            else []
         ),
-        assets_defn_meta.group_name,
+        asset_key_prefix=list(assets_defn_meta.key_prefix or []),
+        metadata_by_table_name=cast(
+            Dict[str, MetadataUserInput], assets_defn_meta.metadata_by_output_name
+        ),
+        io_manager_key=io_manager_key,
+        table_to_asset_key_map=assets_defn_meta.keys_by_output_name,
+        resource_defs=resource_defs,
+        group_name=assets_defn_meta.group_name,
     )[0]
 
 


### PR DESCRIPTION
## Summary & Motivation

I was working on moving project_fully_featured to declarative scheduling and found myself wanting this.

In service of this:
- Renames `AssetsDefinition. with_prefix_or_group` to `AssetsDefinition.with_attributes` to accommodate more attributes
- Refactors some common code in `load_assets_from_modules` into a shared function.

## How I Tested These Changes
