### PR TITLE
[dagit] Don’t show the partitions missing warning for unpartitioned upstream assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -657,7 +657,7 @@ const UpstreamUnavailableWarning: React.FC<{
   const upstreamUnavailable = (singleDimensionKey: string) =>
     upstreamAssetHealth.some((a) => {
       // If the key is not undefined, it's present in the partition key space of the asset
-      return a.stateForKey([singleDimensionKey]) === PartitionState.MISSING;
+      return a.dimensions.length && a.stateForKey([singleDimensionKey]) === PartitionState.MISSING;
     });
 
   const upstreamUnavailableSpans =


### PR DESCRIPTION
## Summary & Motivation

This is a tiny fix that resolves #[12347](https://github.com/dagster-io/dagster/issues/12347)
