### PR TITLE
Add test coverage for dynamic partitions gRPC methods

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -416,10 +416,6 @@ def get_partition_config(
         ) = _get_job_partitions_and_config_for_partition_set_name(repo_def, partition_set_name)
 
         with _instance_from_ref_for_dynamic_partitions(instance_ref, partitions_def) as instance:
-            partition = partitions_def.get_partition(
-                partition_key, dynamic_partitions_store=instance
-            )
-
             with user_code_error_boundary(
                 PartitionExecutionError,
                 lambda: f"Error occurred during the evaluation of the `run_config_for_partition` function for partition set {partition_set_name}",
@@ -427,7 +423,7 @@ def get_partition_config(
                 run_config = partitioned_config.get_run_config_for_partition_key(
                     partition_key, dynamic_partitions_store=instance
                 )
-                return ExternalPartitionConfigData(name=partition.name, run_config=run_config)
+                return ExternalPartitionConfigData(name=partition_key, run_config=run_config)
     except Exception:
         return ExternalPartitionExecutionErrorData(
             serializable_error_info_from_exc_info(sys.exc_info())
@@ -473,17 +469,15 @@ def get_partition_tags(
         # the instance when necessary for dynamic partitions: https://github.com/dagster-io/dagster/issues/12440
 
         with _instance_from_ref_for_dynamic_partitions(instance_ref, partitions_def) as instance:
-            partition = partitions_def.get_partition(
-                partition_name, dynamic_partitions_store=instance
-            )
             with user_code_error_boundary(
                 PartitionExecutionError,
                 lambda: f"Error occurred during the evaluation of the `tags_for_partition` function for partitioned config on job '{job_def.name}'",
             ):
                 tags = partitioned_config.get_tags_for_partition_key(
-                    partition.name, job_name=job_def.name, dynamic_partitions_store=instance
+                    partition_name, job_name=job_def.name, dynamic_partitions_store=instance
                 )
-                return ExternalPartitionTagsData(name=partition.name, tags=tags)
+                return ExternalPartitionTagsData(name=partition_name, tags=tags)
+
     except Exception:
         return ExternalPartitionExecutionErrorData(
             serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -90,3 +90,69 @@ def test_external_partition_set_execution_params_grpc(instance: DagsterInstance)
         )
         assert isinstance(data, ExternalPartitionSetExecutionParamData)
         assert len(data.partition_data) == 3
+
+
+def test_dynamic_partition_set_grpc(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        instance.add_dynamic_partitions("dynamic_partitions", ["a", "b", "c"])
+        repository_handle = code_location.get_repository("bar_repo").handle
+
+        data = sync_get_external_partition_set_execution_param_data_grpc(
+            code_location.client,  # type: ignore
+            repository_handle,
+            "dynamic_job_partition_set",
+            ["a", "b", "c"],
+            instance=instance,
+        )
+        assert isinstance(data, ExternalPartitionSetExecutionParamData)
+        assert len(data.partition_data) == 3
+
+        data = sync_get_external_partition_config_grpc(
+            code_location.client,  # type: ignore
+            repository_handle,
+            "dynamic_job_partition_set",
+            "a",
+            instance,
+        )
+        assert isinstance(data, ExternalPartitionConfigData)
+        assert data.name == "a"
+        assert data.run_config == {}
+
+        data = sync_get_external_partition_tags_grpc(
+            code_location.client,  # type: ignore
+            repository_handle,
+            "dynamic_job_partition_set",
+            "a",
+            instance,
+        )
+        assert isinstance(data, ExternalPartitionTagsData)
+        assert data.tags
+        assert data.tags["dagster/partition"] == "a"
+
+        data = sync_get_external_partition_set_execution_param_data_grpc(
+            code_location.client,  # type: ignore
+            repository_handle,
+            "dynamic_job_partition_set",
+            ["nonexistent_partition"],
+            instance=instance,
+        )
+        assert isinstance(data, ExternalPartitionSetExecutionParamData)
+        assert data.partition_data == []
+
+        with pytest.raises(DagsterUserCodeProcessError, match="No partition for partition key"):
+            sync_get_external_partition_config_grpc(
+                code_location.client,  # type: ignore
+                repository_handle,
+                "dynamic_job_partition_set",
+                "nonexistent_partition",
+                instance,
+            )
+
+        with pytest.raises(DagsterUserCodeProcessError, match="No partition for partition key"):
+            sync_get_external_partition_tags_grpc(
+                code_location.client,  # type: ignore
+                repository_handle,
+                "dynamic_job_partition_set",
+                "nonexistent_partition",
+                instance,
+            )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -124,7 +124,7 @@ def test_defer_snapshots(instance):
 
         external_repository_data = deserialize_value(ser_repo_data, ExternalRepositoryData)
 
-        assert len(external_repository_data.external_job_refs) == 5
+        assert len(external_repository_data.external_job_refs) == 6
         assert external_repository_data.external_pipeline_datas is None
 
         repo = ExternalRepository(
@@ -133,7 +133,7 @@ def test_defer_snapshots(instance):
             ref_to_data_fn=_ref_to_data,
         )
         jobs = repo.get_all_external_jobs()
-        assert len(jobs) == 5
+        assert len(jobs) == 6
         assert _state.get("cnt", 0) == 0
 
         job = jobs[0]


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/13145 introduced a change where `get_run_config_for_partition_key` and `get_tags_for_partition_key` would accept a partition key and resolve the `Partition` object internally. Subsequently the functionality for dynamic partitions broke as the dynamic partitions store wasn't passed in.

https://github.com/dagster-io/dagster/pull/13310 fixes this issue. This PR adds test coverage for this to ensure future breakages do not occur.