### PR TITLE
clean up graph-backed asset toy

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/graph_backed_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/graph_backed_assets.py
@@ -1,5 +1,4 @@
-from dagster import AssetsDefinition, graph, op
-from dagster._legacy import AssetGroup
+from dagster import graph_asset, op
 
 
 @op
@@ -12,11 +11,6 @@ def world(hello):
     return hello + "world"
 
 
-@graph
-def hello_world():
+@graph_asset
+def graph_backed_asset():
     return world(hello())
-
-
-graph_asset = AssetsDefinition.from_graph(hello_world, group_name="hello_world_group")
-
-graph_backed_group = AssetGroup([graph_asset])

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -20,7 +20,7 @@ from dagster_test.toys.cross_repo_assets import (
 )
 from dagster_test.toys.dynamic import dynamic_job
 from dagster_test.toys.error_monster import error_monster_failing_job, error_monster_passing_job
-from dagster_test.toys.graph_backed_assets import graph_backed_group
+from dagster_test.toys.graph_backed_assets import graph_backed_asset
 from dagster_test.toys.hammer import hammer_default_executor_job
 from dagster_test.toys.input_managers import df_stats_job
 from dagster_test.toys.log_asset import log_asset_job
@@ -180,7 +180,7 @@ def downstream_assets_repository2():
 
 @repository
 def graph_backed_asset_repository():
-    return [graph_backed_group]
+    return [graph_backed_asset]
 
 
 @repository


### PR DESCRIPTION
## Summary & Motivation

- Move it off of AssetGroup
- Use `@graph_asset` instead of `AssetsDefinition.from_graph`
- Give it a name that makes it easier to find

## How I Tested These Changes
