### PR TITLE
[Filtering] Add optional `getKey` function

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Filters/__stories__.tsx/useFilters.stories.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__stories__.tsx/useFilters.stories.tsx
@@ -29,6 +29,7 @@ const TestComponent: React.FC = () => {
       value('today'),
       value('yesterday'),
     ],
+    getKey: (value) => value,
     renderLabel: ({value, isActive}) => (
       <span style={{color: isActive ? 'green' : undefined}}>
         <TruncatedTextWithFullTextOnHover text={value} />
@@ -48,6 +49,7 @@ const TestComponent: React.FC = () => {
       value('today'),
       value('yesterday'),
     ],
+    getKey: (value) => value,
     renderLabel: ({value, isActive}) => (
       <span style={{color: isActive ? 'green' : undefined}}>
         <TruncatedTextWithFullTextOnHover text={value} />

--- a/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useStaticSetFilter.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useStaticSetFilter.test.tsx
@@ -120,4 +120,14 @@ describe('useStaticSetFilter', () => {
 
     expect(filter.result.current.state).toEqual(new Set(['cherry']));
   });
+
+  it('uses getKey to generate keys', () => {
+    const filter = renderHook(() =>
+      useStaticSetFilter({...testFilterProps, getKey: (value: string) => value.toUpperCase()}),
+    );
+    const results = filter.result.current.getResults('');
+    results.forEach((result) => {
+      expect(result.key).toEqual(result.value.toUpperCase());
+    });
+  });
 });

--- a/js_modules/dagit/packages/core/src/ui/Filters/useStaticSetFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useStaticSetFilter.tsx
@@ -13,6 +13,7 @@ type Args<TValue> = {
   name: string;
   icon: IconName;
   renderLabel: (props: {value: TValue; isActive: boolean}) => JSX.Element;
+  getKey?: (value: TValue) => string;
   getStringValue: (value: TValue) => string;
   allValues: SetFilterValue<TValue>[];
   initialState?: Set<TValue> | TValue[];
@@ -24,6 +25,7 @@ export type StaticSetFilter<TValue> = FilterObject<Set<TValue>>;
 export function useStaticSetFilter<TValue>({
   name,
   icon,
+  getKey,
   allValues,
   renderLabel,
   initialState,
@@ -50,7 +52,7 @@ export function useStaticSetFilter<TValue>({
       isActive: state.size > 0,
       getResults: (query) => {
         if (query === '') {
-          return allValues.map(({value}) => ({
+          return allValues.map(({value}, index) => ({
             label: (
               <SetFilterLabel
                 value={value}
@@ -58,7 +60,7 @@ export function useStaticSetFilter<TValue>({
                 filter={filterObjRef.current}
               />
             ),
-            key: getStringValue(value),
+            key: getKey?.(value) || index.toString(),
             value,
           }));
         }
@@ -66,7 +68,7 @@ export function useStaticSetFilter<TValue>({
           .filter(({match}) =>
             match.some((value) => value.toLowerCase().includes(query.toLowerCase())),
           )
-          .map(({value}) => ({
+          .map(({value}, index) => ({
             label: (
               <SetFilterLabel
                 value={value}
@@ -74,7 +76,7 @@ export function useStaticSetFilter<TValue>({
                 filter={filterObjRef.current}
               />
             ),
-            key: getStringValue(value),
+            key: getKey?.(value) || index.toString(),
             value,
           }));
       },


### PR DESCRIPTION
## Summary & Motivation

For setFilter's where some of the string values are non unique (eg. Multiple Rex Ledesma accounts in elementl.dogfood.dagster.cloud) we need to pass a getKey function so that it can return a unique key to use for rendering.

## How I Tested These Changes

jest