### PR TITLE
Don't include the full set of pipeline tags in all logged events

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -394,7 +394,7 @@ class DagsterEvent(
             step_handle=step_context.step.handle,
             node_handle=step_context.step.node_handle,
             step_kind_value=step_context.step.kind.value,
-            logging_tags=step_context.logging_tags,
+            logging_tags=step_context.event_tags,
             event_specific_data=_validate_event_specific_data(event_type, event_specific_data),
             message=check.opt_str_param(message, "message"),
             pid=os.getpid(),
@@ -1271,7 +1271,7 @@ class DagsterEvent(
             step_handle=step_context.step.handle,
             node_handle=step_context.step.node_handle,
             step_kind_value=step_context.step.kind.value,
-            logging_tags=step_context.logging_tags,
+            logging_tags=step_context.event_tags,
             message=(
                 'Finished the execution of hook "{hook_name}" triggered for "{solid_name}".'
             ).format(hook_name=hook_def.name, solid_name=step_context.solid.name),
@@ -1295,7 +1295,7 @@ class DagsterEvent(
             step_handle=step_context.step.handle,
             node_handle=step_context.step.node_handle,
             step_kind_value=step_context.step.kind.value,
-            logging_tags=step_context.logging_tags,
+            logging_tags=step_context.event_tags,
             event_specific_data=_validate_event_specific_data(
                 event_type,
                 HookErroredData(
@@ -1320,7 +1320,7 @@ class DagsterEvent(
             step_handle=step_context.step.handle,
             node_handle=step_context.step.node_handle,
             step_kind_value=step_context.step.kind.value,
-            logging_tags=step_context.logging_tags,
+            logging_tags=step_context.event_tags,
             message=(
                 'Skipped the execution of hook "{hook_name}". It did not meet its triggering '
                 'condition during the execution of "{solid_name}".'

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -147,15 +147,19 @@ class IPlanContext(ABC):
 
     @property
     def logging_tags(self) -> Mapping[str, str]:
-        return self.log.logging_metadata.to_tags()
+        return self.log.logging_metadata.all_tags()
+
+    @property
+    def event_tags(self) -> Mapping[str, str]:
+        return self.log.logging_metadata.event_tags()
 
     def has_tag(self, key: str) -> bool:
         check.str_param(key, "key")
-        return key in self.log.logging_metadata.pipeline_tags
+        return key in self.dagster_run.tags
 
     def get_tag(self, key: str) -> Optional[str]:
         check.str_param(key, "key")
-        return self.log.logging_metadata.pipeline_tags.get(key)
+        return self.dagster_run.tags.get(key)
 
 
 class PlanData(NamedTuple):

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -148,9 +148,13 @@ class DagsterLoggingMetadata(
             return self.pipeline_name or "system"
         return f"resource:{self.resource_name}"
 
-    def to_tags(self) -> Mapping[str, str]:
+    def all_tags(self) -> Mapping[str, str]:
         # converts all values into strings
         return {k: str(v) for k, v in self._asdict().items()}
+
+    def event_tags(self) -> Mapping[str, str]:
+        # Exclude pipeline_tags since it can be quite large and can be found on the run
+        return {k: str(v) for k, v in self._asdict().items() if k != "pipeline_tags"}
 
 
 def construct_log_string(

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
@@ -74,6 +74,7 @@ def test_single_solid_pipeline_success():
         name="single_solid_pipeline",
         node_defs=[solid_one],
         mode_defs=[mode_def(_event_callback)],
+        tags={"foo": "bar"},
     )
 
     result = execute_pipeline(pipeline_def, {"loggers": {"callback": {}}})
@@ -83,6 +84,10 @@ def test_single_solid_pipeline_success():
     start_event = single_dagster_event(events, DagsterEventType.STEP_START)
     assert start_event.pipeline_name == "single_solid_pipeline"
     assert start_event.dagster_event.solid_name == "solid_one"
+
+    # persisted logging tags contain pipeline_name but not pipeline_tags
+    assert start_event.dagster_event.logging_tags["pipeline_name"] == "single_solid_pipeline"
+    assert "pipeline_tags" not in start_event.dagster_event.logging_tags
 
     output_event = single_dagster_event(events, DagsterEventType.STEP_OUTPUT)
     assert output_event

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_subset.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_subset.py
@@ -112,7 +112,7 @@ def test_reentrant_execute_plan():
     pipeline_run = instance.create_run_for_pipeline(
         pipeline_def=pipeline_def, tags={"foo": "bar"}, execution_plan=execution_plan
     )
-    step_events = execute_plan(
+    execute_plan(
         execution_plan,
         InMemoryPipeline(pipeline_def),
         dagster_run=pipeline_run,
@@ -120,8 +120,3 @@ def test_reentrant_execute_plan():
     )
 
     assert called["yup"]
-
-    assert (
-        find_events(step_events, event_type="STEP_OUTPUT")[0].logging_tags["pipeline_tags"]
-        == "{'foo': 'bar'}"
-    )

--- a/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
@@ -18,6 +18,23 @@ from dagster._core.log_manager import (
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 
+def test_metadata_event_tags():
+    logging_metadata = DagsterLoggingMetadata(
+        run_id="f79a8a93-27f1-41b5-b465-b35d0809b26d",
+        pipeline_name="my_pipeline",
+        pipeline_tags={"foo": "bar"},
+    )
+
+    all_tags = logging_metadata.all_tags()
+    event_tags = logging_metadata.event_tags()
+
+    assert all_tags["pipeline_name"] == "my_pipeline"
+    assert all_tags["pipeline_tags"] == "{'foo': 'bar'}"
+
+    assert event_tags["pipeline_name"] == "my_pipeline"
+    assert "pipeline_tags" not in event_tags
+
+
 def test_construct_log_string_for_event():
     step_output_event = DagsterEvent(
         event_type_value="STEP_OUTPUT",
@@ -34,6 +51,7 @@ def test_construct_log_string_for_event():
     logging_metadata = DagsterLoggingMetadata(
         run_id="f79a8a93-27f1-41b5-b465-b35d0809b26d", pipeline_name="my_pipeline"
     )
+
     dagster_message_props = DagsterMessageProps(
         orig_message=step_output_event.message,
         dagster_event=step_output_event,


### PR DESCRIPTION
Summary:
These tags can sometimes be quite large (for example, k8s job and op config can be serialized json, or a run might have a large step selection) so including them as metadata in every logged event seems inadvisable when they're already available on the run.

In one (perhaps somewhat unsusual edge case, since it has 7.5k steps in the dagster/step_selection tag) this changed the total size of the serialized events in the run debug payload from 1.5GB to 7MB.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
