### PR TITLE
[serdes] bottom-up deserialize

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -457,11 +457,11 @@ class AssetMaterializationSerializer(NamedTupleSerializer):
     # There are old `Materialization` objects in storage. We set the default value for asset key to
     # be `AssetKey(["__undefined__"])` to ensure that we can load these objects, without needing to
     # allow for the construction of new `AssetMaterialization` objects with no defined AssetKey.
-    def before_unpack(self, **raw_dict: Any) -> Any:
+    def before_unpack(self, context, unpacked_dict: Any) -> Any:
         # cover both the case where "asset_key" is not present at all and where it is None
-        if raw_dict.get("asset_key") is None:
-            raw_dict["asset_key"] = {"__class__": "AssetKey", "path": UNDEFINED_ASSET_KEY_PATH}
-        return raw_dict
+        if unpacked_dict.get("asset_key") is None:
+            unpacked_dict["asset_key"] = AssetKey(UNDEFINED_ASSET_KEY_PATH)
+        return unpacked_dict
 
 
 @whitelist_for_serdes(

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -25,9 +25,9 @@ from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import (
     FieldSerializer,
     PackableValue,
+    UnpackContext,
     WhitelistMap,
     pack_value,
-    unpack_value,
 )
 from dagster._utils.backcompat import (
     canonicalize_backcompat_args,
@@ -961,21 +961,11 @@ class MetadataFieldSerializer(FieldSerializer):
 
     def unpack(
         self,
-        metadata_entries: List[Mapping[str, Any]],
+        metadata_entries: List["MetadataEntry"],
         whitelist_map: WhitelistMap,
-        descent_path: str,
+        context: UnpackContext,
     ) -> Mapping[str, MetadataValue]:
-        return {
-            e["label"]: unpack_value(
-                e["entry_data"],
-                # MetadataValue itself can't inherit from NamedTuple and so isn't a PackableValue,
-                # but one of its subclasses will always be returned here.
-                as_type=MetadataValue,  # type: ignore
-                whitelist_map=whitelist_map,
-                descent_path=descent_path,
-            )
-            for e in metadata_entries
-        }
+        return {e.label: e.entry_data for e in metadata_entries}
 
 
 T_MetadataValue = TypeVar("T_MetadataValue", bound=MetadataValue, covariant=True)

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -47,6 +47,7 @@ from dagster._serdes import (
     NamedTupleSerializer,
     whitelist_for_serdes,
 )
+from dagster._serdes.serdes import UnpackContext
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.timing import format_duration
 
@@ -314,16 +315,21 @@ def log_resource_event(log_manager: DagsterLogManager, event: "DagsterEvent") ->
 
 
 class DagsterEventSerializer(NamedTupleSerializer["DagsterEvent"]):
-    def before_unpack(self, **storage_dict: Any) -> Dict[str, Any]:
+    def before_unpack(self, context, unpacked_dict: Any) -> Dict[str, Any]:
         event_type_value, event_specific_data = _handle_back_compat(
-            storage_dict["event_type_value"], storage_dict.get("event_specific_data")
+            unpacked_dict["event_type_value"], unpacked_dict.get("event_specific_data")
         )
-        storage_dict["event_type_value"] = event_type_value
-        storage_dict["event_specific_data"] = event_specific_data
+        unpacked_dict["event_type_value"] = event_type_value
+        unpacked_dict["event_specific_data"] = event_specific_data
 
-        return storage_dict
+        return unpacked_dict
 
-    def handle_unpack_error(self, exc: Exception, **storage_dict: Any) -> "DagsterEvent":
+    def handle_unpack_error(
+        self,
+        exc: Exception,
+        context: UnpackContext,
+        storage_dict: Dict[str, Any],
+    ) -> "DagsterEvent":
         event_type_value, _ = _handle_back_compat(
             storage_dict["event_type_value"], storage_dict.get("event_specific_data")
         )
@@ -1733,7 +1739,8 @@ class ComputeLogsCaptureData(
 
 
 def _handle_back_compat(
-    event_type_value: str, event_specific_data: Optional[Dict[str, Any]]
+    event_type_value: str,
+    event_specific_data: Optional[Dict[str, Any]],
 ) -> Tuple[str, Optional[Dict[str, Any]]]:
     # transform old specific process events in to engine events
     if event_type_value in [

--- a/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/pipeline_snapshot.py
@@ -75,15 +75,16 @@ class PipelineSnapshotSerializer(NamedTupleSerializer["PipelineSnapshot"]):
     #     deserialization errors.
     def before_unpack(
         self,
-        **packed: Any,
+        context,
+        unpacked_dict: Any,
     ) -> Dict[str, Any]:
-        if packed.get("graph_def_name") is None:
-            packed["graph_def_name"] = packed["name"]
-        if packed.get("metadata") is None:
-            packed["metadata"] = {}
-        if packed.get("lineage_snapshot") is None:
-            packed["lineage_snapshot"] = None
-        return packed
+        if unpacked_dict.get("graph_def_name") is None:
+            unpacked_dict["graph_def_name"] = unpacked_dict["name"]
+        if unpacked_dict.get("metadata") is None:
+            unpacked_dict["metadata"] = []
+        if unpacked_dict.get("lineage_snapshot") is None:
+            unpacked_dict["lineage_snapshot"] = None
+        return unpacked_dict
 
 
 # Note that unlike other serdes-whitelisted objects that hold metadata, the field here has always

--- a/python_modules/dagster/dagster/_core/storage/pipeline_run.py
+++ b/python_modules/dagster/dagster/_core/storage/pipeline_run.py
@@ -23,7 +23,6 @@ from dagster._core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
 from dagster._core.utils import make_new_run_id
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
-    copy_packed_set,
     whitelist_for_serdes,
 )
 
@@ -152,63 +151,63 @@ class DagsterRunSerializer(NamedTupleSerializer["DagsterRun"]):
     # * renamed environment_dict -> run_config
     # * added asset_selection
     # * added has_repository_load_data
-    def before_unpack(self, **unpacked: Any) -> Dict[str, Any]:
+    def before_unpack(self, context, unpacked_dict: Dict[str, Any]) -> Dict[str, Any]:
         # back compat for environment dict => run_config
-        if "environment_dict" in unpacked:
+        if "environment_dict" in unpacked_dict:
             check.invariant(
-                unpacked.get("run_config") is None,
+                unpacked_dict.get("run_config") is None,
                 "Cannot set both run_config and environment_dict. Use run_config parameter.",
             )
-            unpacked["run_config"] = unpacked["environment_dict"]
-            del unpacked["environment_dict"]
+            unpacked_dict["run_config"] = unpacked_dict["environment_dict"]
+            del unpacked_dict["environment_dict"]
 
         # back compat for previous_run_id => parent_run_id, root_run_id
-        if "previous_run_id" in unpacked and not (
-            "parent_run_id" in unpacked and "root_run_id" in unpacked
+        if "previous_run_id" in unpacked_dict and not (
+            "parent_run_id" in unpacked_dict and "root_run_id" in unpacked_dict
         ):
-            unpacked["parent_run_id"] = unpacked["previous_run_id"]
-            unpacked["root_run_id"] = unpacked["previous_run_id"]
-            del unpacked["previous_run_id"]
+            unpacked_dict["parent_run_id"] = unpacked_dict["previous_run_id"]
+            unpacked_dict["root_run_id"] = unpacked_dict["previous_run_id"]
+            del unpacked_dict["previous_run_id"]
 
         # back compat for selector => pipeline_name, solids_to_execute
-        if "selector" in unpacked:
-            selector = unpacked["selector"]
+        if "selector" in unpacked_dict:
+            selector = unpacked_dict["selector"]
 
-            pipeline_name = unpacked.get("pipeline_name")
+            if not isinstance(selector, ExecutionSelector):
+                check.failed(f"unexpected entry for 'select', {selector}")
+            selector_name = selector.name
+            selector_subset = selector.solid_subset
+
+            pipeline_name = unpacked_dict.get("pipeline_name")
             check.invariant(
-                pipeline_name is None or selector.get("name") == pipeline_name,
+                pipeline_name is None or selector_name == pipeline_name,
                 (
                     f"Conflicting pipeline name {pipeline_name} in arguments to PipelineRun: "
-                    f"selector was passed with pipeline {selector.get('name')}"
+                    f"selector was passed with pipeline {selector_name}"
                 ),
             )
             if pipeline_name is None:
-                unpacked["pipeline_name"] = selector.get("name")
+                unpacked_dict["pipeline_name"] = selector_name
 
-            solids_to_execute = unpacked.get("solids_to_execute")
+            solids_to_execute = unpacked_dict.get("solids_to_execute")
             check.invariant(
-                solids_to_execute is None or set(selector.get("solid_subset")) == solids_to_execute,
+                solids_to_execute is None
+                or (selector_subset and set(selector_subset) == solids_to_execute),
                 (
                     f"Conflicting solids_to_execute {solids_to_execute} in arguments to"
-                    f" PipelineRun: selector was passed with subset {selector.get('solid_subset')}"
+                    f" PipelineRun: selector was passed with subset {selector_subset}"
                 ),
             )
             # for old runs that only have selector but no solids_to_execute
             if solids_to_execute is None:
-                solids_to_execute = (
-                    copy_packed_set(selector["solid_subset"], "__frozenset__")
-                    if selector.get("solid_subset")
-                    else None
-                )
+                solids_to_execute = frozenset(selector_subset) if selector_subset else None
 
         # back compat for solid_subset => solids_to_execute
-        if "solid_subset" in unpacked:
-            unpacked["solids_to_execute"] = copy_packed_set(
-                unpacked["solid_subset"], "__frozenset__"
-            )
-            del unpacked["solid_subset"]
+        if "solid_subset" in unpacked_dict:
+            unpacked_dict["solids_to_execute"] = unpacked_dict["solid_subset"]
+            del unpacked_dict["solid_subset"]
 
-        return unpacked
+        return unpacked_dict
 
 
 @whitelist_for_serdes(
@@ -431,7 +430,8 @@ class DagsterRun(
 class RunsFilterSerializer(NamedTupleSerializer["RunsFilter"]):
     def before_unpack(
         self,
-        **unpacked_dict: Any,
+        context,
+        unpacked_dict: Dict[str, Any],
     ) -> Dict[str, Any]:
         # We store empty run ids as [] but only accept None
         if "run_ids" in unpacked_dict and unpacked_dict["run_ids"] == []:

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -12,11 +12,11 @@ Why not pickle?
 * This isn't meant to replace pickle in the conditions that pickle is reasonable to use
   (in memory, not human readable, etc) just handle the json case effectively.
 """
-
 import collections.abc
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
+from functools import partial
 from inspect import Parameter, signature
 from typing import (
     AbstractSet,
@@ -28,7 +28,6 @@ from typing import (
     List,
     Mapping,
     NamedTuple,
-    NoReturn,
     Optional,
     Sequence,
     Set,
@@ -39,7 +38,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Final, Literal, Self, TypeAlias, TypeGuard, TypeVar
+from typing_extensions import Final, Self, TypeAlias, TypeVar
 
 import dagster._check as check
 import dagster._seven as seven
@@ -74,6 +73,21 @@ PackableValue: TypeAlias = Union[
     Set["PackableValue"],
     FrozenSet["PackableValue"],
     Enum,
+]
+
+UnpackedValue: TypeAlias = Union[
+    Sequence["UnpackedValue"],
+    Mapping[str, "UnpackedValue"],
+    str,
+    int,
+    float,
+    bool,
+    None,
+    NamedTuple,
+    Set["PackableValue"],
+    FrozenSet["PackableValue"],
+    Enum,
+    "UnknownSerdesValue",
 ]
 
 
@@ -314,6 +328,58 @@ def _whitelist_for_serdes(
     return __whitelist_for_serdes
 
 
+###################################################################################################
+# Serializers
+###################################################################################################
+
+
+class UnpackContext:
+    """values are unpacked bottom up."""
+
+    def __init__(self):
+        self.observed_unknown_serdes_values: Set[UnknownSerdesValue] = set()
+
+    def assert_no_unknown_values(self, obj: UnpackedValue) -> PackableValue:
+        if isinstance(obj, UnknownSerdesValue):
+            raise DeserializationError(
+                f"{obj.message}\nThis error can occur due to version skew, verify processes are"
+                " running expected versions."
+            )
+        elif isinstance(obj, (list, set, frozenset)):
+            for inner in obj:
+                self.assert_no_unknown_values(inner)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                self.assert_no_unknown_values(v)
+
+        return cast(PackableValue, obj)
+
+    def observe_unknown_value(self, val: "UnknownSerdesValue") -> "UnknownSerdesValue":
+        self.observed_unknown_serdes_values.add(val)
+        return val
+
+    def clear_ignored_unknown_values(self, obj: T) -> T:
+        if isinstance(obj, UnknownSerdesValue):
+            self.observed_unknown_serdes_values.discard(obj)
+        elif isinstance(obj, (list, set, frozenset)):
+            for inner in obj:
+                self.clear_ignored_unknown_values(inner)
+        elif isinstance(obj, dict):
+            for k, v in obj.items():
+                self.clear_ignored_unknown_values(v)
+
+        return obj
+
+    def finalize_unpack(self, unpacked: UnpackedValue) -> PackableValue:
+        if self.observed_unknown_serdes_values:
+            message = ",".join(v.message for v in self.observed_unknown_serdes_values)
+            raise DeserializationError(
+                f"{message}\nThis error can occur due to version skew, verify processes are"
+                " running expected versions."
+            )
+        return cast(PackableValue, unpacked)
+
+
 class Serializer(ABC):
     pass
 
@@ -329,7 +395,12 @@ class EnumSerializer(Serializer, Generic[T_Enum]):
     def unpack(self, value: str) -> T_Enum:
         return self.klass[value]
 
-    def pack(self, value: Enum, whitelist_map: WhitelistMap, descent_path: str) -> str:
+    def pack(
+        self,
+        value: Enum,
+        whitelist_map: WhitelistMap,
+        descent_path: str,
+    ) -> str:
         return f"{self.get_storage_name()}.{value.name}"
 
     def get_storage_name(self) -> str:
@@ -356,29 +427,41 @@ class NamedTupleSerializer(Serializer, Generic[T_NamedTuple]):
         self.klass = klass
         self.storage_name = storage_name
         self.storage_field_names = storage_field_names or {}
+        self.loaded_field_names = {v: k for k, v in self.storage_field_names.items()}
         self.old_fields = old_fields or {}
         self.skip_when_empty_fields = skip_when_empty_fields or set()
         self.field_serializers = field_serializers or {}
 
     def unpack(
         self,
-        storage_dict: Dict[str, Any],
+        unpacked_dict: Dict[str, UnpackedValue],
         whitelist_map: WhitelistMap,
-        descent_path: str,
+        context: UnpackContext,
     ) -> T_NamedTuple:
         try:
-            storage_dict = self.before_unpack(**storage_dict)
+            unpacked_dict = self.before_unpack(context, unpacked_dict)
             unpacked: Dict[str, PackableValue] = {}
-            for key, value in storage_dict.items():
-                loaded_name = self.get_loaded_field_name(field=key)
+            for key, value in unpacked_dict.items():
+                loaded_name = self.loaded_field_names.get(key, key)
                 # Naively implements backwards compatibility by filtering arguments that aren't present in
                 # the constructor. If a property is present in the serialized object, but doesn't exist in
                 # the version of the class loaded into memory, that property will be completely ignored.
                 if loaded_name in self.constructor_param_names:
-                    unpack_fn = self.get_field_unpack_fn(field=loaded_name)
-                    unpacked[loaded_name] = unpack_fn(
-                        value, whitelist_map=whitelist_map, descent_path=descent_path
-                    )
+                    # custom unpack regardless of hook vs recursive descent
+                    custom = self.field_serializers.get(loaded_name)
+                    if custom:
+                        unpacked[loaded_name] = custom.unpack(
+                            value,
+                            whitelist_map=whitelist_map,
+                            context=context,
+                        )
+                    elif context.observed_unknown_serdes_values:
+                        unpacked[loaded_name] = context.assert_no_unknown_values(value)
+                    else:
+                        unpacked[loaded_name] = cast(PackableValue, value)
+
+                else:
+                    context.clear_ignored_unknown_values(value)
 
             # False positive type error here due to an eccentricity of `NamedTuple`-- calling `NamedTuple`
             # directly acts as a class factory, which is not true for `NamedTuple` subclasses (which act
@@ -386,16 +469,29 @@ class NamedTupleSerializer(Serializer, Generic[T_NamedTuple]):
             # we are invoking the class factory and complains about arguments.
             return self.klass(**unpacked)  # type: ignore
         except Exception as exc:
-            return self.handle_unpack_error(exc, **storage_dict)
+            value = self.handle_unpack_error(exc, context, unpacked_dict)
+            if isinstance(context, UnpackContext):
+                context.assert_no_unknown_values(value)
+                context.clear_ignored_unknown_values(unpacked_dict)
+            return value
 
-    # Hook: Modify the contents of the loaded dict before it is unpacked into domain objects during
+    # Hook: Modify the contents of the unpacked dict before domain object construction during
     # deserialization.
-    def before_unpack(self, **raw_dict: JsonSerializableValue) -> Dict[str, JsonSerializableValue]:
-        return raw_dict
+    def before_unpack(
+        self,
+        context: UnpackContext,
+        unpacked_dict: Dict[str, UnpackedValue],
+    ) -> Dict[str, UnpackedValue]:
+        return unpacked_dict
 
     # Hook: Handle an error that occurs when unpacking a NamedTuple. Can be used to return a default
     # value.
-    def handle_unpack_error(self, exc: Exception, **storage_dict: Any) -> NoReturn:
+    def handle_unpack_error(
+        self,
+        exc: Exception,
+        context: UnpackContext,
+        storage_dict: Dict[str, Any],
+    ) -> Any:
         raise exc
 
     def pack(
@@ -412,7 +508,9 @@ class NamedTupleSerializer(Serializer, Generic[T_NamedTuple]):
             storage_key = self.get_storage_field_name(field=key)
             pack_fn = self.get_field_pack_fn(field=key)
             packed[storage_key] = pack_fn(
-                inner_value, whitelist_map=whitelist_map, descent_path=f"{descent_path}.{key}"
+                inner_value,
+                whitelist_map=whitelist_map,
+                descent_path=f"{descent_path}.{key}",
             )
         for key, default in self.old_fields.items():
             packed[key] = default
@@ -432,22 +530,12 @@ class NamedTupleSerializer(Serializer, Generic[T_NamedTuple]):
     def get_storage_name(self) -> str:
         return self.storage_name or self.klass.__name__
 
-    def get_field_unpack_fn(self, field: str) -> Callable[..., PackableValue]:
-        field_serializer = self.field_serializers.get(field)
-        return field_serializer.unpack if field_serializer else unpack_value
-
     def get_field_pack_fn(self, field: str) -> Callable[..., JsonSerializableValue]:
         field_serializer = self.field_serializers.get(field)
         return field_serializer.pack if field_serializer else pack_value
 
     def get_storage_field_name(self, field: str) -> str:
         return self.storage_field_names.get(field, field)
-
-    def get_loaded_field_name(self, field: str) -> str:
-        for k, v in self.storage_field_names.items():
-            if v == field:
-                return k
-        return field
 
 
 class FieldSerializer(Serializer):
@@ -465,9 +553,9 @@ class FieldSerializer(Serializer):
     @abstractmethod
     def unpack(
         self,
-        __packed_value: Any,
+        __unpacked_value: UnpackedValue,
         whitelist_map: WhitelistMap,
-        descent_path: str,
+        context: UnpackContext,
     ) -> PackableValue:
         ...
 
@@ -487,7 +575,9 @@ class FieldSerializer(Serializer):
 
 
 def serialize_value(
-    val: PackableValue, whitelist_map: WhitelistMap = _WHITELIST_MAP, **json_kwargs: object
+    val: PackableValue,
+    whitelist_map: WhitelistMap = _WHITELIST_MAP,
+    **json_kwargs: object,
 ) -> str:
     """Serialize an object to a JSON string.
 
@@ -499,7 +589,9 @@ def serialize_value(
 
 @overload
 def pack_value(
-    val: T_Scalar, whitelist_map: WhitelistMap = ..., descent_path: Optional[str] = ...
+    val: T_Scalar,
+    whitelist_map: WhitelistMap = ...,
+    descent_path: Optional[str] = ...,
 ) -> T_Scalar:
     ...
 
@@ -538,11 +630,13 @@ def pack_value(
         * frozenset
     """
     descent_path = _root(val) if descent_path is None else descent_path
-    return _pack_value(val, whitelist_map=whitelist_map, descent_path=_root(val))
+    return _pack_value(val, whitelist_map=whitelist_map, descent_path=descent_path)
 
 
 def _pack_value(
-    val: PackableValue, whitelist_map: WhitelistMap, descent_path: str
+    val: PackableValue,
+    whitelist_map: WhitelistMap,
+    descent_path: str,
 ) -> JsonSerializableValue:
     if is_named_tuple_instance(val):
         klass_name = val.__class__.__name__
@@ -550,7 +644,7 @@ def _pack_value(
             raise SerializationError(
                 (
                     "Can only serialize whitelisted namedtuples, received"
-                    f" {val}.{_path_msg(descent_path)}"
+                    f" {val}.\nDescent path: {descent_path}"
                 ),
             )
         serializer = whitelist_map.get_tuple_entry(klass_name)
@@ -561,7 +655,7 @@ def _pack_value(
             raise SerializationError(
                 (
                     "Can only serialize whitelisted Enums, received"
-                    f" {klass_name}.{_path_msg(descent_path)}"
+                    f" {klass_name}.\nDescent path: {descent_path}"
                 ),
             )
         enum_serializer = whitelist_map.get_enum_entry(klass_name)
@@ -654,9 +748,11 @@ def deserialize_value(
     # Never issue warnings when deserializing deprecated objects.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-
-        packed_value = seven.json.loads(val)
-        unpacked_value = unpack_value(packed_value, whitelist_map=whitelist_map)
+        context = UnpackContext()
+        unpacked_value = seven.json.loads(
+            val, object_hook=partial(_unpack_object, whitelist_map=whitelist_map, context=context)
+        )
+        unpacked_value = context.finalize_unpack(unpacked_value)
         if as_type and not (
             is_named_tuple_instance(unpacked_value)
             if as_type is NamedTuple
@@ -665,7 +761,54 @@ def deserialize_value(
             raise DeserializationError(
                 f"Deserialized object was not expected type {as_type}, got {type(unpacked_value)}"
             )
-        return unpacked_value
+
+    return unpacked_value
+
+
+class UnknownSerdesValue:
+    def __init__(self, message: str, value: Mapping[str, UnpackedValue]):
+        self.message = message
+        self.value = value
+
+
+def _unpack_object(val: dict, whitelist_map: WhitelistMap, context: UnpackContext):
+    if "__class__" in val:
+        klass_name = cast(str, val["__class__"])
+        if not whitelist_map.has_tuple_entry(klass_name):
+            return context.observe_unknown_value(
+                UnknownSerdesValue(
+                    f'Attempted to deserialize class "{klass_name}" which is not in the whitelist.',
+                    val,
+                )
+            )
+
+        val.pop("__class__")
+        serializer = whitelist_map.get_tuple_entry(klass_name)
+        return serializer.unpack(val, whitelist_map, context)
+
+    if "__enum__" in val:
+        enum = cast(str, val["__enum__"])
+        name, member = enum.split(".")
+        if not whitelist_map.has_enum_entry(name):
+            return context.observe_unknown_value(
+                UnknownSerdesValue(
+                    f"Attempted to deserialize enum {name} which was not in the whitelist.",
+                    val,
+                )
+            )
+
+        enum_serializer = whitelist_map.get_enum_entry(name)
+        return enum_serializer.unpack(member)
+
+    if "__set__" in val:
+        items = cast(List[JsonSerializableValue], val["__set__"])
+        return set(items)
+
+    if "__frozenset__" in val:
+        items = cast(List[JsonSerializableValue], val["__frozenset__"])
+        return frozenset(items)
+
+    return val
 
 
 @overload
@@ -673,7 +816,7 @@ def unpack_value(
     val: JsonSerializableValue,
     as_type: Tuple[Type[T_PackableValue], Type[U_PackableValue]],
     whitelist_map: WhitelistMap = ...,
-    descent_path: str = ...,
+    context: Optional[UnpackContext] = ...,
 ) -> Union[T_PackableValue, U_PackableValue]:
     ...
 
@@ -683,7 +826,7 @@ def unpack_value(
     val: JsonSerializableValue,
     as_type: Type[T_PackableValue],
     whitelist_map: WhitelistMap = ...,
-    descent_path: str = ...,
+    context: Optional[UnpackContext] = ...,
 ) -> T_PackableValue:
     ...
 
@@ -693,7 +836,7 @@ def unpack_value(
     val: JsonSerializableValue,
     as_type: None = ...,
     whitelist_map: WhitelistMap = ...,
-    descent_path: str = ...,
+    context: Optional[UnpackContext] = ...,
 ) -> PackableValue:
     ...
 
@@ -704,7 +847,7 @@ def unpack_value(
         Union[Type[T_PackableValue], Tuple[Type[T_PackableValue], Type[U_PackableValue]]]
     ] = None,
     whitelist_map: WhitelistMap = _WHITELIST_MAP,
-    descent_path: Optional[str] = None,
+    context: Optional[UnpackContext] = None,
 ) -> Union[PackableValue, T_PackableValue, Union[T_PackableValue, U_PackableValue]]:
     """Convert a JSON-serializable complex of dicts, lists, and scalars into domain objects.
 
@@ -714,12 +857,13 @@ def unpack_value(
     - {"__enum__": "<class>.<name>"}: becomes an Enum class[name], where `class` is an Enum descendant
     - {"__class__": "<class>", ...}: becomes a NamedTuple, where `class` is a NamedTuple descendant
     """
-    descent_path = _root(val) if descent_path is None else descent_path
+    context = UnpackContext() if context is None else context
     unpacked_value = _unpack_value(
         val,
         whitelist_map,
-        descent_path,
+        context,
     )
+    unpacked_value = context.finalize_unpack(unpacked_value)
     if as_type and not (
         is_named_tuple_instance(unpacked_value)
         if as_type is NamedTuple
@@ -732,48 +876,16 @@ def unpack_value(
 
 
 def _unpack_value(
-    val: JsonSerializableValue, whitelist_map: WhitelistMap, descent_path: str
-) -> PackableValue:
+    val: JsonSerializableValue,
+    whitelist_map: WhitelistMap,
+    context: UnpackContext,
+) -> UnpackedValue:
     if isinstance(val, list):
-        return [
-            _unpack_value(item, whitelist_map, f"{descent_path}[{idx}]")
-            for idx, item in enumerate(val)
-        ]
-    if isinstance(val, dict) and val.get("__class__"):
-        klass_name = cast(str, val.pop("__class__"))
-        if not whitelist_map.has_tuple_entry(klass_name):
-            raise DeserializationError(
-                f'Attempted to deserialize class "{klass_name}" which is not in the whitelist. '
-                "This error can occur due to version skew, verify processes are running "
-                f"expected versions.{_path_msg(descent_path)}"
-            )
+        return [_unpack_value(item, whitelist_map, context) for item in val]
 
-        serializer = whitelist_map.get_tuple_entry(klass_name)
-        return serializer.unpack(val, whitelist_map, descent_path)
-    if isinstance(val, dict) and val.get("__enum__"):
-        enum = cast(str, val["__enum__"])
-        name, member = enum.split(".")
-        if not whitelist_map.has_enum_entry(name):
-            raise DeserializationError(
-                f"Attempted to deserialize enum {name} which was not in the whitelist.\n"
-                "This error can occur due to version skew, verify processes are running "
-                f"expected versions.{_path_msg(descent_path)}"
-            )
-        enum_serializer = whitelist_map.get_enum_entry(name)
-        return enum_serializer.unpack(member)
-    if isinstance(val, dict) and "__set__" in val:
-        set_path = descent_path + "{}"
-        items = cast(List[JsonSerializableValue], val["__set__"])
-        return set([_unpack_value(item, whitelist_map, set_path) for item in items])
-    if isinstance(val, dict) and "__frozenset__" in val:
-        frz_set_path = descent_path + "{}"
-        items = cast(List[JsonSerializableValue], val["__frozenset__"])
-        return frozenset([_unpack_value(item, whitelist_map, frz_set_path) for item in items])
     if isinstance(val, dict):
-        return {
-            key: _unpack_value(value, whitelist_map, f"{descent_path}.{key}")
-            for key, value in val.items()
-        }
+        unpacked_vals = {k: _unpack_value(v, whitelist_map, context) for k, v in val.items()}
+        return _unpack_object(unpacked_vals, whitelist_map, context)
 
     return val
 
@@ -841,33 +953,5 @@ def _check_serdes_tuple_class_invariants(klass: Type[NamedTuple]) -> None:
 ###################################################################################################
 
 
-def _path_msg(descent_path: str) -> str:
-    if not descent_path:
-        return ""
-    else:
-        return f"\nDescent path: {descent_path}"
-
-
 def _root(val: Any) -> str:
     return f"<root:{val.__class__.__name__}>"
-
-
-# The below utilities are intended for use in `after_pack` and `before_unpack` hooks in custom
-# namedtuple serializers. They help in manipulating the packed representation of various objects.
-
-
-def is_packed_enum(val: object) -> TypeGuard[Mapping[str, str]]:
-    return isinstance(val, dict) and "__enum__" in val
-
-
-def copy_packed_set(
-    packed_set: Mapping[str, Sequence[JsonSerializableValue]],
-    as_type: Literal["__frozenset__", "__set__"],
-) -> Mapping[str, Sequence[JsonSerializableValue]]:
-    """Returns a copy of the packed collection."""
-    if "__set__" in packed_set:
-        return {as_type: packed_set["__set__"]}
-    elif "__frozenset__" in packed_set:
-        return {as_type: packed_set["__frozenset__"]}
-    else:
-        check.failed(f"Invalid packed set: {packed_set}")

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -11,10 +11,13 @@ from dagster._serdes.serdes import (
     EnumSerializer,
     FieldSerializer,
     NamedTupleSerializer,
+    UnpackContext,
     WhitelistMap,
     _whitelist_for_serdes,
     deserialize_value,
+    pack_value,
     serialize_value,
+    unpack_value,
 )
 from dagster._serdes.utils import hash_str
 
@@ -56,9 +59,21 @@ def test_descent_path():
         buzz: int
 
     # Arg is not actually a namedtuple but the function still works on it
-    ser = serialize_value({"a": {"b": [{}, {}, {"c": Fizz(1)}]}}, whitelist_map=test_map)
+    val = {"a": {"b": [{}, {}, {"c": Fizz(1)}]}}
+    packed = pack_value(val, whitelist_map=test_map)
+    ser = serialize_value(val, whitelist_map=test_map)
 
-    with pytest.raises(DeserializationError, match=re.escape("Descent path: <root:dict>.a.b[2].c")):
+    # when parsing from serialized - we unpack objects bottom-up in instead of so have no path
+    with pytest.raises(
+        DeserializationError,
+        match='Attempted to deserialize class "Fizz" which is not in the whitelist',
+    ):
+        unpack_value(packed, whitelist_map=blank_map)
+
+    with pytest.raises(
+        DeserializationError,
+        match='Attempted to deserialize class "Fizz" which is not in the whitelist',
+    ):
         deserialize_value(ser, whitelist_map=blank_map)
 
 
@@ -197,9 +212,9 @@ def test_forward_compat():
     # Separate scope since we redefine Quux
     def register_orig() -> Any:
         @_whitelist_for_serdes(whitelist_map=old_map)
-        class Quux(namedtuple("_Quux", "bar baz")):
-            def __new__(cls, bar, baz):
-                return super().__new__(cls, bar, baz)
+        class Quux(NamedTuple):
+            bar: str
+            baz: str
 
         return Quux
 
@@ -209,21 +224,33 @@ def test_forward_compat():
     new_map = WhitelistMap.create()
 
     @_whitelist_for_serdes(whitelist_map=new_map)
-    class Quux(namedtuple("_Quux", "foo bar baz")):
-        def __new__(cls, foo, bar, baz):
-            return super().__new__(cls, foo, bar, baz)
+    class Quux(NamedTuple):
+        foo: "Foo"
+        bar: str
+        baz: str
+        buried: dict
 
     @_whitelist_for_serdes(whitelist_map=new_map)
-    class Foo(namedtuple("_Foo", "wow")):
-        def __new__(cls, wow):
-            return super().__new__(cls, wow)
+    class Foo(NamedTuple):
+        s: str
 
-    new_quux = Quux(foo=Foo("wow"), bar="bar", baz="baz")
+    new_quux = Quux(
+        foo=Foo("wow"),
+        bar="bar",
+        baz="baz",
+        buried={
+            "top": Foo("d"),
+            "list": [Foo("l"), 2, 3],
+            "set": {Foo("s"), 2, 3},
+            "frozenset": frozenset((1, 2, Foo("fs"))),
+            "deep": {"1": [{"2": {"3": [Foo("d")]}}]},
+        },
+    )
 
     # write from new
     serialized = serialize_value(new_quux, whitelist_map=new_map)
 
-    # read from old, foo ignored
+    # read from old, Foo ignored
     deserialized = deserialize_value(serialized, as_type=orig_klass, whitelist_map=old_map)
     assert deserialized.bar == "bar"
     assert deserialized.baz == "baz"
@@ -470,12 +497,18 @@ def test_named_tuple_field_serializers() -> None:
 
     class PairsSerializer(FieldSerializer):
         def pack(
-            self, entries: Mapping[str, str], whitelist_map: WhitelistMap, descent_path: str
+            self,
+            entries: Mapping[str, str],
+            whitelist_map: WhitelistMap,
+            descent_path: str,
         ) -> Sequence[Sequence[str]]:
             return list(entries.items())
 
         def unpack(
-            self, entries: Sequence[Sequence[str]], whitelist_map: WhitelistMap, descent_path: str
+            self,
+            entries: Sequence[Sequence[str]],
+            whitelist_map: WhitelistMap,
+            context: UnpackContext,
         ) -> Any:
             return {entry[0]: entry[1] for entry in entries}
 
@@ -556,10 +589,10 @@ def test_named_tuple_custom_serializer():
             del storage_dict["color"]
             return storage_dict
 
-        def before_unpack(self, **storage_dict: Dict[str, Any]):
-            storage_dict["color"] = storage_dict["colour"]
-            del storage_dict["colour"]
-            return storage_dict
+        def before_unpack(self, context, unpacked_dict: Dict[str, Any]):
+            unpacked_dict["color"] = unpacked_dict["colour"]
+            del unpacked_dict["colour"]
+            return unpacked_dict
 
     @_whitelist_for_serdes(whitelist_map=test_map, serializer=FooSerializer)
     class Foo(NamedTuple):
@@ -576,7 +609,7 @@ def test_named_tuple_custom_serializer_error_handling():
     test_map = WhitelistMap.create()
 
     class FooSerializer(NamedTupleSerializer):
-        def handle_unpack_error(self, exc: Exception, **storage_dict: Any) -> "Foo":
+        def handle_unpack_error(self, exc: Exception, context, storage_dict: Any) -> "Foo":
             return Foo("default")
 
     @_whitelist_for_serdes(whitelist_map=test_map, serializer=FooSerializer)


### PR DESCRIPTION
Use `json.loads` `object_hook` to unpack `serdes` entries as we decode the json instead of recursive descent over a fully parsed object tree. 

https://docs.python.org/3/library/json.html#json.load

## How I Tested These Changes

for a benchmark of loading varying serdes payloads 10 times
CPU time:  14s -> 7s
Peak Mem: 217.6MB -> 142.8MB
Allocations: 425461 -> 325478

Before and After:
![Screen Shot 2023-03-30 at 9 25 50 AM](https://user-images.githubusercontent.com/202219/228868496-ea7fdcd3-f079-410d-95c9-4ef2c9825df4.png)
![Screen Shot 2023-03-30 at 9 26 34 AM](https://user-images.githubusercontent.com/202219/228868502-a9201fa9-c07e-4ee0-bbd7-34c08e3cf3ca.png)

Before
```
Target 0 size 826.7KiB:
deserialize_value (25 samples): mean 28.857, stdev 1.431, min 27.118
serialize_value   (25 samples): mean 30.708, stdev 4.840, min 27.711

Target 1 size 4.2KiB:
deserialize_value (25 samples): mean 0.449, stdev 0.316, min 0.304
serialize_value   (25 samples): mean 0.294, stdev 0.093, min 0.255

Target 2 size 3.6KiB:
deserialize_value (25 samples): mean 0.330, stdev 0.102, min 0.277
serialize_value   (25 samples): mean 0.260, stdev 0.013, min 0.239

Target 3 size 8.8KiB:
deserialize_value (25 samples): mean 0.520, stdev 0.171, min 0.423
serialize_value   (25 samples): mean 0.486, stdev 0.184, min 0.417

Target 4 size 1.8MiB:
deserialize_value (25 samples): mean 78.040, stdev 8.390, min 72.277
serialize_value   (25 samples): mean 80.270, stdev 6.421, min 74.635

Target 5 size 23.8MiB:
deserialize_value (25 samples): mean 1076.835, stdev 20.284, min 984.325
serialize_value   (25 samples): mean 1071.841, stdev 9.865, min 1060.849
```

After
```
Target 0 size 826.7KiB:
deserialize_value (25 samples): mean 15.307, stdev 0.267, min 15.024
serialize_value   (25 samples): mean 26.967, stdev 0.406, min 26.309

Target 1 size 4.2KiB:
deserialize_value (25 samples): mean 0.227, stdev 0.076, min 0.190
serialize_value   (25 samples): mean 0.234, stdev 0.013, min 0.218

Target 2 size 3.6KiB:
deserialize_value (25 samples): mean 0.201, stdev 0.013, min 0.185
serialize_value   (25 samples): mean 0.216, stdev 0.012, min 0.202

Target 3 size 8.8KiB:
deserialize_value (25 samples): mean 0.325, stdev 0.104, min 0.261
serialize_value   (25 samples): mean 0.433, stdev 0.028, min 0.385

Target 4 size 1.8MiB:
deserialize_value (25 samples): mean 45.223, stdev 2.878, min 41.869
serialize_value   (25 samples): mean 76.347, stdev 4.487, min 71.088

Target 5 size 23.8MiB:
deserialize_value (25 samples): mean 562.411, stdev 24.907, min 458.196
serialize_value   (25 samples): mean 1038.115, stdev 9.249, min 1028.231
```
