### PR TITLE
[fix][dagster-census] CensusResource poll_sync_run method bug

### DIFF
--- a/python_modules/libraries/dagster-census/dagster_census/resources.py
+++ b/python_modules/libraries/dagster-census/dagster_census/resources.py
@@ -159,7 +159,7 @@ class CensusResource:
 
             sync_id = response_dict["data"]["sync_id"]
 
-            if response_dict["status"] == "working":
+            if response_dict["data"]["status"] == "working":
                 self._log.debug(
                     f"Sync {sync_id} still running after {datetime.datetime.now() - poll_start}."
                 )


### PR DESCRIPTION
## Summary & Motivation

There is a simple bug in the `CensusResource` class's `poll_sync_run` method.

The `response_dict` that's returned by the `self.get_sync_run(sync_run_id)` on [L153](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-census/dagster_census/resources.py#L153) is structured as detailed in the Census API docs [here](https://docs.getcensus.com/basics/developers/api/sync-runs#get-sync_runs-id).

On [L162](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-census/dagster_census/resources.py#L162), the `poll_sync_run` method gets the `status` of the API request with `response_dict["status"]`. This isn't what's intended. What's intended is the `data.status` of the Census sync run. This bug results in the method waiting 10 seconds and then finding the API request status as `"success"` or `"failure"`, never `"working"`, which is required for the while-loop to continue polling the sync run, as seen on [LL162-166](https://github.com/ldnicolasmay/dagster/blob/master/python_modules/libraries/dagster-census/dagster_census/resources.py#L162-L166).

In order to get the `status` of the Census sync run, the method needs to check `response_dict["data"]["status"]`.

## How I Tested These Changes

I ran `pytest .` from the `python_modules/libraries/dagster-census` module, and all test succeeded:
```
======================================== test session starts =========================================
platform linux -- Python 3.10.6, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/hynso/GitHub/ldnicolasmay/dagster, configfile: pyproject.toml
plugins: anyio-3.6.2, forked-1.6.0, cov-2.10.1, rerunfailures-10.0, buildkite-test-collector-0.1.7, mock-3.3.1, dependency-0.5.1, requests-mock-1.10.0, xdist-2.1.0, snapshottest-0.6.0
collected 10 items                                                                                   

dagster_census_tests/test_op.py .                                                              [ 10%]
dagster_census_tests/test_resources.py ........                                                [ 90%]
dagster_census_tests/test_version.py .                                                         [100%]

========================================= 10 passed in 2.39s =========================================
```

I have also tested this against my Census account. Without the bugfix, the method breaks the while-loop after ~10 seconds and returns Census sync run metadata with many `null`/`None` values. With the bugfix, the method successfully continues polling the sync run until it finishes and ultimately returns the expected sync run metadata as a `CensusOutput` object.