### PR TITLE
Remove 'instance/' from Dagit base url

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/sensors.py
@@ -102,7 +102,7 @@ def get_toys_sensors():
 
         slack_client = WebClient(token=os.environ.get("SLACK_DAGSTER_ETL_BOT_TOKEN"))
 
-        run_page_url = f"{base_url}/instance/runs/{context.pipeline_run.run_id}"
+        run_page_url = f"{base_url}/runs/{context.pipeline_run.run_id}"
         channel = "#toy-test"
         message = "\n".join(
             [

--- a/python_modules/dagster/dagster/_utils/alert.py
+++ b/python_modules/dagster/dagster/_utils/alert.py
@@ -192,7 +192,7 @@ def make_email_on_run_failure_sensor(
         email_body = email_body_fn(context)
         if dagit_base_url:
             email_body += (
-                f'<p><a href="{dagit_base_url}/instance/runs/{context.pipeline_run.run_id}">View in'
+                f'<p><a href="{dagit_base_url}/runs/{context.pipeline_run.run_id}">View in'
                 " Dagit</a></p>"
             )
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/links/dagster_link.py
@@ -1,6 +1,6 @@
 from airflow.models import BaseOperatorLink, TaskInstance
 
-LINK_FMT = "https://dagster.cloud/{organization_id}/{deployment_name}/instance/runs/{run_id}"
+LINK_FMT = "https://dagster.cloud/{organization_id}/{deployment_name}/runs/{run_id}"
 
 
 class DagsterLink(BaseOperatorLink):

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/hooks.py
@@ -58,7 +58,7 @@ def teams_on_failure(
     def _hook(context: HookContext):
         text = message_fn(context)
         if dagit_base_url:
-            text += "<a href='{base_url}/instance/runs/{run_id}'>View in Dagit</a>".format(
+            text += "<a href='{base_url}/runs/{run_id}'>View in Dagit</a>".format(
                 base_url=dagit_base_url,
                 run_id=context.run_id,
             )
@@ -109,7 +109,7 @@ def teams_on_success(
     def _hook(context: HookContext):
         text = message_fn(context)
         if dagit_base_url:
-            text += "<a href='{base_url}/instance/runs/{run_id}'>View in Dagit</a>".format(
+            text += "<a href='{base_url}/runs/{run_id}'>View in Dagit</a>".format(
                 base_url=dagit_base_url,
                 run_id=context.run_id,
             )

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
@@ -116,7 +116,7 @@ def make_teams_on_run_failure_sensor(
     def teams_on_run_failure(context: RunFailureSensorContext):
         text = message_fn(context)
         if dagit_base_url:
-            text += "<a href='{base_url}/instance/runs/{run_id}'>View in Dagit</a>".format(
+            text += "<a href='{base_url}/runs/{run_id}'>View in Dagit</a>".format(
                 base_url=dagit_base_url,
                 run_id=context.dagster_run.run_id,
             )

--- a/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
+++ b/python_modules/libraries/dagster-pagerduty/dagster_pagerduty/hooks.py
@@ -65,7 +65,7 @@ def pagerduty_on_failure(
         custom_details = {}
         if dagit_base_url:
             custom_details = {
-                "dagit url": "{base_url}/instance/runs/{run_id}".format(
+                "dagit url": "{base_url}/runs/{run_id}".format(
                     base_url=dagit_base_url, run_id=context.run_id
                 )
             }

--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -62,7 +62,7 @@ def slack_on_failure(
     def _hook(context: HookContext):
         text = message_fn(context)
         if dagit_base_url:
-            text += "\n<{base_url}/instance/runs/{run_id}|View in Dagit>".format(
+            text += "\n<{base_url}/runs/{run_id}|View in Dagit>".format(
                 base_url=dagit_base_url, run_id=context.run_id
             )
 
@@ -112,7 +112,7 @@ def slack_on_success(
     def _hook(context: HookContext):
         text = message_fn(context)
         if dagit_base_url:
-            text += "\n<{base_url}/instance/runs/{run_id}|View in Dagit>".format(
+            text += "\n<{base_url}/runs/{run_id}|View in Dagit>".format(
                 base_url=dagit_base_url, run_id=context.run_id
             )
 

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -77,7 +77,7 @@ def _build_slack_blocks_and_text(
 
     if dagit_base_url:
         if isinstance(context, RunFailureSensorContext):
-            url = f"{dagit_base_url}/instance/runs/{context.pipeline_run.run_id}"
+            url = f"{dagit_base_url}/runs/{context.pipeline_run.run_id}"
         else:
             url = f"{dagit_base_url}/assets/{'/'.join(context.asset_key.path)}"
         blocks.append(


### PR DESCRIPTION
## Summary & Motivation
The slack links to the Dagster runs were not working due to the [removed (release 1.1.4)](https://github.com/dagster-io/dagster/blob/master/CHANGES.md#new-15) `instance/` prefix in Dagit urls.

## How I Tested These Changes
I have checked that the links posted in Slack works just removing the `instance/`.