### PR TITLE
[cached_method] performance optimizations

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
@@ -79,3 +79,20 @@ def test_does_not_leak():
     assert objgraph.count("MyClass") == 0
     assert objgraph.count("KeyClass") == 0
     assert objgraph.count("ValueClass") == 0
+
+
+def test_collisions():
+    class MyClass:
+        @cached_method
+        def stuff(self, a=None, b=None):
+            return {"a": a, "b": b}
+
+    obj = MyClass()
+    a1 = obj.stuff(a=1)
+    b1 = obj.stuff(b=1)
+    a2 = obj.stuff(a=2)
+    b2 = obj.stuff(b=2)
+
+    assert a1 != b1
+    assert a1 != a2
+    assert b1 != b2


### PR DESCRIPTION
Some tweaks based on profiling of code that frequently invokes cached_method - notably on a method with no args. 

## How I Tested These Changes

captures from speedscope samples out of py-spy, looking at `helper` (the cached_method fn) in the sandwich view

https://gist.github.com/alangenfeld/74a5c77fddab62c871bc80161e087d22