### PR TITLE
[refactor] Misc composition and config refactors/renames

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -551,11 +551,13 @@ class PendingNodeInvocation:
             " ".join([output_def.name for output_def in outputs]),
         )(**invoked_output_handles)
 
-    def describe_node(self):
+    def describe_node(self) -> str:
         node_name = self.given_alias if self.given_alias else self.node_def.name
         return f"{self.node_def.node_type_str} '{node_name}'"
 
-    def _process_argument_node(self, node_name, output_node, input_name, input_bindings, arg_desc):
+    def _process_argument_node(
+        self, node_name: str, output_node, input_name, input_bindings, arg_desc
+    ):
         from .source_asset import SourceAsset
 
         # already set - conflict between kwargs and args

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -363,8 +363,7 @@ class GraphDefinition(NodeDefinition):
         for node in self.node_dict.values():
             cur_node_handle = NodeHandle(node.name, parent_node_handle)
             if isinstance(node, GraphNode):
-                graph_def = node.definition.ensure_graph_def()
-                yield from graph_def.iterate_node_handles(cur_node_handle)
+                yield from node.definition.iterate_node_handles(cur_node_handle)
             yield cur_node_handle
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from .asset_layer import AssetLayer
     from .composition import PendingNodeInvocation
     from .dependency import NodeHandle, NodeInputHandle
-    from .graph_definition import GraphDefinition
     from .input import InputDefinition
     from .op_definition import OpDefinition
     from .output import OutputDefinition
@@ -199,72 +198,38 @@ class NodeDefinition(NamedConfigurableDefinition):
             yield output_def.dagster_type
             yield from output_def.dagster_type.inner_types
 
-    def __call__(self, *args: object, **kwargs: object) -> object:
+    def get_pending_invocation(
+        self,
+        given_alias: Optional[str] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        hook_defs: Optional[AbstractSet[HookDefinition]] = None,
+        retry_policy: Optional[RetryPolicy] = None,
+    ) -> "PendingNodeInvocation":
         from .composition import PendingNodeInvocation
 
         return PendingNodeInvocation(
             node_def=self,
-            given_alias=None,
-            tags=None,
-            hook_defs=None,
-            retry_policy=None,
-        )(*args, **kwargs)
-
-    def alias(self, name: str) -> "PendingNodeInvocation":
-        from .composition import PendingNodeInvocation
-
-        check.str_param(name, "name")
-
-        return PendingNodeInvocation(
-            node_def=self,
-            given_alias=name,
-            tags=None,
-            hook_defs=None,
-            retry_policy=None,
-        )
-
-    def tag(self, tags: Optional[Mapping[str, str]]) -> "PendingNodeInvocation":
-        from .composition import PendingNodeInvocation
-
-        return PendingNodeInvocation(
-            node_def=self,
-            given_alias=None,
-            tags=validate_tags(tags),
-            hook_defs=None,
-            retry_policy=None,
-        )
-
-    def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "PendingNodeInvocation":
-        from .composition import PendingNodeInvocation
-
-        hook_defs = frozenset(check.set_param(hook_defs, "hook_defs", of_type=HookDefinition))
-
-        return PendingNodeInvocation(
-            node_def=self,
-            given_alias=None,
-            tags=None,
+            given_alias=given_alias,
+            tags=validate_tags(tags) if tags else None,
             hook_defs=hook_defs,
-            retry_policy=None,
-        )
-
-    def with_retry_policy(self, retry_policy: RetryPolicy) -> "PendingNodeInvocation":
-        from .composition import PendingNodeInvocation
-
-        return PendingNodeInvocation(
-            node_def=self,
-            given_alias=None,
-            tags=None,
-            hook_defs=None,
             retry_policy=retry_policy,
         )
 
-    def ensure_graph_def(self) -> "GraphDefinition":
-        from .graph_definition import GraphDefinition
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return self.get_pending_invocation()(*args, **kwargs)
 
-        if isinstance(self, GraphDefinition):
-            return self
+    def alias(self, name: str) -> "PendingNodeInvocation":
+        return self.get_pending_invocation(given_alias=name)
 
-        check.failed(f"{self.name} is not a GraphDefinition")
+    def tag(self, tags: Optional[Mapping[str, str]]) -> "PendingNodeInvocation":
+        return self.get_pending_invocation(tags=tags)
+
+    def with_hooks(self, hook_defs: AbstractSet[HookDefinition]) -> "PendingNodeInvocation":
+        hook_defs = frozenset(check.set_param(hook_defs, "hook_defs", of_type=HookDefinition))
+        return self.get_pending_invocation(hook_defs=hook_defs)
+
+    def with_retry_policy(self, retry_policy: RetryPolicy) -> "PendingNodeInvocation":
+        return self.get_pending_invocation(retry_policy=retry_policy)
 
     def ensure_op_def(self) -> "OpDefinition":
         from .op_definition import OpDefinition

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -231,14 +231,6 @@ class NodeDefinition(NamedConfigurableDefinition):
     def with_retry_policy(self, retry_policy: RetryPolicy) -> "PendingNodeInvocation":
         return self.get_pending_invocation(retry_policy=retry_policy)
 
-    def ensure_op_def(self) -> "OpDefinition":
-        from .op_definition import OpDefinition
-
-        if isinstance(self, OpDefinition):
-            return self
-
-        check.failed(f"{self.name} is not an OpDefinition")
-
     @abstractmethod
     def get_inputs_must_be_resolved_top_level(
         self, asset_layer: "AssetLayer", handle: Optional["NodeHandle"] = None

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Mapping, Optional, TypeVar, Union, cast
 
 import dagster._check as check
 from dagster._core.errors import (
@@ -24,9 +24,11 @@ if TYPE_CHECKING:
     from .op_definition import OpDefinition
     from .output import OutputDefinition
 
+T = TypeVar("T")
+
 
 def op_invocation_result(
-    op_def_or_invocation: Union["OpDefinition", "PendingNodeInvocation"],
+    op_def_or_invocation: Union["OpDefinition", "PendingNodeInvocation[OpDefinition]"],
     context: Optional["UnboundOpExecutionContext"],
     *args,
     **kwargs,
@@ -37,7 +39,7 @@ def op_invocation_result(
     from .composition import PendingNodeInvocation
 
     op_def = (
-        op_def_or_invocation.node_def.ensure_op_def()
+        op_def_or_invocation.node_def
         if isinstance(op_def_or_invocation, PendingNodeInvocation)
         else op_def_or_invocation
     )
@@ -310,8 +312,8 @@ def _type_check_output_wrapper(
 
 
 def _type_check_function_output(
-    op_def: "OpDefinition", result: Any, context: "BoundOpExecutionContext"
-):
+    op_def: "OpDefinition", result: T, context: "BoundOpExecutionContext"
+) -> T:
     from ..execution.plan.compute_generator import validate_and_coerce_op_result_to_iterator
 
     output_defs_by_name = {output_def.name: output_def for output_def in op_def.output_defs}
@@ -321,8 +323,8 @@ def _type_check_function_output(
 
 
 def _type_check_output(
-    output_def: "OutputDefinition", output: Any, context: "BoundOpExecutionContext"
-) -> Any:
+    output_def: "OutputDefinition", output: T, context: "BoundOpExecutionContext"
+) -> T:
     """Validates and performs core type check on a provided output.
 
     Args:

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -794,7 +794,7 @@ def _iterate_all_nodes(root_node_dict: Mapping[str, Node]) -> Iterator[Node]:
     for node in root_node_dict.values():
         yield node
         if isinstance(node, GraphNode):
-            yield from _iterate_all_nodes(node.definition.ensure_graph_def().node_dict)
+            yield from _iterate_all_nodes(node.definition.node_dict)
 
 
 def _build_all_node_defs(node_defs: Sequence[NodeDefinition]) -> Mapping[str, NodeDefinition]:

--- a/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/pipeline_definition.py
@@ -43,6 +43,7 @@ from .dependency import (
     NodeHandle,
     NodeInvocation,
     NodeOutput,
+    OpNode,
 )
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
@@ -485,6 +486,13 @@ class PipelineDefinition:
     def get_solid(self, handle: NodeHandle) -> Node:
         return self._graph_def.get_node(handle)
 
+    def get_op(self, handle: NodeHandle) -> OpNode:
+        node = self.get_solid(handle)
+        assert isinstance(
+            node, OpNode
+        ), f"Tried to retrieve node {handle} as op, but it represents a nested graph."
+        return node
+
     def has_solid_named(self, name: str) -> bool:
         return self._graph_def.has_node_named(name)
 
@@ -859,12 +867,12 @@ def _create_run_config_schema(
     run_config_schema_type = define_run_config_schema_type(
         RunConfigSchemaCreationData(
             pipeline_name=pipeline_def.name,
-            solids=pipeline_def.graph.nodes,
+            nodes=pipeline_def.graph.nodes,
             graph_def=pipeline_def.graph,
             dependency_structure=pipeline_def.graph.dependency_structure,
             mode_definition=mode_definition,
             logger_defs=mode_definition.loggers,
-            ignored_solids=ignored_solids,
+            ignored_nodes=ignored_solids,
             required_resources=required_resources,
             is_using_graph_job_op_apis=pipeline_def.is_job,
             direct_inputs=get_direct_input_values_from_job(pipeline_def),

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -237,12 +237,12 @@ class UnboundOpExecutionContext(OpExecutionContext):
 
     def bind(
         self,
-        op_def_or_invocation: Union[OpDefinition, PendingNodeInvocation],
+        op_def_or_invocation: Union[OpDefinition, PendingNodeInvocation[OpDefinition]],
     ) -> "BoundOpExecutionContext":
         op_def = (
             op_def_or_invocation
             if isinstance(op_def_or_invocation, OpDefinition)
-            else op_def_or_invocation.node_def.ensure_op_def()
+            else op_def_or_invocation.node_def
         )
 
         _validate_resource_requirements(self._resource_defs, op_def)

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -1,13 +1,15 @@
-from typing import NamedTuple, Optional
+from typing import Callable, Iterator, Mapping, NamedTuple, NoReturn, cast
+
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._config import EvaluateValueResult, process_config
-from dagster._core.definitions.dependency import NodeHandle
-from dagster._core.definitions.graph_definition import GraphDefinition
-from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.asset_layer import AssetLayer
+from dagster._core.definitions.dependency import GraphNode, Node, NodeHandle, OpNode
+from dagster._core.definitions.graph_definition import GraphDefinition, SubselectedGraphDefinition
 from dagster._core.definitions.pipeline_definition import PipelineDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.definitions.run_config import define_solid_dictionary_cls
+from dagster._core.definitions.run_config import define_node_shape
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterInvalidConfigError,
@@ -16,82 +18,95 @@ from dagster._core.errors import (
 from dagster._core.system_config.objects import OpConfig
 from dagster._utils.merger import merge_dicts
 
+RawNodeConfig: TypeAlias = Mapping[str, object]
+
 
 class OpConfigEntry(
     NamedTuple("_SolidConfigEntry", [("handle", NodeHandle), ("solid_config", OpConfig)])
 ):
-    def __new__(cls, handle: NodeHandle, solid_config: OpConfig):
+    def __new__(cls, handle: NodeHandle, op_config: OpConfig):
         return super(OpConfigEntry, cls).__new__(
             cls,
             check.inst_param(handle, "handle", NodeHandle),
-            check.inst_param(solid_config, "solid_config", OpConfig),
+            check.inst_param(op_config, "solid_config", OpConfig),
         )
+
+
+# This is a dummy handle used to simplify the code, corresponding to the root container (graph). It
+# doesn't actually represent a node during execution.
+_ROOT_HANDLE = NodeHandle("root", None)
 
 
 class DescentStack(
-    NamedTuple(
-        "_DescentStack", [("pipeline_def", PipelineDefinition), ("handle", Optional[NodeHandle])]
-    )
+    NamedTuple("_DescentStack", [("pipeline_def", PipelineDefinition), ("handle", NodeHandle)])
 ):
-    def __new__(cls, pipeline_def: PipelineDefinition, handle: Optional[NodeHandle]):
+    def __new__(cls, pipeline_def: PipelineDefinition, handle: NodeHandle):
         return super(DescentStack, cls).__new__(
             cls,
             pipeline_def=check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition),
-            handle=check.opt_inst_param(handle, "handle", NodeHandle),
+            handle=check.inst_param(handle, "handle", NodeHandle),
         )
 
     @property
-    def current_container(self):
-        return self.current_solid.definition if self.handle else self.pipeline_def.graph
+    def current_container(self) -> GraphDefinition:
+        if self.handle == _ROOT_HANDLE:
+            return self.pipeline_def.graph
+        else:
+            assert isinstance(self.current_node, GraphNode)
+            return self.current_node.definition
 
     @property
-    def current_solid(self):
-        check.invariant(self.handle)
+    def current_node(self) -> Node:
+        assert self.handle is not None
         return self.pipeline_def.get_solid(self.handle)
 
     @property
-    def current_handle_str(self):
+    def current_handle_str(self) -> str:
         return check.not_none(self.handle).to_string()
 
-    def descend(self, solid):
-        return self._replace(handle=NodeHandle(solid.name, parent=self.handle))
+    def descend(self, node: Node) -> "DescentStack":
+        parent = self.handle if self.handle != _ROOT_HANDLE else None
+        return self._replace(handle=NodeHandle(node.name, parent=parent))
 
 
-def composite_descent(pipeline_def, solids_config, resource_defs):
-    """This function is responsible for constructing the dictionary
-    of SolidConfig (indexed by handle) that will be passed into the
-    ResolvedRunConfig. Critically this is the codepath that manages config mapping,
-    where the runtime calls into user-defined config mapping functions to
-    produce config for child solids of composites.
+def composite_descent(
+    pipeline_def: PipelineDefinition,
+    ops_config: Mapping[str, RawNodeConfig],
+    resource_defs: Mapping[str, ResourceDefinition],
+) -> Mapping[str, OpConfig]:
+    """This function is responsible for constructing the dictionary of OpConfig (indexed by handle)
+    that will be passed into the ResolvedRunConfig. Critically this is the codepath that manages
+    config mapping, where the runtime calls into user-defined config mapping functions to produce
+    config for child solids of composites.
 
     Args:
         pipeline_def (PipelineDefinition): PipelineDefinition
-        solids_config (dict): Configuration for the solids in the pipeline. The "solids" entry
+        ops_config (dict): Configuration for the ops in the pipeline. The "ops" entry
             of the run_config. Assumed to have already been validated.
 
     Returns:
-        Dict[str, SolidConfig]: A dictionary mapping string representations of NodeHandles to
-            SolidConfig objects. It includes an entry for solids at every level of the
-            composite tree - i.e. not just leaf solids, but composite solids as well
+        Dict[str, OpConfig]: A dictionary mapping string representations of NodeHandles to
+            OpConfig objects. It includes an entry for ops at every level of the
+            composite tree - i.e. not just leaf ops, but composite ops as well
     """
     check.inst_param(pipeline_def, "pipeline_def", PipelineDefinition)
-    check.dict_param(solids_config, "solids_config")
+    check.dict_param(ops_config, "solids_config")
     check.dict_param(resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition)
 
     # If top-level graph has config mapping, apply that config mapping before descending.
     if pipeline_def.graph.has_config_mapping:
-        solids_config = _apply_top_level_config_mapping(
+        ops_config = _apply_top_level_config_mapping(
             pipeline_def,
-            solids_config,
+            ops_config,
             resource_defs,
             pipeline_def.is_job,
         )
 
     return {
-        handle.to_string(): solid_config
-        for handle, solid_config in _composite_descent(
-            parent_stack=DescentStack(pipeline_def, None),
-            solids_config_dict=solids_config,
+        handle.to_string(): op_config
+        for handle, op_config in _composite_descent(
+            parent_stack=DescentStack(pipeline_def, _ROOT_HANDLE),
+            ops_config_dict=ops_config,
             resource_defs=resource_defs,
             is_using_graph_job_op_apis=pipeline_def.is_job,
             asset_layer=pipeline_def.asset_layer,
@@ -100,86 +115,92 @@ def composite_descent(pipeline_def, solids_config, resource_defs):
 
 
 def _composite_descent(
-    parent_stack, solids_config_dict, resource_defs, is_using_graph_job_op_apis, asset_layer
-):
-    """The core implementation of composite_descent. This yields a stream of
-    SolidConfigEntry. This is used by composite_descent to construct a
-    dictionary.
+    parent_stack: DescentStack,
+    ops_config_dict: Mapping[str, RawNodeConfig],
+    resource_defs: Mapping[str, ResourceDefinition],
+    is_using_graph_job_op_apis: bool,
+    asset_layer: AssetLayer,
+) -> Iterator[OpConfigEntry]:
+    """The core implementation of composite_descent. This yields a stream of OpConfigEntry. This is
+    used by composite_descent to construct a dictionary.
 
-    It descends over the entire solid hierarchy, constructing an entry
-    for every handle. If it encounters a composite solid instance
-    with a config mapping, it will invoke that config mapping fn,
-    producing the config that is necessary to configure the child solids.
+    It descends over the entire node hierarchy, constructing an entry for every handle. If it
+    encounters a graph instance with a config mapping, it will invoke that config mapping fn,
+    producing the config that is necessary to configure the child nodes.
 
     This process unrolls recursively as you descend down the tree.
     """
-    for solid in parent_stack.current_container.nodes:
-        current_stack = parent_stack.descend(solid)
+    for node in parent_stack.current_container.nodes:
+        current_stack = parent_stack.descend(node)
         current_handle = current_stack.handle
 
-        current_solid_config = solids_config_dict.get(solid.name, {})
+        current_op_config = ops_config_dict.get(node.name, {})
 
         # the base case
-        if isinstance(solid.definition, OpDefinition):
-            config_mapped_solid_config = solid.definition.apply_config_mapping(
-                {"config": current_solid_config.get("config")}
+        if isinstance(node, OpNode):
+            config_mapped_node_config = node.definition.apply_config_mapping(
+                {"config": current_op_config.get("config")}
             )
-            if not config_mapped_solid_config.success:
+            if not config_mapped_node_config.success:
                 raise DagsterInvalidConfigError(
-                    f"Error in config for {solid.describe_node()}".format(solid.name),
-                    config_mapped_solid_config.errors,
-                    config_mapped_solid_config,
+                    f"Error in config for {node.describe_node()}".format(node.name),
+                    config_mapped_node_config.errors,
+                    config_mapped_node_config,
                 )
 
             complete_config_object = merge_dicts(
-                current_solid_config, config_mapped_solid_config.value
+                current_op_config, config_mapped_node_config.value  # type: ignore  # (unknown EVR type)
             )
             yield OpConfigEntry(current_handle, OpConfig.from_dict(complete_config_object))
             continue
 
-        graph_def = check.inst(solid.definition, GraphDefinition)
+        elif isinstance(node, GraphNode):
+            yield OpConfigEntry(
+                current_handle,
+                OpConfig.from_dict(
+                    {
+                        "inputs": current_op_config.get("inputs"),
+                        "outputs": current_op_config.get("outputs"),
+                    }
+                ),
+            )
+            node_key = "ops" if is_using_graph_job_op_apis else "solids"
 
-        yield OpConfigEntry(
-            current_handle,
-            OpConfig.from_dict(
-                {
-                    "inputs": current_solid_config.get("inputs"),
-                    "outputs": current_solid_config.get("outputs"),
-                }
-            ),
-        )
-        node_key = "ops" if is_using_graph_job_op_apis else "solids"
+            # If there is a config mapping, invoke it and get the descendent solids
+            # config that way. Else just grabs the solids entry of the current config
+            mapped_nodes_config = (
+                _apply_config_mapping(
+                    node,
+                    current_stack,
+                    current_op_config,
+                    resource_defs,
+                    is_using_graph_job_op_apis,
+                    asset_layer,
+                )
+                if node.definition.has_config_mapping
+                else cast(Mapping[str, RawNodeConfig], current_op_config.get(node_key, {}))
+            )
 
-        # If there is a config mapping, invoke it and get the descendent solids
-        # config that way. Else just grabs the solids entry of the current config
-        solids_dict = (
-            _get_mapped_solids_dict(
-                solid,
-                graph_def,
+            yield from _composite_descent(
                 current_stack,
-                current_solid_config,
+                mapped_nodes_config,
                 resource_defs,
                 is_using_graph_job_op_apis,
                 asset_layer,
             )
-            if graph_def.has_config_mapping
-            else current_solid_config.get(node_key, {})
-        )
-
-        yield from _composite_descent(
-            current_stack, solids_dict, resource_defs, is_using_graph_job_op_apis, asset_layer
-        )
+        else:
+            check.failed(f"Unexpected node type {type(node)}")
 
 
 def _apply_top_level_config_mapping(
-    pipeline_def,
-    outer_config,
-    resource_defs,
-    is_using_graph_job_op_apis,
-):
+    pipeline_def: PipelineDefinition,
+    outer_config: Mapping[str, Mapping[str, object]],
+    resource_defs: Mapping[str, ResourceDefinition],
+    is_using_graph_job_op_apis: bool,
+) -> Mapping[str, RawNodeConfig]:
     graph_def = pipeline_def.graph
-
-    if not graph_def.has_config_mapping:
+    config_mapping = graph_def.config_mapping
+    if config_mapping is None:
         return outer_config
 
     else:
@@ -194,16 +215,16 @@ def _apply_top_level_config_mapping(
         with user_code_error_boundary(
             DagsterConfigMappingFunctionError, _get_top_level_error_lambda(pipeline_def)
         ):
-            mapped_graph_config = graph_def.config_mapping.resolve_from_validated_config(
-                mapped_config_evr.value.get("config", {})
+            mapped_graph_config = config_mapping.resolve_from_validated_config(
+                mapped_config_evr.value.get("config", {})  # type: ignore  # (possible none)
             )
 
         # Dynamically construct the type that the output of the config mapping function will
         # be evaluated against
 
-        type_to_evaluate_against = define_solid_dictionary_cls(
-            solids=graph_def.nodes,
-            ignored_solids=None,
+        type_to_evaluate_against = define_node_shape(
+            nodes=graph_def.nodes,
+            ignored_nodes=None,
             dependency_structure=graph_def.dependency_structure,
             resource_defs=resource_defs,
             is_using_graph_job_op_apis=is_using_graph_job_op_apis,
@@ -218,18 +239,17 @@ def _apply_top_level_config_mapping(
         if not evr.success:
             raise_top_level_config_error(pipeline_def, mapped_graph_config, evr)
 
-        return evr.value
+        return evr.value  # type: ignore  # (unknown evr type)
 
 
-def _get_mapped_solids_dict(
-    composite,
-    graph_def,
-    current_stack,
-    current_solid_config,
-    resource_defs,
-    is_using_graph_job_op_apis,
-    asset_layer,
-):
+def _apply_config_mapping(
+    graph_node: GraphNode,
+    current_stack: DescentStack,
+    current_node_config: RawNodeConfig,
+    resource_defs: Mapping[str, ResourceDefinition],
+    is_using_graph_job_op_apis: bool,
+    asset_layer: AssetLayer,
+) -> Mapping[str, RawNodeConfig]:
     # the spec of the config mapping function is that it takes the dictionary at:
     # solid_name:
     #    config: {dict_passed_to_user}
@@ -243,19 +263,21 @@ def _get_mapped_solids_dict(
 
     # apply @configured config mapping to the composite's incoming config before we get to the
     # composite's own config mapping process
-    config_mapped_solid_config = graph_def.apply_config_mapping(current_solid_config)
-    if not config_mapped_solid_config.success:
+    graph_def = graph_node.definition
+    config_mapped_node_config = graph_def.apply_config_mapping(current_node_config)
+    if not config_mapped_node_config.success:
         raise DagsterInvalidConfigError(
-            f"Error in config for composite solid {composite.name}",
-            config_mapped_solid_config.errors,
-            config_mapped_solid_config,
+            f"Error in config for graph {graph_node.name}",
+            config_mapped_node_config.errors,
+            config_mapped_node_config,
         )
 
     with user_code_error_boundary(
         DagsterConfigMappingFunctionError, _get_error_lambda(current_stack)
     ):
-        mapped_solids_config = graph_def.config_mapping.resolve_from_validated_config(
-            config_mapped_solid_config.value.get("config", {})
+        config_mapping = check.not_none(graph_def.config_mapping)
+        mapped_solids_config = config_mapping.resolve_from_validated_config(
+            config_mapped_node_config.value.get("config", {})  # type: ignore  # (unknown EVR type)
         )
 
     # Dynamically construct the type that the output of the config mapping function will
@@ -263,11 +285,15 @@ def _get_mapped_solids_dict(
 
     # diff original graph and the subselected graph to find nodes to ignore so the system knows to
     # skip the validation then when config mapping generates values where the nodes are not selected
-    ignored_solids = graph_def.get_top_level_omitted_nodes() if graph_def.is_subselected else None
+    ignored_solids = (
+        graph_def.get_top_level_omitted_nodes()
+        if isinstance(graph_def, SubselectedGraphDefinition)
+        else None
+    )
 
-    type_to_evaluate_against = define_solid_dictionary_cls(
-        solids=graph_def.nodes,
-        ignored_solids=ignored_solids,
+    type_to_evaluate_against = define_node_shape(
+        nodes=graph_def.nodes,
+        ignored_nodes=ignored_solids,
         dependency_structure=graph_def.dependency_structure,
         parent_handle=current_stack.handle,
         resource_defs=resource_defs,
@@ -283,28 +309,30 @@ def _get_mapped_solids_dict(
     if not evr.success:
         raise_composite_descent_config_error(current_stack, mapped_solids_config, evr)
 
-    return evr.value
+    return evr.value  # type: ignore  # (unknown evr type)
 
 
-def _get_error_lambda(current_stack):
+def _get_error_lambda(current_stack: DescentStack) -> Callable[[], str]:
     return lambda: (
         "The config mapping function on {described_node} in {described_target} "
         "has thrown an unexpected error during its execution. The definition is "
         'instantiated at stack "{stack_str}".'
     ).format(
-        described_node=current_stack.current_solid.describe_node(),
+        described_node=current_stack.current_node.describe_node(),
         described_target=current_stack.pipeline_def.describe_target(),
         stack_str=":".join(current_stack.handle.path),
     )
 
 
-def _get_top_level_error_lambda(pipeline_def):
+def _get_top_level_error_lambda(pipeline_def: PipelineDefinition) -> Callable[[], str]:
     return (
         lambda: f"The config mapping function on top-level graph {pipeline_def.graph.name} in job {pipeline_def.name} has thrown an unexpected error during its execution."
     )
 
 
-def raise_top_level_config_error(pipeline_def, failed_config_value, evr):
+def raise_top_level_config_error(
+    pipeline_def: PipelineDefinition, failed_config_value: object, evr: EvaluateValueResult
+) -> NoReturn:
     message = (
         f"In pipeline '{pipeline_def.name}', top level graph '{pipeline_def.graph.name}' has a "
         "configuration error."
@@ -313,11 +341,13 @@ def raise_top_level_config_error(pipeline_def, failed_config_value, evr):
     raise DagsterInvalidConfigError(message, evr.errors, failed_config_value)
 
 
-def raise_composite_descent_config_error(descent_stack, failed_config_value, evr):
+def raise_composite_descent_config_error(
+    descent_stack: DescentStack, failed_config_value: object, evr: EvaluateValueResult
+) -> NoReturn:
     check.inst_param(descent_stack, "descent_stack", DescentStack)
     check.inst_param(evr, "evr", EvaluateValueResult)
 
-    solid = descent_stack.current_solid
+    solid = descent_stack.current_node
     message = "In pipeline {pipeline_name} at stack {stack}: \n".format(
         pipeline_name=descent_stack.pipeline_def.name,
         stack=":".join(descent_stack.handle.path),

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -20,7 +20,7 @@ from dagster._config import ConfigTypeKind, process_config
 from dagster._core.definitions import create_run_config_schema
 from dagster._core.definitions.run_config import (
     RunConfigSchemaCreationData,
-    define_solid_dictionary_cls,
+    define_node_shape,
 )
 from dagster._core.system_config.objects import OpConfig, ResolvedRunConfig, ResourceConfig
 from dagster._loggers import default_loggers
@@ -33,7 +33,7 @@ def create_creation_data(job_def):
         job_def.dependency_structure,
         job_def.mode_definition,
         logger_defs=default_loggers(),
-        ignored_solids=[],
+        ignored_nodes=[],
         required_resources=set(),
         is_using_graph_job_op_apis=job_def.is_job,
         direct_inputs=job_def._input_values if job_def.is_job else {},  # noqa: SLF001
@@ -274,9 +274,9 @@ def test_whole_environment():
 
 def test_solid_config_error():
     job_def = define_test_solids_config_pipeline()
-    solid_dict_type = define_solid_dictionary_cls(
-        solids=job_def.solids,
-        ignored_solids=None,
+    solid_dict_type = define_node_shape(
+        nodes=job_def.solids,
+        ignored_nodes=None,
         dependency_structure=job_def.dependency_structure,
         parent_handle=None,
         resource_defs={},

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/repo.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/repo.py
@@ -3,13 +3,13 @@ import dagster._legacy as legacy
 
 
 @dagster.op
-def solid(_):
+def node(_):
     pass
 
 
 @legacy.pipeline
 def pipeline():
-    solid()
+    node()
 
 
 @dagster.repository


### PR DESCRIPTION
## Summary & Motivation

Type annotations and some light refactoring/fixing of type errors related to composition and config.

- Make `PendingNodeInvocation` generic in `node_def`
- Eliminate `ensure_graph_def` and `ensure_node_def` (these functions are fulfilled by previously added `Node` subclasses `OpNode` and `GraphNode` coupled with generic `PendingNodeInvocation`)
- Condense some logic used to generate modified `PendingNodeInvocation` in `NodeDefinition`.
- Type annotations for many composition-related functions
- Type annotations for config-mapping/composite-descent functions
- Light refactor some composite descent logic to fix surfaced type errors (use dummy root `NodeHandle`)
- Local variable/arg renames (solid -> op/node/graph) throughout composition and composite descent code

## How I Tested These Changes

Existing test suite
