### PR TITLE
[dagit] Fix crash when loading the asset sidebar without live data ready

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionHealthData.tsx
@@ -527,10 +527,12 @@ export function usePartitionHealthData(
 // or partition events page needs to be reloaded based on the partition counts or
 // a new run / run failure.
 //
-export const healthRefreshHintFromLiveData = (liveData: LiveDataForNode) =>
-  `${liveData.lastMaterialization?.timestamp},${
-    liveData.runWhichFailedToMaterialize?.id
-  },${JSON.stringify(liveData.partitionStats)}`;
+export const healthRefreshHintFromLiveData = (liveData: LiveDataForNode | undefined) =>
+  liveData
+    ? `${liveData.lastMaterialization?.timestamp},${
+        liveData.runWhichFailedToMaterialize?.id
+      },${JSON.stringify(liveData.partitionStats)}`
+    : `-`;
 
 const rangeStatusToState = (rangeStatus: PartitionRangeStatus) =>
   rangeStatus === PartitionRangeStatus.MATERIALIZED


### PR DESCRIPTION
## Summary & Motivation

I observed this case today and it seems like a loading state I didn't exercise fully in my last PR.

## How I Tested These Changes
