### PR TITLE
Asset backfill GQL targeted ranges resolver

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2396,7 +2396,8 @@ type PartitionBackfill {
   error: PythonError
   partitionStatuses: PartitionStatuses!
   partitionStatusCounts: [PartitionStatusCounts!]!
-  assetPartitionsStatusCounts: [AssetPartitionsStatusCounts!]!
+  isAssetBackfill: Boolean!
+  assetBackfillData: AssetBackfillData
   hasCancelPermission: Boolean!
   hasResumePermission: Boolean!
 }
@@ -2408,12 +2409,23 @@ enum BulkActionStatus {
   CANCELED
 }
 
+type AssetBackfillData {
+  assetPartitionsStatusCounts: [AssetPartitionsStatusCounts!]!
+  rootAssetTargetedRanges: [PartitionKeyRange!]
+  rootAssetTargetedPartitions: [String!]
+}
+
 type AssetPartitionsStatusCounts {
   assetKey: AssetKey!
   numPartitionsTargeted: Int!
   numPartitionsRequested: Int!
   numPartitionsCompleted: Int!
   numPartitionsFailed: Int!
+}
+
+type PartitionKeyRange {
+  start: String!
+  end: String!
 }
 
 union PartitionSetOrError = PartitionSet | PartitionSetNotFoundError | PythonError

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -105,6 +105,13 @@ export type AssetAssetObservationsArgs = {
   partitions?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type AssetBackfillData = {
+  __typename: 'AssetBackfillData';
+  assetPartitionsStatusCounts: Array<AssetPartitionsStatusCounts>;
+  rootAssetTargetedPartitions: Maybe<Array<Scalars['String']>>;
+  rootAssetTargetedRanges: Maybe<Array<PartitionKeyRange>>;
+};
+
 export type AssetConnection = {
   __typename: 'AssetConnection';
   nodes: Array<Asset>;
@@ -2245,13 +2252,14 @@ export type PartitionRunsArgs = {
 
 export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
-  assetPartitionsStatusCounts: Array<AssetPartitionsStatusCounts>;
+  assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
   backfillId: Scalars['String'];
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean'];
   hasCancelPermission: Scalars['Boolean'];
   hasResumePermission: Scalars['Boolean'];
+  isAssetBackfill: Scalars['Boolean'];
   isValidSerialization: Scalars['Boolean'];
   numCancelable: Scalars['Int'];
   numPartitions: Maybe<Scalars['Int']>;
@@ -2299,6 +2307,12 @@ export enum PartitionDefinitionType {
   STATIC = 'STATIC',
   TIME_WINDOW = 'TIME_WINDOW',
 }
+
+export type PartitionKeyRange = {
+  __typename: 'PartitionKeyRange';
+  end: Scalars['String'];
+  start: Scalars['String'];
+};
 
 export enum PartitionRangeStatus {
   FAILED = 'FAILED',
@@ -4050,6 +4064,37 @@ export const buildAsset = (
         : relationshipsToOmit.has('AssetKey')
         ? ({} as AssetKey)
         : buildAssetKey({}, relationshipsToOmit),
+  };
+};
+
+export const buildAssetBackfillData = (
+  overrides?: Partial<AssetBackfillData>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'AssetBackfillData'} & AssetBackfillData => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('AssetBackfillData');
+  return {
+    __typename: 'AssetBackfillData',
+    assetPartitionsStatusCounts:
+      overrides && overrides.hasOwnProperty('assetPartitionsStatusCounts')
+        ? overrides.assetPartitionsStatusCounts!
+        : [
+            relationshipsToOmit.has('AssetPartitionsStatusCounts')
+              ? ({} as AssetPartitionsStatusCounts)
+              : buildAssetPartitionsStatusCounts({}, relationshipsToOmit),
+          ],
+    rootAssetTargetedPartitions:
+      overrides && overrides.hasOwnProperty('rootAssetTargetedPartitions')
+        ? overrides.rootAssetTargetedPartitions!
+        : ['accusantium'],
+    rootAssetTargetedRanges:
+      overrides && overrides.hasOwnProperty('rootAssetTargetedRanges')
+        ? overrides.rootAssetTargetedRanges!
+        : [
+            relationshipsToOmit.has('PartitionKeyRange')
+              ? ({} as PartitionKeyRange)
+              : buildPartitionKeyRange({}, relationshipsToOmit),
+          ],
   };
 };
 
@@ -8690,14 +8735,12 @@ export const buildPartitionBackfill = (
   relationshipsToOmit.add('PartitionBackfill');
   return {
     __typename: 'PartitionBackfill',
-    assetPartitionsStatusCounts:
-      overrides && overrides.hasOwnProperty('assetPartitionsStatusCounts')
-        ? overrides.assetPartitionsStatusCounts!
-        : [
-            relationshipsToOmit.has('AssetPartitionsStatusCounts')
-              ? ({} as AssetPartitionsStatusCounts)
-              : buildAssetPartitionsStatusCounts({}, relationshipsToOmit),
-          ],
+    assetBackfillData:
+      overrides && overrides.hasOwnProperty('assetBackfillData')
+        ? overrides.assetBackfillData!
+        : relationshipsToOmit.has('AssetBackfillData')
+        ? ({} as AssetBackfillData)
+        : buildAssetBackfillData({}, relationshipsToOmit),
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection')
         ? overrides.assetSelection!
@@ -8724,6 +8767,8 @@ export const buildPartitionBackfill = (
       overrides && overrides.hasOwnProperty('hasResumePermission')
         ? overrides.hasResumePermission!
         : true,
+    isAssetBackfill:
+      overrides && overrides.hasOwnProperty('isAssetBackfill') ? overrides.isAssetBackfill! : false,
     isValidSerialization:
       overrides && overrides.hasOwnProperty('isValidSerialization')
         ? overrides.isValidSerialization!
@@ -8826,6 +8871,19 @@ export const buildPartitionDefinition = (
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
         : PartitionDefinitionType.DYNAMIC,
+  };
+};
+
+export const buildPartitionKeyRange = (
+  overrides?: Partial<PartitionKeyRange>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'PartitionKeyRange'} & PartitionKeyRange => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionKeyRange');
+  return {
+    __typename: 'PartitionKeyRange',
+    end: overrides && overrides.hasOwnProperty('end') ? overrides.end! : 'repudiandae',
+    start: overrides && overrides.hasOwnProperty('start') ? overrides.start! : 'qui',
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -2,6 +2,9 @@ from typing import TYPE_CHECKING, Optional, Sequence
 
 import dagster._check as check
 import graphene
+from dagster._core.definitions.time_window_partitions import (
+    TimeWindowPartitionsSubset,
+)
 from dagster._core.execution.backfill import BackfillPartitionsStatus, PartitionBackfill
 from dagster._core.host_representation.external import ExternalPartitionSet
 from dagster._core.storage.pipeline_run import RunPartitionData, RunRecord, RunsFilter
@@ -29,11 +32,12 @@ from .util import ResolveInfo, non_null_list
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.partition_sets import (
-        GrapheneAssetPartitionsStatusCounts,
         GraphenePartitionStatusCounts,
     )
 
-    from ..schema.partition_sets import GraphenePartitionSet
+    from ..schema.partition_sets import (
+        GraphenePartitionSet,
+    )
     from .pipelines.pipeline import GrapheneRun
 
 pipeline_execution_error_types = (
@@ -101,6 +105,19 @@ class GrapheneBulkActionStatus(graphene.Enum):
         name = "BulkActionStatus"
 
 
+class GrapheneAssetBackfillData(graphene.ObjectType):
+    class Meta:
+        name = "AssetBackfillData"
+
+    assetPartitionsStatusCounts = non_null_list(
+        "dagster_graphql.schema.partition_sets.GrapheneAssetPartitionsStatusCounts"
+    )
+    rootAssetTargetedRanges = graphene.List(
+        graphene.NonNull("dagster_graphql.schema.partition_sets.GraphenePartitionKeyRange")
+    )
+    rootAssetTargetedPartitions = graphene.List(graphene.NonNull(graphene.String))
+
+
 class GraphenePartitionBackfill(graphene.ObjectType):
     class Meta:
         name = "PartitionBackfill"
@@ -132,9 +149,8 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     partitionStatusCounts = non_null_list(
         "dagster_graphql.schema.partition_sets.GraphenePartitionStatusCounts"
     )
-    assetPartitionsStatusCounts = non_null_list(
-        "dagster_graphql.schema.partition_sets.GrapheneAssetPartitionsStatusCounts"
-    )
+    isAssetBackfill = graphene.NonNull(graphene.Boolean)
+    assetBackfillData = graphene.Field(GrapheneAssetBackfillData)
 
     hasCancelPermission = graphene.NonNull(graphene.Boolean)
     hasResumePermission = graphene.NonNull(graphene.Boolean)
@@ -260,11 +276,13 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             check.not_none(self._backfill_job.get_partition_names(graphene_info.context)),
         )
 
-    def resolve_assetPartitionsStatusCounts(
-        self, graphene_info: ResolveInfo
-    ) -> Sequence["GrapheneAssetPartitionsStatusCounts"]:
+    def resolve_isAssetBackfill(self, _graphene_info: ResolveInfo) -> bool:
+        return self._backfill_job.is_asset_backfill
+
+    def resolve_assetBackfillData(self, graphene_info: ResolveInfo) -> GrapheneAssetBackfillData:
         from dagster_graphql.schema.partition_sets import (
             GrapheneAssetPartitionsStatusCounts,
+            GraphenePartitionKeyRange,
         )
 
         status_counts_by_asset = (
@@ -287,7 +305,28 @@ class GraphenePartitionBackfill(graphene.ObjectType):
                 )
             )
 
-        return asset_partition_status_counts
+        root_partitions_subset = self._backfill_job.get_target_root_partitions_subset(
+            graphene_info.context
+        )
+
+        if not root_partitions_subset:
+            root_targeted_ranges = None
+            root_targeted_partitions = None
+        elif isinstance(root_partitions_subset, TimeWindowPartitionsSubset):
+            root_targeted_ranges = [
+                GraphenePartitionKeyRange(start, end)
+                for start, end in root_partitions_subset.get_partition_key_ranges()
+            ]
+            root_targeted_partitions = None
+        else:  # Default partitions subset
+            root_targeted_ranges = None
+            root_targeted_partitions = root_partitions_subset.get_partition_keys()
+
+        return GrapheneAssetBackfillData(
+            assetPartitionsStatusCounts=asset_partition_status_counts,
+            rootAssetTargetedRanges=root_targeted_ranges,
+            rootAssetTargetedPartitions=root_targeted_partitions,
+        )
 
     def resolve_error(self, _graphene_info: ResolveInfo) -> Optional[GraphenePythonError]:
         if self._backfill_job.error:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -133,6 +133,14 @@ class GrapheneAssetPartitionsStatusCounts(graphene.ObjectType):
     numPartitionsFailed = graphene.NonNull(graphene.Int)
 
 
+class GraphenePartitionKeyRange(graphene.ObjectType):
+    class Meta:
+        name = "PartitionKeyRange"
+
+    start = graphene.NonNull(graphene.String)
+    end = graphene.NonNull(graphene.String)
+
+
 class GraphenePartitionTagsOrError(graphene.Union):
     class Meta:
         types = (GraphenePartitionTags, GraphenePythonError)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -27,6 +27,7 @@ from dagster._core.definitions.assets_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.mode import DEFAULT_MODE_NAME
+from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.errors import DagsterBackfillFailedError
@@ -89,6 +90,23 @@ class AssetBackfillData(NamedTuple):
         return list(
             self.target_subset.filter_asset_keys(root_asset_keys).iterate_asset_partitions()
         )
+
+    def get_target_root_partitions_subset(self) -> PartitionsSubset:
+        """Returns the most upstream partitions subset that was targeted by the backfill."""
+        partitioned_asset_keys = {
+            asset_key
+            for asset_key in self.target_subset.asset_keys
+            if self.target_subset.asset_graph.get_partitions_def(asset_key) is not None
+        }
+
+        root_partitioned_asset_keys = (
+            AssetSelection.keys(*partitioned_asset_keys)
+            .sources()
+            .resolve(self.target_subset.asset_graph)
+        )
+
+        # Return the targeted partitions for the root partitioned asset keys
+        return self.target_subset.get_partitions_subset(next(iter(root_partitioned_asset_keys)))
 
     def get_num_partitions(self) -> Optional[int]:
         """Only valid when the same number of partitions are targeted in every asset.


### PR DESCRIPTION
Adds a resolver to `PartitionBackfill` that returns back the targeted root asset partitions in an asset backfill.
- for time window assets, returns back a list of ranges
- for other assets, return back a set of selected partition keys

Additionally refactors the asset partition status counts and the targeted partitions to be inside a `assetBackfillData` resolver, since these fields only apply to asset backfills.