### PR TITLE
[dagit] redirect trailing slash on GraphQL route

### DIFF
--- a/python_modules/dagit/dagit/webserver.py
+++ b/python_modules/dagit/dagit/webserver.py
@@ -286,6 +286,11 @@ class DagitWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
                     self.graphql_ws_endpoint,
                     name="graphql-ws",
                 ),
+                Route(
+                    "/graphql/",
+                    lambda _: RedirectResponse(url="/graphql"),
+                    methods=["GET", "POST"],
+                ),
             ]
             + self.build_static_routes()
             + [

--- a/python_modules/dagit/dagit_tests/webserver/test_app.py
+++ b/python_modules/dagit/dagit_tests/webserver/test_app.py
@@ -112,6 +112,15 @@ def test_graphql_get(instance, test_client: TestClient):
     assert response.status_code == 400, response.text
 
 
+def test_graphql_trailing_slash(instance, test_client: TestClient):
+    # base case
+    response = test_client.get("/graphql/", params={"query": "{__typename}"}, allow_redirects=False)
+    assert response.status_code == 307, response.text
+
+    response = test_client.get("/graphql/", params={"query": "{__typename}"}, allow_redirects=True)
+    assert response.json() == {"data": {"__typename": "DagitQuery"}}
+
+
 def test_graphql_invalid_json(instance, test_client: TestClient):
     # base case
     response = test_client.post(


### PR DESCRIPTION
## Summary

Adds a redirect from the graphql URL with a trailing slash: `localhost:3000/graphql/`->`localhost:3000/graphql`. A user recently ran into this: https://elementl-workspace.slack.com/archives/C046ZK3KQ5D/p1679944131264839?thread_ts=1679942695.590929&cid=C046ZK3KQ5D
