### PR TITLE
[ui] Upgrade packages to TS 5.0.2

### DIFF
--- a/docs/next/package.json
+++ b/docs/next/package.json
@@ -76,6 +76,6 @@
     "remark-cli": "^9.0.0",
     "remark-gfm": "^1.0.0",
     "remark-preset-prettier": "^0.4.1",
-    "typescript": "^4.1.3"
+    "typescript": "5.0.2"
   }
 }

--- a/docs/next/yarn.lock
+++ b/docs/next/yarn.lock
@@ -8135,10 +8135,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/js_modules/dagit/packages/app/package.json
+++ b/js_modules/dagit/packages/app/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-jest": "^26.4.6",
     "eslint-webpack-plugin": "3.1.1",
     "prettier": "2.2.1",
-    "typescript": "4.8.4",
+    "typescript": "5.0.2",
     "webpack": "^5.0.0",
     "webpack-bundle-analyzer": "^4.7.0"
   },

--- a/js_modules/dagit/packages/app/tsconfig.json
+++ b/js_modules/dagit/packages/app/tsconfig.json
@@ -17,7 +17,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -120,7 +120,7 @@
     "@types/react-router": "^5.1.17",
     "@types/react-router-dom": "^5.3.2",
     "@types/react-virtualized": "^9.21.5",
-    "@types/styled-components": "^5.1.9",
+    "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.2",
     "@types/ws": "^6.0.3",
     "babel-jest": "^26.6.3",
@@ -150,7 +150,7 @@
     "styled-components": "^5.3.3",
     "ts-node": "9.1.1",
     "ts-prune": "0.8.9",
-    "typescript": "4.8.4",
+    "typescript": "5.0.2",
     "webpack": "^5.0.0"
   },
   "babelMacros": {},

--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -27,7 +27,7 @@ type FlagMap = {
 export const useFeatureFlags = () => {
   return React.useMemo(() => {
     const flagSet = new Set(getFeatureFlags());
-    const all = {};
+    const all: Record<string, boolean> = {};
     for (const flag in FeatureFlag) {
       all[flag] = flagSet.has(flag as FeatureFlagType);
     }

--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -60,7 +60,7 @@ export const extractPermissions = (
 ) => {
   const permsMap: PermissionsFromJSON = {};
   for (const item of permissions) {
-    permsMap[item.permission] = {
+    (permsMap as any)[item.permission] = {
       enabled: item.value,
       disabledReason: item.disabledReason || '',
     };
@@ -68,7 +68,7 @@ export const extractPermissions = (
 
   const fallbackMap: PermissionsFromJSON = {};
   for (const item of fallback) {
-    fallbackMap[item.permission] = {
+    (fallbackMap as any)[item.permission] = {
       enabled: item.value,
       disabledReason: item.disabledReason || '',
     };
@@ -168,9 +168,9 @@ const unpackPermissions = (
   const booleans = {};
   const disabledReasons = {};
   Object.keys(permissions).forEach((key) => {
-    const {enabled, disabledReason} = permissions[key] as PermissionResult;
-    booleans[key] = enabled;
-    disabledReasons[key] = disabledReason;
+    const {enabled, disabledReason} = (permissions as any)[key] as PermissionResult;
+    (booleans as any)[key] = enabled;
+    (disabledReasons as any)[key] = disabledReason;
   });
   return {
     booleans: booleans as PermissionBooleans,

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -114,9 +114,9 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
       g.setEdge({v: upstreamId, w: downstreamId}, {weight: 1});
 
       if (!shouldRender(graphData.nodes[downstreamId])) {
-        linksToAssetsOutsideGraphedSet[downstreamId] = true;
+        (linksToAssetsOutsideGraphedSet as any)[downstreamId] = true;
       } else if (!shouldRender(graphData.nodes[upstreamId])) {
-        linksToAssetsOutsideGraphedSet[upstreamId] = true;
+        (linksToAssetsOutsideGraphedSet as any)[upstreamId] = true;
       }
     });
   });

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -156,7 +156,7 @@ export const AssetPartitions: React.FC<Props> = ({
   };
 
   const countsByStateInSelection = keyCountByStateInSelection(assetHealth, selections);
-  const countsFiltered = stateFilters.reduce((a, b) => a + countsByStateInSelection[b], 0);
+  const countsFiltered = stateFilters.reduce((a, b) => a + (countsByStateInSelection as any)[b], 0);
 
   const [focusedDimensionKeys, setFocusedDimensionKey] = usePartitionKeyInParams({
     params,

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
@@ -23,7 +23,7 @@ export const AssetsCatalogRoot = () => {
 
   const params = useParams();
   const history = useHistory();
-  const currentPath: string[] = (params['0'] || '')
+  const currentPath: string[] = ((params as any)['0'] || '')
     .split('/')
     .filter((x: string) => x)
     .map(decodeURIComponent);

--- a/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagit/packages/core/src/assets/MultipartitioningSupport.tsx
@@ -147,12 +147,12 @@ export function assembleRangesFromTransitions(
   for (const transition of transitions) {
     const last = depths[depths.length - 1];
     if (last && last.idx === transition.idx) {
-      last[transition.state] = (last[transition.state] || 0) + transition.delta;
+      (last as any)[transition.state] = ((last as any)[transition.state] || 0) + transition.delta;
     } else {
       depths.push({
         ...(last || {}),
         idx: transition.idx,
-        [transition.state]: (last?.[transition.state] || 0) + transition.delta,
+        [transition.state]: ((last as any)?.[transition.state] || 0) + transition.delta,
       });
     }
   }

--- a/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
@@ -247,13 +247,20 @@ const addChildren = (boxes: GanttChartBox[], box: GanttChartBox, params: BuildLa
 
 const TextColorForStates = {
   [IStepState.RUNNING]: Colors.Blue700,
+  [IStepState.RETRY_REQUESTED]: Colors.White,
+  [IStepState.SUCCEEDED]: Colors.White,
+  [IStepState.FAILED]: Colors.White,
+  [IStepState.SKIPPED]: Colors.White,
+  [IStepState.UNKNOWN]: Colors.White,
 };
+
 const BackgroundColorForStates = {
   [IStepState.RUNNING]: Colors.Blue100,
   [IStepState.RETRY_REQUESTED]: Colors.Yellow500,
   [IStepState.SUCCEEDED]: Colors.Green500,
   [IStepState.FAILED]: Colors.Red500,
   [IStepState.SKIPPED]: Colors.Gray500,
+  [IStepState.UNKNOWN]: Colors.Gray400,
 };
 
 export const boxStyleFor = (
@@ -274,7 +281,7 @@ export const boxStyleFor = (
   // Step has started and has state? Return state color.
   if (state && state !== IStepState.PREPARING) {
     return {
-      color: TextColorForStates[state] || '#fff',
+      color: TextColorForStates[state] || Colors.White,
       background: BackgroundColorForStates[state] || Colors.Gray400,
     };
   }

--- a/js_modules/dagit/packages/core/src/graph/OpTags.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpTags.tsx
@@ -410,7 +410,7 @@ export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTags
   return (
     <OpTagsContainer style={style}>
       {tags.map((tag) => {
-        const known = KNOWN_TAGS[coerceToStandardLabel(tag.label)];
+        const known = (KNOWN_TAGS as any)[coerceToStandardLabel(tag.label)];
         const text = known?.content || tag.label;
         const color = known?.color || generateColorForLabel(tag.label);
         const textcolor = known?.reversed ? Colors.Gray900 : Colors.White;

--- a/js_modules/dagit/packages/core/src/graph/makeSVGPortable.tsx
+++ b/js_modules/dagit/packages/core/src/graph/makeSVGPortable.tsx
@@ -80,12 +80,17 @@ export async function makeSVGPortable(svg: SVGElement) {
     }
     const nodeStyles = window.getComputedStyle(node);
     for (const idx of Object.keys(nodeStyles)) {
-      const attrName: string = nodeStyles[idx];
+      const attrName: string = (nodeStyles as any)[idx];
       if (!USED_ATTRIBUTES.some((prefix) => attrName.startsWith(prefix))) {
         continue;
       }
-      if (!node.style[attrName] && nodeStyles[attrName] !== baseStyles[attrName]) {
-        node.style[attrName] = await makeAttributeValuePortable(nodeStyles[attrName]);
+      if (
+        !(node.style as any)[attrName] &&
+        (nodeStyles as any)[attrName] !== (baseStyles as any)[attrName]
+      ) {
+        (node.style as any)[attrName] = await makeAttributeValuePortable(
+          (nodeStyles as any)[attrName],
+        );
       }
       if (node instanceof HTMLElement) {
         node.style.boxSizing = 'border-box';
@@ -102,12 +107,12 @@ export async function makeSVGPortable(svg: SVGElement) {
   // Apply styles inherited from the surrounding document to the base SVG element. This
   // sets things like the line-height, font smoothing, etc.
   for (const idx of Object.keys(baseStyles)) {
-    const attrName: string = baseStyles[idx];
+    const attrName: string = (baseStyles as any)[idx];
     if (!USED_ATTRIBUTES.some((prefix) => attrName.startsWith(prefix))) {
       continue;
     }
-    if (!svg.style[attrName]) {
-      svg.style[attrName] = baseStyles[attrName];
+    if (!(svg.style as any)[attrName]) {
+      (svg.style as any)[attrName] = (baseStyles as any)[attrName];
     }
   }
 

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -264,7 +264,7 @@ const BackfillRunStatus = ({
   // Coerce the data from the backend into PartitionState, collapsing the counts.
   const partitionCounts = Object.entries(counts).reduce((partitionCounts, [runStatus, count]) => {
     const key = runStatusToPartitionState(runStatus as RunStatus);
-    partitionCounts[key] = (partitionCounts[key] || 0) + count;
+    (partitionCounts as any)[key] = ((partitionCounts as any)[key] || 0) + count;
     return partitionCounts;
   }, {});
 
@@ -292,9 +292,9 @@ const BackfillRunStatus = ({
     />
   ) : (
     <RunStatusTagsWithCounts
-      succeededCount={partitionCounts[PartitionState.SUCCESS]}
-      inProgressCount={partitionCounts[PartitionState.STARTED]}
-      failedCount={partitionCounts[PartitionState.FAILURE]}
+      succeededCount={(partitionCounts as any)[PartitionState.SUCCESS]}
+      inProgressCount={(partitionCounts as any)[PartitionState.STARTED]}
+      failedCount={(partitionCounts as any)[PartitionState.FAILURE]}
     />
   );
 };

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -89,7 +89,7 @@ export const TicksTable = ({
     encode: (states) => {
       const queryState = {};
       Object.keys(states).map((state) => {
-        queryState[state.toLowerCase()] = String(states[state]);
+        (queryState as any)[state.toLowerCase()] = String(states[state as keyof typeof states]);
       });
       return queryState;
     },
@@ -97,7 +97,7 @@ export const TicksTable = ({
       const status: ShownStatusState = {...DEFAULT_SHOWN_STATUS_STATE};
       Object.keys(DEFAULT_SHOWN_STATUS_STATE).forEach((state) => {
         if (state.toLowerCase() in queryState) {
-          status[state] = !(queryState[state.toLowerCase()] === 'false');
+          (status as any)[state] = !(queryState[state.toLowerCase()] === 'false');
         }
       });
 
@@ -108,7 +108,7 @@ export const TicksTable = ({
   const {flagSensorScheduleLogging} = useFeatureFlags();
   const instigationSelector = {...repoAddressToSelector(repoAddress), name};
   const statuses = Object.keys(shownStates)
-    .filter((status) => shownStates[status])
+    .filter((status) => shownStates[status as keyof typeof shownStates])
     .map((status) => status as InstigationTickStatus);
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     TickHistoryQuery,

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -308,11 +308,11 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
                     },
                   ]
                 : []),
-              ...(currentSession?.base?.['presetName']
+              ...(currentSession?.base && (currentSession?.base as any)['presetName']
                 ? [
                     {
                       key: DagsterTag.PresetName,
-                      value: currentSession?.base?.['presetName'],
+                      value: (currentSession?.base as any)['presetName'],
                     },
                   ]
                 : []),
@@ -344,7 +344,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     const toSave: PipelineRunTag[] = [];
     tags.forEach((tag: PipelineRunTag) => {
       if (!(tag.key in tagDict)) {
-        tagDict[tag.key] = tag.value;
+        (tagDict as any)[tag.key] = tag.value;
         toSave.push(tag);
       }
     });

--- a/js_modules/dagit/packages/core/src/launchpad/scaffoldType.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/scaffoldType.ts
@@ -22,7 +22,7 @@ export const scaffoldType = (
       for (const field of type.fields) {
         const {name, isRequired, configTypeKey} = field;
         if (isRequired) {
-          config[name] = scaffoldType(configTypeKey, typeLookup);
+          (config as any)[name] = scaffoldType(configTypeKey, typeLookup);
         }
       }
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraph.tsx
@@ -112,8 +112,8 @@ export const PartitionGraph = ({
           if (hiddenStepKeys?.includes(stepKey) || !stepDataByKey[stepKey]) {
             return;
           }
-          stepData[stepKey] = [
-            ...(stepData[stepKey] || []),
+          (stepData as any)[stepKey] = [
+            ...((stepData as any)[stepKey] || []),
             {
               x: partitionName,
               y: !hidden ? stepDataByKey[stepKey] : undefined,
@@ -126,7 +126,7 @@ export const PartitionGraph = ({
     // stepData may have holes due to missing runs or missing steps.  For these to
     // render properly, fill in the holes with `undefined` values.
     Object.keys(stepData).forEach((stepKey) => {
-      stepData[stepKey] = _fillPartitions(partitionNames, stepData[stepKey]);
+      (stepData as any)[stepKey] = _fillPartitions(partitionNames, (stepData as any)[stepKey]);
     });
 
     return {jobData, stepData};
@@ -149,7 +149,7 @@ export const PartitionGraph = ({
           ]),
       ...Object.keys(stepData).map((stepKey) => ({
         label: stepKey,
-        data: stepData[stepKey],
+        data: stepData[stepKey as keyof typeof stepData],
         borderColor: colorHash(stepKey),
         backgroundColor: 'rgba(0,0,0,0)',
       })),
@@ -169,12 +169,12 @@ export const PartitionGraph = ({
 const _fillPartitions = (partitionNames: string[], points: Point[]) => {
   const pointData = {};
   points.forEach((point) => {
-    pointData[point.x] = point.y;
+    (pointData as any)[point.x] = point.y;
   });
 
   return partitionNames.map((partitionName) => ({
     x: partitionName,
-    y: pointData[partitionName],
+    y: (pointData as any)[partitionName],
   }));
 };
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraphSet.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraphSet.tsx
@@ -57,16 +57,28 @@ export const PartitionGraphSet: React.FC<{
       const toSort = partition.runs.slice();
       toSort.sort(_reverseSortRunCompare);
       const latestRun = toSort[0];
-      jobDurationData[partition.name] = getPipelineDurationForRun(latestRun);
-      stepDurationData[partition.name] = getStepDurationsForRun(latestRun);
-      jobMaterializationData[partition.name] = getPipelineMaterializationCountForRun(latestRun);
-      stepMaterializationData[partition.name] = getStepMaterializationCountForRun(latestRun);
-      jobExpectationSuccessData[partition.name] = getPipelineExpectationSuccessForRun(latestRun);
-      stepExpectationSuccessData[partition.name] = getStepExpectationSuccessForRun(latestRun);
-      jobExpectationFailureData[partition.name] = getPipelineExpectationFailureForRun(latestRun);
-      stepExpectationFailureData[partition.name] = getStepExpectationFailureForRun(latestRun);
-      jobExpectationRateData[partition.name] = getPipelineExpectationRateForRun(latestRun);
-      stepExpectationRateData[partition.name] = getStepExpectationRateForRun(latestRun);
+      (jobDurationData as any)[partition.name] = getPipelineDurationForRun(latestRun);
+      (stepDurationData as any)[partition.name] = getStepDurationsForRun(latestRun);
+      (jobMaterializationData as any)[partition.name] = getPipelineMaterializationCountForRun(
+        latestRun,
+      );
+      (stepMaterializationData as any)[partition.name] = getStepMaterializationCountForRun(
+        latestRun,
+      );
+      (jobExpectationSuccessData as any)[partition.name] = getPipelineExpectationSuccessForRun(
+        latestRun,
+      );
+      (stepExpectationSuccessData as any)[partition.name] = getStepExpectationSuccessForRun(
+        latestRun,
+      );
+      (jobExpectationFailureData as any)[partition.name] = getPipelineExpectationFailureForRun(
+        latestRun,
+      );
+      (stepExpectationFailureData as any)[partition.name] = getStepExpectationFailureForRun(
+        latestRun,
+      );
+      (jobExpectationRateData as any)[partition.name] = getPipelineExpectationRateForRun(latestRun);
+      (stepExpectationRateData as any)[partition.name] = getStepExpectationRateForRun(latestRun);
     }
   });
 

--- a/js_modules/dagit/packages/core/src/partitions/PartitionGraphUtils.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionGraphUtils.tsx
@@ -56,7 +56,7 @@ export const getStepDurationsForRun = (run: PartitionGraphSetRunFragment) => {
   const perStepDuration = {};
   stepStats.forEach((stepStat: any) => {
     if (stepStat.endTime && stepStat.startTime) {
-      perStepDuration[stepStat.stepKey] = stepStat.endTime - stepStat.startTime;
+      (perStepDuration as any)[stepStat.stepKey] = stepStat.endTime - stepStat.startTime;
     }
   });
 
@@ -75,7 +75,7 @@ export const getStepMaterializationCountForRun = (run: PartitionGraphFragment) =
   const {stepStats} = run;
   const perStepCounts = {};
   stepStats.forEach((stepStat) => {
-    perStepCounts[stepStat.stepKey] = stepStat.materializations?.length || 0;
+    (perStepCounts as any)[stepStat.stepKey] = stepStat.materializations?.length || 0;
   });
   return perStepCounts;
 };
@@ -89,7 +89,7 @@ export const getStepExpectationSuccessForRun = (run: PartitionGraphFragment) => 
   const {stepStats} = run;
   const perStepCounts = {};
   stepStats.forEach((stepStat) => {
-    perStepCounts[stepStat.stepKey] =
+    (perStepCounts as any)[stepStat.stepKey] =
       stepStat.expectationResults?.filter((x) => x.success).length || 0;
   });
   return perStepCounts;
@@ -104,7 +104,7 @@ export const getStepExpectationFailureForRun = (run: PartitionGraphFragment) => 
   const {stepStats} = run;
   const perStepCounts = {};
   stepStats.forEach((stepStat) => {
-    perStepCounts[stepStat.stepKey] =
+    (perStepCounts as any)[stepStat.stepKey] =
       stepStat.expectationResults?.filter((x) => !x.success).length || 0;
   });
   return perStepCounts;
@@ -130,7 +130,7 @@ export const getStepExpectationRateForRun = (run: PartitionGraphFragment) => {
   const perStepCounts = {};
   stepStats.forEach((stepStat) => {
     const results = stepStat.expectationResults || [];
-    perStepCounts[stepStat.stepKey] = results.length
+    (perStepCounts as any)[stepStat.stepKey] = results.length
       ? results.filter((x) => x.success).length / results.length
       : 0;
   });

--- a/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionStepStatus.tsx
@@ -215,8 +215,8 @@ const PartitionStepStatus: React.FC<
 
   const sortPartitionSteps = (steps: MatrixStep[]) => {
     const stepsByName = {};
-    steps.forEach((step) => (stepsByName[step.name] = step));
-    return stepRows.map((stepRow) => stepsByName[stepRow.name]);
+    steps.forEach((step) => ((stepsByName as any)[step.name] = step));
+    return stepRows.map((stepRow) => (stepsByName as any)[stepRow.name]);
   };
 
   const visibleCount = getVisibleItemCount(viewport.width);

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.test.tsx
@@ -24,7 +24,10 @@ const MOCK_PARTITIONS = Object.keys(MOCK_PARTITION_STATES).sort();
 describe('SpanRepresentation', () => {
   describe('assembleIntoSpans', () => {
     it('returns spans of each returned value', async () => {
-      const result = assembleIntoSpans(MOCK_PARTITIONS, (key) => MOCK_PARTITION_STATES[key] === 1);
+      const result = assembleIntoSpans(
+        MOCK_PARTITIONS,
+        (key) => MOCK_PARTITION_STATES[key as keyof typeof MOCK_PARTITION_STATES] === 1,
+      );
       const expected = [
         {startIdx: 0, endIdx: 5, status: false},
         {startIdx: 6, endIdx: 8, status: true},

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
@@ -1,5 +1,3 @@
-import {all} from 'deepmerge';
-
 import {
   PartitionDimensionSelection,
   PartitionDimensionSelectionRange,
@@ -83,8 +81,10 @@ export function spanTextToSelections(
         start = -1;
       };
 
-      for (let idx = 0; idx < all.length; idx++) {
-        const match = all[idx].startsWith(prefix) && all[idx].endsWith(suffix);
+      // todo bengotow: Was this change correct??
+      for (let idx = 0; idx < allPartitionKeys.length; idx++) {
+        const match =
+          allPartitionKeys[idx].startsWith(prefix) && allPartitionKeys[idx].endsWith(suffix);
         if (match && start === -1) {
           start = idx;
         }
@@ -93,7 +93,7 @@ export function spanTextToSelections(
         }
       }
       if (start !== -1) {
-        close(all.length - 1);
+        close(allPartitionKeys.length - 1);
       }
     } else {
       const idx = allPartitionKeys.indexOf(term);

--- a/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
@@ -67,11 +67,11 @@ function buildMatrixData(
     // Note this is sorting partition runs in place, I don't think it matters and
     // seems better than cloning all the arrays.
     p.runs.sort(byStartTimeAsc);
-    partitionsByName[p.name] = p;
+    (partitionsByName as any)[p.name] = p;
   });
 
   const partitionColumns = partitionNames.map((name, idx) => {
-    const partition: PartitionRuns = partitionsByName[name] || {
+    const partition: PartitionRuns = (partitionsByName as any)[name] || {
       name,
       runsLoaded: false,
       runs: [],

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineExplorerRoot.tsx
@@ -32,7 +32,7 @@ export const PipelineExplorerSnapshotRoot = () => {
   useTrackPageView();
 
   const params = useParams();
-  const explorerPath = explorerPathFromString(params['0']);
+  const explorerPath = explorerPathFromString((params as any)['0']);
   const {pipelineName, snapshotId} = explorerPath;
   const history = useHistory();
 

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineOverviewRoot.tsx
@@ -30,7 +30,7 @@ export const PipelineOverviewRoot: React.FC<Props> = (props) => {
   const location = useLocation();
   const params = useParams();
 
-  const explorerPath = explorerPathFromString(params['0']);
+  const explorerPath = explorerPathFromString((params as any)['0']);
 
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, explorerPath.pipelineName);

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -18,6 +18,7 @@ export const StateColors = {
   SUCCESS: Colors.Green500,
   FAILURE: Colors.Red500,
   SKIPPED: Colors.Gray500,
+  IN_PROGRESS: Colors.Gray200,
 };
 
 export const SidebarOpExecutionGraphs: React.FC<{

--- a/js_modules/dagit/packages/core/src/plugins/index.ts
+++ b/js_modules/dagit/packages/core/src/plugins/index.ts
@@ -3,7 +3,7 @@ import * as ipynb from '../plugins/ipynb';
 import * as sql from '../plugins/sql';
 import {RepoAddress} from '../workspace/types';
 
-const plugins = {
+const plugins: Record<string, any> = {
   sql,
   ipynb,
   snowflake: sql,

--- a/js_modules/dagit/packages/core/src/runs/CellTruncationProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/CellTruncationProvider.tsx
@@ -80,7 +80,8 @@ export class CellTruncationProvider extends React.Component<
       return;
     }
 
-    const isOverflowing = child.scrollHeight > this.props.style.height!;
+    const isOverflowing =
+      typeof this.props.style.height === 'number' && child.scrollHeight > this.props.style.height;
     if (isOverflowing !== this.state.isOverflowing) {
       this.setState({isOverflowing});
     }

--- a/js_modules/dagit/packages/core/src/runs/LogFilterSelect.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogFilterSelect.tsx
@@ -39,7 +39,7 @@ export const LogFilterSelect: React.FC<Props> = ({options, onSetFilter}) => {
       content={
         <Menu style={{width: '180px'}} aria-label="filter-options">
           {levels.map((level) => {
-            const optionForLevel = options[level];
+            const optionForLevel = options[level as keyof typeof options];
             const {label, count, enabled} = optionForLevel;
             return (
               <MenuItem

--- a/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsToolbar.tsx
@@ -166,13 +166,13 @@ const ComputeLogToolbar = ({
 }) => {
   const logCaptureSteps =
     metadata.logCaptureSteps || extractLogCaptureStepsFromLegacySteps(Object.keys(metadata.steps));
-  const isValidStepSelection = computeLogFileKey && logCaptureSteps[computeLogFileKey];
+  const isValidStepSelection = computeLogFileKey && (logCaptureSteps as any)[computeLogFileKey];
 
   const fileKeyText = (fileKey?: string) => {
-    if (!fileKey || !logCaptureSteps[fileKey]) {
+    if (!fileKey || !(logCaptureSteps as any)[fileKey]) {
       return null;
     }
-    const captureInfo = logCaptureSteps[fileKey];
+    const captureInfo = (logCaptureSteps as any)[fileKey];
     if (captureInfo.stepKeys.length === 1 && fileKey === captureInfo.stepKeys[0]) {
       return fileKey;
     }
@@ -223,12 +223,13 @@ const ComputeLogToolbar = ({
       </Group>
       {isValidStepSelection ? (
         <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
-          {computeLogFileKey && logCaptureSteps[computeLogFileKey] ? (
-            resolveState(metadata, logCaptureSteps[computeLogFileKey]) === IStepState.RUNNING ? (
+          {computeLogFileKey && (logCaptureSteps as any)[computeLogFileKey] ? (
+            resolveState(metadata, (logCaptureSteps as any)[computeLogFileKey]) ===
+            IStepState.RUNNING ? (
               <Spinner purpose="body-text" />
             ) : (
               <ExecutionStateDot
-                state={resolveState(metadata, logCaptureSteps[computeLogFileKey])}
+                state={resolveState(metadata, (logCaptureSteps as any)[computeLogFileKey])}
               />
             )
           ) : null}
@@ -236,8 +237,11 @@ const ComputeLogToolbar = ({
             <Tooltip
               placement="top-end"
               content={
-                computeLogFileKey && logCaptureSteps[computeLogFileKey]?.stepKeys.length === 1
-                  ? `Download ${logCaptureSteps[computeLogFileKey]?.stepKeys[0]} compute logs`
+                computeLogFileKey &&
+                (logCaptureSteps as any)[computeLogFileKey]?.stepKeys.length === 1
+                  ? `Download ${
+                      (logCaptureSteps as any)[computeLogFileKey]?.stepKeys[0]
+                    } compute logs`
                   : `Download compute logs`
               }
             >
@@ -361,7 +365,7 @@ const StructuredLogToolbar = ({
         level,
         {
           label: level.toLowerCase(),
-          count: counts[level],
+          count: counts[level as LogLevel],
           enabled: !!filter.levels[level],
         },
       ] as [LogLevel, FilterOption];

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -94,7 +94,7 @@ export const EMPTY_RUN_METADATA: IRunMetadataDict = {
 export const extractLogCaptureStepsFromLegacySteps = (stepKeys: string[]) => {
   const logCaptureSteps = {};
   stepKeys.forEach(
-    (stepKey) => (logCaptureSteps[stepKey] = {fileKey: stepKey, stepKeys: [stepKey]}),
+    (stepKey) => ((logCaptureSteps as any)[stepKey] = {fileKey: stepKey, stepKeys: [stepKey]}),
   );
   return logCaptureSteps;
 };

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -69,7 +69,7 @@ export const RunTags: React.FC<{
     for (const tag of copiedTags) {
       const {key} = tag;
       if (renamedTags.hasOwnProperty(key)) {
-        tag.key = renamedTags[key];
+        tag.key = renamedTags[key as keyof typeof renamedTags];
       }
 
       if (

--- a/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTimeline.tsx
@@ -77,7 +77,7 @@ export const RunTimeline = (props: Props) => {
     const repoKey = repoAddressAsURLString(repoAddress);
     const jobsForRepo = accum[repoKey] || [];
     return {...accum, [repoKey]: [...jobsForRepo, job]};
-  }, {});
+  }, {} as Record<string, TimelineJob[]>);
 
   const allKeys = Object.keys(buckets);
   const {expandedKeys, onToggle, onToggleAll} = useRepoExpansionState(

--- a/js_modules/dagit/packages/core/src/runs/mergeStatusToBackground.tsx
+++ b/js_modules/dagit/packages/core/src/runs/mergeStatusToBackground.tsx
@@ -44,7 +44,7 @@ export const mergeStatusToBackground = (runs: TimelineRun[]) => {
   });
 
   const statusArr = Object.keys(counts).filter(
-    (status) => counts[status] > 0,
+    (status) => counts[status as keyof typeof counts] > 0,
   ) as BackgroundStatus[];
 
   if (statusArr.length === 1) {

--- a/js_modules/dagit/packages/core/src/schedules/SchedulePartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulePartitionStatus.tsx
@@ -129,7 +129,10 @@ const RetrievedSchedulePartitionStatus: React.FC<{
   const partitionsByType = {};
   partitions.forEach((partition) => {
     const displayStatus = calculateDisplayStatus(partition);
-    partitionsByType[displayStatus] = [...(partitionsByType[displayStatus] || []), partition];
+    (partitionsByType as any)[displayStatus] = [
+      ...((partitionsByType as any)[displayStatus] || []),
+      partition,
+    ];
   });
 
   return (
@@ -148,10 +151,10 @@ const RetrievedSchedulePartitionStatus: React.FC<{
                     to={`${partitionURL}?showFailuresAndGapsOnly=true`}
                     style={{color: Colors.Gray900}}
                   >
-                    {partitionsByType[status].length}
+                    {(partitionsByType as any)[status].length}
                   </Link>
                 ) : (
-                  partitionsByType[status].length
+                  (partitionsByType as any)[status].length
                 )}
               </td>
             </tr>

--- a/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
+++ b/js_modules/dagit/packages/core/src/scripts/generateGraphQLTypes.ts
@@ -25,7 +25,7 @@ execSync(`yarn prettier --loglevel silent --write ${TARGET_FILE}`, {stdio: 'inhe
 
 // Write `possibleTypes.generated.json`, used in prod for `AppCache` and in tests for creating
 // a mocked schema.
-const possibleTypes = {};
+const possibleTypes: Record<string, string[]> = {};
 
 schemaJson.__schema.types.forEach((supertype: {name: string; possibleTypes: [{name: string}]}) => {
   if (supertype.possibleTypes) {

--- a/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useTimeRangeFilter.tsx
@@ -41,11 +41,14 @@ export function calculateTimeRanges(timezone: string) {
     },
     CUSTOM: {label: 'Custom...', range: [null, null] as TimeRangeState},
   };
-  const array = Object.keys(obj).map((key) => ({
-    key: key as keyof typeof obj,
-    label: obj[key].label,
-    range: obj[key].range,
-  }));
+  const array = Object.keys(obj).map((keyString) => {
+    const key = keyString as keyof typeof obj;
+    return {
+      key,
+      label: obj[key].label,
+      range: obj[key].range,
+    };
+  });
   return {timeRanges: obj, timeRangesArray: array};
 }
 

--- a/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GraphRoot.tsx
@@ -31,7 +31,7 @@ export const GraphRoot: React.FC<Props> = (props) => {
   const {repoAddress} = props;
   const params = useParams();
 
-  const path = explorerPathFromString(params[0]);
+  const path = explorerPathFromString((params as any)[0]);
 
   // Show the name of the composite solid we are within (-1 is the selection, -2 is current parent)
   // or the name of the pipeline tweaked to look a bit more like a graph name.
@@ -62,7 +62,7 @@ const GraphExplorerRoot: React.FC<Props> = (props) => {
   const {repoAddress} = props;
   const params = useParams();
 
-  const explorerPath = explorerPathFromString(params['0']);
+  const explorerPath = explorerPathFromString((params as any)['0']);
   const history = useHistory();
   const [options, setOptions] = React.useState<GraphExplorerOptions>({
     explodeComposites: false,

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -34,8 +34,8 @@ export const VirtualizedRepoAssetTable: React.FC<Props> = ({repoAddress, assets}
     `${repoKey}-${ASSET_GROUPS_EXPANSION_STATE_STORAGE_KEY}`,
   );
 
-  const grouped: {[key: string]: Asset[]} = React.useMemo(() => {
-    const groups = {};
+  const grouped: Record<string, Asset[]> = React.useMemo(() => {
+    const groups: Record<string, Asset[]> = {};
     for (const asset of assets) {
       const groupName = asset.groupName || UNGROUPED_NAME;
       const assetsForGroup = groups[groupName] || [];

--- a/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspacePipelineRoot.tsx
@@ -20,7 +20,7 @@ export const WorkspacePipelineRoot = () => {
   const entireMatch = useRouteMatch(['/locations/pipelines/(/?.*)', '/locations/jobs/(/?.*)']);
   const location = useLocation();
 
-  const toAppend = entireMatch!.params[0];
+  const toAppend = (entireMatch!.params as any)[0];
   const {search} = location;
 
   const {pipelineName} = explorerPathFromString(pipelinePath);

--- a/js_modules/dagit/packages/core/tsconfig.json
+++ b/js_modules/dagit/packages/core/tsconfig.json
@@ -14,7 +14,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,
     "types": [
       "jest",

--- a/js_modules/dagit/packages/eslint-config/package.json
+++ b/js_modules/dagit/packages/eslint-config/package.json
@@ -14,8 +14,8 @@
     "prettier": "2.8.1"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "5.47.0",
-    "@typescript-eslint/parser": "5.47.0",
+    "@typescript-eslint/eslint-plugin": "5.57.0",
+    "@typescript-eslint/parser": "5.57.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-dagster-rules": "link:./rules",
     "eslint-plugin-import": "2.26.0",
@@ -31,6 +31,6 @@
     "jest": "^29.4",
     "prettier": "2.2.1",
     "ts-jest": "^28.0.3",
-    "typescript": "4.8.4"
+    "typescript": "5.0.2"
   }
 }

--- a/js_modules/dagit/packages/ui/package.json
+++ b/js_modules/dagit/packages/ui/package.json
@@ -73,7 +73,7 @@
     "@types/mdx-js__react": "^1",
     "@types/react-is": "^17",
     "@types/rollup-plugin-node-globals": "^1",
-    "@types/styled-components": "^5",
+    "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.2",
     "babel-jest": "^27.4.6",
     "babel-loader": "^8.2.4",
@@ -90,7 +90,7 @@
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-polyfill-node": "^0.8.0",
     "rollup-plugin-styles": "^4.0.0",
-    "typescript": "4.8.4",
+    "typescript": "5.0.2",
     "webpack": "^5.0.0"
   },
   "browserslist": {

--- a/js_modules/dagit/packages/ui/src/components/Colors.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Colors.stories.tsx
@@ -21,14 +21,17 @@ export default {
 } as Meta;
 
 const ColorsToHex = Object.keys(Colors).reduce(
-  (accum, key) => ({...accum, [key]: `#${rgbHex(Colors[key]).slice(0, 6)}`}),
+  (accum, key) => ({...accum, [key]: `#${rgbHex(Colors[key as keyof typeof Colors]).slice(0, 6)}`}),
   {},
 );
 
 const toCurrent = nearestColor.from(ColorsToHex);
 
 const BlueprintToHex = Object.keys(BlueprintColors).reduce(
-  (accum, key) => ({...accum, [key]: `${BlueprintColors[key].slice(0, 7)}`}),
+  (accum, key) => ({
+    ...accum,
+    [key]: `${BlueprintColors[key as keyof typeof BlueprintColors].slice(0, 7)}`,
+  }),
   {},
 );
 
@@ -38,15 +41,15 @@ export const Comparison = () => {
       <Box flex={{direction: 'column', alignItems: 'stretch', gap: 4}}>
         <div>Current colors</div>
         {Object.keys(ColorsToHex).map((key) => (
-          <ColorExample key={key} name={key} color={ColorsToHex[key]} />
+          <ColorExample key={key} name={key} color={ColorsToHex[key as keyof typeof ColorsToHex]} />
         ))}
       </Box>
       <Box flex={{direction: 'column', alignItems: 'stretch', gap: 4}}>
         <div>Blueprint colors</div>
         {Object.keys(BlueprintToHex).map((key) => (
           <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}} key={key}>
-            <ColorExample name={key} color={BlueprintToHex[key]} />
-            <div>{toCurrent(BlueprintToHex[key]).name}</div>
+            <ColorExample name={key} color={BlueprintToHex[key as keyof typeof BlueprintToHex]} />
+            <div>{toCurrent(BlueprintToHex[key as keyof typeof BlueprintToHex]).name}</div>
           </Box>
         ))}
       </Box>

--- a/js_modules/dagit/packages/ui/src/components/Icon.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Icon.stories.tsx
@@ -42,7 +42,7 @@ export const IconColors = () => {
   const colorAtIndex = (index: number) => {
     const colorKey = colorKeys[index % numColors];
     if (colorKey) {
-      const colorAtKey = Colors[colorKey];
+      const colorAtKey = Colors[colorKey as keyof typeof Colors];
       if (colorAtKey) {
         return colorAtKey;
       }

--- a/js_modules/dagit/packages/ui/src/components/TokenizingField.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TokenizingField.stories.tsx
@@ -71,7 +71,7 @@ export const TokenAndSuggestionProviders = () => {
       values: () => Object.keys(users),
       suggestionFilter: (typed: string, s: Suggestion) =>
         s.text.toLowerCase().includes(typed.toLowerCase()) ||
-        users[s.text].toLowerCase().includes(typed.toLowerCase()),
+        (users as any)[s.text].toLowerCase().includes(typed.toLowerCase()),
     },
   ];
 
@@ -102,7 +102,7 @@ export const CustomSuggestionRenderer = () => {
       suggestionProviders={suggestionProviders}
       suggestionRenderer={(suggestion) => (
         <Group direction="row" spacing={8} alignItems="center">
-          <ColorSwatch $color={colors[suggestion.text]} />
+          <ColorSwatch $color={suggestion.text} />
           {suggestion.text}
         </Group>
       )}

--- a/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Tooltip.tsx
@@ -95,6 +95,7 @@ export const Tooltip: React.FC<Props> = (props) => {
 
 interface StyledTooltipProps {
   $display: React.CSSProperties['display'];
+  children: React.ReactNode;
 }
 
 const StyledTooltip = styled(Tooltip2)<StyledTooltipProps>`

--- a/js_modules/dagit/packages/ui/tsconfig.json
+++ b/js_modules/dagit/packages/ui/tsconfig.json
@@ -13,7 +13,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noUncheckedIndexedAccess": true,
     "allowSyntheticDefaultImports": true,
     "types": [

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -6207,7 +6207,7 @@ __metadata:
     react-router: ^5.2.1
     react-router-dom: ^5.3.0
     react-router-dom-v5-compat: ^6.3.0
-    typescript: 4.8.4
+    typescript: 5.0.2
     uuid: ^9.0.0
     validator: ^13.7.0
     web-vitals: ^2.1.3
@@ -6272,7 +6272,7 @@ __metadata:
     "@types/react-router": ^5.1.17
     "@types/react-router-dom": ^5.3.2
     "@types/react-virtualized": ^9.21.5
-    "@types/styled-components": ^5.1.9
+    "@types/styled-components": ^5.1.26
     "@types/testing-library__jest-dom": ^5.14.2
     "@types/ws": ^6.0.3
     "@vx/shape": ^0.0.192
@@ -6335,7 +6335,7 @@ __metadata:
     subscriptions-transport-ws: ^0.9.15
     ts-node: 9.1.1
     ts-prune: 0.8.9
-    typescript: 4.8.4
+    typescript: 5.0.2
     webpack: ^5.0.0
     worker-loader: ^3.0.8
     yaml: 2.0.0-10
@@ -6365,8 +6365,8 @@ __metadata:
   resolution: "@dagster-io/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@types/jest": ^27.5.1
-    "@typescript-eslint/eslint-plugin": 5.47.0
-    "@typescript-eslint/parser": 5.47.0
+    "@typescript-eslint/eslint-plugin": 5.57.0
+    "@typescript-eslint/parser": 5.57.0
     eslint: ^8.6.0
     eslint-config-prettier: 8.5.0
     eslint-plugin-dagster-rules: "link:./rules"
@@ -6379,7 +6379,7 @@ __metadata:
     jest: ^29.4
     prettier: 2.2.1
     ts-jest: ^28.0.3
-    typescript: 4.8.4
+    typescript: 5.0.2
   peerDependencies:
     eslint: ^8.30.0
     prettier: 2.8.1
@@ -6495,7 +6495,7 @@ __metadata:
     "@types/mdx-js__react": ^1
     "@types/react-is": ^17
     "@types/rollup-plugin-node-globals": ^1
-    "@types/styled-components": ^5
+    "@types/styled-components": ^5.1.26
     "@types/testing-library__jest-dom": ^5.14.2
     amator: ^1.1.0
     babel-jest: ^27.4.6
@@ -6517,7 +6517,7 @@ __metadata:
     rollup-plugin-node-globals: ^1.4.0
     rollup-plugin-polyfill-node: ^0.8.0
     rollup-plugin-styles: ^4.0.0
-    typescript: 4.8.4
+    typescript: 5.0.2
     webpack: ^5.0.0
     yaml: 2.0.0-10
   peerDependencies:
@@ -6697,6 +6697,24 @@ __metadata:
   peerDependencies:
     cosmiconfig: ">=6"
   checksum: 7fe0198622b1063c40572034df7e8ba867865a1b4815afe230795929abcf785758b34d7806a8e2100ba8ab4e92c5a1c3e11a980c466c4406df6e7ec6e50df8b6
+  languageName: node
+  linkType: hard
+
+"@eslint-community/eslint-utils@npm:^4.2.0":
+  version: 4.4.0
+  resolution: "@eslint-community/eslint-utils@npm:4.4.0"
+  dependencies:
+    eslint-visitor-keys: ^3.3.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: cdfe3ae42b4f572cbfb46d20edafe6f36fc5fb52bf2d90875c58aefe226892b9677fef60820e2832caf864a326fe4fc225714c46e8389ccca04d5f9288aabd22
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.4.0":
+  version: 4.5.0
+  resolution: "@eslint-community/regexpp@npm:4.5.0"
+  checksum: 99c01335947dbd7f2129e954413067e217ccaa4e219fe0917b7d2bd96135789384b8fedbfb8eb09584d5130b27a7b876a7150ab7376f51b3a0c377d5ce026a10
   languageName: node
   linkType: hard
 
@@ -11255,25 +11273,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/styled-components@npm:^5":
-  version: 5.1.19
-  resolution: "@types/styled-components@npm:5.1.19"
+"@types/styled-components@npm:^5.1.26":
+  version: 5.1.26
+  resolution: "@types/styled-components@npm:5.1.26"
   dependencies:
     "@types/hoist-non-react-statics": "*"
     "@types/react": "*"
     csstype: ^3.0.2
-  checksum: ccd2baa6c980ad176650889f2fb286edbb57f5e2b74a01d80d349f751fa7fbdb4f21ed34a893a4c417cc5731c5f0174dba5d180c3a11954996d29c2818ecab13
-  languageName: node
-  linkType: hard
-
-"@types/styled-components@npm:^5.1.9":
-  version: 5.1.9
-  resolution: "@types/styled-components@npm:5.1.9"
-  dependencies:
-    "@types/hoist-non-react-statics": "*"
-    "@types/react": "*"
-    csstype: ^3.0.2
-  checksum: 99b5e069a01980b6baec40ecb273bcb51baabbb5ca12905e59d575ab8672e2db1b60a5cf3715214ccf99597d4094aebbaa5d5c54c314332332fe6ec41a19e6c6
+  checksum: 84f53b3101739b20d1731554fb7735bc2f3f5d050a8b392e9845403c8c8bbd729737d033978649f9195a97b557875b010d46e35a4538564a2d0dbcce661dbf76
   languageName: node
   linkType: hard
 
@@ -11468,17 +11475,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.47.0"
+"@typescript-eslint/eslint-plugin@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.57.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.47.0
-    "@typescript-eslint/type-utils": 5.47.0
-    "@typescript-eslint/utils": 5.47.0
+    "@eslint-community/regexpp": ^4.4.0
+    "@typescript-eslint/scope-manager": 5.57.0
+    "@typescript-eslint/type-utils": 5.57.0
+    "@typescript-eslint/utils": 5.57.0
     debug: ^4.3.4
+    grapheme-splitter: ^1.0.4
     ignore: ^5.2.0
     natural-compare-lite: ^1.4.0
-    regexpp: ^3.2.0
     semver: ^7.3.7
     tsutils: ^3.21.0
   peerDependencies:
@@ -11487,7 +11495,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: fd867eb2b668d1f476fd28d38c2df2a680bf510a265a6e714b28d8f77e7a37e74e32294b70262a6fd1aec99ddb2fddef0212c862b4465ca4f83bb1172476f6e7
+  checksum: be13aa74ee6f15f0ae67781c625d9dcf3ce8a3feca2b125eef0cfee850b7f9f0cec23fc56a729ef25926298fe3ea51603ebeee2b93fc9b73fce1410638707177
   languageName: node
   linkType: hard
 
@@ -11507,20 +11515,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/parser@npm:5.47.0"
+"@typescript-eslint/parser@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/parser@npm:5.57.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.47.0
-    "@typescript-eslint/types": 5.47.0
-    "@typescript-eslint/typescript-estree": 5.47.0
+    "@typescript-eslint/scope-manager": 5.57.0
+    "@typescript-eslint/types": 5.57.0
+    "@typescript-eslint/typescript-estree": 5.57.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 5c864ca74b86ca740c73e5b87d90d43bb832b20ba6be0a39089175435771527722a7bf0a8ef7ddbd64b85235fbb7f6dbe8ae55a8bc73c6242f5559d580a8a80c
+  checksum: b7e8345631911f721591ba970fea5c888f0f3bf2e2ea2dbc3e5b0dc345c0776b62b92c534edfde1379b4b182958a421f35ac26d84705fe6ae7dd37aa675d9493
   languageName: node
   linkType: hard
 
@@ -11534,13 +11542,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.47.0"
+"@typescript-eslint/scope-manager@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.57.0"
   dependencies:
-    "@typescript-eslint/types": 5.47.0
-    "@typescript-eslint/visitor-keys": 5.47.0
-  checksum: f637268a4cb065a89bb53d72620cc553f8c0d9f00805d6e6aac558cc4d3c08f3329208b0b4d5566d21eb636b080d453e5890221baef0e4bc4d67251f07cccd0d
+    "@typescript-eslint/types": 5.57.0
+    "@typescript-eslint/visitor-keys": 5.57.0
+  checksum: 4a851f23da2adbf6341b04c1e3f19fcb66415683f26805d3123725d18845bd4a150bd182de0a91279d5682f2568bb5dd831d4ad0bdb70f49d9ca7381cec4dd17
   languageName: node
   linkType: hard
 
@@ -11554,12 +11562,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/type-utils@npm:5.47.0"
+"@typescript-eslint/type-utils@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/type-utils@npm:5.57.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": 5.47.0
-    "@typescript-eslint/utils": 5.47.0
+    "@typescript-eslint/typescript-estree": 5.57.0
+    "@typescript-eslint/utils": 5.57.0
     debug: ^4.3.4
     tsutils: ^3.21.0
   peerDependencies:
@@ -11567,7 +11575,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 504b3e883ac02cb8e69957b706e76cb79fa2192aa62702c2a658119f28f8f50f1e668efb62318e85aeda6522e1d948b59382cae4ef3300a3f4eea809a87dec26
+  checksum: 649d000edabfe4e567b8a384d0012c56396e40ce2123a78857d4b8da6bf2288627dc355745bd7d4a2877d4cc8a26e1d1dbfc422e6382ac3d3ab431b92eb5b852
   languageName: node
   linkType: hard
 
@@ -11578,10 +11586,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/types@npm:5.47.0"
-  checksum: 5a856e190cc2103427dbe15ccbbf87238261b5ed0859390a9e55f93afc2057f79dcbb4ac0db4d35787466f5e73f271111d19b2e725cf444af41d30e09678bf7a
+"@typescript-eslint/types@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/types@npm:5.57.0"
+  checksum: 79a100fb650965f63c01c20e6abd79ca0d2043c3a329b9fef89917d6b9ba3c0f946dca3f14f2975ee6349daadd6ce0e98fde3aafe4b710e5a27abe1adc590c85
   languageName: node
   linkType: hard
 
@@ -11610,12 +11618,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.47.0"
+"@typescript-eslint/typescript-estree@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.57.0"
   dependencies:
-    "@typescript-eslint/types": 5.47.0
-    "@typescript-eslint/visitor-keys": 5.47.0
+    "@typescript-eslint/types": 5.57.0
+    "@typescript-eslint/visitor-keys": 5.57.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -11624,7 +11632,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: a9adfe8955b7dc9dfa9f43d450b782b83f506eaadae2a13f4e1bbe6c733be446d3edb26910954aec1bdc60d94ecc55c4e200d5b19bb24e6742f02329a4fb3e8c
+  checksum: 648b88f88ea6cc293ec67b4c0f4f3c2bf733be7e0f2eee08aadbaec6939fd724a6c287decc336abbf67b9e366cc2c48f2e0e48d8302b533e783f798332a06e83
   languageName: node
   linkType: hard
 
@@ -11646,21 +11654,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/utils@npm:5.47.0"
+"@typescript-eslint/utils@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/utils@npm:5.57.0"
   dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
     "@types/json-schema": ^7.0.9
     "@types/semver": ^7.3.12
-    "@typescript-eslint/scope-manager": 5.47.0
-    "@typescript-eslint/types": 5.47.0
-    "@typescript-eslint/typescript-estree": 5.47.0
+    "@typescript-eslint/scope-manager": 5.57.0
+    "@typescript-eslint/types": 5.57.0
+    "@typescript-eslint/typescript-estree": 5.57.0
     eslint-scope: ^5.1.1
-    eslint-utils: ^3.0.0
     semver: ^7.3.7
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: f168920eec6f77651107f190b4ecadd82951fe4e3c0321ff660ac7380f4315d5ae30a1b63b4d2818f5e6f007a3f34c5df202619c24ec3a7e2ef25b215ec7b813
+  checksum: 461258e1194d24c5e642c65ba1afd612712fa8e617ac85cfbbe3dde2557fe4abadedbce19a6954ae0cccbfb92b8a09f38d65a3eedca0394861a5d1c4c893c5ed
   languageName: node
   linkType: hard
 
@@ -11690,13 +11698,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.47.0":
-  version: 5.47.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.47.0"
+"@typescript-eslint/visitor-keys@npm:5.57.0":
+  version: 5.57.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.57.0"
   dependencies:
-    "@typescript-eslint/types": 5.47.0
+    "@typescript-eslint/types": 5.57.0
     eslint-visitor-keys: ^3.3.0
-  checksum: 2191c079154bdfd1b85b8cd24baa6c0f55c73527c6c8460789483555b4eb5c72e3dc6d1aa4bbac2cf7b86b474588b45682a8deb151e9d903cf72c8f336141f1f
+  checksum: 77d53f74648e48bf1c6313cd60568c2b1539157ac13945f26204a54beb156666c24f3d033dd0db8ed5d1d4595ee63c072732b17132e4488b46763bf8fdcefa49
   languageName: node
   linkType: hard
 
@@ -19150,6 +19158,13 @@ __metadata:
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: 68ea4e07ff2c041ada184f9278b830375f8e0b75154e3f080af6b70f66172fabb4108d19b3863a96b53fc068a310b9b6493d86d1291acc5f3861eb4b79d26ad6
+  languageName: node
+  linkType: hard
+
+"grapheme-splitter@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "grapheme-splitter@npm:1.0.4"
+  checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
   languageName: node
   linkType: hard
 
@@ -31444,13 +31459,13 @@ typescript@*:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:5.0.2":
+  version: 5.0.2
+  resolution: "typescript@npm:5.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
   languageName: node
   linkType: hard
 
@@ -31474,13 +31489,13 @@ typescript@*:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=0102e9"
+"typescript@patch:typescript@5.0.2#~builtin<compat/typescript>":
+  version: 5.0.2
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=d73830"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 301459fc3eb3b1a38fe91bf96d98eb55da88a9cb17b4ef80b4d105d620f4d547ba776cc27b44cc2ef58b66eda23fe0a74142feb5e79a6fb99f54fc018a696afa
+  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Upgrade `dagster` packages to TypeScript 5.0.2.

- Remove `suppressImplicitAnyIndexErrors` throughout. This means applying `any` annotations on a lot of objects, which I believe should basically have the same effect as the current suppression behavior. I fixed the ones that seemed readily fixable.
- Update some eslint-config packages as well, to eliminate an eslint warning related to the TS upgrade.

## How I Tested These Changes

TS, lint, jest.
