### PR TITLE
[Checkbox] stopPropagation for `onClick`

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/Filters/useStaticSetFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useStaticSetFilter.tsx
@@ -217,13 +217,7 @@ function SetFilterLabel(props: SetFilterLabelProps) {
       margin={{left: 4}}
       style={{maxWidth: '500px'}}
     >
-      <Checkbox
-        checked={isActive}
-        onChange={(_) => {
-          labelRef.current?.click();
-        }}
-        size="small"
-      />
+      <Checkbox checked={isActive} size="small" />
       <Box
         flex={{direction: 'row', alignItems: 'center', grow: 1, shrink: 1}}
         style={{overflow: 'hidden'}}

--- a/js_modules/dagit/packages/ui/src/components/Checkbox.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Checkbox.tsx
@@ -14,6 +14,7 @@ type Props = Omit<
   'size'
 > & {
   checked: boolean;
+  onClick?: (e: React.MouseEvent<HTMLLabelElement>) => void;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   label?: React.ReactNode;
   indeterminate?: boolean;
@@ -173,6 +174,7 @@ const Base = ({
   fillColor = Colors.Blue500,
   children, // not passed to input
   size,
+  onClick,
   ...rest
 }: Props) => {
   const uid = useRef(id || uniqueId());
@@ -181,7 +183,7 @@ const Base = ({
   ];
 
   return (
-    <label htmlFor={uid.current} className={className}>
+    <label htmlFor={uid.current} className={className} onClick={onClick}>
       <input
         {...rest}
         type="checkbox"

--- a/js_modules/dagit/packages/ui/src/components/Checkbox.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Checkbox.tsx
@@ -14,7 +14,7 @@ type Props = Omit<
   'size'
 > & {
   checked: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   label?: React.ReactNode;
   indeterminate?: boolean;
   format?: Format;
@@ -189,6 +189,10 @@ const Base = ({
         tabIndex={0}
         checked={checked}
         disabled={disabled}
+        onClick={(e) => {
+          // https://codesandbox.io/s/muddy-https-6zypxg?file=/src/index.js
+          e.stopPropagation();
+        }}
       />
       <Component
         disabled={disabled}


### PR DESCRIPTION
## Summary & Motivation

The Checkbox component wraps the checkbox input and its label in a `<label>` element. This means that when the checkbox is clicked, any parent `onClick` handlers will fire twice (see this codesandbox for a demonstration: https://codesandbox.io/s/muddy-https-6zypxg?file=/src/index.js) .

To fix this I move the `onClick` handler onto the `label` element, and I call `stopPropagation` when clicking on the checkbox input directly. see for demonstration of the fix: https://codesandbox.io/s/nice-star-ppf0hk?file=/src/index.js