### PR TITLE
Fix for pdb

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/run_pdb.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/run_pdb.py
@@ -1,0 +1,5 @@
+import pdb
+
+foo = "HELLO"
+
+pdb.set_trace()

--- a/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
+++ b/python_modules/dagster/dagster_tests/core_tests/serdes_tests/test_ipc.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import time
 from contextlib import ExitStack
@@ -228,6 +229,19 @@ def test_input_signal_hang():
         [sys.executable, file_relative_path(__file__, "import_readline.py")],
     )
     please_dont_hang.communicate(timeout=10)
+
+
+def test_pdb_works():
+    please_dont_hang = open_ipc_subprocess(
+        [sys.executable, file_relative_path(__file__, "run_pdb.py")],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    stdout, _stderr = please_dont_hang.communicate(timeout=10, input=b"p foo\nquit\n")
+
+    assert "'HELLO'" in stdout.decode()
+    assert "bdb.BdbQuit" in stdout.decode()
 
 
 def test_interrupt_compute_log_tail_grandchild(


### PR DESCRIPTION
Summary:
Disabling stdin entirely breaks pdb - apply a different suggested fix from https://bugs.python.org/issue14892 to prevent code like "import readline" from hanging while still allowing pdb to work

Test Plan:
BK, run an op with pdb, now works

## Summary & Motivation

## How I Tested These Changes
