### PR TITLE
Allow sensor context constructors to take Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -32,6 +32,7 @@ from dagster._core.errors import (
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
+from dagster._utils import normalize_to_repository
 
 from .events import AssetKey
 from .run_request import RunRequest, SensorResult, SkipReason
@@ -48,6 +49,7 @@ from .target import ExecutableDefinition
 from .utils import check_valid_name
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.repository_definition import RepositoryDefinition
     from dagster._core.storage.event_log.base import EventLogRecord
 
@@ -185,7 +187,9 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         monitored_assets (Union[Sequence[AssetKey], AssetSelection]): The assets monitored
             by the sensor. If an AssetSelection object is provided, it will only apply to assets
             within the Definitions that this sensor is part of.
-        repository_def (RepositoryDefinition): The repository that the sensor belongs to.
+        repository_def (Optional[RepositoryDefinition]): The repository that the sensor belongs to.
+            If needed by the sensor top-level resource definitions will be pulled from this repository.
+            You can provide either this or `definitions`.
         instance_ref (Optional[InstanceRef]): The serialized instance configured to run the schedule
         cursor (Optional[str]): The cursor, passed back from the last sensor evaluation via
             the cursor attribute of SkipReason and RunRequest. Must be a dictionary of asset key
@@ -197,6 +201,9 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
         instance (Optional[DagsterInstance]): The deserialized instance can also be passed in
             directly (primarily useful in testing contexts).
+        definitions (Optional[Definitions]): `Definitions` object that the sensor is defined in.
+            If needed by the sensor, top-level resource definitions will be pulled from these
+            definitions. You can provide either this or `repository_def`.
 
     Example:
         .. code-block:: python
@@ -215,14 +222,20 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         last_run_key: Optional[str],
         cursor: Optional[str],
         repository_name: Optional[str],
-        repository_def: "RepositoryDefinition",
+        repository_def: Optional["RepositoryDefinition"],
         monitored_assets: Union[Sequence[AssetKey], AssetSelection],
         instance: Optional[DagsterInstance] = None,
         resources: Optional[Mapping[str, ResourceDefinition]] = None,
+        definitions: Optional["Definitions"] = None,
     ):
+        from dagster._core.definitions.definitions_class import Definitions
+        from dagster._core.definitions.repository_definition import RepositoryDefinition
         from dagster._core.storage.event_log.base import EventLogRecord
 
-        self._repository_def = repository_def
+        self._repository_def = normalize_to_repository(
+            check.opt_inst_param(definitions, "definitions", Definitions),
+            check.opt_inst_param(repository_def, "repository_def", RepositoryDefinition),
+        )
         self._monitored_asset_keys: Sequence[AssetKey]
         if isinstance(monitored_assets, AssetSelection):
             repo_assets = self._repository_def.assets_defs_by_key.values()
@@ -920,13 +933,15 @@ def get_cursor_from_latest_materializations(
 
 @experimental
 def build_multi_asset_sensor_context(
-    repository_def: "RepositoryDefinition",
+    *,
     monitored_assets: Union[Sequence[AssetKey], AssetSelection],
+    repository_def: Optional["RepositoryDefinition"] = None,
     instance: Optional[DagsterInstance] = None,
     cursor: Optional[str] = None,
     repository_name: Optional[str] = None,
     cursor_from_latest_materializations: bool = False,
     resources: Optional[Mapping[str, ResourceDefinition]] = None,
+    definitions: Optional["Definitions"] = None,
 ) -> MultiAssetSensorEvaluationContext:
     """Builds multi asset sensor execution context for testing purposes using the provided parameters.
 
@@ -935,10 +950,11 @@ def build_multi_asset_sensor_context(
     error.
 
     Args:
-        repository_def (RepositoryDefinition): The repository definition that the sensor belongs to.
         monitored_assets (Union[Sequence[AssetKey], AssetSelection]): The assets monitored
             by the sensor. If an AssetSelection object is provided, it will only apply to assets
             within the Definitions that this sensor is part of.
+        repository_def (RepositoryDefinition): `RepositoryDefinition` object that
+            the sensor is defined in. Must provide `definitions` if this is not provided.
         instance (Optional[DagsterInstance]): The dagster instance configured to run the sensor.
         cursor (Optional[str]): A string cursor to provide to the evaluation of the sensor. Must be
             a dictionary of asset key strings to ints that has been converted to a json string
@@ -947,6 +963,8 @@ def build_multi_asset_sensor_context(
             materialization for each monitored asset. By default, set to False.
         resources (Optional[Mapping[str, ResourceDefinition]]): The resource definitions
             to provide to the sensor.
+        definitions (Optional[Definitions]): `Definitions` object that the sensor is defined in.
+            Must provide `repository_def` if this is not provided.
 
     Examples:
         .. code-block:: python
@@ -960,11 +978,15 @@ def build_multi_asset_sensor_context(
 
     """
     from dagster._core.definitions import RepositoryDefinition
+    from dagster._core.definitions.definitions_class import Definitions
 
     check.opt_inst_param(instance, "instance", DagsterInstance)
     check.opt_str_param(cursor, "cursor")
     check.opt_str_param(repository_name, "repository_name")
-    check.inst_param(repository_def, "repository_def", RepositoryDefinition)
+    repository_def = normalize_to_repository(
+        check.opt_inst_param(definitions, "definitions", Definitions),
+        check.opt_inst_param(repository_def, "repository_def", RepositoryDefinition),
+    )
 
     check.bool_param(cursor_from_latest_materializations, "cursor_from_latest_materializations")
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -44,9 +44,10 @@ from dagster._core.errors import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._serdes import whitelist_for_serdes
+from dagster._utils import normalize_to_repository
 
 from ..decorator_utils import (
-    get_function_params,  # pylint: disable=unused-import
+    get_function_params,
 )
 from .asset_selection import AssetSelection
 from .graph_definition import GraphDefinition
@@ -65,6 +66,7 @@ from .utils import check_valid_name
 
 if TYPE_CHECKING:
     from dagster import ResourceDefinition
+    from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.repository_definition import RepositoryDefinition
 
 
@@ -102,8 +104,14 @@ class SensorEvaluationContext:
         last_run_key (str): DEPRECATED The run key of the RunRequest most recently created by this
             sensor. Use the preferred `cursor` attribute instead.
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
+        repository_def (Optional[RepositoryDefinition]): The repository or that
+            the sensor belongs to. If needed by the sensor top-level resource definitions will be
+            pulled from this repository. You can provide either this or `definitions`.
         instance (Optional[DagsterInstance]): The deserialized instance can also be passed in
             directly (primarily useful in testing contexts).
+        definitions (Optional[Definitions]): `Definitions` object that the sensor is defined in.
+            If needed by the sensor, top-level resource definitions will be pulled from these
+            definitions. You can provide either this or `repository_def`.
 
     Example:
         .. code-block:: python
@@ -127,7 +135,11 @@ class SensorEvaluationContext:
         instance: Optional[DagsterInstance] = None,
         sensor_name: Optional[str] = None,
         resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
+        definitions: Optional["Definitions"] = None,
     ):
+        from dagster._core.definitions.definitions_class import Definitions
+        from dagster._core.definitions.repository_definition import RepositoryDefinition
+
         self._exit_stack = ExitStack()
         self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)
         self._last_completion_time = check.opt_float_param(
@@ -136,7 +148,11 @@ class SensorEvaluationContext:
         self._last_run_key = check.opt_str_param(last_run_key, "last_run_key")
         self._cursor = check.opt_str_param(cursor, "cursor")
         self._repository_name = check.opt_str_param(repository_name, "repository_name")
-        self._repository_def = repository_def
+        self._repository_def = normalize_to_repository(
+            check.opt_inst_param(definitions, "definitions", Definitions),
+            check.opt_inst_param(repository_def, "repository_def", RepositoryDefinition),
+            error_on_none=False,
+        )
         self._instance = check.opt_inst_param(instance, "instance", DagsterInstance)
         self._sensor_name = sensor_name
 
@@ -834,6 +850,7 @@ def build_sensor_context(
     repository_def: Optional["RepositoryDefinition"] = None,
     sensor_name: Optional[str] = None,
     resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
+    definitions: Optional["Definitions"] = None,
 ) -> SensorEvaluationContext:
     """Builds sensor execution context using the provided parameters.
 
@@ -847,9 +864,13 @@ def build_sensor_context(
         repository_name (Optional[str]): The name of the repository that the sensor belongs to.
         repository_def (Optional[RepositoryDefinition]): The repository that the sensor belongs to.
             If needed by the sensor top-level resource definitions will be pulled from this repository.
+            You can provide either this or `definitions`.
         resources (Optional[Mapping[str, ResourceDefinition]]): A set of resource definitions
             to provide to the sensor. If passed, these will override any resource definitions
             provided by the repository.
+        definitions (Optional[Definitions]): `Definitions` object that the sensor is defined in.
+            If needed by the sensor, top-level resource definitions will be pulled from these
+            definitions. You can provide either this or `repository_def`.
 
     Examples:
         .. code-block:: python
@@ -858,9 +879,17 @@ def build_sensor_context(
             my_sensor(context)
 
     """
+    from dagster._core.definitions.definitions_class import Definitions
+    from dagster._core.definitions.repository_definition import RepositoryDefinition
+
     check.opt_inst_param(instance, "instance", DagsterInstance)
     check.opt_str_param(cursor, "cursor")
     check.opt_str_param(repository_name, "repository_name")
+    repository_def = normalize_to_repository(
+        check.opt_inst_param(definitions, "definitions", Definitions),
+        check.opt_inst_param(repository_def, "repository_def", RepositoryDefinition),
+        error_on_none=False,
+    )
 
     return SensorEvaluationContext(
         instance_ref=None,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -14,6 +14,7 @@ from dagster import (
     DagsterRunStatus,
     DagsterUnknownPartitionError,
     DailyPartitionsDefinition,
+    Definitions,
     EventRecordsFilter,
     FreshnessPolicy,
     Output,
@@ -770,18 +771,19 @@ def test_multi_asset_sensor():
             context.advance_all_cursors()
             return RunRequest(run_key=context.cursor, run_config={})
 
-    @repository
-    def my_repo():
-        return [asset_a, asset_b, a_and_b_sensor]
+    defs = Definitions(assets=[asset_a, asset_b], sensors=[a_and_b_sensor])
+    my_repo = defs.get_repository_def()
 
-    with instance_for_test() as instance:
-        materialize([asset_a, asset_b], instance=instance)
-        ctx = build_multi_asset_sensor_context(
-            monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
-            instance=instance,
-            repository_def=my_repo,
-        )
-        assert a_and_b_sensor(ctx).run_config == {}
+    for definitions, repository_def in [(defs, None), (None, my_repo)]:
+        with instance_for_test() as instance:
+            materialize([asset_a, asset_b], instance=instance)
+            ctx = build_multi_asset_sensor_context(
+                monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
+                instance=instance,
+                repository_def=repository_def,
+                definitions=definitions,
+            )
+            assert a_and_b_sensor(ctx).run_config == {}
 
 
 def test_multi_asset_sensor_selection():


### PR DESCRIPTION
## Summary & Motivation

Allows sensor context constructors to take a `Definitions` object instead of a `RepositoryDefinition`. Resolves #13207.

## How I Tested These Changes

Modified existing sensor context tests.
