### PR TITLE
[pythonic config] Improve error message for bad config types directly on ops/assets

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_basic_structured_config.py
@@ -25,7 +25,10 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.run_config import RunConfig
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
-from dagster._core.errors import DagsterInvalidConfigDefinitionError, DagsterInvalidConfigError
+from dagster._core.errors import (
+    DagsterInvalidConfigError,
+    DagsterInvalidPythonicConfigDefinitionError,
+)
 from dagster._core.execution.context.invocation import build_op_context
 from dagster._utils.cached_method import cached_method
 from pydantic import (
@@ -262,7 +265,7 @@ def test_primitive_struct_config():
 
 def test_invalid_struct_config():
     # Config should extend Config, not BaseModel
-    with pytest.raises(DagsterInvalidConfigDefinitionError):
+    with pytest.raises(DagsterInvalidPythonicConfigDefinitionError):
 
         class BaseModelExtendingConfig(BaseModel):
             a_string: str

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -1,5 +1,7 @@
+from typing import Tuple
+
 import pytest
-from dagster import Config, op
+from dagster import Config, asset, op
 from dagster._config.structured_config import ConfigurableResource
 from dagster._core.errors import DagsterInvalidPythonicConfigDefinitionError
 
@@ -85,3 +87,82 @@ If this config type represents a resource dependency, its annotation must either
     - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency\\[MyUnsupportedType\\]""",
     ):
         MyBadResource(unsupported_param=MyUnsupportedType())
+
+
+def test_invalid_config_class_directly_on_op() -> None:
+    class MyUnsupportedType:
+        pass
+
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match="""Error defining Dagster config class.
+Unable to resolve config type <class 'test_errors.test_invalid_config_class_directly_on_op.<locals>.MyUnsupportedType'>.
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type""",
+    ):
+
+        @op
+        def my_op(config: MyUnsupportedType):
+            pass
+
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match="""Error defining Dagster config class.
+Unable to resolve config type <class 'test_errors.test_invalid_config_class_directly_on_op.<locals>.MyUnsupportedType'>.
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type""",
+    ):
+
+        @asset
+        def my_asset(config: MyUnsupportedType):
+            pass
+
+
+def test_unsupported_primitive_config_type_directly_on_op() -> None:
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match="""Error defining Dagster config class.
+Unable to resolve config type typing.Tuple\\[str, str\\].
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type""",
+    ):
+
+        @op
+        def my_op(config: Tuple[str, str]):
+            pass
+
+    with pytest.raises(
+        DagsterInvalidPythonicConfigDefinitionError,
+        match="""Error defining Dagster config class.
+Unable to resolve config type typing.Tuple\\[str, str\\].
+
+
+This value can be a:
+    - Python primitive type
+        - int, float, bool, str, list
+    - A Python Dict or List type containing other valid types
+    - Custom data classes extending dagster.Config
+    - A Pydantic discriminated union type""",
+    ):
+
+        @asset
+        def my_asset(config: Tuple[str, str]):
+            pass

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -96,15 +96,15 @@ def test_invalid_config_class_directly_on_op() -> None:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class.
-Unable to resolve config type <class 'test_errors.test_invalid_config_class_directly_on_op.<locals>.MyUnsupportedType'>.
+Unable to resolve config type <class 'test_errors.test_invalid_config_class_directly_on_op.<locals>.MyUnsupportedType'> to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type""",
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)""",
     ):
 
         @op
@@ -114,15 +114,15 @@ This value can be a:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class.
-Unable to resolve config type <class 'test_errors.test_invalid_config_class_directly_on_op.<locals>.MyUnsupportedType'>.
+Unable to resolve config type <class 'test_errors.test_invalid_config_class_directly_on_op.<locals>.MyUnsupportedType'> to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type""",
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)""",
     ):
 
         @asset
@@ -134,15 +134,15 @@ def test_unsupported_primitive_config_type_directly_on_op() -> None:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class.
-Unable to resolve config type typing.Tuple\\[str, str\\].
+Unable to resolve config type typing.Tuple\\[str, str\\] to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type""",
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)""",
     ):
 
         @op
@@ -152,15 +152,15 @@ This value can be a:
     with pytest.raises(
         DagsterInvalidPythonicConfigDefinitionError,
         match="""Error defining Dagster config class.
-Unable to resolve config type typing.Tuple\\[str, str\\].
+Unable to resolve config type typing.Tuple\\[str, str\\] to a supported Dagster config type.
 
 
-This value can be a:
+This config type can be a:
     - Python primitive type
         - int, float, bool, str, list
     - A Python Dict or List type containing other valid types
     - Custom data classes extending dagster.Config
-    - A Pydantic discriminated union type""",
+    - A Pydantic discriminated union type \\(https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions\\)""",
     ):
 
         @asset


### PR DESCRIPTION
## Summary

Extends the better error messaging on the stacked PR to also affect bad annotations directly on an op or asset's `config` parame, e.g.

```python
@op
def my_op(config: Tuple[str, str]):
    pass
```


## Test Plan

New unit tests.