### PR TITLE
[test-api-update] rename utility solids to op equivalents

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/basics/test_types.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/basics/test_types.py
@@ -1,8 +1,8 @@
 import csv
 from collections import OrderedDict
 
-from dagster._legacy import execute_solid
 from dagster._utils import script_relative_path
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from docs_snippets.intro_tutorial.basics.testing.custom_types_2 import sort_by_calories
 from docs_snippets.intro_tutorial.basics.testing.custom_types_4 import (
     less_simple_data_frame_type_check,
@@ -35,4 +35,4 @@ def test_sort():
     ) as fd:
         cereals = [row for row in csv.DictReader(fd)]
 
-    execute_solid(sort_by_calories, input_values={"cereals": cereals})
+    wrap_op_in_graph_and_execute(sort_by_calories, input_values={"cereals": cereals})

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -145,7 +145,6 @@ def launch_run_over_graphql(
     pipeline_name,
     repository_name="demo_execution_repo",
     code_location_name="user-code-deployment-1",
-    mode="default",
     solid_selection=None,
     tags=None,
 ):
@@ -160,7 +159,6 @@ def launch_run_over_graphql(
                     "solidSelection": solid_selection,
                 },
                 "runConfigData": run_config,
-                "mode": mode,
                 "executionMetadata": {
                     "tags": [{"key": key, "value": value} for key, value in tags.items()]
                 },

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_monitoring.py
@@ -83,7 +83,7 @@ def test_run_monitoring_fails_on_interrupt(
         get_celery_job_engine_config(dagster_docker_image=dagster_docker_image),
     )
 
-    pipeline_name = "demo_job_celery"
+    pipeline_name = "demo_job_celery_k8s"
 
     try:
         run_id = launch_run_over_graphql(
@@ -122,7 +122,7 @@ def test_run_monitoring_startup_fail(
         ),
     )
 
-    pipeline_name = "demo_job_celery"
+    pipeline_name = "demo_job_celery_k8s"
 
     try:
         run_id = launch_run_over_graphql(

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_queued_run_coordinator.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_queued_run_coordinator.py
@@ -11,14 +11,12 @@ from marks import mark_daemon
 def get_celery_engine_config(dagster_docker_image, job_namespace):
     return {
         "execution": {
-            "celery-k8s": {
-                "config": {
-                    "job_image": dagster_docker_image,
-                    "job_namespace": job_namespace,
-                    "image_pull_policy": image_pull_policy(),
-                }
+            "config": {
+                "job_image": dagster_docker_image,
+                "job_namespace": job_namespace,
+                "image_pull_policy": image_pull_policy(),
             }
-        },
+        }
     }
 
 
@@ -50,7 +48,7 @@ def test_execute_queued_run_on_celery_k8s(
     )
 
     run_id = launch_run_over_graphql(
-        dagit_url_for_daemon, run_config=run_config, pipeline_name="demo_pipeline_celery"
+        dagit_url_for_daemon, run_config=run_config, pipeline_name="demo_job_celery_k8s"
     )
 
     wait_for_job_and_get_raw_logs(

--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_user_code_deployment_subchart.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_user_code_deployment_subchart.py
@@ -16,7 +16,7 @@ def test_execute_on_celery_k8s_subchart_disabled(
     helm_namespace_for_user_deployments_subchart_disabled,
 ):
     namespace = helm_namespace_for_user_deployments_subchart_disabled
-    job_name = "demo_job_celery"
+    job_name = "demo_job_celery_k8s"
 
     core_api = kubernetes.client.CoreV1Api()
     batch_api = kubernetes.client.BatchV1Api()

--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -16,7 +16,7 @@ from dagster_test.test_project import (
     get_buildkite_registry_config,
     get_test_project_docker_image,
     get_test_project_environments_path,
-    get_test_project_recon_pipeline,
+    get_test_project_recon_job,
     get_test_project_workspace_and_external_pipeline,
 )
 
@@ -93,13 +93,12 @@ def test_docker_monitoring():
     run_config = merge_dicts(
         load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
         {
-            "solids": {
+            "ops": {
                 "multiply_the_word_slow": {
                     "inputs": {"word": "bar"},
                     "config": {"factor": 2, "sleep_time": 20},
                 }
             },
-            "execution": {"docker": {"config": {}}},
         },
     )
 
@@ -113,9 +112,9 @@ def test_docker_monitoring():
             },
         }
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_docker_slow", docker_image)
+        recon_pipeline = get_test_project_recon_job("demo_slow_job_docker", docker_image)
         with get_test_project_workspace_and_external_pipeline(
-            instance, "demo_pipeline_docker_slow", container_image=docker_image
+            instance, "demo_slow_job_docker", container_image=docker_image
         ) as (
             workspace,
             orig_pipeline,
@@ -177,13 +176,12 @@ def test_docker_monitoring_run_out_of_attempts():
     run_config = merge_dicts(
         load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
         {
-            "solids": {
+            "ops": {
                 "multiply_the_word_slow": {
                     "inputs": {"word": "bar"},
                     "config": {"factor": 2, "sleep_time": 20},
                 }
             },
-            "execution": {"docker": {"config": {}}},
         },
     )
 
@@ -201,9 +199,9 @@ def test_docker_monitoring_run_out_of_attempts():
             },
         }
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_docker_slow", docker_image)
+        recon_pipeline = get_test_project_recon_job("demo_slow_job_docker", docker_image)
         with get_test_project_workspace_and_external_pipeline(
-            instance, "demo_pipeline_docker_slow", container_image=docker_image
+            instance, "demo_slow_job_docker", container_image=docker_image
         ) as (
             workspace,
             orig_pipeline,

--- a/integration_tests/test_suites/k8s-test-suite/conftest.py
+++ b/integration_tests/test_suites/k8s-test-suite/conftest.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from typing import Iterator
 
 import docker
 import pytest
@@ -18,7 +19,7 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 
 @pytest.fixture(scope="session", autouse=True)
-def dagster_home():
+def dagster_home() -> Iterator[None]:
     old_env = os.getenv("DAGSTER_HOME")
     os.environ["DAGSTER_HOME"] = "/opt/dagster/dagster_home"
     yield
@@ -36,13 +37,13 @@ cluster_provider = define_cluster_provider_fixture(
 
 
 @pytest.yield_fixture
-def schedule_tempdir():
+def schedule_tempdir() -> Iterator[str]:
     with tempfile.TemporaryDirectory() as tempdir:
         yield tempdir
 
 
 @pytest.fixture(scope="session")
-def dagster_docker_image():
+def dagster_docker_image() -> str:
     docker_image = get_test_project_docker_image()
 
     if not IS_BUILDKITE:
@@ -60,7 +61,7 @@ def dagster_docker_image():
 
 
 # See: https://stackoverflow.com/a/31526934/324449
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     # We catch the ValueError to support cases where we are loading multiple test suites, e.g., in
     # the VSCode test explorer. When pytest tries to add an option twice, we get, e.g.
     #

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_integration.py
@@ -38,7 +38,7 @@ def test_k8s_run_launcher_default(
     check.invariant(not celery_pod_names)
 
     run_config = load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env.yaml"))
-    pipeline_name = "demo_pipeline"
+    pipeline_name = "demo_job"
 
     run_id = launch_run_over_graphql(
         dagit_url_for_k8s_run_launcher, run_config=run_config, pipeline_name=pipeline_name
@@ -60,12 +60,10 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 def get_celery_engine_config(dagster_docker_image, job_namespace):
     return {
         "execution": {
-            "celery-k8s": {
-                "config": {
-                    "job_image": dagster_docker_image,
-                    "job_namespace": job_namespace,
-                    "image_pull_policy": image_pull_policy(),
-                }
+            "config": {
+                "job_image": dagster_docker_image,
+                "job_namespace": job_namespace,
+                "image_pull_policy": image_pull_policy(),
             }
         },
     }
@@ -90,10 +88,10 @@ def test_k8s_run_launcher_with_celery_executor_fails(
         ),
     )
 
-    pipeline_name = "demo_pipeline_celery"
+    job_name = "demo_job_celery_k8s"
 
     run_id = launch_run_over_graphql(
-        dagit_url_for_k8s_run_launcher, run_config=run_config, pipeline_name=pipeline_name
+        dagit_url_for_k8s_run_launcher, run_config=run_config, pipeline_name=job_name
     )
 
     timeout = datetime.timedelta(0, 120)
@@ -131,7 +129,7 @@ def test_failing_k8s_run_launcher(
 ):
     run_config = load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env.yaml"))
 
-    pipeline_name = "always_fail_pipeline"
+    pipeline_name = "always_fail_job"
 
     run_id = launch_run_over_graphql(
         dagit_url_for_k8s_run_launcher, run_config=run_config, pipeline_name=pipeline_name
@@ -154,7 +152,7 @@ def test_k8s_run_launcher_terminate(
     user_code_namespace_for_k8s_run_launcher,
     dagit_url_for_k8s_run_launcher,
 ):
-    pipeline_name = "slow_pipeline"
+    pipeline_name = "slow_job_k8s"
 
     run_config = load_yaml_from_path(
         os.path.join(get_test_project_environments_path(), "env_s3.yaml")
@@ -204,7 +202,7 @@ def test_k8s_run_launcher_secret_from_deployment(
     run_config = load_yaml_from_path(
         os.path.join(get_test_project_environments_path(), "env_config_from_secrets.yaml")
     )
-    pipeline_name = "demo_pipeline"
+    pipeline_name = "demo_job"
 
     run_id = launch_run_over_graphql(
         dagit_url_for_k8s_run_launcher, run_config=run_config, pipeline_name=pipeline_name

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_monitoring.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_monitoring.py
@@ -28,14 +28,12 @@ def test_k8s_run_monitoring_startup_fail(
         load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
         {
             "execution": {
-                "k8s": {
-                    "config": {
-                        "job_namespace": user_code_namespace_for_k8s_run_launcher,
-                        "image_pull_policy": image_pull_policy(),
-                        "env_config_maps": ["non-existent-config-map"],
-                    }
+                "config": {
+                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
+                    "image_pull_policy": image_pull_policy(),
+                    "env_config_maps": ["non-existent-config-map"],
                 }
-            },
+            }
         },
     )
     run_id = None
@@ -43,8 +41,7 @@ def test_k8s_run_monitoring_startup_fail(
         run_id = launch_run_over_graphql(
             dagit_url_for_k8s_run_launcher,
             run_config=run_config,
-            pipeline_name="slow_pipeline",
-            mode="k8s",
+            pipeline_name="slow_job_k8s",
             tags={
                 "dagster-k8s/config": json.dumps(
                     {
@@ -76,11 +73,9 @@ def test_k8s_run_monitoring_resume(
         load_yaml_from_path(os.path.join(get_test_project_environments_path(), "env_s3.yaml")),
         {
             "execution": {
-                "k8s": {
-                    "config": {
-                        "job_namespace": user_code_namespace_for_k8s_run_launcher,
-                        "image_pull_policy": image_pull_policy(),
-                    }
+                "config": {
+                    "job_namespace": user_code_namespace_for_k8s_run_launcher,
+                    "image_pull_policy": image_pull_policy(),
                 }
             },
         },
@@ -98,7 +93,7 @@ def _launch_run_and_wait_for_resume(
     run_config,
     instance,
     namespace,
-    pipeline_name="slow_pipeline",
+    pipeline_name="slow_job_k8s",
 ):
     run_id = None
 
@@ -107,7 +102,6 @@ def _launch_run_and_wait_for_resume(
             dagit_url_for_k8s_run_launcher,
             run_config=run_config,
             pipeline_name=pipeline_name,
-            mode="k8s",
         )
 
         start_time = time.time()

--- a/python_modules/dagster-test/dagster_test/test_project/environments/env.yaml
+++ b/python_modules/dagster-test/dagster_test/test_project/environments/env.yaml
@@ -3,7 +3,7 @@ loggers:
     config:
       log_level: DEBUG
 
-solids:
+ops:
   multiply_the_word:
     inputs:
       word: bar

--- a/python_modules/dagster-test/dagster_test/test_project/environments/env_config_from_secrets.yaml
+++ b/python_modules/dagster-test/dagster_test/test_project/environments/env_config_from_secrets.yaml
@@ -3,7 +3,7 @@ loggers:
     config:
       log_level: DEBUG
 
-solids:
+ops:
   multiply_the_word:
     inputs:
       word: bar

--- a/python_modules/dagster-test/dagster_test/test_project/environments/env_environment_vars.yaml
+++ b/python_modules/dagster-test/dagster_test/test_project/environments/env_environment_vars.yaml
@@ -1,4 +1,4 @@
-solids:
-  get_environment_solid:
+ops:
+  get_environment:
     config:
       looking_for: FIND_ME

--- a/python_modules/dagster-test/dagster_test/test_project/environments/env_subset.yaml
+++ b/python_modules/dagster-test/dagster_test/test_project/environments/env_subset.yaml
@@ -3,7 +3,7 @@ loggers:
     config:
       log_level: DEBUG
 
-solids:
+ops:
   count_letters:
     inputs:
       word:

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/pending_repo.py
@@ -50,7 +50,7 @@ def define_demo_execution_repo():
         return [
             with_resources([foo], {"s3": s3_resource, "io_manager": s3_pickle_io_manager}),
             MyCacheableAssetsDefinition("xyz"),
-            define_asset_job("demo_pipeline_docker", executor_def=docker_executor),
+            define_asset_job("demo_job_docker", executor_def=docker_executor),
         ]
 
     return demo_execution_repo

--- a/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_pipelines/repo.py
@@ -4,6 +4,7 @@ import random
 import time
 from collections import defaultdict
 from contextlib import contextmanager
+from typing import Any, Callable, Mapping, Optional, Union
 
 import boto3
 from dagster import (
@@ -18,20 +19,18 @@ from dagster import (
     RetryRequested,
     VersionStrategy,
     file_relative_path,
-    fs_io_manager,
+    graph,
     job,
     op,
     repository,
     resource,
 )
 from dagster._core.definitions.decorators import schedule
+from dagster._core.definitions.graph_definition import GraphDefinition
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.output import Out
-from dagster._core.test_utils import nesting_graph_pipeline
-from dagster._legacy import (
-    ModeDefinition,
-    default_executors,
-    pipeline,
-)
+from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.test_utils import nesting_graph
 from dagster._utils import segfault
 from dagster._utils.merger import merge_dicts
 from dagster._utils.yaml_utils import merge_yamls
@@ -52,49 +51,89 @@ def image_pull_policy():
         return "IfNotPresent"
 
 
-def celery_mode_defs(resources=None, name="default"):
-    from dagster_celery import celery_executor
-    from dagster_celery_k8s import celery_k8s_job_executor
+_S3_RESOURCES = {
+    "io_manager": s3_pickle_io_manager,
+    "s3": s3_resource,
+}
 
-    resources = resources if resources else {"s3": s3_resource}
-    resources = merge_dicts(resources, {"io_manager": s3_pickle_io_manager})
-    return [
-        ModeDefinition(
-            name=name,
-            resource_defs=resources
-            if resources
-            else {"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-            executor_defs=default_executors + [celery_executor, celery_k8s_job_executor],
-        )
-    ]
+_GCS_RESOURCES = {
+    "io_manager": gcs_pickle_io_manager,
+    "gcs": gcs_resource,
+}
 
 
-def k8s_mode_defs(resources=None, name="default"):
-    from dagster_k8s.executor import k8s_job_executor
+def define_job(
+    graph_def: GraphDefinition,
+    platform: Optional[str] = None,
+    extra_resources: Optional[Mapping[str, ResourceDefinition]] = None,
+    name: Optional[str] = None,
+    **kwargs: Any,  # forwarded to graph_def.to_job
+) -> Union[JobDefinition, Callable[[], JobDefinition]]:
+    if not name:
+        base_name = graph_def.name.rsplit("_", 1)[0]  # remove "_graph" suffix
+        suffix = f"_job_{platform}" if platform else "_job"
+        name = f"{base_name}{suffix}"
+    job_def = graph_def.to_job(name=name, **kwargs)
 
-    resources = resources if resources else {"s3": s3_resource}
-    resources = merge_dicts(resources, {"io_manager": s3_pickle_io_manager})
-
-    return [
-        ModeDefinition(
-            name=name,
-            resource_defs=resources
-            if resources
-            else {"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-            executor_defs=default_executors + [k8s_job_executor],
-        )
-    ]
+    if platform:
+        return lambda: apply_platform_settings(job_def, platform, extra_resources or {})
+    else:
+        return job_def
 
 
-def docker_mode_defs():
-    from dagster_docker import docker_executor
+# keep this separate because we need to call it externally for cleanup in some lib tests
+def define_memoization_job(platform: str) -> Callable[[], JobDefinition]:
+    return define_job(
+        graph_def=memoization_graph,
+        platform=platform,
+        version_strategy=BasicVersionStrategy(),
+    )
 
-    return [
-        ModeDefinition(
-            resource_defs={"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-            executor_defs=[docker_executor],
-        )
-    ]
+
+def apply_platform_settings(
+    job_def: JobDefinition,
+    platform: Optional[str],
+    extra_resources: Mapping[str, ResourceDefinition] = {},
+) -> JobDefinition:
+    if platform == "k8s":
+        from dagster_k8s.executor import k8s_job_executor
+
+        executor = k8s_job_executor
+        resources = _S3_RESOURCES
+    elif platform == "celery":
+        from dagster_celery import celery_executor
+
+        executor = celery_executor
+        resources = _S3_RESOURCES
+    elif platform == "celery_docker":
+        from dagster_celery_docker import celery_docker_executor
+
+        executor = celery_docker_executor
+        resources = _S3_RESOURCES
+    elif platform == "celery_k8s":
+        from dagster_celery_k8s import celery_k8s_job_executor
+
+        executor = celery_k8s_job_executor
+        resources = _S3_RESOURCES
+    elif platform == "docker":
+        from dagster_docker import docker_executor
+
+        executor = docker_executor
+        resources = _S3_RESOURCES
+    elif platform == "s3":
+        executor = None
+        resources = _S3_RESOURCES
+    elif platform == "gcs":
+        executor = None
+        resources = _GCS_RESOURCES
+    elif platform:
+        raise Exception(f"Unknown platform: {platform}")
+    else:
+        executor = None
+        resources = {}
+
+    job_def = job_def.with_top_level_resources({**resources, **extra_resources})
+    return job_def.with_executor_def(executor) if executor else job_def
 
 
 @op(
@@ -109,14 +148,6 @@ def multiply_the_word(context, word: str) -> str:
     return word * context.op_config["factor"]
 
 
-@op(
-    config_schema={"factor": IntSource, "sleep_time": IntSource},
-)
-def multiply_the_word_slow(context, word: str) -> str:
-    time.sleep(context.op_config["sleep_time"])
-    return word * context.op_config["factor"]
-
-
 @op
 def count_letters(word: str):
     counts = defaultdict(int)
@@ -125,92 +156,48 @@ def count_letters(word: str):
     return dict(counts)
 
 
+@graph
+def demo_graph():
+    count_letters(multiply_the_word())
+
+
 @op
 def always_fail(context, word: str):
     raise Exception("Op Exception Message")
 
 
 @op(
-    config_schema={"factor": IntSource},
+    config_schema={"factor": IntSource, "sleep_time": IntSource},
 )
-def multiply_the_word_op(context, word: str) -> str:
+def multiply_the_word_slow(context, word: str) -> str:
+    time.sleep(context.op_config["sleep_time"])
     return word * context.op_config["factor"]
 
 
-@op(ins={"word": In()})
-def count_letters_op(word):
-    counts = defaultdict(int)
-    for letter in word:
-        counts[letter] += 1
-    return dict(counts)
-
-
-@op()
-def error_solid():
-    raise Exception("Unusual error")
+@graph
+def demo_slow_graph():
+    count_letters(multiply_the_word_slow())
 
 
 @op
-def hanging_solid(_):
+def hanging_op(_):
     while True:
         time.sleep(0.1)
 
 
 @op(config_schema={"looking_for": str})
-def get_environment_solid(context):
+def get_environment(context):
     return os.environ.get(context.op_config["looking_for"])
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-        )
-    ]
-)
-def hanging_pipeline():
-    hanging_solid()
+@graph
+def hanging_graph():
+    hanging_op()
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-        )
-    ]
-)
-def demo_pipeline():
-    count_letters(multiply_the_word())
-
-
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-        )
-    ]
-)
-def always_fail_pipeline():
+@graph
+def always_fail_graph():
     always_fail(multiply_the_word())
-
-
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-        )
-    ]
-)
-def demo_pipeline_s3():
-    count_letters(multiply_the_word())
-
-
-def define_demo_pipeline_docker():
-    @pipeline(mode_defs=docker_mode_defs())
-    def demo_pipeline_docker():
-        count_letters(multiply_the_word())
-
-    return demo_pipeline_docker
 
 
 @op
@@ -224,41 +211,9 @@ def fail_first_time(context):
     raise RetryRequested()
 
 
-def definie_step_retries_pipeline_docker():
-    @pipeline(mode_defs=docker_mode_defs())
-    def step_retries_pipeline_docker():
-        fail_first_time()
-
-    return step_retries_pipeline_docker
-
-
-def define_demo_pipeline_docker_slow():
-    @pipeline(mode_defs=docker_mode_defs())
-    def demo_pipeline_docker_slow():
-        count_letters(multiply_the_word_slow())
-
-    return demo_pipeline_docker_slow
-
-
-def define_demo_pipeline_celery():
-    @pipeline(mode_defs=celery_mode_defs())
-    def demo_pipeline_celery():
-        count_letters(multiply_the_word())
-
-    return demo_pipeline_celery
-
-
-def define_demo_job_celery():
-    from dagster_celery_k8s import celery_k8s_job_executor
-
-    @job(
-        resource_defs={"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-        executor_def=celery_k8s_job_executor,
-    )
-    def demo_job_celery():
-        count_letters_op.alias("count_letters")(multiply_the_word_op.alias("multiply_the_word")())
-
-    return demo_job_celery
+@graph
+def step_retries_graph():
+    fail_first_time()
 
 
 @op(required_resource_keys={"buggy_resource"})
@@ -266,98 +221,33 @@ def hello(context):
     context.log.info("Hello, world from IMAGE 1")
 
 
-def define_docker_celery_pipeline():
-    from dagster_celery_docker import celery_docker_executor
-
-    @resource
-    def resource_with_output():
-        print("writing to stdout")  # noqa: T201
-        print("{}")  # noqa: T201
-        return 42
-
-    @op(required_resource_keys={"resource_with_output"})
-    def use_resource_with_output_solid():
-        pass
-
-    @pipeline(
-        mode_defs=[
-            ModeDefinition(
-                resource_defs={
-                    "s3": s3_resource,
-                    "io_manager": s3_pickle_io_manager,
-                    "resource_with_output": resource_with_output,
-                },
-                executor_defs=default_executors + [celery_docker_executor],
-            )
-        ]
-    )
-    def docker_celery_pipeline():
-        count_letters(multiply_the_word())
-        get_environment_solid()
-        use_resource_with_output_solid()
-
-    return docker_celery_pipeline
+@resource
+def resource_with_output():
+    print("writing to stdout")  # noqa: T201
+    print("{}")  # noqa: T201
+    return 42
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"gcs": gcs_resource, "io_manager": gcs_pickle_io_manager},
-        )
-    ]
-)
-def demo_pipeline_gcs():
+@op(required_resource_keys={"resource_with_output"})
+def use_resource_with_output():
+    pass
+
+
+@graph
+def demo_resource_output_graph():
     count_letters(multiply_the_word())
+    get_environment()
+    use_resource_with_output()
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-        )
-    ]
-)
-def demo_error_pipeline():
-    error_solid()
-
-
-# TODO: migrate test_project to crag
 @op
-def emit_airflow_execution_date_op(context):
-    airflow_execution_date = context.pipeline_run.tags["airflow_execution_date"]
-    yield AssetMaterialization(
-        asset_key="airflow_execution_date",
-        metadata={
-            "airflow_execution_date": airflow_execution_date,
-        },
-    )
-    yield Output(airflow_execution_date)
-
-
-@op()
 def error_op():
     raise Exception("Unusual error")
 
 
-@job
-def demo_error_job():
-    error_solid()
-
-
-@job
-def demo_airflow_execution_date_job():
-    emit_airflow_execution_date_op()
-
-
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-        )
-    ]
-)
-def demo_error_pipeline_s3():
-    error_solid()
+@graph
+def demo_error_graph():
+    error_op()
 
 
 @op(
@@ -376,101 +266,84 @@ def bar(_, input_arg):
     return input_arg
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"io_manager": fs_io_manager})])
-def optional_outputs():
+@graph
+def optional_outputs_graph():
     foo_res = foo()
     bar.alias("first_consumer")(input_arg=foo_res.out_1)
     bar.alias("second_consumer")(input_arg=foo_res.out_2)
     bar.alias("third_consumer")(input_arg=foo_res.out_3)
 
 
-def define_long_running_pipeline_celery():
-    @op
-    def long_running_task(context):
-        iterations = 20 * 30  # 20 minutes
-        for i in range(iterations):
-            context.log.info(
-                "task in progress [%d/100]%% complete" % math.floor(100.0 * float(i) / iterations)
-            )
-            time.sleep(2)
-        return random.randint(0, iterations)
-
-    @op
-    def post_process(context, input_count):
-        context.log.info("received input %d" % input_count)
-        iterations = 60 * 2  # 2 hours
-        for i in range(iterations):
-            context.log.info(
-                "post-process task in progress [%d/100]%% complete"
-                % math.floor(100.0 * float(i) / iterations)
-            )
-            time.sleep(60)
-
-    @pipeline(mode_defs=celery_mode_defs())
-    def long_running_pipeline_celery():
-        for i in range(10):
-            t = long_running_task.alias("first_%d" % i)()
-            post_process.alias("post_process_%d" % i)(t)
-
-    return long_running_pipeline_celery
+@op
+def long_running_task(context):
+    iterations = 20 * 30  # 20 minutes
+    for i in range(iterations):
+        context.log.info(
+            "task in progress [%d/100]%% complete" % math.floor(100.0 * float(i) / iterations)
+        )
+        time.sleep(2)
+    return random.randint(0, iterations)
 
 
-def define_large_pipeline_celery():
-    return nesting_graph_pipeline(
-        depth=1,
-        num_children=6,
-        mode_defs=celery_mode_defs(),
-        name="large_pipeline_celery",
-    )
+@op
+def post_process(context, input_count):
+    context.log.info("received input %d" % input_count)
+    iterations = 60 * 2  # 2 hours
+    for i in range(iterations):
+        context.log.info(
+            "post-process task in progress [%d/100]%% complete"
+            % math.floor(100.0 * float(i) / iterations)
+        )
+        time.sleep(60)
 
 
-@op(
-    tags={
-        "dagster-k8s/config": {
-            "container_config": {
-                "resources": {
-                    "requests": {"cpu": "250m", "memory": "64Mi"},
-                    "limits": {"cpu": "500m", "memory": "2560Mi"},
-                }
+@graph
+def long_running_graph():
+    for i in range(10):
+        t = long_running_task.alias("first_%d" % i)()
+        post_process.alias("post_process_%d" % i)(t)
+
+
+large_graph = nesting_graph(depth=1, num_children=6, name="large_graph")
+
+resources_limit_tags = {
+    "dagster-k8s/config": {
+        "container_config": {
+            "resources": {
+                "requests": {"cpu": "250m", "memory": "64Mi"},
+                "limits": {"cpu": "500m", "memory": "2560Mi"},
             }
         }
     }
-)
-def resource_req_solid(context):
+}
+
+
+@op(tags=resources_limit_tags)
+def resource_req_op(context):
     context.log.info("running")
 
 
-def define_resources_limit_pipeline():
-    @pipeline(
-        mode_defs=celery_mode_defs() + k8s_mode_defs(name="k8s"),
-        tags={
-            "dagster-k8s/config": {
-                "container_config": {
-                    "resources": {
-                        "requests": {"cpu": "250m", "memory": "64Mi"},
-                        "limits": {"cpu": "500m", "memory": "2560Mi"},
-                    }
-                }
-            }
-        },
-    )
-    def resources_limit_pipeline():
-        resource_req_solid()
+@graph
+def resources_limit_graph():
+    resource_req_op()
 
-    return resources_limit_pipeline
+
+@job(tags=resources_limit_tags)
+def resources_limit_job_k8s():
+    resource_req_op()
 
 
 def define_schedules():
     @schedule(
         cron_schedule="@daily",
         name="daily_optional_outputs",
-        job_name=optional_outputs.name,
+        job_name="optional_outputs_job",
     )
     def daily_optional_outputs(_context):
         return {}
 
     @schedule(
-        job_name="demo_pipeline_celery",
+        job_name="demo_job_celery_k8s",
         cron_schedule="* * * * *",
     )
     def frequent_celery():
@@ -497,89 +370,76 @@ def define_schedules():
     }
 
 
-def define_step_retry_pipeline():
-    @pipeline(mode_defs=celery_mode_defs() + k8s_mode_defs(name="k8s"))
-    def retry_pipeline():
-        fail_first_time()
-
-    return retry_pipeline
+@graph
+def retry_graph():
+    fail_first_time()
 
 
-def define_slow_pipeline():
-    @op
-    def slow_solid(_):
-        time.sleep(100)
-
-    @pipeline(mode_defs=celery_mode_defs() + k8s_mode_defs(name="k8s"))
-    def slow_pipeline():
-        slow_solid()
-
-    return slow_pipeline
+@op
+def slow_op(_):
+    time.sleep(100)
 
 
-def define_resource_pipeline():
-    @resource
-    @contextmanager
-    def s3_resource_with_context_manager(context):
-        try:
-            context.log.info("initializing s3_resource_with_context_manager")
-            s3 = boto3.resource(
-                "s3", region_name="us-west-1", use_ssl=True, endpoint_url=None
-            ).meta.client
-            yield s3
-        finally:
-            context.log.info("tearing down s3_resource_with_context_manager")
-            bucket = "dagster-scratch-80542c2"
-            key = f"resource_termination_test/{context.run_id}"
-            s3.put_object(Bucket=bucket, Key=key, Body=b"foo")
-
-    @op(required_resource_keys={"s3_resource_with_context_manager"})
-    def super_slow_solid():
-        time.sleep(1000)
-
-    @pipeline(
-        mode_defs=celery_mode_defs(
-            resources={
-                "s3": s3_resource,
-                "s3_resource_with_context_manager": s3_resource_with_context_manager,
-                "io_manager": s3_pickle_io_manager,
-            }
-        )
-    )
-    def resource_pipeline():
-        super_slow_solid()
-
-    return resource_pipeline
+@graph
+def slow_graph():
+    slow_op()
 
 
-def define_fan_in_fan_out_pipeline():
-    @op
-    def return_one(_) -> int:
-        return 1
+@resource
+@contextmanager
+def s3_resource_with_context_manager(context):
+    try:
+        context.log.info("initializing s3_resource_with_context_manager")
+        s3 = boto3.resource(
+            "s3", region_name="us-west-1", use_ssl=True, endpoint_url=None
+        ).meta.client
+        yield s3
+    finally:
+        context.log.info("tearing down s3_resource_with_context_manager")
+        bucket = "dagster-scratch-80542c2"
+        key = f"resource_termination_test/{context.run_id}"
+        s3.put_object(Bucket=bucket, Key=key, Body=b"foo")
 
-    @op
-    def add_one_fan(_, num: int) -> int:
-        return num + 1
 
-    @op(ins={"nums": In(List[int])})
-    def sum_fan_in(_, nums):
-        return sum(nums)
+@op(required_resource_keys={"s3_resource_with_context_manager"})
+def super_slow_solid():
+    time.sleep(1000)
 
-    def construct_fan_in_level(source, level, fanout):
-        fan_outs = []
-        for i in range(0, fanout):
-            fan_outs.append(add_one_fan.alias(f"add_one_fan_{level}_{i}")(source))
 
-        return sum_fan_in.alias(f"sum_{level}")(fan_outs)
+@graph
+def resource_graph():
+    super_slow_solid()
 
-    @pipeline(mode_defs=celery_mode_defs())
-    def fan_in_fan_out_pipeline():
-        return_one_out = return_one()
-        prev_level_out = return_one_out
-        for level in range(0, 20):
-            prev_level_out = construct_fan_in_level(prev_level_out, level, 2)
 
-    return fan_in_fan_out_pipeline
+@op
+def return_one(_) -> int:
+    return 1
+
+
+@op
+def add_one_fan(_, num: int) -> int:
+    return num + 1
+
+
+@op(ins={"nums": In(List[int])})
+def sum_fan_in(_, nums):
+    return sum(nums)
+
+
+def construct_fan_in_level(source, level, fanout):
+    fan_outs = []
+    for i in range(0, fanout):
+        fan_outs.append(add_one_fan.alias(f"add_one_fan_{level}_{i}")(source))
+
+    return sum_fan_in.alias(f"sum_{level}")(fan_outs)
+
+
+@graph
+def fan_in_fan_out_graph():
+    return_one_out = return_one()
+    prev_level_out = return_one_out
+    for level in range(0, 20):
+        prev_level_out = construct_fan_in_level(prev_level_out, level, 2)
 
 
 @op
@@ -594,56 +454,28 @@ def emit_airflow_execution_date(context):
     yield Output(airflow_execution_date)
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-        )
-    ]
-)
-def demo_airflow_execution_date_pipeline():
+@graph
+def demo_airflow_execution_date_graph():
     emit_airflow_execution_date()
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"s3": s3_resource, "io_manager": s3_pickle_io_manager},
-        )
-    ]
+@op(
+    config_schema={"fail": Field(Bool, is_required=False, default_value=False)},
 )
-def demo_airflow_execution_date_pipeline_s3():
-    emit_airflow_execution_date()
+def hard_fail_or_0(context) -> int:
+    if context.op_config["fail"]:
+        segfault()
+    return 0
 
 
-def define_hard_failer():
-    @pipeline(mode_defs=celery_mode_defs())
-    def hard_failer():
-        @op(
-            config_schema={"fail": Field(Bool, is_required=False, default_value=False)},
-        )
-        def hard_fail_or_0(context) -> int:
-            if context.op_config["fail"]:
-                segfault()
-            return 0
-
-        @op
-        def increment(_, n: int):
-            return n + 1
-
-        increment(hard_fail_or_0())
-
-    return hard_failer
+@op
+def increment(_, n: int):
+    return n + 1
 
 
-def define_demo_k8s_executor_pipeline():
-    @pipeline(
-        mode_defs=k8s_mode_defs(),
-    )
-    def demo_k8s_executor_pipeline():
-        count_letters(multiply_the_word())
-
-    return demo_k8s_executor_pipeline
+@graph
+def hard_failer_graph():
+    increment(hard_fail_or_0())
 
 
 @op
@@ -656,71 +488,79 @@ def check_volume_mount(context):
         assert contents == "BAR_CONTENTS"
 
 
-def define_volume_mount_pipeline():
-    @pipeline(
-        mode_defs=k8s_mode_defs(name="k8s") + celery_mode_defs(name="celery"),
-    )
-    def volume_mount_pipeline():
-        check_volume_mount()
-
-    return volume_mount_pipeline
+@graph
+def volume_mount_graph():
+    check_volume_mount()
 
 
-def define_memoization_pipeline():
-    @op
-    def foo_solid():
+@op
+def foo_op():
+    return "foo"
+
+
+class BasicVersionStrategy(VersionStrategy):
+    def get_op_version(self, _):
         return "foo"
 
-    class BasicVersionStrategy(VersionStrategy):
-        def get_op_version(self, _):
-            return "foo"
 
-    @pipeline(
-        mode_defs=k8s_mode_defs(name="k8s") + celery_mode_defs(name="celery"),
-        version_strategy=BasicVersionStrategy(),
-    )
-    def memoization_pipeline():
-        foo_solid()
-
-    return memoization_pipeline
+@graph
+def memoization_graph():
+    foo_op()
 
 
 def define_demo_execution_repo():
     @repository
     def demo_execution_repo():
         return {
-            "pipelines": {
-                "always_fail_pipeline": always_fail_pipeline,
-                "demo_pipeline_celery": define_demo_pipeline_celery,
-                "demo_pipeline_docker": define_demo_pipeline_docker,
-                "demo_pipeline_docker_slow": define_demo_pipeline_docker_slow,
-                "step_retries_pipeline_docker": definie_step_retries_pipeline_docker,
-                "large_pipeline_celery": define_large_pipeline_celery,
-                "long_running_pipeline_celery": define_long_running_pipeline_celery,
-                "optional_outputs": optional_outputs,
-                "demo_pipeline": demo_pipeline,
-                "demo_pipeline_s3": demo_pipeline_s3,
-                "demo_pipeline_gcs": demo_pipeline_gcs,
-                "demo_error_pipeline": demo_error_pipeline,
-                "demo_error_pipeline_s3": demo_error_pipeline_s3,
-                "resources_limit_pipeline": define_resources_limit_pipeline,
-                "retry_pipeline": define_step_retry_pipeline,
-                "slow_pipeline": define_slow_pipeline,
-                "fan_in_fan_out_pipeline": define_fan_in_fan_out_pipeline,
-                "resource_pipeline": define_resource_pipeline,
-                "docker_celery_pipeline": define_docker_celery_pipeline,
-                "demo_airflow_execution_date_pipeline": demo_airflow_execution_date_pipeline,
-                "demo_airflow_execution_date_pipeline_s3": demo_airflow_execution_date_pipeline_s3,
-                "hanging_pipeline": hanging_pipeline,
-                "hard_failer": define_hard_failer,
-                "demo_k8s_executor_pipeline": define_demo_k8s_executor_pipeline,
-                "volume_mount_pipeline": define_volume_mount_pipeline,
-                "memoization_pipeline": define_memoization_pipeline,
-            },
             "jobs": {
-                "demo_error_job": demo_error_job,
-                "demo_airflow_execution_date_job": demo_airflow_execution_date_job,
-                "demo_job_celery": define_demo_job_celery,
+                "always_fail_job": define_job(always_fail_graph),
+                "demo_job": define_job(demo_graph),
+                "demo_job_s3": define_job(demo_graph, "s3"),
+                "demo_airflow_execution_date_job": define_job(demo_airflow_execution_date_graph),
+                "demo_airflow_execution_date_job_s3": define_job(
+                    demo_airflow_execution_date_graph, "s3"
+                ),
+                "demo_error_job": define_job(demo_error_graph),
+                "demo_error_job_s3": define_job(demo_error_graph, "s3"),
+                "demo_job_celery_k8s": define_job(demo_graph, "celery_k8s"),
+                "demo_job_docker": define_job(demo_graph, "docker"),
+                "demo_slow_job_docker": define_job(demo_slow_graph, "docker"),
+                "demo_job_gcs": define_job(demo_graph, "gcs"),
+                "demo_job_k8s": define_job(demo_graph, "k8s"),
+                "docker_celery_job": define_job(
+                    demo_resource_output_graph,
+                    "celery_docker",
+                    name="docker_celery_job",
+                    extra_resources={"resource_with_output": resource_with_output},
+                ),
+                "fan_in_fan_out_job": define_job(fan_in_fan_out_graph),
+                "hanging_job": define_job(hanging_graph),
+                "hard_failer_job_celery_k8s": define_job(hard_failer_graph, "celery_k8s"),
+                "volume_mount_job_k8s": define_job(volume_mount_graph, "k8s"),
+                "large_job_celery": define_job(large_graph, "celery"),
+                "long_running_job_celery_k8s": define_job(long_running_graph, "celery_k8s"),
+                "memoization_job_celery_k8s": define_memoization_job("celery_k8s"),
+                "memoization_job_k8s": define_memoization_job("k8s"),
+                "optional_outputs_job": define_job(optional_outputs_graph),
+                "resources_limit_job_k8s": define_job(
+                    resources_limit_graph, "k8s", tags=resources_limit_tags
+                ),
+                "resources_limit_job_celery_k8s": define_job(
+                    resources_limit_graph, "celery_k8s", tags=resources_limit_tags
+                ),
+                "resource_job_celery_k8s": define_job(
+                    resource_graph,
+                    "celery_k8s",
+                    extra_resources={
+                        "s3_resource_with_context_manager": s3_resource_with_context_manager
+                    },
+                ),
+                "retry_job_celery_k8s": define_job(retry_graph, "celery_k8s"),
+                "retry_job_k8s": define_job(retry_graph, "k8s"),
+                "slow_job_celery_k8s": define_job(slow_graph, "celery_k8s"),
+                "slow_job_k8s": define_job(slow_graph, "k8s"),
+                "step_retries_job_docker": define_job(step_retries_graph, "docker"),
+                "volume_mount_job_celery_k8s": define_job(volume_mount_graph, "celery_k8s"),
             },
             "schedules": define_schedules(),
         }

--- a/python_modules/dagster-test/dagster_test_tests/test_test_project.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_test_project.py
@@ -7,7 +7,7 @@ from dagster_test.test_project import (
 
 def test_reoriginated_external_pipeline():
     with instance_for_test() as instance:
-        with get_test_project_workspace_and_external_pipeline(instance, "demo_pipeline_celery") as (
+        with get_test_project_workspace_and_external_pipeline(instance, "demo_job_celery_k8s") as (
             _workspace,
             external_pipeline,
         ):

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -453,7 +453,7 @@ def execute_job(
 
     `execute_job` expects a persistent :py:class:`DagsterInstance` for
     execution, meaning the `$DAGSTER_HOME` environment variable must be set.
-    It als expects a reconstructable pointer to a :py:class:`JobDefinition` so
+    It also expects a reconstructable pointer to a :py:class:`JobDefinition` so
     that it can be reconstructed in separate processes. This can be done by
     wrapping the ``JobDefinition`` in a call to :py:func:`dagster.
     reconstructable`.

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -121,6 +121,18 @@ class ExecutionResult(ABC):
 
         return self._filter_events_by_handle(NodeHandle.from_string(node_name))
 
+    def is_node_success(self, node_str: str) -> bool:
+        return any(evt.is_step_success for evt in self.events_for_node(node_str))
+
+    def is_node_failed(self, node_str: str) -> bool:
+        return any(evt.is_step_failure for evt in self.events_for_node(node_str))
+
+    def is_node_skipped(self, node_str: str) -> bool:
+        return any(evt.is_step_skipped for evt in self.events_for_node(node_str))
+
+    def is_node_untouched(self, node_str: str) -> bool:
+        return len(self.events_for_node(node_str)) == 0
+
     def get_job_failure_event(self) -> DagsterEvent:
         """Returns a DagsterEvent with type DagsterEventType.PIPELINE_FAILURE if it ocurred during
         execution.
@@ -169,6 +181,9 @@ class ExecutionResult(ABC):
 
     def get_step_skipped_events(self) -> Sequence[DagsterEvent]:
         return [event for event in self.all_events if event.is_step_skipped]
+
+    def get_step_failure_events(self) -> Sequence[DagsterEvent]:
+        return [event for event in self.all_events if event.is_step_failure]
 
     def get_failed_step_keys(self) -> AbstractSet[str]:
         failure_events = self.filter_events(

--- a/python_modules/dagster/dagster/_legacy/__init__.py
+++ b/python_modules/dagster/dagster/_legacy/__init__.py
@@ -25,6 +25,5 @@ from dagster._core.storage.fs_io_manager import (
     fs_io_manager as fs_io_manager,
 )
 from dagster._utils.test import (
-    execute_solid as execute_solid,
     execute_solid_within_pipeline as execute_solid_within_pipeline,
 )

--- a/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_config_scaffolder.py
@@ -2,7 +2,6 @@ from dagster import (
     Int,
     OpDefinition,
     ResourceDefinition,
-    String,
     _check as check,
 )
 from dagster._cli.config_scaffolder import scaffold_pipeline_config, scaffold_type
@@ -70,11 +69,11 @@ def test_two_modes(snapshot):
         mode_defs=[
             ModeDefinition(
                 "mode_one",
-                resource_defs={"value": dummy_resource({"mode_one_field": String})},
+                resource_defs={"value": dummy_resource({"mode_one_field": str})},
             ),
             ModeDefinition(
                 "mode_two",
-                resource_defs={"value": dummy_resource({"mode_two_field": Int})},
+                resource_defs={"value": dummy_resource({"mode_two_field": int})},
             ),
         ],
     )

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_dict.py
@@ -11,7 +11,7 @@ from dagster import (
     op,
     usable_as_dagster_type,
 )
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_basic_python_dictionary_output():
@@ -19,7 +19,7 @@ def test_basic_python_dictionary_output():
     def emit_dict():
         return {"key": "value"}
 
-    assert execute_solid(emit_dict).output_value() == {"key": "value"}
+    assert wrap_op_in_graph_and_execute(emit_dict).output_value() == {"key": "value"}
 
 
 def test_basic_python_dictionary_input():
@@ -28,7 +28,10 @@ def test_basic_python_dictionary_input():
         return data["key"]
 
     assert (
-        execute_solid(input_dict, input_values={"data": {"key": "value"}}).output_value() == "value"
+        wrap_op_in_graph_and_execute(
+            input_dict, input_values={"data": {"key": "value"}}
+        ).output_value()
+        == "value"
     )
 
 
@@ -38,7 +41,7 @@ def test_basic_python_dictionary_wrong():
         return 1
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict)
+        wrap_op_in_graph_and_execute(emit_dict)
 
 
 def test_basic_python_dictionary_input_wrong():
@@ -47,7 +50,7 @@ def test_basic_python_dictionary_input_wrong():
         return data["key"]
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(input_dict, input_values={"data": 123})
+        wrap_op_in_graph_and_execute(input_dict, input_values={"data": 123})
 
 
 def test_execute_dict_from_config():
@@ -56,9 +59,10 @@ def test_execute_dict_from_config():
         return data["key"]
 
     assert (
-        execute_solid(
+        wrap_op_in_graph_and_execute(
             input_dict,
-            run_config={"solids": {"input_dict": {"inputs": {"data": {"key": "in_config"}}}}},
+            run_config={"ops": {"input_dict": {"inputs": {"data": {"key": "in_config"}}}}},
+            do_input_mapping=False,
         ).output_value()
         == "in_config"
     )
@@ -69,7 +73,7 @@ def test_dagster_dictionary_output():
     def emit_dict():
         return {"key": "value"}
 
-    assert execute_solid(emit_dict).output_value() == {"key": "value"}
+    assert wrap_op_in_graph_and_execute(emit_dict).output_value() == {"key": "value"}
 
 
 def test_basic_dagster_dictionary_input():
@@ -78,7 +82,10 @@ def test_basic_dagster_dictionary_input():
         return data["key"]
 
     assert (
-        execute_solid(input_dict, input_values={"data": {"key": "value"}}).output_value() == "value"
+        wrap_op_in_graph_and_execute(
+            input_dict, input_values={"data": {"key": "value"}}
+        ).output_value()
+        == "value"
     )
 
 
@@ -87,7 +94,7 @@ def test_basic_typing_dictionary_output():
     def emit_dict():
         return {"key": "value"}
 
-    assert execute_solid(emit_dict).output_value() == {"key": "value"}
+    assert wrap_op_in_graph_and_execute(emit_dict).output_value() == {"key": "value"}
 
 
 def test_basic_typing_dictionary_input():
@@ -99,7 +106,10 @@ def test_basic_typing_dictionary_input():
         return data["key"]
 
     assert (
-        execute_solid(input_dict, input_values={"data": {"key": "value"}}).output_value() == "value"
+        wrap_op_in_graph_and_execute(
+            input_dict, input_values={"data": {"key": "value"}}
+        ).output_value()
+        == "value"
     )
 
 
@@ -109,7 +119,7 @@ def test_basic_closed_typing_dictionary_wrong():
         return 1
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict)
+        wrap_op_in_graph_and_execute(emit_dict)
 
 
 def test_basic_closed_typing_dictionary_output():
@@ -117,7 +127,7 @@ def test_basic_closed_typing_dictionary_output():
     def emit_dict():
         return {"key": "value"}
 
-    assert execute_solid(emit_dict).output_value() == {"key": "value"}
+    assert wrap_op_in_graph_and_execute(emit_dict).output_value() == {"key": "value"}
     assert emit_dict.output_defs[0].dagster_type.key == "TypedPythonDict.String.String"
     assert emit_dict.output_defs[0].dagster_type.key_type.unique_name == "String"
     assert emit_dict.output_defs[0].dagster_type.value_type.unique_name == "String"
@@ -132,7 +142,10 @@ def test_basic_closed_typing_dictionary_input():
         return data["key"]
 
     assert (
-        execute_solid(input_dict, input_values={"data": {"key": "value"}}).output_value() == "value"
+        wrap_op_in_graph_and_execute(
+            input_dict, input_values={"data": {"key": "value"}}
+        ).output_value()
+        == "value"
     )
 
 
@@ -142,7 +155,7 @@ def test_basic_closed_typing_dictionary_key_wrong():
         return {1: "foo"}
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict)
+        wrap_op_in_graph_and_execute(emit_dict)
 
 
 def test_basic_closed_typing_dictionary_value_wrong():
@@ -151,7 +164,7 @@ def test_basic_closed_typing_dictionary_value_wrong():
         return {"foo": 1}
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict)
+        wrap_op_in_graph_and_execute(emit_dict)
 
 
 def test_complicated_dictionary_typing_pass():
@@ -159,7 +172,7 @@ def test_complicated_dictionary_typing_pass():
     def emit_dict():
         return {"foo": [{1: 1, 2: 2}]}
 
-    assert execute_solid(emit_dict).output_value() == {"foo": [{1: 1, 2: 2}]}
+    assert wrap_op_in_graph_and_execute(emit_dict).output_value() == {"foo": [{1: 1, 2: 2}]}
 
 
 def test_complicated_dictionary_typing_fail():
@@ -168,7 +181,7 @@ def test_complicated_dictionary_typing_fail():
         return {"foo": [{1: 1, "2": 2}]}
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict)
+        wrap_op_in_graph_and_execute(emit_dict)
 
 
 def test_dict_type_loader():
@@ -178,9 +191,10 @@ def test_dict_type_loader():
     def emit_dict(dict_input):
         return dict_input
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         emit_dict,
-        run_config={"solids": {"emit_dict": {"inputs": {"dict_input": test_input}}}},
+        run_config={"ops": {"emit_dict": {"inputs": {"dict_input": test_input}}}},
+        do_input_mapping=False,
     )
     assert result.success
     assert result.output_value() == test_input
@@ -201,9 +215,10 @@ def test_dict_type_loader_typing_fail():
         DagsterInvalidDefinitionError,
         match="Input 'dict_input' of op 'emit_dict' has no way of being resolved.",
     ):
-        execute_solid(
+        wrap_op_in_graph_and_execute(
             emit_dict,
-            run_config={"op": {"emit_dict": {"inputs": {"dict_input": test_input}}}},
+            run_config={"ops": {"emit_dict": {"inputs": {"dict_input": test_input}}}},
+            do_input_mapping=False,
         )
 
 
@@ -215,7 +230,7 @@ def test_dict_type_loader_inner_type_mismatch():
         return dict_input
 
     with pytest.raises(DagsterInvalidConfigError):
-        execute_solid(
+        wrap_op_in_graph_and_execute(
             emit_dict,
             run_config={"ops": {"emit_dict": {"inputs": {"dict_input": test_input}}}},
         )

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_set.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_set.py
@@ -4,7 +4,7 @@ import pytest
 from dagster import DagsterTypeCheckDidNotPass, In, Optional, Out, op
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._core.types.python_set import create_typed_runtime_set
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_vanilla_set_output():
@@ -12,7 +12,7 @@ def test_vanilla_set_output():
     def emit_set():
         return {1, 2}
 
-    assert execute_solid(emit_set).output_value() == {1, 2}
+    assert wrap_op_in_graph_and_execute(emit_set).output_value() == {1, 2}
 
 
 def test_vanilla_set_output_fail():
@@ -21,7 +21,7 @@ def test_vanilla_set_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_set)
+        wrap_op_in_graph_and_execute(emit_set)
 
 
 def test_vanilla_set_input():
@@ -29,7 +29,10 @@ def test_vanilla_set_input():
     def take_set(tt):
         return tt
 
-    assert execute_solid(take_set, input_values={"tt": {2, 3}}).output_value() == {2, 3}
+    assert wrap_op_in_graph_and_execute(take_set, input_values={"tt": {2, 3}}).output_value() == {
+        2,
+        3,
+    }
 
 
 def test_vanilla_set_input_fail():
@@ -38,7 +41,7 @@ def test_vanilla_set_input_fail():
         return tt
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_set, input_values={"tt": "fkjdf"})
+        wrap_op_in_graph_and_execute(take_set, input_values={"tt": "fkjdf"})
 
 
 def test_open_typing_set_output():
@@ -46,7 +49,7 @@ def test_open_typing_set_output():
     def emit_set():
         return {1, 2}
 
-    assert execute_solid(emit_set).output_value() == {1, 2}
+    assert wrap_op_in_graph_and_execute(emit_set).output_value() == {1, 2}
 
 
 def test_open_typing_set_output_fail():
@@ -55,7 +58,7 @@ def test_open_typing_set_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_set)
+        wrap_op_in_graph_and_execute(emit_set)
 
 
 def test_open_typing_set_input():
@@ -63,7 +66,10 @@ def test_open_typing_set_input():
     def take_set(tt):
         return tt
 
-    assert execute_solid(take_set, input_values={"tt": {2, 3}}).output_value() == {2, 3}
+    assert wrap_op_in_graph_and_execute(take_set, input_values={"tt": {2, 3}}).output_value() == {
+        2,
+        3,
+    }
 
 
 def test_open_typing_set_input_fail():
@@ -72,7 +78,7 @@ def test_open_typing_set_input_fail():
         return tt
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_set, input_values={"tt": "fkjdf"})
+        wrap_op_in_graph_and_execute(take_set, input_values={"tt": "fkjdf"})
 
 
 def test_runtime_set_of_int():
@@ -110,7 +116,10 @@ def test_closed_typing_set_input():
     def take_set(tt):
         return tt
 
-    assert execute_solid(take_set, input_values={"tt": {2, 3}}).output_value() == {2, 3}
+    assert wrap_op_in_graph_and_execute(take_set, input_values={"tt": {2, 3}}).output_value() == {
+        2,
+        3,
+    }
 
 
 def test_closed_typing_set_input_fail():
@@ -119,10 +128,10 @@ def test_closed_typing_set_input_fail():
         return tt
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_set, input_values={"tt": "fkjdf"})
+        wrap_op_in_graph_and_execute(take_set, input_values={"tt": "fkjdf"})
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_set, input_values={"tt": {"fkjdf"}})
+        wrap_op_in_graph_and_execute(take_set, input_values={"tt": {"fkjdf"}})
 
 
 def test_typed_set_type_loader():
@@ -132,9 +141,10 @@ def test_typed_set_type_loader():
 
     expected_output = set([1, 2, 3, 4])
     assert (
-        execute_solid(
+        wrap_op_in_graph_and_execute(
             take_set,
-            run_config={"solids": {"take_set": {"inputs": {"tt": list(expected_output)}}}},
+            run_config={"ops": {"take_set": {"inputs": {"tt": list(expected_output)}}}},
+            do_input_mapping=False,
         ).output_value()
         == expected_output
     )

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_tuple.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_python_tuple.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import pytest
 from dagster import DagsterTypeCheckDidNotPass, In, Out, op
 from dagster._core.types.python_tuple import create_typed_tuple
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_vanilla_tuple_output():
@@ -11,7 +11,7 @@ def test_vanilla_tuple_output():
     def emit_tuple():
         return (1, 2)
 
-    assert execute_solid(emit_tuple).output_value() == (1, 2)
+    assert wrap_op_in_graph_and_execute(emit_tuple).output_value() == (1, 2)
 
 
 def test_vanilla_tuple_output_fail():
@@ -20,7 +20,7 @@ def test_vanilla_tuple_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_tuple)
+        wrap_op_in_graph_and_execute(emit_tuple)
 
 
 def test_vanilla_tuple_input():
@@ -28,7 +28,7 @@ def test_vanilla_tuple_input():
     def take_tuple(tt):
         return tt
 
-    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
+    assert wrap_op_in_graph_and_execute(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
         2,
         3,
     )
@@ -40,7 +40,7 @@ def test_vanilla_tuple_input_fail():
         return tt
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_tuple, input_values={"tt": "fkjdf"})
+        wrap_op_in_graph_and_execute(take_tuple, input_values={"tt": "fkjdf"})
 
 
 def test_open_typing_tuple_output():
@@ -48,7 +48,7 @@ def test_open_typing_tuple_output():
     def emit_tuple():
         return (1, 2)
 
-    assert execute_solid(emit_tuple).output_value() == (1, 2)
+    assert wrap_op_in_graph_and_execute(emit_tuple).output_value() == (1, 2)
 
 
 def test_open_typing_tuple_output_fail():
@@ -57,7 +57,7 @@ def test_open_typing_tuple_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_tuple)
+        wrap_op_in_graph_and_execute(emit_tuple)
 
 
 def test_open_typing_tuple_input():
@@ -65,7 +65,7 @@ def test_open_typing_tuple_input():
     def take_tuple(tt):
         return tt
 
-    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
+    assert wrap_op_in_graph_and_execute(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
         2,
         3,
     )
@@ -77,7 +77,7 @@ def test_open_typing_tuple_input_fail():
         return tt
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_tuple, input_values={"tt": "fkjdf"})
+        wrap_op_in_graph_and_execute(take_tuple, input_values={"tt": "fkjdf"})
 
 
 def test_typed_python_tuple_directly():
@@ -120,7 +120,7 @@ def test_closed_typing_tuple_output():
     def emit_tuple():
         return (1, 2)
 
-    assert execute_solid(emit_tuple).output_value() == (1, 2)
+    assert wrap_op_in_graph_and_execute(emit_tuple).output_value() == (1, 2)
 
 
 def test_closed_typing_tuple_output_fail():
@@ -129,7 +129,7 @@ def test_closed_typing_tuple_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_tuple)
+        wrap_op_in_graph_and_execute(emit_tuple)
 
 
 def test_closed_typing_tuple_output_fail_wrong_member_types():
@@ -138,7 +138,7 @@ def test_closed_typing_tuple_output_fail_wrong_member_types():
         return (1, "nope")
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_tuple)
+        wrap_op_in_graph_and_execute(emit_tuple)
 
 
 def test_closed_typing_tuple_output_fail_wrong_length():
@@ -147,7 +147,7 @@ def test_closed_typing_tuple_output_fail_wrong_length():
         return (1,)
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_tuple)
+        wrap_op_in_graph_and_execute(emit_tuple)
 
 
 def test_closed_typing_tuple_input():
@@ -155,7 +155,7 @@ def test_closed_typing_tuple_input():
     def take_tuple(tt):
         return tt
 
-    assert execute_solid(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
+    assert wrap_op_in_graph_and_execute(take_tuple, input_values={"tt": (2, 3)}).output_value() == (
         2,
         3,
     )
@@ -167,4 +167,4 @@ def test_closed_typing_tuple_input_fail():
         return tt
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(take_tuple, input_values={"tt": "fkjdf"})
+        wrap_op_in_graph_and_execute(take_tuple, input_values={"tt": "fkjdf"})

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_list.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_list.py
@@ -2,7 +2,7 @@ import typing
 
 import pytest
 from dagster import DagsterTypeCheckDidNotPass, In, Out, op
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_basic_list_output_pass():
@@ -10,7 +10,7 @@ def test_basic_list_output_pass():
     def emit_list():
         return [1]
 
-    assert execute_solid(emit_list).output_value() == [1]
+    assert wrap_op_in_graph_and_execute(emit_list).output_value() == [1]
 
 
 def test_basic_list_output_fail():
@@ -19,7 +19,7 @@ def test_basic_list_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_list).output_value()
+        wrap_op_in_graph_and_execute(emit_list).output_value()
 
 
 def test_basic_list_input_pass():
@@ -27,7 +27,9 @@ def test_basic_list_input_pass():
     def ingest_list(alist):
         return alist
 
-    assert execute_solid(ingest_list, input_values={"alist": [2]}).output_value() == [2]
+    assert wrap_op_in_graph_and_execute(
+        ingest_list, input_values={"alist": [2]}
+    ).output_value() == [2]
 
 
 def test_basic_list_input_fail():
@@ -36,7 +38,7 @@ def test_basic_list_input_fail():
         return alist
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(ingest_list, input_values={"alist": "foobar"})
+        wrap_op_in_graph_and_execute(ingest_list, input_values={"alist": "foobar"})
 
 
 def test_typing_list_output_pass():
@@ -44,7 +46,7 @@ def test_typing_list_output_pass():
     def emit_list():
         return [1]
 
-    assert execute_solid(emit_list).output_value() == [1]
+    assert wrap_op_in_graph_and_execute(emit_list).output_value() == [1]
 
 
 def test_typing_list_output_fail():
@@ -53,7 +55,7 @@ def test_typing_list_output_fail():
         return "foo"
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_list).output_value()
+        wrap_op_in_graph_and_execute(emit_list).output_value()
 
 
 def test_typing_list_input_pass():
@@ -61,7 +63,9 @@ def test_typing_list_input_pass():
     def ingest_list(alist):
         return alist
 
-    assert execute_solid(ingest_list, input_values={"alist": [2]}).output_value() == [2]
+    assert wrap_op_in_graph_and_execute(
+        ingest_list, input_values={"alist": [2]}
+    ).output_value() == [2]
 
 
 def test_typing_list_input_fail():
@@ -70,7 +74,7 @@ def test_typing_list_input_fail():
         return alist
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(ingest_list, input_values={"alist": "foobar"})
+        wrap_op_in_graph_and_execute(ingest_list, input_values={"alist": "foobar"})
 
 
 def test_typing_list_of_int_output_pass():
@@ -78,7 +82,7 @@ def test_typing_list_of_int_output_pass():
     def emit_list():
         return [1]
 
-    assert execute_solid(emit_list).output_value() == [1]
+    assert wrap_op_in_graph_and_execute(emit_list).output_value() == [1]
 
 
 def test_typing_list_of_int_output_fail():
@@ -87,7 +91,7 @@ def test_typing_list_of_int_output_fail():
         return ["foo"]
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_list).output_value()
+        wrap_op_in_graph_and_execute(emit_list).output_value()
 
 
 def test_typing_list_of_int_input_pass():
@@ -95,7 +99,9 @@ def test_typing_list_of_int_input_pass():
     def ingest_list(alist):
         return alist
 
-    assert execute_solid(ingest_list, input_values={"alist": [2]}).output_value() == [2]
+    assert wrap_op_in_graph_and_execute(
+        ingest_list, input_values={"alist": [2]}
+    ).output_value() == [2]
 
 
 def test_typing_list_of_int_input_fail():
@@ -104,7 +110,7 @@ def test_typing_list_of_int_input_fail():
         return alist
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(ingest_list, input_values={"alist": ["foobar"]})
+        wrap_op_in_graph_and_execute(ingest_list, input_values={"alist": ["foobar"]})
 
 
 LIST_LIST_INT = typing.List[typing.List[int]]
@@ -115,7 +121,7 @@ def test_typing_list_of_list_of_int_output_pass():
     def emit_list():
         return [[1, 2], [3, 4]]
 
-    assert execute_solid(emit_list).output_value() == [[1, 2], [3, 4]]
+    assert wrap_op_in_graph_and_execute(emit_list).output_value() == [[1, 2], [3, 4]]
 
 
 def test_typing_list_of_list_of_int_output_fail():
@@ -124,7 +130,7 @@ def test_typing_list_of_list_of_int_output_fail():
         return [[1, 2], [3, "4"]]
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_list).output_value()
+        wrap_op_in_graph_and_execute(emit_list).output_value()
 
 
 def test_typing_list_of_list_of_int_input_pass():
@@ -132,7 +138,9 @@ def test_typing_list_of_list_of_int_input_pass():
     def ingest_list(alist):
         return alist
 
-    assert execute_solid(ingest_list, input_values={"alist": [[1, 2], [3, 4]]}).output_value() == [
+    assert wrap_op_in_graph_and_execute(
+        ingest_list, input_values={"alist": [[1, 2], [3, 4]]}
+    ).output_value() == [
         [1, 2],
         [3, 4],
     ]
@@ -144,4 +152,4 @@ def test_typing_list_of_list_of_int_input_fail():
         return alist
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(ingest_list, input_values={"alist": [[1, 2], [3, "4"]]})
+        wrap_op_in_graph_and_execute(ingest_list, input_values={"alist": [[1, 2], [3, "4"]]})

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_python_dict.py
@@ -1,6 +1,6 @@
 import pytest
 from dagster import DagsterTypeCheckDidNotPass, Dict, In, Out, op
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_typed_python_dict():
@@ -21,7 +21,7 @@ def test_basic_solid_dict_int_int_output():
     def emit_dict_int_int():
         return {1: 1}
 
-    assert execute_solid(emit_dict_int_int).output_value() == {1: 1}
+    assert wrap_op_in_graph_and_execute(emit_dict_int_int).output_value() == {1: 1}
 
 
 def test_basic_solid_dict_int_int_output_faile():
@@ -30,7 +30,7 @@ def test_basic_solid_dict_int_int_output_faile():
         return {1: "1"}
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict_int_int)
+        wrap_op_in_graph_and_execute(emit_dict_int_int)
 
 
 def test_basic_solid_dict_int_int_input_pass():
@@ -38,7 +38,9 @@ def test_basic_solid_dict_int_int_input_pass():
     def emit_dict_int_int(ddict):
         return ddict
 
-    assert execute_solid(emit_dict_int_int, input_values={"ddict": {1: 2}}).output_value() == {1: 2}
+    assert wrap_op_in_graph_and_execute(
+        emit_dict_int_int, input_values={"ddict": {1: 2}}
+    ).output_value() == {1: 2}
 
 
 def test_basic_solid_dict_int_int_input_fails():
@@ -47,4 +49,4 @@ def test_basic_solid_dict_int_int_input_fails():
         return ddict
 
     with pytest.raises(DagsterTypeCheckDidNotPass):
-        execute_solid(emit_dict_int_int, input_values={"ddict": {"1": 2}})
+        wrap_op_in_graph_and_execute(emit_dict_int_int, input_values={"ddict": {"1": 2}})

--- a/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_multiple_outputs.py
@@ -14,9 +14,9 @@ from dagster._core.definitions.output import Out
 from dagster._core.test_utils import default_mode_def_for_test, instance_for_test
 from dagster._legacy import (
     execute_pipeline,
-    execute_solid,
     pipeline,
 )
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_multiple_outputs():
@@ -200,6 +200,8 @@ def test_warning_for_conditional_output(capsys):
         if context.op_config["return"]:
             return 3
 
-    result = execute_solid(maybe, run_config={"solids": {"maybe": {"config": {"return": False}}}})
+    result = wrap_op_in_graph_and_execute(
+        maybe, run_config={"solids": {"maybe": {"config": {"return": False}}}}
+    )
     assert result.success
     assert "This value will be passed to downstream ops" in capsys.readouterr().err

--- a/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_pipeline_errors.py
@@ -16,9 +16,9 @@ from dagster._core.definitions.output import Out
 from dagster._legacy import (
     PipelineDefinition,
     execute_pipeline,
-    execute_solid,
     pipeline,
 )
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def create_root_success_solid(name):
@@ -154,7 +154,7 @@ def test_do_not_yield_result():
         DagsterInvariantViolationError,
         match='Compute function for op "do_not_yield_result" returned an Output',
     ):
-        execute_solid(solid_inst)
+        wrap_op_in_graph_and_execute(solid_inst)
 
 
 def test_yield_non_result():
@@ -170,7 +170,7 @@ def test_yield_non_result():
             " 'str'> rather than an instance of Output, AssetMaterialization, or ExpectationResult."
         ),
     ):
-        execute_solid(yield_wrong_thing)
+        wrap_op_in_graph_and_execute(yield_wrong_thing)
 
 
 def test_single_compute_fn_returning_result():
@@ -181,7 +181,7 @@ def test_single_compute_fn_returning_result():
     )
 
     with pytest.raises(DagsterInvariantViolationError):
-        execute_solid(test_return_result)
+        wrap_op_in_graph_and_execute(test_return_result)
 
 
 def test_user_error_propogation():

--- a/python_modules/dagster/dagster_tests/core_tests/test_solid_arguments.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_solid_arguments.py
@@ -1,7 +1,7 @@
 import pytest
 from dagster import In, op
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_solid_input_arguments():
@@ -97,14 +97,22 @@ def test_execution_cases():
     def underscore_inputs(x, _):
         return x + _
 
-    assert execute_solid(underscore_inputs, input_values={"x": 5, "_": 6}).output_value() == 11
+    assert (
+        wrap_op_in_graph_and_execute(
+            underscore_inputs, input_values={"x": 5, "_": 6}
+        ).output_value()
+        == 11
+    )
 
     @op
     def context_underscore_inputs(context, x, _):
         return x + _
 
     assert (
-        execute_solid(context_underscore_inputs, input_values={"x": 5, "_": 6}).output_value() == 11
+        wrap_op_in_graph_and_execute(
+            context_underscore_inputs, input_values={"x": 5, "_": 6}
+        ).output_value()
+        == 11
     )
 
     @op
@@ -112,7 +120,7 @@ def test_execution_cases():
         return x + context_
 
     assert (
-        execute_solid(
+        wrap_op_in_graph_and_execute(
             underscore_context_poorly_named_input, input_values={"x": 5, "context_": 6}
         ).output_value()
         == 11

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_solid.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_solid.py
@@ -16,7 +16,7 @@ from dagster import (
     job,
     op,
 )
-from dagster._core.utility_solids import define_stub_solid
+from dagster._core.utility_solids import create_stub_op
 
 # This file tests a lot of parameter name stuff, so these warnings are spurious
 
@@ -148,7 +148,7 @@ def test_solid_with_input():
 
     the_job = JobDefinition(
         graph_def=GraphDefinition(
-            node_defs=[define_stub_solid("test_value", {"foo": "bar"}), hello_world],
+            node_defs=[create_stub_op("test_value", {"foo": "bar"}), hello_world],
             name="test",
             dependencies={"hello_world": {"foo_to_foo": DependencyDefinition("test_value")}},
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
@@ -14,7 +14,7 @@ from dagster import (
     op,
 )
 from dagster._check import ParameterCheckError
-from dagster._core.utility_solids import define_stub_solid
+from dagster._core.utility_solids import create_stub_op
 
 
 def solid_a_b_list():
@@ -39,9 +39,7 @@ def test_create_pipeline_with_bad_solids_list():
         ParameterCheckError,
         match=r'Param "node_defs" is not one of \[\'Sequence\'\]',
     ):
-        GraphDefinition(
-            name="a_pipeline", node_defs=define_stub_solid("stub", [{"a key": "a value"}])
-        )
+        GraphDefinition(name="a_pipeline", node_defs=create_stub_op("stub", [{"a key": "a value"}]))
 
 
 def test_circular_dep():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_async.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_async.py
@@ -2,7 +2,7 @@ import asyncio
 
 from dagster import Output
 from dagster._core.definitions.decorators import op
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_aio_solid():
@@ -11,7 +11,7 @@ def test_aio_solid():
         await asyncio.sleep(0.01)
         return "done"
 
-    result = execute_solid(aio_solid)
+    result = wrap_op_in_graph_and_execute(aio_solid)
     assert result.output_value() == "done"
 
 
@@ -21,5 +21,5 @@ def test_aio_gen_solid():
         await asyncio.sleep(0.01)
         yield Output("done")
 
-    result = execute_solid(aio_gen)
+    result = wrap_op_in_graph_and_execute(aio_gen)
     assert result.output_value() == "done"

--- a/python_modules/dagster/dagster_tests/execution_tests/test_solid_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_solid_iterators.py
@@ -1,7 +1,7 @@
 from dagster import AssetMaterialization, Output
 from dagster._annotations import experimental
 from dagster._core.definitions.decorators import op
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_generator_return_solid():
@@ -12,7 +12,7 @@ def test_generator_return_solid():
     def gen_ret_solid(_):
         return _gen()
 
-    result = execute_solid(gen_ret_solid)
+    result = wrap_op_in_graph_and_execute(gen_ret_solid)
     assert result.output_value() == "done"
 
 
@@ -25,7 +25,7 @@ def test_generator_yield_solid():
         for event in _gen():
             yield event
 
-    result = execute_solid(gen_yield_solid)
+    result = wrap_op_in_graph_and_execute(gen_yield_solid)
     assert result.output_value() == "done"
 
 
@@ -37,7 +37,7 @@ def test_generator_yield_from_solid():
     def gen_yield_solid(_):
         yield from _gen()
 
-    result = execute_solid(gen_yield_solid)
+    result = wrap_op_in_graph_and_execute(gen_yield_solid)
     assert result.output_value() == "done"
 
 
@@ -56,7 +56,7 @@ def test_nested_generator_solid():
     def gen_return_solid(_):
         return _gen()
 
-    result = execute_solid(gen_return_solid)
+    result = wrap_op_in_graph_and_execute(gen_return_solid)
     assert result.output_value() == "done"
 
 
@@ -66,5 +66,5 @@ def test_experimental_generator_solid():
     def gen_solid():
         yield Output("done")
 
-    result = execute_solid(gen_solid)
+    result = wrap_op_in_graph_and_execute(gen_solid)
     assert result.output_value() == "done"

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -15,7 +15,8 @@ from dagster import (
 from dagster._core.definitions.decorators.graph_decorator import graph
 from dagster._core.definitions.inference import infer_input_props, infer_output_props
 from dagster._core.types.dagster_type import DagsterTypeKind
-from dagster._legacy import execute_pipeline, execute_solid, pipeline
+from dagster._legacy import execute_pipeline, pipeline
+from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
 def test_infer_solid_description_from_docstring():
@@ -190,7 +191,7 @@ def test_emit_dict():
     def emit_dict() -> dict:
         return {"foo": "bar"}
 
-    solid_result = execute_solid(emit_dict)
+    solid_result = wrap_op_in_graph_and_execute(emit_dict)
 
     assert solid_result.output_value() == {"foo": "bar"}
 
@@ -200,7 +201,7 @@ def test_dict_input():
     def intake_dict(inp: dict) -> str:
         return inp["foo"]
 
-    solid_result = execute_solid(intake_dict, input_values={"inp": {"foo": "bar"}})
+    solid_result = wrap_op_in_graph_and_execute(intake_dict, input_values={"inp": {"foo": "bar"}})
     assert solid_result.output_value() == "bar"
 
 
@@ -209,7 +210,7 @@ def test_emit_dagster_dict():
     def emit_dagster_dict() -> Dict:
         return {"foo": "bar"}
 
-    solid_result = execute_solid(emit_dagster_dict)
+    solid_result = wrap_op_in_graph_and_execute(emit_dagster_dict)
 
     assert solid_result.output_value() == {"foo": "bar"}
 
@@ -219,7 +220,9 @@ def test_dict_dagster_input():
     def intake_dagster_dict(inp: Dict) -> str:
         return inp["foo"]
 
-    solid_result = execute_solid(intake_dagster_dict, input_values={"inp": {"foo": "bar"}})
+    solid_result = wrap_op_in_graph_and_execute(
+        intake_dagster_dict, input_values={"inp": {"foo": "bar"}}
+    )
     assert solid_result.output_value() == "bar"
 
 
@@ -228,7 +231,9 @@ def test_python_tuple_input():
     def intake_tuple(inp: tuple) -> int:
         return inp[1]
 
-    assert execute_solid(intake_tuple, input_values={"inp": (3, 4)}).output_value() == 4
+    assert (
+        wrap_op_in_graph_and_execute(intake_tuple, input_values={"inp": (3, 4)}).output_value() == 4
+    )
 
 
 def test_python_tuple_output():
@@ -236,7 +241,7 @@ def test_python_tuple_output():
     def emit_tuple() -> tuple:
         return (4, 5)
 
-    assert execute_solid(emit_tuple).output_value() == (4, 5)
+    assert wrap_op_in_graph_and_execute(emit_tuple).output_value() == (4, 5)
 
 
 def test_nested_kitchen_sink():

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecr_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecr_tests/test_resources.py
@@ -1,5 +1,5 @@
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_aws.ecr import fake_ecr_public_resource
 
 
@@ -8,9 +8,9 @@ def test_ecr_public_get_login_password():
     def ecr_public_solid(context):
         return context.resources.ecr_public.get_login_password()
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         ecr_public_solid,
-        mode_def=ModeDefinition(resource_defs={"ecr_public": fake_ecr_public_resource}),
+        resources={"ecr_public": fake_ecr_public_resource},
     )
 
     assert result.output_value() == "token"

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -347,7 +347,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             )
 
             celery_k8s_run_launcher.register_instance(instance)
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run_config = {"execution": {"celery-k8s": {"config": {"job_image": "fake-image-name"}}}}
             run = create_run_for_test(
                 instance,
@@ -423,7 +423,7 @@ def test_raise_on_error(kubeconfig_file):
             )
 
             celery_k8s_run_launcher.register_instance(instance)
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run_config = {"execution": {"celery-k8s": {"config": {"job_image": "fake-image-name"}}}}
             run = create_run_for_test(
                 instance,
@@ -466,7 +466,7 @@ def test_k8s_executor_config_override(kubeconfig_file):
         k8s_client_batch_api=mock_k8s_client_batch_api,
     )
 
-    pipeline_name = "demo_pipeline"
+    pipeline_name = "demo_job"
 
     with instance_for_test() as instance:
         with get_test_project_workspace_and_external_pipeline(

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/conftest.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/conftest.py
@@ -2,10 +2,12 @@ import os
 import subprocess
 import tempfile
 import time
+from typing import Iterator
 
 import docker
 import pytest
 from dagster import file_relative_path
+from dagster._core.instance import DagsterInstance
 from dagster._core.test_utils import environ, instance_for_test
 from dagster_test.test_project import build_and_tag_test_image, get_test_project_docker_image
 
@@ -73,7 +75,7 @@ def instance(tempdir):
 
 
 @pytest.fixture(scope="function")
-def dagster_celery_worker(rabbitmq, instance):
+def dagster_celery_worker(rabbitmq, instance: DagsterInstance) -> Iterator[None]:
     with start_celery_worker():
         yield
 

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/repo.py
@@ -1,23 +1,10 @@
 import time
 
-from dagster import Int, Output, RetryRequested, VersionStrategy, fs_io_manager
+from dagster import Int, Output, RetryRequested, VersionStrategy, job
 from dagster._core.definitions.decorators import op
 from dagster._core.definitions.output import Out
-from dagster._core.test_utils import nesting_graph_pipeline
-from dagster._legacy import (
-    ModeDefinition,
-    default_executors,
-    pipeline,
-)
+from dagster._core.test_utils import nesting_graph
 from dagster_celery import celery_executor
-
-celery_mode_defs = [
-    ModeDefinition(
-        executor_defs=[*default_executors, celery_executor],
-        resource_defs={"io_manager": fs_io_manager},
-    )
-]
-
 
 # test_execute pipelines
 
@@ -32,14 +19,14 @@ def add_one(_, num):
     return num + 1
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def test_pipeline():
-    return simple()
+@job(executor_def=celery_executor)
+def test_job():
+    simple()
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def test_serial_pipeline():
-    return add_one(simple())
+@job(executor_def=celery_executor)
+def test_serial_job():
+    add_one(simple())
 
 
 @op(out={"value_one": Out(), "value_two": Out()})
@@ -53,14 +40,14 @@ def subtract(num_one, num_two):
     return num_one - num_two
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def test_diamond_pipeline():
+@job(executor_def=celery_executor)
+def test_diamond_job():
     value_one, value_two = emit_values()
-    return subtract(num_one=add_one(num=value_one), num_two=add_one.alias("renamed")(num=value_two))
+    subtract(num_one=add_one(num=value_one), num_two=add_one.alias("renamed")(num=value_two))
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def test_parallel_pipeline():
+@job(executor_def=celery_executor)
+def test_parallel_job():
     value = simple()
     for i in range(10):
         add_one.alias("add_one_" + str(i))(value)
@@ -69,8 +56,8 @@ def test_parallel_pipeline():
 COMPOSITE_DEPTH = 3
 
 
-def composite_pipeline():
-    return nesting_graph_pipeline(COMPOSITE_DEPTH, 2, mode_defs=celery_mode_defs)
+def composite_job():
+    return nesting_graph(COMPOSITE_DEPTH, 2).to_job(executor_def=celery_executor)
 
 
 @op(
@@ -89,7 +76,7 @@ def bar(_, input_arg):
     return input_arg
 
 
-@pipeline(mode_defs=celery_mode_defs)
+@job(executor_def=celery_executor)
 def test_optional_outputs():
     foo_res = foo()
     bar.alias("first_consumer")(input_arg=foo_res.out_1)
@@ -107,7 +94,7 @@ def should_never_execute(foo):
     assert False  # should never execute
 
 
-@pipeline(mode_defs=celery_mode_defs)
+@job(executor_def=celery_executor)
 def test_fails():
     should_never_execute(fails())
 
@@ -117,7 +104,7 @@ def retry_request():
     raise RetryRequested()
 
 
-@pipeline(mode_defs=celery_mode_defs)
+@job(executor_def=celery_executor)
 def test_retries():
     retry_request()
 
@@ -127,7 +114,7 @@ def destroy(context, x):
     raise ValueError()
 
 
-@pipeline(mode_defs=celery_mode_defs)
+@job(executor_def=celery_executor)
 def engine_error():
     a = simple()
     b = destroy(a)
@@ -143,13 +130,13 @@ def engine_error():
         }
     }
 )
-def resource_req_solid(context):
+def resource_req_op(context):
     context.log.info("running")
 
 
-@pipeline(mode_defs=celery_mode_defs)
+@job(executor_def=celery_executor)
 def test_resources_limit():
-    resource_req_solid()
+    resource_req_op()
 
 
 # test_priority pipelines
@@ -157,94 +144,94 @@ def test_resources_limit():
 
 @op(tags={"dagster-celery/priority": 0})
 def zero(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "0"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "0"
     context.log.info("Executing with priority 0")
     return True
 
 
 @op(tags={"dagster-celery/priority": 1})
 def one(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "1"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "1"
     context.log.info("Executing with priority 1")
     return True
 
 
 @op(tags={"dagster-celery/priority": 2})
 def two(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "2"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "2"
     context.log.info("Executing with priority 2")
     return True
 
 
 @op(tags={"dagster-celery/priority": 3})
 def three(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "3"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "3"
     context.log.info("Executing with priority 3")
     return True
 
 
 @op(tags={"dagster-celery/priority": 4})
 def four(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "4"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "4"
     context.log.info("Executing with priority 4")
     return True
 
 
 @op(tags={"dagster-celery/priority": 5})
 def five(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "5"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "5"
     context.log.info("Executing with priority 5")
     return True
 
 
 @op(tags={"dagster-celery/priority": 6})
 def six(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "6"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "6"
     context.log.info("Executing with priority 6")
     return True
 
 
 @op(tags={"dagster-celery/priority": 7})
 def seven_(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "7"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "7"
     context.log.info("Executing with priority 7")
     return True
 
 
 @op(tags={"dagster-celery/priority": 8})
 def eight(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "8"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "8"
     context.log.info("Executing with priority 8")
     return True
 
 
 @op(tags={"dagster-celery/priority": 9})
 def nine(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "9"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "9"
     context.log.info("Executing with priority 9")
     return True
 
 
 @op(tags={"dagster-celery/priority": 10})
 def ten(context):
-    assert "dagster-celery/priority" in context.solid.tags
-    assert context.solid.tags["dagster-celery/priority"] == "10"
+    assert "dagster-celery/priority" in context.op.tags
+    assert context.op.tags["dagster-celery/priority"] == "10"
     context.log.info("Executing with priority 10")
     return True
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def priority_pipeline():
+@job(executor_def=celery_executor)
+def priority_job():
     for i in range(50):
         zero.alias("zero_" + str(i))()
         one.alias("one_" + str(i))()
@@ -259,8 +246,8 @@ def priority_pipeline():
         ten.alias("ten_" + str(i))()
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def simple_priority_pipeline():
+@job(executor_def=celery_executor)
+def simple_priority_job():
     zero()
     one()
     two()
@@ -275,33 +262,33 @@ def simple_priority_pipeline():
 
 
 @op
-def sleep_solid(_):
+def sleep_op(_):
     time.sleep(0.5)
     return True
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def low_pipeline():
-    sleep_solid.alias("low_one")()
-    sleep_solid.alias("low_two")()
-    sleep_solid.alias("low_three")()
-    sleep_solid.alias("low_four")()
-    sleep_solid.alias("low_five")()
+@job(executor_def=celery_executor)
+def low_job():
+    sleep_op.alias("low_one")()
+    sleep_op.alias("low_two")()
+    sleep_op.alias("low_three")()
+    sleep_op.alias("low_four")()
+    sleep_op.alias("low_five")()
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def hi_pipeline():
-    sleep_solid.alias("hi_one")()
-    sleep_solid.alias("hi_two")()
-    sleep_solid.alias("hi_three")()
-    sleep_solid.alias("hi_four")()
-    sleep_solid.alias("hi_five")()
+@job(executor_def=celery_executor)
+def hi_job():
+    sleep_op.alias("hi_one")()
+    sleep_op.alias("hi_two")()
+    sleep_op.alias("hi_three")()
+    sleep_op.alias("hi_four")()
+    sleep_op.alias("hi_five")()
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def interrupt_pipeline():
+@job(executor_def=celery_executor)
+def interrupt_job():
     for i in range(50):
-        sleep_solid.alias("sleep_" + str(i))()
+        sleep_op.alias("sleep_" + str(i))()
 
 
 # test_queues pipelines
@@ -314,8 +301,8 @@ def fooqueue(context):
     return True
 
 
-@pipeline(mode_defs=celery_mode_defs)
-def multiqueue_pipeline():
+@job(executor_def=celery_executor)
+def multiqueue_job():
     fooqueue()
 
 
@@ -329,14 +316,9 @@ class BasicVersionStrategy(VersionStrategy):
         return "bar"
 
 
-@pipeline(
-    mode_defs=[
-        ModeDefinition(
-            resource_defs={"io_manager": fs_io_manager},
-            executor_defs=[*default_executors, celery_executor],
-        )
-    ],
+@job(
+    executor_def=celery_executor,
     version_strategy=BasicVersionStrategy(),
 )
-def bar_pipeline():
+def bar_job():
     bar_solid()

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_queues.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_queues.py
@@ -16,7 +16,7 @@ def test_multiqueue(rabbitmq):
         with start_celery_worker():
             execute_thread = threading.Thread(
                 target=execute_on_thread,
-                args=("multiqueue_pipeline", done, instance.get_ref()),
+                args=("multiqueue_job", done, instance.get_ref()),
             )
             execute_thread.daemon = True
             execute_thread.start()

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -2,7 +2,7 @@ import dask.dataframe as dd
 import pytest
 from dagster import file_relative_path, op
 from dagster._core.definitions.input import In
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_dask import DataFrame
 from dagster_dask.data_frame import DataFrameReadTypes
 from dagster_dask.utils import DataFrameUtilities
@@ -29,13 +29,14 @@ def test_dataframe_inputs(file_type):
 
     file_name = file_relative_path(__file__, f"num.{file_type}")
 
-    read_result = execute_solid(
+    read_result = wrap_op_in_graph_and_execute(
         return_df,
         run_config={
             "solids": {
                 "return_df": {"inputs": {"input_df": {"read": {file_type: {"path": file_name}}}}}
             }
         },
+        do_input_mapping=False,
     )
     assert read_result.success
     assert assert_eq(read_result.output_value(), create_dask_df())

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_resources.py
@@ -1,10 +1,13 @@
 from typing import Any, Mapping
 
 from dagster import Dict, Output, op
+from dagster._core.definitions.decorators.job_decorator import job
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.output import Out
-from dagster._core.execution.results import PipelineExecutionResult
+from dagster._core.definitions.reconstruct import reconstructable
+from dagster._core.execution.api import execute_job
+from dagster._core.execution.execution_result import ExecutionResult
 from dagster._core.test_utils import instance_for_test
-from dagster._legacy import ModeDefinition, execute_pipeline, pipeline
 from dagster_dask import dask_resource
 from dask.distributed import Client
 
@@ -16,7 +19,7 @@ from dask.distributed import Client
     },
     required_resource_keys={"dask"},
 )
-def scheduler_info_solid(context):
+def scheduler_info_op(context):
     with context.resources.dask.client.as_current():
         client = Client.current()
 
@@ -24,9 +27,12 @@ def scheduler_info_solid(context):
         yield Output(client.nthreads(), "nthreads")
 
 
-@pipeline(mode_defs=[ModeDefinition(resource_defs={"dask": dask_resource})])
-def scheduler_info_pipeline():
-    scheduler_info_solid()
+def scheduler_info_job() -> JobDefinition:
+    @job(resource_defs={"dask": dask_resource})
+    def job_def():
+        scheduler_info_op()
+
+    return job_def
 
 
 def test_single_local_cluster():
@@ -37,12 +43,12 @@ def test_single_local_cluster():
     }
     with instance_for_test() as instance:
         run_config = {"resources": {"dask": {"config": {"cluster": {"local": cluster_config}}}}}
-        result = execute_pipeline(
-            scheduler_info_pipeline,
+        with execute_job(
+            reconstructable(scheduler_info_job),
             run_config=run_config,
             instance=instance,
-        )
-        _assert_scheduler_info_result(result, cluster_config)
+        ) as result:
+            _assert_scheduler_info_result(result, cluster_config)
 
 
 def test_multiple_local_cluster():
@@ -62,21 +68,19 @@ def test_multiple_local_cluster():
     with instance_for_test() as instance:
         for cluster_config in cluster_configs:
             run_config = {"resources": {"dask": {"config": {"cluster": {"local": cluster_config}}}}}
-            result = execute_pipeline(
-                scheduler_info_pipeline,
+            with execute_job(
+                reconstructable(scheduler_info_job),
                 run_config=run_config,
                 instance=instance,
-            )
-            _assert_scheduler_info_result(result, cluster_config)
+            ) as result:
+                _assert_scheduler_info_result(result, cluster_config)
 
 
-def _assert_scheduler_info_result(result: PipelineExecutionResult, config: Mapping[str, Any]):
-    scheduler_info_solid_result = result.result_for_node("scheduler_info_solid")
-
-    scheduler_info = scheduler_info_solid_result.output_value("scheduler_info")
+def _assert_scheduler_info_result(result: ExecutionResult, config: Mapping[str, Any]):
+    scheduler_info = result.output_for_node("scheduler_info_op", "scheduler_info")
     assert isinstance(scheduler_info, dict)
     assert len(scheduler_info["workers"]) == config["n_workers"]
 
-    nthreads = scheduler_info_solid_result.output_value("nthreads")
+    nthreads = result.output_for_node("scheduler_info_op", "nthreads")
     assert isinstance(nthreads, dict)
     assert all(v == config["threads_per_worker"] for v in nthreads.values())

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_utils.py
@@ -2,7 +2,7 @@ import dask.dataframe as dd
 from dagster import file_relative_path
 from dagster._core.definitions.decorators import op
 from dagster._core.definitions.input import In
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_dask import DataFrame
 
 
@@ -13,7 +13,7 @@ def passthrough(_, input_df: DataFrame) -> DataFrame:  # type: ignore
 
 def generate_config(path, **df_opts):
     return {
-        "solids": {
+        "ops": {
             "passthrough": {
                 "inputs": {
                     "input_df": {
@@ -39,7 +39,9 @@ def test_drop():
 
     # Drop the "current" column.
     run_config = generate_config(path, drop={"columns": col})
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert col not in output_df.columns
 
@@ -51,7 +53,9 @@ def test_sample():
     input_df = dd.read_csv(path)
 
     run_config = generate_config(path, sample={"frac": frac})
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
 
     assert len(input_df) * frac == len(output_df)
@@ -65,7 +69,9 @@ def test_reset_index():
     # Reset the index without dropping. We expect the index to be moved
     # to the columns, as a column named "index".
     run_config = generate_config(path, reset_index={})
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert "index" in output_df.columns
     assert len(output_df.columns) == len(input_df.columns) + 1
@@ -80,13 +86,17 @@ def test_set_index():
 
     # Set index to ID. We expect the column to be dropped by default.
     run_config = generate_config(path, set_index={"other": col})
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert col not in output_df.columns
 
     # Set index to ID without dropping the column.
     run_config = generate_config(path, set_index={"other": col, "drop": False})
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert col in output_df.columns
 
@@ -100,7 +110,9 @@ def test_repartition():
 
     # Repartition from 1 to 2 partitions.
     run_config = generate_config(path, repartition={"npartitions": npartitions})
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert output_df.npartitions == npartitions
 
@@ -113,13 +125,17 @@ def test_normalize_column_names():
 
     # Set normalize_column_names=False to not modify the column names
     run_config = generate_config(path, normalize_column_names=False)
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert all(col in output_df.columns for col in ("ID", "provinceOrTerritory", "country"))
 
     # Set normalize_column_names=True to modify the column names
     run_config = generate_config(path, normalize_column_names=True)
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
     assert all(col in output_df.columns for col in ("id", "province_or_territory", "country"))
 
@@ -141,7 +157,9 @@ def test_utilities_combo():
         sample={"frac": 0.5},
         reset_index={"drop": True},
     )
-    result = execute_solid(passthrough, run_config=run_config)
+    result = wrap_op_in_graph_and_execute(
+        passthrough, run_config=run_config, do_input_mapping=False
+    )
     output_df = result.output_value()
 
     # sample(frac=0.5)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/rpc/test_resources.py
@@ -1,7 +1,7 @@
 import pytest
 import responses
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_dbt import (
     DbtRpcOutput,
     DbtRpcResource,
@@ -97,12 +97,10 @@ def test_dbt_rpc_resource():
         assert context.resources.dbt_rpc.port == 8580
         it["ran"] = True
 
-    execute_solid(
+    wrap_op_in_graph_and_execute(
         a_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": dbt_rpc_resource}),
-        None,
-        None,
-        {"resources": {"dbt_rpc": {"config": {"host": "<default host>"}}}},
+        resources={"dbt_rpc": dbt_rpc_resource},
+        run_config={"resources": {"dbt_rpc": {"config": {"host": "<default host>"}}}},
     )
     assert it["ran"]
 
@@ -117,7 +115,7 @@ def test_local_dbt_rpc_resource():
         assert context.resources.dbt_rpc.port == 8580
         it["ran"] = True
 
-    execute_solid(a_solid, ModeDefinition(resource_defs={"dbt_rpc": local_dbt_rpc_resource}))
+    wrap_op_in_graph_and_execute(a_solid, resources={"dbt_rpc": local_dbt_rpc_resource})
     assert it["ran"]
 
 
@@ -131,12 +129,12 @@ def test_dbt_rpc_sync_resource():
         assert context.resources.dbt_rpc.port == 8580
         it["ran"] = True
 
-    execute_solid(
+    wrap_op_in_graph_and_execute(
         a_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": dbt_rpc_sync_resource}),
-        None,
-        None,
-        {"resources": {"dbt_rpc": {"config": {"host": "<default host>", "poll_interval": 5}}}},
+        resources={"dbt_rpc": dbt_rpc_sync_resource},
+        run_config={
+            "resources": {"dbt_rpc": {"config": {"host": "<default host>", "poll_interval": 5}}}
+        },
     )
     assert it["ran"]
 
@@ -158,9 +156,9 @@ def test_dbt_rpc_resource_status(dbt_rpc_server, client_class, resource):
         out = context.resources.dbt_rpc.status()
         return out
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         compile_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+        resources={"dbt_rpc": resource.configured({"host": "localhost"})},
     )
 
     assert result.success
@@ -182,11 +180,8 @@ def test_dbt_rpc_resource_is_not_waiting(
         out = context.resources.dbt_rpc.cli("run")
         return out
 
-    result = execute_solid(
-        cli_solid,
-        ModeDefinition(
-            resource_defs={"dbt_rpc": dbt_rpc_resource.configured({"host": "localhost"})}
-        ),
+    result = wrap_op_in_graph_and_execute(
+        cli_solid, resources={"dbt_rpc": dbt_rpc_resource.configured({"host": "localhost"})}
     )
 
     assert result.success
@@ -213,11 +208,8 @@ def test_dbt_rpc_sync_resource_is_waiting(
         out = context.resources.dbt_rpc.cli("run")
         return out
 
-    result = execute_solid(
-        cli_solid,
-        ModeDefinition(
-            resource_defs={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
-        ),
+    result = wrap_op_in_graph_and_execute(
+        cli_solid, resources={"dbt_rpc": dbt_rpc_sync_resource.configured({"host": "localhost"})}
     )
 
     assert result.success
@@ -246,9 +238,9 @@ def test_dbt_rpc_resource_cli(dbt_rpc_server, client_class, resource):
         out = context.resources.dbt_rpc.cli("run")
         return out
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         cli_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+        resources={"dbt_rpc": resource.configured({"host": "localhost"})},
     )
 
     assert result.success
@@ -272,9 +264,9 @@ def test_dbt_rpc_resource_run(dbt_rpc_server, client_class, resource):
         out = context.resources.dbt_rpc.run(["sort_by_calories"])
         return out
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         cli_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+        resources={"dbt_rpc": resource.configured({"host": "localhost"})},
     )
 
     assert result.success
@@ -298,9 +290,9 @@ def test_dbt_rpc_resource_generate_docs(dbt_rpc_server, client_class, resource):
         out = context.resources.dbt_rpc.generate_docs(True)
         return out
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         compile_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+        resources={"dbt_rpc": resource.configured({"host": "localhost"})},
     )
 
     assert result.success
@@ -324,9 +316,9 @@ def test_dbt_rpc_resource_run_operation(dbt_rpc_server, client_class, resource):
         out = context.resources.dbt_rpc.run_operation("log_macro", {"msg": "hello world"})
         return out
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         compile_solid,
-        ModeDefinition(resource_defs={"dbt_rpc": resource.configured({"host": "localhost"})}),
+        resources={"dbt_rpc": resource.configured({"host": "localhost"})},
     )
 
     assert result.success

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -17,7 +17,7 @@ from dagster_test.test_project import (
     get_buildkite_registry_config,
     get_test_project_docker_image,
     get_test_project_environments_path,
-    get_test_project_recon_pipeline,
+    get_test_project_recon_job,
     get_test_project_workspace_and_external_pipeline,
 )
 
@@ -52,9 +52,9 @@ def test_launch_docker_no_network(aws_env):
             "params": {"connect_timeout": 2},
         },
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_s3", docker_image)
+        recon_pipeline = get_test_project_recon_job("demo_job_s3", docker_image)
         with get_test_project_workspace_and_external_pipeline(
-            instance, "demo_pipeline_s3", container_image=docker_image
+            instance, "demo_job_s3", container_image=docker_image
         ) as (workspace, orig_pipeline):
             external_pipeline = ReOriginatedExternalPipelineForTest(
                 orig_pipeline,
@@ -135,9 +135,9 @@ def test_launch_docker_image_on_pipeline_config(aws_env):
                 }
             }
         ) as instance:
-            recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_s3", docker_image)
+            recon_pipeline = get_test_project_recon_job("demo_job_s3", docker_image)
             with get_test_project_workspace_and_external_pipeline(
-                instance, "demo_pipeline_s3", container_image=docker_image
+                instance, "demo_job_s3", container_image=docker_image
             ) as (workspace, orig_pipeline):
                 external_pipeline = ReOriginatedExternalPipelineForTest(
                     orig_pipeline,
@@ -199,9 +199,9 @@ def test_terminate_launched_docker_run(aws_env):
             }
         }
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline("hanging_pipeline", docker_image)
+        recon_pipeline = get_test_project_recon_job("hanging_job", docker_image)
         with get_test_project_workspace_and_external_pipeline(
-            instance, "hanging_pipeline", container_image=docker_image
+            instance, "hanging_job", container_image=docker_image
         ) as (workspace, orig_pipeline):
             external_pipeline = ReOriginatedExternalPipelineForTest(
                 orig_pipeline,
@@ -233,8 +233,8 @@ def test_terminate_launched_docker_run(aws_env):
                 run_logs,
                 [
                     ("PIPELINE_CANCELING", "Sending run termination request"),
-                    ("STEP_FAILURE", 'Execution of step "hanging_solid" failed.'),
-                    ("PIPELINE_CANCELED", 'Execution of run for "hanging_pipeline" canceled.'),
+                    ("STEP_FAILURE", 'Execution of step "hanging_op" failed.'),
+                    ("PIPELINE_CANCELED", 'Execution of run for "hanging_job" canceled.'),
                     ("ENGINE_EVENT", "Process for run exited"),
                 ],
             )
@@ -267,8 +267,8 @@ def test_launch_docker_invalid_image(aws_env):
             }
         }
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline("demo_pipeline_s3")
-        with get_test_project_workspace_and_external_pipeline(instance, "demo_pipeline_s3") as (
+        recon_pipeline = get_test_project_recon_job("demo_job_s3")
+        with get_test_project_workspace_and_external_pipeline(instance, "demo_job_s3") as (
             workspace,
             orig_pipeline,
         ):
@@ -391,11 +391,11 @@ def _test_launch(
             }
         }
     ) as instance:
-        recon_pipeline = get_test_project_recon_pipeline(
-            "demo_pipeline_s3", container_image=container_image, container_context=container_context
+        recon_pipeline = get_test_project_recon_job(
+            "demo_job_s3", container_image=container_image, container_context=container_context
         )
         with get_test_project_workspace_and_external_pipeline(
-            instance, "demo_pipeline_s3", container_image=container_image
+            instance, "demo_job_s3", container_image=container_image
         ) as (
             workspace,
             orig_pipeline,

--- a/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_github import github_resource
 from dagster_github.resources import GithubResource
 
@@ -35,7 +35,7 @@ def test_github_resource_get_installations():
             )
             context.resources.github.get_installations()
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         github_solid,
         run_config={
             "resources": {
@@ -48,7 +48,7 @@ def test_github_resource_get_installations():
                 }
             }
         },
-        mode_def=ModeDefinition(resource_defs={"github": github_resource}),
+        resources={"github": github_resource},
     )
     assert result.success
 
@@ -67,7 +67,7 @@ def test_github_resource_get_installations_with_hostname():
             )
             context.resources.github.get_installations()
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         github_solid,
         run_config={
             "resources": {
@@ -81,7 +81,7 @@ def test_github_resource_get_installations_with_hostname():
                 }
             }
         },
-        mode_def=ModeDefinition(resource_defs={"github": github_resource}),
+        resources={"github": github_resource},
     )
     assert result.success
 
@@ -122,7 +122,7 @@ def test_github_resource_create_issue():
                 body="body",
             )
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         github_solid,
         run_config={
             "resources": {
@@ -135,7 +135,7 @@ def test_github_resource_create_issue():
                 }
             }
         },
-        mode_def=ModeDefinition(resource_defs={"github": github_resource}),
+        resources={"github": github_resource},
     )
     assert result.success
 
@@ -173,7 +173,7 @@ def test_github_resource_execute():
                 variables={"repo_name": "dagster", "repo_owner": "dagster-io"},
             )
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         github_solid,
         run_config={
             "resources": {
@@ -187,7 +187,7 @@ def test_github_resource_execute():
                 }
             }
         },
-        mode_def=ModeDefinition(resource_defs={"github": github_resource}),
+        resources={"github": github_resource},
     )
     assert result.success
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -126,7 +126,7 @@ def test_launcher_with_container_context(kubeconfig_file):
             )
 
             # Launch the run in a fake Dagster instance.
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run = create_run_for_test(
                 instance,
                 pipeline_name=pipeline_name,
@@ -240,7 +240,7 @@ def test_launcher_with_k8s_config(kubeconfig_file):
             )
 
             # Launch the run in a fake Dagster instance.
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run = create_run_for_test(
                 instance,
                 pipeline_name=pipeline_name,
@@ -327,7 +327,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             )
 
             # Launch the run in a fake Dagster instance.
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run = create_run_for_test(
                 instance,
                 pipeline_name=pipeline_name,
@@ -408,7 +408,7 @@ def test_raise_on_error(kubeconfig_file):
             )
 
             # Launch the run in a fake Dagster instance.
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run = create_run_for_test(
                 instance,
                 pipeline_name=pipeline_name,
@@ -469,7 +469,7 @@ def test_no_postgres(kubeconfig_file):
             )
 
             # Launch the run in a fake Dagster instance.
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
             run = create_run_for_test(
                 instance,
                 pipeline_name=pipeline_name,
@@ -535,7 +535,7 @@ def test_check_run_health(kubeconfig_file):
             )
 
             # Launch the run in a fake Dagster instance.
-            pipeline_name = "demo_pipeline"
+            pipeline_name = "demo_job"
 
             started_run = create_run_for_test(
                 instance,

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_resources.py
@@ -1,7 +1,7 @@
 import json
 
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_msteams import msteams_resource
 from mock import patch
 
@@ -20,7 +20,7 @@ def test_msteams_resource(mock_teams_post_message, json_message, teams_client):
         teams_client.post_message(json_message)
         assert mock_teams_post_message.called
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         msteams_solid,
         run_config={
             "resources": {
@@ -32,6 +32,6 @@ def test_msteams_resource(mock_teams_post_message, json_message, teams_client):
                 }
             }
         },
-        mode_def=ModeDefinition(resource_defs={"msteams": msteams_resource}),
+        resources={"msteams": msteams_resource},
     )
     assert result.success

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus_tests/test_resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus_tests/test_resources.py
@@ -1,13 +1,13 @@
 import time
 
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_prometheus import prometheus_resource
 from prometheus_client import Counter, Enum, Gauge, Histogram, Info, Summary
 
 EPS = 0.001
 ENV = {"resources": {"prometheus": {"config": {"gateway": "localhost:9091"}}}}
-MODE = ModeDefinition(resource_defs={"prometheus": prometheus_resource})
+RESOURCES = {"prometheus": prometheus_resource}
 
 
 def test_prometheus_counter():
@@ -25,7 +25,9 @@ def test_prometheus_counter():
         )
         assert abs(2.6 - recorded) < EPS
 
-    assert execute_solid(prometheus_solid, run_config=ENV, mode_def=MODE).success
+    assert wrap_op_in_graph_and_execute(
+        prometheus_solid, run_config=ENV, resources=RESOURCES
+    ).success
 
 
 def test_prometheus_gauge():
@@ -42,7 +44,9 @@ def test_prometheus_gauge():
         )
         assert abs(time.time() - recorded) < 10.0
 
-    assert execute_solid(prometheus_solid, run_config=ENV, mode_def=MODE).success
+    assert wrap_op_in_graph_and_execute(
+        prometheus_solid, run_config=ENV, resources=RESOURCES
+    ).success
 
 
 def test_prometheus_summary():
@@ -73,7 +77,9 @@ def test_prometheus_summary():
         )
         assert abs(1.0 - recorded) < 1.0
 
-    assert execute_solid(prometheus_solid, run_config=ENV, mode_def=MODE).success
+    assert wrap_op_in_graph_and_execute(
+        prometheus_solid, run_config=ENV, resources=RESOURCES
+    ).success
 
 
 def test_prometheus_histogram():
@@ -90,7 +96,9 @@ def test_prometheus_histogram():
         )
         assert abs(4.7 - recorded) < EPS
 
-    assert execute_solid(prometheus_solid, run_config=ENV, mode_def=MODE).success
+    assert wrap_op_in_graph_and_execute(
+        prometheus_solid, run_config=ENV, resources=RESOURCES
+    ).success
 
 
 def test_prometheus_info():
@@ -109,7 +117,9 @@ def test_prometheus_info():
                 break
         assert metric and metric.samples[0].labels == info_labels
 
-    assert execute_solid(prometheus_solid, run_config=ENV, mode_def=MODE).success
+    assert wrap_op_in_graph_and_execute(
+        prometheus_solid, run_config=ENV, resources=RESOURCES
+    ).success
 
 
 def test_prometheus_enum():
@@ -130,4 +140,6 @@ def test_prometheus_enum():
                 break
         assert metric and metric.samples[0].labels == {"my_task_state": "starting"}
 
-    assert execute_solid(prometheus_solid, run_config=ENV, mode_def=MODE).success
+    assert wrap_op_in_graph_and_execute(
+        prometheus_solid, run_config=ENV, resources=RESOURCES
+    ).success

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_types.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_types.py
@@ -2,8 +2,8 @@ import pytest
 from dagster import file_relative_path
 from dagster._core.definitions.decorators import op
 from dagster._core.definitions.input import In
-from dagster._legacy import ModeDefinition, execute_solid
 from dagster._utils import dict_without_keys
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_pyspark import (
     DataFrame as DagsterPySparkDataFrame,
     lazy_pyspark_resource,
@@ -48,10 +48,11 @@ def test_dataframe_inputs(file_type, read, other, resource):
         options["format"] = file_type
         file_type = "other"
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         return_df,
-        mode_def=ModeDefinition(resource_defs={"pyspark": resource}),
-        run_config={"solids": {"return_df": {"inputs": {"input_df": {file_type: options}}}}},
+        resources={"pyspark": resource},
+        run_config={"ops": {"return_df": {"inputs": {"input_df": {file_type: options}}}}},
+        do_input_mapping=False,
     )
     assert result.success
     actual = read(options["path"], **dict_without_keys(options, "path"))

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_solids.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_solids.py
@@ -5,7 +5,7 @@ from dagster import Failure, job, op
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.decorators.graph_decorator import graph
 from dagster._core.definitions.output import GraphOut
-from dagster._legacy import execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_shell import create_shell_command_op, create_shell_script_op, shell_op
 
 
@@ -13,11 +13,11 @@ from dagster_shell import create_shell_command_op, create_shell_script_op, shell
 def test_shell_command(factory):
     solid = factory('echo "this is a test message: $MY_ENV_VAR"', name="foobar")
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         solid,
-        run_config={"solids": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
+        run_config={"ops": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
     )
-    assert result.output_values == {"result": "this is a test message: foobar\n"}
+    assert result.output_value() == "this is a test message: foobar\n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_command_op])
@@ -26,28 +26,28 @@ def test_shell_command_inherits_environment(monkeypatch, factory):
     # to jobs. eg. 12-factor app secrets, defined in your Docker container, etc.
     monkeypatch.setenv("OUTSIDE_ENV_VAR", "foo")
 
-    solid = factory('echo "$OUTSIDE_ENV_VAR:$MY_ENV_VAR"', name="foobar")
+    op_def = factory('echo "$OUTSIDE_ENV_VAR:$MY_ENV_VAR"', name="foobar")
 
     # inherit outside environment variables if none specified for op
-    result = execute_solid(solid)
-    assert result.output_values == {"result": "foo:\n"}
+    result = wrap_op_in_graph_and_execute(op_def)
+    assert result.output_value() == "foo:\n"
 
     # also inherit outside environment variables if env vars specified for op
-    result = execute_solid(
-        solid,
-        run_config={"solids": {"foobar": {"config": {"env": {"MY_ENV_VAR": "bar"}}}}},
+    result = wrap_op_in_graph_and_execute(
+        op_def,
+        run_config={"ops": {"foobar": {"config": {"env": {"MY_ENV_VAR": "bar"}}}}},
     )
-    assert result.output_values == {"result": "foo:bar\n"}
+    assert result.output_value() == "foo:bar\n"
 
 
 @pytest.mark.parametrize("shell_defn,name", [(shell_op, "shell_op")])
 def test_shell(shell_defn, name):
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         shell_defn,
         input_values={"shell_command": 'echo "this is a test message: $MY_ENV_VAR"'},
-        run_config={"solids": {name: {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
+        run_config={"ops": {name: {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
     )
-    assert result.output_values == {"result": "this is a test message: foobar\n"}
+    assert result.output_value() == "this is a test message: foobar\n"
 
 
 def test_shell_op_inside_job():
@@ -69,23 +69,23 @@ def test_shell_op_inside_job():
 @pytest.mark.parametrize("factory", [create_shell_command_op])
 def test_shell_command_retcode(factory):
     with pytest.raises(Failure, match="Shell command execution failed"):
-        execute_solid(factory("exit 1", name="exit_solid"))
+        wrap_op_in_graph_and_execute(factory("exit 1", name="exit_op"))
 
 
 @pytest.mark.parametrize("shell_defn", [shell_op])
 def test_shell_solid_retcode(shell_defn):
     with pytest.raises(Failure, match="Shell command execution failed"):
-        execute_solid(shell_defn, input_values={"shell_command": "exit 1"})
+        wrap_op_in_graph_and_execute(shell_defn, input_values={"shell_command": "exit 1"})
 
 
 @pytest.mark.parametrize("factory", [create_shell_command_op])
 def test_shell_command_stream_logs(factory):
-    solid = factory('for i in 1 2 3 4 5; do echo "hello ${i}"; done', name="foobar")
+    op_def = factory('for i in 1 2 3 4 5; do echo "hello ${i}"; done', name="foobar")
 
-    result = execute_solid(
-        solid,
+    result = wrap_op_in_graph_and_execute(
+        op_def,
         run_config={
-            "solids": {
+            "ops": {
                 "foobar": {
                     "config": {
                         "output_logging": "STREAM",
@@ -95,32 +95,32 @@ def test_shell_command_stream_logs(factory):
             }
         },
     )
-    assert result.output_values == {"result": "hello 1\nhello 2\nhello 3\nhello 4\nhello 5\n"}
+    assert result.output_value() == "hello 1\nhello 2\nhello 3\nhello 4\nhello 5\n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
 def test_shell_script_solid(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
-    result = execute_solid(
-        solid,
-        run_config={"solids": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
+    op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
+    result = wrap_op_in_graph_and_execute(
+        op_def,
+        run_config={"ops": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
     )
-    assert result.output_values == {"result": "this is a test message: foobar\n"}
+    assert result.output_value() == "this is a test message: foobar\n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
 def test_shell_script_solid_no_config(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
-    result = execute_solid(solid)
-    assert result.output_values == {"result": "this is a test message: \n"}
+    op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
+    result = wrap_op_in_graph_and_execute(op_def)
+    assert result.output_value() == "this is a test message: \n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
 def test_shell_script_solid_no_config_composite(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
+    op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
 
     @graph(
         config=ConfigMapping(
@@ -129,42 +129,42 @@ def test_shell_script_solid_no_config_composite(factory):
         ),
         out={"result": GraphOut()},
     )
-    def composite():
-        return solid()
+    def graph_def():
+        return op_def()
 
-    result = execute_solid(composite)
-    assert result.output_values == {"result": "this is a test message: \n"}
+    result = graph_def.execute_in_process()
+    assert result.output_value() == "this is a test message: \n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_command_op])
 def test_shell_command_solid_overrides(factory):
-    solid = factory(
+    op_def = factory(
         'echo "this is a test message: $MY_ENV_VAR"',
         name="foobar",
         description="a description override",
     )
 
-    result = execute_solid(
-        solid,
-        run_config={"solids": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
+    result = wrap_op_in_graph_and_execute(
+        op_def,
+        run_config={"ops": {"foobar": {"config": {"env": {"MY_ENV_VAR": "foobar"}}}}},
     )
-    assert result.output_values == {"result": "this is a test message: foobar\n"}
+    assert result.output_value() == "this is a test message: foobar\n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
 def test_shell_script_solid_run_time_config(factory, monkeypatch):
     monkeypatch.setattr(os, "environ", {"MY_ENV_VAR": "foobar"})
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
-    result = execute_solid(solid)
-    assert result.output_values == {"result": "this is a test message: foobar\n"}
+    op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
+    result = wrap_op_in_graph_and_execute(op_def)
+    assert result.output_value() == "this is a test message: foobar\n"
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
 def test_shell_script_solid_run_time_config_composite(factory, monkeypatch):
     monkeypatch.setattr(os, "environ", {"MY_ENV_VAR": "foobar"})
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    solid = factory(os.path.join(script_dir, "test.sh"), name="foobar")
+    op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
 
     @graph(
         config=ConfigMapping(
@@ -173,8 +173,8 @@ def test_shell_script_solid_run_time_config_composite(factory, monkeypatch):
         ),
         out={"result": GraphOut()},
     )
-    def composite():
-        return solid()
+    def my_graph():
+        return op_def()
 
-    result = execute_solid(composite)
-    assert result.output_values == {"result": "this is a test message: foobar\n"}
+    result = my_graph.execute_in_process()
+    assert result.output_value() == "this is a test message: foobar\n"

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
@@ -1,7 +1,7 @@
 import json
 
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_slack import slack_resource
 from mock import patch
 
@@ -22,11 +22,11 @@ def test_slack_resource(mock_api_call):
 
         assert mock_api_call.called
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         slack_solid,
         run_config={
             "resources": {"slack": {"config": {"token": "xoxp-1234123412341234-12341234-1234"}}}
         },
-        mode_def=ModeDefinition(resource_defs={"slack": slack_resource}),
+        resources={"slack": slack_resource},
     )
     assert result.success

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_solids.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_solids.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_snowflake import snowflake_resource
 from dagster_snowflake.solids import snowflake_solid_for_query
 
@@ -11,7 +11,7 @@ from .utils import create_mock_connector
 def test_snowflake_solid(snowflake_connect):
     snowflake_solid = snowflake_solid_for_query("SELECT 1")
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         snowflake_solid,
         run_config={
             "resources": {
@@ -27,7 +27,7 @@ def test_snowflake_solid(snowflake_connect):
                 }
             }
         },
-        mode_def=ModeDefinition(resource_defs={"snowflake": snowflake_resource}),
+        resources={"snowflake": snowflake_resource},
     )
     assert result.success
     snowflake_connect.assert_called_once_with(

--- a/python_modules/libraries/dagster-ssh/dagster_ssh_tests/test_resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh_tests/test_resources.py
@@ -7,8 +7,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from dagster import Field
 from dagster._core.definitions.decorators import op
-from dagster._legacy import ModeDefinition, execute_solid
 from dagster._seven import get_system_temp_directory
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_ssh.resources import (
     SSHResource,
     key_from_str,
@@ -228,9 +228,9 @@ def test_ssh_sftp(sftpserver):
         return context.resources.ssh_resource.sftp_get(remote_filepath, local_filepath)
 
     with sftpserver.serve_content({"a_dir": {"readme.txt": "hello, world"}}):
-        result = execute_solid(
+        result = wrap_op_in_graph_and_execute(
             sftp_solid_get,
-            ModeDefinition(resource_defs={"ssh_resource": sshresource}),
+            resources={"ssh_resource": sshresource},
             run_config={
                 "solids": {
                     "sftp_solid_get": {

--- a/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
+++ b/python_modules/libraries/dagster-twilio/dagster_twilio_tests/test_resources.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from dagster import op
-from dagster._legacy import ModeDefinition, execute_solid
+from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_twilio import twilio_resource
 from twilio.base.exceptions import TwilioRestException
 
@@ -28,13 +28,13 @@ def test_twilio_resource():
             )
         assert "The 'To' number +15005550001 is not a valid phone number" in str(exc_info.value)
 
-    result = execute_solid(
+    result = wrap_op_in_graph_and_execute(
         twilio_solid,
         run_config={
             "resources": {
                 "twilio": {"config": {"account_sid": account_sid, "auth_token": auth_token}}
             }
         },
-        mode_def=ModeDefinition(resource_defs={"twilio": twilio_resource}),
+        resources={"twilio": twilio_resource},
     )
     assert result.success


### PR DESCRIPTION
## Summary & Motivation

This is a migration of a large number of tests to job/op/graph APIs. It started with an attempt to remove `execute_solid` and friends, but that ended up to be pulling on a string that had to be further unraveled to get to a passing state-- so this now includes not only `execute_solid` conversions but also a full conversion of the test-project repo and updating of associated tests.

## How I Tested These Changes

Test suite, much of which is changed.