### PR TITLE
feat(dbt): follow dbt Core's version support constraints

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -35,7 +35,8 @@ setup(
     packages=find_packages(exclude=["dagster_dbt_tests*"]),
     install_requires=[
         f"dagster{pin}",
-        "dbt-core",
+        # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
+        "dbt-core>=1.1",
         "requests",
         "typer[all]",
     ],


### PR DESCRIPTION
## Summary & Motivation
Follow https://docs.getdbt.com/docs/dbt-versions/core, and explicitly prevent older versions of `dbt-core` from being installed.

## How I Tested These Changes
bk
