### PR TITLE
[pythonic resources] Better ergonomics for direct invocation of sensors/schedules

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -169,14 +169,17 @@ class SensorEvaluationContext:
     def resource_defs(self) -> Optional[Mapping[str, "ResourceDefinition"]]:
         return self._resource_defs
 
-    def replace_resources(self, resources_dict: Mapping[str, Any]) -> "SensorEvaluationContext":
-        """Replace the resources of this context.
+    def merge_resources(self, resources_dict: Mapping[str, Any]) -> "SensorEvaluationContext":
+        """Merge the specified resources into this context.
 
         This method is intended to be used by the Dagster framework, and should not be called by user code.
 
         Args:
-            resources (Mapping[str, Any]): The resources to replace in the context.
+            resources_dict (Mapping[str, Any]): The resources to replace in the context.
         """
+        check.invariant(
+            self._resources is None, "Cannot merge resources in context that has been initialized."
+        )
         return SensorEvaluationContext(
             instance_ref=self._instance_ref,
             last_completion_time=self._last_completion_time,
@@ -186,7 +189,7 @@ class SensorEvaluationContext:
             repository_def=self._repository_def,
             instance=self._instance,
             sensor_name=self._sensor_name,
-            resources=resources_dict,
+            resources={**(self._resource_defs or {}), **resources_dict},
         )
 
     @property
@@ -908,11 +911,7 @@ def get_sensor_context_from_args_or_kwargs(
             raise DagsterInvalidInvocationError(
                 f"Sensor invocation expected argument '{context_param_name}'."
             )
-        context = (
-            check.opt_inst(kwargs.get(context_param_name), context_type)
-            if context_param_name
-            else check.opt_inst(kwargs.get("context"), context_type)
-        )
+        context = check.opt_inst(kwargs.get(context_param_name or "context"), context_type)
     elif context_param_name:
         # If the context parameter is present but no value was provided, we error
         raise DagsterInvalidInvocationError(
@@ -949,14 +948,9 @@ def get_or_create_sensor_context(
     for resource_arg in resource_args:
         if resource_arg in kwargs:
             resource_args_from_kwargs[resource_arg] = kwargs[resource_arg]
-            del kwargs[resource_arg]
-
-    resources_provided_in_multiple_places = (resource_args_from_kwargs) and (context.resource_defs)
-    if resources_provided_in_multiple_places:
-        raise DagsterInvalidInvocationError("Cannot provide resources in both context and kwargs")
 
     if resource_args_from_kwargs:
-        return context.replace_resources(resource_args_from_kwargs)
+        return context.merge_resources(resource_args_from_kwargs)
 
     return context
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -206,19 +206,16 @@ def test_schedule_invocation_resources_direct_many() -> None:
         ),
     ).run_config == {"foo": "foo", "bar": "bar"}
 
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-    ):
-        # Cannot pass resources both directly and in context
-        assert cast(
-            RunRequest,
-            basic_schedule_resource_req(
-                context=build_schedule_context(
-                    resources={"my_other_resource": MyResource(a_str="foo")}
-                ),
-                my_resource=MyResource(a_str="foo"),
+    # Can pass resources both directly and in context
+    assert cast(
+        RunRequest,
+        basic_schedule_resource_req(
+            context=build_schedule_context(
+                resources={"my_other_resource": MyResource(a_str="bar")}
             ),
-        ).run_config == {"foo": "foo"}
+            my_resource=MyResource(a_str="foo"),
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
 
 
 def test_partition_key_run_request_schedule():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -102,8 +102,8 @@ def test_sensor_invocation_args():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Sensor invocation received multiple arguments. Only a first positional context "
-            "parameter should be provided when invoking."
+            "Sensor invocation received multiple non-resource arguments. Only a first positional"
+            " context parameter should be provided when invoking."
         ),
     ):
         basic_sensor_with_context(context, _arbitrary_context=None)
@@ -134,6 +134,108 @@ def test_sensor_invocation_resources() -> None:
             build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
     ).run_config == {"foo": "foo"}
+
+
+def test_sensor_invocation_resources_direct() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    # Test no arg invocation
+    @sensor(job_name="foo_pipeline")
+    def basic_sensor_resource_req(my_resource: MyResource):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by sensor 'basic_sensor_resource_req' was not"
+            " provided."
+        ),
+    ):
+        basic_sensor_resource_req()
+
+    # Can pass resource through context
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(
+            context=build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
+        ),
+    ).run_config == {"foo": "foo"}
+
+    # Can pass resource directly
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=(
+            "If directly invoking a sensor, you may not provide resources as"
+            " positional"
+            " arguments, only as keyword arguments."
+        ),
+    ):
+        # We don't allow providing resources as args, this adds too much complexity
+        # They must be kwargs, and we will error accordingly
+        assert cast(
+            RunRequest,
+            basic_sensor_resource_req(MyResource(a_str="foo")),
+        ).run_config == {"foo": "foo"}
+
+    # Can pass resource directly with context
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(build_sensor_context(), my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+    # Test with context arg requirement
+    @sensor(job_name="foo_pipeline")
+    def basic_sensor_with_context_resource_req(my_resource: MyResource, context):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    assert cast(
+        RunRequest,
+        basic_sensor_with_context_resource_req(
+            build_sensor_context(), my_resource=MyResource(a_str="foo")
+        ),
+    ).run_config == {"foo": "foo"}
+
+
+def test_sensor_invocation_resources_direct_many() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    # Test no arg invocation
+    @sensor(job_name="foo_pipeline")
+    def basic_sensor_resource_req(my_resource: MyResource, my_other_resource: MyResource):
+        return RunRequest(
+            run_key=None,
+            run_config={"foo": my_resource.a_str, "bar": my_other_resource.a_str},
+            tags={},
+        )
+
+    # Can pass resource directly
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(
+            my_other_resource=MyResource(a_str="bar"), my_resource=MyResource(a_str="foo")
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+    ):
+        # Cannot pass resources both directly and in context
+        assert cast(
+            RunRequest,
+            basic_sensor_resource_req(
+                context=build_sensor_context(
+                    resources={"my_other_resource": MyResource(a_str="foo")}
+                ),
+                my_resource=MyResource(a_str="foo"),
+            ),
+        ).run_config == {"foo": "foo"}
 
 
 def test_sensor_invocation_resources_context_manager() -> None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -223,19 +223,14 @@ def test_sensor_invocation_resources_direct_many() -> None:
         ),
     ).run_config == {"foo": "foo", "bar": "bar"}
 
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-    ):
-        # Cannot pass resources both directly and in context
-        assert cast(
-            RunRequest,
-            basic_sensor_resource_req(
-                context=build_sensor_context(
-                    resources={"my_other_resource": MyResource(a_str="foo")}
-                ),
-                my_resource=MyResource(a_str="foo"),
-            ),
-        ).run_config == {"foo": "foo"}
+    # Pass resources both directly and in context
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(
+            context=build_sensor_context(resources={"my_other_resource": MyResource(a_str="bar")}),
+            my_resource=MyResource(a_str="foo"),
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
 
 
 def test_sensor_invocation_resources_context_manager() -> None:


### PR DESCRIPTION
## Summary

Implements similar functionality to #13002 to make passing resources to sensors and schedules easier in the direct invocation case. This makes testing in particular easier.


The new API changes enable the following (schedule behavior is identical):

```python
class MyResource(ConfigurableResource):
    a_str: str

@sensor(job_name="foo_pipeline")
def basic_sensor_resource_req(my_resource: MyResource):
    return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})


# Can pass resource through context
assert cast(
    RunRequest,
    basic_sensor_resource_req(
        context=build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
    ),
).run_config == {"foo": "foo"}

# Can pass resource directly
assert cast(
    RunRequest,
    basic_sensor_resource_req(my_resource=MyResource(a_str="foo")),
).run_config == {"foo": "foo"}


# Can pass resource directly with context
assert cast(
    RunRequest,
    basic_sensor_resource_req(build_sensor_context(), my_resource=MyResource(a_str="foo")),
).run_config == {"foo": "foo"}

```


## Test Plan

New unit tests; existing unit tests.