### PR TITLE
Fix spring DST schedule transitions

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -44,6 +44,13 @@ def cron_string_iterator(
     # and matches the cron schedule
     next_date = date_iter.get_prev(datetime.datetime)
 
+    if not croniter.match(cron_string, next_date):
+        # Workaround for upstream croniter bug where get_prev sometimes overshoots to a time
+        # that doesn't actually match the cron string (e.g. 3AM on Spring DST day
+        # goes back to 1AM on the previous day) - when this happens, advance to the correct
+        # time that actually matches the cronstring
+        next_date = date_iter.get_next(datetime.datetime)
+
     check.invariant(start_offset <= 0)
     for _ in range(-start_offset):
         next_date = date_iter.get_prev(datetime.datetime)

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -96,6 +96,12 @@ def cron_string_iterator(
                 check.invariant(next_date_cand.hour == curr_hour)
 
             next_date = next_date_cand
+
+            if start_offset == 0 and next_date.timestamp() < start_timestamp:
+                # Guard against edge cases where croniter get_prev() returns unexpected
+                # results that cause us to get stuck
+                continue
+
             yield next_date
     else:
         # Otherwise fall back to croniter
@@ -103,6 +109,11 @@ def cron_string_iterator(
             next_date = to_timezone(
                 pendulum.instance(date_iter.get_next(datetime.datetime)), timezone_str
             )
+
+            if start_offset == 0 and next_date.timestamp() < start_timestamp:
+                # Guard against edge cases where croniter get_prev() returns unexpected
+                # results that cause us to get stuck
+                continue
 
             yield next_date
 
@@ -169,6 +180,12 @@ def reverse_cron_string_iterator(
                 check.invariant(next_date_cand.hour == curr_hour)
 
             next_date = next_date_cand
+
+            if next_date.timestamp() > end_timestamp:
+                # Guard against edge cases where croniter get_next() returns unexpected
+                # results that cause us to get stuck
+                continue
+
             yield next_date
     else:
         # Otherwise fall back to croniter
@@ -176,6 +193,11 @@ def reverse_cron_string_iterator(
             next_date = to_timezone(
                 pendulum.instance(date_iter.get_prev(datetime.datetime)), timezone_str
             )
+
+            if next_date.timestamp() > end_timestamp:
+                # Guard against edge cases where croniter get_next() returns unexpected
+                # results that cause us to get stuck
+                continue
 
             yield next_date
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -1,0 +1,63 @@
+from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
+from dagster._utils.schedules import cron_string_iterator
+
+
+def test_cron_iterator_always_advances():
+    tz = "Europe/Berlin"
+
+    start_timestamp = create_pendulum_time(2023, 3, 27, 1, 0, 0, tz=tz).timestamp()
+
+    cron_iter = cron_string_iterator(
+        start_timestamp + 1,
+        "0 2 * * *",
+        tz,
+    )
+
+    next_datetime = next(cron_iter)
+
+    assert next_datetime.timestamp() > start_timestamp
+
+
+# These are not what one might expect due to upstream croniter bugs, but verifies that we
+# don't get stuck
+time_sequences = (
+    "Europe/Berlin",
+    "0 2 * * *",
+    [
+        create_pendulum_time(2023, 3, 24, 2, 0, 0, tz="Europe/Berlin"),
+        create_pendulum_time(2023, 3, 25, 2, 0, 0, tz="Europe/Berlin"),
+        create_pendulum_time(  # 2AM on 3/26 does not exist, move forward
+            2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"
+        ),
+        create_pendulum_time(
+            2023, 3, 27, 1, 0, 0, tz="Europe/Berlin"
+        ),  # Should be 2AM, is 1AM due to croniter bug
+        create_pendulum_time(  # 3/28 fires twice due to croniter bug
+            2023, 3, 28, 1, 0, 0, tz="Europe/Berlin"
+        ),
+        create_pendulum_time(2023, 3, 28, 2, 0, 0, tz="Europe/Berlin"),
+        create_pendulum_time(2023, 3, 29, 2, 0, 0, tz="Europe/Berlin"),
+    ],
+)
+
+
+def test_dst_spring_forward_transition_advances():
+    execution_timezone, cron_string, times = time_sequences
+
+    start_timestamp = to_timezone(times[0], "UTC").timestamp()
+
+    cron_string_iterator(
+        start_timestamp + 1,
+        cron_string,
+        execution_timezone,
+    )
+
+    # Starting 1 second after each time individually also produces the next tick
+    for i in range(len(times) - 1):
+        start_timestamp = to_timezone(times[i], "UTC").timestamp() + 1
+        fresh_cron_iter = cron_string_iterator(start_timestamp, cron_string, execution_timezone)
+        next_time = next(fresh_cron_iter)
+
+        assert (
+            next_time.timestamp() == times[i + 1].timestamp()
+        ), f"Expected {times[i]} to advance to {times[i+1]}, got {str(next_time)}"

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -77,20 +77,14 @@ def test_cron_iterator_always_advances():
     ],
 )
 def test_dst_spring_forward_transition_advances(execution_timezone, cron_string, times):
-    start_timestamp = to_timezone(times[0], "UTC").timestamp()
-
-    cron_string_iterator(
-        start_timestamp + 1,
-        cron_string,
-        execution_timezone,
-    )
-
-    # Starting 1 second after each time individually also produces the next tick
+    # Starting 1 second after each time produces the next tick
     for i in range(len(times) - 1):
         start_timestamp = to_timezone(times[i], "UTC").timestamp() + 1
         fresh_cron_iter = cron_string_iterator(start_timestamp, cron_string, execution_timezone)
-        next_time = next(fresh_cron_iter)
 
-        assert (
-            next_time.timestamp() == times[i + 1].timestamp()
-        ), f"Expected {times[i]} to advance to {times[i+1]}, got {str(next_time)}"
+        for j in range(i + 1, len(times)):
+            next_time = next(fresh_cron_iter)
+
+            assert (
+                next_time.timestamp() == times[j].timestamp()
+            ), f"Expected {times[i]} to advance to {times[j]}, got {str(next_time)}"

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -24,6 +24,18 @@ def test_cron_iterator_always_advances():
     [
         (
             "Europe/Berlin",
+            "0 1 * * *",
+            [
+                create_pendulum_time(2023, 3, 24, 1, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 25, 1, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 27, 1, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 28, 1, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 29, 1, 0, 0, tz="Europe/Berlin"),
+            ],
+        ),
+        (
+            "Europe/Berlin",
             "0 2 * * *",
             [
                 create_pendulum_time(2023, 3, 24, 2, 0, 0, tz="Europe/Berlin"),
@@ -31,9 +43,7 @@ def test_cron_iterator_always_advances():
                 create_pendulum_time(  # 2AM on 3/26 does not exist, move forward
                     2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"
                 ),
-                create_pendulum_time(
-                    2023, 3, 27, 3, 0, 0, tz="Europe/Berlin"
-                ),  # Should be 2AM, is 3AM due to croniter bug
+                create_pendulum_time(2023, 3, 27, 2, 0, 0, tz="Europe/Berlin"),
                 create_pendulum_time(2023, 3, 28, 2, 0, 0, tz="Europe/Berlin"),
                 create_pendulum_time(2023, 3, 29, 2, 0, 0, tz="Europe/Berlin"),
             ],
@@ -44,14 +54,24 @@ def test_cron_iterator_always_advances():
             [
                 create_pendulum_time(2023, 3, 24, 2, 30, 0, tz="Europe/Berlin"),
                 create_pendulum_time(2023, 3, 25, 2, 30, 0, tz="Europe/Berlin"),
-                create_pendulum_time(  # 2AM on 3/26 does not exist, move forward
+                create_pendulum_time(  # 2AM on 3/26 does not exist, move forward to 3AM
                     2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"
                 ),
-                create_pendulum_time(
-                    2023, 3, 27, 3, 30, 0, tz="Europe/Berlin"
-                ),  # Should be 2AM, is 3AM due to croniter bug
+                create_pendulum_time(2023, 3, 27, 2, 30, 0, tz="Europe/Berlin"),
                 create_pendulum_time(2023, 3, 28, 2, 30, 0, tz="Europe/Berlin"),
                 create_pendulum_time(2023, 3, 29, 2, 30, 0, tz="Europe/Berlin"),
+            ],
+        ),
+        (
+            "Europe/Berlin",
+            "0 3 * * *",
+            [
+                create_pendulum_time(2023, 3, 24, 3, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 25, 3, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 27, 3, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 28, 3, 0, 0, tz="Europe/Berlin"),
+                create_pendulum_time(2023, 3, 29, 3, 0, 0, tz="Europe/Berlin"),
             ],
         ),
     ],

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -578,9 +578,7 @@ def test_execute_during_dst_transition_spring_forward(
         expected_datetimes_utc = [
             to_timezone(create_pendulum_time(2019, 3, 13, 2, 30, 0, tz="US/Central"), "UTC"),
             to_timezone(create_pendulum_time(2019, 3, 12, 2, 30, 0, tz="US/Central"), "UTC"),
-            to_timezone(
-                create_pendulum_time(2019, 3, 11, 3, 30, 0, tz="US/Central"), "UTC"
-            ),  # Incorrect due to croniter bug
+            to_timezone(create_pendulum_time(2019, 3, 11, 2, 30, 0, tz="US/Central"), "UTC"),
             to_timezone(create_pendulum_time(2019, 3, 10, 3, 00, 0, tz="US/Central"), "UTC"),
             to_timezone(create_pendulum_time(2019, 3, 9, 2, 30, 0, tz="US/Central"), "UTC"),
         ]

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -560,7 +560,7 @@ def test_execute_during_dst_transition_spring_forward(
         ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
         assert len(ticks) == 0
 
-    for _ in range(2):
+    for _ in range(4):
         freeze_datetime = freeze_datetime.add(days=1)
         with pendulum.test(freeze_datetime):
             evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
@@ -571,17 +571,21 @@ def test_execute_during_dst_transition_spring_forward(
 
         wait_for_all_runs_to_start(instance)
 
-        assert instance.get_runs_count() == 3
+        assert instance.get_runs_count() == 5
         ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
-        assert len(ticks) == 3
+        assert len(ticks) == 5
 
         expected_datetimes_utc = [
-            to_timezone(create_pendulum_time(2019, 3, 11, 1, 30, 0, tz="US/Central"), "UTC"),
+            to_timezone(create_pendulum_time(2019, 3, 13, 2, 30, 0, tz="US/Central"), "UTC"),
+            to_timezone(create_pendulum_time(2019, 3, 12, 2, 30, 0, tz="US/Central"), "UTC"),
+            to_timezone(
+                create_pendulum_time(2019, 3, 11, 3, 30, 0, tz="US/Central"), "UTC"
+            ),  # Incorrect due to croniter bug
             to_timezone(create_pendulum_time(2019, 3, 10, 3, 00, 0, tz="US/Central"), "UTC"),
             to_timezone(create_pendulum_time(2019, 3, 9, 2, 30, 0, tz="US/Central"), "UTC"),
         ]
 
-        for i in range(3):
+        for i in range(5):
             validate_tick(
                 ticks[i],
                 external_schedule,
@@ -598,9 +602,9 @@ def test_execute_during_dst_transition_spring_forward(
 
         # Verify idempotence
         evaluate_schedules(workspace_context, executor, pendulum.now("UTC"))
-        assert instance.get_runs_count() == 3
+        assert instance.get_runs_count() == 5
         ticks = instance.get_ticks(schedule_origin.get_id(), external_schedule.selector_id)
-        assert len(ticks) == 3
+        assert len(ticks) == 5
 
 
 @pytest.mark.parametrize("executor", get_schedule_executors())

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -10,8 +10,8 @@ setenv =
   STRICT_GRPC_SERVER_PROCESS_WAIT = "1"
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE* DAGSTER_DOCKER_* GRPC_SERVER_HOST
 deps =
-  scheduler_tests_old_pendulum: pendulum==1.4.4
-  definitions_tests_old_pendulum: pendulum==1.4.4
+  scheduler_tests_old_pendulum: pendulum<2
+  definitions_tests_old_pendulum: pendulum<2
   storage_tests_old_sqlalchemy: sqlalchemy==1.3.24
   general_tests_old_protobuf: protobuf<4
   -e ../dagster-test


### PR DESCRIPTION
Summary:
- Workarounds for upstream issues with croniter where it sometimes has trouble around DST transitions
- Better handle a spring DST transition in our own day incrementing code that increments things by a day but didn't realize it needed to go from 3AM back to 2AM