### PR TITLE
Dagster-aws feature: Add capacity provider strategy and ephemeral storage

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -110,6 +110,68 @@ If the `ecs/cpu` or `ecs/memory` tags are set, they will override any defaults s
 
 **Note**: [Fargate tasks only support certain combinations of CPU and memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
 
+
+### Customizing ephemeral storage in ECS
+
+You can use job tags to customize the ephemeral storage of every run for a particular job:
+
+```py
+from dagster import job, op
+
+@op()
+def my_op(context):
+  context.log.info('running')
+
+@job(
+  tags = {
+    "ecs/ephemeralStorage": "21",
+  }
+)
+def my_job():
+  my_op()
+```
+
+If the `ecs/ephemeralStorage` tag is set, it will override any defaults set in the task definition.
+
+**Note**: Fargate tasks only support values of ephemeral storage between 21 and 200 GiB (default is set to 20 GiB)
+
+
+### Customizing capacity provider strategy in ECS (Fargate Spot integration)
+
+You can set the `run_launcher.config.run_task_kwargs` field to customize the default capacity provider strategy for Dagster runs. For example:
+
+```yaml
+run_launcher:
+  module: "dagster_aws.ecs"
+  class: "EcsRunLauncher"
+  config:
+    run_task_kwargs:
+      capacityProviderStrategy: "FARGATE_SPOT"
+```
+
+You can also use job tags to customize the capacity provider strategy of every run for a particular job:
+
+```py
+from dagster import job, op
+
+@op()
+def my_op(context):
+  context.log.info('running')
+
+@job(
+  tags = {
+    "ecs/capacityProvider": "FARGATE_SPOT",
+  }
+)
+def my_job():
+  my_op()
+```
+
+If the `ecs/capacityProvider` tag is set, it will override any defaults set on the run launcher.
+
+**Note**: FARGATE and FARGATE_SPOT are default capacity strategies within ECS, however, you can also pass on personalized capacity provider strategies as long as they are present in the ECS cluster.
+
+
 ### Customizing the launched run's task
 
 The <PyObject module="dagster_aws.ecs" object="EcsRunLauncher" /> creates a new task for each run, using the current ECS task to determine network configuration. For example, the launched run will use the same ECS cluster, subnets, security groups, and launch type (e.g. Fargate or EC2).

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -373,6 +373,9 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
         cpu_and_memory_overrides = self.get_cpu_and_memory_overrides(container_context, run)
 
+        # Set ephemeral storage overrides
+        ephemeral_storage_overrides = self._get_task_ephemeral_storage_from_tags(run)
+
         task_overrides = self._get_task_overrides(run)
 
         container_overrides: List[Dict[str, Any]] = [
@@ -389,11 +392,22 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             # taskOverrides expects cpu/memory as strings
             **cpu_and_memory_overrides,
             **task_overrides,
+            # Add ephemeral storage to overrides
+            **ephemeral_storage_overrides,
         }
         run_task_kwargs["tags"] = [
             *run_task_kwargs.get("tags", []),
             *self.build_ecs_tags_for_run_task(run),
         ]
+
+        # Capacity provider can also be specified as tag in the task
+        capacity_provider_overrides = self._get_task_capacity_provider_from_tags(run)
+        if capacity_provider_overrides:
+            run_task_kwargs.update(capacity_provider_overrides)
+            # Also remove LaunchType when set, just in case it was inherited from
+            # the current task
+            if "launchType" in run_task_kwargs:
+                del run_task_kwargs["launchType"]
 
         # Run a task using the same network configuration as this processes's
         # task.
@@ -450,11 +464,35 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         return overrides
 
+    def _get_task_ephemeral_storage_from_tags(self, run: DagsterRun) -> Mapping[str, Any]:
+        overrides = {}
+
+        ephemeral_storage = run.tags.get("ecs/ephemeralStorage")
+
+        if ephemeral_storage:
+            overrides["ephemeralStorage"] = {
+                "sizeInGiB": int(ephemeral_storage)
+            }
+
+        return overrides
+
     def _get_task_overrides(self, run: DagsterRun) -> Mapping[str, Any]:
         overrides = run.tags.get("ecs/task_overrides")
         if overrides:
             return json.loads(overrides)
         return {}
+
+    def _get_task_capacity_provider_from_tags(self, run: DagsterRun) -> Mapping[str, Any]:
+        capacity_tag = run.tags.get("ecs/capacityProvider")
+        returnDict = {}
+        if capacity_tag:
+            returnDict["capacityProviderStrategy"] = [{
+                   "capacityProvider": capacity_tag,
+                   # Assume weight and base at 1, since Dagster is our orchestrator
+                   "weight": 1,
+                   "base": 1
+                }]
+        return returnDict
 
     def terminate(self, run_id):
         tags = self._get_run_tags(run_id)

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/tasks.py
@@ -319,7 +319,7 @@ def get_task_kwargs_from_current_task(
         for group in eni.groups:
             security_groups.append(group["GroupId"])
 
-    return {
+    returnDict = {
         "cluster": cluster,
         "networkConfiguration": {
             "awsvpcConfiguration": {
@@ -327,6 +327,14 @@ def get_task_kwargs_from_current_task(
                 "assignPublicIp": "ENABLED" if public_ip else "DISABLED",
                 "securityGroups": security_groups,
             },
-        },
-        "launchType": task.get("launchType") or "FARGATE",
+        }
     }
+
+    # LaunchType and CapacityProviderStrategy are mutually exclusive
+    # Note: it can also be defined as tag in the run itself, overriding this
+    if not task.get("capacityProviderStrategy"):
+        returnDict["launchType"] = task.get("launchType") or "FARGATE"
+    else:
+        returnDict["capacityProviderStrategy"] = task.get("capacityProviderStrategy")
+
+    return returnDict


### PR DESCRIPTION
## Summary & Motivation
Currently the dagster_aws library is missing options to add a capacity provider strategy, and ephemeral storage.
This PR aims to add these features using `run_task_kwargs` and from Dagster reserved tags.

Relevant issues:
https://github.com/dagster-io/dagster/issues/12437
https://github.com/dagster-io/dagster/issues/12442

Slack thread:
https://app.slack.com/client/TCDGQDUKF/C014UDS8LAV/thread/C014UDS8LAV-1676628523.743189

## How I Tested These Changes
We tested this in our own environment against AWS. We have not written unit tests, since we had some issues getting this to work from our Windows environment.