### PR TITLE
add graphql fields to query schedules/sensors by status

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2771,12 +2771,18 @@ type DagitQuery {
   graphOrError(selector: GraphSelector): GraphOrError!
   scheduler: SchedulerOrError!
   scheduleOrError(scheduleSelector: ScheduleSelector!): ScheduleOrError!
-  schedulesOrError(repositorySelector: RepositorySelector!): SchedulesOrError!
+  schedulesOrError(
+    repositorySelector: RepositorySelector!
+    scheduleStatus: InstigationStatus
+  ): SchedulesOrError!
   topLevelResourceDetailsOrError(resourceSelector: ResourceSelector!): ResourceDetailsOrError!
   allTopLevelResourceDetailsOrError(repositorySelector: RepositorySelector!): ResourcesOrError!
   utilizedEnvVarsOrError(repositorySelector: RepositorySelector!): EnvVarWithConsumersOrError!
   sensorOrError(sensorSelector: SensorSelector!): SensorOrError!
-  sensorsOrError(repositorySelector: RepositorySelector!): SensorsOrError!
+  sensorsOrError(
+    repositorySelector: RepositorySelector!
+    sensorStatus: InstigationStatus
+  ): SensorsOrError!
   instigationStateOrError(instigationSelector: InstigationSelector!): InstigationStateOrError!
   unloadableInstigationStatesOrError(instigationType: InstigationType): InstigationStatesOrError!
   partitionSetsOrError(

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -796,6 +796,7 @@ export type DagitQueryScheduleOrErrorArgs = {
 
 export type DagitQuerySchedulesOrErrorArgs = {
   repositorySelector: RepositorySelector;
+  scheduleStatus?: InputMaybe<InstigationStatus>;
 };
 
 export type DagitQuerySensorOrErrorArgs = {
@@ -804,6 +805,7 @@ export type DagitQuerySensorOrErrorArgs = {
 
 export type DagitQuerySensorsOrErrorArgs = {
   repositorySelector: RepositorySelector;
+  sensorStatus?: InputMaybe<InstigationStatus>;
 };
 
 export type DagitQueryTopLevelResourceDetailsOrErrorArgs = {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -7,7 +7,8 @@ from dagster._core.definitions.selector import (
     RepositorySelector,
     ScheduleSelector,
 )
-from dagster._core.scheduler.instigation import InstigatorState
+from dagster._core.host_representation.external import ExternalSchedule
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._core.workspace.permissions import Permissions
 from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 
@@ -99,7 +100,9 @@ def get_scheduler_or_error(graphene_info: ResolveInfo) -> "GrapheneScheduler":
 
 @capture_error
 def get_schedules_or_error(
-    graphene_info: ResolveInfo, repository_selector: RepositorySelector
+    graphene_info: ResolveInfo,
+    repository_selector: RepositorySelector,
+    schedule_status: Optional[InstigatorStatus] = None,
 ) -> "GrapheneSchedules":
     from ..schema.schedules import GrapheneSchedule, GrapheneSchedules
 
@@ -109,23 +112,60 @@ def get_schedules_or_error(
     repository = location.get_repository(repository_selector.repository_name)
     batch_loader = RepositoryScopedBatchLoader(graphene_info.context.instance, repository)
     external_schedules = repository.get_external_schedules()
-    schedule_states_by_name = {
-        state.name: state
-        for state in graphene_info.context.instance.all_instigator_state(
+    if schedule_status == InstigatorStatus.RUNNING:
+        schedule_states = graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
             repository_selector_id=repository_selector.selector_id,
             instigator_type=InstigatorType.SCHEDULE,
+            instigator_status=InstigatorStatus.RUNNING,
+        ) + graphene_info.context.instance.all_instigator_state(
+            repository_origin_id=repository.get_external_origin_id(),
+            repository_selector_id=repository_selector.selector_id,
+            instigator_type=InstigatorType.SCHEDULE,
+            instigator_status=InstigatorStatus.AUTOMATICALLY_RUNNING,
         )
-    }
+    else:
+        schedule_states = graphene_info.context.instance.all_instigator_state(
+            repository_origin_id=repository.get_external_origin_id(),
+            repository_selector_id=repository_selector.selector_id,
+            instigator_type=InstigatorType.SCHEDULE,
+            instigator_status=schedule_status,
+        )
+
+    schedule_states_by_name = {state.name: state for state in schedule_states}
+    if schedule_status:
+        filtered = [
+            external_schedule
+            for external_schedule in external_schedules
+            if _apply_status_filter(
+                external_schedule,
+                schedule_states_by_name.get(external_schedule.name),
+                schedule_status,
+            )
+        ]
+    else:
+        filtered = external_schedules
 
     results = [
-        GrapheneSchedule(
-            external_schedule, schedule_states_by_name.get(external_schedule.name), batch_loader
-        )
-        for external_schedule in external_schedules
+        GrapheneSchedule(schedule, schedule_states_by_name.get(schedule.name), batch_loader)
+        for schedule in filtered
     ]
 
     return GrapheneSchedules(results=results)
+
+
+def _apply_status_filter(
+    external_schedule: ExternalSchedule,
+    stored_state: Optional[InstigatorState],
+    filter_status: InstigatorStatus,
+):
+    schedule_state = external_schedule.get_current_instigator_state(stored_state)
+    return (
+        filter_status == InstigatorStatus.STOPPED and schedule_state.status == filter_status
+    ) or (
+        filter_status == InstigatorStatus.RUNNING
+        and schedule_state.status != InstigatorStatus.STOPPED
+    )
 
 
 def get_schedules_for_pipeline(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -125,7 +125,7 @@ def get_schedules_or_error(
             for external_schedule in external_schedules
             if external_schedule.get_current_instigator_state(
                 schedule_states_by_name.get(external_schedule.name)
-            )
+            ).status
             in instigator_statuses
         ]
     else:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -3,7 +3,12 @@ from typing import TYPE_CHECKING, Optional, Sequence
 import dagster._check as check
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.selector import PipelineSelector, RepositorySelector, SensorSelector
-from dagster._core.scheduler.instigation import InstigatorState, SensorInstigatorData
+from dagster._core.host_representation.external import ExternalSensor
+from dagster._core.scheduler.instigation import (
+    InstigatorState,
+    InstigatorStatus,
+    SensorInstigatorData,
+)
 from dagster._core.workspace.permissions import Permissions
 from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 
@@ -28,7 +33,9 @@ if TYPE_CHECKING:
 
 @capture_error
 def get_sensors_or_error(
-    graphene_info: ResolveInfo, repository_selector: RepositorySelector
+    graphene_info: ResolveInfo,
+    repository_selector: RepositorySelector,
+    sensor_status: Optional[InstigatorStatus] = None,
 ) -> "GrapheneSensors":
     from ..schema.sensors import GrapheneSensor, GrapheneSensors
 
@@ -38,19 +45,57 @@ def get_sensors_or_error(
     repository = location.get_repository(repository_selector.repository_name)
     batch_loader = RepositoryScopedBatchLoader(graphene_info.context.instance, repository)
     sensors = repository.get_external_sensors()
-    sensor_states_by_name = {
-        state.name: state
-        for state in graphene_info.context.instance.all_instigator_state(
+    if sensor_status == InstigatorStatus.RUNNING:
+        sensor_states = graphene_info.context.instance.all_instigator_state(
             repository_origin_id=repository.get_external_origin_id(),
             repository_selector_id=repository_selector.selector_id,
             instigator_type=InstigatorType.SENSOR,
+            instigator_status=InstigatorStatus.RUNNING,
+        ) + graphene_info.context.instance.all_instigator_state(
+            repository_origin_id=repository.get_external_origin_id(),
+            repository_selector_id=repository_selector.selector_id,
+            instigator_type=InstigatorType.SENSOR,
+            instigator_status=InstigatorStatus.AUTOMATICALLY_RUNNING,
         )
-    }
+    else:
+        sensor_states = graphene_info.context.instance.all_instigator_state(
+            repository_origin_id=repository.get_external_origin_id(),
+            repository_selector_id=repository_selector.selector_id,
+            instigator_type=InstigatorType.SENSOR,
+            instigator_status=sensor_status,
+        )
+
+    sensor_states_by_name = {state.name: state for state in sensor_states}
+    if sensor_status:
+        filtered = [
+            sensor
+            for sensor in sensors
+            if _apply_status_filter(
+                sensor,
+                sensor_states_by_name.get(sensor.name),
+                sensor_status,
+            )
+        ]
+    else:
+        filtered = sensors
+
     return GrapheneSensors(
         results=[
             GrapheneSensor(sensor, sensor_states_by_name.get(sensor.name), batch_loader)
-            for sensor in sensors
+            for sensor in filtered
         ]
+    )
+
+
+def _apply_status_filter(
+    sensor: ExternalSensor,
+    stored_state: Optional[InstigatorState],
+    filter_status: InstigatorStatus,
+):
+    sensor_state = sensor.get_current_instigator_state(stored_state)
+    return (filter_status == InstigatorStatus.STOPPED and sensor_state.status == filter_status) or (
+        filter_status == InstigatorStatus.RUNNING
+        and sensor_state.status != InstigatorStatus.STOPPED
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -56,7 +56,7 @@ def get_sensors_or_error(
         filtered = [
             sensor
             for sensor in sensors
-            if sensor.get_current_instigator_state(sensor_states_by_name.get(sensor.name))
+            if sensor.get_current_instigator_state(sensor_states_by_name.get(sensor.name)).status
             in instigator_statuses
         ]
     else:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -537,11 +537,17 @@ class GrapheneDagitQuery(graphene.ObjectType):
         repositorySelector: GrapheneRepositorySelector,
         scheduleStatus: Optional[GrapheneInstigationStatus] = None,
     ):
-        schedule_status = InstigatorStatus(scheduleStatus) if scheduleStatus else None
+        if scheduleStatus == GrapheneInstigationStatus.RUNNING:
+            instigator_statuses = {InstigatorStatus.RUNNING, InstigatorStatus.AUTOMATICALLY_RUNNING}
+        elif scheduleStatus == GrapheneInstigationStatus.STOPPED:
+            instigator_statuses = {InstigatorStatus.STOPPED}
+        else:
+            instigator_statuses = None
+
         return get_schedules_or_error(
             graphene_info,
             RepositorySelector.from_graphql_input(repositorySelector),
-            schedule_status,
+            instigator_statuses,
         )
 
     def resolve_topLevelResourceDetailsOrError(self, graphene_info: ResolveInfo, resourceSelector):
@@ -572,9 +578,16 @@ class GrapheneDagitQuery(graphene.ObjectType):
         repositorySelector: GrapheneRepositorySelector,
         sensorStatus: Optional[GrapheneInstigationStatus] = None,
     ):
-        sensor_status = InstigatorStatus(sensorStatus) if sensorStatus else None
+        if sensorStatus == GrapheneInstigationStatus.RUNNING:
+            instigator_statuses = {InstigatorStatus.RUNNING, InstigatorStatus.AUTOMATICALLY_RUNNING}
+        elif sensorStatus == GrapheneInstigationStatus.STOPPED:
+            instigator_statuses = {InstigatorStatus.STOPPED}
+        else:
+            instigator_statuses = None
         return get_sensors_or_error(
-            graphene_info, RepositorySelector.from_graphql_input(repositorySelector), sensor_status
+            graphene_info,
+            RepositorySelector.from_graphql_input(repositorySelector),
+            instigator_statuses,
         )
 
     def resolve_instigationStateOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.selector import (
 )
 from dagster._core.execution.backfill import BulkActionStatus
 from dagster._core.nux import get_has_seen_nux
-from dagster._core.scheduler.instigation import InstigatorType
+from dagster._core.scheduler.instigation import InstigatorStatus, InstigatorType
 
 from dagster_graphql.implementation.fetch_env_vars import get_utilized_env_vars_or_error
 from dagster_graphql.implementation.fetch_logs import get_captured_log_metadata
@@ -107,6 +107,7 @@ from ..instance import GrapheneInstance
 from ..instigation import (
     GrapheneInstigationStateOrError,
     GrapheneInstigationStatesOrError,
+    GrapheneInstigationStatus,
     GrapheneInstigationType,
 )
 from ..logs.compute_logs import (
@@ -208,6 +209,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
     schedulesOrError = graphene.Field(
         graphene.NonNull(GrapheneSchedulesOrError),
         repositorySelector=graphene.NonNull(GrapheneRepositorySelector),
+        scheduleStatus=graphene.Argument(GrapheneInstigationStatus),
         description="Retrieve all the schedules.",
     )
 
@@ -240,6 +242,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
     sensorsOrError = graphene.Field(
         graphene.NonNull(GrapheneSensorsOrError),
         repositorySelector=graphene.NonNull(GrapheneRepositorySelector),
+        sensorStatus=graphene.Argument(GrapheneInstigationStatus),
         description="Retrieve all the sensors.",
     )
 
@@ -529,11 +532,16 @@ class GrapheneDagitQuery(graphene.ObjectType):
         )
 
     def resolve_schedulesOrError(
-        self, graphene_info: ResolveInfo, repositorySelector: GrapheneRepositorySelector
+        self,
+        graphene_info: ResolveInfo,
+        repositorySelector: GrapheneRepositorySelector,
+        scheduleStatus: Optional[GrapheneInstigationStatus] = None,
     ):
+        schedule_status = InstigatorStatus(scheduleStatus) if scheduleStatus else None
         return get_schedules_or_error(
             graphene_info,
             RepositorySelector.from_graphql_input(repositorySelector),
+            schedule_status,
         )
 
     def resolve_topLevelResourceDetailsOrError(self, graphene_info: ResolveInfo, resourceSelector):
@@ -558,10 +566,15 @@ class GrapheneDagitQuery(graphene.ObjectType):
     ):
         return get_sensor_or_error(graphene_info, SensorSelector.from_graphql_input(sensorSelector))
 
-    def resolve_sensorsOrError(self, graphene_info, repositorySelector: GrapheneRepositorySelector):
+    def resolve_sensorsOrError(
+        self,
+        graphene_info,
+        repositorySelector: GrapheneRepositorySelector,
+        sensorStatus: Optional[GrapheneInstigationStatus] = None,
+    ):
+        sensor_status = InstigatorStatus(sensorStatus) if sensorStatus else None
         return get_sensors_or_error(
-            graphene_info,
-            RepositorySelector.from_graphql_input(repositorySelector),
+            graphene_info, RepositorySelector.from_graphql_input(repositorySelector), sensor_status
         )
 
     def resolve_instigationStateOrError(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_sensors.py
@@ -7,542 +7,1249 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["TestSensors.test_get_sensor[non_launchable_sqlite_instance_deployed_grpc_env] 1"] = {
-    "__typename": "Sensor",
-    "minIntervalSeconds": 30,
-    "name": "always_no_config_sensor",
-    "nextTick": None,
-    "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-    "sensorType": "STANDARD",
-    "targets": [{"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}],
+snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
+    '__typename': 'Sensor',
+    'minIntervalSeconds': 30,
+    'name': 'always_no_config_sensor',
+    'nextTick': None,
+    'sensorState': {
+        'runs': [
+        ],
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': [
+        ]
+    },
+    'sensorType': 'STANDARD',
+    'targets': [
+        {
+            'mode': 'default',
+            'pipelineName': 'no_config_pipeline',
+            'solidSelection': None
+        }
+    ]
 }
 
-snapshots["TestSensors.test_get_sensor[non_launchable_sqlite_instance_lazy_repository] 1"] = {
-    "__typename": "Sensor",
-    "minIntervalSeconds": 30,
-    "name": "always_no_config_sensor",
-    "nextTick": None,
-    "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-    "sensorType": "STANDARD",
-    "targets": [{"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}],
+snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_lazy_repository] 1'] = {
+    '__typename': 'Sensor',
+    'minIntervalSeconds': 30,
+    'name': 'always_no_config_sensor',
+    'nextTick': None,
+    'sensorState': {
+        'runs': [
+        ],
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': [
+        ]
+    },
+    'sensorType': 'STANDARD',
+    'targets': [
+        {
+            'mode': 'default',
+            'pipelineName': 'no_config_pipeline',
+            'solidSelection': None
+        }
+    ]
 }
 
-snapshots["TestSensors.test_get_sensor[non_launchable_sqlite_instance_managed_grpc_env] 1"] = {
-    "__typename": "Sensor",
-    "minIntervalSeconds": 30,
-    "name": "always_no_config_sensor",
-    "nextTick": None,
-    "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-    "sensorType": "STANDARD",
-    "targets": [{"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}],
+snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_managed_grpc_env] 1'] = {
+    '__typename': 'Sensor',
+    'minIntervalSeconds': 30,
+    'name': 'always_no_config_sensor',
+    'nextTick': None,
+    'sensorState': {
+        'runs': [
+        ],
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': [
+        ]
+    },
+    'sensorType': 'STANDARD',
+    'targets': [
+        {
+            'mode': 'default',
+            'pipelineName': 'no_config_pipeline',
+            'solidSelection': None
+        }
+    ]
 }
 
-snapshots["TestSensors.test_get_sensor[non_launchable_sqlite_instance_multi_location] 1"] = {
-    "__typename": "Sensor",
-    "minIntervalSeconds": 30,
-    "name": "always_no_config_sensor",
-    "nextTick": None,
-    "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-    "sensorType": "STANDARD",
-    "targets": [{"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}],
+snapshots['TestSensors.test_get_sensor[non_launchable_sqlite_instance_multi_location] 1'] = {
+    '__typename': 'Sensor',
+    'minIntervalSeconds': 30,
+    'name': 'always_no_config_sensor',
+    'nextTick': None,
+    'sensorState': {
+        'runs': [
+        ],
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': [
+        ]
+    },
+    'sensorType': 'STANDARD',
+    'targets': [
+        {
+            'mode': 'default',
+            'pipelineName': 'no_config_pipeline',
+            'solidSelection': None
+        }
+    ]
 }
 
-snapshots["TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_grpc_env] 1"] = [
+snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = [
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_error_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 60,
-        "name": "custom_interval_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 60,
+        'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "fresh_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "logging_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "many_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "multi_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'multi_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "never_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'never_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "once_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'once_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "run_status",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "running_in_code_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "RUNNING", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "single_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "the_failure_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "update_cursor_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
-    },
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'update_cursor_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    }
 ]
 
-snapshots["TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repository] 1"] = [
+snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_lazy_repository] 1'] = [
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_error_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 60,
-        "name": "custom_interval_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 60,
+        'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "fresh_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "logging_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "many_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "multi_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'multi_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "never_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'never_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "once_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'once_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "run_status",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "running_in_code_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "RUNNING", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "single_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "the_failure_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "update_cursor_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
-    },
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'update_cursor_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    }
 ]
 
-snapshots["TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_grpc_env] 1"] = [
+snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_managed_grpc_env] 1'] = [
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_error_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 60,
-        "name": "custom_interval_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 60,
+        'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "fresh_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "logging_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "many_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "multi_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'multi_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "never_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'never_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "once_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'once_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "run_status",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "running_in_code_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "RUNNING", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "single_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "the_failure_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "update_cursor_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
-    },
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'update_cursor_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    }
 ]
 
-snapshots["TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_location] 1"] = [
+snapshots['TestSensors.test_get_sensors[non_launchable_sqlite_instance_multi_location] 1'] = [
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_error_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_error_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "always_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'always_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 60,
-        "name": "custom_interval_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 60,
+        'name': 'custom_interval_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "fresh_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'fresh_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "logging_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'logging_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "many_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'many_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "multi_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'multi_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "never_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'never_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "once_no_config_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'once_no_config_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "run_status",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'run_status',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "running_in_code_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "RUNNING", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'RUNNING',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "single_asset_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "single_asset_pipeline", "solidSelection": None}
-        ],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'single_asset_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'single_asset_pipeline',
+                'solidSelection': None
+            }
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "the_failure_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [],
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'the_failure_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+        ]
     },
     {
-        "description": None,
-        "minIntervalSeconds": 30,
-        "name": "update_cursor_sensor",
-        "sensorState": {"runs": [], "runsCount": 0, "status": "STOPPED", "ticks": []},
-        "targets": [
-            {"mode": "default", "pipelineName": "no_config_pipeline", "solidSelection": None}
-        ],
-    },
+        'description': None,
+        'minIntervalSeconds': 30,
+        'name': 'update_cursor_sensor',
+        'sensorState': {
+            'runs': [
+            ],
+            'runsCount': 0,
+            'status': 'STOPPED',
+            'ticks': [
+            ]
+        },
+        'targets': [
+            {
+                'mode': 'default',
+                'pipelineName': 'no_config_pipeline',
+                'solidSelection': None
+            }
+        ]
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_postgres_instance_lazy_repository] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_postgres_instance_managed_grpc_env] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_postgres_instance_multi_location] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_sqlite_instance_lazy_repository] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_sqlite_instance_managed_grpc_env] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
+]
+
+snapshots['TestSensors.test_get_sensors_filtered[non_launchable_sqlite_instance_multi_location] 1'] = [
+    {
+        'name': 'running_in_code_sensor',
+        'sensorState': {
+            'status': 'RUNNING'
+        }
+    }
 ]

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
     from dagster._core.scheduler import Scheduler, SchedulerDebugInfo
     from dagster._core.scheduler.instigation import (
         InstigatorState,
+        InstigatorStatus,
         InstigatorTick,
         TickData,
         TickStatus,
@@ -2313,11 +2314,12 @@ class DagsterInstance(DynamicPartitionsStore):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
+        instigator_status: Optional[InstigatorStatus] = None,
     ):
         if not self._schedule_storage:
             check.failed("Schedule storage not available")
         return self._schedule_storage.all_instigator_state(
-            repository_origin_id, repository_selector_id, instigator_type
+            repository_origin_id, repository_selector_id, instigator_type, instigator_status
         )
 
     @traced

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2314,12 +2314,12 @@ class DagsterInstance(DynamicPartitionsStore):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
-        instigator_status: Optional[InstigatorStatus] = None,
+        instigator_statuses: Optional[Set[InstigatorStatus]] = None,
     ):
         if not self._schedule_storage:
             check.failed("Schedule storage not available")
         return self._schedule_storage.all_instigator_state(
-            repository_origin_id, repository_selector_id, instigator_type, instigator_status
+            repository_origin_id, repository_selector_id, instigator_type, instigator_statuses
         )
 
     @traced

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance
     from dagster._core.scheduler.instigation import (
         InstigatorState,
+        InstigatorStatus,
         InstigatorTick,
         TickData,
         TickStatus,
@@ -580,8 +581,11 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional["InstigatorType"] = None,
+        instigator_status: Optional["InstigatorStatus"] = None,
     ) -> Iterable["InstigatorState"]:
-        return self._storage.schedule_storage.all_instigator_state()
+        return self._storage.schedule_storage.all_instigator_state(
+            repository_origin_id, repository_selector_id, instigator_type, instigator_status
+        )
 
     def get_instigator_state(self, origin_id: str, selector_id: str) -> Optional["InstigatorState"]:
         return self._storage.schedule_storage.get_instigator_state(origin_id, selector_id)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -581,10 +581,10 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional["InstigatorType"] = None,
-        instigator_status: Optional["InstigatorStatus"] = None,
+        instigator_statuses: Optional[Set["InstigatorStatus"]] = None,
     ) -> Iterable["InstigatorState"]:
         return self._storage.schedule_storage.all_instigator_state(
-            repository_origin_id, repository_selector_id, instigator_type, instigator_status
+            repository_origin_id, repository_selector_id, instigator_type, instigator_statuses
         )
 
     def get_instigator_state(self, origin_id: str, selector_id: str) -> Optional["InstigatorState"]:

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.scheduler.instigation import (
     InstigatorState,
+    InstigatorStatus,
     InstigatorTick,
     TickData,
     TickStatus,
@@ -26,6 +27,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
+        instigator_status: Optional[InstigatorStatus] = None,
     ) -> Sequence[InstigatorState]:
         """Return all InstigationStates present in storage.
 
@@ -33,6 +35,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             repository_origin_id (Optional[str]): The ExternalRepository target id to scope results to
             repository_selector_id (Optional[str]): The repository selector id to scope results to
             instigator_type (Optional[InstigatorType]): The InstigatorType to scope results to
+            instigator_status (Optional[InstigatorStatus]): The InstigatorStatus to scope results to
         """
 
     @abc.abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence, Set
 
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
@@ -27,7 +27,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         repository_origin_id: Optional[str] = None,
         repository_selector_id: Optional[str] = None,
         instigator_type: Optional[InstigatorType] = None,
-        instigator_status: Optional[InstigatorStatus] = None,
+        instigator_statuses: Optional[Set[InstigatorStatus]] = None,
     ) -> Sequence[InstigatorState]:
         """Return all InstigationStates present in storage.
 
@@ -35,7 +35,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             repository_origin_id (Optional[str]): The ExternalRepository target id to scope results to
             repository_selector_id (Optional[str]): The repository selector id to scope results to
             instigator_type (Optional[InstigatorType]): The InstigatorType to scope results to
-            instigator_status (Optional[InstigatorStatus]): The InstigatorStatus to scope results to
+            instigator_statuses (Optional[Set[InstigatorStatus]]): The InstigatorStatuses to scope results to
         """
 
     @abc.abstractmethod

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -102,9 +102,13 @@ class TestScheduleStorage:
     def test_add_multiple_schedules(self, storage):
         assert storage
 
-        schedule = self.build_schedule("my_schedule", "* * * * *")
-        schedule_2 = self.build_schedule("my_schedule_2", "* * * * *")
-        schedule_3 = self.build_schedule("my_schedule_3", "* * * * *")
+        schedule = self.build_schedule("my_schedule", "* * * * *", status=InstigatorStatus.RUNNING)
+        schedule_2 = self.build_schedule(
+            "my_schedule_2", "* * * * *", status=InstigatorStatus.STOPPED
+        )
+        schedule_3 = self.build_schedule(
+            "my_schedule_3", "* * * * *", status=InstigatorStatus.AUTOMATICALLY_RUNNING
+        )
 
         storage.add_instigator_state(schedule)
         storage.add_instigator_state(schedule_2)
@@ -120,6 +124,33 @@ class TestScheduleStorage:
         assert any(s.instigator_name == "my_schedule" for s in schedules)
         assert any(s.instigator_name == "my_schedule_2" for s in schedules)
         assert any(s.instigator_name == "my_schedule_3" for s in schedules)
+
+        running = storage.all_instigator_state(
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().get_selector_id(),
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.RUNNING,
+        )
+        assert len(running) == 1
+        assert running[0].instigator_name == "my_schedule"
+
+        stopped = storage.all_instigator_state(
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().get_selector_id(),
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.STOPPED,
+        )
+        assert len(stopped) == 1
+        assert stopped[0].instigator_name == "my_schedule_2"
+
+        automatically_running = storage.all_instigator_state(
+            self.fake_repo_target().get_id(),
+            self.fake_repo_target().get_selector_id(),
+            InstigatorType.SCHEDULE,
+            InstigatorStatus.AUTOMATICALLY_RUNNING,
+        )
+        assert len(automatically_running) == 1
+        assert automatically_running[0].instigator_name == "my_schedule_3"
 
     def test_get_schedule_state(self, storage):
         assert storage

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -129,28 +129,20 @@ class TestScheduleStorage:
             self.fake_repo_target().get_id(),
             self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
-            InstigatorStatus.RUNNING,
+            {InstigatorStatus.RUNNING, InstigatorStatus.AUTOMATICALLY_RUNNING},
         )
-        assert len(running) == 1
-        assert running[0].instigator_name == "my_schedule"
+        assert len(running) == 2
+        assert "my_schedule" in [state.instigator_name for state in running]
+        assert "my_schedule_3" in [state.instigator_name for state in running]
 
         stopped = storage.all_instigator_state(
             self.fake_repo_target().get_id(),
             self.fake_repo_target().get_selector_id(),
             InstigatorType.SCHEDULE,
-            InstigatorStatus.STOPPED,
+            {InstigatorStatus.STOPPED},
         )
         assert len(stopped) == 1
         assert stopped[0].instigator_name == "my_schedule_2"
-
-        automatically_running = storage.all_instigator_state(
-            self.fake_repo_target().get_id(),
-            self.fake_repo_target().get_selector_id(),
-            InstigatorType.SCHEDULE,
-            InstigatorStatus.AUTOMATICALLY_RUNNING,
-        )
-        assert len(automatically_running) == 1
-        assert automatically_running[0].instigator_name == "my_schedule_3"
 
     def test_get_schedule_state(self, storage):
         assert storage


### PR DESCRIPTION
## Summary & Motivation
GraphQL fields to filter sensors/schedules by status.  Resolves the stored status `AUTOMATICALLY_RUNNING` to simply `RUNNING`.

## How I Tested These Changes
BK