### PR TITLE
Render TableMetadata type in asset definition sidebar

### DIFF
--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -171,7 +171,13 @@ export const MetadataEntry: React.FC<{
         </MetadataEntryLink>
       );
     case 'TableMetadataEntry':
-      return null;
+      console.log(entry);
+      return (
+        <Box>
+          <TableSchema schema={entry.table.schema} />
+        </Box>
+      );
+
     case 'TableSchemaMetadataEntry':
       return <TableSchema schema={entry.schema} />;
     case 'NotebookMetadataEntry':

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -10,6 +10,8 @@ import {
   Tooltip,
   FontFamily,
   tryPrettyPrintJSON,
+  Table,
+  DialogBody,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
@@ -19,6 +21,7 @@ import {copyValue} from '../app/DomUtils';
 import {assertUnreachable} from '../app/Util';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {TableMetadataEntry} from '../graphql/types';
 import {Markdown} from '../ui/Markdown';
 import {NotebookButton} from '../ui/NotebookButton';
 
@@ -171,12 +174,7 @@ export const MetadataEntry: React.FC<{
         </MetadataEntryLink>
       );
     case 'TableMetadataEntry':
-      console.log(entry);
-      return (
-        <Box>
-          <TableSchema schema={entry.table.schema} />
-        </Box>
-      );
+      return <TableMetadataEntryComponent entry={entry} />;
 
     case 'TableSchemaMetadataEntry':
       return <TableSchema schema={entry.schema} />;
@@ -324,6 +322,53 @@ const MetadataEntryModalAction: React.FC<{
         </DialogFooter>
       </Dialog>
     </>
+  );
+};
+
+const TableMetadataEntryComponent: React.FC<{entry: TableMetadataEntry}> = ({entry}) => {
+  const [showSchema, setShowSchema] = React.useState(false);
+
+  const schema = entry.table.schema;
+  const records = entry.table.records.map((record) => JSON.parse(record));
+
+  return (
+    <Box flex={{direction: 'column', gap: 8}}>
+      <MetadataEntryAction onClick={() => setShowSchema(true)}>Show schema</MetadataEntryAction>
+      <Table style={{borderRight: `1px solid ${Colors.KeylineGray}`}}>
+        <thead>
+          <tr>
+            {schema.columns.map((column) => (
+              <th key={column.name}>{column.name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((record, idx) => (
+            <tr key={idx}>
+              {schema.columns.map((column) => (
+                <td key={column.name}>{record[column.name].toString()}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+      <Dialog isOpen={showSchema}>
+        <DialogBody>
+          <TableSchema schema={schema} />
+        </DialogBody>
+        <DialogFooter topBorder>
+          <Button
+            intent="primary"
+            autoFocus={true}
+            onClick={() => {
+              setShowSchema(false);
+            }}
+          >
+            Close
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </Box>
   );
 };
 

--- a/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/MetadataEntry.tsx
@@ -352,7 +352,7 @@ const TableMetadataEntryComponent: React.FC<{entry: TableMetadataEntry}> = ({ent
           ))}
         </tbody>
       </Table>
-      <Dialog isOpen={showSchema}>
+      <Dialog isOpen={showSchema} title={`Schema for ${entry.label}`}>
         <DialogBody>
           <TableSchema schema={schema} />
         </DialogBody>

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -154,6 +154,13 @@ def partitioned_assets_repository():
 
 
 @repository
+def table_metadata_repository():
+    from . import table_metadata
+
+    return load_assets_from_modules([table_metadata])
+
+
+@repository
 def long_asset_keys_repository():
     return [long_asset_keys_group]
 


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/13005

## How I Tested These Changes

<img width="861" alt="Screen Shot 2023-03-30 at 3 32 39 PM" src="https://user-images.githubusercontent.com/2286579/228944471-5ba88cf2-a6b6-4d42-87d0-5bed0ffb1978.png">

Dialog opens when you click on "Show schema":
<img width="632" alt="Screen Shot 2023-03-30 at 3 40 05 PM" src="https://user-images.githubusercontent.com/2286579/228946486-6e29911b-db60-4d16-ba04-7385389d35ca.png">

