### PR TITLE
Make menu items keyboard navigable

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Menu.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Menu.tsx
@@ -69,12 +69,23 @@ interface ItemProps
 
 export const MenuItem: React.FC<ItemProps> = (props) => {
   const {icon, intent, ...rest} = props;
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
   return (
-    <StyledMenuItem
-      {...rest}
-      $textColor={intentToTextColor(intent)}
-      icon={iconWithColor(icon, intent)}
-    />
+    <div
+      onKeyUp={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          wrapperRef.current?.querySelector('a')?.click();
+        }
+      }}
+      ref={wrapperRef}
+    >
+      <StyledMenuItem
+        {...rest}
+        $textColor={intentToTextColor(intent)}
+        icon={iconWithColor(icon, intent)}
+        tabIndex={0}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

As titled. We want to be able to navigate menu items with the keyboard and select items.

This is a little hacky in that I find the "a" tag that Blueprint renders and trigger "click" on it.
This was necessary because we need to pass a mouse event to the onClick handler but the event is being triggered by a keyboard event. 

The wrapper div is necessary to click on the `a` tag which has the `onClick` prop handler binded to it. 
It's necessary because passing a `ref` to a MenuItem returns an instance of `BlueprintMenuItem` instead of the actual HTML element.


## How I Tested These Changes

I spot checked a few places where we use MenuItem and it all seemed fine. I don't expect anything to break since MenuItems were already being rendered as block level everywhere.

<img width="237" alt="Screen Shot 2023-03-28 at 11 45 19 AM" src="https://user-images.githubusercontent.com/2286579/228293500-10a24abc-9f78-4a67-b3df-28113391a8b4.png">

<img width="592" alt="Screen Shot 2023-03-28 at 12 10 31 PM" src="https://user-images.githubusercontent.com/2286579/228302377-c9d45860-06ca-46b4-937c-bb5b88c0e39d.png">

The focus CSS on MenuItem is a little weird as you can see in the screenshot above but we can tackle that separately
