### PR TITLE
[sphinx] make autodoc support Pythonic Resources

### DIFF
--- a/docs/sphinx/_ext/autodoc_dagster.py
+++ b/docs/sphinx/_ext/autodoc_dagster.py
@@ -15,6 +15,10 @@ from dagster._config.config_type import (
     Noneable,
     ScalarUnion,
 )
+from dagster._config.structured_config import (
+    ConfigurableResource,
+    infer_schema_from_config_class,
+)
 from dagster._core.definitions.configurable import ConfigurableDefinition
 from dagster._serdes import ConfigurableClass
 from sphinx.ext.autodoc import ClassDocumenter, DataDocumenter, ObjectMembers
@@ -138,10 +142,15 @@ class ConfigurableDocumenter(DataDocumenter):
         else:
             obj = self.object
 
-        obj = cast(Union[ConfigurableDefinition, Type[ConfigurableClass]], obj)
+        obj = cast(
+            Union[ConfigurableDefinition, Type[ConfigurableClass], ConfigurableResource], obj
+        )
+
         config_field = None
         if isinstance(obj, ConfigurableDefinition):
             config_field = check.not_none(obj.config_schema).as_field()
+        elif inspect.isclass(obj) and issubclass(obj, ConfigurableResource):
+            config_field = infer_schema_from_config_class(obj)
         elif isinstance(obj, type) and issubclass(obj, ConfigurableClass):
             config_field = Field(obj.config_type())
 


### PR DESCRIPTION
## Summary & Motivation
Updates the autodoc function so that the config for new Pythonic Resources is displayed

## How I Tested These Changes
ran on docs from the new duckdb io resources and visually confirmed that the config shows