### PR TITLE
Fix DST transition issues with cron string iterator

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -40,65 +40,26 @@ def cron_string_iterator(
 
     date_iter = croniter(cron_string, start_datetime)
 
-    # Go back one iteration so that the next iteration is the first time that is >= start_datetime
-    # and matches the cron schedule
-    next_date = date_iter.get_prev(datetime.datetime)
+    next_date = start_datetime
 
-    check.invariant(start_offset <= 0)
     for _ in range(-start_offset):
         next_date = date_iter.get_prev(datetime.datetime)
 
+    # Special-case hourly intervals where croniter struggles, particularly over DST
     cron_parts, nth_weekday_of_month = croniter.expand(cron_string)
-
     is_numeric = [len(part) == 1 and part[0] != "*" for part in cron_parts]
     is_wildcard = [len(part) == 1 and part[0] == "*" for part in cron_parts]
 
-    delta_fn = None
-    should_hour_change = False
+    if not nth_weekday_of_month and is_numeric[0] and all(is_wildcard[1:]):
+        next_date = date_iter.get_prev(datetime.datetime)
 
-    # Special-case common intervals (hourly/daily/weekly/monthly) since croniter iteration can be
-    # much slower than adding a fixed interval
-    if not nth_weekday_of_month:
-        if all(is_numeric[0:3]) and all(is_wildcard[3:]):  # monthly
-            delta_fn = lambda d, num: d.add(months=num)
-            should_hour_change = False
-        elif all(is_numeric[0:2]) and is_numeric[4] and all(is_wildcard[2:4]):  # weekly
-            delta_fn = lambda d, num: d.add(weeks=num)
-            should_hour_change = False
-        elif all(is_numeric[0:2]) and all(is_wildcard[2:]):  # daily
-            delta_fn = lambda d, num: d.add(days=num)
-            should_hour_change = False
-        elif is_numeric[0] and all(is_wildcard[1:]):  # hourly
-            delta_fn = lambda d, num: d.add(hours=num)
-            should_hour_change = True
-
-    if delta_fn is not None:
-        # Use pendulums for intervals when possible
         next_date = to_timezone(pendulum.instance(next_date), timezone_str)
         while True:
-            curr_hour = next_date.hour
-
-            next_date_cand = delta_fn(next_date, 1)
-            new_hour = next_date_cand.hour
-
-            if not should_hour_change and new_hour != curr_hour:
-                # If the hour changes during a daily/weekly/monthly schedule, it
-                # indicates that the time shifted due to falling in a time that doesn't
-                # exist due to a DST transition (for example, 2:30AM CST on 3/10/2019).
-                # Instead, execute at the first time that does exist (the start of the hour),
-                # but return to the original hour for all subsequent executions so that the
-                # hour doesn't stay different permanently.
-
-                check.invariant(new_hour == curr_hour + 1)
-                yield next_date_cand.replace(minute=0)
-
-                next_date_cand = delta_fn(next_date, 2)
-                check.invariant(next_date_cand.hour == curr_hour)
-
-            next_date = next_date_cand
+            next_date = next_date.add(hours=1)
             yield next_date
     else:
-        # Otherwise fall back to croniter
+        if next_date.second == 0 and croniter.match(cron_string, next_date):
+            yield to_timezone(pendulum.instance(next_date), timezone_str)
         while True:
             next_date = to_timezone(
                 pendulum.instance(date_iter.get_next(datetime.datetime)), timezone_str
@@ -118,60 +79,19 @@ def reverse_cron_string_iterator(
 
     date_iter = croniter(cron_string, end_datetime)
 
-    # Go forward one iteration so that the next iteration is the first time that is < end_datetime
-    # and matches the cron schedule
-    next_date = date_iter.get_next(datetime.datetime)
-
-    cron_parts, _ = croniter.expand(cron_string)
-
+    cron_parts, nth_weekday_of_month = croniter.expand(cron_string)
     is_numeric = [len(part) == 1 and part[0] != "*" for part in cron_parts]
     is_wildcard = [len(part) == 1 and part[0] == "*" for part in cron_parts]
-
-    # Special-case common intervals (hourly/daily/weekly/monthly) since croniter iteration can be
-    # much slower than adding a fixed interval
-    if all(is_numeric[0:3]) and all(is_wildcard[3:]):  # monthly
-        delta_fn = lambda d, num: d.subtract(months=num)
-        should_hour_change = False
-    elif all(is_numeric[0:2]) and is_numeric[4] and all(is_wildcard[2:4]):  # weekly
-        delta_fn = lambda d, num: d.subtract(weeks=num)
-        should_hour_change = False
-    elif all(is_numeric[0:2]) and all(is_wildcard[2:]):  # daily
-        delta_fn = lambda d, num: d.subtract(days=num)
-        should_hour_change = False
-    elif is_numeric[0] and all(is_wildcard[1:]):  # hourly
-        delta_fn = lambda d, num: d.subtract(hours=num)
-        should_hour_change = True
-    else:
-        delta_fn = None
-        should_hour_change = False
-
-    if delta_fn is not None:
-        # Use pendulums for intervals when possible
+    if not nth_weekday_of_month and is_numeric[0] and all(is_wildcard[1:]):
+        next_date = date_iter.get_next(datetime.datetime)
         next_date = to_timezone(pendulum.instance(next_date), timezone_str)
         while True:
-            curr_hour = next_date.hour
-
-            next_date_cand = delta_fn(next_date, 1)
-            new_hour = next_date_cand.hour
-
-            if not should_hour_change and new_hour != curr_hour:
-                # If the hour changes during a daily/weekly/monthly schedule, it
-                # indicates that the time shifted due to falling in a time that doesn't
-                # exist due to a DST transition (for example, 2:30AM CST on 3/10/2019).
-                # Instead, execute at the first time that does exist (the start of the hour),
-                # but return to the original hour for all subsequent executions so that the
-                # hour doesn't stay different permanently.
-
-                check.invariant(new_hour == curr_hour + 1)
-                yield next_date_cand.replace(minute=0)
-
-                next_date_cand = delta_fn(next_date, 2)
-                check.invariant(next_date_cand.hour == curr_hour)
-
-            next_date = next_date_cand
+            next_date = next_date.subtract(hours=1)
             yield next_date
     else:
-        # Otherwise fall back to croniter
+        if end_datetime.second == 0 and croniter.match(cron_string, end_datetime):
+            yield to_timezone(pendulum.instance(end_datetime), timezone_str)
+
         while True:
             next_date = to_timezone(
                 pendulum.instance(date_iter.get_prev(datetime.datetime)), timezone_str

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -1,0 +1,48 @@
+# ruff: noqa: T201
+
+from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._utils.schedules import cron_string_iterator
+
+time_sequences = (
+    "Europe/Berlin",
+    "0 2 * * *",
+    [
+        create_pendulum_time(2023, 3, 24, 2, 0, 0, tz="Europe/Berlin"),
+        create_pendulum_time(2023, 3, 25, 2, 0, 0, tz="Europe/Berlin"),
+        create_pendulum_time(  # 2AM on 3/26 does not exist, move forward
+            2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"
+        ),
+        create_pendulum_time(2023, 3, 27, 2, 0, 0, tz="Europe/Berlin"),  # return to 2AM
+        create_pendulum_time(2023, 3, 28, 2, 0, 0, tz="Europe/Berlin"),
+    ],
+)
+
+
+def test_dst_spring_forward_transition():
+    execution_timezone, cron_string, times = time_sequences
+
+    start_timestamp = to_timezone(times[0], "UTC").timestamp()
+
+    cron_iter = cron_string_iterator(
+        start_timestamp + 1,
+        cron_string,
+        execution_timezone,
+    )
+
+    # A single cron_iter covers the expected times
+    for i in range(1, len(times)):
+        next_datetime = next(cron_iter)
+        print(f"Next time: {next_datetime} Expected: {times[i]}")
+        assert next_datetime.timestamp() == times[i].timestamp()
+
+    # Starting 1 second after each time individually also produces the next tick
+    for i in range(len(times) - 1):
+        start_timestamp = to_timezone(times[i], "UTC").timestamp() + 1
+        fresh_cron_iter = cron_string_iterator(start_timestamp, cron_string, execution_timezone)
+
+        for j in range(i + 1, len(times) - 1):
+            next_time = next(fresh_cron_iter)
+
+            assert (
+                next_time.timestamp() == times[j].timestamp()
+            ), f"Expected {times[i]} to advance to {times[j]}, got {str(next_time)}"


### PR DESCRIPTION
Summary:
This fixes issues related to spring DST transitions for schedules that are running at a time that does not exist once each year (e.g. 2AM). Neither croniter.get_prev or croniter.match appear to handle times like that correctly, but croniter.get_next appears to work just fine.

Our existing tests that specifically cover DST transitions weren't catching this because they used a single iterator over multiple days - but the way the scheduler work is it spins up a brand new iterator for each tick. Added a test case that does that to reproduce the problem that we were seeing.

To get around the problem, simplify the logic of cron_string_iterator quite a bit - no longer use get_prev to try to move backwards onto the right cron interval, and instead rely on get_next to push us ahead to the correct next place. (There are some comments here about performance on hourly partition sets - that may have been true a couple years ago, but I did some quick testing and it doesn't seem to be at all worth the added complexity in 2023 - hourly partition sets going back to 2018 are maybe a couple of seconds slower to load thousands of partitions than they were before)

## Summary & Motivation

## How I Tested These Changes
