### PR TITLE
Add ephemeral storage and capacity provider strategy support to EcsRunLauncher and EcsContainerContext

### DIFF
--- a/docs/content/deployment/guides/aws.mdx
+++ b/docs/content/deployment/guides/aws.mdx
@@ -73,9 +73,9 @@ run_launcher:
     container_name: "my_container_name"
 ```
 
-### Customizing CPU and memory in ECS
+### Customizing CPU, memory, and ephemeral storage in ECS
 
-You can set the `run_launcher.config.run_resources` field to customize the default memory and CPU resources for Dagster runs. For example:
+You can set the `run_launcher.config.run_resources` field to customize the default resources for Dagster runs. For example:
 
 ```yaml
 run_launcher:
@@ -84,10 +84,13 @@ run_launcher:
   config:
     run_resources:
       cpu: 256
-      memory: 512
+      memory: 512 # In MiB
+      ephemeral_storage: 128 # In GiB
 ```
 
-You can also use job tags to customize the CPU and memory of every run for a particular job:
+**Note**: Fargate tasks only support [certain combinations of CPU and memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) and values of ephemeral storage between 21 and 200 GiB (the default is set to 20 GiB).
+
+You can also use job tags to customize the CPU, memory, or ephemeral storage of every run for a particular job:
 
 ```py
 from dagster import job, op
@@ -100,15 +103,14 @@ def my_op(context):
   tags = {
     "ecs/cpu": "256",
     "ecs/memory": "512",
+    "ecs/ephemeralStorage": "40",
   }
 )
 def my_job():
   my_op()
 ```
 
-If the `ecs/cpu` or `ecs/memory` tags are set, they will override any defaults set on the run launcher.
-
-**Note**: [Fargate tasks only support certain combinations of CPU and memory.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)
+If these tags are set, they will override any defaults set on the run launcher.
 
 ### Customizing the launched run's task
 
@@ -123,6 +125,42 @@ run_launcher:
   config:
     run_task_kwargs:
       launchType: "EC2"
+```
+
+or to set the capacity provider strategy to run in Fargate Spot instances:
+
+```yaml
+run_launcher:
+  module: "dagster_aws.ecs"
+  class: "EcsRunLauncher"
+  config:
+    run_task_kwargs:
+      capacityProviderStrategy:
+        - capacityProvider: "FARGATE_SPOT"
+```
+
+You can also use the `ecs/run_task_kwargs` tag to customize the ECS task of every run for a particular job:
+
+```py
+from dagster import job, op
+
+@op()
+def my_op(context):
+  context.log.info('running')
+
+@job(
+  tags = {
+    "ecs/run_task_kwargs": {
+      "capacityProviderStrategy": [
+        {
+          "capacityProvider": "FARGATE_SPOT",
+        },
+      ],
+    },
+  }
+)
+def my_job():
+  my_op()
 ```
 
 Refer to the [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task) for the full set of available arguments to `run_task`. Additionally, note that:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -44,6 +44,11 @@ SHARED_ECS_SCHEMA = {
                     is_required=False,
                     description="The memory override to use for the launched task.",
                 ),
+                "ephemeral_storage": Field(
+                    int,
+                    is_required=False,
+                    description="The ephemeral storage, in GiB, to use for the launched task.",
+                ),
             }
         )
     ),
@@ -89,6 +94,11 @@ ECS_CONTAINER_CONTEXT_SCHEMA = {
                     str,
                     is_required=False,
                     description="The memory override to use for the launched task.",
+                ),
+                "ephemeral_storage": Field(
+                    int,
+                    is_required=False,
+                    description="The ephemeral storage, in GiB, to use for the launched task.",
                 ),
             }
         )
@@ -137,8 +147,8 @@ class EcsContainerContext(
             ("env_vars", Sequence[str]),
             ("task_definition_arn", Optional[str]),
             ("container_name", Optional[str]),
-            ("server_resources", Mapping[str, str]),
-            ("run_resources", Mapping[str, str]),
+            ("server_resources", Mapping[str, Any]),
+            ("run_resources", Mapping[str, Any]),
             ("task_role_arn", Optional[str]),
             ("execution_role_arn", Optional[str]),
             ("runtime_platform", Mapping[str, Any]),

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -75,7 +75,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         include_sidecars=False,
         use_current_ecs_task_config: bool = True,
         run_task_kwargs: Optional[Mapping[str, Any]] = None,
-        run_resources: Optional[Dict[str, str]] = None,
+        run_resources: Optional[Dict[str, Any]] = None,
     ):
         self._inst_data = inst_data
         self.ecs = boto3.client("ecs")
@@ -373,7 +373,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
         cpu_and_memory_overrides = self.get_cpu_and_memory_overrides(container_context, run)
 
-        task_overrides = self._get_task_overrides(run)
+        task_overrides = self._get_task_overrides(container_context, run)
 
         container_overrides: List[Dict[str, Any]] = [
             {
@@ -395,8 +395,14 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             *self.build_ecs_tags_for_run_task(run),
         ]
 
-        # Run a task using the same network configuration as this processes's
-        # task.
+        run_task_kwargs_from_run = self._get_run_task_kwargs_from_run(run)
+        run_task_kwargs.update(run_task_kwargs_from_run)
+
+        # launchType and capacityProviderStrategy are incompatible - prefer the latter if it is set
+        if "launchType" in run_task_kwargs and run_task_kwargs.get("capacityProviderStrategy"):
+            del run_task_kwargs["launchType"]
+
+        # Run a task using the same network configuration as this processes's task.
         response = self.ecs.run_task(**run_task_kwargs)
 
         tasks = response["tasks"]
@@ -450,10 +456,28 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         return overrides
 
-    def _get_task_overrides(self, run: DagsterRun) -> Mapping[str, Any]:
-        overrides = run.tags.get("ecs/task_overrides")
-        if overrides:
-            return json.loads(overrides)
+    def _get_task_overrides(
+        self, container_context: EcsContainerContext, run: DagsterRun
+    ) -> Mapping[str, Any]:
+        tag_overrides = run.tags.get("ecs/task_overrides")
+
+        overrides = {}
+
+        if tag_overrides:
+            overrides = json.loads(tag_overrides)
+
+        ephemeral_storage = run.tags.get(
+            "ecs/ephemeral_storage", container_context.run_resources.get("ephemeral_storage")
+        )
+        if ephemeral_storage:
+            overrides["ephemeralStorage"] = {"sizeInGiB": int(ephemeral_storage)}
+
+        return overrides
+
+    def _get_run_task_kwargs_from_run(self, run: DagsterRun) -> Mapping[str, Any]:
+        run_task_kwargs = run.tags.get("ecs/run_task_kwargs")
+        if run_task_kwargs:
+            return json.loads(run_task_kwargs)
         return {}
 
     def terminate(self, run_id):
@@ -547,6 +571,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                     memory=container_context.run_resources.get(
                         "memory", default_resources["memory"]
                     ),
+                    ephemeral_storage=container_context.run_resources.get("ephemeral_storage"),
                     runtime_platform=runtime_platform,
                 )
                 task_definition_dict = task_definition_config.task_definition_dict()
@@ -565,6 +590,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                     cpu=container_context.run_resources.get("cpu"),
                     memory=container_context.run_resources.get("memory"),
                     runtime_platform=container_context.runtime_platform,
+                    ephemeral_storage=container_context.run_resources.get("ephemeral_storage"),
                 )
 
                 task_definition_config = DagsterEcsTaskDefinitionConfig.from_task_definition_dict(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/test_utils.py
@@ -49,7 +49,9 @@ class CustomECSRunLauncher(EcsRunLauncher):
     ) -> Mapping[str, str]:
         return {"cpu": "4096", "memory": "16384"}
 
-    def _get_task_overrides(self, run: DagsterRun) -> Mapping[str, Any]:
+    def _get_task_overrides(
+        self, container_context: EcsContainerContext, run: DagsterRun
+    ) -> Mapping[str, Any]:
         return {"ephemeralStorage": {"sizeInGiB": 128}}
 
     def report_launch_events(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -167,6 +167,7 @@ def instance_with_resources(instance_cm):
             "run_resources": {
                 "cpu": "1024",
                 "memory": "2048",
+                "ephemeral_storage": 50,
             }
         }
     ) as dagster_instance:
@@ -186,6 +187,22 @@ def instance_dont_use_current_task(instance_cm, subnet):
                         "assignPublicIp": "ENABLED",
                     },
                 },
+            },
+        }
+    ) as dagster_instance:
+        yield dagster_instance
+
+
+@pytest.fixture
+def instance_fargate_spot(instance_cm):
+    with instance_cm(
+        config={
+            "run_task_kwargs": {
+                "capacityProviderStrategy": [
+                    {
+                        "capacityProvider": "FARGATE_SPOT",
+                    }
+                ],
             },
         }
     ) as dagster_instance:
@@ -379,10 +396,12 @@ def container_context_config(configured_secret):
             "run_resources": {
                 "cpu": "4096",
                 "memory": "8192",
+                "ephemeral_storage": 100,
             },
             "server_resources": {
                 "cpu": "1024",
                 "memory": "2048",
+                "ephemeral_storage": 25,
             },
             "task_role_arn": "fake-task-role",
             "execution_role_arn": "fake-execution-role",

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_container_context.py
@@ -82,13 +82,11 @@ def test_merge(
 
     assert merged.container_name == "bar"
 
-    assert merged.run_resources == {
-        "cpu": "256",
-        "memory": "8192",
-    }
+    assert merged.run_resources == {"cpu": "256", "memory": "8192", "ephemeral_storage": 100}
     assert merged.server_resources == {
         "cpu": "2048",
         "memory": "4096",
+        "ephemeral_storage": 25,
     }
 
     assert merged.task_role_arn == "other-task-role"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -73,6 +74,7 @@ def test_default_launcher(
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
     assert subnet.id in str(task)
     assert task["taskDefinitionArn"] == task_definition["taskDefinitionArn"]
+    assert task["launchType"] == "FARGATE"
 
     # The run is tagged with info about the ECS task
     assert instance.get_run_by_id(run.run_id).tags["ecs/task_arn"] == task_arn
@@ -107,6 +109,82 @@ def test_default_launcher(
     # check status and stop task
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
     ecs.stop_task(task=task_arn)
+
+
+def test_launcher_fargate_spot(
+    ecs,
+    instance_fargate_spot,
+    workspace,
+    external_pipeline,
+    pipeline,
+    subnet,
+    image,
+    environment,
+):
+    instance = instance_fargate_spot
+    run = instance.create_run_for_pipeline(
+        pipeline,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )
+    initial_task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    initial_tasks = ecs.list_tasks()["taskArns"]
+
+    instance.launch_run(run.run_id, workspace)
+
+    # A new task definition is still created
+    task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    assert len(task_definitions) == len(initial_task_definitions) + 1
+    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    task_definition = task_definition["taskDefinition"]
+
+    # A new task is launched
+    tasks = ecs.list_tasks()["taskArns"]
+
+    assert len(tasks) == len(initial_tasks) + 1
+    task_arn = list(set(tasks).difference(initial_tasks))[0]
+    task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+
+    assert task["capacityProviderName"] == "FARGATE_SPOT"
+
+    # Override capacity provider strategy with tags
+    run = instance.create_run_for_pipeline(
+        pipeline,
+        external_pipeline_origin=external_pipeline.get_external_origin(),
+        pipeline_code_origin=external_pipeline.get_python_origin(),
+    )
+    instance.add_run_tags(
+        run.run_id,
+        {
+            "ecs/run_task_kwargs": json.dumps(
+                {
+                    "capacityProviderStrategy": [
+                        {
+                            "capacityProvider": "CUSTOM",
+                        },
+                    ],
+                }
+            )
+        },
+    )
+    instance.launch_run(run.run_id, workspace)
+
+    # A new task definition is still created
+    task_definitions = ecs.list_task_definitions()["taskDefinitionArns"]
+    assert len(task_definitions) == len(initial_task_definitions) + 1
+    task_definition_arn = list(set(task_definitions).difference(initial_task_definitions))[0]
+    task_definition = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    task_definition = task_definition["taskDefinition"]
+
+    # A new task is launched
+    second_tasks = ecs.list_tasks()["taskArns"]
+
+    assert len(second_tasks) == len(tasks) + 1
+    task_arn = list(set(second_tasks).difference(tasks))[0]
+    task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+
+    assert task["capacityProviderName"] == "CUSTOM"
 
 
 def test_launcher_dont_use_current_task(
@@ -554,7 +632,7 @@ def test_default_task_definition_resources(
                 "task_role_arn": task_role_arn,
                 "execution_role_arn": execution_role_arn,
             },
-            "run_resources": {"cpu": "2048", "memory": "4096"},
+            "run_resources": {"cpu": "2048", "memory": "4096", "ephemeral_storage": 36},
         }
     ) as instance:
         run = instance.create_run_for_pipeline(
@@ -579,6 +657,7 @@ def test_default_task_definition_resources(
 
         assert task_definition["cpu"] == "2048"
         assert task_definition["memory"] == "4096"
+        assert task_definition["ephemeralStorage"]["sizeInGiB"] == 36
 
 
 def test_launching_with_task_definition_dict(
@@ -834,6 +913,10 @@ def test_launch_run_with_container_context(
     assert (
         task.get("overrides").get("cpu") == container_context_config["ecs"]["run_resources"]["cpu"]
     )
+    assert (
+        task.get("overrides").get("ephemeralStorage").get("sizeInGiB")
+        == container_context_config["ecs"]["run_resources"]["ephemeral_storage"]
+    )
 
     task_definition_arn = task["taskDefinitionArn"]
 
@@ -848,6 +931,10 @@ def test_launch_run_with_container_context(
     assert task_definition["runtimePlatform"] == container_context_config["ecs"]["runtime_platform"]
     assert task_definition["cpu"] == container_context_config["ecs"]["run_resources"]["cpu"]
     assert task_definition["memory"] == container_context_config["ecs"]["run_resources"]["memory"]
+    assert (
+        task_definition["ephemeralStorage"]["sizeInGiB"]
+        == container_context_config["ecs"]["run_resources"]["ephemeral_storage"]
+    )
 
 
 def test_memory_and_cpu(ecs, instance, workspace, run, task_definition):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/stubbed_ecs.py
@@ -416,6 +416,14 @@ class StubbedEcs:
                     "memory": task_definition["memory"],
                 }
 
+                if kwargs.get("launchType"):
+                    task["launchType"] = kwargs["launchType"]
+
+                if kwargs.get("capacityProviderStrategy"):
+                    task["capacityProviderName"] = kwargs["capacityProviderStrategy"][0][
+                        "capacityProvider"
+                    ]
+
                 if vpc_configuration:
                     for subnet_name in vpc_configuration["subnets"]:
                         ec2 = boto3.resource("ec2", region_name=self.client.meta.region_name)


### PR DESCRIPTION
summary:
Heavily based on https://github.com/dagster-io/dagster/pull/13217 by [AranVinkItility](https://github.com/AranVinkItility) - but putting the ephemeral storage field on EcsContainerContext as well so that it can be set per code location, and some small cosmetic tweaks to the way that the parameters are set.

## Summary & Motivation

## How I Tested These Changes
