### PR TITLE
add selection argument to materialize and materialize_to_memory

### DIFF
--- a/docs/content/concepts/assets/asset-selection-syntax.mdx
+++ b/docs/content/concepts/assets/asset-selection-syntax.mdx
@@ -13,7 +13,7 @@ To specify an asset selection as a string, Dagster supports a simple query synta
 
 It works as follows:
 
-- A query includes a list of clauses. Clauses are separated by commas, except in the case of the `selection` parameter of <PyObject object="define_asset_job" />, where each clause is a separate element in a list.
+- A query includes a list of clauses. Clauses are separated by commas, except in the case of the `selection` parameter of <PyObject object="define_asset_job" />, <PyObject object="materialize" />, and <PyObject object="materialize_to_memory" />, where each clause is a separate element in a list.
 - A clause can be an asset key, in which case that asset is selected.
 - An asset key with multiple components can be specified by inserting slashes between the components.
 - A clause can be an asset key preceded by `*`, in which case that asset and all of its ancestors (upstream dependencies) are selected.

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -1,18 +1,33 @@
 import operator
 from abc import ABC, abstractmethod
 from functools import reduce
-from typing import AbstractSet, Iterable, Optional, Union
+from typing import AbstractSet, Iterable, Optional, Sequence, Union, cast
+
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import deprecated, public
 from dagster._core.errors import DagsterInvalidSubsetError
-from dagster._core.selector.subset_selector import fetch_connected, fetch_sinks, fetch_sources
+from dagster._core.selector.subset_selector import (
+    fetch_connected,
+    fetch_sinks,
+    fetch_sources,
+    parse_clause,
+)
 from dagster._utils.backcompat import deprecation_warning
 
 from .asset_graph import AssetGraph
 from .assets import AssetsDefinition
 from .events import AssetKey, CoercibleToAssetKey
 from .source_asset import SourceAsset
+
+CoercibleToAssetSelection: TypeAlias = Union[
+    str,
+    Sequence[str],
+    Sequence[AssetKey],
+    Sequence[Union["AssetsDefinition", "SourceAsset"]],
+    "AssetSelection",
+]
 
 
 class AssetSelection(ABC):
@@ -202,6 +217,50 @@ class AssetSelection(ABC):
     @abstractmethod
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         raise NotImplementedError()
+
+    @staticmethod
+    def _selection_from_string(string: str) -> "AssetSelection":
+        from dagster._core.definitions import AssetSelection
+
+        if string == "*":
+            return AssetSelection.all()
+
+        parts = parse_clause(string)
+        if not parts:
+            check.failed(f"Invalid selection string: {string}")
+        u, item, d = parts
+
+        selection: AssetSelection = AssetSelection.keys(item)
+        if u:
+            selection = selection.upstream(u)
+        if d:
+            selection = selection.downstream(d)
+        return selection
+
+    @classmethod
+    def from_coercible(cls, selection: CoercibleToAssetSelection) -> "AssetSelection":
+        if isinstance(selection, str):
+            return cls._selection_from_string(selection)
+        elif isinstance(selection, AssetSelection):
+            return selection
+        elif isinstance(selection, list) and all(isinstance(el, str) for el in selection):
+            return reduce(
+                operator.or_, [cls._selection_from_string(cast(str, s)) for s in selection]
+            )
+        elif isinstance(selection, list) and all(
+            isinstance(el, (AssetsDefinition, SourceAsset)) for el in selection
+        ):
+            return AssetSelection.keys(
+                *(el.key for el in cast(Sequence[Union[AssetsDefinition, SourceAsset]], selection))
+            )
+        elif isinstance(selection, list) and all(isinstance(el, AssetKey) for el in selection):
+            return cls.keys(*cast(Sequence[AssetKey], selection))
+        else:
+            check.failed(
+                "selection argument must be one of str, Sequence[str], Sequence[AssetKey],"
+                " Sequence[AssetsDefinition], Sequence[SourceAsset], AssetSelection. Was"
+                f" {type(selection)}."
+            )
 
 
 class AllAssetSelection(AssetSelection):

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -1,15 +1,12 @@
-import operator
 from collections import defaultdict
 from datetime import datetime
-from functools import reduce
-from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
-from dagster._core.selector.subset_selector import parse_clause
 from dagster._utils.backcompat import deprecation_warning
 
 from .asset_layer import build_asset_selection_job
@@ -26,6 +23,7 @@ if TYPE_CHECKING:
         SourceAsset,
     )
     from dagster._core.definitions.asset_graph import InternalAssetGraph
+    from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 
 
 class UnresolvedAssetJobDefinition(
@@ -234,36 +232,9 @@ class UnresolvedAssetJobDefinition(
         )
 
 
-def _selection_from_string(string: str) -> "AssetSelection":
-    from dagster._core.definitions import AssetSelection
-
-    if string == "*":
-        return AssetSelection.all()
-
-    parts = parse_clause(string)
-    if not parts:
-        check.failed(f"Invalid selection string: {string}")
-    u, item, d = parts
-
-    selection: AssetSelection = AssetSelection.keys(item)
-    if u:
-        selection = selection.upstream(u)
-    if d:
-        selection = selection.downstream(d)
-    return selection
-
-
 def define_asset_job(
     name: str,
-    selection: Optional[
-        Union[
-            str,
-            Sequence[str],
-            Sequence[AssetKey],
-            Sequence[Union["AssetsDefinition", "SourceAsset"]],
-            "AssetSelection",
-        ]
-    ] = None,
+    selection: Optional["CoercibleToAssetSelection"] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"]] = None,
     description: Optional[str] = None,
     tags: Optional[Mapping[str, Any]] = None,
@@ -378,34 +349,13 @@ def define_asset_job(
             )
 
     """
-    from dagster._core.definitions import AssetsDefinition, AssetSelection, SourceAsset
+    from dagster._core.definitions import AssetSelection
 
     # convert string-based selections to AssetSelection objects
-    resolved_selection: AssetSelection
     if selection is None:
         resolved_selection = AssetSelection.all()
-    elif isinstance(selection, str):
-        resolved_selection = _selection_from_string(selection)
-    elif isinstance(selection, AssetSelection):
-        resolved_selection = selection
-    elif isinstance(selection, list) and all(isinstance(el, str) for el in selection):
-        resolved_selection = reduce(
-            operator.or_, [_selection_from_string(cast(str, s)) for s in selection]
-        )
-    elif isinstance(selection, list) and all(
-        isinstance(el, (AssetsDefinition, SourceAsset)) for el in selection
-    ):
-        resolved_selection = AssetSelection.keys(
-            *(el.key for el in cast(Sequence[Union[AssetsDefinition, SourceAsset]], selection))
-        )
-    elif isinstance(selection, list) and all(isinstance(el, AssetKey) for el in selection):
-        resolved_selection = AssetSelection.keys(*cast(Sequence[AssetKey], selection))
     else:
-        check.failed(
-            "selection argument must be one of str, Sequence[str], Sequence[AssetKey],"
-            " Sequence[AssetsDefinition], Sequence[SourceAsset], AssetSelection. Was"
-            f" {type(selection)}."
-        )
+        resolved_selection = AssetSelection.from_coercible(selection)
 
     return UnresolvedAssetJobDefinition(
         name=name,

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -161,6 +161,9 @@ class ExecutionResult(ABC):
             if event.event_type_value == DagsterEventType.ASSET_OBSERVATION.value
         ]
 
+    def get_asset_materialization_events(self) -> Sequence[DagsterEvent]:
+        return [event for event in self.all_events if event.is_step_materialization]
+
     def get_step_success_events(self) -> Sequence[DagsterEvent]:
         return [event for event in self.all_events if event.is_step_success]
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -321,3 +321,21 @@ def test_raise_on_error():
         raise ValueError()
 
     assert not materialize_to_memory([asset1], raise_on_error=False).success
+
+
+def test_selection():
+    @asset
+    def upstream():
+        ...
+
+    @asset
+    def downstream(upstream):
+        ...
+
+    assets = [upstream, downstream]
+
+    result1 = materialize_to_memory(assets, selection=[upstream])
+    assert result1.success
+    materialization_events = result1.get_asset_materialization_events()
+    assert len(materialization_events) == 1
+    assert materialization_events[0].materialization.asset_key == AssetKey("upstream")


### PR DESCRIPTION
## Summary & Motivation

Before:
```python
materialize([*upstream.to_source_assets(), downstream])
```

After:
```python
materialize([upstream, downstream], selection=[downstream])
```

While the after state doesn't have fewer characters, I think it's much easier to understand.

## How I Tested These Changes
