### PR TITLE
[dagit] Improvements to the asset partition detail page

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -1,5 +1,6 @@
-import {Box, Caption, Colors, Icon, Mono} from '@dagster-io/ui';
+import {Box, Caption, Colors, Mono} from '@dagster-io/ui';
 import dayjs from 'dayjs';
+import uniqBy from 'lodash/uniqBy';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -23,8 +24,16 @@ export const AssetEventMetadataEntriesTable: React.FC<{
   if (!event || (!event.metadataEntries.length && !observations?.length)) {
     return <Caption color={Colors.Gray500}>No materializations</Caption>;
   }
-
   const {metadataEntries, timestamp} = event;
+
+  // If there are multiple observation events that contain entries with the same label,
+  // only include the latest (newest) line for that metadata label in the table.
+  const observationEntries = uniqBy(
+    (observations || []).flatMap((o) =>
+      o.metadataEntries.map((entry) => ({timestamp: o.timestamp, runId: o.runId, entry})),
+    ),
+    (e) => e.entry.label,
+  );
 
   return (
     <AssetEventMetadataScrollContainer>
@@ -43,39 +52,32 @@ export const AssetEventMetadataEntriesTable: React.FC<{
               <td style={{opacity: 0.7}}>{entry.description}</td>
             </tr>
           ))}
-          {(observations || []).map((obs) => (
-            <React.Fragment key={obs.timestamp}>
-              {obs.metadataEntries.map((entry) => (
-                <tr key={`metadata-${obs.timestamp}-${entry.label}`}>
-                  <td>
-                    <Mono>{entry.label}</Mono>
-                  </td>
-                  <td>
-                    <Mono>
-                      <MetadataEntry entry={entry} expandSmallValues={true} />
-                    </Mono>
-                  </td>
-                  <td style={{opacity: 0.7}}>
-                    <Box flex={{gap: 8}}>
-                      <Icon name="observation" size={16} style={{marginTop: 2}} />
-                      <span>
-                        {`${obs.stepKey} in `}
-                        <Link to={`/runs/${obs.runId}?timestamp=${obs.timestamp}`}>
-                          <Mono>{titleForRun({runId: obs.runId})}</Mono>
-                        </Link>
-                      </span>
-                    </Box>
-                    <Caption style={{marginLeft: 24}}>
-                      {`(${dayjs(Number(obs.timestamp)).from(
-                        Number(timestamp),
-                        true /* withoutSuffix */,
-                      )} later)`}
-                    </Caption>
-                    {entry.description}
-                  </td>
-                </tr>
-              ))}
-            </React.Fragment>
+          {observationEntries.map((obv) => (
+            <tr key={`metadata-${obv.timestamp}-${obv.entry.label}`}>
+              <td>
+                <Mono>{obv.entry.label}</Mono>
+              </td>
+              <td>
+                <Mono>
+                  <MetadataEntry entry={obv.entry} expandSmallValues={true} />
+                </Mono>
+              </td>
+              <td style={{opacity: 0.7}}>
+                <Box>
+                  {`Observed in run `}
+                  <Link to={`/runs/${obv.runId}?timestamp=${timestamp}`}>
+                    <Mono>{titleForRun({runId: obv.runId})}</Mono>
+                  </Link>
+                </Box>
+                <Caption>
+                  {`(${dayjs(Number(obv.timestamp)).from(
+                    Number(timestamp),
+                    true /* withoutSuffix */,
+                  )} later)`}
+                </Caption>
+                {obv.entry.description}
+              </td>
+            </tr>
           ))}
         </tbody>
       </AssetEventMetadataTable>

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -69,7 +69,9 @@ export const AssetMaterializationUpstreamData: React.FC<{
                 timeFormat={{showSeconds: true, showTimezone: false}}
               />
             </Link>
-            <span>({dayjs(Number(entry.timestamp)).from(Number(timestamp), true)} earlier)</span>
+            <span style={{opacity: 0.7}}>
+              ({dayjs(Number(entry.timestamp)).from(Number(timestamp), true)} earlier)
+            </span>
           </Box>
         </td>
       </tr>,

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -170,6 +170,8 @@ export const AssetPartitionDetail: React.FC<{
         )
       : [];
 
+  const prior = latest ? all.slice(all.indexOf(latest)) : all;
+
   return (
     <Box padding={{horizontal: 24, bottom: 24}} style={{flex: 1}}>
       <Box
@@ -216,14 +218,21 @@ export const AssetPartitionDetail: React.FC<{
         border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
         padding={{vertical: 16}}
       >
-        <Box flex={{gap: 4, direction: 'column'}}>
-          <Subheading>Latest event</Subheading>
-          {!latest ? (
+        {!latest ? (
+          <Box flex={{gap: 4, direction: 'column'}}>
+            <Subheading>Latest materialization</Subheading>
             <Box flex={{gap: 4}}>
               <Icon name="materialization" />
               None
             </Box>
-          ) : (
+          </Box>
+        ) : (
+          <Box flex={{gap: 4, direction: 'column'}}>
+            <Subheading>
+              {latest.__typename === 'MaterializationEvent'
+                ? 'Latest materialization'
+                : 'Latest observation'}
+            </Subheading>
             <Box flex={{gap: 4}} style={{whiteSpace: 'nowrap'}}>
               {latest.__typename === 'MaterializationEvent' ? (
                 <Icon name="materialization" />
@@ -231,14 +240,14 @@ export const AssetPartitionDetail: React.FC<{
                 <Icon name="observation" />
               )}
               <Timestamp timestamp={{ms: Number(latest.timestamp)}} />
-              {all.length > 1 && (
+              {prior.length > 0 && (
                 <AllIndividualEventsLink hasPartitions hasLineage={hasLineage} events={all}>
-                  {`(${all.length} events)`}
+                  {`(${prior.length - 1} prior ${prior.length - 1 === 1 ? 'event' : 'events'})`}
                 </AllIndividualEventsLink>
               )}
             </Box>
-          )}
-        </Box>
+          </Box>
+        )}
         <Box flex={{gap: 4, direction: 'column'}}>
           <Subheading>Run</Subheading>
           {latestEventRun && latest ? (

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.mocks.ts
@@ -292,7 +292,14 @@ export const buildAssetPartitionDetailMock = (
         __typename: 'AssetNode',
         id: 'test.py.repo.["asset_1"]',
         assetMaterializations: [MaterializationEventFull, MaterializationEventOlder],
-        assetObservations: [BasicObservationEvent],
+        assetObservations: [
+          BasicObservationEvent,
+          {
+            ...BasicObservationEvent,
+            stepKey: 'a_different_step',
+            timestamp: `${Number(BasicObservationEvent.timestamp) + 2 * 60 * 1000}`,
+          },
+        ],
         latestRunForPartition: currentRunStatus
           ? {
               __typename: 'Run',

--- a/js_modules/dagit/packages/core/src/assets/__stories__/AssetPartitionDetail.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/AssetPartitionDetail.stories.tsx
@@ -28,7 +28,7 @@ export const EmptyState = () => {
   );
 };
 
-export const MaterializationFollowedByObservation = () => {
+export const MaterializationFollowedByObservations = () => {
   return (
     <MockedProvider
       mocks={[buildAssetPartitionDetailMock(), MaterializationUpstreamDataFullMock]}


### PR DESCRIPTION
## Summary & Motivation

This PR updates the asset partition detail page based on @sryza's feedback and resolves #13068.

## How I Tested These Changes

We have storybooks covering the major states of this page, before and after screenshots below! I also tested it live in Dagit just to be safe.

I also expanded our storybook to include a case where the same metadata is observed in several events.

Before:

![Screen Shot 2023-03-28 at 3 42 51 PM](https://user-images.githubusercontent.com/1037212/228362078-a8818465-d6d4-4152-adb5-b9eb21f20d73.png)

After:

![Screen Shot 2023-03-28 at 3 42 40 PM](https://user-images.githubusercontent.com/1037212/228362107-9fdd78e8-768a-404a-9bc6-41d8b2e85e41.png)
