### PR TITLE
[bugfix] make AssetSelection.groups() resolve to only regular assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -285,7 +285,7 @@ class GroupsAssetSelection(AssetSelection):
         return {
             asset_key
             for asset_key, group in asset_graph.group_names_by_key.items()
-            if group in self._groups
+            if group in self._groups and asset_key not in asset_graph.source_asset_keys
         }
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from typing_extensions import TypeAlias
 
-earth = SourceAsset("earth")
+earth = SourceAsset("earth", group_name="planets")
 
 
 @asset(group_name="ladies")
@@ -97,7 +97,8 @@ def test_asset_selection_downstream(all_assets: _AssetList):
 
 
 def test_asset_selection_groups(all_assets: _AssetList):
-    sel = AssetSelection.groups("ladies")
+    sel = AssetSelection.groups("ladies", "planets")
+    # should not include source assets
     assert sel.resolve(all_assets) == _asset_keys_of({alice, candace, fiona})
 
 


### PR DESCRIPTION
## Summary & Motivation

Currently this resolves to a mix of source and regular assets, which will cause an error as of last week's release.

## How I Tested These Changes

Modified `AssetSelection.groups()` test.
