### PR TITLE
[dagit] Partition status cleanup + support for materializing and mixed failed/missing statuses, etc.

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -167,8 +167,8 @@ export function weakmapMemoize<T extends object, R>(
   };
 }
 
-export function assertUnreachable(_: never): never {
-  throw new Error("Didn't expect to get here");
+export function assertUnreachable(value: never): never {
+  throw new Error(`Didn't expect to get here with value: ${value}`);
 }
 
 export function debugLog(...args: any[]) {

--- a/js_modules/dagit/packages/core/src/app/Util.tsx
+++ b/js_modules/dagit/packages/core/src/app/Util.tsx
@@ -168,7 +168,7 @@ export function weakmapMemoize<T extends object, R>(
 }
 
 export function assertUnreachable(value: never): never {
-  throw new Error(`Didn't expect to get here with value: ${value}`);
+  throw new Error(`Didn't expect to get here with value: ${JSON.stringify(value)}`);
 }
 
 export function debugLog(...args: any[]) {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -350,6 +350,7 @@ export const LiveDataForNodePartitionedSomeMissing: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 6,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -373,6 +374,7 @@ export const LiveDataForNodePartitionedSomeFailed: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 6,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 849,
   },
@@ -396,6 +398,7 @@ export const LiveDataForNodePartitionedNoneMissing: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 1500,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -415,6 +418,7 @@ export const LiveDataForNodePartitionedNeverMaterialized: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 0,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -434,6 +438,7 @@ export const LiveDataForNodePartitionedMaterializing: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 0,
+    numMaterializing: 5,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -457,6 +462,7 @@ export const LiveDataForNodePartitionedStale: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 1500,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -488,6 +494,7 @@ export const LiveDataForNodePartitionedStaleAndLate: LiveDataForNode = {
   },
   partitionStats: {
     numMaterialized: 1500,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -519,6 +526,7 @@ export const LiveDataForNodePartitionedStaleAndFresh: LiveDataForNode = {
   },
   partitionStats: {
     numMaterialized: 1500,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 0,
   },
@@ -543,6 +551,7 @@ export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNode = {
   freshnessPolicy: null,
   partitionStats: {
     numMaterialized: 1495,
+    numMaterializing: 0,
     numPartitions: 1500,
     numFailed: 1,
   },
@@ -710,7 +719,7 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Materializing...',
     liveData: LiveDataForNodePartitionedMaterializing,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['Materializing', 'ABCDEF'],
+    expectedText: ['Materializing 5 partitions', 'ABCDEF'],
   },
 
   {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -105,7 +105,7 @@ const AssetNodePartitionsRow: React.FC<StatusRowProps> = (props) => {
   );
 };
 
-const StyleForPartitionState: {
+const StyleForAssetPartitionStatus: {
   [state: string]: {
     background: string;
     foreground: string;
@@ -137,7 +137,7 @@ const StyleForPartitionState: {
   },
 };
 
-const partitionStateToString = (count: number | undefined, adjective = '') =>
+const partitionCountString = (count: number | undefined, adjective = '') =>
   `${count === undefined ? '-' : count.toLocaleString()} ${adjective}${adjective ? ' ' : ''}${
     count === 1 ? 'partition' : 'partitions'
   }`;
@@ -147,7 +147,7 @@ const AssetNodePartitionCountBox: React.FC<{
   value: number | undefined;
   total: number | undefined;
 }> = ({status, value, total}) => {
-  const style = StyleForPartitionState[status];
+  const style = StyleForAssetPartitionStatus[status];
   const foreground = value ? style.foreground : Colors.Gray500;
   const background = value ? style.background : Colors.Gray50;
 
@@ -156,7 +156,7 @@ const AssetNodePartitionCountBox: React.FC<{
       display="block"
       position="top"
       canShow={value !== undefined}
-      content={partitionStateToString(value, style.adjective)}
+      content={partitionCountString(value, style.adjective)}
     >
       <AssetNodePartitionCountContainer style={{color: foreground, background}}>
         <Icon name={style.icon} color={foreground} size={16} />
@@ -304,7 +304,7 @@ function buildAssetNodeStatusRow({
   if (liveData.partitionStats) {
     const {numPartitions, numMaterialized, numFailed} = liveData.partitionStats;
     const numMissing = numPartitions - numFailed - numMaterialized;
-    const {background, foreground, border} = StyleForPartitionState[
+    const {background, foreground, border} = StyleForAssetPartitionStatus[
       late || numFailed
         ? AssetPartitionStatus.FAILED
         : numMissing
@@ -324,7 +324,7 @@ function buildAssetNodeStatusRow({
           >
             {late
               ? humanizedLateString(liveData.freshnessInfo.currentMinutesLate)
-              : partitionStateToString(numPartitions)}
+              : partitionCountString(numPartitions)}
           </Link>
         </Caption>
       ),

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -6,10 +6,10 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {withMiddleTruncation} from '../app/Util';
+import {AssetPartitionStatus} from '../assets/AssetPartitionStatus';
 import {humanizedLateString, isAssetLate} from '../assets/CurrentMinutesLateTag';
 import {isAssetStale, StaleCausesInfoDot} from '../assets/StaleTag';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {AssetPartitionStatus} from '../assets/usePartitionHealthData';
 import {AssetComputeKindTag} from '../graph/OpTags';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -9,8 +9,8 @@ import {withMiddleTruncation} from '../app/Util';
 import {humanizedLateString, isAssetLate} from '../assets/CurrentMinutesLateTag';
 import {isAssetStale, StaleCausesInfoDot} from '../assets/StaleTag';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {AssetPartitionStatus} from '../assets/usePartitionHealthData';
 import {AssetComputeKindTag} from '../graph/OpTags';
-import {PartitionState} from '../partitions/PartitionStatus';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
@@ -87,17 +87,17 @@ const AssetNodePartitionsRow: React.FC<StatusRowProps> = (props) => {
       padding={{bottom: 8, horizontal: 8}}
     >
       <AssetNodePartitionCountBox
-        state={PartitionState.SUCCESS}
+        status={AssetPartitionStatus.MATERIALIZED}
         value={data?.numMaterialized}
         total={data?.numPartitions}
       />
       <AssetNodePartitionCountBox
-        state={PartitionState.MISSING}
+        status={AssetPartitionStatus.MISSING}
         value={data ? data.numPartitions - data.numFailed - data.numMaterialized : undefined}
         total={data?.numPartitions}
       />
       <AssetNodePartitionCountBox
-        state={PartitionState.FAILURE}
+        status={AssetPartitionStatus.FAILED}
         value={data?.numFailed}
         total={data?.numPartitions}
       />
@@ -114,21 +114,21 @@ const StyleForPartitionState: {
     adjective: string;
   };
 } = {
-  [PartitionState.FAILURE]: {
+  [AssetPartitionStatus.FAILED]: {
     background: Colors.Red50,
     foreground: Colors.Red700,
     border: Colors.Red500,
     icon: 'partition_failure',
     adjective: 'failed',
   },
-  [PartitionState.SUCCESS]: {
+  [AssetPartitionStatus.MATERIALIZED]: {
     background: Colors.Green50,
     foreground: Colors.Green700,
     border: Colors.Green500,
     icon: 'partition_success',
     adjective: 'materialized',
   },
-  [PartitionState.MISSING]: {
+  [AssetPartitionStatus.MISSING]: {
     background: Colors.Gray100,
     foreground: Colors.Gray900,
     border: Colors.Gray500,
@@ -143,11 +143,11 @@ const partitionStateToString = (count: number | undefined, adjective = '') =>
   }`;
 
 const AssetNodePartitionCountBox: React.FC<{
-  state: PartitionState;
+  status: AssetPartitionStatus;
   value: number | undefined;
   total: number | undefined;
-}> = ({state, value, total}) => {
-  const style = StyleForPartitionState[state];
+}> = ({status, value, total}) => {
+  const style = StyleForPartitionState[status];
   const foreground = value ? style.foreground : Colors.Gray500;
   const background = value ? style.background : Colors.Gray50;
 
@@ -306,10 +306,10 @@ function buildAssetNodeStatusRow({
     const numMissing = numPartitions - numFailed - numMaterialized;
     const {background, foreground, border} = StyleForPartitionState[
       late || numFailed
-        ? PartitionState.FAILURE
+        ? AssetPartitionStatus.FAILURE
         : numMissing
-        ? PartitionState.MISSING
-        : PartitionState.SUCCESS
+        ? AssetPartitionStatus.MISSING
+        : AssetPartitionStatus.SUCCESS
     ];
 
     return {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -291,7 +291,9 @@ function buildAssetNodeStatusRow({
         <>
           <AssetLatestRunSpinner liveData={liveData} />
           <Caption style={{flex: 1}} color={Colors.Gray800}>
-            Materializing...
+            {liveData.partitionStats?.numMaterializing
+              ? `Materializing ${liveData.partitionStats.numMaterializing} partitions...`
+              : `Materializing...`}
           </Caption>
           <AssetRunLink runId={materializingRunId} />
         </>
@@ -479,6 +481,7 @@ export const ASSET_NODE_LIVE_FRAGMENT = gql`
     }
     partitionStats {
       numMaterialized
+      numMaterializing
       numPartitions
       numFailed
     }

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -306,10 +306,10 @@ function buildAssetNodeStatusRow({
     const numMissing = numPartitions - numFailed - numMaterialized;
     const {background, foreground, border} = StyleForPartitionState[
       late || numFailed
-        ? AssetPartitionStatus.FAILURE
+        ? AssetPartitionStatus.FAILED
         : numMissing
         ? AssetPartitionStatus.MISSING
-        : AssetPartitionStatus.SUCCESS
+        : AssetPartitionStatus.MATERIALIZED
     ];
 
     return {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -291,7 +291,9 @@ function buildAssetNodeStatusRow({
         <>
           <AssetLatestRunSpinner liveData={liveData} />
           <Caption style={{flex: 1}} color={Colors.Gray800}>
-            {liveData.partitionStats?.numMaterializing
+            {liveData.partitionStats?.numMaterializing === 1
+              ? `Materializing 1 partition...`
+              : liveData.partitionStats?.numMaterializing
               ? `Materializing ${liveData.partitionStats.numMaterializing} partitions...`
               : `Materializing...`}
           </Caption>

--- a/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/Utils.tsx
@@ -136,7 +136,12 @@ export interface LiveDataForNode {
   lastObservation: AssetNodeLiveObservationFragment | null;
   staleStatus: StaleStatus | null;
   staleCauses: {dependency: Maybe<AssetKey>; key: AssetKey; reason: string}[];
-  partitionStats: {numMaterialized: number; numPartitions: number; numFailed: number} | null;
+  partitionStats: {
+    numMaterialized: number;
+    numMaterializing: number;
+    numPartitions: number;
+    numFailed: number;
+  } | null;
 }
 
 export const MISSING_LIVE_DATA: LiveDataForNode = {

--- a/js_modules/dagit/packages/core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/AssetNode.types.ts
@@ -31,6 +31,7 @@ export type AssetNodeLiveFragment = {
   partitionStats: {
     __typename: 'PartitionStats';
     numMaterialized: number;
+    numMaterializing: number;
     numPartitions: number;
     numFailed: number;
   } | null;

--- a/js_modules/dagit/packages/core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/types/useLiveDataForAssetKeys.types.ts
@@ -57,6 +57,7 @@ export type AssetGraphLiveQuery = {
     partitionStats: {
       __typename: 'PartitionStats';
       numMaterialized: number;
+      numMaterializing: number;
       numPartitions: number;
       numFailed: number;
     } | null;

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -2,23 +2,22 @@ import {Box, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {PartitionState, partitionStateToStyle} from '../partitions/PartitionStatus';
 import {Inner} from '../ui/VirtualizedTable';
 
 import {AssetListRow, AssetListContainer} from './AssetEventList';
-import {AssetPartitionStatus} from './usePartitionHealthData';
+import {AssetPartitionStatus, assetPartitionStatusesToStyle} from './usePartitionHealthData';
 
 export interface AssetPartitionListProps {
   partitions: string[];
-  stateForPartition: (dimensionKey: string) => AssetPartitionStatus[];
+  statusForPartition: (dimensionKey: string) => AssetPartitionStatus[];
   focusedDimensionKey?: string;
   setFocusedDimensionKey?: (dimensionKey: string | undefined) => void;
 }
 export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
   focusedDimensionKey,
   setFocusedDimensionKey,
+  statusForPartition,
   partitions,
-  stateForPartition,
 }) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -61,7 +60,7 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
           const dimensionKey = partitions[index];
-          const state = stateForPartition(dimensionKey);
+          const state = statusForPartition(dimensionKey);
           return (
             <AssetListRow
               key={key}
@@ -90,13 +89,13 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
                   {dimensionKey}
                   <div style={{flex: 1}} />
                   {state.includes(AssetPartitionStatus.MATERIALIZED) && (
-                    <StateDot state={AssetPartitionStatus.MATERIALIZED} />
+                    <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />
                   )}
                   {state.includes(AssetPartitionStatus.MISSING) && (
-                    <StateDot state={AssetPartitionStatus.MISSING} />
+                    <AssetPartitionStatusDot status={[AssetPartitionStatus.MISSING]} />
                   )}
                   {state.includes(AssetPartitionStatus.FAILED) && (
-                    <StateDot state={AssetPartitionStatus.FAILED} />
+                    <AssetPartitionStatusDot status={[AssetPartitionStatus.FAILED]} />
                   )}
                 </Box>
               </Box>
@@ -108,14 +107,13 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
   );
 };
 
-export const StateDot = ({state}: {state: PartitionState | AssetPartitionStatus}) => (
+export const AssetPartitionStatusDot = ({status}: {status: AssetPartitionStatus[]}) => (
   <div
-    key={state}
     style={{
       width: 10,
       height: 10,
       borderRadius: '100%',
-      ...partitionStateToStyle(state),
+      ...assetPartitionStatusesToStyle(status),
     }}
   />
 );

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -2,7 +2,7 @@ import {Box, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {PartitionState, partitionStateToStyle} from '../partitions/PartitionStatus';
+import {partitionStateToStyle} from '../partitions/PartitionStatus';
 import {Inner} from '../ui/VirtualizedTable';
 
 import {AssetListRow, AssetListContainer} from './AssetEventList';
@@ -10,7 +10,7 @@ import {AssetPartitionStatus} from './usePartitionHealthData';
 
 export interface AssetPartitionListProps {
   partitions: string[];
-  stateForPartition: (dimensionKey: string) => PartitionState;
+  stateForPartition: (dimensionKey: string) => AssetPartitionStatus[];
   focusedDimensionKey?: string;
   setFocusedDimensionKey?: (dimensionKey: string | undefined) => void;
 }
@@ -89,16 +89,14 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
                 <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
                   {dimensionKey}
                   <div style={{flex: 1}} />
-                  {(state === AssetPartitionStatus.SUCCESS_MISSING ||
-                    state === AssetPartitionStatus.SUCCESS) && (
-                    <StateDot state={AssetPartitionStatus.SUCCESS} />
+                  {state.includes(AssetPartitionStatus.MATERIALIZED) && (
+                    <StateDot state={AssetPartitionStatus.MATERIALIZED} />
                   )}
-                  {(state === AssetPartitionStatus.SUCCESS_MISSING ||
-                    state === AssetPartitionStatus.MISSING) && (
+                  {state.includes(AssetPartitionStatus.MISSING) && (
                     <StateDot state={AssetPartitionStatus.MISSING} />
                   )}
-                  {state === AssetPartitionStatus.FAILURE && (
-                    <StateDot state={AssetPartitionStatus.FAILURE} />
+                  {state.includes(AssetPartitionStatus.FAILED) && (
+                    <StateDot state={AssetPartitionStatus.FAILED} />
                   )}
                 </Box>
               </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import {Inner} from '../ui/VirtualizedTable';
 
 import {AssetListRow, AssetListContainer} from './AssetEventList';
-import {AssetPartitionStatus, assetPartitionStatusesToStyle} from './usePartitionHealthData';
+import {AssetPartitionStatus, assetPartitionStatusesToStyle} from './AssetPartitionStatus';
 
 export interface AssetPartitionListProps {
   partitions: string[];
@@ -88,14 +88,18 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
                 <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
                   {dimensionKey}
                   <div style={{flex: 1}} />
-                  {state.includes(AssetPartitionStatus.MATERIALIZED) && (
-                    <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />
-                  )}
+                  {/* Note: we could just state.map, but we want these in a particular order*/}
                   {state.includes(AssetPartitionStatus.MISSING) && (
                     <AssetPartitionStatusDot status={[AssetPartitionStatus.MISSING]} />
                   )}
                   {state.includes(AssetPartitionStatus.FAILED) && (
                     <AssetPartitionStatusDot status={[AssetPartitionStatus.FAILED]} />
+                  )}
+                  {state.includes(AssetPartitionStatus.MATERIALIZING) && (
+                    <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZING]} />
+                  )}
+                  {state.includes(AssetPartitionStatus.MATERIALIZED) && (
+                    <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />
                   )}
                 </Box>
               </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -6,6 +6,7 @@ import {PartitionState, partitionStateToStyle} from '../partitions/PartitionStat
 import {Inner} from '../ui/VirtualizedTable';
 
 import {AssetListRow, AssetListContainer} from './AssetEventList';
+import {AssetPartitionStatus} from './usePartitionHealthData';
 
 export interface AssetPartitionListProps {
   partitions: string[];
@@ -88,15 +89,17 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
                 <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
                   {dimensionKey}
                   <div style={{flex: 1}} />
-                  {(state === PartitionState.SUCCESS_MISSING ||
-                    state === PartitionState.SUCCESS) && (
-                    <StateDot state={PartitionState.SUCCESS} />
+                  {(state === AssetPartitionStatus.SUCCESS_MISSING ||
+                    state === AssetPartitionStatus.SUCCESS) && (
+                    <StateDot state={AssetPartitionStatus.SUCCESS} />
                   )}
-                  {(state === PartitionState.SUCCESS_MISSING ||
-                    state === PartitionState.MISSING) && (
-                    <StateDot state={PartitionState.MISSING} />
+                  {(state === AssetPartitionStatus.SUCCESS_MISSING ||
+                    state === AssetPartitionStatus.MISSING) && (
+                    <StateDot state={AssetPartitionStatus.MISSING} />
                   )}
-                  {state === PartitionState.FAILURE && <StateDot state={PartitionState.FAILURE} />}
+                  {state === AssetPartitionStatus.FAILURE && (
+                    <StateDot state={AssetPartitionStatus.FAILURE} />
+                  )}
                 </Box>
               </Box>
             </AssetListRow>
@@ -107,7 +110,7 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
   );
 };
 
-export const StateDot = ({state}: {state: PartitionState}) => (
+export const StateDot = ({state}: {state: AssetPartitionStatus}) => (
   <div
     key={state}
     style={{

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionList.tsx
@@ -2,7 +2,7 @@ import {Box, Colors} from '@dagster-io/ui';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
-import {partitionStateToStyle} from '../partitions/PartitionStatus';
+import {PartitionState, partitionStateToStyle} from '../partitions/PartitionStatus';
 import {Inner} from '../ui/VirtualizedTable';
 
 import {AssetListRow, AssetListContainer} from './AssetEventList';
@@ -108,7 +108,7 @@ export const AssetPartitionList: React.FC<AssetPartitionListProps> = ({
   );
 };
 
-export const StateDot = ({state}: {state: AssetPartitionStatus}) => (
+export const StateDot = ({state}: {state: PartitionState | AssetPartitionStatus}) => (
   <div
     key={state}
     style={{

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatus.tsx
@@ -1,0 +1,68 @@
+// Same as PartitionRangeStatus but we need a "MISSING" value
+
+import {Colors} from '@dagster-io/ui';
+import {CSSProperties} from 'react';
+
+import {assertUnreachable} from '../app/Util';
+
+// Same as PartitionRangeStatus but we need a "MISSING" value
+//
+export enum AssetPartitionStatus {
+  FAILED = 'FAILED',
+  MATERIALIZED = 'MATERIALIZED',
+  MATERIALIZING = 'MATERIALIZING',
+  MISSING = 'MISSING',
+}
+
+export const emptyAssetPartitionStatusCounts = () => ({
+  [AssetPartitionStatus.MISSING]: 0,
+  [AssetPartitionStatus.MATERIALIZED]: 0,
+  [AssetPartitionStatus.MATERIALIZING]: 0,
+  [AssetPartitionStatus.FAILED]: 0,
+});
+
+export const assetPartitionStatusToText = (status: AssetPartitionStatus) => {
+  switch (status) {
+    case AssetPartitionStatus.MATERIALIZED:
+      return 'Materialized';
+    case AssetPartitionStatus.MATERIALIZING:
+      return 'Materializing';
+    case AssetPartitionStatus.FAILED:
+      return 'Failed';
+    case AssetPartitionStatus.MISSING:
+      return 'Missing';
+    default:
+      assertUnreachable(status);
+  }
+};
+
+export const assetPartitionStatusToColor = (status: AssetPartitionStatus) => {
+  switch (status) {
+    case AssetPartitionStatus.MATERIALIZED:
+      return Colors.Green500;
+    case AssetPartitionStatus.MATERIALIZING:
+      return Colors.Blue500;
+    case AssetPartitionStatus.FAILED:
+      return Colors.Red500;
+    case AssetPartitionStatus.MISSING:
+      return Colors.Gray200;
+    default:
+      assertUnreachable(status);
+  }
+};
+
+export const assetPartitionStatusesToStyle = (status: AssetPartitionStatus[]): CSSProperties => {
+  if (status.length === 0) {
+    return {background: Colors.Gray200};
+  }
+  if (status.length === 1) {
+    return {background: assetPartitionStatusToColor(status[0])};
+  }
+  const a = assetPartitionStatusToColor(status[0]);
+  const b = assetPartitionStatusToColor(status[1]);
+
+  return {
+    background: `linear-gradient(135deg, ${a} 25%, ${b} 25%, ${b} 50%, ${a} 50%, ${a} 75%, ${b} 75%, ${b} 100%)`,
+    backgroundSize: '8.49px 8.49px',
+  };
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
@@ -1,0 +1,47 @@
+import {Box, Checkbox} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {testId} from '../testing/testId';
+
+import {partitionStatusToText} from './PartitionStatus';
+import {AssetPartitionStatus} from './usePartitionHealthData';
+
+export function countsByState(
+  partitionKeysForCounts: {partitionKey: string; state: AssetPartitionStatus}[],
+) {
+  const result: {[state: string]: number} = {
+    [AssetPartitionStatus.MATERIALIZED]: 0,
+    [AssetPartitionStatus.MISSING]: 0,
+    [AssetPartitionStatus.FAILED]: 0,
+  };
+  for (const key of partitionKeysForCounts) {
+    result[key.state] = (result[key.state] || 0) + 1;
+  }
+  return result;
+}
+
+export const AssetPartitionStatusCheckboxes: React.FC<{
+  counts: {[state: string]: number};
+  value: AssetPartitionStatus[];
+  allowed: AssetPartitionStatus[];
+  onChange: (selected: AssetPartitionStatus[]) => void;
+  disabled?: boolean;
+}> = ({counts, value, onChange, allowed, disabled}) => {
+  return (
+    <Box flex={{direction: 'row', alignItems: 'center', gap: 12}} style={{overflow: 'hidden'}}>
+      {allowed.map((state) => (
+        <Checkbox
+          key={state}
+          data-testid={testId(`partition-state-${state}-checkbox`)}
+          disabled={disabled}
+          style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
+          checked={value.includes(state) && !disabled}
+          label={`${partitionStatusToText(state)} (${counts[state]})`}
+          onChange={() =>
+            onChange(value.includes(state) ? value.filter((v) => v !== state) : [...value, state])
+          }
+        />
+      ))}
+    </Box>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
@@ -1,10 +1,9 @@
 import {Box, Checkbox} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {partitionStatusToText} from '../partitions/PartitionStatus';
 import {testId} from '../testing/testId';
 
-import {AssetPartitionStatus} from './usePartitionHealthData';
+import {AssetPartitionStatus, assetPartitionStatusToText} from './usePartitionHealthData';
 
 export function countsByState(
   partitionKeysForCounts: {partitionKey: string; state: AssetPartitionStatus}[],
@@ -36,7 +35,7 @@ export const AssetPartitionStatusCheckboxes: React.FC<{
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
           checked={value.includes(state) && !disabled}
-          label={`${partitionStatusToText(state)} (${counts[state]})`}
+          label={`${assetPartitionStatusToText(state)} (${counts[state]})`}
           onChange={() =>
             onChange(value.includes(state) ? value.filter((v) => v !== state) : [...value, state])
           }

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
@@ -9,8 +9,9 @@ export function countsByState(
   partitionKeysForCounts: {partitionKey: string; state: AssetPartitionStatus}[],
 ) {
   const result: {[state: string]: number} = {
-    [AssetPartitionStatus.MATERIALIZED]: 0,
     [AssetPartitionStatus.MISSING]: 0,
+    [AssetPartitionStatus.MATERIALIZED]: 0,
+    [AssetPartitionStatus.MATERIALIZING]: 0,
     [AssetPartitionStatus.FAILED]: 0,
   };
   for (const key of partitionKeysForCounts) {

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
@@ -1,9 +1,9 @@
 import {Box, Checkbox} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {partitionStatusToText} from '../partitions/PartitionStatus';
 import {testId} from '../testing/testId';
 
-import {partitionStatusToText} from './PartitionStatus';
 import {AssetPartitionStatus} from './usePartitionHealthData';
 
 export function countsByState(

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatusCheckboxes.tsx
@@ -3,17 +3,16 @@ import * as React from 'react';
 
 import {testId} from '../testing/testId';
 
-import {AssetPartitionStatus, assetPartitionStatusToText} from './usePartitionHealthData';
+import {
+  AssetPartitionStatus,
+  assetPartitionStatusToText,
+  emptyAssetPartitionStatusCounts,
+} from './AssetPartitionStatus';
 
 export function countsByState(
   partitionKeysForCounts: {partitionKey: string; state: AssetPartitionStatus}[],
 ) {
-  const result: {[state: string]: number} = {
-    [AssetPartitionStatus.MISSING]: 0,
-    [AssetPartitionStatus.MATERIALIZED]: 0,
-    [AssetPartitionStatus.MATERIALIZING]: 0,
-    [AssetPartitionStatus.FAILED]: 0,
-  };
+  const result = emptyAssetPartitionStatusCounts();
   for (const key of partitionKeysForCounts) {
     result[key.state] = (result[key.state] || 0) + 1;
   }
@@ -21,7 +20,7 @@ export function countsByState(
 }
 
 export const AssetPartitionStatusCheckboxes: React.FC<{
-  counts: {[state: string]: number};
+  counts: {[status: string]: number};
   value: AssetPartitionStatus[];
   allowed: AssetPartitionStatus[];
   onChange: (selected: AssetPartitionStatus[]) => void;
@@ -29,16 +28,18 @@ export const AssetPartitionStatusCheckboxes: React.FC<{
 }> = ({counts, value, onChange, allowed, disabled}) => {
   return (
     <Box flex={{direction: 'row', alignItems: 'center', gap: 12}} style={{overflow: 'hidden'}}>
-      {allowed.map((state) => (
+      {allowed.map((status) => (
         <Checkbox
-          key={state}
-          data-testid={testId(`partition-state-${state}-checkbox`)}
+          key={status}
+          data-testid={testId(`partition-status-${status}-checkbox`)}
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
-          checked={value.includes(state) && !disabled}
-          label={`${assetPartitionStatusToText(state)} (${counts[state]})`}
+          checked={value.includes(status) && !disabled}
+          label={`${assetPartitionStatusToText(status)} (${counts[status]})`}
           onChange={() =>
-            onChange(value.includes(state) ? value.filter((v) => v !== state) : [...value, state])
+            onChange(
+              value.includes(status) ? value.filter((v) => v !== status) : [...value, status],
+            )
           }
         />
       ))}

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -21,7 +21,7 @@ import {
   usePartitionHealthData,
   rangesClippedToSelection,
   keyCountByStateInSelection,
-  partitionStateAtIndex,
+  partitionStatusAtIndex,
   AssetPartitionStatus,
 } from './usePartitionHealthData';
 import {usePartitionKeyInParams} from './usePartitionKeyInParams';
@@ -80,7 +80,7 @@ export const AssetPartitions: React.FC<Props> = ({
   // Get asset health on all dimensions, with the non-time dimensions scoped
   // to the time dimension selection (so the status of partition "VA" reflects
   // the selection you've made on the time axis.)
-  const materializedRangesByDimension = React.useMemo(
+  const rangesForEachDimension = React.useMemo(
     () =>
       selections.map((_s, idx) =>
         assetHealth
@@ -122,10 +122,7 @@ export const AssetPartitions: React.FC<Props> = ({
       return sort === 1 ? result : result.reverse();
     }
 
-    const rangesInSelection = rangesClippedToSelection(
-      materializedRangesByDimension[idx],
-      selectedRanges,
-    );
+    const rangesInSelection = rangesClippedToSelection(rangesForEachDimension[idx], selectedRanges);
 
     const getKeysWithStates = (states: AssetPartitionStatus[]) => {
       return rangesInSelection.flatMap((r) =>
@@ -176,7 +173,7 @@ export const AssetPartitions: React.FC<Props> = ({
         >
           <DimensionRangeWizard
             partitionKeys={selections[timeDimensionIdx].dimension.partitionKeys}
-            health={{ranges: materializedRangesByDimension[timeDimensionIdx]}}
+            health={{ranges: rangesForEachDimension[timeDimensionIdx]}}
             selected={selections[timeDimensionIdx].selectedKeys}
             setSelected={(selectedKeys) =>
               setSelections(
@@ -257,12 +254,12 @@ export const AssetPartitions: React.FC<Props> = ({
             ) : (
               <AssetPartitionList
                 partitions={dimensionKeysInSelection(idx)}
-                stateForPartition={(dimensionKey) => {
+                statusForPartition={(dimensionKey) => {
                   if (idx === 1 && focusedDimensionKeys[0]) {
                     return [assetHealth.stateForKey([focusedDimensionKeys[0], dimensionKey])];
                   }
                   const dimensionKeyIdx = selection.dimension.partitionKeys.indexOf(dimensionKey);
-                  return partitionStateAtIndex(materializedRangesByDimension[idx], dimensionKeyIdx);
+                  return partitionStatusAtIndex(rangesForEachDimension[idx], dimensionKeyIdx);
                 }}
                 focusedDimensionKey={focusedDimensionKeys[idx]}
                 setFocusedDimensionKey={(dimensionKey) => {

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -129,13 +129,13 @@ export const AssetPartitions: React.FC<Props> = ({
 
     const getKeysWithStates = (states: AssetPartitionStatus[]) => {
       return rangesInSelection.flatMap((r) =>
-        states.includes(r.value) ? allKeys.slice(r.start.idx, r.end.idx + 1) : [],
+        states.some((s) => r.value.includes(s)) ? allKeys.slice(r.start.idx, r.end.idx + 1) : [],
       );
     };
 
     const states: AssetPartitionStatus[] = [];
     if (stateFilters.includes(AssetPartitionStatus.MATERIALIZED)) {
-      states.push(AssetPartitionStatus.MATERIALIZED, AssetPartitionStatus.SUCCESS_MISSING);
+      states.push(AssetPartitionStatus.MATERIALIZED);
     }
     if (stateFilters.includes(AssetPartitionStatus.FAILED)) {
       states.push(AssetPartitionStatus.FAILED);
@@ -259,7 +259,7 @@ export const AssetPartitions: React.FC<Props> = ({
                 partitions={dimensionKeysInSelection(idx)}
                 stateForPartition={(dimensionKey) => {
                   if (idx === 1 && focusedDimensionKeys[0]) {
-                    return assetHealth.stateForKey([focusedDimensionKeys[0], dimensionKey]);
+                    return [assetHealth.stateForKey([focusedDimensionKeys[0], dimensionKey])];
                   }
                   const dimensionKeyIdx = selection.dimension.partitionKeys.indexOf(dimensionKey);
                   return partitionStateAtIndex(materializedRangesByDimension[idx], dimensionKeyIdx);

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -58,6 +58,7 @@ import {DagsterTag} from '../runs/RunTag';
 import {testId} from '../testing/testId';
 import {RepoAddress} from '../workspace/types';
 
+import {AssetPartitionStatus} from './AssetPartitionStatus';
 import {
   executionParamsForAssetJob,
   LaunchAssetsChoosePartitionsTarget,
@@ -75,11 +76,7 @@ import {
 } from './types/LaunchAssetChoosePartitionsDialog.types';
 import {PartitionDefinitionForLaunchAssetFragment} from './types/LaunchAssetExecutionButton.types';
 import {usePartitionDimensionSelections} from './usePartitionDimensionSelections';
-import {
-  AssetPartitionStatus,
-  PartitionDimensionSelection,
-  usePartitionHealthData,
-} from './usePartitionHealthData';
+import {PartitionDimensionSelection, usePartitionHealthData} from './usePartitionHealthData';
 
 interface Props {
   open: boolean;

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -53,7 +53,6 @@ import {
   USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT,
 } from '../partitions/BackfillMessaging';
 import {DimensionRangeWizard} from '../partitions/DimensionRangeWizard';
-import {PartitionState} from '../partitions/PartitionStatus';
 import {assembleIntoSpans, stringForSpan} from '../partitions/SpanRepresentation';
 import {DagsterTag} from '../runs/RunTag';
 import {testId} from '../testing/testId';
@@ -190,17 +189,11 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
   const keysInSelection = React.useMemo(
     () =>
       explodePartitionKeysInSelection(selections, (dimensionKeys: string[]) => {
-        // Note: If the merged asset health for a given partition is "partial", we want
-        // to group it into "missing" within the backfill UI. We don't have a fine-grained
-        // way to run just the missing assets within the partition.
-        //
-        // The alternative would be to offer a "Partial" checkbox alongside "Missing",
-        // but defining missing as "missing for /any/ asset I've selected" is simpler.
-        //
-        const state = displayedHealth.stateForKey(dimensionKeys);
-        return state === AssetPartitionStatus.SUCCESS_MISSING
-          ? AssetPartitionStatus.MISSING
-          : state;
+        let states = displayedHealth.stateForKey(dimensionKeys);
+        if (!(states instanceof Array)) {
+          states = [states];
+        }
+        return states;
       }),
     [selections, displayedHealth],
   );
@@ -213,7 +206,9 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     () =>
       missingFailedOnly
         ? keysInSelection.filter((key) =>
-            [AssetPartitionStatus.MISSING, AssetPartitionStatus.FAILURE].includes(key.state),
+            [AssetPartitionStatus.MISSING, AssetPartitionStatus.FAILED].some((state) =>
+              key.state.includes(state),
+            ),
           )
         : keysInSelection,
     [keysInSelection, missingFailedOnly],

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -76,7 +76,11 @@ import {
 } from './types/LaunchAssetChoosePartitionsDialog.types';
 import {PartitionDefinitionForLaunchAssetFragment} from './types/LaunchAssetExecutionButton.types';
 import {usePartitionDimensionSelections} from './usePartitionDimensionSelections';
-import {PartitionDimensionSelection, usePartitionHealthData} from './usePartitionHealthData';
+import {
+  AssetPartitionStatus,
+  PartitionDimensionSelection,
+  usePartitionHealthData,
+} from './usePartitionHealthData';
 
 interface Props {
   open: boolean;
@@ -194,7 +198,9 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
         // but defining missing as "missing for /any/ asset I've selected" is simpler.
         //
         const state = displayedHealth.stateForKey(dimensionKeys);
-        return state === PartitionState.SUCCESS_MISSING ? PartitionState.MISSING : state;
+        return state === AssetPartitionStatus.SUCCESS_MISSING
+          ? AssetPartitionStatus.MISSING
+          : state;
       }),
     [selections, displayedHealth],
   );
@@ -207,7 +213,7 @@ const LaunchAssetChoosePartitionsDialogBody: React.FC<Props> = ({
     () =>
       missingFailedOnly
         ? keysInSelection.filter((key) =>
-            [PartitionState.MISSING, PartitionState.FAILURE].includes(key.state),
+            [AssetPartitionStatus.MISSING, AssetPartitionStatus.FAILURE].includes(key.state),
           )
         : keysInSelection,
     [keysInSelection, missingFailedOnly],
@@ -657,7 +663,9 @@ const UpstreamUnavailableWarning: React.FC<{
   const upstreamUnavailable = (singleDimensionKey: string) =>
     upstreamAssetHealth.some((a) => {
       // If the key is not undefined, it's present in the partition key space of the asset
-      return a.dimensions.length && a.stateForKey([singleDimensionKey]) === PartitionState.MISSING;
+      return (
+        a.dimensions.length && a.stateForKey([singleDimensionKey]) === AssetPartitionStatus.MISSING
+      );
     });
 
   const upstreamUnavailableSpans =

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -3,12 +3,12 @@ import uniq from 'lodash/uniq';
 
 import {PartitionDefinitionType} from '../graphql/types';
 
+import {AssetPartitionStatus, emptyAssetPartitionStatusCounts} from './AssetPartitionStatus';
 import {
   PartitionHealthData,
   PartitionHealthDimension,
   PartitionDimensionSelection,
   Range,
-  AssetPartitionStatus,
   PartitionHealthDataMerged,
 } from './usePartitionHealthData';
 
@@ -123,9 +123,7 @@ export function assembleRangesFromTransitions(
   maxOverlap: number,
 ) {
   // sort the input array, this algorithm does not work unless the transitions are in order
-  const transitions = [...transitionsUnsorted].sort(
-    (a, b) => a.idx - b.idx || `${a.state}`.localeCompare(`${b.state}`),
-  );
+  const transitions = [...transitionsUnsorted].sort((a, b) => a.idx - b.idx || b.delta - a.delta);
 
   // walk the transitions array and apply the transitions to a counter, creating an array of just the changes
   // in the number of currently-overlapping ranges. (eg: how many of the assets are materialized at this time).
@@ -135,23 +133,21 @@ export function assembleRangesFromTransitions(
   //
   const depths: {
     idx: number;
-    MISSING: number;
-    MATERIALIZED: number;
-    MATERIALIZING: number;
-    FAILED: number;
+    [AssetPartitionStatus.FAILED]: number;
+    [AssetPartitionStatus.MATERIALIZING]: number;
+    [AssetPartitionStatus.MATERIALIZED]: number;
+    [AssetPartitionStatus.MISSING]: number;
   }[] = [];
   for (const transition of transitions) {
-    const last = depths[depths.length - 1];
-    if (last && last.idx === transition.idx) {
-      for (const state of transition.state) {
+    for (const state of transition.state) {
+      const last = depths[depths.length - 1];
+      if (last && last.idx === transition.idx) {
         last[state] = (last[state] || 0) + transition.delta;
-      }
-    } else {
-      for (const state of transition.state) {
+      } else {
         depths.push({
-          ...(last || {}),
-          idx: transition.idx,
+          ...(last || emptyAssetPartitionStatusCounts()),
           [state]: (last?.[state] || 0) + transition.delta,
+          idx: transition.idx,
         });
       }
     }
@@ -173,7 +169,7 @@ export function assembleRangesFromTransitions(
     if (MATERIALIZING > 0) {
       value.push(AssetPartitionStatus.MATERIALIZING);
     }
-    if (MISSING || FAILED + MATERIALIZED + MATERIALIZING < maxOverlap) {
+    if (MISSING > 0 || FAILED + MATERIALIZED + MATERIALIZING < maxOverlap) {
       value.push(AssetPartitionStatus.MISSING);
     }
 
@@ -186,7 +182,10 @@ export function assembleRangesFromTransitions(
       result.push({start: {idx, key: allKeys[idx]}, end: {idx, key: allKeys[idx]}, value});
     }
   }
-  return result.filter((range) => !isEqual(range.value, [AssetPartitionStatus.MISSING]));
+  return result.filter(
+    (range) =>
+      range.start.idx < allKeys.length && !isEqual(range.value, [AssetPartitionStatus.MISSING]),
+  );
 }
 
 export function partitionDefinitionsEqual(

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -2,11 +2,15 @@ import {Spinner, Box, Colors, Caption} from '@dagster-io/ui';
 import React from 'react';
 
 import {displayNameForAssetKey} from '../asset-graph/Utils';
-import {PartitionState, PartitionStatus} from '../partitions/PartitionStatus';
+import {PartitionStatus} from '../partitions/PartitionStatus';
 
 import {isTimeseriesDimension} from './MultipartitioningSupport';
 import {AssetKey} from './types';
-import {PartitionHealthData, PartitionDimensionSelection} from './usePartitionHealthData';
+import {
+  PartitionHealthData,
+  PartitionDimensionSelection,
+  AssetPartitionStatus,
+} from './usePartitionHealthData';
 
 export const PartitionHealthSummary: React.FC<{
   assetKey: AssetKey;
@@ -38,7 +42,7 @@ export const PartitionHealthSummary: React.FC<{
           : d.map((key) => [key]),
       [] as string[][],
     )
-    .filter((dkeys) => assetData.stateForKey(dkeys) === PartitionState.SUCCESS).length;
+    .filter((dkeys) => assetData.stateForKey(dkeys) === AssetPartitionStatus.MATERIALIZED).length;
 
   return (
     <Box color={Colors.Gray500}>

--- a/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/PartitionHealthSummary.tsx
@@ -4,13 +4,10 @@ import React from 'react';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {PartitionStatus} from '../partitions/PartitionStatus';
 
+import {AssetPartitionStatus} from './AssetPartitionStatus';
 import {isTimeseriesDimension} from './MultipartitioningSupport';
 import {AssetKey} from './types';
-import {
-  PartitionHealthData,
-  PartitionDimensionSelection,
-  AssetPartitionStatus,
-} from './usePartitionHealthData';
+import {PartitionHealthData, PartitionDimensionSelection} from './usePartitionHealthData';
 
 export const PartitionHealthSummary: React.FC<{
   assetKey: AssetKey;

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetsCatalogTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetsCatalogTable.mocks.ts
@@ -259,6 +259,7 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<SingleAssetQuery> = {
           partitionStats: {
             __typename: 'PartitionStats',
             numMaterialized: 8,
+            numMaterializing: 0,
             numPartitions: 11,
             numFailed: 0,
           },

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthSummary.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/PartitionHealthSummary.mocks.ts
@@ -1595,6 +1595,7 @@ export const SingleDimensionStaticPartitionHealthQuery: MockedResponse<Partition
         ],
         assetPartitionStatuses: {
           materializedPartitions: ['IL', 'VA', 'SC', 'WV', 'OH', 'GA'],
+          materializingPartitions: [],
           failedPartitions: ['PA', 'NC'],
           __typename: 'DefaultPartitions',
         },
@@ -1638,6 +1639,7 @@ export const MultiDimensionStaticPartitionHealthQuery: MockedResponse<PartitionH
               primaryDimEndTime: null,
               secondaryDim: {
                 materializedPartitions: ['IL', 'VA', 'SC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1661,6 +1663,7 @@ export const MultiDimensionStaticPartitionHealthQuery: MockedResponse<PartitionH
                   'NC',
                   'KY',
                 ],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1725,6 +1728,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
                   'NC',
                   'KY',
                 ],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1737,6 +1741,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
               primaryDimEndTime: 1659139200,
               secondaryDim: {
                 materializedPartitions: ['TN', 'VA', 'GA', 'PA', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1761,6 +1766,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
                   'NC',
                   'KY',
                 ],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1773,6 +1779,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
               primaryDimEndTime: 1661731200,
               secondaryDim: {
                 materializedPartitions: ['TN', 'VA'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1785,6 +1792,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
               primaryDimEndTime: 1663286400,
               secondaryDim: {
                 materializedPartitions: ['IL', 'VA', 'SC', 'PA', 'WV', 'FL'],
+                materializingPartitions: [],
                 failedPartitions: ['TN', 'GA', 'OH', 'NC', 'KY'],
                 __typename: 'DefaultPartitions',
               },
@@ -1797,6 +1805,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
               primaryDimEndTime: 1663372800,
               secondaryDim: {
                 materializedPartitions: ['IL', 'VA', 'SC', 'PA', 'FL'],
+                materializingPartitions: [],
                 failedPartitions: ['TN', 'GA', 'OH', 'NC', 'KY'],
                 __typename: 'DefaultPartitions',
               },
@@ -1821,6 +1830,7 @@ export const MultiDimensionTimeFirstPartitionHealthQuery: MockedResponse<Partiti
                   'NC',
                   'KY',
                 ],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1873,6 +1883,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1626134400,
               secondaryDim: {
                 materializedPartitions: ['TN'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1885,6 +1896,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665100800,
               secondaryDim: {
                 materializedPartitions: ['TN', 'VA'],
+                materializingPartitions: [],
                 failedPartitions: ['OH'],
                 __typename: 'DefaultPartitions',
               },
@@ -1897,6 +1909,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665273600,
               secondaryDim: {
                 materializedPartitions: ['OH', 'FL', 'TN', 'VA', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1909,6 +1922,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665360000,
               secondaryDim: {
                 materializedPartitions: ['OH', 'FL', 'TN', 'VA', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1921,6 +1935,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665532800,
               secondaryDim: {
                 materializedPartitions: ['FL', 'TN', 'VA', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1933,6 +1948,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665619200,
               secondaryDim: {
                 materializedPartitions: ['OH', 'VA', 'TN', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1945,6 +1961,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665792000,
               secondaryDim: {
                 materializedPartitions: ['FL', 'PA', 'VA', 'TN', 'SC', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1957,6 +1974,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665878400,
               secondaryDim: {
                 materializedPartitions: ['FL', 'TN', 'VA', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1969,6 +1987,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1665964800,
               secondaryDim: {
                 materializedPartitions: ['PA', 'TN', 'VA', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1981,6 +2000,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666051200,
               secondaryDim: {
                 materializedPartitions: ['VA', 'SC', 'PA', 'FL', 'TN', 'GA', 'OH', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -1993,6 +2013,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666137600,
               secondaryDim: {
                 materializedPartitions: ['FL', 'TN', 'GA', 'VA', 'SC', 'PA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2005,6 +2026,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666396800,
               secondaryDim: {
                 materializedPartitions: ['VA', 'SC', 'PA', 'FL', 'TN', 'GA', 'OH', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2017,6 +2039,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666483200,
               secondaryDim: {
                 materializedPartitions: ['FL', 'TN', 'GA', 'VA', 'SC', 'PA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2029,6 +2052,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666569600,
               secondaryDim: {
                 materializedPartitions: ['VA', 'SC', 'OH', 'FL', 'TN', 'GA', 'PA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2041,6 +2065,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666656000,
               secondaryDim: {
                 materializedPartitions: ['VA', 'TN', 'PA', 'SC', 'OH', 'GA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2053,6 +2078,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666828800,
               secondaryDim: {
                 materializedPartitions: ['VA', 'SC', 'PA', 'FL', 'TN', 'GA', 'OH', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2065,6 +2091,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1666915200,
               secondaryDim: {
                 materializedPartitions: ['NC', 'VA', 'TN', 'GA', 'SC', 'OH', 'PA', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2077,6 +2104,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667260800,
               secondaryDim: {
                 materializedPartitions: ['VA', 'SC', 'PA', 'FL', 'TN', 'GA', 'OH', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2089,6 +2117,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667347200,
               secondaryDim: {
                 materializedPartitions: ['TN', 'GA', 'VA', 'PA', 'OH', 'SC', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2101,6 +2130,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667433600,
               secondaryDim: {
                 materializedPartitions: ['FL', 'TN', 'GA', 'VA', 'SC', 'PA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2113,6 +2143,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667520000,
               secondaryDim: {
                 materializedPartitions: ['VA', 'SC', 'PA', 'FL', 'TN', 'GA', 'OH', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2125,6 +2156,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667606400,
               secondaryDim: {
                 materializedPartitions: ['FL', 'VA', 'TN', 'GA', 'SC', 'PA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2137,6 +2169,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667692800,
               secondaryDim: {
                 materializedPartitions: ['NC', 'FL', 'VA', 'TN', 'GA', 'OH', 'PA', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2149,6 +2182,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1667779200,
               secondaryDim: {
                 materializedPartitions: ['FL', 'VA', 'GA', 'TN', 'SC', 'PA', 'NC', 'KY'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2161,6 +2195,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668038400,
               secondaryDim: {
                 materializedPartitions: ['OH', 'FL', 'TN', 'VA', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2173,6 +2208,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668124800,
               secondaryDim: {
                 materializedPartitions: ['TN', 'VA', 'PA', 'SC', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2185,6 +2221,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668297600,
               secondaryDim: {
                 materializedPartitions: ['FL', 'TN', 'VA', 'PA', 'SC', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2197,6 +2234,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668384000,
               secondaryDim: {
                 materializedPartitions: ['OH', 'VA', 'TN', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2209,6 +2247,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668556800,
               secondaryDim: {
                 materializedPartitions: ['OH', 'FL', 'TN', 'VA', 'SC', 'PA', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2221,6 +2260,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668643200,
               secondaryDim: {
                 materializedPartitions: ['OH', 'FL', 'TN', 'VA', 'SC', 'PA'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2233,6 +2273,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668729600,
               secondaryDim: {
                 materializedPartitions: ['FL', 'PA', 'SC', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2245,6 +2286,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668816000,
               secondaryDim: {
                 materializedPartitions: ['PA', 'NC', 'FL', 'SC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2257,6 +2299,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1668902400,
               secondaryDim: {
                 materializedPartitions: ['OH', 'PA', 'FL'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2281,6 +2324,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
                   'NC',
                   'KY',
                 ],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2293,6 +2337,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1669075200,
               secondaryDim: {
                 materializedPartitions: ['OH', 'NC', 'FL'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2305,6 +2350,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1669161600,
               secondaryDim: {
                 materializedPartitions: ['OH', 'NC', 'FL', 'SC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2317,6 +2363,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1669248000,
               secondaryDim: {
                 materializedPartitions: ['OH', 'NC', 'PA', 'SC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2329,6 +2376,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1669334400,
               secondaryDim: {
                 materializedPartitions: ['FL', 'PA', 'SC', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2341,6 +2389,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1669420800,
               secondaryDim: {
                 materializedPartitions: ['OH', 'NC', 'FL', 'SC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2353,6 +2402,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1669507200,
               secondaryDim: {
                 materializedPartitions: ['FL', 'PA', 'SC', 'OH', 'NC'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2365,6 +2415,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1673481600,
               secondaryDim: {
                 materializedPartitions: ['WV'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2377,6 +2428,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1673827200,
               secondaryDim: {
                 materializedPartitions: ['IL', 'WV'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2389,6 +2441,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1674086400,
               secondaryDim: {
                 materializedPartitions: ['IL', 'WV'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2413,6 +2466,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
                   'NC',
                   'KY',
                 ],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },
@@ -2425,6 +2479,7 @@ export const MultiDimensionTimeSecondPartitionHealthQuery: MockedResponse<Partit
               primaryDimEndTime: 1675123200,
               secondaryDim: {
                 materializedPartitions: ['WV'],
+                materializingPartitions: [],
                 failedPartitions: [],
                 __typename: 'DefaultPartitions',
               },

--- a/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -6,6 +6,7 @@ import {MemoryRouter, Route} from 'react-router-dom';
 
 import {AssetKeyInput} from '../../graphql/types';
 import {AssetPartitionListProps} from '../AssetPartitionList';
+import {AssetPartitionStatus} from '../AssetPartitionStatus';
 import {AssetPartitions} from '../AssetPartitions';
 import {AssetViewParams} from '../AssetView';
 import {
@@ -87,7 +88,7 @@ describe('AssetPartitions', () => {
     });
     await waitFor(() => {
       expect(screen.getByText('Missing (135)')).toBeVisible();
-      expect(screen.getByText('Completed (15)')).toBeVisible();
+      expect(screen.getByText('Materialized (15)')).toBeVisible();
     });
     await waitFor(() => {
       // Verify that the items shown on the left update to reflect the subrange
@@ -124,18 +125,28 @@ describe('AssetPartitions', () => {
       expect(screen.getByTestId('partitions-selected')).toHaveTextContent('6,000 Partitions');
     });
 
-    const successCheck = screen.getByTestId('partition-state-success-checkbox');
+    const successCheck = screen.getByTestId(
+      `partition-status-${AssetPartitionStatus.MATERIALIZED}-checkbox`,
+    );
     await userEvent.click(successCheck);
-    expect(screen.getByTestId('router-search')).toHaveTextContent('states=failure%2Cmissing');
+    expect(screen.getByTestId('router-search')).toHaveTextContent(
+      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MISSING}`,
+    );
     expect(screen.getByTestId('partitions-selected')).toHaveTextContent('5,310 Partitions');
 
-    const missingCheck = screen.getByTestId('partition-state-missing-checkbox');
+    const missingCheck = screen.getByTestId(
+      `partition-status-${AssetPartitionStatus.MISSING}-checkbox`,
+    );
     await userEvent.click(missingCheck);
-    expect(screen.getByTestId('router-search')).toHaveTextContent('states=failure');
+    expect(screen.getByTestId('router-search')).toHaveTextContent(
+      `status=${AssetPartitionStatus.FAILED}`,
+    );
     expect(screen.getByTestId('partitions-selected')).toHaveTextContent('22 Partitions Selected');
 
     await userEvent.click(successCheck);
-    expect(screen.getByTestId('router-search')).toHaveTextContent('states=failure%2Csuccess');
+    expect(screen.getByTestId('router-search')).toHaveTextContent(
+      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZED}`,
+    );
     expect(screen.getByTestId('partitions-selected')).toHaveTextContent('712 Partitions Selected');
 
     // verify that filtering by state updates the left sidebar

--- a/js_modules/dagit/packages/core/src/assets/__tests__/MultipartitioningSupport.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/MultipartitioningSupport.test.tsx
@@ -1,60 +1,7 @@
-import {PartitionState} from '../../partitions/PartitionStatus';
-import {mergedRanges, mergedStates} from '../MultipartitioningSupport';
+import {mergedRanges} from '../MultipartitioningSupport';
 import {AssetPartitionStatus, Range} from '../usePartitionHealthData';
 
 describe('multipartitioning support', () => {
-  describe('mergedStates', () => {
-    it('returns SUCCESS_MISSING if SUCCESS and MISSING are both present', () => {
-      expect(
-        mergedStates([
-          AssetPartitionStatus.MATERIALIZED,
-          AssetPartitionStatus.MISSING,
-          AssetPartitionStatus.MISSING,
-        ]),
-      ).toEqual(AssetPartitionStatus.MATERIALIZED_MISSING);
-    });
-
-    it('returns SUCCESS_MISSING if SUCCESS_MISSING is present', () => {
-      expect(
-        mergedStates([
-          AssetPartitionStatus.MATERIALIZED_MISSING,
-          AssetPartitionStatus.MISSING,
-          AssetPartitionStatus.MISSING,
-        ]),
-      ).toEqual(AssetPartitionStatus.MATERIALIZED_MISSING);
-    });
-
-    it('returns SUCCESS if all states are success', () => {
-      expect(
-        mergedStates([
-          AssetPartitionStatus.MATERIALIZED,
-          AssetPartitionStatus.MATERIALIZED,
-          AssetPartitionStatus.MATERIALIZED,
-        ]),
-      ).toEqual(AssetPartitionStatus.MATERIALIZED);
-    });
-
-    it('returns MISSING if all states are missing', () => {
-      expect(
-        mergedStates([
-          AssetPartitionStatus.MISSING,
-          AssetPartitionStatus.MISSING,
-          AssetPartitionStatus.MISSING,
-        ]),
-      ).toEqual(AssetPartitionStatus.MISSING);
-    });
-    it('should not modify the input data', () => {
-      const input = [
-        AssetPartitionStatus.MATERIALIZED_MISSING,
-        AssetPartitionStatus.MISSING,
-        AssetPartitionStatus.MISSING,
-      ];
-      const before = JSON.stringify({input});
-      mergedStates(input);
-      expect(JSON.stringify({input})).toEqual(before);
-    });
-  });
-
   describe('mergedRanges', () => {
     const KEYS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
     const A_I: Range = {

--- a/js_modules/dagit/packages/core/src/assets/__tests__/MultipartitioningSupport.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/MultipartitioningSupport.test.tsx
@@ -1,41 +1,53 @@
 import {PartitionState} from '../../partitions/PartitionStatus';
 import {mergedRanges, mergedStates} from '../MultipartitioningSupport';
-import {Range} from '../usePartitionHealthData';
+import {AssetPartitionStatus, Range} from '../usePartitionHealthData';
 
 describe('multipartitioning support', () => {
   describe('mergedStates', () => {
     it('returns SUCCESS_MISSING if SUCCESS and MISSING are both present', () => {
       expect(
-        mergedStates([PartitionState.SUCCESS, PartitionState.MISSING, PartitionState.MISSING]),
-      ).toEqual(PartitionState.SUCCESS_MISSING);
+        mergedStates([
+          AssetPartitionStatus.MATERIALIZED,
+          AssetPartitionStatus.MISSING,
+          AssetPartitionStatus.MISSING,
+        ]),
+      ).toEqual(AssetPartitionStatus.MATERIALIZED_MISSING);
     });
 
     it('returns SUCCESS_MISSING if SUCCESS_MISSING is present', () => {
       expect(
         mergedStates([
-          PartitionState.SUCCESS_MISSING,
-          PartitionState.MISSING,
-          PartitionState.MISSING,
+          AssetPartitionStatus.MATERIALIZED_MISSING,
+          AssetPartitionStatus.MISSING,
+          AssetPartitionStatus.MISSING,
         ]),
-      ).toEqual(PartitionState.SUCCESS_MISSING);
+      ).toEqual(AssetPartitionStatus.MATERIALIZED_MISSING);
     });
 
     it('returns SUCCESS if all states are success', () => {
       expect(
-        mergedStates([PartitionState.SUCCESS, PartitionState.SUCCESS, PartitionState.SUCCESS]),
-      ).toEqual(PartitionState.SUCCESS);
+        mergedStates([
+          AssetPartitionStatus.MATERIALIZED,
+          AssetPartitionStatus.MATERIALIZED,
+          AssetPartitionStatus.MATERIALIZED,
+        ]),
+      ).toEqual(AssetPartitionStatus.MATERIALIZED);
     });
 
     it('returns MISSING if all states are missing', () => {
       expect(
-        mergedStates([PartitionState.MISSING, PartitionState.MISSING, PartitionState.MISSING]),
-      ).toEqual(PartitionState.MISSING);
+        mergedStates([
+          AssetPartitionStatus.MISSING,
+          AssetPartitionStatus.MISSING,
+          AssetPartitionStatus.MISSING,
+        ]),
+      ).toEqual(AssetPartitionStatus.MISSING);
     });
     it('should not modify the input data', () => {
       const input = [
-        PartitionState.SUCCESS_MISSING,
-        PartitionState.MISSING,
-        PartitionState.MISSING,
+        AssetPartitionStatus.MATERIALIZED_MISSING,
+        AssetPartitionStatus.MISSING,
+        AssetPartitionStatus.MISSING,
       ];
       const before = JSON.stringify({input});
       mergedStates(input);
@@ -48,21 +60,21 @@ describe('multipartitioning support', () => {
     const A_I: Range = {
       start: {idx: 0, key: 'A'},
       end: {idx: 8, key: 'I'},
-      value: PartitionState.SUCCESS,
+      value: AssetPartitionStatus.MATERIALIZED,
     };
     const A_I_Partial: Range = {
       ...A_I,
-      value: PartitionState.SUCCESS_MISSING,
+      value: AssetPartitionStatus.MATERIALIZED_MISSING,
     };
     const B_E: Range = {
       start: {idx: 1, key: 'B'},
       end: {idx: 4, key: 'E'},
-      value: PartitionState.SUCCESS,
+      value: AssetPartitionStatus.MATERIALIZED,
     };
     const G_I: Range = {
       start: {idx: 6, key: 'G'},
       end: {idx: 8, key: 'I'},
-      value: PartitionState.SUCCESS,
+      value: AssetPartitionStatus.MATERIALIZED,
     };
 
     it('merges two [A...I] range set into one [A...I] range set', () => {
@@ -88,17 +100,17 @@ describe('multipartitioning support', () => {
         {
           start: {idx: 0, key: 'A'},
           end: {idx: 0, key: 'A'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
         {
           start: {idx: 1, key: 'B'},
           end: {idx: 4, key: 'E'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {idx: 5, key: 'F'},
           end: {idx: 8, key: 'I'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
       ]);
     });
@@ -108,22 +120,22 @@ describe('multipartitioning support', () => {
         {
           start: {idx: 0, key: 'A'},
           end: {idx: 0, key: 'A'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
         {
           start: {idx: 1, key: 'B'},
           end: {idx: 4, key: 'E'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {idx: 5, key: 'F'},
           end: {idx: 5, key: 'F'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
         {
           start: {idx: 6, key: 'G'},
           end: {idx: 8, key: 'I'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
     });

--- a/js_modules/dagit/packages/core/src/assets/__tests__/MultipartitioningSupport.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/MultipartitioningSupport.test.tsx
@@ -1,5 +1,6 @@
+import {AssetPartitionStatus} from '../AssetPartitionStatus';
 import {mergedRanges} from '../MultipartitioningSupport';
-import {AssetPartitionStatus, Range} from '../usePartitionHealthData';
+import {Range} from '../usePartitionHealthData';
 
 describe('multipartitioning support', () => {
   describe('mergedRanges', () => {
@@ -7,21 +8,21 @@ describe('multipartitioning support', () => {
     const A_I: Range = {
       start: {idx: 0, key: 'A'},
       end: {idx: 8, key: 'I'},
-      value: AssetPartitionStatus.MATERIALIZED,
+      value: [AssetPartitionStatus.MATERIALIZED],
     };
     const A_I_Partial: Range = {
       ...A_I,
-      value: AssetPartitionStatus.MATERIALIZED_MISSING,
+      value: [AssetPartitionStatus.MATERIALIZED, AssetPartitionStatus.MISSING],
     };
     const B_E: Range = {
       start: {idx: 1, key: 'B'},
       end: {idx: 4, key: 'E'},
-      value: AssetPartitionStatus.MATERIALIZED,
+      value: [AssetPartitionStatus.MATERIALIZED],
     };
     const G_I: Range = {
       start: {idx: 6, key: 'G'},
       end: {idx: 8, key: 'I'},
-      value: AssetPartitionStatus.MATERIALIZED,
+      value: [AssetPartitionStatus.MATERIALIZED],
     };
 
     it('merges two [A...I] range set into one [A...I] range set', () => {
@@ -47,17 +48,17 @@ describe('multipartitioning support', () => {
         {
           start: {idx: 0, key: 'A'},
           end: {idx: 0, key: 'A'},
-          value: AssetPartitionStatus.MATERIALIZED_MISSING,
+          value: [AssetPartitionStatus.MATERIALIZED, AssetPartitionStatus.MISSING],
         },
         {
           start: {idx: 1, key: 'B'},
           end: {idx: 4, key: 'E'},
-          value: AssetPartitionStatus.MATERIALIZED,
+          value: [AssetPartitionStatus.MATERIALIZED],
         },
         {
           start: {idx: 5, key: 'F'},
           end: {idx: 8, key: 'I'},
-          value: AssetPartitionStatus.MATERIALIZED_MISSING,
+          value: [AssetPartitionStatus.MATERIALIZED, AssetPartitionStatus.MISSING],
         },
       ]);
     });
@@ -67,22 +68,22 @@ describe('multipartitioning support', () => {
         {
           start: {idx: 0, key: 'A'},
           end: {idx: 0, key: 'A'},
-          value: AssetPartitionStatus.MATERIALIZED_MISSING,
+          value: [AssetPartitionStatus.MATERIALIZED, AssetPartitionStatus.MISSING],
         },
         {
           start: {idx: 1, key: 'B'},
           end: {idx: 4, key: 'E'},
-          value: AssetPartitionStatus.MATERIALIZED,
+          value: [AssetPartitionStatus.MATERIALIZED],
         },
         {
           start: {idx: 5, key: 'F'},
           end: {idx: 5, key: 'F'},
-          value: AssetPartitionStatus.MATERIALIZED_MISSING,
+          value: [AssetPartitionStatus.MATERIALIZED, AssetPartitionStatus.MISSING],
         },
         {
           start: {idx: 6, key: 'G'},
           end: {idx: 8, key: 'I'},
-          value: AssetPartitionStatus.MATERIALIZED,
+          value: [AssetPartitionStatus.MATERIALIZED],
         },
       ]);
     });

--- a/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -14,6 +14,7 @@ import {
   PartitionDimensionSelection,
   keyCountInRanges,
   keyCountInSelection,
+  AssetPartitionStatus,
 } from '../usePartitionHealthData';
 
 const {SUCCESS, MISSING, FAILURE} = PartitionState;
@@ -272,12 +273,12 @@ describe('usePartitionHealthData', () => {
         {
           start: {idx: 3, key: '2022-01-04'},
           end: {idx: 4, key: '2022-01-05'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {idx: 4, key: '2022-01-05'},
           end: {idx: 5, key: '2022-01-06'},
-          value: PartitionState.FAILURE,
+          value: AssetPartitionStatus.FAILED,
         },
       ]);
 
@@ -313,17 +314,17 @@ describe('usePartitionHealthData', () => {
         {
           start: {idx: 0, key: '2022-01-01'},
           end: {idx: 2, key: '2022-01-03'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
         {
           start: {idx: 3, key: '2022-01-04'},
           end: {idx: 3, key: '2022-01-04'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {idx: 4, key: '2022-01-05'},
           end: {idx: 5, key: '2022-01-06'},
-          value: PartitionState.FAILURE,
+          value: AssetPartitionStatus.FAILED,
         },
       ]);
 
@@ -339,7 +340,7 @@ describe('usePartitionHealthData', () => {
         {
           start: {idx: 0, key: '2022-01-01'},
           end: {idx: 5, key: '2022-01-06'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
 
@@ -355,22 +356,22 @@ describe('usePartitionHealthData', () => {
         {
           start: {idx: 0, key: '2022-01-01'},
           end: {idx: 0, key: '2022-01-01'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {idx: 1, key: '2022-01-02'},
           end: {idx: 2, key: '2022-01-03'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
         {
           start: {idx: 3, key: '2022-01-04'},
           end: {idx: 3, key: '2022-01-04'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {idx: 4, key: '2022-01-05'},
           end: {idx: 5, key: '2022-01-06'},
-          value: PartitionState.FAILURE,
+          value: AssetPartitionStatus.FAILED,
         },
       ]);
 
@@ -382,17 +383,17 @@ describe('usePartitionHealthData', () => {
         {
           start: {idx: 0, key: 'TN'},
           end: {idx: 1, key: 'CA'},
-          value: PartitionState.SUCCESS_MISSING,
+          value: AssetPartitionStatus.MATERIALIZED_MISSING,
         },
         {
           start: {idx: 2, key: 'VA'},
           end: {idx: 3, key: 'NY'},
-          value: PartitionState.FAILURE,
+          value: AssetPartitionStatus.FAILED,
         },
         {
           start: {idx: 4, key: 'MN'},
           end: {idx: 4, key: 'MN'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
 
@@ -408,7 +409,7 @@ describe('usePartitionHealthData', () => {
         {
           start: {idx: 3, key: 'NY'},
           end: {idx: 4, key: 'MN'},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
 
@@ -472,27 +473,27 @@ const KEYS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
 const A_F: Range = {
   start: {idx: 0, key: 'A'},
   end: {idx: 5, key: 'F'},
-  value: PartitionState.SUCCESS,
+  value: AssetPartitionStatus.MATERIALIZED,
 };
 const A_C: Range = {
   start: {idx: 0, key: 'A'},
   end: {key: 'C', idx: 2},
-  value: PartitionState.SUCCESS,
+  value: AssetPartitionStatus.MATERIALIZED,
 };
 const A_I: Range = {
   start: {idx: 0, key: 'A'},
   end: {idx: 8, key: 'I'},
-  value: PartitionState.SUCCESS,
+  value: AssetPartitionStatus.MATERIALIZED,
 };
 const B_E: Range = {
   start: {idx: 1, key: 'B'},
   end: {idx: 4, key: 'E'},
-  value: PartitionState.SUCCESS,
+  value: AssetPartitionStatus.MATERIALIZED,
 };
 const G_I: Range = {
   start: {idx: 6, key: 'G'},
   end: {idx: 8, key: 'I'},
-  value: PartitionState.SUCCESS,
+  value: AssetPartitionStatus.MATERIALIZED,
 };
 
 const SEL_A_C: PartitionDimensionSelectionRange = [
@@ -519,16 +520,20 @@ const SEL_G_G: PartitionDimensionSelectionRange = [
 describe('usePartitionHealthData utilities', () => {
   describe('partitionStatusGivenRanges', () => {
     it('should return SUCCESS if the ranges span the total key count', () => {
-      expect(partitionStatusGivenRanges([A_I], KEYS.length)).toEqual(PartitionState.SUCCESS);
-      expect(partitionStatusGivenRanges([A_F, G_I], KEYS.length)).toEqual(PartitionState.SUCCESS);
+      expect(partitionStatusGivenRanges([A_I], KEYS.length)).toEqual(
+        AssetPartitionStatus.MATERIALIZED,
+      );
+      expect(partitionStatusGivenRanges([A_F, G_I], KEYS.length)).toEqual(
+        AssetPartitionStatus.MATERIALIZED,
+      );
     });
 
     it('should return SUCCESS_MISSING if the ranges are not empty', () => {
       expect(partitionStatusGivenRanges([A_F], KEYS.length)).toEqual(
-        PartitionState.SUCCESS_MISSING,
+        AssetPartitionStatus.MATERIALIZED_MISSING,
       );
       expect(partitionStatusGivenRanges([G_I], KEYS.length)).toEqual(
-        PartitionState.SUCCESS_MISSING,
+        AssetPartitionStatus.MATERIALIZED_MISSING,
       );
     });
 
@@ -543,7 +548,7 @@ describe('usePartitionHealthData utilities', () => {
         {
           start: {key: 'C', idx: 2},
           end: {key: 'D', idx: 3},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
     });
@@ -553,7 +558,7 @@ describe('usePartitionHealthData utilities', () => {
         {
           start: {key: 'B', idx: 1},
           end: {key: 'D', idx: 3},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
     });
@@ -563,12 +568,12 @@ describe('usePartitionHealthData utilities', () => {
         {
           start: {key: 'B', idx: 1},
           end: {key: 'C', idx: 2},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
         {
           start: {key: 'E', idx: 4},
           end: {key: 'E', idx: 4},
-          value: PartitionState.SUCCESS,
+          value: AssetPartitionStatus.MATERIALIZED,
         },
       ]);
     });
@@ -617,7 +622,11 @@ describe('usePartitionHealthData utilities', () => {
       expect(rangesForKeys(['B', 'C', 'D', 'E'], KEYS)).toEqual([B_E]);
       expect(rangesForKeys(['A', 'B', 'C', 'G', 'H', 'I'], KEYS)).toEqual([A_C, G_I]);
       expect(rangesForKeys(['G'], KEYS)).toEqual([
-        {start: {idx: 6, key: 'G'}, end: {idx: 6, key: 'G'}, value: PartitionState.SUCCESS},
+        {
+          start: {idx: 6, key: 'G'},
+          end: {idx: 6, key: 'G'},
+          value: AssetPartitionStatus.MATERIALIZED,
+        },
       ]);
     });
     it('should return no ranges if no keys are provided', () => {
@@ -627,8 +636,8 @@ describe('usePartitionHealthData utilities', () => {
 
   describe('partitionStateAtIndex', () => {
     it('should return range.value if the index is within one of the ranges, missing otherwise', () => {
-      expect(partitionStateAtIndex([A_C, G_I], 0)).toEqual(PartitionState.SUCCESS);
-      expect(partitionStateAtIndex([A_C, G_I], 6)).toEqual(PartitionState.SUCCESS);
+      expect(partitionStateAtIndex([A_C, G_I], 0)).toEqual(AssetPartitionStatus.MATERIALIZED);
+      expect(partitionStateAtIndex([A_C, G_I], 6)).toEqual(AssetPartitionStatus.MATERIALIZED);
       expect(partitionStateAtIndex([A_C, G_I], 3)).toEqual(PartitionState.MISSING);
       expect(partitionStateAtIndex([A_C, G_I], -1)).toEqual(PartitionState.MISSING);
       expect(partitionStateAtIndex([A_C, G_I], 100)).toEqual(PartitionState.MISSING);
@@ -641,12 +650,12 @@ describe('usePartitionHealthData utilities', () => {
             {
               start: {idx: 0, key: 'A'},
               end: {idx: 8, key: 'G'},
-              value: PartitionState.SUCCESS_MISSING,
+              value: AssetPartitionStatus.MATERIALIZED_MISSING,
             },
           ],
           2,
         ),
-      ).toEqual(PartitionState.SUCCESS_MISSING);
+      ).toEqual(AssetPartitionStatus.MATERIALIZED_MISSING);
     });
   });
 

--- a/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -7,7 +7,7 @@ import {
   partitionStatusGivenRanges,
   rangeClippedToSelection,
   rangesForKeys,
-  partitionStateAtIndex,
+  partitionStatusAtIndex,
   keyCountByStateInSelection,
   PartitionHealthDimension,
   PartitionDimensionSelection,
@@ -642,18 +642,18 @@ describe('usePartitionHealthData utilities', () => {
     });
   });
 
-  describe('partitionStateAtIndex', () => {
+  describe('partitionStatusAtIndex', () => {
     it('should return range.value if the index is within one of the ranges, missing otherwise', () => {
-      expect(partitionStateAtIndex([A_C, G_I], 0)).toEqual(AssetPartitionStatus.MATERIALIZED);
-      expect(partitionStateAtIndex([A_C, G_I], 6)).toEqual(AssetPartitionStatus.MATERIALIZED);
-      expect(partitionStateAtIndex([A_C, G_I], 3)).toEqual(AssetPartitionStatus.MISSING);
-      expect(partitionStateAtIndex([A_C, G_I], -1)).toEqual(AssetPartitionStatus.MISSING);
-      expect(partitionStateAtIndex([A_C, G_I], 100)).toEqual(AssetPartitionStatus.MISSING);
-      expect(partitionStateAtIndex([], 3)).toEqual(AssetPartitionStatus.MISSING);
-      expect(partitionStateAtIndex([], -1)).toEqual(AssetPartitionStatus.MISSING);
-      expect(partitionStateAtIndex([], 100)).toEqual(AssetPartitionStatus.MISSING);
+      expect(partitionStatusAtIndex([A_C, G_I], 0)).toEqual(AssetPartitionStatus.MATERIALIZED);
+      expect(partitionStatusAtIndex([A_C, G_I], 6)).toEqual(AssetPartitionStatus.MATERIALIZED);
+      expect(partitionStatusAtIndex([A_C, G_I], 3)).toEqual(AssetPartitionStatus.MISSING);
+      expect(partitionStatusAtIndex([A_C, G_I], -1)).toEqual(AssetPartitionStatus.MISSING);
+      expect(partitionStatusAtIndex([A_C, G_I], 100)).toEqual(AssetPartitionStatus.MISSING);
+      expect(partitionStatusAtIndex([], 3)).toEqual(AssetPartitionStatus.MISSING);
+      expect(partitionStatusAtIndex([], -1)).toEqual(AssetPartitionStatus.MISSING);
+      expect(partitionStatusAtIndex([], 100)).toEqual(AssetPartitionStatus.MISSING);
       expect(
-        partitionStateAtIndex(
+        partitionStatusAtIndex(
           [
             {
               start: {idx: 0, key: 'A'},

--- a/js_modules/dagit/packages/core/src/assets/types/usePartitionHealthData.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/usePartitionHealthData.types.ts
@@ -22,6 +22,7 @@ export type PartitionHealthQuery = {
           | {
               __typename: 'DefaultPartitions';
               materializedPartitions: Array<string>;
+              materializingPartitions: Array<string>;
               failedPartitions: Array<string>;
             }
           | {
@@ -37,6 +38,7 @@ export type PartitionHealthQuery = {
                   | {
                       __typename: 'DefaultPartitions';
                       materializedPartitions: Array<string>;
+                      materializingPartitions: Array<string>;
                       failedPartitions: Array<string>;
                     }
                   | {

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -52,6 +52,17 @@ export interface PartitionHealthData {
   ) => Range[];
 }
 
+export interface PartitionHealthDataMerged {
+  dimensions: PartitionHealthDimension[];
+
+  stateForKey: (dimensionKeys: string[]) => AssetPartitionStatus[];
+
+  rangesForSingleDimension: (
+    dimensionIdx: number,
+    otherDimensionSelectedRanges?: PartitionDimensionSelectionRange[] | undefined,
+  ) => Range[];
+}
+
 export interface PartitionHealthDimension {
   name: string;
   type: PartitionDefinitionType;
@@ -80,6 +91,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
     __typename: 'DefaultPartitions',
     unmaterializedPartitions: [],
     materializedPartitions: [],
+    materializingPartitions: [],
     failedPartitions: [],
   };
 
@@ -118,12 +130,12 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       return AssetPartitionStatus.MISSING;
     }
     if (!d0Range.subranges || dIndexes.length === 1) {
-      return d0Range.value; // 1D case
+      return d0Range.value[0]; // 1D case
     }
     const d1Range = d0Range.subranges.find(
       (r) => r.start.idx <= dIndexes[1] && r.end.idx >= dIndexes[1],
     );
-    return d1Range ? d1Range.value : AssetPartitionStatus.MISSING;
+    return d1Range ? d1Range.value[0] : AssetPartitionStatus.MISSING;
   };
 
   const rangesForSingleDimension = (
@@ -161,7 +173,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
             subranges,
           };
         })
-        .filter((range) => range.value !== AssetPartitionStatus.MISSING) as Range[];
+        .filter((range) => !isEqual(range.value, AssetPartitionStatus.MISSING)) as Range[];
       return removeSubrangesAndJoin(clipped);
     } else {
       const [d0, d1] = dimensions;
@@ -208,7 +220,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
 export type Range = {
   start: {key: string; idx: number};
   end: {key: string; idx: number};
-  value: AssetPartitionStatus;
+  value: AssetPartitionStatus[];
   subranges?: Range[];
 };
 
@@ -219,19 +231,28 @@ export type Range = {
  */
 export function partitionStatusGivenRanges(ranges: Range[], totalKeyCount: number) {
   const successCount = keyCountInRanges(
-    ranges.filter((r) => r.value === AssetPartitionStatus.MATERIALIZED),
+    ranges.filter((r) => r.value.includes(AssetPartitionStatus.MATERIALIZED)),
+  );
+  const materializingCount = keyCountInRanges(
+    ranges.filter((r) => r.value.includes(AssetPartitionStatus.MATERIALIZING)),
   );
   const failedCount = keyCountInRanges(
-    ranges.filter((r) => r.value === AssetPartitionStatus.FAILED),
+    ranges.filter((r) => r.value.includes(AssetPartitionStatus.FAILED)),
   );
-
-  return successCount === totalKeyCount
-    ? AssetPartitionStatus.MATERIALIZED
-    : failedCount > 0
-    ? AssetPartitionStatus.FAILED
-    : successCount > 0
-    ? AssetPartitionStatus.MATERIALIZED_MISSING
-    : AssetPartitionStatus.MISSING;
+  const statuses: AssetPartitionStatus[] = [];
+  if (successCount > 0) {
+    statuses.push(AssetPartitionStatus.MATERIALIZED);
+  }
+  if (failedCount > 0) {
+    statuses.push(AssetPartitionStatus.FAILED);
+  }
+  if (materializingCount > 0) {
+    statuses.push(AssetPartitionStatus.MATERIALIZING);
+  }
+  if (successCount + failedCount + materializingCount < totalKeyCount) {
+    statuses.push(AssetPartitionStatus.MISSING);
+  }
+  return statuses;
 }
 
 /**
@@ -317,6 +338,7 @@ export function keyCountByStateInSelection(
     return {
       [AssetPartitionStatus.MISSING]: 0,
       [AssetPartitionStatus.MATERIALIZED]: 0,
+      [AssetPartitionStatus.MATERIALIZING]: 0,
       [AssetPartitionStatus.FAILED]: 0,
     };
   }
@@ -344,11 +366,11 @@ export function keyCountByStateInSelection(
         (b.end.idx - b.start.idx + 1) *
           (b.subranges
             ? keyCountInRanges(
-                rangesClippedToSelection(b.subranges, selections[1].selectedRanges).filter(
-                  (b) => b.value === status,
+                rangesClippedToSelection(b.subranges, selections[1].selectedRanges).filter((b) =>
+                  b.value.includes(status),
                 ),
               )
-            : b.value === status
+            : b.value.includes(status)
             ? secondDimensionKeyCount
             : 0),
       0,
@@ -356,39 +378,44 @@ export function keyCountByStateInSelection(
   };
 
   const failed = sumWithStatus(AssetPartitionStatus.FAILED);
+  const materializing = sumWithStatus(AssetPartitionStatus.MATERIALIZING);
   const success = sumWithStatus(AssetPartitionStatus.MATERIALIZED);
 
   return {
-    [AssetPartitionStatus.MISSING]: total - success - failed,
+    [AssetPartitionStatus.MISSING]: total - success - failed - materializing,
     [AssetPartitionStatus.MATERIALIZED]: success,
+    [AssetPartitionStatus.MATERIALIZING]: materializing,
     [AssetPartitionStatus.FAILED]: failed,
   };
 }
 
 // Given a set of ranges representing materialization status across the key space,
-// find the range containing the given key and reutnr it's state, or MISSING.
+// find the range containing the given key and return it's state, or MISSING.
 //
 export function partitionStateAtIndex(ranges: Range[], idx: number) {
   return (
-    ranges.find((r) => r.start.idx <= idx && r.end.idx >= idx)?.value ||
-    AssetPartitionStatus.MISSING
+    ranges.find((r) => r.start.idx <= idx && r.end.idx >= idx)?.value || [
+      AssetPartitionStatus.MISSING,
+    ]
   );
 }
 
 function addKeyIndexesToMaterializedRanges(
   dimensions: {name: string; partitionKeys: string[]}[],
-  materializedPartitions: PartitionHealthMaterializedPartitions,
+  partitions: PartitionHealthMaterializedPartitions,
 ) {
   const result: Range[] = [];
   if (dimensions.length === 0) {
     return result;
   }
-  if (materializedPartitions.__typename === 'DefaultPartitions') {
+  if (partitions.__typename === 'DefaultPartitions') {
     const dim = dimensions[0];
     const spans = assembleIntoSpans(dim.partitionKeys, (key) =>
-      materializedPartitions.materializedPartitions.includes(key)
+      partitions.materializedPartitions.includes(key)
         ? AssetPartitionStatus.MATERIALIZED
-        : materializedPartitions.failedPartitions.includes(key)
+        : partitions.materializingPartitions.includes(key)
+        ? AssetPartitionStatus.MATERIALIZING
+        : partitions.failedPartitions.includes(key)
         ? AssetPartitionStatus.FAILED
         : AssetPartitionStatus.MISSING,
     );
@@ -397,17 +424,17 @@ function addKeyIndexesToMaterializedRanges(
         ({
           start: {key: dim.partitionKeys[s.startIdx], idx: s.startIdx},
           end: {key: dim.partitionKeys[s.endIdx], idx: s.endIdx},
-          value: s.status,
+          value: [s.status as AssetPartitionStatus],
         } as Range),
     );
   }
 
-  for (const range of materializedPartitions.ranges) {
+  for (const range of partitions.ranges) {
     if (range.__typename === 'TimePartitionRange') {
       result.push({
         start: {key: range.startKey, idx: dimensions[0].partitionKeys.indexOf(range.startKey)},
         end: {key: range.endKey, idx: dimensions[0].partitionKeys.indexOf(range.endKey)},
-        value: rangeStatusToState(range.status),
+        value: [rangeStatusToState(range.status)],
       });
     } else if (range.__typename === 'MaterializedPartitionRange2D') {
       if (dimensions.length !== 2) {
@@ -417,7 +444,7 @@ function addKeyIndexesToMaterializedRanges(
       const [dim0, dim1] = dimensions;
       const subranges: Range[] = addKeyIndexesToMaterializedRanges([dim1], range.secondaryDim);
       const value = partitionStatusGivenRanges(subranges, dim1.partitionKeys.length);
-      if (value === AssetPartitionStatus.MISSING) {
+      if (isEqual(value, [AssetPartitionStatus.MISSING])) {
         continue; // should not happen, just for Typescript correctness
       }
       result.push({
@@ -451,7 +478,7 @@ export function rangesForKeys(keys: string[], allKeys: string[]): Range[] {
       {
         start: {key: allKeys[0], idx: 0},
         end: {key: allKeys[allKeys.length - 1], idx: allKeys.length - 1},
-        value: AssetPartitionStatus.MATERIALIZED as const,
+        value: [AssetPartitionStatus.MATERIALIZED],
       },
     ];
   }
@@ -470,7 +497,7 @@ export function rangesForKeys(keys: string[], allKeys: string[]): Range[] {
       ranges.push({
         start: {idx, key: allKeys[idx]},
         end: {idx, key: allKeys[idx]},
-        value: AssetPartitionStatus.MATERIALIZED,
+        value: [AssetPartitionStatus.MATERIALIZED],
       });
     }
   }
@@ -576,6 +603,7 @@ export const PARTITION_HEALTH_QUERY = gql`
           }
           ... on DefaultPartitions {
             materializedPartitions
+            materializingPartitions
             failedPartitions
           }
           ... on MultiPartitions {
@@ -597,6 +625,7 @@ export const PARTITION_HEALTH_QUERY = gql`
                 }
                 ... on DefaultPartitions {
                   materializedPartitions
+                  materializingPartitions
                   failedPartitions
                 }
               }

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -38,6 +38,21 @@ export enum AssetPartitionStatus {
   MISSING = 'MISSING',
 }
 
+export const assetPartitionStatusToText = (status: AssetPartitionStatus) => {
+  switch (status) {
+    case AssetPartitionStatus.MATERIALIZED:
+      return 'Materialized';
+    case AssetPartitionStatus.MATERIALIZING:
+      return 'Materializing';
+    case AssetPartitionStatus.FAILED:
+      return 'Failed';
+    case AssetPartitionStatus.MISSING:
+      return 'Missing';
+    default:
+      assertUnreachable(status);
+  }
+};
+
 export interface PartitionHealthData {
   assetKey: AssetKey;
   dimensions: PartitionHealthDimension[];

--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -145,6 +145,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
     if (isRangeDataInverted) {
       dimensionIdx = 1 - dimensionIdx;
     }
+
     if (dimensionIdx === 0 && !otherDimensionSelectedRanges) {
       return removeSubrangesAndJoin(ranges);
     } else if (dimensionIdx === 0 && otherDimensionSelectedRanges) {
@@ -301,6 +302,17 @@ function removeSubrangesAndJoin(ranges: Range[]): Range[] {
     }
   }
   return result;
+}
+
+export function selectionRangeWithSingleKey(
+  key: string,
+  dim: PartitionHealthDimension,
+): PartitionDimensionSelectionRange {
+  const idx = dim.partitionKeys.indexOf(key);
+  return [
+    {key, idx},
+    {key, idx},
+  ];
 }
 
 // In a follow-up, maybe we make these two data structures share a signature

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -271,9 +271,7 @@ const BackfillRunStatus = ({
   const health = React.useMemo(
     () => ({
       partitionStateForKey: (key: string) =>
-        statuses
-          ? runStatusToPartitionState(statuses.filter((s) => s.partitionName === key)[0]?.runStatus)
-          : PartitionState.MISSING,
+        statuses?.filter((s) => s.partitionName === key)[0]?.runStatus || RunStatus.NOT_STARTED,
     }),
     [statuses],
   );
@@ -424,7 +422,7 @@ const RequestedPartitionStatusBar = ({all, requested}: {all: string[]; requested
   const health = React.useMemo(
     () => ({
       partitionStateForKey: (key: string) =>
-        requested && requested.includes(key) ? PartitionState.QUEUED : PartitionState.MISSING,
+        requested && requested.includes(key) ? RunStatus.QUEUED : RunStatus.NOT_STARTED,
     }),
     [requested],
   );

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -257,7 +257,7 @@ const BackfillRunStatus = ({
   const partitionCounts = Object.entries(counts).reduce((partitionCounts, [runStatus, count]) => {
     partitionCounts[runStatus] = (partitionCounts[runStatus] || 0) + count;
     return partitionCounts;
-  }, {});
+  }, {} as {[status: string]: number});
 
   const health: PartitionStatusHealthSourceOps = React.useMemo(
     () => ({

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -10,11 +10,7 @@ import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {RunStatus, BulkActionStatus} from '../graphql/types';
-import {
-  PartitionState,
-  PartitionStatus,
-  runStatusToPartitionState,
-} from '../partitions/PartitionStatus';
+import {PartitionStatus, PartitionStatusHealthSourceOps} from '../partitions/PartitionStatus';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {AssetKeyTagCollection} from '../runs/AssetKeyTagCollection';
 import {inProgressStatuses} from '../runs/RunStatuses';
@@ -258,19 +254,14 @@ const BackfillRunStatus = ({
   counts: {[status: string]: number};
 }) => {
   const history = useHistory();
-
-  // Note: The backend reports a run status as the state of each partition, but
-  // Dagit doesn't consider all run statuses (eg: "Canceling") a valid partition state.
-  // Coerce the data from the backend into PartitionState, collapsing the counts.
   const partitionCounts = Object.entries(counts).reduce((partitionCounts, [runStatus, count]) => {
-    const key = runStatusToPartitionState(runStatus as RunStatus);
-    (partitionCounts as any)[key] = ((partitionCounts as any)[key] || 0) + count;
+    partitionCounts[runStatus] = (partitionCounts[runStatus] || 0) + count;
     return partitionCounts;
   }, {});
 
-  const health = React.useMemo(
+  const health: PartitionStatusHealthSourceOps = React.useMemo(
     () => ({
-      partitionStateForKey: (key: string) =>
+      runStatusForPartitionKey: (key: string) =>
         statuses?.filter((s) => s.partitionName === key)[0]?.runStatus || RunStatus.NOT_STARTED,
     }),
     [statuses],
@@ -290,9 +281,9 @@ const BackfillRunStatus = ({
     />
   ) : (
     <RunStatusTagsWithCounts
-      succeededCount={(partitionCounts as any)[PartitionState.SUCCESS]}
-      inProgressCount={(partitionCounts as any)[PartitionState.STARTED]}
-      failedCount={(partitionCounts as any)[PartitionState.FAILURE]}
+      succeededCount={partitionCounts[RunStatus.SUCCESS]}
+      inProgressCount={partitionCounts[RunStatus.STARTED]}
+      failedCount={partitionCounts[RunStatus.FAILURE]}
     />
   );
 };
@@ -419,9 +410,9 @@ const BackfillRequestedRange = ({
 };
 
 const RequestedPartitionStatusBar = ({all, requested}: {all: string[]; requested: string[]}) => {
-  const health = React.useMemo(
+  const health: PartitionStatusHealthSourceOps = React.useMemo(
     () => ({
-      partitionStateForKey: (key: string) =>
+      runStatusForPartitionKey: (key: string) =>
         requested && requested.includes(key) ? RunStatus.QUEUED : RunStatus.NOT_STARTED,
     }),
     [requested],

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -17,7 +17,7 @@ import {RepoAddress} from '../workspace/types';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {CountBox, usePartitionDurations} from './OpJobPartitionsView';
 import {PartitionGraph} from './PartitionGraph';
-import {PartitionState, PartitionStatus} from './PartitionStatus';
+import {PartitionStatus} from './PartitionStatus';
 import {getVisibleItemCount, PartitionPerAssetStatus} from './PartitionStepStatus';
 import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
 import {allPartitionsRange} from './SpanRepresentation';
@@ -53,7 +53,7 @@ export const AssetJobPartitionsView: React.FC<{
     return {
       merged,
       total: allKeys.length,
-      missing: allKeys.filter((p) => p.state === AssetPartitionStatus.MISSING).length,
+      missing: allKeys.filter((p) => p.state.includes(AssetPartitionStatus.MISSING)).length,
     };
   }, [assetHealth]);
 

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -2,13 +2,14 @@ import {Box, Button, Colors, Subheading, useViewport} from '@dagster-io/ui';
 import React from 'react';
 
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
+import {AssetPartitionStatus} from '../assets/AssetPartitionStatus';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
 import {
   mergedAssetHealth,
   explodePartitionKeysInSelection,
   isTimeseriesDimension,
 } from '../assets/MultipartitioningSupport';
-import {AssetPartitionStatus, usePartitionHealthData} from '../assets/usePartitionHealthData';
+import {usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {RepositorySelector} from '../graphql/types';
 import {DagsterTag} from '../runs/RunTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';

--- a/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/AssetJobPartitionsView.tsx
@@ -8,7 +8,7 @@ import {
   explodePartitionKeysInSelection,
   isTimeseriesDimension,
 } from '../assets/MultipartitioningSupport';
-import {usePartitionHealthData} from '../assets/usePartitionHealthData';
+import {AssetPartitionStatus, usePartitionHealthData} from '../assets/usePartitionHealthData';
 import {RepositorySelector} from '../graphql/types';
 import {DagsterTag} from '../runs/RunTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -53,7 +53,7 @@ export const AssetJobPartitionsView: React.FC<{
     return {
       merged,
       total: allKeys.length,
-      missing: allKeys.filter((p) => p.state === PartitionState.MISSING).length,
+      missing: allKeys.filter((p) => p.state === AssetPartitionStatus.MISSING).length,
     };
   }, [assetHealth]);
 

--- a/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/DimensionRangeWizard.tsx
@@ -13,9 +13,10 @@ import {
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {StateDot} from '../assets/AssetPartitionList';
-import {partitionStateAtIndex, Range} from '../assets/usePartitionHealthData';
+import {AssetPartitionStatusDot} from '../assets/AssetPartitionList';
+import {partitionStatusAtIndex} from '../assets/usePartitionHealthData';
 import {PartitionDefinitionType} from '../graphql/types';
+import {RunStatusDot} from '../runs/RunStatusDots';
 import {testId} from '../testing/testId';
 import {RepoAddress} from '../workspace/types';
 
@@ -138,13 +139,15 @@ const OrdinalPartitionSelector: React.FC<{
   isDynamic,
   health,
 }) => {
-  const statusForPartitionKey = React.useCallback(
+  const dotForPartitionKey = React.useCallback(
     (partitionKey: string) => {
       const index = allPartitions.indexOf(partitionKey);
       if ('ranges' in health) {
-        return partitionStateAtIndex(health.ranges as Range[], index);
+        return <AssetPartitionStatusDot status={partitionStatusAtIndex(health.ranges, index)} />;
       } else {
-        return health.partitionStateForKey(partitionKey, index);
+        return (
+          <RunStatusDot size={10} status={health.runStatusForPartitionKey(partitionKey, index)} />
+        );
       }
     },
     [allPartitions, health],
@@ -169,7 +172,7 @@ const OrdinalPartitionSelector: React.FC<{
                         checked={dropdownItemProps.selected}
                         onChange={dropdownItemProps.toggle}
                       />
-                      <StateDot state={statusForPartitionKey(tag)} />
+                      {dotForPartitionKey(tag)}
                       <span>{tag}</span>
                     </Box>
                   }
@@ -177,7 +180,7 @@ const OrdinalPartitionSelector: React.FC<{
               </label>
             );
           },
-          [statusForPartitionKey],
+          [dotForPartitionKey],
         )}
         renderDropdown={React.useCallback(
           (dropdown, {width, allTags}: TagSelectorDropdownProps) => {

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -13,7 +13,7 @@ import {BackfillPartitionSelector} from './BackfillSelector';
 import {JobBackfillsTable} from './JobBackfillsTable';
 import {PartitionGraph} from './PartitionGraph';
 import {PartitionState, PartitionStatus, runStatusToPartitionState} from './PartitionStatus';
-import {getVisibleItemCount, PartitionPerOpStatus} from './PartitionStepStatus';
+import {getVisibleItemCount} from './PartitionStepStatus';
 import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
 import {
   OpJobPartitionSetFragment,

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunStatusCheckboxes.tsx
@@ -6,7 +6,7 @@ import {runStatusToString} from '../runs/RunStatusTag';
 import {testId} from '../testing/testId';
 
 export function countsByState(partitionKeysForCounts: {partitionKey: string; state: RunStatus}[]) {
-  const result: {[state: string]: number} = {
+  const result: {[status: string]: number} = {
     [RunStatus.SUCCESS]: 0,
     [RunStatus.NOT_STARTED]: 0,
     [RunStatus.FAILURE]: 0,
@@ -20,7 +20,7 @@ export function countsByState(partitionKeysForCounts: {partitionKey: string; sta
 }
 
 export const PartitionRunStatusCheckboxes: React.FC<{
-  counts: {[state: string]: number};
+  counts: {[status: string]: number};
   value: RunStatus[];
   allowed: RunStatus[];
   onChange: (selected: RunStatus[]) => void;
@@ -28,16 +28,18 @@ export const PartitionRunStatusCheckboxes: React.FC<{
 }> = ({counts, value, onChange, allowed, disabled}) => {
   return (
     <Box flex={{direction: 'row', alignItems: 'center', gap: 12}} style={{overflow: 'hidden'}}>
-      {allowed.map((state) => (
+      {allowed.map((status) => (
         <Checkbox
-          key={state}
-          data-testid={testId(`partition-state-${state}-checkbox`)}
+          key={status}
+          data-testid={testId(`run-status-${status}-checkbox`)}
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
-          checked={value.includes(state) && !disabled}
-          label={`${runStatusToString(state)} (${counts[state]})`}
+          checked={value.includes(status) && !disabled}
+          label={`${runStatusToString(status)} (${counts[status]})`}
           onChange={() =>
-            onChange(value.includes(state) ? value.filter((v) => v !== state) : [...value, state])
+            onChange(
+              value.includes(status) ? value.filter((v) => v !== status) : [...value, status],
+            )
           }
         />
       ))}

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunStatusCheckboxes.tsx
@@ -1,20 +1,17 @@
 import {Box, Checkbox} from '@dagster-io/ui';
 import * as React from 'react';
 
+import {RunStatus} from '../graphql/types';
+import {runStatusToString} from '../runs/RunStatusTag';
 import {testId} from '../testing/testId';
 
-import {PartitionState, partitionStatusToText} from './PartitionStatus';
-
-export function countsByState(
-  partitionKeysForCounts: {partitionKey: string; state: PartitionState}[],
-) {
+export function countsByState(partitionKeysForCounts: {partitionKey: string; state: RunStatus}[]) {
   const result: {[state: string]: number} = {
-    [PartitionState.SUCCESS]: 0,
-    [PartitionState.SUCCESS_MISSING]: 0,
-    [PartitionState.MISSING]: 0,
-    [PartitionState.FAILURE]: 0,
-    [PartitionState.QUEUED]: 0,
-    [PartitionState.STARTED]: 0,
+    [RunStatus.SUCCESS]: 0,
+    [RunStatus.NOT_STARTED]: 0,
+    [RunStatus.FAILURE]: 0,
+    [RunStatus.QUEUED]: 0,
+    [RunStatus.STARTED]: 0,
   };
   for (const key of partitionKeysForCounts) {
     result[key.state] = (result[key.state] || 0) + 1;
@@ -22,11 +19,11 @@ export function countsByState(
   return result;
 }
 
-export const PartitionStateCheckboxes: React.FC<{
+export const PartitionRunStatusCheckboxes: React.FC<{
   counts: {[state: string]: number};
-  value: PartitionState[];
-  allowed: PartitionState[];
-  onChange: (selected: PartitionState[]) => void;
+  value: RunStatus[];
+  allowed: RunStatus[];
+  onChange: (selected: RunStatus[]) => void;
   disabled?: boolean;
 }> = ({counts, value, onChange, allowed, disabled}) => {
   return (
@@ -38,7 +35,7 @@ export const PartitionStateCheckboxes: React.FC<{
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
           checked={value.includes(state) && !disabled}
-          label={`${partitionStatusToText(state)} (${counts[state]})`}
+          label={`${runStatusToString(state)} (${counts[state]})`}
           onChange={() =>
             onChange(value.includes(state) ? value.filter((v) => v !== state) : [...value, state])
           }

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunStatusCheckboxes.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunStatusCheckboxes.tsx
@@ -2,7 +2,7 @@ import {Box, Checkbox} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {RunStatus} from '../graphql/types';
-import {runStatusToString} from '../runs/RunStatusTag';
+import {runStatusToBackfillStateString} from '../runs/RunStatusTag';
 import {testId} from '../testing/testId';
 
 export function countsByState(partitionKeysForCounts: {partitionKey: string; state: RunStatus}[]) {
@@ -35,7 +35,7 @@ export const PartitionRunStatusCheckboxes: React.FC<{
           disabled={disabled}
           style={{marginBottom: 0, marginLeft: 10, minWidth: 200}}
           checked={value.includes(status) && !disabled}
-          label={`${runStatusToString(status)} (${counts[status]})`}
+          label={`${runStatusToBackfillStateString(status)} (${counts[status]})`}
           onChange={() =>
             onChange(
               value.includes(status) ? value.filter((v) => v !== status) : [...value, status],

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -32,7 +32,7 @@ export enum PartitionState {
 export type PartitionStatusRange = {
   start: {idx: number; key: string};
   end: {idx: number; key: string};
-  value: AssetPartitionStatus;
+  value: AssetPartitionStatus[];
 };
 
 // This component can be wired up to assets, which provide partition status in terms
@@ -43,8 +43,8 @@ export type PartitionStatusRange = {
 // and assemble ranges by itself for display.
 //
 export type PartitionStatusHealthSource =
-  | {ranges: PartitionStatusRange[]}
-  | {partitionStateForKey: (partitionKey: string, partitionIdx: number) => PartitionState};
+  | {ranges: PartitionStatusRange[]} // assets
+  | {partitionStateForKey: (partitionKey: string, partitionIdx: number) => RunStatus};
 
 export const runStatusToPartitionState = (runStatus: RunStatus | null) => {
   switch (runStatus) {

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -2,6 +2,7 @@ import {Box, Tooltip, Colors, useViewport} from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
+import {AssetPartitionStatus} from '../assets/usePartitionHealthData';
 import {RunStatus} from '../graphql/types';
 
 import {assembleIntoSpans} from './SpanRepresentation';
@@ -31,7 +32,7 @@ export enum PartitionState {
 export type PartitionStatusRange = {
   start: {idx: number; key: string};
   end: {idx: number; key: string};
-  value: PartitionState;
+  value: AssetPartitionStatus;
 };
 
 // This component can be wired up to assets, which provide partition status in terms
@@ -401,7 +402,9 @@ function buildRangesFromStateFn(
   }));
 }
 
-export const partitionStateToStyle = (status: PartitionState): React.CSSProperties => {
+export const partitionStateToStyle = (
+  status: PartitionState | AssetPartitionStatus,
+): React.CSSProperties => {
   switch (status) {
     case PartitionState.SUCCESS:
       return {background: Colors.Green500};

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 import {
-  assetPartitionStatusesToStyle,
   assetPartitionStatusToText,
-  Range,
-} from '../assets/usePartitionHealthData';
+  assetPartitionStatusesToStyle,
+} from '../assets/AssetPartitionStatus';
+import {Range} from '../assets/usePartitionHealthData';
 import {RunStatus} from '../graphql/types';
 import {runStatusToString, RUN_STATUS_COLORS} from '../runs/RunStatusTag';
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStatus.tsx
@@ -8,7 +8,7 @@ import {
 } from '../assets/AssetPartitionStatus';
 import {Range} from '../assets/usePartitionHealthData';
 import {RunStatus} from '../graphql/types';
-import {runStatusToString, RUN_STATUS_COLORS} from '../runs/RunStatusTag';
+import {runStatusToBackfillStateString, RUN_STATUS_COLORS} from '../runs/RunStatusTag';
 
 import {assembleIntoSpans} from './SpanRepresentation';
 
@@ -382,7 +382,7 @@ function opRunStatusToColorRanges(
     : assembleIntoSpans(partitionNames, runStatusForKey);
 
   return spans.map((s) => ({
-    label: runStatusToString(s.status),
+    label: runStatusToBackfillStateString(s.status),
     start: {idx: s.startIdx, key: partitionNames[s.startIdx]},
     end: {idx: s.endIdx, key: partitionNames[s.endIdx]},
     style: {

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -17,6 +17,7 @@ import styled from 'styled-components/macro';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {tokenForAssetKey} from '../asset-graph/Utils';
 import {
+  AssetPartitionStatus,
   PartitionHealthData,
   PartitionHealthDimension,
   partitionStateAtIndex,
@@ -126,7 +127,7 @@ export const PartitionPerAssetStatus: React.FC<
       steps: layoutBoxesWithRangeDimension.map((box) => ({
         name: box.node.name,
         unix: 0,
-        color: partitionStateToStatusSquareColor(
+        color: assetPartitionStatusToSquareColor(
           partitionStateAtIndex(rangesByAssetKey[box.node.name], partitionKeyIdx),
         ),
       })),
@@ -141,6 +142,17 @@ export const PartitionPerAssetStatus: React.FC<
       showLatestRun={false}
     />
   );
+};
+
+export const assetPartitionStatusToSquareColor = (state: AssetPartitionStatus[]) => {
+  return state.includes(AssetPartitionStatus.MATERIALIZED) &&
+    state.includes(AssetPartitionStatus.MISSING)
+    ? 'SUCCESS-MISSING'
+    : state.includes(AssetPartitionStatus.MATERIALIZED)
+    ? 'SUCCESS'
+    : state.includes(AssetPartitionStatus.FAILED)
+    ? 'FAILURE'
+    : 'MISSING';
 };
 
 export const partitionStateToStatusSquareColor = (state: PartitionState) => {

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -16,8 +16,8 @@ import styled from 'styled-components/macro';
 
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {tokenForAssetKey} from '../asset-graph/Utils';
+import {AssetPartitionStatus} from '../assets/AssetPartitionStatus';
 import {
-  AssetPartitionStatus,
   PartitionHealthData,
   PartitionHealthDimension,
   partitionStatusAtIndex,

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -20,7 +20,7 @@ import {
   AssetPartitionStatus,
   PartitionHealthData,
   PartitionHealthDimension,
-  partitionStateAtIndex,
+  partitionStatusAtIndex,
   Range,
 } from '../assets/usePartitionHealthData';
 import {GanttChartMode} from '../gantt/Constants';
@@ -33,7 +33,6 @@ import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
 import {RepoAddress} from '../workspace/types';
 
 import {PartitionRunList} from './PartitionRunList';
-import {PartitionState} from './PartitionStatus';
 import {
   BOX_SIZE,
   GridColumn,
@@ -54,6 +53,7 @@ import {
   useMatrixData,
   MatrixData,
   PARTITION_MATRIX_SOLID_HANDLE_FRAGMENT,
+  StatusSquareColor,
 } from './useMatrixData';
 
 const BUFFER = 3;
@@ -128,7 +128,7 @@ export const PartitionPerAssetStatus: React.FC<
         name: box.node.name,
         unix: 0,
         color: assetPartitionStatusToSquareColor(
-          partitionStateAtIndex(rangesByAssetKey[box.node.name], partitionKeyIdx),
+          partitionStatusAtIndex(rangesByAssetKey[box.node.name], partitionKeyIdx),
         ),
       })),
     })),
@@ -144,23 +144,17 @@ export const PartitionPerAssetStatus: React.FC<
   );
 };
 
-export const assetPartitionStatusToSquareColor = (state: AssetPartitionStatus[]) => {
+export const assetPartitionStatusToSquareColor = (
+  state: AssetPartitionStatus[],
+): StatusSquareColor => {
   return state.includes(AssetPartitionStatus.MATERIALIZED) &&
     state.includes(AssetPartitionStatus.MISSING)
     ? 'SUCCESS-MISSING'
     : state.includes(AssetPartitionStatus.MATERIALIZED)
     ? 'SUCCESS'
+    : state.includes(AssetPartitionStatus.FAILED) && state.includes(AssetPartitionStatus.MISSING)
+    ? 'FAILURE-MISSING'
     : state.includes(AssetPartitionStatus.FAILED)
-    ? 'FAILURE'
-    : 'MISSING';
-};
-
-export const partitionStateToStatusSquareColor = (state: PartitionState) => {
-  return state === PartitionState.SUCCESS
-    ? 'SUCCESS'
-    : state === PartitionState.SUCCESS_MISSING
-    ? 'SUCCESS-MISSING'
-    : state === PartitionState.FAILURE
     ? 'FAILURE'
     : 'MISSING';
 };

--- a/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
@@ -15,7 +15,12 @@ import {
   PartitionMatrixSolidHandleFragment,
 } from './types/useMatrixData.types';
 
-type StatusSquareColor = 'SUCCESS' | 'FAILURE' | 'MISSING' | 'FAILURE-MISSING' | 'SUCCESS-MISSING';
+export type StatusSquareColor =
+  | 'SUCCESS'
+  | 'FAILURE'
+  | 'MISSING'
+  | 'FAILURE-MISSING'
+  | 'SUCCESS-MISSING';
 
 export interface PartitionRuns {
   name: string;

--- a/js_modules/dagit/packages/core/src/runs/RunStatusDots.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusDots.tsx
@@ -1,26 +1,12 @@
-import {Colors, Popover, Spinner} from '@dagster-io/ui';
+import {Popover, Spinner} from '@dagster-io/ui';
 import * as React from 'react';
 import styled, {css, keyframes} from 'styled-components/macro';
 
 import {RunStatus} from '../graphql/types';
 
 import {RunStats} from './RunStats';
+import {RUN_STATUS_COLORS} from './RunStatusTag';
 import {inProgressStatuses, queuedStatuses} from './RunStatuses';
-
-const RUN_STATUS_COLORS = {
-  QUEUED: Colors.Blue200,
-  NOT_STARTED: Colors.Gray600,
-  STARTING: Colors.Gray400,
-  MANAGED: Colors.Gray400,
-  STARTED: Colors.Blue500,
-  SUCCESS: Colors.Green500,
-  FAILURE: Colors.Red500,
-  CANCELING: Colors.Red500,
-  CANCELED: Colors.Red500,
-
-  // Not technically a RunStatus, but useful.
-  SCHEDULED: Colors.Blue200,
-};
 
 export const RunStatusWithStats: React.FC<RunStatusProps & {runId: string}> = React.memo(
   ({runId, ...rest}) => (

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -7,21 +7,10 @@ import {RunStatus} from '../graphql/types';
 import {StepSummaryForRun} from '../instance/StepSummaryForRun';
 
 import {RunStatusIndicator} from './RunStatusDots';
+import {RUN_STATUS_COLORS} from './RunStatusTag';
 import {failedStatuses, inProgressStatuses} from './RunStatuses';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
 import {RunTimeFragment} from './types/RunUtils.types';
-
-const RUN_STATUS_COLORS = {
-  QUEUED: Colors.Blue500,
-  NOT_STARTED: Colors.Blue500,
-  STARTING: Colors.Blue500,
-  MANAGED: Colors.Blue500,
-  STARTED: Colors.Blue500,
-  SUCCESS: Colors.Green500,
-  FAILURE: Colors.Red500,
-  CANCELING: Colors.Red500,
-  CANCELED: Colors.Red500,
-};
 
 const MIN_OPACITY = 0.2;
 const MAX_OPACITY = 1.0;

--- a/js_modules/dagit/packages/core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusTag.tsx
@@ -1,4 +1,4 @@
-import {Box, Popover, Tag} from '@dagster-io/ui';
+import {Box, Colors, Popover, Tag} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {assertUnreachable} from '../app/Util';
@@ -28,7 +28,7 @@ const statusToIntent = (status: RunStatus) => {
   }
 };
 
-const statusToString = (status: RunStatus) => {
+export const runStatusToString = (status: RunStatus) => {
   switch (status) {
     case RunStatus.QUEUED:
       return 'Queued';
@@ -53,13 +53,28 @@ const statusToString = (status: RunStatus) => {
   }
 };
 
+export const RUN_STATUS_COLORS = {
+  QUEUED: Colors.Blue200,
+  NOT_STARTED: Colors.Gray600,
+  STARTING: Colors.Gray400,
+  MANAGED: Colors.Gray400,
+  STARTED: Colors.Blue500,
+  SUCCESS: Colors.Green500,
+  FAILURE: Colors.Red500,
+  CANCELING: Colors.Red500,
+  CANCELED: Colors.Red500,
+
+  // Not technically a RunStatus, but useful.
+  SCHEDULED: Colors.Blue200,
+};
+
 export const RunStatusTag = (props: {status: RunStatus}) => {
   const {status} = props;
   return (
     <Tag intent={statusToIntent(status)}>
       <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
         <RunStatusIndicator status={status} size={10} />
-        <div>{statusToString(status)}</div>
+        <div>{runStatusToString(status)}</div>
       </Box>
     </Tag>
   );

--- a/js_modules/dagit/packages/core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusTag.tsx
@@ -53,12 +53,32 @@ export const runStatusToString = (status: RunStatus) => {
   }
 };
 
+export const runStatusToBackfillStateString = (status: RunStatus) => {
+  switch (status) {
+    case RunStatus.CANCELED:
+    case RunStatus.CANCELING:
+    case RunStatus.FAILURE:
+      return 'Failed';
+    case RunStatus.STARTING:
+    case RunStatus.STARTED:
+      return 'In progress';
+    case RunStatus.QUEUED:
+      return 'Queued';
+    case RunStatus.SUCCESS:
+      return 'Completed';
+    case RunStatus.MANAGED:
+    case RunStatus.NOT_STARTED:
+      return 'Missing';
+    default:
+      return assertUnreachable(status);
+  }
+};
 export const RUN_STATUS_COLORS = {
   QUEUED: Colors.Blue200,
   NOT_STARTED: Colors.Gray600,
-  STARTING: Colors.Gray400,
   MANAGED: Colors.Gray400,
   STARTED: Colors.Blue500,
+  STARTING: Colors.Blue500,
   SUCCESS: Colors.Green500,
   FAILURE: Colors.Red500,
   CANCELING: Colors.Red500,

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedAssetRow.types.ts
@@ -63,6 +63,7 @@ export type SingleAssetQuery = {
           partitionStats: {
             __typename: 'PartitionStats';
             numMaterialized: number;
+            numMaterializing: number;
             numPartitions: number;
             numFailed: number;
           } | null;


### PR DESCRIPTION
## Summary & Motivation

Partial failed / other states!
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/1037212/228565154-52043548-5567-4888-afd5-bfd7e3c19331.png">

New blue "materializing" status!
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/1037212/228567364-3f35e302-6a00-4772-a021-05bd91b99b5d.png">

Partial states supported in dots:
<img width="741" alt="image" src="https://user-images.githubusercontent.com/1037212/228565360-fdb1608c-b2f1-4e03-a12d-e1d99ea3c7b6.png">


This PR implements the new GraphQL endpoint for `numMaterializing` and also shows the new "materializing" state on the asset health partition bar.

This unfortunately required a lot of changes -- our previous implementation of the health bar used an enum called PartitionState for each color band. This was bad because:

- Each combinatorial state (eg: partially materializing, partially failed) would be a new enum value. Until now we have not supported partial states with the new "failed" red color because there just weren't enum values for it.

- Both assets and op backfills used this PartitionState enum. This was nice in a few places but led to a lot of code supporting just a subset of the enum values, mapping materialized = success, etc. Asset and op backfill status are getting more different and it's preferable to separate them now.

- The enum was called `PartitionState` even though the GraphQL types are all "status"

Most of the changes in this PR fold this enum away in favor of:

- PartitionState => AssetPartitionStatus (materialized, materializing, failed, missing, and soon stale)

- PartitionState => RunStatus for op backfills (we were previously taking RunStatus and converting it to a PartitionState client-side)

- Multiple AssetPartitionStatus values allowed for each partition key. This is useful for the first dimension of multi-partitioned assets but ALSO surfaces in Dagit if you select two assets with the same partitioning and open the backfill modal. Their bars are folded into one with "partial red / partial green", etc.

## How I Tested These Changes

We have extensive test coverage of the asset portion of this stuff! The tests are all passing and I'm fairly confident the changes there are safe. I manually reviewed the storybooks and the asset pages for correctness as well.

There are a few changes in this PR that impact the Op backfill UI, and I am testing the following manually:
- Viewing the op job partitions page
- Viewing the op job backfill history to see "Requested runs" and "Run status" elements are unchanged
- Clicking "Launch backfill" and confirming that the partition range selector renders properly and that the checkboxes below function correctly.

- Open our Backfill table storybooks and make sure they are unchanged

![image](https://user-images.githubusercontent.com/1037212/229926203-83431fe8-1ce6-4566-bf8c-73bb5e50fb6e.png)

