### PR TITLE
[asset-reconciliation] Use source asset observations to inform when to kick off eager reconciliation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -329,6 +329,15 @@ def find_parent_materialized_asset_partitions(
 
     for asset_key in target_asset_keys_and_parents:
         if asset_graph.is_source(asset_key):
+            if asset_graph.is_observable(asset_key) and instance_queryer.new_version_exists(
+                observable_source_asset_key=asset_key, after_cursor=latest_storage_id
+            ):
+                for child in asset_graph.get_children_partitions(
+                    instance_queryer, asset_key, partition_key=None
+                ):
+                    if child.asset_key in target_asset_keys:
+                        result_asset_partitions.add(child)
+
             continue
 
         partitions_def = asset_graph.get_partitions_def(asset_key)

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/observable_source_asset_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/observable_source_asset_scenarios.py
@@ -1,0 +1,108 @@
+from dagster import PartitionKeyRange
+from dagster._seven.compat.pendulum import create_pendulum_time
+
+from .asset_reconciliation_scenario import (
+    AssetReconciliationScenario,
+    asset_def,
+    observable_source_asset_def,
+    run,
+    run_request,
+)
+from .partition_scenarios import hourly_partitions_def
+
+unpartitioned_downstream_of_observable_source = [
+    observable_source_asset_def("source_asset"),
+    asset_def("asset1", ["source_asset"]),
+]
+
+partitioned_downstream_of_observable_source = [
+    observable_source_asset_def("source_asset"),
+    asset_def(
+        "asset1",
+        ["source_asset"],
+        partitions_def=hourly_partitions_def,
+    ),
+]
+
+downstream_of_multiple_observable_source_assets = [
+    observable_source_asset_def("source_asset1"),
+    observable_source_asset_def("source_asset2"),
+    asset_def("asset1", ["source_asset1"]),
+    asset_def("asset2", ["source_asset2"]),
+    asset_def("asset3", ["asset1", "asset2"]),
+]
+
+observable_source_asset_scenarios = {
+    "observable_to_unpartitioned1": AssetReconciliationScenario(
+        assets=unpartitioned_downstream_of_observable_source,
+        unevaluated_runs=[
+            run(["source_asset"], is_observation=True),
+            run(["asset1"]),
+        ],
+        expected_run_requests=[],
+    ),
+    "observable_to_unpartitioned2": AssetReconciliationScenario(
+        assets=unpartitioned_downstream_of_observable_source,
+        unevaluated_runs=[
+            run(["source_asset"], is_observation=True),
+            run(["asset1"]),
+            run(["source_asset"], is_observation=True),
+        ],
+        expected_run_requests=[run_request(["asset1"])],
+    ),
+    "observable_to_partitioned": AssetReconciliationScenario(
+        assets=partitioned_downstream_of_observable_source,
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        unevaluated_runs=[
+            run(["source_asset"], is_observation=True),
+        ]
+        + [
+            run(["asset1"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-06-04:00", end="2013-01-07-03:00")
+            )
+        ],
+        expected_run_requests=[],
+    ),
+    "observable_to_partitioned2": AssetReconciliationScenario(
+        assets=partitioned_downstream_of_observable_source,
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        unevaluated_runs=[
+            run(["source_asset"], is_observation=True),
+        ]
+        + [
+            run(["asset1"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-06-04:00", end="2013-01-07-03:00")
+            )
+        ]
+        + [
+            run(["source_asset"], is_observation=True),
+        ]
+        + [
+            # update some subset of the partitions
+            run(["asset1"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-06-04:00", end="2013-01-06-17:00")
+            )
+        ],
+        expected_run_requests=[
+            # only execute the non-updated ones
+            run_request(asset_keys=["asset1"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-06-18:00", end="2013-01-07-03:00")
+            )
+        ],
+    ),
+    "multiple_observable": AssetReconciliationScenario(
+        assets=downstream_of_multiple_observable_source_assets,
+        unevaluated_runs=[
+            run(["source_asset1", "source_asset2"], is_observation=True),
+            run(["asset1", "asset2", "asset3"]),
+            run(["source_asset1"], is_observation=True),
+        ],
+        expected_run_requests=[
+            run_request(asset_keys=["asset1", "asset3"]),
+        ],
+    ),
+}

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/scenarios.py
@@ -4,6 +4,7 @@ from .auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
 from .basic_scenarios import basic_scenarios
 from .exotic_partition_mapping_scenarios import exotic_partition_mapping_scenarios
 from .freshness_policy_scenarios import freshness_policy_scenarios
+from .observable_source_asset_scenarios import observable_source_asset_scenarios
 from .partition_scenarios import partition_scenarios
 
 ASSET_RECONCILIATION_SCENARIOS = {
@@ -12,6 +13,7 @@ ASSET_RECONCILIATION_SCENARIOS = {
     **basic_scenarios,
     **freshness_policy_scenarios,
     **auto_materialize_policy_scenarios,
+    **observable_source_asset_scenarios,
 }
 
 # put repos in the global namespace so that the daemon can load them with LoadableTargetOrigin


### PR DESCRIPTION
## Summary & Motivation

We did a similar sort of thing for data time calculations.

Note the TODO. The material impact is the following. Imagine you have an asset graph `OS -> A -> B`, where OS is an observable source asset.

- Your asset_selection for your sensor is just `B`.
- `OS` is observed having version `1`, after which all downstreams are materialized in order.
- `A` is manually materialized again (not pulling in any new data, as no version was updated).
- `OS` is observed, still having version `1`.

The sensor will see that `A` has a new materialization, but will erroneously treat it as "unreconciled", as a new observation record has come in after the latest materialization of `A`. This means that a materialization of `B` will not be kicked off.

In a fun twist of fate, this is actually arguably desirable behavior, as there really isn't a reason for `B` to be kicked off in this scenario. However, we're kinda getting the right answer for the wrong reason, if that makes sense. We don't factor this sort of versioning information into other parts of the reconciliation logic, and the following sequence of events would give us an unambiguously incorrect behavior:

- `OS` is observed having version `1`, after which all downstreams are materialized in order.
- `A` is manually materialized again (not pulling in any new data, as no version was updated).
- `OS` is observed, now having version `2`.
- `A` is manually materialized again.
- `OS` is observed again, still having version `2`.

In this case, we get the same behavior (`B` not getting kicked off), because there is an observation record after the most recent materialization of `A` (this is the same reason as before).

In reality, we should search backwards for the FIRST occurrence of the current version, this was just a minor pain to implement in the time I have today.

## How I Tested These Changes
