### PR TITLE
Make sure we always wait for all grpc server processes to spin down in tests

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_memory.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_memory.py
@@ -75,14 +75,7 @@ def test_no_memory_leaks():
                 "module": "dagster.core.run_coordinator",
                 "class": "QueuedRunCoordinator",
             },
-            "run_launcher": {
-                "class": "DefaultRunLauncher",
-                "module": "dagster.core.launcher.default_run_launcher",
-                "config": {
-                    "wait_for_processes": False,
-                },
-            },
-        }
+        },
     ) as instance:
         with get_example_repo(instance) as repo:
             external_schedule = repo.get_external_schedule("always_run_schedule")
@@ -94,7 +87,6 @@ def test_no_memory_leaks():
             with daemon_controller_from_instance(
                 instance,
                 workspace_load_target=workspace_load_target(),
-                wait_for_processes_on_exit=True,
             ) as controller:
                 start_time = time.time()
 

--- a/js_modules/dagit/tox.ini
+++ b/js_modules/dagit/tox.ini
@@ -5,7 +5,8 @@ skipsdist = True
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE*
-
+setenv =
+    STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 deps =
   -e ../../python_modules/dagster[test]
   -e ../../python_modules/dagster-graphql

--- a/python_modules/dagit/dagit/debug.py
+++ b/python_modules/dagit/dagit/debug.py
@@ -44,13 +44,14 @@ def dagit_debug_command(input_files, port):
             debug_payloads.append(debug_payload)
 
     instance = DagsterInstance.ephemeral(preload=debug_payloads)
-    host_dagit_ui_with_workspace_process_context(
-        workspace_process_context=WorkspaceProcessContext(instance, None, version=__version__),
-        port=port,
-        host=DEFAULT_DAGIT_HOST,
-        path_prefix="",
-        log_level="debug",
-    )
+    with WorkspaceProcessContext(instance, None, version=__version__) as workspace_process_context:
+        host_dagit_ui_with_workspace_process_context(
+            workspace_process_context=workspace_process_context,
+            port=port,
+            host=DEFAULT_DAGIT_HOST,
+            path_prefix="",
+            log_level="debug",
+        )
 
 
 def main():

--- a/python_modules/dagit/tox.ini
+++ b/python_modules/dagit/tox.ini
@@ -5,6 +5,8 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
+setenv =
+  STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 deps =
   objgraph
   -e ../dagster[test]

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -9,6 +9,8 @@ skipsdist = true
 [testenv]
 download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE* POSTGRES_TEST_DB_HOST
+setenv =
+  STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 deps =
   -e ../dagster[test]
   postgres: -e ../libraries/dagster-postgres

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -295,7 +295,11 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
             }
         ),
         "code_servers": Field(
-            {"local_startup_timeout": Field(int, is_required=False)}, is_required=False
+            {
+                "local_startup_timeout": Field(int, is_required=False),
+                "wait_for_local_processes_on_shutdown": Field(bool, is_required=False),
+            },
+            is_required=False,
         ),
         "secrets": secrets_loader_config_schema(),
         "retention": retention_config_schema(),

--- a/python_modules/dagster/dagster/_core/instance_for_test.py
+++ b/python_modules/dagster/dagster/_core/instance_for_test.py
@@ -68,18 +68,14 @@ def instance_for_test(
         if not temp_dir:
             temp_dir = stack.enter_context(tempfile.TemporaryDirectory())
 
-        # If using the default run launcher, wait for any grpc processes that created runs
-        # during test disposal to finish, since they might also be using this instance's tempdir
+        # wait for any grpc processes that created runs during test disposal to finish,
+        # since they might also be using this instance's tempdir (and to keep each test
+        # isolated / avoid race conditions in newer versions of grpcio when servers are
+        # shutting down and spinning up at the same time)
         instance_overrides = merge_dicts(
             {
-                "run_launcher": {
-                    "class": "DefaultRunLauncher",
-                    "module": "dagster._core.launcher.default_run_launcher",
-                    "config": {
-                        "wait_for_processes": True,
-                    },
-                },
                 "telemetry": {"enabled": False},
+                "code_servers": {"wait_for_local_processes_on_shutdown": True},
             },
             (overrides if overrides else {}),
         )

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -80,7 +80,6 @@ def daemon_controller_from_instance(
     workspace_load_target: WorkspaceLoadTarget,
     heartbeat_interval_seconds: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
     heartbeat_tolerance_seconds: int = DEFAULT_DAEMON_HEARTBEAT_TOLERANCE_SECONDS,
-    wait_for_processes_on_exit: bool = False,
     gen_daemons: Callable[
         [DagsterInstance], Iterable[DagsterDaemon]
     ] = create_daemons_from_instance,
@@ -90,33 +89,29 @@ def daemon_controller_from_instance(
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(workspace_load_target, "workspace_load_target", WorkspaceLoadTarget)
     grpc_server_registry: Optional[GrpcServerRegistry] = None
-    try:
-        with ExitStack() as stack:
-            grpc_server_registry = stack.enter_context(
-                create_daemon_grpc_server_registry(instance, code_server_log_level)
+    with ExitStack() as stack:
+        grpc_server_registry = stack.enter_context(
+            create_daemon_grpc_server_registry(instance, code_server_log_level)
+        )
+        daemons = [stack.enter_context(daemon) for daemon in gen_daemons(instance)]
+        workspace_process_context = stack.enter_context(
+            WorkspaceProcessContext(
+                instance=instance,
+                workspace_load_target=workspace_load_target,
+                grpc_server_registry=grpc_server_registry,
             )
-            daemons = [stack.enter_context(daemon) for daemon in gen_daemons(instance)]
-            workspace_process_context = stack.enter_context(
-                WorkspaceProcessContext(
-                    instance=instance,
-                    workspace_load_target=workspace_load_target,
-                    grpc_server_registry=grpc_server_registry,
-                )
+        )
+        controller = stack.enter_context(
+            DagsterDaemonController(
+                workspace_process_context,
+                daemons,
+                heartbeat_interval_seconds=heartbeat_interval_seconds,
+                heartbeat_tolerance_seconds=heartbeat_tolerance_seconds,
+                error_interval_seconds=error_interval_seconds,
             )
-            controller = stack.enter_context(
-                DagsterDaemonController(
-                    workspace_process_context,
-                    daemons,
-                    heartbeat_interval_seconds=heartbeat_interval_seconds,
-                    heartbeat_tolerance_seconds=heartbeat_tolerance_seconds,
-                    error_interval_seconds=error_interval_seconds,
-                )
-            )
+        )
 
-            yield controller
-    finally:
-        if wait_for_processes_on_exit and grpc_server_registry:
-            grpc_server_registry.wait_for_processes()
+        yield controller
 
 
 class DagsterDaemonController(AbstractContextManager):

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -321,15 +321,16 @@ def args_with_default_cli_test_instance(*args):
 
 @contextmanager
 def grpc_server_bar_kwargs(instance, pipeline_name=None):
-    server_process = GrpcServerProcess(
+    with GrpcServerProcess(
         instance_ref=instance.get_ref(),
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
             python_file=file_relative_path(__file__, "test_cli_commands.py"),
             attribute="bar",
         ),
-    )
-    with server_process.create_ephemeral_client() as client:
+        wait_on_exit=True,
+    ) as server_process:
+        client = server_process.create_client()
         args = {"grpc_host": client.host}
         if pipeline_name:
             args["job_name"] = "foo"
@@ -338,7 +339,6 @@ def grpc_server_bar_kwargs(instance, pipeline_name=None):
         if client.socket:
             args["grpc_socket"] = client.socket
         yield args
-    server_process.wait()
 
 
 @contextmanager
@@ -357,15 +357,16 @@ def python_bar_cli_args(job_name=None):
 
 @contextmanager
 def grpc_server_bar_cli_args(instance, job_name=None):
-    server_process = GrpcServerProcess(
+    with GrpcServerProcess(
         instance.get_ref(),
         loadable_target_origin=LoadableTargetOrigin(
             executable_path=sys.executable,
             python_file=file_relative_path(__file__, "test_cli_commands.py"),
             attribute="bar",
         ),
-    )
-    with server_process.create_ephemeral_client() as client:
+        wait_on_exit=True,
+    ) as server_process:
+        client = server_process.create_client()
         args = ["--grpc-host", client.host]
         if client.port:
             args.append("--grpc-port")
@@ -378,7 +379,6 @@ def grpc_server_bar_cli_args(instance, job_name=None):
             args.append(job_name)
 
         yield args
-    server_process.wait()
 
 
 @contextmanager

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -20,10 +20,14 @@ def instance():
 
 @pytest.mark.skipif(_seven.IS_WINDOWS, reason="no named sockets on Windows")
 def test_grpc_socket_workspace(instance):
-    first_server_process = GrpcServerProcess(instance_ref=instance.get_ref())
-    with first_server_process.create_ephemeral_client() as first_server:
-        second_server_process = GrpcServerProcess(instance_ref=instance.get_ref())
-        with second_server_process.create_ephemeral_client() as second_server:
+    with GrpcServerProcess(
+        instance_ref=instance.get_ref(), wait_on_exit=True
+    ) as first_server_process:
+        first_server = first_server_process.create_client()
+        with GrpcServerProcess(
+            instance_ref=instance.get_ref(), wait_on_exit=True
+        ) as second_server_process:
+            second_server = second_server_process.create_client()
             first_socket = first_server.socket
             second_socket = second_server.socket
             workspace_yaml = """
@@ -67,8 +71,6 @@ load_from:
                 assert local_port_default_host.port is None
 
                 assert all(map(lambda x: x.name, code_locations.values()))
-        second_server_process.wait()
-    first_server_process.wait()
 
 
 def test_grpc_server_env_vars():
@@ -116,44 +118,46 @@ def test_grpc_server_env_vars():
 
 
 def test_ssl_grpc_server_workspace(instance):
-    server_process = GrpcServerProcess(instance_ref=instance.get_ref(), force_port=True)
-    try:
-        with server_process.create_ephemeral_client() as client:
-            assert client.heartbeat(echo="Hello")
+    with GrpcServerProcess(
+        instance_ref=instance.get_ref(), force_port=True, wait_on_exit=True
+    ) as server_process:
+        client = server_process.create_client()
+        assert client.heartbeat(echo="Hello")
 
-            port = server_process.port
-            ssl_yaml = f"""
-    load_from:
-    - grpc_server:
-        host: localhost
-        port: {port}
-        ssl: true
-    """
-            origins = location_origins_from_config(
-                yaml.safe_load(ssl_yaml),
-                # fake out as if it were loaded by a yaml file in this directory
-                file_relative_path(__file__, "not_a_real.yaml"),
-            )
-            origin = list(origins.values())[0]
-            assert origin.use_ssl
+        port = server_process.port
+        ssl_yaml = f"""
+load_from:
+- grpc_server:
+    host: localhost
+    port: {port}
+    ssl: true
+"""
+        origins = location_origins_from_config(
+            yaml.safe_load(ssl_yaml),
+            # fake out as if it were loaded by a yaml file in this directory
+            file_relative_path(__file__, "not_a_real.yaml"),
+        )
+        origin = list(origins.values())[0]
+        assert origin.use_ssl
 
-            # Actually connecting to the server will fail since it's expecting SSL
-            # and we didn't set up the server with SSL
-            try:
-                with origin.create_location():
-                    assert False
-            except DagsterUserCodeUnreachableError:
-                pass
-
-    finally:
-        server_process.wait()
+        # Actually connecting to the server will fail since it's expecting SSL
+        # and we didn't set up the server with SSL
+        try:
+            with origin.create_location():
+                assert False
+        except DagsterUserCodeUnreachableError:
+            pass
 
 
 def test_grpc_server_workspace(instance):
-    first_server_process = GrpcServerProcess(instance_ref=instance.get_ref(), force_port=True)
-    with first_server_process.create_ephemeral_client() as first_server:
-        second_server_process = GrpcServerProcess(instance_ref=instance.get_ref(), force_port=True)
-        with second_server_process.create_ephemeral_client() as second_server:
+    with GrpcServerProcess(
+        instance_ref=instance.get_ref(), force_port=True, wait_on_exit=True
+    ) as first_server_process:
+        first_server = first_server_process.create_client()
+        with GrpcServerProcess(
+            instance_ref=instance.get_ref(), force_port=True, wait_on_exit=True
+        ) as second_server_process:
+            second_server = second_server_process.create_client()
             first_port = first_server.port
             second_port = second_server.port
             workspace_yaml = """
@@ -197,8 +201,6 @@ load_from:
                 assert local_port_default_host.socket is None
 
                 assert all(map(lambda x: x.name, code_locations.values()))
-        second_server_process.wait()
-    first_server_process.wait()
 
 
 def test_cannot_set_socket_and_port():

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -67,23 +67,21 @@ def workspace_process_context_fixture(instance):
         executable_path=sys.executable,
         python_file=file_relative_path(__file__, "test_custom_repository_data.py"),
     )
-    server_process = GrpcServerProcess(
-        instance_ref=instance.get_ref(), loadable_target_origin=loadable_target_origin
-    )
-    try:
-        with server_process.create_ephemeral_client():  # shuts down when leaves this context
-            with WorkspaceProcessContext(
-                instance,
-                GrpcServerTarget(
-                    host="localhost",
-                    socket=server_process.socket,
-                    port=server_process.port,
-                    location_name="test",
-                ),
-            ) as workspace_process_context:
-                yield workspace_process_context
-    finally:
-        server_process.wait()
+    with GrpcServerProcess(
+        instance_ref=instance.get_ref(),
+        loadable_target_origin=loadable_target_origin,
+        wait_on_exit=True,
+    ) as server_process:
+        with WorkspaceProcessContext(
+            instance,
+            GrpcServerTarget(
+                host="localhost",
+                socket=server_process.socket,
+                port=server_process.port,
+                location_name="test",
+            ),
+        ) as workspace_process_context:
+            yield workspace_process_context
 
 
 def test_repository_data_can_reload_without_restarting(workspace_process_context):

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -61,7 +61,10 @@ def test_error_repo_in_registry(instance):
         ),
     )
     with GrpcServerRegistry(
-        instance=instance, reload_interval=5, heartbeat_ttl=10, startup_timeout=5
+        instance=instance,
+        reload_interval=5,
+        heartbeat_ttl=10,
+        startup_timeout=5,
     ) as registry:
         # Repository with a loading error does not raise an exception
         endpoint = registry.get_grpc_endpoint(error_origin)
@@ -101,7 +104,10 @@ def test_server_registry(instance):
     )
 
     with GrpcServerRegistry(
-        instance=instance, reload_interval=5, heartbeat_ttl=10, startup_timeout=5
+        instance=instance,
+        reload_interval=5,
+        heartbeat_ttl=10,
+        startup_timeout=5,
     ) as registry:
         endpoint_one = registry.get_grpc_endpoint(origin)
         endpoint_two = registry.get_grpc_endpoint(origin)
@@ -146,7 +152,6 @@ def test_server_registry(instance):
                 assert _can_connect(origin, endpoint_four)
                 break
 
-    registry.wait_for_processes()
     assert not _can_connect(origin, endpoint_three)
     assert not _can_connect(origin, endpoint_four)
 
@@ -166,7 +171,10 @@ def test_registry_multithreading(instance):
     )
 
     with GrpcServerRegistry(
-        instance=instance, reload_interval=300, heartbeat_ttl=600, startup_timeout=30
+        instance=instance,
+        reload_interval=300,
+        heartbeat_ttl=600,
+        startup_timeout=30,
     ) as registry:
         endpoint = registry.get_grpc_endpoint(origin)
 
@@ -189,7 +197,6 @@ def test_registry_multithreading(instance):
 
         assert _can_connect(origin, endpoint)
 
-    registry.wait_for_processes()
     assert not _can_connect(origin, endpoint)
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_health_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_health_check.py
@@ -15,16 +15,16 @@ def test_health_check_success():
             attribute="bar_repo",
             python_file=file_relative_path(__file__, "grpc_repo.py"),
         )
-        server = GrpcServerProcess(
+        with GrpcServerProcess(
             instance_ref=instance.get_ref(),
             loadable_target_origin=loadable_target_origin,
             max_workers=2,
             heartbeat=True,
             heartbeat_timeout=1,
-        )
-        with server.create_ephemeral_client() as client:
+            wait_on_exit=True,
+        ) as server:
+            client = server.create_client()
             assert client.health_check_query() == "SERVING"
-        server.wait()
 
 
 def test_health_check_fail():

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_heartbeat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_heartbeat.py
@@ -14,14 +14,15 @@ def test_heartbeat():
             attribute="bar_repo",
             python_file=file_relative_path(__file__, "grpc_repo.py"),
         )
-        server = GrpcServerProcess(
+        with GrpcServerProcess(
             instance_ref=instance.get_ref(),
             loadable_target_origin=loadable_target_origin,
             max_workers=2,
             heartbeat=True,
             heartbeat_timeout=1,
-        )
-        with server.create_ephemeral_client() as client:
+            wait_on_exit=True,
+        ) as server:
+            client = server.create_client()
             assert server.server_process.poll() is None
 
             # heartbeat keeps the server alive

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -28,12 +28,12 @@ def test_run_always_finishes():
             attribute="nope",
             python_file=file_relative_path(__file__, "test_default_run_launcher.py"),
         )
-        server_process = GrpcServerProcess(
+        with GrpcServerProcess(
             instance_ref=instance.get_ref(),
             loadable_target_origin=loadable_target_origin,
             max_workers=4,
-        )
-        with server_process.create_ephemeral_client():  # Shuts down when leaves context
+            wait_on_exit=False,
+        ) as server_process:
             with WorkspaceProcessContext(
                 instance,
                 GrpcServerTarget(
@@ -88,12 +88,12 @@ def test_run_from_pending_repository():
             attribute="pending",
             python_file=file_relative_path(__file__, "pending_repository.py"),
         )
-        server_process = GrpcServerProcess(
+        with GrpcServerProcess(
             instance_ref=instance.get_ref(),
             loadable_target_origin=loadable_target_origin,
             max_workers=4,
-        )
-        with server_process.create_ephemeral_client():  # Shuts down when leaves context
+            wait_on_exit=False,
+        ) as server_process:
             with WorkspaceProcessContext(
                 instance,
                 GrpcServerTarget(
@@ -258,14 +258,14 @@ def test_server_down():
             python_file=file_relative_path(__file__, "test_default_run_launcher.py"),
         )
 
-        server_process = GrpcServerProcess(
+        with GrpcServerProcess(
             instance_ref=instance.get_ref(),
             loadable_target_origin=loadable_target_origin,
             max_workers=4,
             force_port=True,
-        )
-
-        with server_process.create_ephemeral_client() as api_client:
+            wait_on_exit=True,
+        ) as server_process:
+            api_client = server_process.create_client()
             with WorkspaceProcessContext(
                 instance,
                 GrpcServerTarget(
@@ -316,5 +316,3 @@ def test_server_down():
                 )
 
                 assert launcher.terminate(pipeline_run.run_id)
-
-        server_process.wait()

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -7,6 +7,7 @@ download = True
 setenv =
   !windows: COVERAGE_ARGS =  --cov-append --cov-report term:skip-covered --cov-report html --cov-report xml
   windows: COVERAGE_ARGS =
+  STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE* DAGSTER_DOCKER_* GRPC_SERVER_HOST
 deps =
   scheduler_tests_old_pendulum: pendulum==1.4.4


### PR DESCRIPTION
Summary:
Some of the grpc flakiness we are seeing on upgrade seems to stem from lingering grpc subprocesses still running after their test is finished. We previously only spun these down for launched runs due to issues with filesystem contention - this PR takes a step beyond that and ensures that any grpc server process that is opened during a test is closed before that test ends.

## Summary & Motivation

## How I Tested These Changes
