### PR TITLE
[caching-refactor] Remove use of get_and_update_asset_status_cache.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -56,7 +56,6 @@ class CachingDataTimeResolver:
         beginning of that time window, or all data up until the end of the first filled time window
         in the total set, whichever is less.
         """
-
         # the total set of materialized partitions
         partition_subset = partitions_def.empty_subset().with_partition_keys(
             partition_key

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -45,8 +45,7 @@ class CachingDataTimeResolver:
         At a high level, this algorithm works as follows:
 
         First, calculate the subset of partitions that have been materialized up until this point
-        in time (ignoring the cursor). This is done by querying the asset status cache if it is
-        available, otherwise by using a (slower) get_materialization_count_by_partition query.
+        in time (ignoring the cursor). This is done using the get_materialized_partitions query,
 
         Next, we calculate the set of partitions that are net-new since the cursor. This is done by
         comparing the count of materializations before after the cursor to the total count of
@@ -57,30 +56,13 @@ class CachingDataTimeResolver:
         beginning of that time window, or all data up until the end of the first filled time window
         in the total set, whichever is less.
         """
-        from dagster._core.storage.partition_status_cache import (
-            get_and_update_asset_status_cache_value,
-        )
 
-        if self.instance_queryer.instance.can_cache_asset_status_data():
-            # this is the current state of the asset, not the state of the asset at the time of record_id
-            status_cache_value = get_and_update_asset_status_cache_value(
-                instance=self.instance_queryer.instance,
-                asset_key=asset_key,
-                partitions_def=partitions_def,
-            )
-            partition_subset = (
-                status_cache_value.deserialize_materialized_partition_subsets(
-                    partitions_def=partitions_def
-                )
-                if status_cache_value
-                else partitions_def.empty_subset()
-            )
-        else:
-            # if we can't use the asset status cache, then we get the subset by querying for the
-            # existing partitions
-            partition_subset = partitions_def.empty_subset().with_partition_keys(
-                self._instance_queryer.get_materialized_partitions(asset_key)
-            )
+        # the total set of materialized partitions
+        partition_subset = partitions_def.empty_subset().with_partition_keys(
+            partition_key
+            for partition_key in self._instance_queryer.get_materialized_partitions(asset_key)
+            if partitions_def.is_valid_partition_key(partition_key)
+        )
 
         if not isinstance(partition_subset, TimeWindowPartitionsSubset):
             check.failed(f"Invalid partition subset {type(partition_subset)}")

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -1,7 +1,6 @@
 import datetime
 from collections import defaultdict
 from typing import List, NamedTuple, Optional
-from dagster._core.definitions.data_time import CachingDataTimeResolver
 
 import mock
 import pendulum
@@ -19,6 +18,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_layer import build_asset_selection_job
+from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
 from dagster._core.event_api import EventRecordsFilter


### PR DESCRIPTION
## Summary & Motivation

Previously, we only attempted to use this in cases where this method was available, now we don't use it at all. Also updated the method to actually check which keys were valid.

The updated test wasn't running before because it was in a folder instead of a module. So it actually needed to be updated to pass as it was executing refactored functions.

## How I Tested These Changes
