### PR TITLE
Fix min on empty list in data time resolution

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -405,10 +405,10 @@ class CachingDataTimeResolver:
 
         data_times = set(self.get_data_time_by_key_for_record(latest_record).values())
 
-        if None in data_times:
+        if None in data_times or not data_times:
             return None
 
-        return min(cast(AbstractSet[datetime.datetime], data_times))
+        return min(cast(AbstractSet[datetime.datetime], data_times), default=None)
 
     def get_current_minutes_late(
         self,


### PR DESCRIPTION
## Summary & Motivation

Unclear why, but in some cases, this list is empty. Guard against this scenario

Edit: this was happening because of a weirdly-structured query in get_event_log_records, which would do the wrong thing if rows were deleted. The root issue has been corrected, but this doesn't hurt as a safeguard

## How I Tested These Changes
