### PR TITLE
[dagster] remove required positional argument to __dir__

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -579,5 +579,5 @@ def __getattr__(name: str) -> TypingAny:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
-def __dir__(_self: ModuleType) -> Sequence[str]:
+def __dir__() -> Sequence[str]:
     return [*globals(), *_DEPRECATED.keys(), *_DEPRECATED_RENAMED.keys()]

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -1,5 +1,4 @@
 import sys
-from types import ModuleType
 
 from . import _module_alias_map
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -614,7 +614,7 @@ def test_dependency_resolution_partition_mapping():
 def test_exported_partition_mappings_whitelisted():
     import dagster
 
-    dagster_exports = (getattr(dagster, attr_name) for attr_name in dagster.__dir__(dagster))
+    dagster_exports = (getattr(dagster, attr_name) for attr_name in dagster.__dir__())
 
     exported_partition_mapping_classes = {
         export


### PR DESCRIPTION
## Summary & Motivation
fixes:

```py
>>> import dagster
>>> dir(dagster)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __dir__() missing 1 required positional argument: '_self'
```
according to [pep562](https://peps.python.org/pep-0562/#:~:text=The%20__dir__%20function%20should%20accept%20no%20arguments%2C%20and%20return%20a%20list%20of%20strings%20that%20represents%20the%20names%20accessible%20on%20module%3A) for `__dir__` on modules:
> The `__dir__` function should accept no arguments, and return a list of strings that represents the names accessible on module:
## How I Tested These Changes
bk