### PR TITLE
Restore asset key null check

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -964,6 +964,10 @@ class TestEventLogStorage:
             assert isinstance(record, EventLogRecord)
             assert record.event_log_entry.dagster_event.asset_key == asset_key
 
+    def test_asset_materialization_null_key_fails(self):
+        with pytest.raises(check.CheckError):
+            AssetMaterialization(asset_key=None)
+
     def test_asset_events_error_parsing(self, storage):
         if not isinstance(storage, SqlEventLogStorage):
             pytest.skip("This test is for SQL-backed Event Log behavior")


### PR DESCRIPTION
## Summary & Motivation

`AssetMaterialization` has inadvertently been allowing `AssetKey` to be set to `None` for several months. This PR restores the runtime check to prevent this while maintaining compatibility with stored `AssetMaterialization` (or older `Materialization`) objects that lack an `AssetKey`.

See: https://github.com/dagster-io/dagster/pull/13030 for further context.

## How I Tested These Changes

Modified `test_load_old_materialization` unit test.
