### PR TITLE
Fix multipartition mapping import error on Dagit load

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -265,6 +265,7 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.partition_key_range import PartitionKeyRange as PartitionKeyRange
 from dagster._core.definitions.partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
+    DimensionPartitionMapping as DimensionPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
     MultiPartitionMapping as MultiPartitionMapping,

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -161,6 +161,7 @@ from .partition import (
 from .partition_key_range import PartitionKeyRange as PartitionKeyRange
 from .partition_mapping import (
     AllPartitionMapping as AllPartitionMapping,
+    DimensionPartitionMapping as DimensionPartitionMapping,
     IdentityPartitionMapping as IdentityPartitionMapping,
     LastPartitionMapping as LastPartitionMapping,
     MultiPartitionMapping as MultiPartitionMapping,

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -554,6 +554,7 @@ class MultiToSingleDimensionPartitionMapping(
             )
 
 
+@whitelist_for_serdes
 class DimensionPartitionMapping(
     NamedTuple(
         "_DimensionPartitionMapping",


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/13293

Also adds `MultiPartitionMapping` and `DimensionPartitionMapping` as top level imports