### PR TITLE
[docs build] cancel old builds on same branch

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     paths:
       - docs/**
+concurrency:
+  # Cancel in-progress runs on same branch
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Cancels runs of the docs build action if a newer run exists on the given branch. Useful to prevent unnecessary vercel deploys if you're making several commits in sequence:

![Screen Shot 2023-03-29 at 1 17 01 PM](https://user-images.githubusercontent.com/10215173/228657379-8cabcbbb-f46b-4d67-b858-0a9126afc8f8.png)

