### PR TITLE
Re-implement schedule/sensor changes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -24,7 +24,7 @@ class AssetSensorParamNames(NamedTuple):
     event_log_entry_param_name: Optional[str]
 
 
-def get_context_and_event_log_entry_param_names(fn: Callable) -> AssetSensorParamNames:
+def get_asset_sensor_param_names(fn: Callable) -> AssetSensorParamNames:
     """Determines the names of the context and event log entry parameters for an asset sensor function.
     These are assumed to be the first two non-resource params, in order (context param before event log entry).
     """
@@ -127,7 +127,7 @@ class AssetSensorDefinition(SensorDefinition):
                 (
                     context_param_name,
                     event_log_entry_param_name,
-                ) = get_context_and_event_log_entry_param_names(materialization_fn)
+                ) = get_asset_sensor_param_names(materialization_fn)
 
                 resource_args_populated = validate_and_get_resource_dict(
                     context.resources, name, resource_arg_names

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -1,8 +1,10 @@
 import inspect
-from typing import TYPE_CHECKING, Callable, Optional, Sequence
+from typing import Any, Callable, NamedTuple, Optional, Sequence, Set
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.resource_annotation import get_resource_args
 
 from .events import AssetKey
 from .run_request import RunRequest, SkipReason
@@ -10,14 +12,34 @@ from .sensor_definition import (
     DefaultSensorStatus,
     RawSensorEvaluationFunctionReturn,
     SensorDefinition,
-    SensorEvaluationContext,
     SensorType,
+    validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
 from .utils import check_valid_name
 
-if TYPE_CHECKING:
-    from dagster._core.events.log import EventLogEntry
+
+class AssetSensorParamNames(NamedTuple):
+    context_param_name: Optional[str]
+    event_log_entry_param_name: Optional[str]
+
+
+def get_context_and_event_log_entry_param_names(fn: Callable) -> AssetSensorParamNames:
+    """Determines the names of the context and event log entry parameters for an asset sensor function.
+    These are assumed to be the first two non-resource params, in order (context param before event log entry).
+    """
+    resource_params = {param.name for param in get_resource_args(fn)}
+
+    non_resource_params = [
+        param.name for param in get_function_params(fn) if param.name not in resource_params
+    ]
+
+    context_param_name = non_resource_params[0] if len(non_resource_params) > 0 else None
+    event_log_entry_param_name = non_resource_params[1] if len(non_resource_params) > 1 else None
+
+    return AssetSensorParamNames(
+        context_param_name=context_param_name, event_log_entry_param_name=event_log_entry_param_name
+    )
 
 
 class AssetSensorDefinition(SensorDefinition):
@@ -51,7 +73,7 @@ class AssetSensorDefinition(SensorDefinition):
         asset_key: AssetKey,
         job_name: Optional[str],
         asset_materialization_fn: Callable[
-            [SensorEvaluationContext, "EventLogEntry"],
+            ...,
             RawSensorEvaluationFunctionReturn,
         ],
         minimum_interval_seconds: Optional[int] = None,
@@ -59,14 +81,24 @@ class AssetSensorDefinition(SensorDefinition):
         job: Optional[ExecutableDefinition] = None,
         jobs: Optional[Sequence[ExecutableDefinition]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+        required_resource_keys: Optional[Set[str]] = None,
     ):
         self._asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
 
         from dagster._core.events import DagsterEventType
         from dagster._core.storage.event_log.base import EventRecordsFilter
 
-        def _wrap_asset_fn(materialization_fn):
-            def _fn(context):
+        resource_arg_names: Set[str] = {
+            arg.name for arg in get_resource_args(asset_materialization_fn)
+        }
+
+        combined_required_resource_keys = (
+            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
+            | resource_arg_names
+        )
+
+        def _wrap_asset_fn(materialization_fn) -> Any:
+            def _fn(context) -> Any:
                 after_cursor = None
                 if context.cursor:
                     try:
@@ -91,7 +123,25 @@ class AssetSensorDefinition(SensorDefinition):
                     return
 
                 event_record = event_records[0]
-                result = materialization_fn(context, event_record.event_log_entry)
+
+                (
+                    context_param_name,
+                    event_log_entry_param_name,
+                ) = get_context_and_event_log_entry_param_names(materialization_fn)
+
+                resource_args_populated = validate_and_get_resource_dict(
+                    context.resources, name, resource_arg_names
+                )
+
+                # Build asset sensor function args, which can include any subset of
+                # context arg, event log entry arg, and any resource args
+                args = resource_args_populated
+                if context_param_name:
+                    args[context_param_name] = context
+                if event_log_entry_param_name:
+                    args[event_log_entry_param_name] = event_record.event_log_entry
+
+                result = materialization_fn(**args)
                 if inspect.isgenerator(result) or isinstance(result, list):
                     for item in result:
                         yield item
@@ -112,6 +162,7 @@ class AssetSensorDefinition(SensorDefinition):
             job=job,
             jobs=jobs,
             default_status=default_status,
+            required_resource_keys=combined_required_resource_keys,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -1,7 +1,7 @@
 import collections.abc
 import inspect
 from functools import update_wrapper
-from typing import Callable, Optional, Sequence, Set, Union
+from typing import Any, Callable, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
@@ -157,8 +157,8 @@ def asset_sensor(
         check.callable_param(fn, "fn")
         sensor_name = name or fn.__name__
 
-        def _wrapped_fn(context, event):
-            result = fn(context, event)
+        def _wrapped_fn(*args, **kwargs) -> Any:
+            result = fn(*args, **kwargs)
 
             if inspect.isgenerator(result) or isinstance(result, list):
                 for item in result:
@@ -183,6 +183,10 @@ def asset_sensor(
                         "RunRequest objects."
                     ).format(sensor_name=sensor_name, result=result, type_=type(result))
                 )
+
+        # Preserve any resource arguments from the underlying function, for when we inspect the
+        # wrapped function later on
+        _wrapped_fn.__signature__ = inspect.signature(fn)
 
         return AssetSensorDefinition(
             name=sensor_name,

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1124,7 +1124,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     repository_def=context.repository_def,
                     monitored_assets=monitored_assets,
                     instance=context.instance,
-                    resources=context.resource_defs,
+                    resource_defs=context.resource_defs,
                 ) as multi_asset_sensor_context:
                     context_param_name = get_context_param_name(materialization_fn)
                     context_param = (

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -1,13 +1,16 @@
 import logging
 import warnings
+from contextlib import ExitStack
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Callable,
     Iterator,
+    Mapping,
     NamedTuple,
     Optional,
     Sequence,
+    Set,
     Union,
     cast,
     overload,
@@ -18,11 +21,14 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.decorator_utils import has_at_least_one_parameter
 from dagster._core.definitions.instigation_logger import InstigationLogger
+from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.scoped_resources_builder import (
+    Resources,
+    ScopedResourcesBuilder,
+)
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
-    DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
     RunStatusSensorExecutionError,
     user_code_error_boundary,
@@ -41,7 +47,6 @@ from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.error import serializable_error_info_from_exc_info
 
-from ..decorator_utils import get_function_params
 from .graph_definition import GraphDefinition
 from .pipeline_definition import PipelineDefinition
 from .sensor_definition import (
@@ -54,11 +59,15 @@ from .sensor_definition import (
     SensorResult,
     SensorType,
     SkipReason,
+    get_context_param_name,
+    get_sensor_context_from_args_or_kwargs,
+    validate_and_get_resource_dict,
 )
 from .target import ExecutableDefinition
 from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.resource_definition import ResourceDefinition
     from dagster._core.definitions.selector import (
         CodeLocationSelector,
         JobSelector,
@@ -66,12 +75,12 @@ if TYPE_CHECKING:
     )
 
 RunStatusSensorEvaluationFunction: TypeAlias = Union[
-    Callable[[], RawSensorEvaluationFunctionReturn],
-    Callable[["RunStatusSensorContext"], RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
 ]
 RunFailureSensorEvaluationFn: TypeAlias = Union[
-    Callable[[], RawSensorEvaluationFunctionReturn],
-    Callable[["RunFailureSensorContext"], RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
+    Callable[..., RawSensorEvaluationFunctionReturn],
 ]
 
 
@@ -116,13 +125,35 @@ class RunStatusSensorContext:
         log (logging.Logger): the logger for the given sensor evaluation
     """
 
-    def __init__(self, sensor_name, dagster_run, dagster_event, instance, context=None):
+    def __init__(
+        self,
+        sensor_name,
+        dagster_run,
+        dagster_event,
+        instance,
+        context=None,
+        resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
+    ) -> None:
+        self._exit_stack = ExitStack()
         self._sensor_name = check.str_param(sensor_name, "sensor_name")
         self._dagster_run = check.inst_param(dagster_run, "dagster_run", DagsterRun)
         self._dagster_event = check.inst_param(dagster_event, "dagster_event", DagsterEvent)
         self._instance = check.inst_param(instance, "instance", DagsterInstance)
-        self._context = check.opt_inst_param(context, "context", SensorEvaluationContext)
+        self._context: Optional[SensorEvaluationContext] = check.opt_inst_param(
+            context, "context", SensorEvaluationContext
+        )
         self._logger: Optional[logging.Logger] = None
+
+        if self._context and self._context.resource_defs:
+            resources = {
+                **(self._context.resource_defs),
+                **(resources or {}),
+            }
+
+        # Wait to set resources unless they're accessed
+        self._resource_defs = resources
+        self._resources = None
+        self._cm_scope_entered = False
 
     def for_run_failure(self):
         """Converts RunStatusSensorContext to RunFailureSensorContext."""
@@ -133,6 +164,49 @@ class RunStatusSensorContext:
             instance=self._instance,
             context=self._context,
         )
+
+    @property
+    def resource_defs(self) -> Optional[Mapping[str, "ResourceDefinition"]]:
+        return self._resource_defs
+
+    @property
+    def resources(self) -> Resources:
+        from dagster._core.definitions.scoped_resources_builder import (
+            IContainsGenerator,
+        )
+        from dagster._core.execution.build_resources import build_resources
+
+        if not self._resources:
+            """
+            This is similar to what we do in e.g. the op context - we set up a resource
+            building context manager, and immediately enter it. This is so that in cases
+            where a user is not using any context-manager based resources, they don't
+            need to enter this SensorEvaluationContext themselves.
+
+            For example:
+
+            my_sensor(build_sensor_context(resources={"my_resource": my_non_cm_resource})
+
+            will work ok, but for a CM resource we must do
+
+            with build_sensor_context(resources={"my_resource": my_cm_resource}) as context:
+                my_sensor(context)
+            """
+
+            instance = self.instance if self._instance else None
+
+            resources_cm = build_resources(resources=self._resource_defs or {}, instance=instance)
+            self._resources = self._exit_stack.enter_context(resources_cm)
+
+            if isinstance(self._resources, IContainsGenerator) and not self._cm_scope_entered:
+                self._exit_stack.close()
+                raise DagsterInvariantViolationError(
+                    "At least one provided resource is a generator, but attempting to access"
+                    " resources outside of context manager scope. You can use the following syntax"
+                    " to open a context manager: `with build_schedule_context(...) as context:`"
+                )
+
+        return self._resources
 
     @public
     @property
@@ -173,6 +247,14 @@ class RunStatusSensorContext:
         )
         return self.dagster_run
 
+    def __enter__(self) -> "RunStatusSensorContext":
+        self._cm_scope_entered = True
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._exit_stack.close()
+        self._logger = None
+
 
 class RunFailureSensorContext(RunStatusSensorContext):
     """The ``context`` object available to a decorated function of ``run_failure_sensor``.
@@ -194,6 +276,7 @@ def build_run_status_sensor_context(
     dagster_instance: DagsterInstance,
     dagster_run: DagsterRun,
     context: Optional[SensorEvaluationContext] = None,
+    resources: Optional[Mapping[str, "ResourceDefinition"]] = None,
 ) -> RunStatusSensorContext:
     """Builds run status sensor context from provided parameters.
 
@@ -230,6 +313,7 @@ def build_run_status_sensor_context(
         dagster_run=dagster_run,
         dagster_event=dagster_event,
         context=context,
+        resources=resources,
     )
 
 
@@ -365,7 +449,7 @@ def run_failure_sensor(
             request_jobs=request_jobs,
         )
         def _run_failure_sensor(context: RunStatusSensorContext):
-            return fn(context.for_run_failure())  # type: ignore  # fmt: skip
+            return fn(context.for_run_failure())  # fmt: skip
 
         return _run_failure_sensor
 
@@ -426,6 +510,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         request_job: Optional[ExecutableDefinition] = None,
         request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
+        required_resource_keys: Optional[Set[str]] = None,
     ):
         from dagster._core.definitions.selector import (
             CodeLocationSelector,
@@ -453,6 +538,13 @@ class RunStatusSensorDefinition(SensorDefinition):
             ),
         )
         check.inst_param(default_status, "default_status", DefaultSensorStatus)
+
+        resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(run_status_sensor_fn)}
+
+        combined_required_resource_keys = (
+            check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
+            | resource_arg_names
+        )
 
         # coerce CodeLocationSelectors to RepositorySelectors with repo name "__repository__"
         monitored_jobs = [
@@ -610,31 +702,32 @@ class RunStatusSensorDefinition(SensorDefinition):
 
                 serializable_error = None
 
-                try:
-                    with user_code_error_boundary(
-                        RunStatusSensorExecutionError,
-                        lambda: f'Error occurred during the execution sensor "{name}".',
-                    ):
-                        if has_at_least_one_parameter(run_status_sensor_fn):
-                            # one user code invocation maps to one failure event
-                            sensor_return = run_status_sensor_fn(
-                                RunStatusSensorContext(
-                                    sensor_name=name,
-                                    dagster_run=pipeline_run,
-                                    dagster_event=event_log_entry.dagster_event,
-                                    instance=context.instance,
-                                    context=context,
-                                )
-                            )
-                        else:
-                            sensor_return = run_status_sensor_fn()  # type: ignore
+                resource_args_populated = validate_and_get_resource_dict(
+                    context.resources, name, resource_arg_names
+                )
 
-                        if sensor_return is not None:
-                            context.update_cursor(
-                                RunStatusSensorCursor(
-                                    record_id=storage_id,
-                                    update_timestamp=update_timestamp.isoformat(),
-                                ).to_json()
+                try:
+                    with RunStatusSensorContext(
+                        sensor_name=name,
+                        dagster_run=pipeline_run,
+                        dagster_event=event_log_entry.dagster_event,
+                        instance=context.instance,
+                        context=context,
+                        resources=context.resource_defs,
+                    ) as sensor_context:
+                        with user_code_error_boundary(
+                            RunStatusSensorExecutionError,
+                            lambda: f'Error occurred during the execution sensor "{name}".',
+                        ):
+                            # one user code invocation maps to one failure event
+                            context_param_name = get_context_param_name(run_status_sensor_fn)
+                            context_param = (
+                                {context_param_name: sensor_context} if context_param_name else {}
+                            )
+
+                            sensor_return = run_status_sensor_fn(
+                                **context_param,
+                                **resource_args_populated,
                             )
 
                             if isinstance(sensor_return, SensorResult):
@@ -683,49 +776,25 @@ class RunStatusSensorDefinition(SensorDefinition):
             default_status=default_status,
             job=request_job,
             jobs=request_jobs,
+            required_resource_keys=combined_required_resource_keys,
         )
 
-    def __call__(self, *args, **kwargs):
-        if has_at_least_one_parameter(self._run_status_sensor_fn):
-            if len(args) + len(kwargs) == 0:
-                raise DagsterInvalidInvocationError(
-                    "Run status sensor function expected context argument, but no context argument "
-                    "was provided when invoking."
-                )
-            if len(args) + len(kwargs) > 1:
-                raise DagsterInvalidInvocationError(
-                    "Run status sensor invocation received multiple arguments. Only a first "
-                    "positional context parameter should be provided when invoking."
-                )
+    def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
+        context_param_name = get_context_param_name(self._run_status_sensor_fn)
+        context = get_sensor_context_from_args_or_kwargs(
+            self._run_status_sensor_fn,
+            args,
+            kwargs,
+            context_type=RunStatusSensorContext,
+        )
+        context_param = {context_param_name: context} if context_param_name and context else {}
 
-            context_param_name = get_function_params(self._run_status_sensor_fn)[0].name
-
-            if args:
-                context = check.opt_inst_param(args[0], context_param_name, RunStatusSensorContext)
-            else:
-                if context_param_name not in kwargs:
-                    raise DagsterInvalidInvocationError(
-                        f"Run status sensor invocation expected argument '{context_param_name}'."
-                    )
-                context = check.opt_inst_param(
-                    kwargs[context_param_name], context_param_name, RunStatusSensorContext
-                )
-
-            if not context:
-                raise DagsterInvalidInvocationError(
-                    "Context must be provided for direct invocation of run status sensor."
-                )
-
-            return self._run_status_sensor_fn(context)
-
-        else:
-            if len(args) + len(kwargs) > 0:
-                raise DagsterInvalidInvocationError(
-                    "Run status sensor decorated function has no arguments, but arguments were "
-                    "provided to invocation."
-                )
-
-            return self._run_status_sensor_fn()
+        resources = validate_and_get_resource_dict(
+            context.resources if context else ScopedResourcesBuilder.build_empty(),
+            self._name,
+            self._required_resource_keys,
+        )
+        return self._run_status_sensor_fn(**context_param, **resources)
 
     @property
     def sensor_type(self) -> SensorType:

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -446,7 +446,7 @@ def run_failure_sensor(
             request_jobs=request_jobs,
         )
         def _run_failure_sensor(context: RunStatusSensorContext):
-            return fn(context.for_run_failure())  # type: ignore  # fmt: skip
+            return fn(context.for_run_failure())  # fmt: skip
 
         return _run_failure_sensor
 

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -94,7 +94,7 @@ def get_or_create_schedule_context(
     Raises an exception if the user passes more than one argument or if the user-provided
     function requires a context parameter but none is passed.
     """
-    from dagster._config.structured_config import ResourceDefinition
+    from dagster import ResourceDefinition
     from dagster._core.definitions.sensor_definition import get_context_param_name
 
     context_param_name = get_context_param_name(fn)

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -94,14 +94,22 @@ def get_or_create_schedule_context(
     Raises an exception if the user passes more than one argument or if the user-provided
     function requires a context parameter but none is passed.
     """
+    from dagster._config.structured_config import ResourceDefinition
     from dagster._core.definitions.sensor_definition import get_context_param_name
 
     context_param_name = get_context_param_name(fn)
 
-    if len(args) + len(kwargs) > 1:
+    kwarg_keys_non_resource = set(kwargs.keys()) - {param.name for param in get_resource_args(fn)}
+    if len(args) + len(kwarg_keys_non_resource) > 1:
         raise DagsterInvalidInvocationError(
-            "Schedule invocation received multiple arguments. Only a first "
-            "positional context parameter should be provided."
+            "Schedule invocation received multiple non-resource arguments. Only a first "
+            "positional context parameter should be provided when invoking."
+        )
+
+    if any(isinstance(arg, ResourceDefinition) for arg in args):
+        raise DagsterInvalidInvocationError(
+            "If directly invoking a schedule, you may not provide resources as"
+            " positional arguments, only as keyword arguments."
         )
 
     context: Optional[ScheduleEvaluationContext] = None
@@ -113,8 +121,9 @@ def get_or_create_schedule_context(
             raise DagsterInvalidInvocationError(
                 f"Schedule invocation expected argument '{context_param_name}'."
             )
-        context_param_name = context_param_name or list(kwargs.keys())[0]
-        context = check.opt_inst(kwargs.get(context_param_name), ScheduleEvaluationContext)
+        context = check.opt_inst(
+            kwargs.get(context_param_name or "context"), ScheduleEvaluationContext
+        )
     elif context_param_name:
         # If the context parameter is present but no value was provided, we error
         raise DagsterInvalidInvocationError(
@@ -122,7 +131,18 @@ def get_or_create_schedule_context(
             "was provided when invoking."
         )
 
-    return context or build_schedule_context()
+    context = context or build_schedule_context()
+    resource_args_from_kwargs = {}
+
+    resource_args = {param.name for param in get_resource_args(fn)}
+    for resource_arg in resource_args:
+        if resource_arg in kwargs:
+            resource_args_from_kwargs[resource_arg] = kwargs[resource_arg]
+
+    if resource_args_from_kwargs:
+        return context.merge_resources(resource_args_from_kwargs)
+
+    return context
 
 
 class ScheduleEvaluationContext:
@@ -216,6 +236,10 @@ class ScheduleEvaluationContext:
         self._logger = None
 
     @property
+    def resource_defs(self) -> Optional[Mapping[str, "ResourceDefinition"]]:
+        return self._resource_defs
+
+    @property
     def resources(self) -> Resources:
         from dagster._core.definitions.scoped_resources_builder import (
             IContainsGenerator,
@@ -237,6 +261,25 @@ class ScheduleEvaluationContext:
                 )
 
         return self._resources
+
+    def merge_resources(self, resources_dict: Mapping[str, Any]) -> "ScheduleEvaluationContext":
+        """Merge the specified resources into this context.
+        This method is intended to be used by the Dagster framework, and should not be called by user code.
+
+        Args:
+            resources_dict (Mapping[str, Any]): The resources to replace in the context.
+        """
+        check.invariant(
+            self._resources is None, "Cannot merge resources in context that has been initialized."
+        )
+        return ScheduleEvaluationContext(
+            instance_ref=self._instance_ref,
+            scheduled_execution_time=self._scheduled_execution_time,
+            repository_name=self._repository_name,
+            schedule_name=self._schedule_name,
+            resources={**(self._resource_defs or {}), **resources_dict},
+            repository_def=self._repository_def,
+        )
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/scoped_resources_builder.py
@@ -122,3 +122,8 @@ class ScopedResourcesBuilder(
                     return resource_instance_dict
 
             return _ScopedResources(**resources_to_attach_to_context)  # type: ignore[call-arg]
+
+    @classmethod
+    def build_empty(cls) -> Resources:
+        """Returns an empty Resources object, equivalent to ScopedResourcesBuilder().build(None)."""
+        return cls().build(None)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -6,22 +6,42 @@ from typing import Iterator, Optional
 import pendulum
 import pytest
 from dagster import (
+    AssetKey,
     SensorEvaluationContext,
     job,
+    multi_asset_sensor,
     op,
     resource,
     sensor,
 )
 from dagster._check import ParameterCheckError
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.decorators.sensor_decorator import asset_sensor
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.freshness_policy_sensor_definition import (
+    FreshnessPolicySensorContext,
+    freshness_policy_sensor,
+)
+from dagster._core.definitions.multi_asset_sensor_definition import (
+    MultiAssetSensorEvaluationContext,
+)
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.definitions.run_request import InstigatorType
+from dagster._core.definitions.run_status_sensor_definition import (
+    RunStatusSensorContext,
+    run_status_sensor,
+)
 from dagster._core.definitions.sensor_definition import RunRequest
+from dagster._core.events.log import EventLogEntry
+from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.storage.pipeline_run import DagsterRunStatus
 from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
 )
@@ -33,13 +53,16 @@ from dagster._seven.compat.pendulum import create_pendulum_time, to_timezone
 from .test_sensor_run import evaluate_sensors, validate_tick, wait_for_all_runs_to_start
 
 
-@op
-def the_op(_):
-    return 1
+@op(out={})
+def the_op(context: OpExecutionContext):
+    yield AssetMaterialization(
+        asset_key=AssetKey("my_asset"),
+        description="my_asset",
+    )
 
 
 @job
-def the_job():
+def the_job() -> None:
     the_op()
 
 
@@ -109,6 +132,117 @@ def sensor_resource_deps(context):
     return RunRequest(context.resources.the_outer, run_config={}, tags={})
 
 
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset(my_resource: MyResource, not_called_context: SensorEvaluationContext):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset_with_cm(
+    my_cm_resource: ResourceParam[str], not_called_context: SensorEvaluationContext
+):
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    assert is_in_cm
+
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset_with_event(
+    my_resource: MyResource,
+    not_called_context: SensorEvaluationContext,
+    my_asset_event: EventLogEntry,
+):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    assert my_asset_event.dagster_event
+    assert my_asset_event.dagster_event.asset_key == AssetKey("my_asset")
+
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@asset_sensor(asset_key=AssetKey("my_asset"), job_name="the_job")
+def sensor_asset_no_context(
+    my_resource: MyResource,
+):
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@multi_asset_sensor(
+    monitored_assets=[AssetKey("my_asset")],
+    job_name="the_job",
+)
+def sensor_multi_asset(
+    my_resource: MyResource,
+    not_called_context: MultiAssetSensorEvaluationContext,
+) -> RunRequest:
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+
+    asset_events = list(
+        not_called_context.materialization_records_for_key(asset_key=AssetKey("my_asset"), limit=1)
+    )
+    if asset_events:
+        not_called_context.advance_all_cursors()
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@multi_asset_sensor(
+    monitored_assets=[AssetKey("my_asset")],
+    job_name="the_job",
+)
+def sensor_multi_asset_with_cm(
+    my_cm_resource: ResourceParam[str],
+    not_called_context: MultiAssetSensorEvaluationContext,
+) -> RunRequest:
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    assert is_in_cm
+
+    asset_events = list(
+        not_called_context.materialization_records_for_key(asset_key=AssetKey("my_asset"), limit=1)
+    )
+    if asset_events:
+        not_called_context.advance_all_cursors()
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
+@freshness_policy_sensor(asset_selection=AssetSelection.all())
+def sensor_freshness_policy(
+    my_resource: MyResource, not_called_context: FreshnessPolicySensorContext
+):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@freshness_policy_sensor(asset_selection=AssetSelection.all())
+def sensor_freshness_policy_with_cm(
+    my_cm_resource: ResourceParam[str], not_called_context: FreshnessPolicySensorContext
+):
+    assert is_in_cm
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
+@run_status_sensor(
+    monitor_all_repositories=True, run_status=DagsterRunStatus.SUCCESS, request_job=the_job
+)
+def sensor_run_status(my_resource: MyResource, not_called_context: RunStatusSensorContext):
+    assert not_called_context.resources.my_resource.a_str == my_resource.a_str
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
+@run_status_sensor(
+    monitor_all_repositories=True, run_status=DagsterRunStatus.SUCCESS, request_job=the_job
+)
+def sensor_run_status_with_cm(
+    my_cm_resource: ResourceParam[str], not_called_context: RunStatusSensorContext
+):
+    assert not_called_context.resources.my_cm_resource == my_cm_resource
+    assert is_in_cm
+    return RunRequest(my_cm_resource, run_config={}, tags={})
+
+
 the_repo = Definitions(
     jobs=[the_job],
     sensors=[
@@ -119,6 +253,16 @@ the_repo = Definitions(
         sensor_from_fn_arg_no_context,
         sensor_context_arg_not_first_and_weird_name,
         sensor_resource_deps,
+        sensor_asset,
+        sensor_asset_with_cm,
+        sensor_asset_with_event,
+        sensor_asset_no_context,
+        sensor_multi_asset,
+        sensor_multi_asset_with_cm,
+        sensor_freshness_policy,
+        sensor_freshness_policy_with_cm,
+        sensor_run_status,
+        sensor_run_status_with_cm,
     ],
     resources={
         "my_resource": MyResource(a_str="foo"),
@@ -189,15 +333,22 @@ def test_cant_use_required_resource_keys_and_params_both() -> None:
         "sensor_from_fn_arg_no_context",
         "sensor_context_arg_not_first_and_weird_name",
         "sensor_resource_deps",
+        "sensor_asset",
+        "sensor_asset_with_cm",
+        "sensor_asset_with_event",
+        "sensor_asset_no_context",
+        "sensor_multi_asset",
+        "sensor_multi_asset_with_cm",
     ],
 )
 def test_resources(
     caplog,
-    instance,
+    instance: DagsterInstance,
     workspace_context_struct_resources,
     external_repo_struct_resources,
     sensor_name,
-):
+) -> None:
+    assert not is_in_cm
     freeze_datetime = to_timezone(
         create_pendulum_time(
             year=2019,
@@ -212,6 +363,11 @@ def test_resources(
     )
 
     with pendulum.test(freeze_datetime):
+        base_run_count = 0
+        if "asset" in sensor_name:
+            the_job.execute_in_process(instance=instance)
+            base_run_count = 1
+
         external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
@@ -220,7 +376,7 @@ def test_resources(
                 InstigatorStatus.RUNNING,
             )
         )
-        assert instance.get_runs_count() == 0
+        assert instance.get_runs_count() == base_run_count
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
@@ -229,7 +385,7 @@ def test_resources(
         evaluate_sensors(workspace_context_struct_resources, None)
         wait_for_all_runs_to_start(instance)
 
-        assert instance.get_runs_count() == 1
+        assert instance.get_runs_count() == base_run_count + 1
         run = instance.get_runs()[0]
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -243,3 +399,161 @@ def test_resources(
             TickStatus.SUCCESS,
             expected_run_ids=[run.run_id],
         )
+    assert not is_in_cm
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_freshness_policy",
+        "sensor_freshness_policy_with_cm",
+    ],
+)
+def test_resources_freshness_policy_sensor(
+    caplog,
+    instance,
+    workspace_context_struct_resources,
+    external_repo_struct_resources,
+    sensor_name,
+) -> None:
+    assert not is_in_cm
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+    original_time = freeze_datetime
+
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 0
+
+    # We have to do two ticks because the first tick will be skipped due to the freshness policy
+    # sensor initializing its cursor
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+    freeze_datetime = freeze_datetime.add(seconds=60)
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+
+    with pendulum.test(freeze_datetime):
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SKIPPED,
+            expected_run_ids=[],
+        )
+        validate_tick(
+            ticks[1],
+            external_sensor,
+            original_time,
+            TickStatus.SKIPPED,
+            expected_run_ids=[],
+        )
+    assert not is_in_cm
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_run_status",
+        "sensor_run_status_with_cm",
+    ],
+)
+def test_resources_run_status_sensor(
+    caplog,
+    instance: DagsterInstance,
+    workspace_context_struct_resources,
+    external_repo_struct_resources,
+    sensor_name,
+) -> None:
+    assert not is_in_cm
+
+    freeze_datetime = to_timezone(
+        create_pendulum_time(
+            year=2019,
+            month=2,
+            day=27,
+            hour=23,
+            minute=59,
+            second=59,
+            tz="UTC",
+        ),
+        "US/Central",
+    )
+    original_time = freeze_datetime
+
+    with pendulum.test(freeze_datetime):
+        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 0
+
+    # We have to do two ticks because the first tick will be skipped due to the run status
+    # sensor initializing its cursor
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+    the_job.execute_in_process(instance=instance)
+    freeze_datetime = freeze_datetime.add(seconds=60)
+    with pendulum.test(freeze_datetime):
+        evaluate_sensors(workspace_context_struct_resources, None)
+        wait_for_all_runs_to_start(instance)
+
+    with pendulum.test(freeze_datetime):
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 2
+
+        assert instance.get_runs_count() == 2
+        run = instance.get_runs()[0]
+        assert ticks[0].run_keys == ["foo"]
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            freeze_datetime,
+            TickStatus.SUCCESS,
+            expected_run_ids=[run.run_id],
+        )
+
+        validate_tick(
+            ticks[1],
+            external_sensor,
+            original_time,
+            TickStatus.SKIPPED,
+            expected_run_ids=[],
+        )
+    assert not is_in_cm

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -120,6 +120,105 @@ def test_schedule_invocation_resources() -> None:
     ).run_config == {"foo": "foo"}
 
 
+def test_schedule_invocation_resources_direct() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    # Test no arg invocation
+    @schedule(job_name="foo_pipeline", cron_schedule="* * * * *")
+    def basic_schedule_resource_req(my_resource: MyResource):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by schedule 'basic_schedule_resource_req' was"
+            " not provided."
+        ),
+    ):
+        basic_schedule_resource_req()
+
+    # Can pass resource through context
+    assert cast(
+        RunRequest,
+        basic_schedule_resource_req(
+            context=build_schedule_context(resources={"my_resource": MyResource(a_str="foo")})
+        ),
+    ).run_config == {"foo": "foo"}
+
+    # Can pass resource directly
+    assert cast(
+        RunRequest,
+        basic_schedule_resource_req(my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=(
+            "If directly invoking a schedule, you may not provide resources as"
+            " positional"
+            " arguments, only as keyword arguments."
+        ),
+    ):
+        # We don't allow providing resources as args, this adds too much complexity
+        # They must be kwargs, and we will error accordingly
+        assert cast(
+            RunRequest,
+            basic_schedule_resource_req(MyResource(a_str="foo")),
+        ).run_config == {"foo": "foo"}
+
+    # Can pass resource directly with context
+    assert cast(
+        RunRequest,
+        basic_schedule_resource_req(build_schedule_context(), my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+    # Test with context arg requirement
+    @schedule(job_name="foo_pipeline", cron_schedule="* * * * *")
+    def basic_schedule_with_context_resource_req(my_resource: MyResource, context):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    assert cast(
+        RunRequest,
+        basic_schedule_with_context_resource_req(
+            build_schedule_context(), my_resource=MyResource(a_str="foo")
+        ),
+    ).run_config == {"foo": "foo"}
+
+
+def test_schedule_invocation_resources_direct_many() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    # Test no arg invocation
+    @schedule(job_name="foo_pipeline", cron_schedule="* * * * *")
+    def basic_schedule_resource_req(my_resource: MyResource, my_other_resource: MyResource):
+        return RunRequest(
+            run_key=None,
+            run_config={"foo": my_resource.a_str, "bar": my_other_resource.a_str},
+            tags={},
+        )
+
+    # Can pass resource directly
+    assert cast(
+        RunRequest,
+        basic_schedule_resource_req(
+            my_other_resource=MyResource(a_str="bar"), my_resource=MyResource(a_str="foo")
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
+
+    # Can pass resources both directly and in context
+    assert cast(
+        RunRequest,
+        basic_schedule_resource_req(
+            context=build_schedule_context(
+                resources={"my_other_resource": MyResource(a_str="bar")}
+            ),
+            my_resource=MyResource(a_str="foo"),
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
+
+
 def test_partition_key_run_request_schedule():
     @job(partitions_def=StaticPartitionsDefinition(["a"]))
     def my_job():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -48,6 +48,7 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
+from dagster._core.execution.build_resources import build_resources
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import instance_for_test
 
@@ -102,8 +103,8 @@ def test_sensor_invocation_args():
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "Sensor invocation received multiple arguments. Only a first positional context "
-            "parameter should be provided when invoking."
+            "Sensor invocation received multiple non-resource arguments. Only a first positional"
+            " context parameter should be provided when invoking."
         ),
     ):
         basic_sensor_with_context(context, _arbitrary_context=None)
@@ -134,6 +135,103 @@ def test_sensor_invocation_resources() -> None:
             build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
         ),
     ).run_config == {"foo": "foo"}
+
+
+def test_sensor_invocation_resources_direct() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    # Test no arg invocation
+    @sensor(job_name="foo_pipeline")
+    def basic_sensor_resource_req(my_resource: MyResource):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by sensor 'basic_sensor_resource_req' was not"
+            " provided."
+        ),
+    ):
+        basic_sensor_resource_req()
+
+    # Can pass resource through context
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(
+            context=build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
+        ),
+    ).run_config == {"foo": "foo"}
+
+    # Can pass resource directly
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=(
+            "If directly invoking a sensor, you may not provide resources as"
+            " positional"
+            " arguments, only as keyword arguments."
+        ),
+    ):
+        # We don't allow providing resources as args, this adds too much complexity
+        # They must be kwargs, and we will error accordingly
+        assert cast(
+            RunRequest,
+            basic_sensor_resource_req(MyResource(a_str="foo")),
+        ).run_config == {"foo": "foo"}
+
+    # Can pass resource directly with context
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(build_sensor_context(), my_resource=MyResource(a_str="foo")),
+    ).run_config == {"foo": "foo"}
+
+    # Test with context arg requirement
+    @sensor(job_name="foo_pipeline")
+    def basic_sensor_with_context_resource_req(my_resource: MyResource, context):
+        return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})
+
+    assert cast(
+        RunRequest,
+        basic_sensor_with_context_resource_req(
+            build_sensor_context(), my_resource=MyResource(a_str="foo")
+        ),
+    ).run_config == {"foo": "foo"}
+
+
+def test_sensor_invocation_resources_direct_many() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    # Test no arg invocation
+    @sensor(job_name="foo_pipeline")
+    def basic_sensor_resource_req(my_resource: MyResource, my_other_resource: MyResource):
+        return RunRequest(
+            run_key=None,
+            run_config={"foo": my_resource.a_str, "bar": my_other_resource.a_str},
+            tags={},
+        )
+
+    # Can pass resource directly
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(
+            my_other_resource=MyResource(a_str="bar"), my_resource=MyResource(a_str="foo")
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
+
+    # Pass resources both directly and in context
+    assert cast(
+        RunRequest,
+        basic_sensor_resource_req(
+            context=build_sensor_context(resources={"my_other_resource": MyResource(a_str="bar")}),
+            my_resource=MyResource(a_str="foo"),
+        ),
+    ).run_config == {"foo": "foo", "bar": "bar"}
 
 
 def test_sensor_invocation_resources_context_manager() -> None:
@@ -177,6 +275,135 @@ def test_sensor_invocation_resources_deferred() -> None:
     with context as open_context:
         with pytest.raises(Exception):
             basic_sensor_resource_req(open_context)
+
+
+def test_multi_asset_sensor_invocation_resources() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @op
+    def an_op():
+        return 1
+
+    @job
+    def the_job():
+        an_op()
+
+    @asset
+    def asset_a():
+        return 1
+
+    @asset
+    def asset_b():
+        return 1
+
+    @multi_asset_sensor(monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")], job=the_job)
+    def a_and_b_sensor(context, my_resource: MyResource):
+        asset_events = context.latest_materialization_records_by_key()
+        if all(asset_events.values()):
+            context.advance_all_cursors()
+            return RunRequest(
+                run_key=context.cursor, run_config={"foo": my_resource.a_str}, tags={}
+            )
+
+    @repository
+    def my_repo():
+        return [asset_a, asset_b, a_and_b_sensor]
+
+    with instance_for_test() as instance:
+        materialize([asset_a, asset_b], instance=instance)
+        ctx = build_multi_asset_sensor_context(
+            monitored_assets=[AssetKey("asset_a"), AssetKey("asset_b")],
+            instance=instance,
+            repository_def=my_repo,
+            resources={"my_resource": MyResource(a_str="bar")},
+        )
+        assert cast(RunRequest, a_and_b_sensor(ctx)).run_config == {"foo": "bar"}
+
+
+def test_freshness_policy_sensor_invocation_resources() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @freshness_policy_sensor(asset_selection=AssetSelection.all())
+    def freshness_sensor(context, my_resource: MyResource) -> None:
+        assert context.minutes_late == 10
+        assert context.previous_minutes_late is None
+        assert my_resource.a_str == "bar"
+
+    with build_resources({"my_resource": MyResource(a_str="bar")}) as resources:
+        context = build_freshness_policy_sensor_context(
+            sensor_name="status_sensor",
+            asset_key=AssetKey("a"),
+            freshness_policy=FreshnessPolicy(maximum_lag_minutes=30),
+            minutes_late=10,
+            # This is a bit gross right now, but FressnessPolicySensorContext is not a subclass of
+            # SensorEvaluationContext and isn't set up to be a context manager
+            # Direct invocation of freshness policy sensors should be rare anyway
+            resources=resources,
+        )
+
+        freshness_sensor(context)
+
+
+def test_run_status_sensor_invocation_resources() -> None:
+    class MyResource(ConfigurableResource):
+        a_str: str
+
+    @run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
+    def status_sensor(context, my_resource: MyResource):
+        assert context.dagster_event.event_type_value == "PIPELINE_SUCCESS"
+        assert my_resource.a_str == "bar"
+
+    @run_status_sensor(run_status=DagsterRunStatus.SUCCESS)
+    def status_sensor_no_context(my_resource: MyResource):
+        assert my_resource.a_str == "bar"
+
+    @op
+    def succeeds():
+        return 1
+
+    @job
+    def my_job_2():
+        succeeds()
+
+    instance = DagsterInstance.ephemeral()
+    result = my_job_2.execute_in_process(instance=instance, raise_on_error=False)
+
+    dagster_run = result.dagster_run
+    dagster_event = result.get_job_success_event()
+
+    context = build_run_status_sensor_context(
+        sensor_name="status_sensor",
+        dagster_instance=instance,
+        dagster_run=dagster_run,
+        dagster_event=dagster_event,
+        resources={"my_resource": MyResource(a_str="bar")},
+    )
+
+    status_sensor(context)
+    status_sensor_no_context(context)
+
+    # also keeps resources from nested `context`
+    context = build_run_status_sensor_context(
+        sensor_name="status_sensor",
+        dagster_instance=instance,
+        dagster_run=dagster_run,
+        dagster_event=dagster_event,
+        context=build_sensor_context(resources={"my_resource": MyResource(a_str="bar")}),
+    )
+
+    status_sensor(context)
+    status_sensor_no_context(context)
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by sensor 'status_sensor_no_context' was not"
+            " provided."
+        ),
+    ):
+        status_sensor_no_context()
 
 
 def test_instance_access_built_sensor():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -384,27 +384,6 @@ def test_run_status_sensor_invocation_resources() -> None:
     status_sensor(context)
     status_sensor_no_context(context)
 
-    # also keeps resources from nested `context`
-    context = build_run_status_sensor_context(
-        sensor_name="status_sensor",
-        dagster_instance=instance,
-        dagster_run=dagster_run,
-        dagster_event=dagster_event,
-        context=build_sensor_context(resources={"my_resource": MyResource(a_str="bar")}),
-    )
-
-    status_sensor(context)
-    status_sensor_no_context(context)
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match=(
-            "Resource with key 'my_resource' required by sensor 'status_sensor_no_context' was not"
-            " provided."
-        ),
-    ):
-        status_sensor_no_context()
-
 
 def test_instance_access_built_sensor():
     with pytest.raises(


### PR DESCRIPTION
## Summary

Undoes the revert (#13359) of some schedule/sensor changes (#13359 and #2607).

See this commit for the actual changes (first commit is the revert-of-the-revert):
https://github.com/dagster-io/dagster/pull/13367/commits/649b9e7f4cd2156701cb98122fd6cf83c55c7c53

## Change 1

Implements similar functionality to #13002 to make passing resources to sensors and schedules easier in the direct invocation case. This makes testing in particular easier.


The new API changes enable the following (schedule behavior is identical):

```python
class MyResource(ConfigurableResource):
    a_str: str

@sensor(job_name="foo_pipeline")
def basic_sensor_resource_req(my_resource: MyResource):
    return RunRequest(run_key=None, run_config={"foo": my_resource.a_str}, tags={})


# Can pass resource through context
assert cast(
    RunRequest,
    basic_sensor_resource_req(
        context=build_sensor_context(resources={"my_resource": MyResource(a_str="foo")})
    ),
).run_config == {"foo": "foo"}

# Can pass resource directly
assert cast(
    RunRequest,
    basic_sensor_resource_req(my_resource=MyResource(a_str="foo")),
).run_config == {"foo": "foo"}


# Can pass resource directly with context
assert cast(
    RunRequest,
    basic_sensor_resource_req(build_sensor_context(), my_resource=MyResource(a_str="foo")),
).run_config == {"foo": "foo"}

```

## Change 2

Adding resource support for all of our various complex sensor types (`@asset_sensor`, `@multi_asset_sensor`, `@freshness_policy_sensor`, and `@run_status_sensor`).

For most cases, this is straightforward replication of what's done in #12401. There are a few interesting cases, e.g. asset sensors currently take two inputs (context and event log entry). This is now set up so that the first two non-resource params are treated as context and event log entry, respectively.

## Test Plan

Ran previously broken run status sensor tests locally.