### PR TITLE
Remove double @capture_error in GrapheneLaunchBackfillMutation

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
 
-@capture_error
 def create_and_launch_partition_backfill(
     graphene_info: "ResolveInfo",
     backfill_params: BackfillParams,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -119,6 +119,31 @@ def test_launch_asset_backfill():
 
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
             # launchPartitionBackfill
+
+            # can't launch with allPartitions
+
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b"],
+                        "assetSelection": [key.to_graphql_input() for key in all_asset_keys],
+                        "allPartitions": True,
+                    }
+                },
+            )
+
+            assert launch_backfill_result
+            assert (
+                launch_backfill_result.data["launchPartitionBackfill"]["__typename"]
+                == "PythonError"
+            )
+            assert (
+                "allPartitions is not supported for pure asset backfills"
+                in launch_backfill_result.data["launchPartitionBackfill"]["message"]
+            )
+
             launch_backfill_result = execute_dagster_graphql(
                 context,
                 LAUNCH_PARTITION_BACKFILL_MUTATION,


### PR DESCRIPTION
summary:

This capture_error => require_permission_check => capture_error sandwich was causing errors to get caught and turned into PythonErrors before they needed to be, confusing the require_permission_check (which should have just let the exception bubble up). Remove the inner one and rely on the outer one.

Test Plan: New test that was failing before with an incorrect error message

## Summary & Motivation

## How I Tested These Changes
