### PR TITLE
[pythonic config] Add ConfigurableResourceFactory base class

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -105,6 +105,7 @@ from dagster._config.structured_config import (
     ConfigurableLegacyIOManagerAdapter as ConfigurableLegacyIOManagerAdapter,
     ConfigurableLegacyResourceAdapter as ConfigurableLegacyResourceAdapter,
     ConfigurableResource as ConfigurableResource,
+    ConfigurableResourceFactory as ConfigurableResourceFactory,
     PermissiveConfig as PermissiveConfig,
     ResourceDependency as ResourceDependency,
 )

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -31,6 +31,7 @@ from dagster._config.structured_config import (
     ConfigurableLegacyIOManagerAdapter,
     ConfigurableLegacyResourceAdapter,
     ConfigurableResource,
+    ConfigurableResourceFactory,
     ResourceDependency,
 )
 from dagster._core.definitions.assets_job import build_assets_job
@@ -220,7 +221,7 @@ def test_abc_resource():
 def test_yield_in_resource_function():
     called = []
 
-    class ResourceWithCleanup(ConfigurableResource):
+    class ResourceWithCleanup(ConfigurableResourceFactory[bool]):
         idx: int
 
         def create_resource(self, context):
@@ -673,7 +674,7 @@ def test_nested_resources_runtime_config_complex():
 
 
 def test_resources_which_return():
-    class StringResource(ConfigurableResource[str]):
+    class StringResource(ConfigurableResourceFactory[str]):
         a_string: str
 
         def create_resource(self, context) -> str:
@@ -741,7 +742,7 @@ def test_nested_function_resource():
 
         return output
 
-    class PostfixWriterResource(ConfigurableResource[Callable[[str], None]]):
+    class PostfixWriterResource(ConfigurableResourceFactory[Callable[[str], None]]):
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
@@ -779,7 +780,7 @@ def test_nested_function_resource_configured():
 
         return output
 
-    class PostfixWriterResource(ConfigurableResource[Callable[[str], None]]):
+    class PostfixWriterResource(ConfigurableResourceFactory[Callable[[str], None]]):
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
@@ -831,7 +832,7 @@ def test_nested_function_resource_runtime_config():
 
         return output
 
-    class PostfixWriterResource(ConfigurableResource[Callable[[str], None]]):
+    class PostfixWriterResource(ConfigurableResourceFactory[Callable[[str], None]]):
         writer: ResourceDependency[Callable[[str], None]]
         postfix: str
 
@@ -994,7 +995,7 @@ reveal_type(my_str_resource.a_string)
         # resource function that returns a str
         assert (
             pyright_out[0]
-            == "(self: StringDependentResource, a_string: ConfigurableResource[str] |"
+            == "(self: StringDependentResource, a_string: ConfigurableResourceFactory[str] |"
             " PartialResource[str] | ResourceDefinition | str) -> None"
         )
 


### PR DESCRIPTION
## Summary

Adds a new `ConfigurableResourceFactory` class based on offline discussion with @schrockn. This doesn't lead to a functional change, but makes the new resource system a bit more self-documenting for new users.

Now, there's two base classes, one you use (`ConfigurableResource`) for the case where the resource class itself is passed to user code:

```python
class MyResource(ConfigurableResource):
    a_str: str


@op
def my_op(foo_resource: MyResource):
    print(foo_resource.a_str)
```

And one you use (`ConfigurableResourceFactory`) when the class produces a plain Python value which is passed to user code:

```python
class MyResourceFactory(ConfigurableResourceFactory[str]):
    a_str: str

    def construct_resource(self):
        return self.a_str
    
@op
def my_op(foo_resource: str, context):
    print(foo_resource)
```

(Previously, users would just use `ConfigurableResource` and override `construct_resource`, but having these as two separate base classes makes explaining it in docs nicer.)

## Test Plan

Existing unit tests.
