### PR TITLE
[dagster-dbt] Fix bug when calculating transitive dependencies

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -208,7 +208,8 @@ def _get_deps(
             if _is_non_asset_node(parent_node_info):
                 visited = set()
                 replaced_parent_ids = set()
-                queue = parent_node_info.get("depends_on", {}).get("nodes", [])
+                # make a copy to avoid mutating the actual dictionary
+                queue = list(parent_node_info.get("depends_on", {}).get("nodes", []))
                 while queue:
                     candidate_parent_id = queue.pop()
                     if candidate_parent_id in visited:


### PR DESCRIPTION
## Summary & Motivation

Previously, the queue that our BFS was using actually targeted the underlying data structure that we parsed out of the manifest.json file. This means `queue.pop()` was altering the `dbt_nodes` mapping! This is fine as long as no two assets try to traverse the same node, which is likely why this escaped detection.

## How I Tested These Changes
