### PR TITLE
[docs][pythonic config] Add advanced config types page

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -204,6 +204,10 @@
           {
             "title": "Run Configuration",
             "path": "/concepts/configuration/config-schema"
+          },
+          {
+            "title": "Advanced Config Types",
+            "path": "/concepts/configuration/advanced-config-types"
           }
         ]
       },

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -3,17 +3,21 @@ title: Advanced Config Types | Dagster
 description: Dagster's config system supports a variety of more advanced config types.
 ---
 
-# Advanced Config Types
+# Advanced config types
 
 <Note>
   This guide covers using the new Pythonic config system introduced in Dagster
-  1.3. If your code is still using the legacy config system, see the [legacy
-  configuration guide](/concepts/configuration/config-schema-legacy).
+  1.3. If your code is still using the legacy config system, see the{" "}
+  <a href="/concepts/configuration/config-schema-legacy">
+    legacy configuration guide
+  </a>
 </Note>
 
-In some cases, you may want to define a more complex [config schema](/çoncepts/configuration/config-schema) for your ops and assets.. For example, you may want to define a config schema that takes in a list of files or complex data. Below we'll walk through some common patterns for defining more complex config schemas.
+In some cases, you may want to define a more complex [config schema](/concepts/configuration/config-schema) for your ops and assets. For example, you may want to define a config schema that takes in a list of files or complex data. In this guide, we'll walk through some common patterns for defining more complex config schemas.
 
-### Attaching metadata to config fields
+\--
+
+## Attaching metadata to config fields
 
 Config fields can be annotated with metadata, which can be used to provide additional information about the field, using the Pydantic <PyObject object="Field"/> class.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -63,7 +63,9 @@ asset_result = materialize(
 )
 ```
 
-### Basic data structures
+---
+
+## Basic data structures
 
 Many basic Python data structures can be used in your config schemas, including lists and mappings.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -94,7 +94,9 @@ result = materialize(
 )
 ```
 
-### Nested schemas
+---
+
+## Nested schemas
 
 Schemas can be nested in one another, or in basic Python data structures.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -38,7 +38,9 @@ class MyMetadataConfig(Config):
 MyMetadataConfig(person_name="Alice", age=200)
 ```
 
-### Defaults and optional config fields
+---
+
+## Defaults and optional config fields
 
 Config fields can be marked as optional by specifying a default value. For example, we can mark the `greeting_phrase` field as optional by specifying a default of `hello`. Optional fields, such as `person_name`, can be specified a default value of `None`.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -178,7 +178,9 @@ result = materialize(
 )
 ```
 
-### Enum types
+---
+
+## Enum types
 
 Python enums which subclass `Enum` are supported as config fields. Here, we define a schema that takes in a list of users, whose roles are specified as enum values:
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -131,7 +131,9 @@ result = materialize(
 )
 ```
 
-### Union types
+---
+
+## Union types
 
 Union types are supported using Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions). Each union type must be a subclass of <PyObject object="Config"/>. The `discriminator` argument to <PyObject object="Field"/> specifies the field that will be used to determine which union type to use.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -26,7 +26,9 @@ from pydantic import Field
 class MyMetadataConfig(Config):
     # Here, the ellipses `...` indicates that the field is required and has no default value.
     person_name: str = Field(..., description="The name of the person to greet")
-    age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
+    age: int = Field(
+        ..., gt=0, lt=100, description="The age of the person to greet"
+    )
 
 # errors!
 MyMetadataConfig(person_name="Alice", age=200)
@@ -188,7 +190,7 @@ class ProcessUsersConfig(Config):
 def process_users(config: ProcessUsersConfig):
     for user, permission in config.users_list.items():
         if permission == UserPermissions.ADMIN:
-            print(f"{user} is an admin")
+            print(f"{user} is an admin")  # noqa: T201
 
 @job
 def process_users_job():

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -1,0 +1,258 @@
+---
+title: Advanced Config Types | Dagster
+description: Dagster's config system supports a variety of more advanced config types.
+---
+
+# Advanced Config Types
+
+<Note>
+  This guide covers using the new Pythonic config system introduced in Dagster
+  1.3. If your code is still using the legacy config system, see the [legacy
+  configuration guide](/concepts/configuration/config-schema-legacy).
+</Note>
+
+In some cases, you may want to define a more complex [config schema](/çoncepts/configuration/config-schema) for your ops and assets.. For example, you may want to define a config schema that takes in a list of files or complex data. Below we'll walk through some common patterns for defining more complex config schemas.
+
+### Attaching metadata to config fields
+
+Config fields can be annotated with metadata, which can be used to provide additional information about the field, using the Pydantic <PyObject object="Field"/> class.
+
+For example, we can annotate a config field with a description, which will be displayed in the documentation for the config field. We can add a value range to a field, which will be validated when config is specified.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_metadata_config endbefore=end_metadata_config dedent=4
+from dagster import Config
+from pydantic import Field
+
+class MyMetadataConfig(Config):
+    # Here, the ellipses `...` indicates that the field is required and has no default value.
+    person_name: str = Field(..., description="The name of the person to greet")
+    age: int = Field(..., gt=0, lt=100, description="The age of the person to greet")
+
+# errors!
+MyMetadataConfig(person_name="Alice", age=200)
+```
+
+### Defaults and optional config fields
+
+Config fields can be marked as optional by specifying a default value. For example, we can mark the `greeting_phrase` field as optional by specifying a default of `hello`. Optional fields, such as `person_name`, can be specified a default value of `None`.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_optional_config endbefore=end_optional_config dedent=4
+from typing import Optional
+from dagster import asset, Config, materialize, RunConfig
+
+class MyAssetConfig(Config):
+    person_name: Optional[str] = None
+    greeting_phrase: str = "hello"
+
+@asset
+def greeting(config: MyAssetConfig) -> str:
+    if config.person_name:
+        return f"{config.greeting_phrase} {config.person_name}"
+    else:
+        return config.greeting_phrase
+
+asset_result = materialize(
+    [greeting],
+    run_config=RunConfig({"greeting": MyAssetConfig()}),
+)
+```
+
+### Basic data structures
+
+Many basic Python data structures can be used in your config schemas, including lists and mappings.
+
+For example, we can define a config schema that takes in a list of user names and a mapping of user names to user scores.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_basic_data_structures_config endbefore=end_basic_data_structures_config dedent=4
+from dagster import Config, materialize, asset, RunConfig
+from typing import List, Dict
+
+class MyDataStructuresConfig(Config):
+    user_names: List[str]
+    user_scores: Dict[str, int]
+
+@asset
+def scoreboard(config: MyDataStructuresConfig):
+    ...
+
+result = materialize(
+    [scoreboard],
+    run_config=RunConfig(
+        {
+            "scoreboard": MyDataStructuresConfig(
+                user_names=["Alice", "Bob"],
+                user_scores={"Alice": 10, "Bob": 20},
+            )
+        }
+    ),
+)
+```
+
+### Nested schemas
+
+Schemas can be nested in one another, or in basic Python data structures.
+
+Here, we define a schema which contains a mapping of user names to complex user data objects.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_nested_schema_config endbefore=end_nested_schema_config dedent=4
+from dagster import asset, materialize, Config, RunConfig
+from typing import Dict
+
+class UserData(Config):
+    age: int
+    email: str
+    profile_picture_url: str
+
+class MyNestedConfig(Config):
+    user_data: Dict[str, UserData]
+
+@asset
+def average_age(config: MyNestedConfig):
+    ...
+
+result = materialize(
+    [average_age],
+    run_config=RunConfig(
+        {
+            "average_age": MyNestedConfig(
+                user_data={
+                    "Alice": UserData(age=10, email="alice@gmail.com", profile_picture_url=...),
+                    "Bob": UserData(age=20, email="bob@gmail.com", profile_picture_url=...),
+                }
+            )
+        }
+    ),
+)
+```
+
+### Union types
+
+Union types are supported using Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions). Each union type must be a subclass of <PyObject object="Config"/>. The `discriminator` argument to <PyObject object="Field"/> specifies the field that will be used to determine which union type to use.
+
+Here, we define a config schema which takes in a `pet` field, which can be either a `Cat` or a `Dog`, as indicated by the `pet_type` field.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_union_schema_config endbefore=end_union_schema_config dedent=4
+from dagster import asset, materialize, Config, RunConfig
+from pydantic import Field
+from typing import Union
+from typing_extensions import Literal
+
+class Cat(Config):
+    pet_type: Literal["cat"] = "cat"
+    meows: int
+
+class Dog(Config):
+    pet_type: Literal["dog"] = "dog"
+    barks: float
+
+class ConfigWithUnion(Config):
+    # Here, the ellipses `...` indicates that the field is required and has no default value.
+    pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+
+@asset
+def pet_stats(config: ConfigWithUnion):
+    if isinstance(config.pet, Cat):
+        return f"Cat meows {config.pet.meows} times"
+    else:
+        return f"Dog barks {config.pet.barks} times"
+
+result = materialize(
+    [pet_stats],
+    run_config=RunConfig(
+        {
+            "pet_stats": ConfigWithUnion(
+                pet=Cat(meows=10),
+            )
+        }
+    ),
+)
+```
+
+### Enum types
+
+Python enums which subclass `Enum` are supported as config fields. Here, we define a schema that takes in a list of users, whose roles are specified as enum values:
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_enum_schema_config endbefore=end_enum_schema_config dedent=4
+from dagster import Config, RunConfig, op, job
+from enum import Enum
+
+class UserPermissions(Enum):
+    GUEST = "guest"
+    MEMBER = "member"
+    ADMIN = "admin"
+
+class ProcessUsersConfig(Config):
+    users_list: Dict[str, UserPermissions]
+
+@op
+def process_users(config: ProcessUsersConfig):
+    for user, permission in config.users_list.items():
+        if permission == UserPermissions.ADMIN:
+            print(f"{user} is an admin")
+
+@job
+def process_users_job():
+    process_users()
+
+op_result = process_users_job.execute_in_process(
+    run_config=RunConfig(
+        {
+            "process_users": ProcessUsersConfig(
+                users_list={
+                    "Bob": UserPermissions.GUEST,
+                    "Alice": UserPermissions.ADMIN,
+                }
+            )
+        }
+    ),
+)
+```
+
+### Validated config fields
+
+Config fields can have custom validation logic applied using [Pydantic validators](https://docs.pydantic.dev/usage/validators/). Pydantic validators are defined as methods on the config class, and are decorated with the `@validator` decorator. Here, we define some validators on a configured user's name and username, which will throw exceptions if incorrect values are passed in the launchpad or from a schedule or sensor.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_validated_schema_config endbefore=end_validated_schema_config dedent=4
+from dagster import Config, RunConfig, op, job
+from pydantic import validator
+
+class UserConfig(Config):
+    name: str
+    username: str
+
+    @validator("name")
+    def name_must_contain_space(cls, v):
+        if " " not in v:
+            raise ValueError("must contain a space")
+        return v.title()
+
+    @validator("username")
+    def username_alphanumeric(cls, v):
+        assert v.isalnum(), "must be alphanumeric"
+        return v
+
+executed = {}
+
+@op
+def greet_user(config: UserConfig) -> None:
+    print(f"Hello {config.name}!")  # noqa: T201
+    executed["greet_user"] = True
+
+@job
+def greet_user_job() -> None:
+    greet_user()
+
+# Input is valid, so this will work
+op_result = greet_user_job.execute_in_process(
+    run_config=RunConfig(
+        {"greet_user": UserConfig(name="Alice Smith", username="alice123")}
+    ),
+)
+
+# Name has no space, so this will fail
+op_result = greet_user_job.execute_in_process(
+    run_config=RunConfig(
+        {"greet_user": UserConfig(name="John", username="johndoe44")}
+    ),
+)
+```

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -15,7 +15,7 @@ description: Dagster's config system supports a variety of more advanced config 
 
 In some cases, you may want to define a more complex [config schema](/concepts/configuration/config-schema) for your ops and assets. For example, you may want to define a config schema that takes in a list of files or complex data. In this guide, we'll walk through some common patterns for defining more complex config schemas.
 
-\--
+---
 
 ## Attaching metadata to config fields
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -214,7 +214,9 @@ op_result = process_users_job.execute_in_process(
 )
 ```
 
-### Validated config fields
+---
+
+## Validated config fields
 
 Config fields can have custom validation logic applied using [Pydantic validators](https://docs.pydantic.dev/usage/validators/). Pydantic validators are defined as methods on the config class, and are decorated with the `@validator` decorator. Here, we define some validators on a configured user's name and username, which will throw exceptions if incorrect values are passed in the launchpad or from a schedule or sensor.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -46,10 +46,15 @@ For example, we can attach a default value of `"hello"` to the `greeting_phrase`
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_optional_config endbefore=end_optional_config dedent=4
 from typing import Optional
 from dagster import asset, Config, materialize, RunConfig
+from pydantic import Field
 
 class MyAssetConfig(Config):
     person_name: Optional[str] = None
-    greeting_phrase: str = "hello"
+
+    # can pass default to pydantic.Field to attach metadata to the field
+    greeting_phrase: str = Field(
+        default="hello", description="The greeting phrase to use."
+    )
 
 @asset
 def greeting(config: MyAssetConfig) -> str:
@@ -69,33 +74,44 @@ asset_result = materialize(
 By default, fields which are typed as `Optional` are not required to be specified in the config, and have an implicit default value of `None`. If you want to require that a field be specified in the config, you may use an ellipsis (`...`) to [require that a value be passed](https://docs.pydantic.dev/usage/models/#required-fields).
 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_required_config endbefore=end_required_config dedent=4
-from typing import Optional
+from typing import Optional, Callable
 from dagster import asset, Config
+from pydantic import Field
 
 class MyAssetConfig(Config):
     # ellipsis indicates that even though the type is Optional,
     # an input is required
-    person_name: Optional[str] = ...
+    person_first_name: Optional[str] = ...
+
+    # ellipsis can also be used with pydantic.Field to attach metadata
+    person_last_name: Optional[Callable] = Field(
+        default=..., description="The last name of the person to greet"
+    )
 
 @asset
 def goodbye(config: MyAssetConfig) -> str:
-    if config.person_name:
-        return f"Goodbye, {config.person_name}"
+    full_name = f"{config.person_first_name} {config.person_last_name}".strip()
+    if full_name:
+        return f"Goodbye, {full_name}"
     else:
         return "Goodbye"
 
-# errors, since person_name is required
+# errors, since person_first_name and person_last_name are required
 goodbye(MyAssetConfig())
 
-# works, since person_name is provided
-goodbye(MyAssetConfig(person_name=None))
+# works, since both person_first_name and person_last_name are provided
+goodbye(MyAssetConfig(person_first_name="Alice", person_last_name=None))
 ```
 
 ---
 
 ## Basic data structures
 
-Basic Python data structures can be used in your config schemas, including `List`s and `Dict`s, along with nested versions of these data structures.
+Basic Python data structures can be used in your config schemas along with nested versions of these data structures. The data structures which can be used are:
+
+- `List`
+- `Dict`
+- `Mapping`
 
 For example, we can define a config schema that takes in a list of user names and a mapping of user names to user scores.
 
@@ -191,7 +207,7 @@ filtered_listings(FilterConfig(title="hotel", beds=4))
 
 ## Union types
 
-Union types are supported using Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions). Each union type must be a subclass of <PyObject object="Config"/>. The `discriminator` argument to <PyObject object="Field"/> specifies the field that will be used to determine which union type to use.
+Union types are supported using Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions). Each union type must be a subclass of <PyObject object="Config"/>. The `discriminator` argument to <PyObject object="Field"/> specifies the field that will be used to determine which union type to use. Discriminated unions provide comparable functionality to the `Selector` type in the legacy Dagster config APIs.
 
 Here, we define a config schema which takes in a `pet` field, which can be either a `Cat` or a `Dog`, as indicated by the `pet_type` field.
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -28,13 +28,10 @@ from dagster import Config
 from pydantic import Field
 
 class MyMetadataConfig(Config):
-    # Here, the ellipses `...` indicates that the field is required and has no default value.
-    person_name: str = Field(..., description="The name of the person to greet")
-    age: int = Field(
-        ..., gt=0, lt=100, description="The age of the person to greet"
-    )
+    person_name: str = Field(description="The name of the person to greet")
+    age: int = Field(gt=0, lt=100, description="The age of the person to greet")
 
-# errors!
+# errors, since age is not in the valid range!
 MyMetadataConfig(person_name="Alice", age=200)
 ```
 

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -7,7 +7,7 @@ description: Dagster's config system supports a variety of more advanced config 
 
 <Note>
   This guide covers using the new Pythonic config system introduced in Dagster
-  1.3. If your code is still using the legacy config system, see the{" "}
+  1.3. If your code is still using the legacy APIs, see the{" "}
   <a href="/concepts/configuration/config-schema-legacy">
     legacy configuration guide
   </a>

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -39,7 +39,9 @@ MyMetadataConfig(person_name="Alice", age=200)
 
 ## Defaults and optional config fields
 
-Config fields can be marked as optional by specifying a default value. For example, we can mark the `greeting_phrase` field as optional by specifying a default of `hello`. Optional fields, such as `person_name`, can be specified a default value of `None`.
+Config fields can have an attached default value. Fields with defaults are not required, meaning they do not need to be specified when constructing the config object.
+
+For example, we can attach a default value of `"hello"` to the `greeting_phrase` field, and can construct `MyAssetConfig` without specifying a phrase. Fields which are marked as `Optional`, such as `person_name`, implicitly have a default value of `None`, but can also be explicitly set to `None` as in the example below.
 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_optional_config endbefore=end_optional_config dedent=4
 from typing import Optional
@@ -60,6 +62,33 @@ asset_result = materialize(
     [greeting],
     run_config=RunConfig({"greeting": MyAssetConfig()}),
 )
+```
+
+### Required config fields
+
+By default, fields which are typed as `Optional` are not required to be specified in the config, and have an implicit default value of `None`. If you want to require that a field be specified in the config, you may use an ellipsis (`...`) to [require that a value be passed](https://docs.pydantic.dev/usage/models/#required-fields).
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_required_config endbefore=end_required_config dedent=4
+from typing import Optional
+from dagster import asset, Config
+
+class MyAssetConfig(Config):
+    # ellipsis indicates that even though the type is Optional,
+    # an input is required
+    person_name: Optional[str] = ...
+
+@asset
+def goodbye(config: MyAssetConfig) -> str:
+    if config.person_name:
+        return f"Goodbye, {config.person_name}"
+    else:
+        return "Goodbye"
+
+# errors, since person_name is required
+goodbye(MyAssetConfig())
+
+# works, since person_name is provided
+goodbye(MyAssetConfig(person_name=None))
 ```
 
 ---
@@ -202,6 +231,28 @@ result = materialize(
 )
 ```
 
+### YAML and config dictionary representations of union types
+
+The YAML or config dictionary representation of a discriminated union is structured slightly differently than the Python representation. In the YAML representation, the discriminator key is used as the key for the union type's dictionary. For example, a `Cat` object would be represented as:
+
+```yaml
+pet:
+  cat:
+    meows: 10
+```
+
+In the config dictionary representation, the same pattern is used:
+
+```python
+{
+    "pet": {
+        "cat": {
+            "meows": 10,
+        }
+    }
+}
+```
+
 ---
 
 ## Enum types
@@ -242,6 +293,27 @@ op_result = process_users_job.execute_in_process(
         }
     ),
 )
+```
+
+### YAML and config dictionary representations of enum types
+
+The YAML or config dictionary representation of a Python enum uses the enum's name. For example, a YAML specification of the user list above would be:
+
+```yaml
+users_list:
+  Bob: GUEST
+  Alice: ADMIN
+```
+
+In the config dictionary representation, the same pattern is used:
+
+```python
+{
+    "users_list": {
+        "Bob": "GUEST",
+        "Alice": "ADMIN",
+    }
+}
 ```
 
 ---

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -69,7 +69,7 @@ asset_result = materialize(
 
 ## Basic data structures
 
-Many basic Python data structures can be used in your config schemas, including lists and mappings.
+Basic Python data structures can be used in your config schemas, including `List`s and `Dict`s, along with nested versions of these data structures.
 
 For example, we can define a config schema that takes in a list of user names and a mapping of user names to user scores.
 
@@ -139,6 +139,30 @@ result = materialize(
 
 ---
 
+## Permissive schemas
+
+By default, `Config` schemas are strict, meaning that they will only accept fields that are explicitly defined in the schema. This can be cumbersome if you want to allow users to specify arbitrary fields in their config. For this purpose, you can use the `PermissiveConfig` base class, which allows arbitrary fields to be specified in the config.
+
+```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_permissive_schema_config endbefore=end_permissive_schema_config dedent=4
+from dagster import asset, PermissiveConfig
+from typing import Optional
+import requests
+
+class FilterConfig(PermissiveConfig):
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+@asset
+def filtered_listings(config: FilterConfig):
+    # extract all config fields, including those not defined in the schema
+    url_params = config.dict()
+    return requests.get("https://my-api.com/listings", params=url_params).json()
+
+filtered_listings(FilterConfig(title="hotel", beds=4))
+```
+
+---
+
 ## Union types
 
 Union types are supported using Pydantic [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions). Each union type must be a subclass of <PyObject object="Config"/>. The `discriminator` argument to <PyObject object="Field"/> specifies the field that will be used to determine which union type to use.
@@ -160,8 +184,7 @@ class Dog(Config):
     barks: float
 
 class ConfigWithUnion(Config):
-    # Here, the ellipses `...` indicates that the field is required and has no default value.
-    pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+    pet: Union[Cat, Dog] = Field(discriminator="pet_type")
 
 @asset
 def pet_stats(config: ConfigWithUnion):
@@ -228,7 +251,9 @@ op_result = process_users_job.execute_in_process(
 
 ## Validated config fields
 
-Config fields can have custom validation logic applied using [Pydantic validators](https://docs.pydantic.dev/usage/validators/). Pydantic validators are defined as methods on the config class, and are decorated with the `@validator` decorator. Here, we define some validators on a configured user's name and username, which will throw exceptions if incorrect values are passed in the launchpad or from a schedule or sensor.
+Config fields can have custom validation logic applied using [Pydantic validators](https://docs.pydantic.dev/usage/validators/). Pydantic validators are defined as methods on the config class, and are decorated with the `@validator` decorator. These validators are triggered when the config class is instantiated. In the case of config defined at runtime, a failing validator will not prevent the launch button from being pressed, but will raise an exception and prevent run start.
+
+Here, we define some validators on a configured user's name and username, which will throw exceptions if incorrect values are passed in the launchpad or from a schedule or sensor.
 
 ```python file=/guides/dagster/pythonic_config/pythonic_config.py startafter=start_validated_schema_config endbefore=end_validated_schema_config dedent=4
 from dagster import Config, RunConfig, op, job

--- a/docs/content/concepts/configuration/advanced-config-types.mdx
+++ b/docs/content/concepts/configuration/advanced-config-types.mdx
@@ -200,6 +200,7 @@ def filtered_listings(config: FilterConfig):
     url_params = config.dict()
     return requests.get("https://my-api.com/listings", params=url_params).json()
 
+# can pass in any fields, including those not defined in the schema
 filtered_listings(FilterConfig(title="hotel", beds=4))
 ```
 

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -71,6 +71,8 @@ You can also build config into jobs, as described in [the Jobs documentation](/c
 </TabItem>
 </TabGroup>
 
+These examples showcase the most basic config types that can be used. For more information on the set of config types Dagster supports, see [the advanced config types documentation](/concepts/configuration/advanced-config-types).
+
 ---
 
 ## Defining and accessing Pythonic configuration for a resource
@@ -199,3 +201,9 @@ asset_result = materialize(
     ),
 )
 ```
+
+---
+
+## Next steps
+
+Config is a powerful tool for making your Dagster pipelines more flexible and reusable. For a deeper dive into the supported config types, see [the advanced config types documentation](/concepts/configuration/advanced-config-types). For more information on using resources, which are a powerful way to encapsulate reusable logic, see [the resources guide](/concepts/resources).

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -206,4 +206,4 @@ asset_result = materialize(
 
 ## Next steps
 
-Config is a powerful tool for making your Dagster pipelines more flexible and reusable. For a deeper dive into the supported config types, see [the advanced config types documentation](/concepts/configuration/advanced-config-types). For more information on using resources, which are a powerful way to encapsulate reusable logic, see [the resources guide](/concepts/resources).
+Config is a powerful tool for making your Dagster pipelines more flexible and observable. For a deeper dive into the supported config types, see [the advanced config types documentation](/concepts/configuration/advanced-config-types). For more information on using resources, which are a powerful way to encapsulate reusable logic, see [the resources guide](/concepts/resources).

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -219,13 +219,10 @@ def metadata_config() -> None:
     from pydantic import Field
 
     class MyMetadataConfig(Config):
-        # Here, the ellipses `...` indicates that the field is required and has no default value.
-        person_name: str = Field(..., description="The name of the person to greet")
-        age: int = Field(
-            ..., gt=0, lt=100, description="The age of the person to greet"
-        )
+        person_name: str = Field(description="The name of the person to greet")
+        age: int = Field(gt=0, lt=100, description="The age of the person to greet")
 
-    # errors!
+    # errors, since age is not in the valid range!
     MyMetadataConfig(person_name="Alice", age=200)
 
     # end_metadata_config

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -291,7 +291,7 @@ def enum_schema_config() -> None:
     def process_users(config: ProcessUsersConfig):
         for user, permission in config.users_list.items():
             if permission == UserPermissions.ADMIN:
-                print(f"{user} is an admin")
+                print(f"{user} is an admin")  # noqa: T201
 
     @job
     def process_users_job():

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -44,7 +44,8 @@ def permissive_schema_config() -> None:
         url_params = config.dict()
         return requests.get("https://my-api.com/listings", params=url_params).json()
 
-    filtered_listings(FilterConfig(title="hotel", beds=4))
+    # can pass in any fields, including those not defined in the schema
+    filtered_listings(FilterConfig(title="hotel", beds=4))  # type: ignore
     # end_permissive_schema_config
 
 
@@ -329,7 +330,7 @@ def enum_schema_config() -> None:
                     }
                 )
             }
-        ),  # type: ignore
+        ),
     )
     # end_enum_schema_config
 
@@ -370,14 +371,14 @@ def validated_schema_config() -> None:
     op_result = greet_user_job.execute_in_process(
         run_config=RunConfig(
             {"greet_user": UserConfig(name="Alice Smith", username="alice123")}
-        ),  # type: ignore
+        ),
     )
 
     # Name has no space, so this will fail
     op_result = greet_user_job.execute_in_process(
         run_config=RunConfig(
             {"greet_user": UserConfig(name="John", username="johndoe44")}
-        ),  # type: ignore
+        ),
     )
 
     # end_validated_schema_config

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -376,3 +376,29 @@ def validated_schema_config() -> None:
     )
 
     # end_validated_schema_config
+
+
+def required_config() -> None:
+    # start_required_config
+    from typing import Optional
+    from dagster import asset, Config
+
+    class MyAssetConfig(Config):
+        # ellipsis indicates that even though the type is Optional,
+        # an input is required
+        person_name: Optional[str] = ...  # type: ignore
+
+    @asset
+    def goodbye(config: MyAssetConfig) -> str:
+        if config.person_name:
+            return f"Goodbye, {config.person_name}"
+        else:
+            return "Goodbye"
+
+    # errors, since person_name is required
+    goodbye(MyAssetConfig())
+
+    # works, since person_name is provided
+    goodbye(MyAssetConfig(person_name=None))
+
+    # end_required_config

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_config/pythonic_config.py
@@ -27,6 +27,27 @@ def basic_resource_config() -> None:
     # end_basic_resource_config
 
 
+def permissive_schema_config() -> None:
+    # start_permissive_schema_config
+
+    from dagster import asset, PermissiveConfig
+    from typing import Optional
+    import requests
+
+    class FilterConfig(PermissiveConfig):
+        title: Optional[str] = None
+        description: Optional[str] = None
+
+    @asset
+    def filtered_listings(config: FilterConfig):
+        # extract all config fields, including those not defined in the schema
+        url_params = config.dict()
+        return requests.get("https://my-api.com/listings", params=url_params).json()
+
+    filtered_listings(FilterConfig(title="hotel", beds=4))
+    # end_permissive_schema_config
+
+
 def execute_with_config() -> None:
     # start_basic_op_config
 
@@ -170,8 +191,7 @@ def union_schema_config() -> None:
         barks: float
 
     class ConfigWithUnion(Config):
-        # Here, the ellipses `...` indicates that the field is required and has no default value.
-        pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+        pet: Union[Cat, Dog] = Field(discriminator="pet_type")
 
     @asset
     def pet_stats(config: ConfigWithUnion):


### PR DESCRIPTION
## Summary

Adds a new page which covers more advanced config use-cases, most taken from the Pythonic config experimental guide.
