### PR TITLE
[pythonic config] Add better error message for unsupported config types

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -972,7 +972,10 @@ def _config_type_for_type_on_pydantic_field(
             return convert_potential_field(potential_dagster_type).config_type
         except DagsterInvalidConfigDefinitionError as e:
             raise DagsterInvalidPythonicConfigDefinitionError(
-                config_class=model_cls, field_name=field_name, invalid_type=e.current_value
+                config_class=model_cls,
+                field_name=field_name,
+                invalid_type=e.current_value,
+                is_resource=model_cls and safe_is_subclass(model_cls, ConfigurableResourceFactory),
             )
 
 

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -975,7 +975,8 @@ def _config_type_for_type_on_pydantic_field(
                 config_class=model_cls,
                 field_name=field_name,
                 invalid_type=e.current_value,
-                is_resource=model_cls and safe_is_subclass(model_cls, ConfigurableResourceFactory),
+                is_resource=model_cls is not None
+                and safe_is_subclass(model_cls, ConfigurableResourceFactory),
             )
 
 

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -936,9 +936,7 @@ def _convert_pydantic_field(pydantic_field: ModelField, model_cls: Optional[Type
         )
 
 
-def _config_type_for_pydantic_field(
-    pydantic_field: ModelField,
-) -> ConfigType:
+def _config_type_for_pydantic_field(pydantic_field: ModelField) -> ConfigType:
     """Generates a Dagster ConfigType from a Pydantic field.
 
     Args:

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -91,9 +91,10 @@ def _generate_pythonic_config_error_message(
     invalid_type: Any,
     is_resource: bool = False,
 ) -> str:
+    invalid_type_name = getattr(invalid_type, "__name__", "<my type>")
     pythonic_config_error_verbiage = (
         PYTHONIC_CONFIG_ERROR_VERBIAGE + (PYTHONIC_RESOURCE_ADDITIONAL_TYPES if is_resource else "")
-    ).format(invalid_type_str=invalid_type.__name__)
+    ).format(invalid_type_str=invalid_type_name)
 
     return (
         """

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -77,13 +77,24 @@ This value can be a:
     - A Pydantic discriminated union type
 """
 
+PYTHONIC_RESOURCE_ADDITIONAL_TYPES = """
+\nIf this value represents a resource dependency, its annotation must either:
+    - Extend dagster.ConfigurableResource, dagster.ConfigurableIOManager, or
+    - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency[GitHub]
+"""
+
 
 class DagsterInvalidPythonicConfigDefinitionError(DagsterError):
     """Indicates that you have attempted to construct a Pythonic config or resource class with an invalid value.
     """
 
     def __init__(
-        self, config_class: Optional[Type], field_name: Optional[str], invalid_type: Any, **kwargs
+        self,
+        config_class: Optional[Type],
+        field_name: Optional[str],
+        invalid_type: Any,
+        is_resource: bool = False,
+        **kwargs,
     ):
         self.invalid_type = invalid_type
         self.field_name = field_name
@@ -96,7 +107,8 @@ class DagsterInvalidPythonicConfigDefinitionError(DagsterError):
                 config_class=f" {repr(config_class)}" if config_class else "",
                 field_name=f"on field '{field_name}'" if field_name else "",
                 invalid_type=repr(invalid_type),
-                PYTHONIC_CONFIG_ERROR_VERBIAGE=PYTHONIC_CONFIG_ERROR_VERBIAGE,
+                PYTHONIC_CONFIG_ERROR_VERBIAGE=PYTHONIC_CONFIG_ERROR_VERBIAGE
+                + (PYTHONIC_RESOURCE_ADDITIONAL_TYPES if is_resource else ""),
             ),
             **kwargs,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -14,15 +14,15 @@ def test_invalid_config_type_basic() -> None:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class <class 'test_errors.test_invalid_config_type_basic.<locals>.DoSomethingConfig'> on field 'unsupported_param'.
-Unable to resolve config type <class 'test_errors.test_invalid_config_type_basic.<locals>.MyUnsupportedType'>.
+Unable to resolve config type <class 'test_errors.test_invalid_config_type_basic.<locals>.MyUnsupportedType'> to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type""",
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)""",
     ):
 
         @op
@@ -43,15 +43,15 @@ def test_invalid_config_type_nested() -> None:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class <class 'test_errors.test_invalid_config_type_nested.<locals>.MyNestedConfig'> on field 'unsupported_param'.
-Unable to resolve config type <class 'test_errors.test_invalid_config_type_nested.<locals>.MyUnsupportedType'>.
+Unable to resolve config type <class 'test_errors.test_invalid_config_type_nested.<locals>.MyUnsupportedType'> to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type""",
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)""",
     ):
 
         @op
@@ -69,19 +69,19 @@ def test_invalid_resource_basic() -> None:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class <class 'test_errors.test_invalid_resource_basic.<locals>.MyBadResource'> on field 'unsupported_param'.
-Unable to resolve config type <class 'test_errors.test_invalid_resource_basic.<locals>.MyUnsupportedType'>.
+Unable to resolve config type <class 'test_errors.test_invalid_resource_basic.<locals>.MyUnsupportedType'> to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)
 
 
-If this value represents a resource dependency, its annotation must either:
+If this config type represents a resource dependency, its annotation must either:
     - Extend dagster.ConfigurableResource, dagster.ConfigurableIOManager, or
-    - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency\\[GitHub\\]""",
+    - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency\\[MyUnsupportedType\\]""",
     ):
         MyBadResource(unsupported_param=MyUnsupportedType())

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -52,6 +52,12 @@ def test_invalid_config_type_nested() -> None:
 
 
 def test_invalid_resource_basic() -> None:
+    class MyUnsupportedType:
+        pass
+
+    class MyBadResource(ConfigurableResource):
+        unsupported_param: MyUnsupportedType
+
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match=(
@@ -59,13 +65,7 @@ def test_invalid_resource_basic() -> None:
             r" '.*MyBadResource'>on field"
             " 'unsupported_param'.\nUnable to resolve config type <class"
             r" '.*MyUnsupportedType'>."
+            r"(?s).*If this value represents a resource dependency, its annotation must either"
         ),
     ):
-
-        class MyUnsupportedType:
-            pass
-
-        class MyBadResource(ConfigurableResource):
-            unsupported_param: MyUnsupportedType
-
         MyBadResource(unsupported_param=MyUnsupportedType())

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -13,12 +13,16 @@ def test_invalid_config_type_basic() -> None:
 
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
-        match=(
-            "Error defining Dagster config class <class"
-            r" '.*DoSomethingConfig'>on field"
-            " 'unsupported_param'.\nUnable to resolve config type <class"
-            r" '.*MyUnsupportedType'>."
-        ),
+        match="""Error defining Dagster config class <class 'test_errors.test_invalid_config_type_basic.<locals>.DoSomethingConfig'> on field 'unsupported_param'.
+Unable to resolve config type <class 'test_errors.test_invalid_config_type_basic.<locals>.MyUnsupportedType'>.
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type""",
     ):
 
         @op
@@ -38,12 +42,16 @@ def test_invalid_config_type_nested() -> None:
 
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
-        match=(
-            "Error defining Dagster config class <class"
-            r" '.*MyNestedConfig'>on field"
-            " 'unsupported_param'.\nUnable to resolve config type <class"
-            r" '.*MyUnsupportedType'>."
-        ),
+        match="""Error defining Dagster config class <class 'test_errors.test_invalid_config_type_nested.<locals>.MyNestedConfig'> on field 'unsupported_param'.
+Unable to resolve config type <class 'test_errors.test_invalid_config_type_nested.<locals>.MyUnsupportedType'>.
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type""",
     ):
 
         @op
@@ -60,12 +68,20 @@ def test_invalid_resource_basic() -> None:
 
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
-        match=(
-            "Error defining Dagster config class <class"
-            r" '.*MyBadResource'>on field"
-            " 'unsupported_param'.\nUnable to resolve config type <class"
-            r" '.*MyUnsupportedType'>."
-            r"(?s).*If this value represents a resource dependency, its annotation must either"
-        ),
+        match="""Error defining Dagster config class <class 'test_errors.test_invalid_resource_basic.<locals>.MyBadResource'> on field 'unsupported_param'.
+Unable to resolve config type <class 'test_errors.test_invalid_resource_basic.<locals>.MyUnsupportedType'>.
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type
+
+
+If this value represents a resource dependency, its annotation must either:
+    - Extend dagster.ConfigurableResource, dagster.ConfigurableIOManager, or
+    - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency\\[GitHub\\]""",
     ):
         MyBadResource(unsupported_param=MyUnsupportedType())

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -1,0 +1,71 @@
+import pytest
+from dagster import Config, op
+from dagster._config.structured_config import ConfigurableResource
+from dagster._core.errors import DagsterInvalidPythonicConfigDefinitionError
+
+
+def test_invalid_config_type_basic() -> None:
+    class MyUnsupportedType:
+        pass
+
+    class DoSomethingConfig(Config):
+        unsupported_param: MyUnsupportedType
+
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match=(
+            "Error defining Dagster config class <class"
+            r" '.*DoSomethingConfig'>on field"
+            " 'unsupported_param'.\nUnable to resolve config type <class"
+            r" '.*MyUnsupportedType'>."
+        ),
+    ):
+
+        @op
+        def my_op(config: DoSomethingConfig):
+            pass
+
+
+def test_invalid_config_type_nested() -> None:
+    class MyUnsupportedType:
+        pass
+
+    class MyNestedConfig(Config):
+        unsupported_param: MyUnsupportedType
+
+    class DoSomethingConfig(Config):
+        nested_param: MyNestedConfig
+
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match=(
+            "Error defining Dagster config class <class"
+            r" '.*MyNestedConfig'>on field"
+            " 'unsupported_param'.\nUnable to resolve config type <class"
+            r" '.*MyUnsupportedType'>."
+        ),
+    ):
+
+        @op
+        def my_op(config: DoSomethingConfig):
+            pass
+
+
+def test_invalid_resource_basic() -> None:
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match=(
+            "Error defining Dagster config class <class"
+            r" '.*MyBadResource'>on field"
+            " 'unsupported_param'.\nUnable to resolve config type <class"
+            r" '.*MyUnsupportedType'>."
+        ),
+    ):
+
+        class MyUnsupportedType:
+            pass
+
+        class MyBadResource(ConfigurableResource):
+            unsupported_param: MyUnsupportedType
+
+        MyBadResource(unsupported_param=MyUnsupportedType())


### PR DESCRIPTION
## Summary

Introduces a new error type which fires when the Pydantic -> Dagster Type code encounters an unconvertible config type. This is a bit more actionable than the typical `DagsterInvalidConfigDefinitionError` since it points to the config class & field name. It also includes more specific details about what config types are allowed and disallowed.

## Test Plan

New unit tests.
