### PR TITLE
in asset reconciliation, only take action on partitions that are part of PartitionsDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -335,6 +335,17 @@ class PartitionsDefinition(ABC, Generic[T_cov]):
     ) -> int:
         return len(self.get_partition_keys(current_time, dynamic_partitions_store))
 
+    def has_partition_key(
+        self,
+        partition_key: str,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> bool:
+        return partition_key in self.get_partition_keys(
+            current_time=current_time,
+            dynamic_partitions_store=dynamic_partitions_store,
+        )
+
 
 def raise_error_on_invalid_partition_key_substring(partition_keys: Sequence[str]) -> None:
     for partition_key in partition_keys:
@@ -681,6 +692,23 @@ class DynamicPartitionsDefinition(
                 partitions_def_name=self._validated_name()
             )
             return [Partition(key) for key in partitions]
+
+    def has_partition_key(
+        self,
+        partition_key: str,
+        current_time: Optional[datetime] = None,
+        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    ) -> bool:
+        if dynamic_partitions_store is None:
+            check.failed(
+                "The instance is not available to load partitions. You may be seeing this error"
+                " when using dynamic partitions with a version of dagit or dagster-cloud that"
+                " is older than 1.1.18."
+            )
+
+        return dynamic_partitions_store.has_dynamic_partition(
+            partitions_def_name=self._validated_name(), partition_key=partition_key
+        )
 
 
 class PartitionedConfig(Generic[T_cov]):

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -270,6 +270,11 @@ class DynamicPartitionsStore(Protocol):
     def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
         return self.get_dynamic_partitions(partitions_def_name=partitions_def_name)
 
+    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+        return self.has_dynamic_partition(
+            partitions_def_name=partitions_def_name, partition_key=partition_key
+        )
+
 
 class DagsterInstance(DynamicPartitionsStore):
     """Core abstraction for managing Dagster's access to storage and other resources.

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -466,6 +466,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             ] = self.instance.get_dynamic_partitions(partitions_def_name)
         return self._dynamic_partitions_cache[partitions_def_name]
 
+    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+        return partition_key in self.get_dynamic_partitions(partitions_def_name)
+
     ####################
     # RECONCILIATION
     ####################

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -9,6 +9,7 @@ import pytest
 from dagster import (
     AssetIn,
     AssetKey,
+    AssetMaterialization,
     AssetOut,
     AssetsDefinition,
     AssetSelection,
@@ -27,8 +28,10 @@ from dagster import (
     asset,
     build_asset_reconciliation_sensor,
     build_sensor_context,
+    job,
     materialize_to_memory,
     multi_asset,
+    op,
     repository,
 )
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
@@ -1421,3 +1424,28 @@ def test_sensor(scenario):
         )
         result2 = reconciliation_sensor(context2)
         assert len(list(result2)) == 0
+
+
+def test_bad_partition_key():
+    assets = [
+        asset_def("hourly1", partitions_def=hourly_partitions_def),
+        asset_def("hourly2", ["hourly1"], partitions_def=hourly_partitions_def),
+    ]
+
+    instance = DagsterInstance.ephemeral()
+
+    @op
+    def materialization_op(context):
+        context.log_event(AssetMaterialization("hourly1", partition="bad partition key"))
+
+    @job
+    def materialization_job():
+        materialization_op()
+
+    materialization_job.execute_in_process(instance=instance)
+
+    scenario = AssetReconciliationScenario(
+        assets=assets, unevaluated_runs=[], asset_selection=AssetSelection.keys("hourly2")
+    )
+    run_requests, _ = scenario.do_scenario(instance)
+    assert len(run_requests) == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -201,3 +201,13 @@ def test_unpartitioned_downstream_of_dynamic_asset():
             materialize([dynamic1], instance=instance, partition_key=partition)
 
         materialize([unpartitioned, dynamic1], instance=instance, partition_key=partitions[-1])
+
+
+def test_has_partition_key():
+    partitions_def = DynamicPartitionsDefinition(name="fruits")
+
+    with instance_for_test() as instance:
+        instance.add_dynamic_partitions(partitions_def.name, ["apple", "banana"])
+        assert partitions_def.has_partition_key("apple", dynamic_partitions_store=instance)
+        assert partitions_def.has_partition_key("banana", dynamic_partitions_store=instance)
+        assert not partitions_def.has_partition_key("peach", dynamic_partitions_store=instance)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -801,3 +801,20 @@ def test_get_cron_schedule_weekdays_with_hour_offset():
         match="does not support minute_of_hour/hour_of_day/day_of_week/day_of_month arguments",
     ):
         partitions_def.get_cron_schedule(hour_of_day=3)
+
+
+def test_has_partition_key():
+    partitions_def = DailyPartitionsDefinition(start_date="2020-01-01")
+    assert not partitions_def.has_partition_key("fdsjkl")
+    assert not partitions_def.has_partition_key("2020-01-01 00:00")
+    assert not partitions_def.has_partition_key("2020-01-01-00:00")
+    assert not partitions_def.has_partition_key("2020/01/01")
+    assert not partitions_def.has_partition_key("2019-12-31")
+    assert not partitions_def.has_partition_key(
+        "2020-03-15", current_time=datetime.strptime("2020-03-14", "%Y-%m-%d")
+    )
+    assert not partitions_def.has_partition_key(
+        "2020-03-15", current_time=datetime.strptime("2020-03-15", "%Y-%m-%d")
+    )
+    assert partitions_def.has_partition_key("2020-01-01")
+    assert partitions_def.has_partition_key("2020-03-15")


### PR DESCRIPTION
## Summary & Motivation

Before this change, if we found an asset materialization with a poorly formatted or out-of-range partition, we would try to use it, which could result in parse errors or other oddities.

## How I Tested These Changes
