### PR TITLE
[docs] Update build docs action to link to changed pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,5 +1,14 @@
 name: Deploy Docs
-on: push
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+    paths:
+      - docs/**
+  pull_request:
+    paths:
+      - docs/**
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,21 +1,35 @@
 name: Deploy Docs
-on:
-  push:
-    branches:
-      - master
-      - 'release-*'
-    paths:
-      - docs/**
-  pull_request:
-    paths:
-      - docs/**
+on: push
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: amondnet/vercel-action@v25
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+
+      - name: Get changed docs files
+        if: ${{ github.event.pull_request }}
+        run: |
+          echo "Base ref is $GITHUB_BASE_SHA"
+          echo "Head ref is $GITHUB_HEAD_SHA"
+          git fetch origin $GITHUB_HEAD_SHA
+          CHANGED_MDX_FILES=$(git diff --name-only "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.mdx')
+          CHANGES_ENTRY=$(echo "$CHANGED_MDX_FILES" | sed 's/\.mdx$//' | sed 's/^docs\/content/- {{deploymentUrl}}/')
+          CHANGES_ENTRY=$(echo -e "Preview available at {{deploymentUrl}}\n\nDirect link to changed pages:\n$CHANGES_ENTRY")
+          echo "$CHANGES_ENTRY"
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "CHANGES_ENTRY<<$EOF" >> $GITHUB_ENV
+          echo "$CHANGES_ENTRY" >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Publish to Vercel
+        uses: amondnet/vercel-action@v25
         with:
+          github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary

Updates the "build docs" GitHub action to assemble a list of changed pages and link to them in the comment, rather than the generic message. This makes it easier to jump directly to the new/changed page rather than navigating in the PR docs instance manually.

## Test Plan

Tested on this PR - the message is a bit updated from the last test but the GH actions outage is preventing it from rerunning 😄 