### PR TITLE
[dagit] Unify “selection” and “range” types in front-end asset health logic

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitions.tsx
@@ -124,7 +124,7 @@ export const AssetPartitions: React.FC<Props> = ({
     const sort = selectionSorts[idx] || defaultSort(selections[idx].dimension.type);
 
     const getSelectionKeys = () =>
-      uniq(selectedRanges.flatMap(([start, end]) => allKeys.slice(start.idx, end.idx + 1)));
+      uniq(selectedRanges.flatMap(({start, end}) => allKeys.slice(start.idx, end.idx + 1)));
 
     if (isEqual(DISPLAYED_STATUSES, statusFilters)) {
       const result = getSelectionKeys();

--- a/js_modules/dagit/packages/core/src/assets/__stories__/PartitionHealthSummary.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/PartitionHealthSummary.stories.tsx
@@ -34,12 +34,7 @@ const PartitionHealthSummaryWithData: React.FC<{
           return {
             dimension: dim,
             selectedKeys: dim.partitionKeys.slice(idx0, idx1 + 1),
-            selectedRanges: [
-              [
-                {idx: idx0, key: range[0]},
-                {idx: idx1, key: range[1]},
-              ],
-            ],
+            selectedRanges: [{start: {idx: idx0, key: range[0]}, end: {idx: idx1, key: range[1]}}],
           } as PartitionDimensionSelection;
         })
       : undefined;

--- a/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -13,7 +13,6 @@ import {
   PartitionHealthDimension,
   PartitionDimensionSelection,
   keyCountInRanges,
-  keyCountInSelection,
 } from '../usePartitionHealthData';
 
 const {MATERIALIZED, FAILED, MISSING} = AssetPartitionStatus;
@@ -251,10 +250,10 @@ function selectionWithSlice(
     dimension: dim,
     selectedKeys: dim.partitionKeys.slice(start, end + 1),
     selectedRanges: [
-      [
-        {idx: start, key: dim.partitionKeys[start]},
-        {idx: end, key: dim.partitionKeys[end]},
-      ],
+      {
+        start: {idx: start, key: dim.partitionKeys[start]},
+        end: {idx: end, key: dim.partitionKeys[end]},
+      },
     ],
   };
 }
@@ -341,10 +340,7 @@ describe('usePartitionHealthData', () => {
       // Ask for ranges of a row, clipped to a column selection
       expect(
         assetHealth.rangesForSingleDimension(0, [
-          [
-            {key: 'MN', idx: 4},
-            {key: 'MN', idx: 4},
-          ],
+          {start: {key: 'MN', idx: 4}, end: {key: 'MN', idx: 4}},
         ]),
       ).toEqual([
         {
@@ -357,10 +353,7 @@ describe('usePartitionHealthData', () => {
       // Ask for ranges of a row, clipped to a column selection
       expect(
         assetHealth.rangesForSingleDimension(0, [
-          [
-            {key: 'NY', idx: 3},
-            {key: 'MN', idx: 4},
-          ],
+          {start: {key: 'NY', idx: 3}, end: {key: 'MN', idx: 4}},
         ]),
       ).toEqual([
         {
@@ -414,10 +407,10 @@ describe('usePartitionHealthData', () => {
       // Ask for ranges of a column, clipped to a row selection
       expect(
         assetHealth.rangesForSingleDimension(1, [
-          [
-            {key: '2022-01-01', idx: 0},
-            {key: '2022-01-01', idx: 0},
-          ],
+          {
+            start: {key: '2022-01-01', idx: 0},
+            end: {key: '2022-01-01', idx: 0},
+          },
         ]),
       ).toEqual([
         {
@@ -444,20 +437,20 @@ describe('usePartitionHealthData', () => {
       expect(assetHealth.rangesForSingleDimension(0)).toEqual([]);
       expect(
         assetHealth.rangesForSingleDimension(0, [
-          [
-            {key: 'NY', idx: 3},
-            {key: 'MN', idx: 4},
-          ],
+          {
+            start: {key: 'NY', idx: 3},
+            end: {key: 'MN', idx: 4},
+          },
         ]),
       ).toEqual([]);
 
       expect(assetHealth.rangesForSingleDimension(1)).toEqual([]);
       expect(
         assetHealth.rangesForSingleDimension(1, [
-          [
-            {key: '2022-01-01', idx: 0},
-            {key: '2022-01-01', idx: 0},
-          ],
+          {
+            start: {key: '2022-01-01', idx: 0},
+            end: {key: '2022-01-01', idx: 0},
+          },
         ]),
       ).toEqual([]);
     });
@@ -510,26 +503,26 @@ const G_I: Range = {
   value: [AssetPartitionStatus.MATERIALIZED],
 };
 
-const SEL_A_C: PartitionDimensionSelectionRange = [
-  {key: 'A', idx: 0},
-  {key: 'C', idx: 2},
-];
-const SEL_A_D: PartitionDimensionSelectionRange = [
-  {key: 'A', idx: 0},
-  {key: 'D', idx: 3},
-];
-const SEL_C_D: PartitionDimensionSelectionRange = [
-  {key: 'C', idx: 2},
-  {key: 'D', idx: 3},
-];
-const SEL_E_G: PartitionDimensionSelectionRange = [
-  {key: 'E', idx: 4},
-  {key: 'G', idx: 6},
-];
-const SEL_G_G: PartitionDimensionSelectionRange = [
-  {key: 'G', idx: 6},
-  {key: 'G', idx: 6},
-];
+const SEL_A_C: PartitionDimensionSelectionRange = {
+  start: {key: 'A', idx: 0},
+  end: {key: 'C', idx: 2},
+};
+const SEL_A_D: PartitionDimensionSelectionRange = {
+  start: {key: 'A', idx: 0},
+  end: {key: 'D', idx: 3},
+};
+const SEL_C_D: PartitionDimensionSelectionRange = {
+  start: {key: 'C', idx: 2},
+  end: {key: 'D', idx: 3},
+};
+const SEL_E_G: PartitionDimensionSelectionRange = {
+  start: {key: 'E', idx: 4},
+  end: {key: 'G', idx: 6},
+};
+const SEL_G_G: PartitionDimensionSelectionRange = {
+  start: {key: 'G', idx: 6},
+  end: {key: 'G', idx: 6},
+};
 
 describe('usePartitionHealthData utilities', () => {
   describe('partitionStatusGivenRanges', () => {
@@ -611,15 +604,6 @@ describe('usePartitionHealthData utilities', () => {
     });
     it('should return the sum of the lengths of the ranges', () => {
       expect(keyCountInRanges([A_C, G_I])).toEqual(6);
-    });
-  });
-
-  describe('keyCountInSelection', () => {
-    it('should return 0 if passed no selections', () => {
-      expect(keyCountInSelection([])).toEqual(0);
-    });
-    it('should return the sum of the lengths of the selections', () => {
-      expect(keyCountInSelection([SEL_A_C, SEL_E_G])).toEqual(6);
     });
   });
 

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.test.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.test.tsx
@@ -62,10 +62,10 @@ describe('SpanRepresentation', () => {
       const result = spanTextToSelections(MOCK_PARTITIONS, '2022-01-01');
       expect(result.selectedKeys).toEqual(['2022-01-01']);
       expect(result.selectedRanges).toEqual([
-        [
-          {idx: 0, key: '2022-01-01'},
-          {idx: 0, key: '2022-01-01'},
-        ],
+        {
+          start: {idx: 0, key: '2022-01-01'},
+          end: {idx: 0, key: '2022-01-01'},
+        },
       ]);
     });
     it('should parse comma-separated values', () => {
@@ -73,28 +73,25 @@ describe('SpanRepresentation', () => {
 
       expect(result.selectedKeys).toEqual(['2022-01-01', '2022-01-02', '2022-01-03']);
       expect(result.selectedRanges).toEqual([
-        [
-          {idx: 0, key: '2022-01-01'},
-          {idx: 0, key: '2022-01-01'},
-        ],
-        [
-          {idx: 1, key: '2022-01-02'},
-          {idx: 1, key: '2022-01-02'},
-        ],
-        [
-          {idx: 2, key: '2022-01-03'},
-          {idx: 2, key: '2022-01-03'},
-        ],
+        {
+          start: {idx: 0, key: '2022-01-01'},
+          end: {idx: 0, key: '2022-01-01'},
+        },
+        {
+          start: {idx: 1, key: '2022-01-02'},
+          end: {idx: 1, key: '2022-01-02'},
+        },
+        {
+          start: {idx: 2, key: '2022-01-03'},
+          end: {idx: 2, key: '2022-01-03'},
+        },
       ]);
     });
     it('should parse spans using the [...] syntax', () => {
       const result = spanTextToSelections(MOCK_PARTITIONS, '[2022-01-01...2022-01-03]');
       expect(result.selectedKeys).toEqual(['2022-01-01', '2022-01-02', '2022-01-03']);
       expect(result.selectedRanges).toEqual([
-        [
-          {idx: 0, key: '2022-01-01'},
-          {idx: 2, key: '2022-01-03'},
-        ],
+        {start: {idx: 0, key: '2022-01-01'}, end: {idx: 2, key: '2022-01-03'}},
       ]);
     });
     it('should parse a multi-span string', () => {
@@ -111,18 +108,18 @@ describe('SpanRepresentation', () => {
         '2022-01-07',
       ]);
       expect(result.selectedRanges).toEqual([
-        [
-          {idx: 0, key: '2022-01-01'},
-          {idx: 2, key: '2022-01-03'},
-        ],
-        [
-          {idx: 4, key: '2022-01-05'},
-          {idx: 4, key: '2022-01-05'},
-        ],
-        [
-          {idx: 5, key: '2022-01-06'},
-          {idx: 6, key: '2022-01-07'},
-        ],
+        {
+          start: {idx: 0, key: '2022-01-01'},
+          end: {idx: 2, key: '2022-01-03'},
+        },
+        {
+          start: {idx: 4, key: '2022-01-05'},
+          end: {idx: 4, key: '2022-01-05'},
+        },
+        {
+          start: {idx: 5, key: '2022-01-06'},
+          end: {idx: 6, key: '2022-01-07'},
+        },
       ]);
     });
     it('should throw an exception if the string is invalid', () => {

--- a/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/SpanRepresentation.tsx
@@ -34,10 +34,10 @@ export function allPartitionsRange({
 }: {
   partitionKeys: string[];
 }): PartitionDimensionSelectionRange {
-  return [
-    {idx: 0, key: partitionKeys[0]},
-    {idx: partitionKeys.length - 1, key: partitionKeys[partitionKeys.length - 1]},
-  ];
+  return {
+    start: {idx: 0, key: partitionKeys[0]},
+    end: {idx: partitionKeys.length - 1, key: partitionKeys[partitionKeys.length - 1]},
+  };
 }
 
 export function spanTextToSelections(
@@ -64,20 +64,20 @@ export function spanTextToSelections(
         throw new Error(`Could not find partitions for provided range: ${start}...${end}`);
       }
       result.selectedKeys.push(...allPartitionKeys.slice(allStartIdx, allEndIdx + 1));
-      result.selectedRanges.push([
-        {idx: allStartIdx, key: allPartitionKeys[allStartIdx]},
-        {idx: allEndIdx, key: allPartitionKeys[allEndIdx]},
-      ]);
+      result.selectedRanges.push({
+        start: {idx: allStartIdx, key: allPartitionKeys[allStartIdx]},
+        end: {idx: allEndIdx, key: allPartitionKeys[allEndIdx]},
+      });
     } else if (term.includes('*')) {
       const [prefix, suffix] = term.split('*');
 
       let start = -1;
       const close = (end: number) => {
         result.selectedKeys.push(...allPartitionKeys.slice(start, end + 1));
-        result.selectedRanges.push([
-          {idx: start, key: allPartitionKeys[start]},
-          {idx: end, key: allPartitionKeys[end]},
-        ]);
+        result.selectedRanges.push({
+          start: {idx: start, key: allPartitionKeys[start]},
+          end: {idx: end, key: allPartitionKeys[end]},
+        });
         start = -1;
       };
 
@@ -101,10 +101,10 @@ export function spanTextToSelections(
         throw new Error(`Could not find partition: ${term}`);
       }
       result.selectedKeys.push(term);
-      result.selectedRanges.push([
-        {idx, key: term},
-        {idx, key: term},
-      ]);
+      result.selectedRanges.push({
+        start: {idx, key: term},
+        end: {idx, key: term},
+      });
     }
   }
 


### PR DESCRIPTION
### Summary & Motivation

Last bit of cleanup here for a bit -- there were two data structures in this code, one that represents a materialized range as `{start, end}` and another for a selected partition range that was encoded as `[start, end]`. This converts the selection one to be an object instead of a tuple for consistency.

## How I Tested These Changes

All tests still pass!
