### PR TITLE
celery-k8s executor: handle stdout that's valid json but not a dagster event

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -273,6 +273,7 @@ def define_docker_celery_pipeline():
     @resource
     def resource_with_output():
         print("writing to stdout")  # noqa: T201
+        print("{}")  # noqa: T201
         return 42
 
     @op(required_resource_keys={"resource_with_output"})

--- a/python_modules/dagster/dagster/_core/events/utils.py
+++ b/python_modules/dagster/dagster/_core/events/utils.py
@@ -2,6 +2,7 @@ from json import JSONDecodeError
 
 import dagster._check as check
 from dagster._core.events import DagsterEvent
+from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
 
 
@@ -42,6 +43,8 @@ def filter_dagster_events_from_cli_logs(log_lines):
         except JSONDecodeError:
             pass
         except check.CheckError:
+            pass
+        except DeserializationError:
             pass
 
     return events

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_utils.py
@@ -80,3 +80,13 @@ def test_filter_dagster_events_from_cli_logs_coalesce():
     event = res[0]
     check.inst(event, DagsterEvent)
     check.inst(event.event_specific_data, StepSuccessData)
+
+
+def test_filter_dagster_events_from_cli_logs_user_json():
+    logs = """
+    {}
+    """.split(
+        "\n"
+    )
+
+    assert filter_dagster_events_from_cli_logs(logs) == []


### PR DESCRIPTION
Celery-k8s step workers write json serialized events to stdout. The celery workers parse them. It seems like if you write a line to stdout that parses as json but isn't an event, we fail with a DeserializationError: https://dagster.slack.com/archives/C01U954MEER/p1679635251354799

https://github.com/dagster-io/dagster/pull/7665 added 

```
except JSONDecodeError:
            pass
```

in order to skip lines that don't parse as valid json. We can add DeserializationError to the errors to skip, so we just ignore lines that aren't events.

Of course ideally we should switch to reading events from the db but that's a larger change. I don't think there's too much risk of true errors getting swallowed by this?

---

Side note:

I'm not sure what the 

```
        except check.CheckError:
            pass
```

catches. Is it possible that before the `deserialize_json_to_dagster_namedtuple`, this would raise a CheckError instead of a DeserializationError? Doesn't look like it from some quick browsing but I am a bit surprised this hasn't come up before. Maybe bc it's rare to write directly to stdout?

---

Testing the test here: https://github.com/dagster-io/dagster/pull/13144