### PR TITLE
[test-api-update] update errors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -26,7 +26,7 @@ from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.definition_config_schema import IDefinitionConfigSchema
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.selector.subset_selector import AssetSelectionData
 from dagster._core.types.dagster_type import (
     DagsterType,
@@ -323,10 +323,8 @@ class GraphDefinition(NodeDefinition):
 
     def node_named(self, name: str) -> Node:
         check.str_param(name, "name")
-        check.invariant(
-            name in self._node_dict,
-            f"{self._name} has no op named {name}.",
-        )
+        if name not in self._node_dict:
+            raise DagsterInvariantViolationError(f"{self._name} has no op named {name}.")
 
         return self._node_dict[name]
 

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -13,6 +13,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.configurable import NamedConfigurableDefinition
 from dagster._core.definitions.policy import RetryPolicy
+from dagster._core.errors import DagsterInvariantViolationError
 
 from .hook_definition import HookDefinition
 from .utils import check_valid_name, validate_tags
@@ -147,6 +148,8 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     def output_def_named(self, name: str) -> "OutputDefinition":
         check.str_param(name, "name")
+        if name not in self._output_dict:
+            raise DagsterInvariantViolationError(f"{self._name} has no output named {name}.")
         return self._output_dict[name]
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -353,7 +353,7 @@ def raise_composite_descent_config_error(
         stack=":".join(descent_stack.handle.path),
     )
     message += (
-        'Solid "{solid_name}" with definition "{solid_def_name}" has a '
+        f'Op "{solid.name}" with definition "{solid.definition.name}" has a '
         "configuration error. "
         "It has produced config a via its config_fn that fails to "
         "pass validation in the solids that it contains. "
@@ -361,9 +361,6 @@ def raise_composite_descent_config_error(
         "produce correct config for its constiuent solids in all cases. The correct "
         "resolution is to fix the mapping function. Details on the error (and the paths "
         'on this error are relative to config mapping function "root", not the entire document): '
-    ).format(
-        solid_name=solid.name,
-        solid_def_name=solid.definition.name,
     )
 
     raise DagsterInvalidConfigError(message, evr.errors, failed_config_value)

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_composite_descent.py
@@ -215,7 +215,7 @@ def test_mix_layer_computed_mapping():
             resource_defs={"io_manager": mem_io_manager},
         )
 
-    assert 'Solid "layer_two_double_wrap" with definition "layer_two_double_wrap"' in str(
+    assert 'Op "layer_two_double_wrap" with definition "layer_two_double_wrap"' in str(
         exc_info.value
     )
     assert (
@@ -467,7 +467,7 @@ def test_direct_composite_descent_with_error():
     assert "In pipeline wrap_pipeline_with_error at stack layer0:layer1:" in str(exc_info.value)
 
     assert (
-        'Solid "layer1" with definition "wrap_coerce_to_wrong_type" has a configuration error.'
+        'Op "layer1" with definition "wrap_coerce_to_wrong_type" has a configuration error.'
         in str(exc_info.value)
     )
     assert 'Error 1: Invalid scalar at path root:layer2:config. Value "214"' in str(exc_info.value)

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
@@ -160,7 +160,7 @@ def test_bad_override():
 
     message = str(exc_info.value)
 
-    assert 'Solid "do_stuff" with definition "bad_wrap" has a configuration error.' in message
+    assert 'Op "do_stuff" with definition "bad_wrap" has a configuration error.' in message
     assert "Error 1: Invalid scalar at path root:scalar_config_solid:config" in message
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_in_process.py
@@ -16,7 +16,6 @@ from dagster import (
     op,
     resource,
 )
-from dagster._check import CheckError
 from dagster._core.definitions.output import GraphOut
 from dagster._core.errors import DagsterMaxRetriesExceededError
 
@@ -179,7 +178,7 @@ def test_output_for_node_not_found():
     result = basic.execute_in_process()
     assert result.success
 
-    with pytest.raises(KeyError, match="name_doesnt_exist"):
+    with pytest.raises(DagsterInvariantViolationError, match="name_doesnt_exist"):
         result.output_for_node("op_exists", "name_doesnt_exist")
 
     with pytest.raises(
@@ -187,7 +186,9 @@ def test_output_for_node_not_found():
     ):
         result.output_value("name_doesnt_exist")
 
-    with pytest.raises(CheckError, match="basic has no op named op_doesnt_exist"):
+    with pytest.raises(
+        DagsterInvariantViolationError, match="basic has no op named op_doesnt_exist"
+    ):
         result.output_for_node("op_doesnt_exist")
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_solid_isolation.py
@@ -9,7 +9,6 @@ from dagster import (
     op,
     resource,
 )
-from dagster._check import CheckError
 from dagster._core.definitions.decorators import graph
 from dagster._core.definitions.input import In
 from dagster._core.definitions.output import Out
@@ -162,7 +161,7 @@ def test_graphs():
     assert result.output_for_node("hello") == "hello"
 
     with pytest.raises(
-        CheckError,
+        DagsterInvariantViolationError,
         match=re.escape("hello_graph has no op named goodbye"),
     ):
         _ = result.output_for_node("goodbye")

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -10,10 +10,10 @@ import pytest
 from dagster import (
     AssetMaterialization,
     ResourceDefinition,
-    _check as check,
 )
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.reconstruct import ReconstructablePipeline
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.test_utils import instance_for_test
 from dagster._core.utils import make_new_run_id
@@ -125,7 +125,7 @@ def test_yield_unserializable_result():
 
 def test_in_job_manager_bad_op():
     with pytest.raises(
-        check.CheckError,
+        DagsterInvariantViolationError,
         match="hello_world_job has no op named foobar",
     ):
         with in_job_manager(node_handle=NodeHandle("foobar", None)) as _manager:


### PR DESCRIPTION
## Summary & Motivation

Update a small number of errors to throw `DagsterInvariantViolationError` instead of generic `CheckError` or `KeyError`. This was in the middle of a stack and TBH I can't 100% remember the motivation, but I believe it was for consistency with similar errors in other contexts.

## How I Tested These Changes

BK