### PR TITLE
[dagit] Silence warning about updates to background CSS property

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionStatus.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionStatus.tsx
@@ -62,7 +62,7 @@ export const assetPartitionStatusesToStyle = (status: AssetPartitionStatus[]): C
   const b = assetPartitionStatusToColor(status[1]);
 
   return {
-    background: `linear-gradient(135deg, ${a} 25%, ${b} 25%, ${b} 50%, ${a} 50%, ${a} 75%, ${b} 75%, ${b} 100%)`,
+    backgroundImage: `linear-gradient(135deg, ${a} 25%, ${b} 25%, ${b} 50%, ${a} 50%, ${a} 75%, ${b} 75%, ${b} 100%)`,
     backgroundSize: '8.49px 8.49px',
   };
 };


### PR DESCRIPTION
## Summary & Motivation

This is a fix for a styled-components console.warn which could make it's way to datadog. It's upset that background could include background-size, and changes to the background value (which is dynamic) could cause the precedence to change.

## How I Tested These Changes

Verified warning is gone