### PR TITLE
[ui] Consolidate Ad hoc materializations in Run timeline

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -244,7 +244,7 @@ const RunRow: React.FC<{
   };
 
   return (
-    <Row key={run.runId} highlighted={!!isHighlighted}>
+    <Row highlighted={!!isHighlighted}>
       <td>
         {canTerminateOrDelete && onToggleChecked ? (
           <Checkbox checked={!!checked} onChange={onChange} />

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -198,7 +198,7 @@ export const RunsRoot = () => {
                             {filterTokens
                               .filter((token) => token.token === 'status')
                               .map(({token, value}) => (
-                                <Tag key={token}>{`${token}:${value}`}</Tag>
+                                <Tag key={`${token}:${value}`}>{`${token}:${value}`}</Tag>
                               ))}
                           </Box>
                         ) : null}

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -1,7 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import * as React from 'react';
 
-import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {isHiddenAssetGroupJob, __ASSET_JOB_PREFIX} from '../asset-graph/Utils';
 import {InstigationStatus, RunsFilter, RunStatus} from '../graphql/types';
 import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -100,7 +100,7 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
       return [];
     }
 
-    const jobs = [];
+    const jobs: TimelineJob[] = [];
     for (const locationEntry of workspaceOrError.locationEntries) {
       if (
         locationEntry.__typename !== 'WorkspaceLocationEntry' ||
@@ -143,21 +143,32 @@ export const useRunsForTimeline = (range: [number, number], runsFilter: RunsFilt
           const jobName = isAdHoc ? 'Ad hoc materializations' : pipeline.name;
 
           const jobRuns = runsByJobKey[jobKey] || [];
-          if (jobTicks.length || jobRuns.length) {
-            jobs.push({
-              key: jobKey,
-              jobName,
-              jobType: isAdHoc ? 'asset' : 'job',
-              repoAddress,
-              path: workspacePipelinePath({
-                repoName: repoAddress.name,
-                repoLocation: repoAddress.location,
-                pipelineName: pipeline.name,
-                isJob: pipeline.isJob,
-              }),
-              runs: [...jobRuns, ...jobTicks],
-            } as TimelineJob);
+          if (!jobTicks.length && !jobRuns.length) {
+            continue;
           }
+
+          const jobsAndTicksToAdd = [...jobRuns, ...jobTicks];
+          if (isAdHoc) {
+            const adHocJobs = jobs.find(({jobType}) => jobType === 'asset');
+            if (adHocJobs) {
+              adHocJobs.runs.push(...jobsAndTicksToAdd);
+              continue;
+            }
+          }
+
+          jobs.push({
+            key: jobKey,
+            jobName,
+            jobType: isAdHoc ? 'asset' : 'job',
+            repoAddress,
+            path: workspacePipelinePath({
+              repoName: repoAddress.name,
+              repoLocation: repoAddress.location,
+              pipelineName: pipeline.name,
+              isJob: pipeline.isJob,
+            }),
+            runs: [...jobRuns, ...jobTicks],
+          } as TimelineJob);
         }
       }
     }


### PR DESCRIPTION
## Summary & Motivation

Individual "__ASSET_JOB" runs end up batched separately in the run timeline, even though they're all labeled as "Ad hoc materializations". Instead, group them all together.

<img width="890" alt="Screenshot 2023-03-30 at 11 17 45 AM" src="https://user-images.githubusercontent.com/2823852/228900328-8293ac02-d8d5-4fc2-8d32-c26e349afd1d.png">

## How I Tested These Changes

Kick off backfills on a couple different assets in http://localhost:3000/locations/partitioned_assets_repository@dagster_test.toys.repo/asset-groups/default. Verify that the `pipelineName` value for each is different, but that they get batched together in a single row in the Run timeline.

Run a non-asset job, sanity check that it appears correctly in the timeline.
