### PR TITLE
Enable context partition time window methods for multipartitioned runs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -35,7 +35,7 @@ from .partition import (
     PartitionsSubset,
     StaticPartitionsDefinition,
 )
-from .time_window_partitions import TimeWindowPartitionsDefinition
+from .time_window_partitions import TimeWindow, TimeWindowPartitionsDefinition
 
 INVALID_STATIC_PARTITIONS_KEY_CHARACTERS = set(["|", ",", "[", "]"])
 
@@ -407,6 +407,17 @@ class MultiPartitionsDefinition(PartitionsDefinition):
         return cast(
             TimeWindowPartitionsDefinition, self.time_window_dimension.partitions_def
         ).timezone
+
+    def time_window_for_partition_key(self, partition_key: str) -> TimeWindow:
+        if not isinstance(partition_key, MultiPartitionKey):
+            partition_key = self.get_partition_key_from_str(partition_key)
+
+        time_window_dimension = self.time_window_dimension
+        return cast(
+            TimeWindowPartitionsDefinition, time_window_dimension.partitions_def
+        ).time_window_for_partition_key(
+            cast(MultiPartitionKey, partition_key).keys_by_dimension[time_window_dimension.name]
+        )
 
     def get_multipartition_keys_with_dimension_value(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1680,3 +1680,23 @@ def fetch_flattened_time_window_ranges(
         )
 
     return flattened_time_window_statuses
+
+
+def has_one_dimension_time_window_partitioning(
+    partitions_def: PartitionsDefinition,
+) -> bool:
+    from .multi_dimensional_partitions import MultiPartitionsDefinition
+
+    if isinstance(partitions_def, TimeWindowPartitionsDefinition):
+        return True
+
+    if isinstance(partitions_def, MultiPartitionsDefinition):
+        time_window_dims = [
+            dim
+            for dim in partitions_def.partitions_defs
+            if isinstance(dim.partitions_def, TimeWindowPartitionsDefinition)
+        ]
+        if len(time_window_dims) == 1:
+            return True
+
+    return False

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -398,7 +398,8 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
         Raises an error if either of the following are true:
         - The output asset has no partitioning.
-        - The output asset is not partitioned with a TimeWindowPartitionsDefinition.
+        - The output asset is not partitioned with a TimeWindowPartitionsDefinition or a
+          MultiPartitionsDefinition with one time-partitioned dimension.
         """
         return self._step_execution_context.asset_partitions_time_window_for_output(output_name)
 

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -25,6 +25,7 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.mode import ModeDefinition
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.resource_definition import (
@@ -38,6 +39,7 @@ from dagster._core.definitions.step_launcher import StepLauncher
 from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
+    has_one_dimension_time_window_partitioning,
 )
 from dagster._core.errors import (
     DagsterInvalidInvocationError,
@@ -562,17 +564,20 @@ class BoundOpExecutionContext(OpExecutionContext):
     def asset_partition_key_for_output(self, output_name: str = "result") -> str:
         return self.partition_key
 
-    def asset_partitions_time_window_for_output(
-        self, output_name: str = "result"
-    ) -> Optional[TimeWindow]:
+    def asset_partitions_time_window_for_output(self, output_name: str = "result") -> TimeWindow:
         partitions_def = self.assets_def.partitions_def
         if partitions_def is None:
             check.failed("Tried to access partition_key for a non-partitioned asset")
 
-        if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
-            check.failed("Tried to access output time window for a non-time-partitioned asset")
+        if not has_one_dimension_time_window_partitioning(partitions_def=partitions_def):
+            raise DagsterInvariantViolationError(
+                "Expected a TimeWindowPartitionsDefinition or MultiPartitionsDefinition with a"
+                f" single time dimension, but instead found {type(partitions_def)}"
+            )
 
-        return partitions_def.time_window_for_partition_key(self.partition_key)
+        return cast(
+            Union[MultiPartitionsDefinition, TimeWindowPartitionsDefinition], partitions_def
+        ).time_window_for_partition_key(self.partition_key)
 
     def add_output_metadata(
         self,

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -467,7 +467,8 @@ class OutputContext:
 
         Raises an error if either of the following are true:
         - The output asset has no partitioning.
-        - The output asset is not partitioned with a TimeWindowPartitionsDefinition.
+        - The output asset is not partitioned with a TimeWindowPartitionsDefinition or a
+          MultiPartitionsDefinition with one time-partitioned dimension.
         """
         if self._warn_on_step_context_use:
             warnings.warn(


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/13077

Makes the following context methods work for multipartitioned runs:
- context.partition_time_window
- context.asset_partitions_time_window_for_output

Not sure why we have both of these methods considering that they do the same thing (until we support per-output partitioning). For now, this PR continues to support both methods.

Also enables these methods to work on direct invocation too.