### PR TITLE
Use specific events to trigger a "Preparing" state instead of assuming that any logged event means that the step has started

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -812,6 +812,7 @@ export const GanttChartLoadingState = ({runId}: {runId: string}) => (
       firstInitialPercent={70}
       second={
         <GanttStatusPanel
+          graph={[]}
           metadata={EMPTY_RUN_METADATA}
           selection={{keys: [], query: '*'}}
           runId={runId}
@@ -845,6 +846,7 @@ export const QueuedState = ({run}: {run: RunFragment}) => (
       firstInitialPercent={70}
       second={
         <GanttStatusPanel
+          graph={[]}
           metadata={EMPTY_RUN_METADATA}
           selection={{keys: [], query: '*'}}
           runId={run.id}

--- a/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttStatusPanel.tsx
@@ -2,6 +2,7 @@ import {Colors, Spinner, Tooltip} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {formatElapsedTime} from '../app/Util';
 import {SidebarSection} from '../pipelines/SidebarComponents';
 import {IRunMetadataDict, IStepState} from '../runs/RunMetadataProvider';
@@ -12,6 +13,7 @@ import {boxStyleFor} from './GanttChartLayout';
 import {RunGroupPanel} from './RunGroupPanel';
 
 interface GanttStatusPanelProps {
+  graph: GraphQueryItem[];
   metadata: IRunMetadataDict;
   selection: StepSelection;
   runId: string;
@@ -25,18 +27,20 @@ interface GanttStatusPanelProps {
 export const GanttStatusPanel: React.FC<GanttStatusPanelProps> = ({
   runId,
   nowMs,
+  graph,
   metadata,
   selection,
   onClickStep,
   onDoubleClickStep,
   onHighlightStep,
 }) => {
-  const {preparing, executing, errored, succeeded} = React.useMemo(() => {
+  const {preparing, executing, errored, succeeded, notExecuted} = React.useMemo(() => {
     const keys = Object.keys(metadata.steps);
     const preparing = [];
     const executing = [];
     const errored = [];
     const succeeded = [];
+    const notExecuted = [];
     for (const key of keys) {
       const state = metadata.steps[key].state;
       switch (state) {
@@ -52,10 +56,18 @@ export const GanttStatusPanel: React.FC<GanttStatusPanelProps> = ({
           break;
         case IStepState.SUCCEEDED:
           succeeded.push(key);
+          break;
       }
     }
-    return {preparing, executing, errored, succeeded};
-  }, [metadata]);
+
+    for (const node of graph) {
+      const name = node.name;
+      if (!metadata.steps[name]?.state) {
+        notExecuted.push(name);
+      }
+    }
+    return {preparing, executing, errored, succeeded, notExecuted};
+  }, [metadata, graph]);
 
   const renderStepItem = (stepName: string) => (
     <StepItem
@@ -70,8 +82,6 @@ export const GanttStatusPanel: React.FC<GanttStatusPanelProps> = ({
     />
   );
 
-  const isFinished = metadata?.exitedAt && metadata.exitedAt > 0;
-
   return (
     <div style={{overflowY: 'auto'}}>
       <RunGroupPanel
@@ -80,7 +90,7 @@ export const GanttStatusPanel: React.FC<GanttStatusPanelProps> = ({
           metadata.exitedAt || metadata.startedProcessAt || metadata.startedPipelineAt || 0
         }
       />
-      <SidebarSection title={`${isFinished ? 'Not executed' : 'Preparing'} (${preparing.length})`}>
+      <SidebarSection title={`Preparing (${preparing.length})`}>
         <div>
           {preparing.length === 0 ? (
             <EmptyNotice>No steps are waiting to execute</EmptyNotice>
@@ -116,6 +126,11 @@ export const GanttStatusPanel: React.FC<GanttStatusPanelProps> = ({
           )}
         </div>
       </SidebarSection>
+      {notExecuted.length > 0 ? (
+        <SidebarSection collapsedByDefault title={`Not executed (${notExecuted.length})`}>
+          <div>{notExecuted.map(renderStepItem)}</div>
+        </SidebarSection>
+      ) : null}
     </div>
   );
 };
@@ -130,7 +145,7 @@ const StepItem: React.FC<{
   onDoubleClick?: (name: string) => void;
 }> = ({nowMs, name, selected, metadata, onClick, onHover, onDoubleClick}) => {
   const step = metadata.steps[name];
-  const end = step.end ?? nowMs;
+  const end = (step && step.end) ?? nowMs;
   return (
     <StepItemContainer
       key={name}
@@ -140,9 +155,9 @@ const StepItem: React.FC<{
       onMouseEnter={() => onHover?.(name)}
       onMouseLeave={() => onHover?.(null)}
     >
-      {step.state === IStepState.RUNNING ? (
+      {step?.state === IStepState.RUNNING ? (
         <Spinner purpose="body-text" />
-      ) : step.state === IStepState.UNKNOWN ? (
+      ) : step?.state === IStepState.UNKNOWN ? (
         <Tooltip
           // Modifiers are to prevent flickering: https://github.com/palantir/blueprint/issues/4019
           modifiers={{
@@ -157,7 +172,7 @@ const StepItem: React.FC<{
       ) : (
         <StepStatusDot
           style={{
-            ...boxStyleFor(metadata.steps[name]?.state, {
+            ...boxStyleFor(step?.state, {
               metadata,
               options: {mode: GanttChartMode.WATERFALL_TIMED},
             }),
@@ -165,7 +180,7 @@ const StepItem: React.FC<{
         />
       )}
       <StepLabel>{name}</StepLabel>
-      {step.start && <Elapsed>{formatElapsedTime(end - step.start)}</Elapsed>}
+      {step?.start && <Elapsed>{formatElapsedTime(end - step.start)}</Elapsed>}
     </StepItemContainer>
   );
 };

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -40,7 +40,7 @@ export interface IStepAttempt {
 
 export interface IStepMetadata {
   // current state
-  state: IStepState;
+  state?: IStepState;
 
   // execution start and stop (user-code) inclusive of all retries
   start?: number;
@@ -262,14 +262,9 @@ export function extractMetadataFromLogs(
       const step =
         metadata.steps[stepKey] ||
         ({
-          state: IStepState.PREPARING,
+          state: undefined,
           attempts: [],
-          transitions: [
-            {
-              state: IStepState.PREPARING,
-              time: timestamp,
-            },
-          ],
+          transitions: [],
           start: undefined,
           end: undefined,
           markers: [],
@@ -285,7 +280,9 @@ export function extractMetadataFromLogs(
         }
       }
 
-      if (log.__typename === 'ExecutionStepStartEvent') {
+      if (log.__typename === 'StepWorkerStartingEvent') {
+        upsertState(step, timestamp, IStepState.PREPARING);
+      } else if (log.__typename === 'ExecutionStepStartEvent') {
         upsertState(step, timestamp, IStepState.RUNNING);
         step.start = timestamp;
       } else if (log.__typename === 'ExecutionStepSuccessEvent') {


### PR DESCRIPTION
Summary:
This is intended to address a problem where the Dagit UI incorrectly thinks that a step is being prepared after its upstream event fails so we log a "Dependencies for step XXX failed. Not executing." events.

Since https://github.com/dagster-io/dagster/commit/e163de1e7d1927199242b87f25b1839b818908d7 we have added additional structured events that explicitly indicate that a step has started. Use those to determine that the step is being prepared - until then, leave the state null.

Furthermore, source the set of steps that haven't executed from the graph, rather than purely the event log - since a step that didn't execute may not have logged an event at all.

Test Plan:
Launch this run:
```
import time

from dagster import asset

@asset
def a():
    time.sleep(45)

@asset
def c(b):
    pass

@asset
def b():
    raise Exception("Oops")

```

Before this change, c is shown in a Preparing / Not executed state in the right hand bar. After this change, it is not shown in the right hand bar at all.

Launch a normal run where every step succeeds or fails, no changes

Are there tests related to dynamic orchestration that I should check, can we count on the nodes in the graph matching up with the keys in the metadata?

## Summary & Motivation

## How I Tested These Changes
