### PR TITLE
[typing/runtime] dagster-graphql implementation layer

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -620,7 +620,7 @@ type Asset {
   id: String!
   key: AssetKey!
   assetMaterializations(
-    partitions: [String]
+    partitions: [String!]
     partitionInLast: Int
     beforeTimestampMillis: String
     afterTimestampMillis: String
@@ -628,7 +628,7 @@ type Asset {
     tags: [InputTag!]
   ): [MaterializationEvent!]!
   assetObservations(
-    partitions: [String]
+    partitions: [String!]
     partitionInLast: Int
     beforeTimestampMillis: String
     afterTimestampMillis: String
@@ -640,13 +640,13 @@ type Asset {
 type AssetNode {
   assetKey: AssetKey!
   assetMaterializations(
-    partitions: [String]
+    partitions: [String!]
     beforeTimestampMillis: String
     limit: Int
   ): [MaterializationEvent!]!
   assetMaterializationUsedData(timestampMillis: String!): [MaterializationUpstreamDataVersion!]!
   assetObservations(
-    partitions: [String]
+    partitions: [String!]
     beforeTimestampMillis: String
     limit: Int
   ): [ObservationEvent!]!
@@ -668,7 +668,7 @@ type AssetNode {
   isSource: Boolean!
   jobNames: [String!]!
   jobs: [Pipeline!]!
-  latestMaterializationByPartition(partitions: [String]): [MaterializationEvent]!
+  latestMaterializationByPartition(partitions: [String!]): [MaterializationEvent]!
   latestRunForPartition(partition: String!): Run
   assetPartitionStatuses: AssetPartitionStatuses!
   partitionStats: PartitionStats

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -93,7 +93,7 @@ export type AssetAssetMaterializationsArgs = {
   beforeTimestampMillis?: InputMaybe<Scalars['String']>;
   limit?: InputMaybe<Scalars['Int']>;
   partitionInLast?: InputMaybe<Scalars['Int']>;
-  partitions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  partitions?: InputMaybe<Array<Scalars['String']>>;
   tags?: InputMaybe<Array<InputTag>>;
 };
 
@@ -102,7 +102,7 @@ export type AssetAssetObservationsArgs = {
   beforeTimestampMillis?: InputMaybe<Scalars['String']>;
   limit?: InputMaybe<Scalars['Int']>;
   partitionInLast?: InputMaybe<Scalars['Int']>;
-  partitions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AssetConnection = {
@@ -231,17 +231,17 @@ export type AssetNodeAssetMaterializationUsedDataArgs = {
 export type AssetNodeAssetMaterializationsArgs = {
   beforeTimestampMillis?: InputMaybe<Scalars['String']>;
   limit?: InputMaybe<Scalars['Int']>;
-  partitions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AssetNodeAssetObservationsArgs = {
   beforeTimestampMillis?: InputMaybe<Scalars['String']>;
   limit?: InputMaybe<Scalars['Int']>;
-  partitions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AssetNodeLatestMaterializationByPartitionArgs = {
-  partitions?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AssetNodeLatestRunForPartitionArgs = {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -1,30 +1,38 @@
-from typing import TYPE_CHECKING, Any, List, Mapping, Union, cast
+from typing import TYPE_CHECKING, List, Union, cast
 
 import dagster._check as check
 import pendulum
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.selector import RepositorySelector
-from dagster._core.errors import DagsterError
+from dagster._core.errors import DagsterError, DagsterUserCodeProcessError
 from dagster._core.events import AssetKey
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import submit_backfill_runs
+from dagster._core.host_representation.external_data import ExternalPartitionExecutionErrorData
 from dagster._core.utils import make_new_backfill_id
 from dagster._core.workspace.permissions import Permissions
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-from ..utils import assert_permission, assert_permission_for_location, capture_error
+from ..utils import BackfillParams, assert_permission, assert_permission_for_location, capture_error
 
 BACKFILL_CHUNK_SIZE = 25
 
 
 if TYPE_CHECKING:
-    from ...schema.backfill import GrapheneLaunchBackfillSuccess
+    from dagster_graphql.schema.util import ResolveInfo
+
+    from ...schema.backfill import (
+        GrapheneCancelBackfillSuccess,
+        GrapheneLaunchBackfillSuccess,
+        GrapheneResumeBackfillSuccess,
+    )
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
 
 @capture_error
 def create_and_launch_partition_backfill(
-    graphene_info, backfill_params: Mapping[str, Any]
+    graphene_info: "ResolveInfo",
+    backfill_params: BackfillParams,
 ) -> Union["GrapheneLaunchBackfillSuccess", "GraphenePartitionSetNotFoundError"]:
     from ...schema.backfill import GrapheneLaunchBackfillSuccess
     from ...schema.errors import GraphenePartitionSetNotFoundError
@@ -74,6 +82,8 @@ def create_and_launch_partition_backfill(
             result = graphene_info.context.get_external_partition_names(
                 external_partition_set, instance=graphene_info.context.instance
             )
+            if isinstance(result, ExternalPartitionExecutionErrorData):
+                raise DagsterUserCodeProcessError.from_error_info(result.error)
             partition_names = result.partition_names
         elif backfill_params.get("partitionNames"):
             partition_names = backfill_params["partitionNames"]
@@ -165,14 +175,17 @@ def create_and_launch_partition_backfill(
 
 
 @capture_error
-def cancel_partition_backfill(graphene_info, backfill_id):
+def cancel_partition_backfill(
+    graphene_info: "ResolveInfo", backfill_id: str
+) -> "GrapheneCancelBackfillSuccess":
     from ...schema.backfill import GrapheneCancelBackfillSuccess
 
     backfill = graphene_info.context.instance.get_backfill(backfill_id)
     if not backfill:
         check.failed(f"No backfill found for id: {backfill_id}")
 
-    location_name = backfill.partition_set_origin.selector.location_name
+    partition_set_origin = check.not_none(backfill.partition_set_origin)
+    location_name = partition_set_origin.selector.location_name
     assert_permission_for_location(
         graphene_info, Permissions.CANCEL_PARTITION_BACKFILL, location_name
     )
@@ -182,14 +195,17 @@ def cancel_partition_backfill(graphene_info, backfill_id):
 
 
 @capture_error
-def resume_partition_backfill(graphene_info, backfill_id):
+def resume_partition_backfill(
+    graphene_info: "ResolveInfo", backfill_id: str
+) -> "GrapheneResumeBackfillSuccess":
     from ...schema.backfill import GrapheneResumeBackfillSuccess
 
     backfill = graphene_info.context.instance.get_backfill(backfill_id)
     if not backfill:
         check.failed(f"No backfill found for id: {backfill_id}")
 
-    location_name = backfill.partition_set_origin.selector.location_name
+    partition_set_origin = check.not_none(backfill.partition_set_origin)
+    location_name = partition_set_origin.selector.location_name
     assert_permission_for_location(
         graphene_info, Permissions.LAUNCH_PARTITION_BACKFILL, location_name
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -58,7 +58,7 @@ def do_launch(
 
 
 def _launch_pipeline_execution(
-    graphene_info, execution_params: ExecutionParams, is_reexecuted: bool = False
+    graphene_info: "ResolveInfo", execution_params: ExecutionParams, is_reexecuted: bool = False
 ) -> "GrapheneLaunchRunSuccess":
     from ...schema.pipelines.pipeline import GrapheneRun
     from ...schema.runs import GrapheneLaunchRunSuccess

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -51,7 +51,7 @@ def compute_step_keys_to_execute(
         return execution_params.step_keys, known_state
 
 
-def is_resume_retry(execution_params):
+def is_resume_retry(execution_params: ExecutionParams) -> bool:
     check.inst_param(execution_params, "execution_params", ExecutionParams)
     return execution_params.execution_metadata.tags.get(RESUME_RETRY_TAG) == "true"
 
@@ -60,7 +60,7 @@ def create_valid_pipeline_run(
     graphene_info: "ResolveInfo",
     external_pipeline: ExternalPipeline,
     execution_params: ExecutionParams,
-):
+) -> DagsterRun:
     from ...schema.errors import GrapheneNoModeProvidedError
 
     mode: Optional[str]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
@@ -1,16 +1,35 @@
+from typing import TYPE_CHECKING, Optional
+
+import dagster._check as check
+from dagster._core.execution.backfill import BulkActionStatus
+
 from .utils import capture_error
+
+if TYPE_CHECKING:
+    from dagster_graphql.schema.util import ResolveInfo
+
+    from ..schema.backfill import (
+        GraphenePartitionBackfill,
+        GraphenePartitionBackfills,
+    )
 
 
 @capture_error
-def get_backfill(graphene_info, backfill_id):
+def get_backfill(graphene_info: "ResolveInfo", backfill_id: str) -> "GraphenePartitionBackfill":
     from ..schema.backfill import GraphenePartitionBackfill
 
-    backfill_job = graphene_info.context.instance.get_backfill(backfill_id)
+    # get_backfill can return None but this resolver assumes that the backfill exists
+    backfill_job = check.not_none(graphene_info.context.instance.get_backfill(backfill_id))
     return GraphenePartitionBackfill(backfill_job)
 
 
 @capture_error
-def get_backfills(graphene_info, status=None, cursor=None, limit=None):
+def get_backfills(
+    graphene_info: "ResolveInfo",
+    status: Optional[BulkActionStatus] = None,
+    cursor: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> "GraphenePartitionBackfills":
     from ..schema.backfill import GraphenePartitionBackfill, GraphenePartitionBackfills
 
     backfills = graphene_info.context.instance.get_backfills(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import dagster._check as check
 from dagster._core.definitions.instigation_logger import get_instigation_log_records
@@ -13,9 +13,18 @@ from .utils import capture_error
 if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
+    from ..schema.instigation import (
+        GrapheneInstigationEventConnection,
+        GrapheneInstigationState,
+        GrapheneInstigationStateNotFoundError,
+        GrapheneInstigationStates,
+    )
+
 
 @capture_error
-def get_unloadable_instigator_states_or_error(graphene_info: "ResolveInfo", instigator_type=None):
+def get_unloadable_instigator_states_or_error(
+    graphene_info: "ResolveInfo", instigator_type: Optional[InstigatorType] = None
+) -> "GrapheneInstigationStates":
     from ..schema.instigation import GrapheneInstigationState, GrapheneInstigationStates
 
     check.opt_inst_param(instigator_type, "instigator_type", InstigatorType)
@@ -48,7 +57,9 @@ def get_unloadable_instigator_states_or_error(graphene_info: "ResolveInfo", inst
 
 
 @capture_error
-def get_instigator_state_or_error(graphene_info, selector):
+def get_instigator_state_or_error(
+    graphene_info: "ResolveInfo", selector: InstigatorSelector
+) -> Union["GrapheneInstigationState", "GrapheneInstigationStateNotFoundError"]:
     from ..schema.instigation import GrapheneInstigationState, GrapheneInstigationStateNotFoundError
 
     check.inst_param(selector, "selector", InstigatorSelector)
@@ -75,7 +86,7 @@ def get_instigator_state_or_error(graphene_info, selector):
     return GrapheneInstigationState(current_state)
 
 
-def get_tick_log_events(graphene_info, tick):
+def get_tick_log_events(graphene_info: "ResolveInfo", tick) -> "GrapheneInstigationEventConnection":
     from ..schema.instigation import GrapheneInstigationEvent, GrapheneInstigationEventConnection
     from ..schema.logs.log_level import GrapheneLogLevel
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_logs.py
@@ -1,11 +1,16 @@
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 
 from dagster_graphql.schema.util import ResolveInfo
 
+if TYPE_CHECKING:
+    from ..schema.logs.compute_logs import GrapheneCapturedLogsMetadata
 
-def get_captured_log_metadata(graphene_info: ResolveInfo, log_key: Sequence[str]):
+
+def get_captured_log_metadata(
+    graphene_info: ResolveInfo, log_key: Sequence[str]
+) -> "GrapheneCapturedLogsMetadata":
     from ..schema.logs.compute_logs import GrapheneCapturedLogsMetadata
 
     if not isinstance(graphene_info.context.instance.compute_log_manager, CapturedLogManager):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @capture_error
 def get_top_level_resources_or_error(
-    graphene_info, repository_selector: RepositorySelector
+    graphene_info: "ResolveInfo", repository_selector: RepositorySelector
 ) -> "GrapheneResourceDetailsList":
     from ..schema.resources import GrapheneResourceDetails, GrapheneResourceDetailsList
 
@@ -41,7 +41,7 @@ def get_top_level_resources_or_error(
 
 @capture_error
 def get_resource_or_error(
-    graphene_info, resource_selector: ResourceSelector
+    graphene_info: "ResolveInfo", resource_selector: ResourceSelector
 ) -> "GrapheneResourceDetails":
     from ..schema.errors import GrapheneResourceNotFoundError
     from ..schema.resources import GrapheneResourceDetails

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -428,7 +428,7 @@ class CrossRepoAssetDependedByLoader:
 
     def get_cross_repo_dependent_assets(
         self, repository_location_name: str, repository_name: str, asset_key: AssetKey
-    ) -> List[ExternalAssetDependedBy]:
+    ) -> Sequence[ExternalAssetDependedBy]:
         _, external_asset_deps = self._build_cross_repo_deps()
         return external_asset_deps.get((repository_location_name, repository_name), {}).get(
             asset_key, []

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Mapping, Optional
+
 import dagster._check as check
 from dagster._config import validate_config_from_snap
 from dagster._core.host_representation import RepresentedPipeline
@@ -7,9 +9,17 @@ from dagster_graphql.schema.util import ResolveInfo
 from .external import get_external_pipeline_or_raise
 from .utils import PipelineSelector, UserFacingGraphQLError, capture_error
 
+if TYPE_CHECKING:
+    from ..schema.pipelines.config import (
+        GraphenePipelineConfigValidationValid,
+    )
+    from ..schema.run_config import GrapheneRunConfigSchema
+
 
 @capture_error
-def resolve_run_config_schema_or_error(graphene_info: ResolveInfo, selector, mode):
+def resolve_run_config_schema_or_error(
+    graphene_info: ResolveInfo, selector: PipelineSelector, mode: Optional[str]
+) -> "GrapheneRunConfigSchema":
     from ..schema.errors import GrapheneModeNotFoundError
     from ..schema.run_config import GrapheneRunConfigSchema
 
@@ -31,7 +41,12 @@ def resolve_run_config_schema_or_error(graphene_info: ResolveInfo, selector, mod
 
 
 @capture_error
-def resolve_is_run_config_valid(graphene_info: ResolveInfo, represented_pipeline, mode, run_config):
+def resolve_is_run_config_valid(
+    graphene_info: ResolveInfo,
+    represented_pipeline: RepresentedPipeline,
+    mode: str,
+    run_config: Mapping[str, object],
+) -> "GraphenePipelineConfigValidationValid":
     from ..schema.pipelines.config import (
         GraphenePipelineConfigValidationError,
         GraphenePipelineConfigValidationValid,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/telemetry.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/telemetry.py
@@ -1,19 +1,28 @@
 import json
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from dagster._core.telemetry import log_action
 
+if TYPE_CHECKING:
+    from dagster_graphql.schema.util import ResolveInfo
 
-def log_dagit_telemetry_event(graphene_info, action, client_time, client_id, metadata):
+    from ..schema.roots.mutation import GrapheneLogTelemetrySuccess
+
+
+def log_dagit_telemetry_event(
+    graphene_info: "ResolveInfo", action: str, client_time: str, client_id, metadata: str
+) -> "GrapheneLogTelemetrySuccess":
     from ..schema.roots.mutation import GrapheneLogTelemetrySuccess
 
     instance = graphene_info.context.instance
     metadata = json.loads(metadata)
-    client_time = datetime.utcfromtimestamp(int(client_time) / 1000)
+    assert isinstance(metadata, dict)
+    client_datetime = datetime.utcfromtimestamp(int(client_time) / 1000)
     log_action(
         instance=instance,
         action=action,
-        client_time=client_time,
+        client_time=client_datetime,
         elapsed_time=None,
         metadata={"client_id": client_id, **metadata},
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -43,7 +43,7 @@ T_Callable = TypeVar("T_Callable", bound=Callable)
 
 def assert_permission_for_location(
     graphene_info: "ResolveInfo", permission: str, location_name: str
-):
+) -> None:
     from dagster_graphql.schema.errors import GrapheneUnauthorizedError
 
     context = cast(BaseWorkspaceRequestContext, graphene_info.context)
@@ -121,7 +121,7 @@ class ErrorCapture:
 def capture_error(
     fn: Callable[P, T]
 ) -> Callable[P, Union[T, "GrapheneError", "GraphenePythonError"]]:
-    def _fn(*args: P.args, **kwargs: P.kwargs):
+    def _fn(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return fn(*args, **kwargs)
         except UserFacingGraphQLError as de_exception:
@@ -242,3 +242,6 @@ class ExecutionMetadata(
             "rootRunId": self.root_run_id,
             "parentRunId": self.parent_run_id,
         }
+
+
+BackfillParams: TypeAlias = Mapping[str, Any]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -71,9 +71,12 @@ from .freshness_policy import GrapheneAssetFreshnessInfo, GrapheneFreshnessPolic
 from .logs.events import GrapheneMaterializationEvent, GrapheneObservationEvent
 from .pipelines.pipeline import (
     GrapheneAssetPartitionStatuses,
+    GrapheneDefaultPartitions,
+    GrapheneMultiPartitions,
     GraphenePartitionStats,
     GraphenePipeline,
     GrapheneRun,
+    GrapheneTimePartitions,
 )
 from .util import ResolveInfo, non_null_list
 
@@ -178,7 +181,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     assetKey = graphene.NonNull(GrapheneAssetKey)
     assetMaterializations = graphene.Field(
         non_null_list(GrapheneMaterializationEvent),
-        partitions=graphene.List(graphene.String),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
         beforeTimestampMillis=graphene.String(),
         limit=graphene.Int(),
     )
@@ -188,7 +191,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     )
     assetObservations = graphene.Field(
         non_null_list(GrapheneObservationEvent),
-        partitions=graphene.List(graphene.String),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
         beforeTimestampMillis=graphene.String(),
         limit=graphene.Int(),
     )
@@ -212,7 +215,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     jobs = non_null_list(GraphenePipeline)
     latestMaterializationByPartition = graphene.Field(
         graphene.NonNull(graphene.List(GrapheneMaterializationEvent)),
-        partitions=graphene.List(graphene.String),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
     )
     latestRunForPartition = graphene.Field(GrapheneRun, partition=graphene.NonNull(graphene.String))
     assetPartitionStatuses = graphene.NonNull(GrapheneAssetPartitionStatuses)
@@ -431,7 +434,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_hasMaterializePermission(
         self,
         graphene_info: ResolveInfo,
-    ):
+    ) -> bool:
         return graphene_info.context.has_permission_for_location(
             Permissions.LAUNCH_PIPELINE_EXECUTION, self._repository_location.name
         )
@@ -487,7 +490,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_assetMaterializations(
         self,
         graphene_info: ResolveInfo,
-        partitions: Optional[Sequence[Optional[str]]] = None,
+        partitions: Optional[Sequence[str]] = None,
         beforeTimestampMillis: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[GrapheneMaterializationEvent]:
@@ -529,7 +532,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_assetObservations(
         self,
         graphene_info: ResolveInfo,
-        partitions: Optional[Sequence[Optional[str]]] = None,
+        partitions: Optional[Sequence[str]] = None,
         beforeTimestampMillis: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> Sequence[GrapheneObservationEvent]:
@@ -596,12 +599,14 @@ class GrapheneAssetNode(graphene.ObjectType):
             "depended_by_loader must exist in order to resolve dependedBy nodes",
         )
 
-        depended_by_asset_nodes = _depended_by_loader.get_cross_repo_dependent_assets(
-            self._repository_location.name,
-            self._external_repository.name,
-            self._external_asset_node.asset_key,
-        )
-        depended_by_asset_nodes.extend(self._external_asset_node.depended_by)
+        depended_by_asset_nodes = [
+            *_depended_by_loader.get_cross_repo_dependent_assets(
+                self._repository_location.name,
+                self._external_repository.name,
+                self._external_asset_node.asset_key,
+            ),
+            *self._external_asset_node.depended_by,
+        ]
 
         if not depended_by_asset_nodes:
             return []
@@ -632,18 +637,20 @@ class GrapheneAssetNode(graphene.ObjectType):
             "depended_by_loader must exist in order to resolve dependedBy nodes",
         )
 
-        depended_by_asset_nodes = depended_by_loader.get_cross_repo_dependent_assets(
-            self._repository_location.name,
-            self._external_repository.name,
-            self._external_asset_node.asset_key,
-        )
-        depended_by_asset_nodes.extend(self._external_asset_node.depended_by)
+        depended_by_asset_nodes = [
+            *depended_by_loader.get_cross_repo_dependent_assets(
+                self._repository_location.name,
+                self._external_repository.name,
+                self._external_asset_node.asset_key,
+            ),
+            *self._external_asset_node.depended_by,
+        ]
 
         return [
             GrapheneAssetKey(path=dep.downstream_asset_key.path) for dep in depended_by_asset_nodes
         ]
 
-    def resolve_dependencyKeys(self, _graphene_info: ResolveInfo):
+    def resolve_dependencyKeys(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneAssetKey]:
         return [
             GrapheneAssetKey(path=dep.upstream_asset_key.path)
             for dep in self._external_asset_node.dependencies
@@ -716,7 +723,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_latestMaterializationByPartition(
         self,
         graphene_info: ResolveInfo,
-        partitions: Optional[Sequence[Optional[str]]] = None,
+        partitions: Optional[Sequence[str]] = None,
     ) -> Sequence[Optional[GrapheneMaterializationEvent]]:
         get_partition = (
             lambda event: event.dagster_event.step_materialization_data.materialization.partition
@@ -753,7 +760,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         partition: str,
-    ):
+    ) -> Optional[GrapheneRun]:
         event_records = list(
             graphene_info.context.instance.event_log_storage.get_event_records(
                 EventRecordsFilter(
@@ -769,7 +776,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         run_record = graphene_info.context.instance.get_run_record_by_id(event_records[0].run_id)
         return GrapheneRun(run_record) if run_record else None
 
-    def resolve_assetPartitionStatuses(self, graphene_info: ResolveInfo):
+    def resolve_assetPartitionStatuses(
+        self, graphene_info: ResolveInfo
+    ) -> Union["GrapheneTimePartitions", "GrapheneDefaultPartitions", "GrapheneMultiPartitions"]:
         asset_key = self._external_asset_node.asset_key
 
         if not self._dynamic_partitions_loader:
@@ -795,7 +804,9 @@ class GrapheneAssetNode(graphene.ObjectType):
             in_progress_subset,
         )
 
-    def resolve_partitionStats(self, graphene_info) -> Optional[GraphenePartitionStats]:
+    def resolve_partitionStats(
+        self, graphene_info: ResolveInfo
+    ) -> Optional[GraphenePartitionStats]:
         partitions_def_data = self._external_asset_node.partitions_def_data
         if partitions_def_data:
             asset_key = self._external_asset_node.asset_key
@@ -877,7 +888,10 @@ class GrapheneAssetNode(graphene.ObjectType):
         return self._external_asset_node.graph_name
 
     def resolve_partitionKeysByDimension(
-        self, _graphene_info: ResolveInfo, **kwargs
+        self,
+        _graphene_info: ResolveInfo,
+        startIdx: Optional[int] = None,
+        endIdx: Optional[int] = None,
     ) -> Sequence[GrapheneDimensionPartitionKeys]:
         # Accepts startIdx and endIdx arguments. This will be used to select a range of
         # time partitions. StartIdx is inclusive, endIdx is exclusive.
@@ -886,15 +900,14 @@ class GrapheneAssetNode(graphene.ObjectType):
         if not self._external_asset_node.partitions_def_data:
             return []
 
-        start_idx, end_idx = kwargs.get("startIdx"), kwargs.get("endIdx")
         if self.is_multipartitioned():
             return [
                 GrapheneDimensionPartitionKeys(
                     name=dimension.name,
                     partition_keys=self.get_partition_keys(
                         dimension.external_partitions_def_data,
-                        start_idx,
-                        end_idx,
+                        startIdx,
+                        endIdx,
                     ),
                     type=GraphenePartitionDefinitionType.from_partition_def_data(
                         dimension.external_partitions_def_data
@@ -912,7 +925,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                 type=GraphenePartitionDefinitionType.from_partition_def_data(
                     self._external_asset_node.partitions_def_data
                 ),
-                partition_keys=self.get_partition_keys(start_idx=start_idx, end_idx=end_idx),
+                partition_keys=self.get_partition_keys(start_idx=startIdx, end_idx=endIdx),
             )
         ]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -166,7 +166,7 @@ class GrapheneAsset(graphene.ObjectType):
     key = graphene.NonNull(GrapheneAssetKey)
     assetMaterializations = graphene.Field(
         non_null_list(GrapheneMaterializationEvent),
-        partitions=graphene.List(graphene.String),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
         partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
         afterTimestampMillis=graphene.String(),
@@ -175,7 +175,7 @@ class GrapheneAsset(graphene.ObjectType):
     )
     assetObservations = graphene.Field(
         non_null_list(GrapheneObservationEvent),
-        partitions=graphene.List(graphene.String),
+        partitions=graphene.List(graphene.NonNull(graphene.String)),
         partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
         afterTimestampMillis=graphene.String(),
@@ -204,7 +204,7 @@ class GrapheneAsset(graphene.ObjectType):
     def resolve_assetMaterializations(
         self,
         graphene_info: ResolveInfo,
-        partitions: Optional[Sequence[Optional[str]]] = None,
+        partitions: Optional[Sequence[str]] = None,
         partitionInLast: Optional[int] = None,
         beforeTimestampMillis: Optional[str] = None,
         afterTimestampMillis: Optional[str] = None,
@@ -234,7 +234,7 @@ class GrapheneAsset(graphene.ObjectType):
     def resolve_assetObservations(
         self,
         graphene_info: ResolveInfo,
-        partitions: Optional[Sequence[Optional[str]]] = None,
+        partitions: Optional[Sequence[str]] = None,
         partitionInLast: Optional[int] = None,
         beforeTimestampMillis: Optional[str] = None,
         afterTimestampMillis: Optional[str] = None,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -495,18 +495,18 @@ class GrapheneDagitQuery(graphene.ObjectType):
             not (snapshotId and activePipelineSelector),
             "Must only pass one of snapshotId or activePipelineSelector",
         )
-        check.invariant(
-            snapshotId or activePipelineSelector,
-            "Must set one of snapshotId or activePipelineSelector",
-        )
 
         if activePipelineSelector:
             pipeline_selector = pipeline_selector_from_graphql(activePipelineSelector)
             return get_pipeline_snapshot_or_error_from_pipeline_selector(
                 graphene_info, pipeline_selector
             )
-        else:
+        elif snapshotId:
             return get_pipeline_snapshot_or_error_from_snapshot_id(graphene_info, snapshotId)
+        else:
+            check.failed(
+                "Must set one of snapshotId or activePipelineSelector",
+            )
 
     def resolve_graphOrError(
         self, graphene_info: ResolveInfo, selector: Optional[GrapheneGraphSelector] = None

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -85,7 +85,7 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
             graphene_info,
             self._represented_pipeline,
             self._mode,
-            parse_run_config_input(runConfigData or {}, raise_on_error=False),
+            parse_run_config_input(runConfigData or {}, raise_on_error=False),  # type: ignore
         )
 
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1702,7 +1702,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def get_asset_keys(
         self,
-        prefix: Optional[str] = None,
+        prefix: Optional[Sequence[str]] = None,
         limit: Optional[int] = None,
         cursor: Optional[str] = None,
     ) -> Sequence[AssetKey]:


### PR DESCRIPTION
## Summary & Motivation

Add type annotations and fix type errors in `dagster_graphql.implementation`.

- Runtime changes were restricted to cases where it was clear the code immediately following a type error would fail if the type error was triggered (typically fixed with `check.not_none` or similar).
- Also includes a minor GQL schema change that I believe is a bugfix. GQL schema was allowing `Optional[List[Optional[str]]]` to be passed as a list of partition names-- but `None` isn't a valid partition name and would cause an error if actually passed. Updated the schema to only allow `Optional[List[str]]`. Probably this is just a mistake that was introduced into the schema at some point due to (to many) unintuitive GQL default nullability.

## How I Tested These Changes

Existing test suite