### PR TITLE
Allow a top-level "run_queue" config field in dagster.yaml instead of requiring users to grok RunCoordinators

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -79,6 +79,16 @@ def dagster_instance_config(
         custom_instance_class = None
         schema = dagster_instance_config_schema()
 
+    if "run_queue" in dagster_config_dict and "run_coordinator" in dagster_config_dict:
+        raise DagsterInvalidConfigError(
+            (
+                "Found config for `run_queue` which is incompatible with `run_coordinator` config"
+                " entry."
+            ),
+            [],
+            None,
+        )
+
     if "storage" in dagster_config_dict and (
         "run_storage" in dagster_config_dict
         or "event_log_storage" in dagster_config_dict
@@ -116,6 +126,15 @@ def dagster_instance_config(
 
 def config_field_for_configurable_class() -> Field:
     return Field(configurable_class_schema(), is_required=False)
+
+
+def run_queue_config_schema() -> Field:
+    from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
+
+    return Field(
+        QueuedRunCoordinator.config_type(),
+        is_required=False,
+    )
 
 
 def storage_config_schema() -> Field:
@@ -265,6 +284,7 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
         "local_artifact_storage": config_field_for_configurable_class(),
         "compute_logs": config_field_for_configurable_class(),
         "storage": storage_config_schema(),
+        "run_queue": run_queue_config_schema(),
         "run_storage": config_field_for_configurable_class(),
         "event_log_storage": config_field_for_configurable_class(),
         "schedule_storage": config_field_for_configurable_class(),

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -418,11 +418,20 @@ class InstanceRef(
             config_value, "scheduler", defaults["scheduler"]
         )
 
-        run_coordinator_data = configurable_class_data_or_default(
-            config_value,
-            "run_coordinator",
-            defaults["run_coordinator"],
-        )
+        if config_value.get("run_queue"):
+            run_coordinator_data = configurable_class_data(
+                {
+                    "module": "dagster.core.run_coordinator",
+                    "class": "QueuedRunCoordinator",
+                    "config": config_value["run_queue"],
+                }
+            )
+        else:
+            run_coordinator_data = configurable_class_data_or_default(
+                config_value,
+                "run_coordinator",
+                defaults["run_coordinator"],
+            )
 
         run_launcher_data = configurable_class_data_or_default(
             config_value,


### PR DESCRIPTION
This makes configuring a run queue in OSS and cloud dramatically more similar and lets you set up queuing functionality without needing to understand a whole separate "run coordinator" concept.

@erinkcochran87 is updating docs separately as part of the new concurrency docs.