### PR TITLE
[pythonic config] Fix deep nesting of data structures in Pythonic config

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -783,6 +783,27 @@ def _wrap_config_type(
         raise NotImplementedError(f"Pydantic shape type {shape_type} not supported.")
 
 
+def _get_inner_field_if_exists(
+    shape_type: PydanticShapeType, field: ModelField
+) -> Optional[ModelField]:
+    """Grabs the inner Pydantic field type for a data structure such as a list or dictionary.
+
+    Returns None for types which have no inner field.
+    """
+    # See https://github.com/pydantic/pydantic/blob/v1.10.3/pydantic/fields.py#L758 for
+    # where sub_fields is set.
+    if shape_type == SHAPE_SINGLETON:
+        return None
+    elif shape_type == SHAPE_LIST:
+        # List has a single subfield, which is the type of the list elements.
+        return check.not_none(field.sub_fields)[0]
+    elif shape_type in MAPPING_TYPES:
+        # Mapping has a single subfield, which is the type of the mapping values.
+        return check.not_none(field.sub_fields)[0]
+    else:
+        raise NotImplementedError(f"Pydantic shape type {shape_type} not supported.")
+
+
 def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
     """Transforms a Pydantic field into a corresponding Dagster config field."""
     key_type = (
@@ -806,10 +827,13 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
 
         return Field(config=wrapped_config_type, description=inferred_field.description)
     else:
-        if pydantic_field.sub_fields:
-            config_type = _convert_pydantic_field(pydantic_field.sub_fields[0]).config_type
+        # For certain data structure types, we need to grab the inner Pydantic field (e.g. List type)
+        inner_field = _get_inner_field_if_exists(pydantic_field.shape, pydantic_field)
+        if inner_field:
+            config_type = _convert_pydantic_field(inner_field).config_type
         else:
             config_type = _config_type_for_pydantic_field(pydantic_field)
+
         wrapped_config_type = _wrap_config_type(
             shape_type=pydantic_field.shape, config_type=config_type, key_type=key_type
         )

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -806,7 +806,10 @@ def _convert_pydantic_field(pydantic_field: ModelField) -> Field:
 
         return Field(config=wrapped_config_type, description=inferred_field.description)
     else:
-        config_type = _config_type_for_pydantic_field(pydantic_field)
+        if pydantic_field.sub_fields:
+            config_type = _convert_pydantic_field(pydantic_field.sub_fields[0]).config_type
+        else:
+            config_type = _config_type_for_pydantic_field(pydantic_field)
         wrapped_config_type = _wrap_config_type(
             shape_type=pydantic_field.shape, config_type=config_type, key_type=key_type
         )

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_structured_config_types.py
@@ -202,6 +202,60 @@ def test_struct_config_mapping() -> None:
     assert executed["yes"]
 
 
+def test_struct_config_mapping_list() -> None:
+    class AnOpConfig(Config):
+        a_list_of_string_to_int_mapping: List[Mapping[str, int]]
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: AnOpConfig):
+        executed["yes"] = True
+        assert config.a_list_of_string_to_int_mapping == [{"foo": 1, "bar": 2}]
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    a_job.execute_in_process(
+        {
+            "ops": {
+                "a_struct_config_op": {
+                    "config": {"a_list_of_string_to_int_mapping": [{"foo": 1, "bar": 2}]}
+                }
+            }
+        }
+    )
+    assert executed["yes"]
+
+
+def test_complex_config_schema() -> None:
+    class AnOpConfig(Config):
+        a_complex_thing: Mapping[int, List[Mapping[str, Optional[int]]]]
+
+    executed = {}
+
+    @op
+    def a_struct_config_op(config: AnOpConfig):
+        executed["yes"] = True
+        assert config.a_complex_thing == {5: [{"foo": 1, "bar": 2, "baz": None}]}
+
+    @job
+    def a_job():
+        a_struct_config_op()
+
+    a_job.execute_in_process(
+        {
+            "ops": {
+                "a_struct_config_op": {
+                    "config": {"a_complex_thing": {5: [{"foo": 1, "bar": 2, "baz": None}]}}
+                }
+            }
+        }
+    )
+    assert executed["yes"]
+
+
 @pytest.mark.skip(reason="not yet supported")
 def test_struct_config_optional_nested() -> None:
     class ANestedConfig(Config):


### PR DESCRIPTION
## Summary

Fixes Pydantic -> Dagster Type conversion when using several-level-deep data structures, e.g.

```python
class AnOpConfig(Config):
    a_complex_thing: Mapping[int, List[Mapping[str, Optional[int]]]]
```

Previously, we weren't applying the "data structure processing logic" on the inner type of Pydantic data structure shapes (lists, dicts etc).

## Test Plan

New unit tests.

