### PR TITLE
[dagster-gcp] allow bigquery resource to auth via config

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -4,7 +4,7 @@ See the BigQuery Python API documentation for reference:
     https://googleapis.github.io/google-cloud-python/latest/bigquery/reference.html
 """
 
-from dagster import Array, Bool, Field, IntSource, String, StringSource
+from dagster import Array, Bool, Field, IntSource, Noneable, String, StringSource
 
 from .types import (
     BQCreateDisposition,
@@ -33,7 +33,20 @@ def bq_resource_config():
         is_required=False,
     )
 
-    return {"project": project, "location": location}
+    gcp_credentials = Field(
+        Noneable(StringSource),
+        is_required=False,
+        default_value=None,
+        description=(
+            "GCP authentication credentials. If provided, a temporary file will be created"
+            " with the credentials and GOOGLE_APPLICATION_CREDENTIALS will be set to the"
+            " temporary file. To avoid issues with newlines in the keys, you must base64"
+            " encode the key. You can retrieve the base64 encoded key with this shell"
+            " command: cat $GOOGLE_AUTH_CREDENTIALS | base64"
+        ),
+    )
+
+    return {"project": project, "location": location, "gcp_credentials": gcp_credentials}
 
 
 def _define_shared_fields():

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -15,7 +15,7 @@ from .configs import bq_resource_config
 )
 def bigquery_resource(context):
     no_creds_config = {
-        key: value for key, value in context.resource_config if key != "gcp_credentials"
+        key: value for key, value in context.resource_config.items() if key != "gcp_credentials"
     }
     bq = bigquery.Client(**no_creds_config)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,4 +1,10 @@
+import base64
+import json
+import os
+import tempfile
+
 from dagster import resource
+from dagster._core.errors import DagsterInvalidDefinitionError
 from google.cloud import bigquery
 
 from .configs import bq_resource_config
@@ -8,4 +14,28 @@ from .configs import bq_resource_config
     config_schema=bq_resource_config(), description="Dagster resource for connecting to BigQuery"
 )
 def bigquery_resource(context):
-    return bigquery.Client(**context.resource_config)
+    no_creds_config = {
+        key: value for key, value in context.resource_config if key != "gcp_credentials"
+    }
+    bq = bigquery.Client(**no_creds_config)
+
+    if context.resource_config.get("gcp_credentials"):
+        if os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None:
+            raise DagsterInvalidDefinitionError(
+                "Resource config error: gcp_credentials config for BigQuery resource cannot"
+                " be used if GOOGLE_APPLICATION_CREDENTIALS environment variable is set."
+            )
+        with tempfile.NamedTemporaryFile("w+") as f:
+            temp_file_name = f.name
+            json.dump(
+                json.loads(base64.b64decode(context.resource_config.get("gcp_credentials"))),
+                f,
+            )
+            f.flush()
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = temp_file_name
+            try:
+                yield bq
+            finally:
+                os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+    else:
+        yield bq

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,13 +1,8 @@
-import base64
-import json
-import os
-import tempfile
-
 from dagster import resource
-from dagster._core.errors import DagsterInvalidDefinitionError
 from google.cloud import bigquery
 
 from .configs import bq_resource_config
+from .utils import setup_gcp_creds
 
 
 @resource(
@@ -17,25 +12,9 @@ def bigquery_resource(context):
     no_creds_config = {
         key: value for key, value in context.resource_config.items() if key != "gcp_credentials"
     }
-    bq = bigquery.Client(**no_creds_config)
 
     if context.resource_config.get("gcp_credentials"):
-        if os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None:
-            raise DagsterInvalidDefinitionError(
-                "Resource config error: gcp_credentials config for BigQuery resource cannot"
-                " be used if GOOGLE_APPLICATION_CREDENTIALS environment variable is set."
-            )
-        with tempfile.NamedTemporaryFile("w+") as f:
-            temp_file_name = f.name
-            json.dump(
-                json.loads(base64.b64decode(context.resource_config.get("gcp_credentials"))),
-                f,
-            )
-            f.flush()
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = temp_file_name
-            try:
-                yield bq
-            finally:
-                os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with setup_gcp_creds(context):
+            yield bigquery.Client(**no_creds_config)
     else:
-        yield bq
+        yield bigquery.Client(**no_creds_config)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/utils.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/utils.py
@@ -1,0 +1,28 @@
+import base64
+import json
+import os
+import tempfile
+from contextlib import contextmanager
+
+from dagster._core.errors import DagsterInvalidDefinitionError
+
+
+@contextmanager
+def setup_gcp_creds(context):
+    if os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None:
+        raise DagsterInvalidDefinitionError(
+            "Resource config error: gcp_credentials config for BigQuery resource cannot"
+            " be used if GOOGLE_APPLICATION_CREDENTIALS environment variable is set."
+        )
+    with tempfile.NamedTemporaryFile("w+") as f:
+        temp_file_name = f.name
+        json.dump(
+            json.loads(base64.b64decode(context.resource_config.get("gcp_credentials"))),
+            f,
+        )
+        f.flush()
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = temp_file_name
+        try:
+            yield
+        finally:
+            os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 from dagster import asset, materialize
-from dagster_gcs import bigquery_resource
+from dagster_gcp import bigquery_resource
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
@@ -1,0 +1,51 @@
+import base64
+import os
+
+import pytest
+from dagster import asset, materialize
+from dagster_gcs import bigquery_resource
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
+def test_authenticate_via_config():
+    asset_info = dict()
+
+    @asset(required_resource_keys={"bigquery"})
+    def test_asset() -> int:
+        asset_info["gcp_creds_file"] = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None
+        return 1
+
+    old_gcp_creds_file = os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+    assert old_gcp_creds_file is not None
+
+    passed = False
+
+    try:
+        with open(old_gcp_creds_file, "r") as f:
+            gcp_creds = f.read()
+
+        resource_defs = {
+            "bigquery": bigquery_resource.configured(
+                {
+                    "project": os.getenv("GCP_PROJECT_ID"),
+                    "gcp_credentials": base64.b64encode(str.encode(gcp_creds)).decode(),
+                }
+            )
+        }
+
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
+
+        result = materialize(
+            [test_asset],
+            resources=resource_defs,
+        )
+        passed = result.success
+
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
+        assert not os.path.exists(asset_info["gcp_creds_file"])
+    finally:
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = old_gcp_creds_file
+        assert passed


### PR DESCRIPTION
## Summary & Motivation
Allows the bigquery resource to authenticate via config (like the io manager). This allows serverless users to pass GCP credentials as configuration instead of uploading a credential file (which they can't do in serverless)

## How I Tested These Changes
unit tests