### PR TITLE
Add backfill resolvers for per-asset status counts

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2390,7 +2390,7 @@ type PartitionBackfill {
   error: PythonError
   partitionStatuses: PartitionStatuses!
   partitionStatusCounts: [PartitionStatusCounts!]!
-  assetPartitionStatusCounts: [AssetPartitionStatusCounts!]!
+  assetPartitionsStatusCounts: [AssetPartitionsStatusCounts!]!
   hasCancelPermission: Boolean!
   hasResumePermission: Boolean!
 }
@@ -2402,15 +2402,12 @@ enum BulkActionStatus {
   CANCELED
 }
 
-type AssetPartitionStatusCounts {
+type AssetPartitionsStatusCounts {
   assetKey: AssetKey!
   numPartitionsTargeted: Int!
-  partitionStatusCounts: [PartitionBulkActionStatusCounts!]!
-}
-
-type PartitionBulkActionStatusCounts {
-  bulkActionStatus: BulkActionStatus!
-  count: Int!
+  numPartitionsRequested: Int!
+  numPartitionsCompleted: Int!
+  numPartitionsFailed: Int!
 }
 
 union PartitionSetOrError = PartitionSet | PartitionSetNotFoundError | PythonError

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2390,6 +2390,7 @@ type PartitionBackfill {
   error: PythonError
   partitionStatuses: PartitionStatuses!
   partitionStatusCounts: [PartitionStatusCounts!]!
+  assetPartitionStatusCounts: [AssetPartitionStatusCounts!]!
   hasCancelPermission: Boolean!
   hasResumePermission: Boolean!
 }
@@ -2399,6 +2400,17 @@ enum BulkActionStatus {
   COMPLETED
   FAILED
   CANCELED
+}
+
+type AssetPartitionStatusCounts {
+  assetKey: AssetKey!
+  numPartitionsTargeted: Int!
+  partitionStatusCounts: [PartitionBulkActionStatusCounts!]!
+}
+
+type PartitionBulkActionStatusCounts {
+  bulkActionStatus: BulkActionStatus!
+  count: Int!
 }
 
 union PartitionSetOrError = PartitionSet | PartitionSetNotFoundError | PythonError

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -268,14 +268,16 @@ export type AssetNotFoundError = Error & {
 
 export type AssetOrError = Asset | AssetNotFoundError;
 
-export type AssetPartitionStatusCounts = {
-  __typename: 'AssetPartitionStatusCounts';
-  assetKey: AssetKey;
-  numPartitionsTargeted: Scalars['Int'];
-  partitionStatusCounts: Array<PartitionBulkActionStatusCounts>;
-};
-
 export type AssetPartitionStatuses = DefaultPartitions | MultiPartitions | TimePartitions;
+
+export type AssetPartitionsStatusCounts = {
+  __typename: 'AssetPartitionsStatusCounts';
+  assetKey: AssetKey;
+  numPartitionsCompleted: Scalars['Int'];
+  numPartitionsFailed: Scalars['Int'];
+  numPartitionsRequested: Scalars['Int'];
+  numPartitionsTargeted: Scalars['Int'];
+};
 
 export type AssetWipeMutationResult =
   | AssetNotFoundError
@@ -2237,7 +2239,7 @@ export type PartitionRunsArgs = {
 
 export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
-  assetPartitionStatusCounts: Array<AssetPartitionStatusCounts>;
+  assetPartitionsStatusCounts: Array<AssetPartitionsStatusCounts>;
   assetSelection: Maybe<Array<AssetKey>>;
   backfillId: Scalars['String'];
   error: Maybe<PythonError>;
@@ -2275,12 +2277,6 @@ export type PartitionBackfills = {
 };
 
 export type PartitionBackfillsOrError = PartitionBackfills | PythonError;
-
-export type PartitionBulkActionStatusCounts = {
-  __typename: 'PartitionBulkActionStatusCounts';
-  bulkActionStatus: BulkActionStatus;
-  count: Scalars['Int'];
-};
 
 export type PartitionDefinition = {
   __typename: 'PartitionDefinition';
@@ -4529,32 +4525,36 @@ export const buildAssetNotFoundError = (
   };
 };
 
-export const buildAssetPartitionStatusCounts = (
-  overrides?: Partial<AssetPartitionStatusCounts>,
+export const buildAssetPartitionsStatusCounts = (
+  overrides?: Partial<AssetPartitionsStatusCounts>,
   _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'AssetPartitionStatusCounts'} & AssetPartitionStatusCounts => {
+): {__typename: 'AssetPartitionsStatusCounts'} & AssetPartitionsStatusCounts => {
   const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('AssetPartitionStatusCounts');
+  relationshipsToOmit.add('AssetPartitionsStatusCounts');
   return {
-    __typename: 'AssetPartitionStatusCounts',
+    __typename: 'AssetPartitionsStatusCounts',
     assetKey:
       overrides && overrides.hasOwnProperty('assetKey')
         ? overrides.assetKey!
         : relationshipsToOmit.has('AssetKey')
         ? ({} as AssetKey)
         : buildAssetKey({}, relationshipsToOmit),
+    numPartitionsCompleted:
+      overrides && overrides.hasOwnProperty('numPartitionsCompleted')
+        ? overrides.numPartitionsCompleted!
+        : 524,
+    numPartitionsFailed:
+      overrides && overrides.hasOwnProperty('numPartitionsFailed')
+        ? overrides.numPartitionsFailed!
+        : 6432,
+    numPartitionsRequested:
+      overrides && overrides.hasOwnProperty('numPartitionsRequested')
+        ? overrides.numPartitionsRequested!
+        : 1501,
     numPartitionsTargeted:
       overrides && overrides.hasOwnProperty('numPartitionsTargeted')
         ? overrides.numPartitionsTargeted!
-        : 893,
-    partitionStatusCounts:
-      overrides && overrides.hasOwnProperty('partitionStatusCounts')
-        ? overrides.partitionStatusCounts!
-        : [
-            relationshipsToOmit.has('PartitionBulkActionStatusCounts')
-              ? ({} as PartitionBulkActionStatusCounts)
-              : buildPartitionBulkActionStatusCounts({}, relationshipsToOmit),
-          ],
+        : 5211,
   };
 };
 
@@ -8658,13 +8658,13 @@ export const buildPartitionBackfill = (
   relationshipsToOmit.add('PartitionBackfill');
   return {
     __typename: 'PartitionBackfill',
-    assetPartitionStatusCounts:
-      overrides && overrides.hasOwnProperty('assetPartitionStatusCounts')
-        ? overrides.assetPartitionStatusCounts!
+    assetPartitionsStatusCounts:
+      overrides && overrides.hasOwnProperty('assetPartitionsStatusCounts')
+        ? overrides.assetPartitionsStatusCounts!
         : [
-            relationshipsToOmit.has('AssetPartitionStatusCounts')
-              ? ({} as AssetPartitionStatusCounts)
-              : buildAssetPartitionStatusCounts({}, relationshipsToOmit),
+            relationshipsToOmit.has('AssetPartitionsStatusCounts')
+              ? ({} as AssetPartitionsStatusCounts)
+              : buildAssetPartitionsStatusCounts({}, relationshipsToOmit),
           ],
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection')
@@ -8762,22 +8762,6 @@ export const buildPartitionBackfills = (
               ? ({} as PartitionBackfill)
               : buildPartitionBackfill({}, relationshipsToOmit),
           ],
-  };
-};
-
-export const buildPartitionBulkActionStatusCounts = (
-  overrides?: Partial<PartitionBulkActionStatusCounts>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'PartitionBulkActionStatusCounts'} & PartitionBulkActionStatusCounts => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('PartitionBulkActionStatusCounts');
-  return {
-    __typename: 'PartitionBulkActionStatusCounts',
-    bulkActionStatus:
-      overrides && overrides.hasOwnProperty('bulkActionStatus')
-        ? overrides.bulkActionStatus!
-        : BulkActionStatus.CANCELED,
-    count: overrides && overrides.hasOwnProperty('count') ? overrides.count! : 4647,
   };
 };
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -268,6 +268,13 @@ export type AssetNotFoundError = Error & {
 
 export type AssetOrError = Asset | AssetNotFoundError;
 
+export type AssetPartitionStatusCounts = {
+  __typename: 'AssetPartitionStatusCounts';
+  assetKey: AssetKey;
+  numPartitionsTargeted: Scalars['Int'];
+  partitionStatusCounts: Array<PartitionBulkActionStatusCounts>;
+};
+
 export type AssetPartitionStatuses = DefaultPartitions | MultiPartitions | TimePartitions;
 
 export type AssetWipeMutationResult =
@@ -2230,6 +2237,7 @@ export type PartitionRunsArgs = {
 
 export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
+  assetPartitionStatusCounts: Array<AssetPartitionStatusCounts>;
   assetSelection: Maybe<Array<AssetKey>>;
   backfillId: Scalars['String'];
   error: Maybe<PythonError>;
@@ -2267,6 +2275,12 @@ export type PartitionBackfills = {
 };
 
 export type PartitionBackfillsOrError = PartitionBackfills | PythonError;
+
+export type PartitionBulkActionStatusCounts = {
+  __typename: 'PartitionBulkActionStatusCounts';
+  bulkActionStatus: BulkActionStatus;
+  count: Scalars['Int'];
+};
 
 export type PartitionDefinition = {
   __typename: 'PartitionDefinition';
@@ -4512,6 +4526,35 @@ export const buildAssetNotFoundError = (
   return {
     __typename: 'AssetNotFoundError',
     message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : 'beatae',
+  };
+};
+
+export const buildAssetPartitionStatusCounts = (
+  overrides?: Partial<AssetPartitionStatusCounts>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'AssetPartitionStatusCounts'} & AssetPartitionStatusCounts => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetPartitionStatusCounts');
+  return {
+    __typename: 'AssetPartitionStatusCounts',
+    assetKey:
+      overrides && overrides.hasOwnProperty('assetKey')
+        ? overrides.assetKey!
+        : relationshipsToOmit.has('AssetKey')
+        ? ({} as AssetKey)
+        : buildAssetKey({}, relationshipsToOmit),
+    numPartitionsTargeted:
+      overrides && overrides.hasOwnProperty('numPartitionsTargeted')
+        ? overrides.numPartitionsTargeted!
+        : 893,
+    partitionStatusCounts:
+      overrides && overrides.hasOwnProperty('partitionStatusCounts')
+        ? overrides.partitionStatusCounts!
+        : [
+            relationshipsToOmit.has('PartitionBulkActionStatusCounts')
+              ? ({} as PartitionBulkActionStatusCounts)
+              : buildPartitionBulkActionStatusCounts({}, relationshipsToOmit),
+          ],
   };
 };
 
@@ -8615,6 +8658,14 @@ export const buildPartitionBackfill = (
   relationshipsToOmit.add('PartitionBackfill');
   return {
     __typename: 'PartitionBackfill',
+    assetPartitionStatusCounts:
+      overrides && overrides.hasOwnProperty('assetPartitionStatusCounts')
+        ? overrides.assetPartitionStatusCounts!
+        : [
+            relationshipsToOmit.has('AssetPartitionStatusCounts')
+              ? ({} as AssetPartitionStatusCounts)
+              : buildAssetPartitionStatusCounts({}, relationshipsToOmit),
+          ],
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection')
         ? overrides.assetSelection!
@@ -8711,6 +8762,22 @@ export const buildPartitionBackfills = (
               ? ({} as PartitionBackfill)
               : buildPartitionBackfill({}, relationshipsToOmit),
           ],
+  };
+};
+
+export const buildPartitionBulkActionStatusCounts = (
+  overrides?: Partial<PartitionBulkActionStatusCounts>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'PartitionBulkActionStatusCounts'} & PartitionBulkActionStatusCounts => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionBulkActionStatusCounts');
+  return {
+    __typename: 'PartitionBulkActionStatusCounts',
+    bulkActionStatus:
+      overrides && overrides.hasOwnProperty('bulkActionStatus')
+        ? overrides.bulkActionStatus!
+        : BulkActionStatus.CANCELED,
+    count: overrides && overrides.hasOwnProperty('count') ? overrides.count! : 4647,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -14,7 +14,6 @@ from dagster._core.host_representation.external_data import (
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._utils.merger import merge_dicts
-from .asset_key import GrapheneAssetKey
 
 from dagster_graphql.implementation.fetch_partition_sets import (
     get_partition_by_name,
@@ -26,7 +25,8 @@ from dagster_graphql.implementation.fetch_partition_sets import (
 )
 from dagster_graphql.implementation.fetch_runs import get_runs
 
-from .backfill import GraphenePartitionBackfill, GrapheneBulkActionStatus
+from .asset_key import GrapheneAssetKey
+from .backfill import GraphenePartitionBackfill
 from .errors import (
     GrapheneDuplicateDynamicPartitionError,
     GraphenePartitionSetNotFoundError,
@@ -122,21 +122,15 @@ class GraphenePartitionStatusesOrError(graphene.Union):
         name = "PartitionStatusesOrError"
 
 
-class GrapheneBulkActionStatusPartitionCounts(graphene.ObjectType):
-    bulkActionStatus = graphene.NonNull(GrapheneBulkActionStatus)
-    count = graphene.NonNull(graphene.Int)
-
+class GrapheneAssetPartitionsStatusCounts(graphene.ObjectType):
     class Meta:
-        name = "PartitionBulkActionStatusCounts"
-
-
-class GrapheneAssetPartitionStatusCounts(graphene.ObjectType):
-    class Meta:
-        name = "AssetPartitionStatusCounts"
+        name = "AssetPartitionsStatusCounts"
 
     assetKey = graphene.NonNull(GrapheneAssetKey)
     numPartitionsTargeted = graphene.NonNull(graphene.Int)
-    partitionStatusCounts = non_null_list(GrapheneBulkActionStatusPartitionCounts)
+    numPartitionsRequested = graphene.NonNull(graphene.Int)
+    numPartitionsCompleted = graphene.NonNull(graphene.Int)
+    numPartitionsFailed = graphene.NonNull(graphene.Int)
 
 
 class GraphenePartitionTagsOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -14,6 +14,7 @@ from dagster._core.host_representation.external_data import (
 from dagster._core.storage.pipeline_run import RunsFilter
 from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._utils.merger import merge_dicts
+from .asset_key import GrapheneAssetKey
 
 from dagster_graphql.implementation.fetch_partition_sets import (
     get_partition_by_name,
@@ -25,7 +26,7 @@ from dagster_graphql.implementation.fetch_partition_sets import (
 )
 from dagster_graphql.implementation.fetch_runs import get_runs
 
-from .backfill import GraphenePartitionBackfill
+from .backfill import GraphenePartitionBackfill, GrapheneBulkActionStatus
 from .errors import (
     GrapheneDuplicateDynamicPartitionError,
     GraphenePartitionSetNotFoundError,
@@ -119,6 +120,23 @@ class GraphenePartitionStatusesOrError(graphene.Union):
     class Meta:
         types = (GraphenePartitionStatuses, GraphenePythonError)
         name = "PartitionStatusesOrError"
+
+
+class GrapheneBulkActionStatusPartitionCounts(graphene.ObjectType):
+    bulkActionStatus = graphene.NonNull(GrapheneBulkActionStatus)
+    count = graphene.NonNull(graphene.Int)
+
+    class Meta:
+        name = "PartitionBulkActionStatusCounts"
+
+
+class GrapheneAssetPartitionStatusCounts(graphene.ObjectType):
+    class Meta:
+        name = "AssetPartitionStatusCounts"
+
+    assetKey = graphene.NonNull(GrapheneAssetKey)
+    numPartitionsTargeted = graphene.NonNull(graphene.Int)
+    partitionStatusCounts = non_null_list(GrapheneBulkActionStatusPartitionCounts)
 
 
 class GraphenePartitionTagsOrError(graphene.Union):

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Mapping, NamedTuple, Optional, Sequence
+from typing import Mapping, NamedTuple, Optional, Sequence, Tuple
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
@@ -15,7 +15,7 @@ from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
-from .asset_backfill import AssetBackfillData
+from .asset_backfill import AssetBackfillData, BackfillPartitionsStatus
 
 
 @whitelist_for_serdes
@@ -126,27 +126,9 @@ class PartitionBackfill(
         else:
             return True
 
-    def get_num_partitions_targeted_by_asset(self, workspace: IWorkspace) -> Mapping[AssetKey, int]:
-        if not self.is_valid_serialization(workspace):
-            return {}
-
-        if self.serialized_asset_backfill_data is not None:
-            try:
-                asset_backfill_data = AssetBackfillData.from_serialized(
-                    self.serialized_asset_backfill_data,
-                    ExternalAssetGraph.from_workspace(workspace),
-                )
-            except DagsterDefinitionChangedDeserializationError:
-                return {}
-
-            return asset_backfill_data.get_num_targeted_partitions_by_asset_key()
-
-        else:
-            return {}
-
-    def get_partition_status_counts_by_asset(
+    def get_partitions_status_counts_and_totals_by_asset(
         self, workspace: IWorkspace
-    ) -> Mapping[AssetKey, Mapping[BulkActionStatus, int]]:
+    ) -> Mapping[AssetKey, Tuple[Mapping[BackfillPartitionsStatus, int], int]]:
         if not self.is_valid_serialization(workspace):
             return {}
 
@@ -159,7 +141,25 @@ class PartitionBackfill(
             except DagsterDefinitionChangedDeserializationError:
                 return {}
 
-            return asset_backfill_data.get_partition_status_counts_by_asset_key()
+            partitions_status_counts_by_asset_key = (
+                asset_backfill_data.get_partitions_status_counts_by_asset_key()
+            )
+            num_targeted_partitions_by_asset_key = (
+                asset_backfill_data.get_num_targeted_partitions_by_asset_key()
+            )
+
+            check.invariant(
+                partitions_status_counts_by_asset_key.keys()
+                == num_targeted_partitions_by_asset_key.keys()
+            )
+
+            return {
+                asset_key: (
+                    partitions_status_counts_by_asset_key[asset_key],
+                    num_targeted_partitions_by_asset_key[asset_key],
+                )
+                for asset_key in partitions_status_counts_by_asset_key
+            }
 
         else:
             return {}

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -126,6 +126,44 @@ class PartitionBackfill(
         else:
             return True
 
+    def get_num_partitions_targeted_by_asset(self, workspace: IWorkspace) -> Mapping[AssetKey, int]:
+        if not self.is_valid_serialization(workspace):
+            return {}
+
+        if self.serialized_asset_backfill_data is not None:
+            try:
+                asset_backfill_data = AssetBackfillData.from_serialized(
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
+                )
+            except DagsterDefinitionChangedDeserializationError:
+                return {}
+
+            return asset_backfill_data.get_num_targeted_partitions_by_asset_key()
+
+        else:
+            return {}
+
+    def get_partition_status_counts_by_asset(
+        self, workspace: IWorkspace
+    ) -> Mapping[AssetKey, Mapping[BulkActionStatus, int]]:
+        if not self.is_valid_serialization(workspace):
+            return {}
+
+        if self.serialized_asset_backfill_data is not None:
+            try:
+                asset_backfill_data = AssetBackfillData.from_serialized(
+                    self.serialized_asset_backfill_data,
+                    ExternalAssetGraph.from_workspace(workspace),
+                )
+            except DagsterDefinitionChangedDeserializationError:
+                return {}
+
+            return asset_backfill_data.get_partition_status_counts_by_asset_key()
+
+        else:
+            return {}
+
     def get_num_partitions(self, workspace: IWorkspace) -> Optional[int]:
         if not self.is_valid_serialization(workspace):
             return 0

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -823,6 +823,7 @@ def test_pure_asset_backfill(
     for asset_key in [AssetKey("a2"), AssetKey("b2"), AssetKey("baz")]:
         assert len(instance.run_ids_for_asset_key(asset_key)) == 0
 
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
     backfill = instance.get_backfill("backfill_with_asset_selection")
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED


### PR DESCRIPTION
This PR adds resolvers to `GraphenePartitionBackfill` to enable querying for partition status counts on a per asset basis, i.e. for backfilled asset `A` one run is requested, one is complete, one is failed.

One thing I came across is that the asset backfill iteration considers a backfill as "complete" when all runs have been requested. Subsequently, the `AssetBackfillData` object contains only the complete and failed partitions at the time that the last set of runs were requested, not including the results from the newly requested set of runs.

In this PR I edited the "complete" logic to instead return true when all requested partitions have either materialized/failed/canceled, so the `AssetBackfillData` object has the full status counts after completion. This has the consequence of instigating asset backfill iterations until all runs have concluded.