### PR TITLE
[pythonic config] Allow ConfigMappings to take, return Pythonic config

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/config_mapping_decorator.py
@@ -1,7 +1,8 @@
-from typing import Any, Callable, Optional, Union, overload
+from typing import Any, Callable, Optional, Type, Union, cast, overload
 
 import dagster._check as check
 from dagster._config import UserConfigSchema
+from dagster._core.decorator_utils import get_function_params
 
 from ..config import ConfigMapping, ConfigMappingFn
 
@@ -19,6 +20,49 @@ class _ConfigMapping:
 
     def __call__(self, fn: Callable[..., Any]) -> ConfigMapping:
         check.callable_param(fn, "fn")
+
+        from dagster._config.structured_config import (
+            Config,
+            infer_schema_from_config_annotation,
+            safe_is_subclass,
+        )
+        from dagster._core.definitions.run_config import RunConfig
+
+        config_fn_params = get_function_params(fn)
+        check.invariant(
+            len(config_fn_params) == 1, "Config mapping should have exactly one parameter"
+        )
+
+        param = config_fn_params[0]
+
+        # If the parameter is a subclass of Config, we can infer the config schema from the
+        # type annotation. We'll also wrap the config mapping function to convert the config
+        # dictionary into the appropriate Config object.
+        if safe_is_subclass(param.annotation, Config):
+            check.invariant(
+                self.config_schema is None,
+                "Cannot provide config_schema to config mapping with Config-annotated param",
+            )
+
+            config_schema = infer_schema_from_config_annotation(param.annotation, param.default)
+            config_cls = cast(Type[Config], param.annotation)
+
+            param_name = param.name
+
+            def wrapped_fn(config_as_dict) -> Any:
+                config_input = config_cls(**config_as_dict)
+                output = fn(**{param_name: config_input})
+
+                if isinstance(output, RunConfig):
+                    return output.to_config_dict()
+                else:
+                    return output
+
+            return ConfigMapping(
+                config_fn=wrapped_fn,
+                config_schema=config_schema,
+                receive_processed_config_values=None,
+            )
 
         return ConfigMapping(
             config_fn=fn,

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_graphs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_graphs.py
@@ -1,0 +1,115 @@
+from enum import Enum
+from typing import Any, Dict
+
+import pytest
+from dagster import Config, RunConfig, config_mapping, job, op
+from dagster._check import CheckError
+
+
+def test_config_mapping_return_config_dict() -> None:
+    class DoSomethingConfig(Config):
+        config_param: str
+
+    @op
+    def do_something(config: DoSomethingConfig) -> str:
+        return config.config_param
+
+    class ConfigMappingConfig(Config):
+        simplified_param: str
+
+    # New, fancy config mapping takes in a Pythonic config object but returns normal config dict
+    @config_mapping
+    def simplified_config(config_in: ConfigMappingConfig) -> Dict[str, Any]:
+        return {"ops": {"do_something": {"config": {"config_param": config_in.simplified_param}}}}
+
+    @job(config=simplified_config)
+    def do_it_all_with_simplified_config() -> None:
+        do_something()
+
+    result = do_it_all_with_simplified_config.execute_in_process(
+        run_config={"simplified_param": "foo"}
+    )
+    assert result.success
+    assert result.output_for_node("do_something") == "foo"
+
+
+def test_config_mapping_return_run_config() -> None:
+    class DoSomethingConfig(Config):
+        config_param: str
+
+    @op
+    def do_something(config: DoSomethingConfig) -> str:
+        return config.config_param
+
+    class ConfigMappingConfig(Config):
+        simplified_param: str
+
+    # New, fancy config mapping takes in a Pythonic config object and returns a RunConfig
+    @config_mapping
+    def simplified_config(config_in: ConfigMappingConfig) -> RunConfig:
+        return RunConfig(
+            ops={"do_something": DoSomethingConfig(config_param=config_in.simplified_param)}
+        )
+
+    @job(config=simplified_config)
+    def do_it_all_with_simplified_config() -> None:
+        do_something()
+
+    result = do_it_all_with_simplified_config.execute_in_process(
+        run_config={"simplified_param": "foo"}
+    )
+    assert result.success
+    assert result.output_for_node("do_something") == "foo"
+
+
+def test_config_mapping_config_schema_errs() -> None:
+    class DoSomethingConfig(Config):
+        config_param: str
+
+    @op
+    def do_something(config: DoSomethingConfig) -> str:
+        return config.config_param
+
+    class ConfigMappingConfig(Config):
+        simplified_param: str
+
+    # No need to specify config_schema when supplying a Pythonic config object
+    with pytest.raises(CheckError):
+
+        @config_mapping(config_schema={"simplified_param": str})
+        def simplified_config(config_in: ConfigMappingConfig) -> RunConfig:
+            return RunConfig(
+                ops={"do_something": DoSomethingConfig(config_param=config_in.simplified_param)}
+            )
+
+
+def test_config_mapping_enum() -> None:
+    class MyEnum(Enum):
+        FOO = "foo"
+        BAR = "bar"
+
+    class DoSomethingConfig(Config):
+        config_param: MyEnum
+
+    @op
+    def do_something(config: DoSomethingConfig) -> MyEnum:
+        return config.config_param
+
+    class ConfigMappingConfig(Config):
+        simplified_param: MyEnum
+
+    @config_mapping
+    def simplified_config(config_in: ConfigMappingConfig) -> Dict[str, Any]:
+        return {
+            "ops": {"do_something": {"config": {"config_param": config_in.simplified_param.name}}}
+        }
+
+    @job(config=simplified_config)
+    def do_it_all_with_simplified_config() -> None:
+        do_something()
+
+    result = do_it_all_with_simplified_config.execute_in_process(
+        run_config={"simplified_param": "FOO"}
+    )
+    assert result.success
+    assert result.output_for_node("do_something") == MyEnum.FOO

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_graphs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_graphs.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict
 
 import pytest
-from dagster import Config, RunConfig, config_mapping, job, op
+from dagster import Config, RunConfig, config_mapping, graph, job, op
 from dagster._check import CheckError
 
 
@@ -113,3 +113,49 @@ def test_config_mapping_enum() -> None:
     )
     assert result.success
     assert result.output_for_node("do_something") == MyEnum.FOO
+
+
+def test_config_mapping_return_run_config_nested() -> None:
+    class DoSomethingConfig(Config):
+        config_param: str
+
+    @op
+    def do_something(config: DoSomethingConfig) -> str:
+        return config.config_param
+
+    class ConfigMappingConfig(Config):
+        simplified_param: str
+
+    # The graph case can't return a RunConfig since graph config looks different (e.g. no ops at top level)
+    @config_mapping
+    def simplified_config(config_in: ConfigMappingConfig) -> Dict[str, Any]:
+        return {
+            "do_something": {"config": {"config_param": config_in.simplified_param}},
+        }
+
+    @graph(config=simplified_config)
+    def do_it_all_with_simplified_config() -> None:
+        do_something()
+
+    class OuterConfigMappingConfig(Config):
+        simplest_param: str
+
+    @config_mapping
+    def even_simpler_config(config_in: OuterConfigMappingConfig) -> RunConfig:
+        return RunConfig(
+            ops={
+                "do_it_all_with_simplified_config": ConfigMappingConfig(
+                    simplified_param=config_in.simplest_param
+                )
+            }
+        )
+
+    @job(config=even_simpler_config)
+    def do_it_all_with_even_simpler_config() -> None:
+        do_it_all_with_simplified_config()
+
+    result = do_it_all_with_even_simpler_config.execute_in_process(
+        run_config={"simplest_param": "foo"}
+    )
+    assert result.success
+    assert result.output_for_node("do_it_all_with_simplified_config.do_something") == "foo"


### PR DESCRIPTION
## Summary

Adds some wrapper code which makes `ConfigMappings` receptive to the new Pythonic config classes - in particular, the input schema can be defined by a Pythonic `Config` and the output can be a `RunConfig` (in addition to the typical config dict). For example:

**Before:**
```python
class DoSomethingConfig(Config):
    config_param: str

@op
def do_something(config: DoSomethingConfig) -> str:
    return config.config_param


@config_mapping(config_schema={"simplified_param": str})
def simplified_config(val):
    return {
        "ops": {
            "do_something": {
                 "config": {
                     "config_param": val["simplified_param"]
                 }
            }
        }
    }

@job(config=simplified_config)
def do_it_all_with_simplified_config() -> None:
    do_something()

result = do_it_all_with_simplified_config.execute_in_process(
    run_config={"simplified_param": "foo"}
)
```

**After:**
```python
class DoSomethingConfig(Config):
    config_param: str

@op
def do_something(config: DoSomethingConfig) -> str:
    return config.config_param

class ConfigMappingConfig(Config):
    simplified_param: str

# New, fancy config mapping takes in a Pythonic config object and returns a RunConfig
@config_mapping
def simplified_config(config_in: ConfigMappingConfig) -> RunConfig:
    return RunConfig(
        ops={"do_something": DoSomethingConfig(config_param=config_in.simplified_param)}
    )

@job(config=simplified_config)
def do_it_all_with_simplified_config() -> None:
    do_something()

result = do_it_all_with_simplified_config.execute_in_process(
    run_config={"simplified_param": "foo"}
)
```

## Test Plan

New set of unit tests, existing tests to test existing `ConfigMapping` functionality.