### PR TITLE
[long-running runs] Move run canceling reporting into callsites of run termination

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -731,6 +731,8 @@ class TestRetryExecutionAsyncOnlyBehavior(ExecutingGraphQLContextTestMatrix):
         # Wait until the first step succeeded
         while instance.get_run_stats(run_id).steps_succeeded < 1:
             sleep(0.1)
+
+        instance.report_run_canceling(instance.get_run_by_id(run_id))
         # Terminate the current pipeline run at the second step
         graphql_context.instance.run_launcher.terminate(run_id)
 

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -167,7 +167,6 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
             )
             return False
 
-        self._instance.report_run_canceling(run)
         res = deserialize_value(
             client.cancel_execution(CancelExecutionRequest(run_id=run_id)), CancelExecutionResult
         )

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -53,7 +53,5 @@ class DefaultRunCoordinator(RunCoordinator, ConfigurableClass):
         run = self._instance.get_run_by_id(run_id)
         if run is None:
             check.failed(f"Failed to load run {run_id}")
-        self._instance.report_run_canceling(
-            run, message="Received cancellation request from default run coordinator"
-        )
+        self._instance.report_run_canceling(run, message="Received cancellation request.")
         return self._instance.run_launcher.terminate(run_id)

--- a/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/default_run_coordinator.py
@@ -50,4 +50,10 @@ class DefaultRunCoordinator(RunCoordinator, ConfigurableClass):
         return run
 
     def cancel_run(self, run_id: str) -> bool:
+        run = self._instance.get_run_by_id(run_id)
+        if run is None:
+            check.failed(f"Failed to load run {run_id}")
+        self._instance.report_run_canceling(
+            run, message="Received cancellation request from default run coordinator"
+        )
         return self._instance.run_launcher.terminate(run_id)

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -258,7 +258,5 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
             self._instance.report_run_canceled(run)
             return True
         else:
-            self._instance.report_run_canceling(
-                run, message="Received cancellation request from queued run coordinator."
-            )
+            self._instance.report_run_canceling(run, message="Received cancellation request.")
             return self._instance.run_launcher.terminate(run_id)

--- a/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/queued_run_coordinator.py
@@ -258,4 +258,7 @@ class QueuedRunCoordinator(RunCoordinator[T_DagsterInstance], ConfigurableClass)
             self._instance.report_run_canceled(run)
             return True
         else:
+            self._instance.report_run_canceling(
+                run, message="Received cancellation request from queued run coordinator."
+            )
             return self._instance.run_launcher.terminate(run_id)

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -431,6 +431,7 @@ def test_terminated_run(instance, workspace, run_config):
     poll_for_step_start(instance, run_id)
 
     launcher = instance.run_launcher
+    instance.report_run_canceling(pipeline_run)
     assert launcher.terminate(run_id)
 
     terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -269,7 +269,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         )
 
     # https://github.com/dagster-io/dagster/issues/2741
-    def can_terminate(self, run_id):
+    def _can_terminate(self, run_id):
         check.str_param(run_id, "run_id")
 
         pipeline_run = self._instance.get_run_by_id(run_id)
@@ -288,7 +288,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         if not run:
             return False
 
-        can_terminate = self.can_terminate(run_id)
+        can_terminate = self._can_terminate(run_id)
         if not can_terminate:
             self._instance.report_engine_event(
                 message="Unable to terminate dagster job: can_terminate returned {}.".format(

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -303,8 +303,6 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
 
         job_namespace = self.get_namespace_from_run_config(run_id)
 
-        self._instance.report_run_canceling(run)
-
         try:
             termination_result = self._api_client.delete_job(
                 job_name=job_name, namespace=job_namespace

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -276,7 +276,7 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
         if not pipeline_run:
             return False
 
-        if pipeline_run.status != DagsterRunStatus.STARTED:
+        if pipeline_run.status != DagsterRunStatus.CANCELING:
             return False
 
         return True

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -205,8 +205,6 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             )
             return False
 
-        self._instance.report_run_canceling(run)
-
         container.stop()
 
         return True

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -221,6 +221,7 @@ def test_terminate_launched_docker_run(aws_env):
 
             poll_for_step_start(instance, run_id)
 
+            instance.report_run_canceling(run)
             assert instance.run_launcher.terminate(run_id)
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -436,6 +436,7 @@ def _test_launch(
                             raise Exception("Timed out waiting for run to start")
 
                 launcher = instance.run_launcher
+                instance.report_run_canceling(run)
                 assert launcher.terminate(run.run_id)
 
                 poll_for_finished_run(instance, run.run_id, timeout=60)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -321,8 +321,6 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             )
             return False
 
-        self._instance.report_run_canceling(run)
-
         job_name = get_job_name_from_run_id(
             run_id, resume_attempt_number=self._instance.count_resume_run_attempts(run.run_id)
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -293,7 +293,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         self._launch_k8s_job_with_args(job_name, args, run)
 
     # https://github.com/dagster-io/dagster/issues/2741
-    def can_terminate(self, run_id):
+    def _can_terminate(self, run_id):
         check.str_param(run_id, "run_id")
 
         pipeline_run = self._instance.get_run_by_id(run_id)
@@ -312,7 +312,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
 
         container_context = self.get_container_context_for_run(run)
 
-        can_terminate = self.can_terminate(run_id)
+        can_terminate = self._can_terminate(run_id)
         if not can_terminate:
             self._instance.report_engine_event(
                 message=f"Unable to terminate run; can_terminate returned {can_terminate}",

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -299,7 +299,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         pipeline_run = self._instance.get_run_by_id(run_id)
         if not pipeline_run:
             return False
-        if pipeline_run.status != DagsterRunStatus.STARTED:
+        if pipeline_run.status != DagsterRunStatus.CANCELING:
             return False
         return True
 

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -90,6 +90,7 @@ def test_terminate_kills_subproc():
             time.sleep(0.5)
 
             launcher = instance.run_launcher
+            instance.report_run_canceling(pipeline_run)
             assert launcher.terminate(run_id)
 
             terminated_pipeline_run = poll_for_finished_run(instance, run_id, timeout=30)


### PR DESCRIPTION
Previously, it was up to the run launcher to report a run as canceling when terminated. This makes it technically possible to terminate a run without reporting it as canceled, if the run launcher implementation does not do so. Moving the cancelation reporting to the callsites makes this less likely, and easier to fix. 

One potentially controversial result of this change is that when `terminate` is called, we now expect the state of the run to already be `CANCELING`. So needed to change the implementation of `can_terminate`. `can_terminate` isn't on the base run launcher class, and is only used within the context of the `terminate` method of K8s and CeleryK8s run launchers, which seem reasonable.
