### PR TITLE
[dagit] Refresh health in the asset sidebar if live data updates

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -16,7 +16,10 @@ import {DependsOnSelfBanner} from '../assets/DependsOnSelfBanner';
 import {PartitionHealthSummary} from '../assets/PartitionHealthSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKey} from '../assets/types';
-import {usePartitionHealthData} from '../assets/usePartitionHealthData';
+import {
+  healthRefreshHintFromLiveData,
+  usePartitionHealthData,
+} from '../assets/usePartitionHealthData';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {DagsterTypeFragment} from '../dagstertype/types/DagsterType.types';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntry';
@@ -34,7 +37,13 @@ export const SidebarAssetInfo: React.FC<{
   liveData: LiveDataForNode;
 }> = ({assetNode, liveData}) => {
   const assetKey = assetNode.assetKey;
-  const partitionHealthData = usePartitionHealthData([assetKey]);
+  const partitionHealthRefreshHint = healthRefreshHintFromLiveData(liveData);
+  const partitionHealthData = usePartitionHealthData(
+    [assetKey],
+    partitionHealthRefreshHint,
+    'background',
+  );
+
   const {data} = useQuery<SidebarAssetQuery, SidebarAssetQueryVariables>(SIDEBAR_ASSET_QUERY, {
     variables: {assetKey: {path: assetKey.path}},
   });

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -54,6 +54,7 @@ import {
   AssetViewDefinitionQuery,
   AssetViewDefinitionQueryVariables,
 } from './types/AssetView.types';
+import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 
 interface Props {
   assetKey: AssetKey;
@@ -106,7 +107,9 @@ export const AssetView: React.FC<Props> = ({assetKey}) => {
 
   // Some tabs make expensive queries that should be refreshed after materializations or failures.
   // We build a hint string from the live summary info and refresh the views when the hint changes.
-  const dataRefreshHint = `${lastMaterializedAt},${liveDataForAsset?.runWhichFailedToMaterialize?.id}`;
+  const dataRefreshHint = liveDataForAsset
+    ? healthRefreshHintFromLiveData(liveDataForAsset)
+    : lastMaterialization?.timestamp;
 
   const refreshState = useMergedRefresh(
     useQueryRefreshAtInterval(definitionQueryResult, FIFTEEN_SECONDS),

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual';
 import React from 'react';
 
 import {assertUnreachable} from '../app/Util';
+import {LiveDataForNode} from '../asset-graph/Utils';
 import {PartitionDefinitionType, PartitionRangeStatus} from '../graphql/types';
 import {PartitionState} from '../partitions/PartitionStatus';
 import {assembleIntoSpans} from '../partitions/SpanRepresentation';
@@ -466,7 +467,8 @@ export function rangesForKeys(keys: string[], allKeys: string[]): Range[] {
 
 // Note: assetLastMaterializedAt is used as a "hint" - if the input value changes, it's
 // a sign that we should invalidate and reload previously loaded health stats. We don't
-// clear them immediately to avoid an empty state.
+// clear them immediately to avoid an empty state. You can generate a hint from the
+// minimal LiveData using healthRefreshHintFromLiveData.
 //
 export function usePartitionHealthData(
   assetKeys: AssetKey[],
@@ -520,6 +522,15 @@ export function usePartitionHealthData(
     );
   }, [assetKeyJSON, result, cacheKey, cacheClearStrategy]);
 }
+
+// This function returns a string value that changes when the partition health bar
+// or partition events page needs to be reloaded based on the partition counts or
+// a new run / run failure.
+//
+export const healthRefreshHintFromLiveData = (liveData: LiveDataForNode) =>
+  `${liveData.lastMaterialization?.timestamp},${
+    liveData.runWhichFailedToMaterialize?.id
+  },${JSON.stringify(liveData.partitionStats)}`;
 
 const rangeStatusToState = (rangeStatus: PartitionRangeStatus) =>
   rangeStatus === PartitionRangeStatus.MATERIALIZED


### PR DESCRIPTION
## Summary & Motivation

This PR resolves #13023. If you're viewing the asset graph and have an asset selected, it's partition health bar is shown in the sidebar. Previously, the health bar would not refresh when the asset's partition counts updated on the graph because the health bar uses a separate GraphQL query that is not refreshed periodically. 

The `usePartitionHealthData` hook already accepts a "cache hint" that allows us to use lightweight polling to trigger a heavy refresh of the health bar (on the asset details page). This PR wires it up on the asset graph as well, and moves some of the code to a shared helper.

## How I Tested These Changes

We don't have tests for the asset graph sidebar yet. To test this I launched runs of an asset from the asset graph and observed that the counts on the graph and the counts in the sidebar are now in sync. 

I also changed the partition definition in code and verified that both the asset graph and the asset sidebar updated to reflect the new number of partitions in the asset. (The case in #12422)