### PR TITLE
[dagit] Collapse large table-schema metadata values

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.stories.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.stories.tsx
@@ -250,6 +250,22 @@ const MetadataEntryMocks = [
     label: 'my_short_json',
     jsonString: '{"short_value": 12}', // Very short JSON is inlined
   } as JsonMetadataEntry,
+
+  {
+    __typename: 'TableSchemaMetadataEntry',
+    description: 'This is the description',
+    label: 'my_table_schema',
+    schema: {
+      ...MetadataTableSchema,
+      columns: [
+        ...MetadataTableSchema.columns,
+        ...MetadataTableSchema.columns,
+        ...MetadataTableSchema.columns,
+        ...MetadataTableSchema.columns,
+        ...MetadataTableSchema.columns,
+      ],
+    },
+  } as TableSchemaMetadataEntry,
 ];
 
 export const EmptyState = () => {

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -173,7 +173,26 @@ export const MetadataEntry: React.FC<{
     case 'TableMetadataEntry':
       return null;
     case 'TableSchemaMetadataEntry':
-      return <TableSchema schema={entry.schema} />;
+      return expandSmallValues && entry.schema.columns.length < 5 ? (
+        <TableSchema schema={entry.schema} />
+      ) : (
+        <MetadataEntryModalAction
+          label={entry.label}
+          copyContent={() => JSON.stringify(entry.schema, null, 2)}
+          content={() => (
+            <Box
+              padding={{vertical: 16, horizontal: 20}}
+              background={Colors.White}
+              style={{overflow: 'auto'}}
+              margin={{bottom: 12}}
+            >
+              <TableSchema schema={entry.schema} />
+            </Box>
+          )}
+        >
+          [Show Table Schema]
+        </MetadataEntryModalAction>
+      );
     case 'NotebookMetadataEntry':
       if (repoLocation) {
         return <NotebookButton path={entry.path} repoLocation={repoLocation} />;


### PR DESCRIPTION
## Summary & Motivation

Previously table schema metadata always rendered inline, even if it was very long. Now we collapse it the same way we collapse JSON and markdown behind a "Show Table Schema" link that opens a modal. Fixes #12075. 

If there are <5 columns on the schema and "expandSmallValues" is set, the data is still shown inline.

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/1037212/228347575-7b8f906f-675c-4d1d-90fe-bac5381ca8ba.png">

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/1037212/228347600-5fc83e83-7ee5-446d-b095-d8d2c1b24064.png">


## How I Tested These Changes

I verified this fix by creating a new storybook test case and verifying both the small and large table schema scenarios.