### PR TITLE
[structured config] respect field aliases for resources

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -134,7 +134,10 @@ class Config(MakeConfigCacheable):
             field = self.__fields__.get(key)
             if field and value is None and not _is_pydantic_field_required(field):
                 continue
-            output[key] = value
+            if field:
+                output[field.alias] = value
+            else:
+                output[key] = value
         return output
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1812,3 +1812,14 @@ def test_aliased_field_structured_resource():
 
     assert prefix_job.execute_in_process().success
     assert out_txt == ["greeting: hello, world!"]
+
+    out_txt.clear()
+
+    @job(resource_defs={"writer": WriterResource.configure_at_launch()})
+    def prefix_job_at_runtime():
+        hello_world_op()
+
+    assert prefix_job_at_runtime.execute_in_process(
+        {"resources": {"writer": {"config": {"prefix": "runtime: "}}}}
+    ).success
+    assert out_txt == ["runtime: hello, world!"]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -46,6 +46,7 @@ from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
 from dagster._core.test_utils import environ
 from dagster._utils.cached_method import cached_method
+from pydantic import Field as PyField
 
 
 def test_basic_structured_resource():
@@ -1781,3 +1782,33 @@ def test_bind_io_manager_override() -> None:
 
     assert defs.get_job_def("hello_world_job").execute_in_process().success
     assert outputs == ["foo"]
+
+
+def test_aliased_field_structured_resource():
+    out_txt = []
+
+    class WriterResource(ConfigurableResource):
+        prefix_: str = PyField(..., alias="prefix")
+
+        def output(self, text: str) -> None:
+            out_txt.append(f"{self.prefix_}{text}")
+
+    @op
+    def hello_world_op(writer: WriterResource):
+        writer.output("hello, world!")
+
+    @job(resource_defs={"writer": WriterResource(prefix="")})
+    def no_prefix_job():
+        hello_world_op()
+
+    assert no_prefix_job.execute_in_process().success
+    assert out_txt == ["hello, world!"]
+
+    out_txt.clear()
+
+    @job(resource_defs={"writer": WriterResource(prefix="greeting: ")})
+    def prefix_job():
+        hello_world_op()
+
+    assert prefix_job.execute_in_process().success
+    assert out_txt == ["greeting: hello, world!"]


### PR DESCRIPTION
## Summary & Motivation
Writing a resource with an aliased config field would error because the alias was not applied when constructing the configuration as a dictionary. 

based off the convo [here](https://github.com/dagster-io/dagster/pull/12695#discussion_r1129763364) it seems like  _as_config_dict should already respect aliases, but in my testing that wasn't the case with resources. Maybe there's a different place that this fix should go that's more resource specific? let me know. I'm still pretty unfamiliar with the code for structured config so idk if i'll be able to find it myself


## How I Tested These Changes
new unit test - failed before the fix and passes now