### PR TITLE
[asset selection] Added required_neighbors asset selection option

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -57,7 +57,7 @@ class AssetSelection(ABC):
             AssetSelection.all() - AssetSelection.groups("marketing")
 
             # Select all assets which are materialized by the same op as "projections":
-            AssetSelection.keys("projections").required_neighbors()
+            AssetSelection.keys("projections").required_multi_asset_neighbors()
     """
 
     @public
@@ -159,7 +159,7 @@ class AssetSelection(ABC):
         return SinkAssetSelection(self)
 
     @public
-    def required_neighbors(self) -> "RequiredNeighborsAssetSelection":
+    def required_multi_asset_neighbors(self) -> "RequiredNeighborsAssetSelection":
         """Given an asset selection in which some assets are output from a mutli-asset compute op
         which cannot be subset, returns a new asset selection that contains all of the assets
         required to execute the original asset selection.

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -55,6 +55,9 @@ class AssetSelection(ABC):
 
             # Select all assets except for those in group "marketing"
             AssetSelection.all() - AssetSelection.groups("marketing")
+
+            # Select all assets which are materialized by the same op as "projections":
+            AssetSelection.keys("projections").required_neighbors()
     """
 
     @public
@@ -154,6 +157,14 @@ class AssetSelection(ABC):
         The sink asset can have downstream dependencies outside of the asset selection.
         """
         return SinkAssetSelection(self)
+
+    @public
+    def required_neighbors(self) -> "RequiredNeighborsAssetSelection":
+        """Given an asset selection in which some assets are output from a mutli-asset compute op
+        which cannot be subset, returns a new asset selection that contains all of the assets
+        required to execute the original asset selection.
+        """
+        return RequiredNeighborsAssetSelection(self)
 
     @public
     def roots(self) -> "RootAssetSelection":
@@ -299,6 +310,18 @@ class SinkAssetSelection(AssetSelection):
     def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
         selection = self._child.resolve_inner(asset_graph)
         return fetch_sinks(asset_graph.asset_dep_graph, selection)
+
+
+class RequiredNeighborsAssetSelection(AssetSelection):
+    def __init__(self, child: AssetSelection):
+        self._child = child
+
+    def resolve_inner(self, asset_graph: AssetGraph) -> AbstractSet[AssetKey]:
+        selection = self._child.resolve_inner(asset_graph)
+        output = set(selection)
+        for asset_key in selection:
+            output.update(asset_graph.get_required_multi_asset_keys(asset_key))
+        return output
 
 
 class RootAssetSelection(AssetSelection):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -183,21 +183,21 @@ def test_asset_selection_sinks(all_assets: _AssetList):
     assert sel.resolve(all_assets) == _asset_keys_of({fiona})
 
 
-def test_asset_selection_required_neighbors(all_assets: _AssetList):
+def test_asset_selection_required_multi_asset_neighbors(all_assets: _AssetList):
     # no effect for single assets
-    sel = AssetSelection.keys("george").required_neighbors()
+    sel = AssetSelection.keys("george").required_multi_asset_neighbors()
     assert sel.resolve(all_assets) == _asset_keys_of({george})
 
     # robots must all be materialized together, so they are expanded
-    # from required_neighbors
-    sel = AssetSelection.keys("rosie").required_neighbors()
+    # from required_multi_asset_neighbors
+    sel = AssetSelection.keys("rosie").required_multi_asset_neighbors()
     assert sel.resolve(all_assets) == _asset_keys_of({robots})
 
-    sel = AssetSelection.keys("alice", "bob", "walle").required_neighbors()
+    sel = AssetSelection.keys("alice", "bob", "walle").required_multi_asset_neighbors()
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob, robots})
 
-    # aliens are subsettable, so no expansion from required_neighbors
-    sel = AssetSelection.keys("zorg").required_neighbors()
+    # aliens are subsettable, so no expansion from required_multi_asset_neighbors
+    sel = AssetSelection.keys("zorg").required_multi_asset_neighbors()
     assert sel.resolve(all_assets) == {AssetKey("zorg")}
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -12,9 +12,7 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.definitions import AssetSelection, asset
-from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.assets import AssetsDefinition
-from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey
 from typing_extensions import TypeAlias
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -1,6 +1,6 @@
 import operator
 from functools import reduce
-from typing import AbstractSet, Iterable, Union
+from typing import AbstractSet, Iterable, Tuple, Union
 
 import pytest
 from dagster import (
@@ -12,7 +12,9 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.definitions import AssetSelection, asset
+from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey
 from typing_extensions import TypeAlias
 
@@ -54,21 +56,37 @@ def george(bob, fiona):
     return "george"
 
 
+@multi_asset(
+    group_name="robots",
+    outs={
+        "rosie": AssetOut(),
+        "r2d2": AssetOut(),
+        "walle": AssetOut(),
+    },
+)
+def robots() -> Tuple[str, str, str]:
+    return "rosie", "r2d2", "walle"
+
+
+@multi_asset(
+    group_name="aliens",
+    outs={
+        "zorg": AssetOut(),
+        "zapp": AssetOut(),
+        "zort": AssetOut(),
+    },
+    can_subset=True,
+)
+def aliens() -> Tuple[str, str, str]:
+    return "zorg", "zapp", "zort"
+
+
 _AssetList: TypeAlias = Iterable[Union[AssetsDefinition, SourceAsset]]
 
 
 @pytest.fixture
 def all_assets() -> _AssetList:
-    return [
-        earth,
-        alice,
-        bob,
-        candace,
-        danny,
-        edgar,
-        fiona,
-        george,
-    ]
+    return [earth, alice, bob, candace, danny, edgar, fiona, george, robots, aliens]
 
 
 def _asset_keys_of(assets_defs: _AssetList) -> AbstractSet[AssetKey]:
@@ -157,12 +175,30 @@ def test_asset_selection_sinks(all_assets: _AssetList):
     assert sel.resolve(all_assets) == _asset_keys_of({bob})
 
     sel = AssetSelection.all().sinks()
-    assert sel.resolve(all_assets) == _asset_keys_of({edgar, george})
+    assert sel.resolve(all_assets) == _asset_keys_of({edgar, george, robots, aliens})
 
     sel = AssetSelection.groups("ladies").sinks()
     # fiona is a sink because it has no downstream dependencies within the "ladies" group
     # candace is not a sink because it is an upstream dependency of fiona
     assert sel.resolve(all_assets) == _asset_keys_of({fiona})
+
+
+def test_asset_selection_required_neighbors(all_assets: _AssetList):
+    # no effect for single assets
+    sel = AssetSelection.keys("george").required_neighbors()
+    assert sel.resolve(all_assets) == _asset_keys_of({george})
+
+    # robots must all be materialized together, so they are expanded
+    # from required_neighbors
+    sel = AssetSelection.keys("rosie").required_neighbors()
+    assert sel.resolve(all_assets) == _asset_keys_of({robots})
+
+    sel = AssetSelection.keys("alice", "bob", "walle").required_neighbors()
+    assert sel.resolve(all_assets) == _asset_keys_of({alice, bob, robots})
+
+    # aliens are subsettable, so no expansion from required_neighbors
+    sel = AssetSelection.keys("zorg").required_neighbors()
+    assert sel.resolve(all_assets) == {AssetKey("zorg")}
 
 
 def test_asset_selection_upstream(all_assets: _AssetList):


### PR DESCRIPTION
## Summary

Adds a new `required_neighbors()` [name not final] asset selection option, which is used to select the minumum set of assets necessary to materialize the selected assets.

This arises from a user who is having trouble materializing the upstream Airbyte assets for their dbt project. The Airbyte sync op cannot be subset.

This is useful for multi-assets which cannot be subselected. For example, if the same op computes `foo`, `bar`, and `baz`, `AssetSelection.keys("foo").required_neighbors()` will return all three assets.

## Test Plan

New unit tests.
