### PR TITLE
feat(dbt): remove unnecessary checks for dbt Core installation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/utils.py
@@ -116,13 +116,6 @@ def _core_execute_cli(
     json_log_format: bool,
 ) -> Iterator[Union[DbtCliEvent, int]]:
     """Runs a dbt command in a subprocess and yields parsed output line by line."""
-    try:
-        import dbt  # noqa: F401
-    except ImportError as e:
-        raise check.CheckError(
-            "You must have `dbt-core` installed in order to execute dbt CLI commands."
-        ) from e
-
     # Execute the dbt CLI command in a subprocess.
     messages: List[str] = []
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -247,21 +247,14 @@ def select_unique_ids_from_manifest(
     manifest_json: Optional[Mapping[str, Any]] = None,
 ) -> AbstractSet[str]:
     """Method to apply a selection string to an existing manifest.json file."""
-    try:
-        import dbt.flags as flags
-        import dbt.graph.cli as graph_cli
-        import dbt.graph.selector as graph_selector
-        from dbt.contracts.graph.manifest import Manifest, WritableManifest
-        from dbt.contracts.state import PreviousState
-        from dbt.graph import SelectionSpec
-        from dbt.graph.selector_spec import IndirectSelection
-        from networkx import DiGraph
-
-    except ImportError as e:
-        raise check.CheckError(
-            "In order to use the `select` argument on load_assets_from_dbt_manifest, you must have"
-            "`dbt-core >= 1.0.0` and `networkx` installed."
-        ) from e
+    import dbt.flags as flags
+    import dbt.graph.cli as graph_cli
+    import dbt.graph.selector as graph_selector
+    from dbt.contracts.graph.manifest import Manifest, WritableManifest
+    from dbt.contracts.state import PreviousState
+    from dbt.graph import SelectionSpec
+    from dbt.graph.selector_spec import IndirectSelection
+    from networkx import DiGraph
 
     if state_path is not None:
         previous_state = PreviousState(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_utils.py
@@ -1,32 +1,7 @@
-import logging
-import os
-import sys
 from typing import List
 
-import dagster._check as check
 import pytest
-from dagster_dbt.cli.utils import _create_command_list, execute_cli
-
-
-def test_execute_cli_requires_dbt_installed(monkeypatch, test_project_dir, dbt_config_dir):
-    monkeypatch.setitem(sys.modules, "dbt", None)
-
-    with pytest.raises(check.CheckError):
-        execute_cli(
-            executable="dbt",
-            command="ls",
-            log=logging.getLogger(__name__),
-            flags_dict={
-                "project-dir": test_project_dir,
-                "profiles-dir": dbt_config_dir,
-                "select": "*",
-                "resource-type": "model",
-                "output": "json",
-            },
-            warn_error=False,
-            ignore_handled_error=False,
-            target_path=os.path.join(test_project_dir, "target"),
-        )
+from dagster_dbt.cli.utils import _create_command_list
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -37,6 +37,7 @@ setup(
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
         "dbt-core>=1.1",
+        "networkx",
         "requests",
         "typer[all]",
     ],


### PR DESCRIPTION
## Summary & Motivation
The installation of `dbt-core` is already enforced by the package requirements. Adding a check for it is superfluous.

## How I Tested These Changes
pytest
