### PR TITLE
[feat][dagster-slack] add interval arg to make_slack_on_run_failure_s…

### DIFF
--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -106,6 +106,7 @@ def make_slack_on_run_failure_sensor(
     blocks_fn: Optional[Callable[[RunFailureSensorContext], List[Dict[Any, Any]]]] = None,
     name: Optional[str] = None,
     dagit_base_url: Optional[str] = None,
+    minimum_interval_seconds: Optional[int] = None,
     monitored_jobs: Optional[
         Sequence[
             Union[
@@ -153,6 +154,8 @@ def make_slack_on_run_failure_sensor(
         name: (Optional[str]): The name of the sensor. Defaults to "slack_on_run_failure".
         dagit_base_url: (Optional[str]): The base url of your Dagit instance. Specify this to allow
             messages to include deeplinks to the failed job run.
+        minimum_interval_seconds: (Optional[int]): The minimum number of seconds that will elapse
+            between sensor evaluations.
         monitored_jobs (Optional[List[Union[PipelineDefinition, GraphDefinition, RepositorySelector, JobSelector, CodeLocationSensor]]]): The jobs in the
             current repository that will be monitored by this failure sensor. Defaults to None, which
             means the alert will be sent when any job in the repository fails. To monitor jobs in external repositories, use RepositorySelector and JobSelector
@@ -197,7 +200,12 @@ def make_slack_on_run_failure_sensor(
         deprecation_warning("job_selection", "2.0.0", "Use monitored_jobs instead.")
     jobs = monitored_jobs if monitored_jobs else job_selection
 
-    @run_failure_sensor(name=name, monitored_jobs=jobs, default_status=default_status)
+    @run_failure_sensor(
+        name=name,
+        minimum_interval_seconds=minimum_interval_seconds,
+        monitored_jobs=jobs,
+        default_status=default_status,
+    )
     def slack_on_run_failure(context: RunFailureSensorContext):
         blocks, main_body_text = _build_slack_blocks_and_text(
             context=context, text_fn=text_fn, blocks_fn=blocks_fn, dagit_base_url=dagit_base_url


### PR DESCRIPTION
…ensor

## Summary & Motivation

Without exposing the `minimum_interval_seconds` parameter that's available in the `@run_failure_sensor` decorator in `dagster._core.definitions.run_status_sensor_definition`, anyone using the `dagster-slack` library's `make_slack_on_run_failure_sensor` function is forced to rely on a hard-coded global `DEFAULT_SENSOR_DAEMON_INTERVAL = 30` seconds set [here](https://github.com/ldnicolasmay/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/sensor_definition.py#L84).

This PR exposes the `minimum_interval_seconds` parameter in the `@run_failure_sensor` decorator so that users can change Slack failure sensor wait intervals to something other than 30 seconds.

## How I Tested These Changes

I ran `pytest .` from the `python_modules/libraries/dagster-slack` directory.

```
======================================== test session starts =========================================
platform linux -- Python 3.10.6, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/hynso/GitHub/ldnicolasmay/dagster, configfile: pyproject.toml
plugins: anyio-3.6.2, forked-1.6.0, cov-2.10.1, rerunfailures-10.0, buildkite-test-collector-0.1.7, mock-3.3.1, dependency-0.5.1, requests-mock-1.10.0, xdist-2.1.0, snapshottest-0.6.0
collected 15 items                                                                                   

dagster_slack_tests/test_hooks.py ....                                                         [ 26%]
dagster_slack_tests/test_resources.py .                                                        [ 33%]
dagster_slack_tests/test_sensors.py .........                                                  [ 93%]
dagster_slack_tests/test_version.py .                                                          [100%]

========================================= 15 passed in 1.39s =========================================
```