### PR TITLE
Fix cache error when single-dimension partition fails and asset becomes multipartitioned

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, cast
+from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 
 from dagster import (
     AssetKey,
@@ -195,22 +195,9 @@ def get_validated_partition_keys(
             & partition_keys
         )
     elif isinstance(partitions_def, MultiPartitionsDefinition):
-        partition_keys_by_dimension = {
-            dim.name: dim.partitions_def.get_partition_keys(
-                dynamic_partitions_store=dynamic_partitions_store
-            )
-            for dim in partitions_def.partitions_defs
-        }
-        validated_partitions = set()
-        for partition_key in partition_keys:
-            multipartition_key = partitions_def.get_partition_key_from_str(partition_key)
-            if all(
-                key in partition_keys_by_dimension.get(dim, [])
-                for dim, key in cast(
-                    MultiPartitionKey, multipartition_key
-                ).keys_by_dimension.items()
-            ):
-                validated_partitions.add(partition_key)
+        validated_partitions = partitions_def.filter_valid_partition_keys(
+            partition_keys, dynamic_partitions_store
+        )
     else:
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Unexpected partitions definition type {partitions_def}")


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/13256

A graphQL error occurs as described in the issue when:
- an asset with single-dimension partitions def fails for one or more partitions
- the partitions def is changed to a multipartitions def
- the cache attempts to build multipartition keys from the failed partition keys, throwing an error as the failed partition keys are single-dimensioned

This PR fixes this issue.