### PR TITLE
[pythonic resources] Error early if a user annotates a param with a ConfigResourceFactory or bare ResourceDef

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -1221,12 +1221,14 @@ def validate_resource_annotated_function(fn) -> None:
             output_type = get_args(orig_bases[0])[0] if orig_bases and len(orig_bases) > 0 else None
             if output_type == TResValue:
                 output_type = None
+
+        output_type_name = getattr(output_type, "__name__", str(output_type))
         raise DagsterInvalidDefinitionError(
             """Resource param '{param_name}' is annotated as '{annotation_type}', but '{annotation_type}' outputs {value_message} value to user code such as @ops and @assets. This annotation should instead be {annotation_suggestion}""".format(
                 param_name=malformed_param.name,
                 annotation_type=malformed_param.annotation,
                 value_message=f"a '{output_type}'" if output_type else "an unknown",
-                annotation_suggestion=f"'Resource[{output_type.__name__}]'"
+                annotation_suggestion=f"'Resource[{output_type_name}]'"
                 if output_type
                 else "'Resource[Any]' or 'Resource[<output type>]'",
             )

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, get_args
 
 from dagster import Enum as DagsterEnum
 from dagster._annotations import experimental
@@ -27,6 +27,7 @@ from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.structured_config.typing_utils import TypecheckAllowPartialResourceInitParams
 from dagster._config.validate import process_config, validate_config
+from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.definition_config_schema import (
     ConfiguredDefinitionConfigSchema,
     DefinitionConfigSchema,
@@ -1190,3 +1191,43 @@ LateBoundTypesForResourceTypeChecking.set_actual_types_for_type_checking(
     resource_type=ConfigurableResourceFactory,
     partial_resource_type=PartialResource,
 )
+
+
+def validate_resource_annotated_function(fn) -> None:
+    """Validates any parameters on the decorated function that are annotated with
+    :py:class:`dagster.ResourceDefinition`, raising a :py:class:`dagster.DagsterInvalidDefinitionError`
+    if any are not also instances of :py:class:`dagster.ConfigurableResource` (these resources should
+    instead be wrapped in the :py:func:`dagster.Resource` Annotation).
+    """
+    from dagster import DagsterInvalidDefinitionError
+    from dagster._config.structured_config import (
+        ConfigurableResource,
+        ConfigurableResourceFactory,
+        TResValue,
+    )
+    from dagster._config.structured_config.utils import safe_is_subclass
+
+    malformed_params = [
+        param
+        for param in get_function_params(fn)
+        if safe_is_subclass(param.annotation, ResourceDefinition)
+        and not safe_is_subclass(param.annotation, ConfigurableResource)
+    ]
+    if len(malformed_params) > 0:
+        malformed_param = malformed_params[0]
+        output_type = None
+        if safe_is_subclass(malformed_param.annotation, ConfigurableResourceFactory):
+            orig_bases = getattr(malformed_param.annotation, "__orig_bases__", None)
+            output_type = get_args(orig_bases[0])[0] if orig_bases and len(orig_bases) > 0 else None
+            if output_type == TResValue:
+                output_type = None
+        raise DagsterInvalidDefinitionError(
+            """Resource param '{param_name}' is annotated as '{annotation_type}', but '{annotation_type}' outputs {value_message} value to user code such as @ops and @assets. This annotation should instead be {annotation_suggestion}""".format(
+                param_name=malformed_param.name,
+                annotation_type=malformed_param.annotation,
+                value_message=f"a '{output_type}'" if output_type else "an unknown",
+                annotation_suggestion=f"'Resource[{output_type.__name__}]'"
+                if output_type
+                else "'Resource[Any]' or 'Resource[<output type>]'",
+            )
+        )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -23,7 +23,6 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataUserInput
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,
-    validate_resource_annotated_function,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.io_manager import IOManagerDefinition
@@ -280,6 +279,8 @@ class _Asset:
         self.code_version = code_version
 
     def __call__(self, fn: Callable) -> AssetsDefinition:
+        from dagster._config.structured_config import validate_resource_annotated_function
+
         validate_resource_annotated_function(fn)
         asset_name = self.name or fn.__name__
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -285,7 +285,7 @@ class _Asset:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
-            arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
+            arg_resource_keys = {arg.name for arg in get_resource_args(fn, err_aggressively=True)}
 
             bare_required_resource_keys = set(self.required_resource_keys)
             resource_defs_keys = set(self.resource_defs.keys())

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -27,7 +27,6 @@ from dagster._core.decorator_utils import (
 from dagster._core.definitions.inference import infer_input_props
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,
-    validate_resource_annotated_function,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
@@ -76,6 +75,8 @@ class _Op:
         self.out = out
 
     def __call__(self, fn: Callable[..., Any]) -> "OpDefinition":
+        from dagster._config.structured_config import validate_resource_annotated_function
+
         from ..op_definition import OpDefinition
 
         validate_resource_annotated_function(fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -289,7 +289,7 @@ class DecoratedOpFunction(NamedTuple):
         check.failed("Requested config arg on function that does not have one")
 
     def get_resource_args(self) -> Sequence[Parameter]:
-        return get_resource_args(self.decorated_fn)
+        return get_resource_args(self.decorated_fn, err_aggressively=True)
 
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -25,7 +25,10 @@ from dagster._core.decorator_utils import (
     positional_arg_name_list,
 )
 from dagster._core.definitions.inference import infer_input_props
-from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.resource_annotation import (
+    get_resource_args,
+    validate_resource_annotated_function,
+)
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
 from dagster._utils.backcompat import canonicalize_backcompat_args
@@ -74,6 +77,8 @@ class _Op:
 
     def __call__(self, fn: Callable[..., Any]) -> "OpDefinition":
         from ..op_definition import OpDefinition
+
+        validate_resource_annotated_function(fn)
 
         if not self.name:
             self.name = fn.__name__
@@ -289,7 +294,7 @@ class DecoratedOpFunction(NamedTuple):
         check.failed("Requested config arg on function that does not have one")
 
     def get_resource_args(self) -> Sequence[Parameter]:
-        return get_resource_args(self.decorated_fn, err_aggressively=True)
+        return get_resource_args(self.decorated_fn)
 
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -115,7 +115,9 @@ def schedule(
             validated_tags = validate_tags(tags, allow_reserved_tags=False)
 
         context_param_name = get_context_param_name(fn)
-        resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(fn)}
+        resource_arg_names: Set[str] = {
+            arg.name for arg in get_resource_args(fn, err_aggressively=True)
+        }
 
         def _wrapped_fn(context: ScheduleEvaluationContext) -> RunRequestIterator:
             if should_execute:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -15,7 +15,6 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,
-    validate_resource_annotated_function,
 )
 from dagster._core.definitions.sensor_definition import get_context_param_name
 from dagster._core.errors import (
@@ -102,6 +101,8 @@ def schedule(
     """
 
     def inner(fn: RawScheduleEvaluationFunction) -> ScheduleDefinition:
+        from dagster._config.structured_config import validate_resource_annotated_function
+
         check.callable_param(fn, "fn")
         validate_resource_annotated_function(fn)
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
@@ -8,6 +8,11 @@ from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
 def validate_resource_annotated_function(fn) -> None:
+    """Validates any parameters on the decorated function that are annotated with
+    :py:class:`dagster.ResourceDefinition`, raising a :py:class:`dagster.DagsterInvalidDefinitionError`
+    if any are not also instances of :py:class:`dagster.ConfigurableResource` (these resources should
+    instead be wrapped in the :py:func:`dagster.Resource` Annotation).
+    """
     from dagster import DagsterInvalidDefinitionError
     from dagster._config.structured_config import (
         ConfigurableResource,

--- a/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
@@ -1,13 +1,50 @@
 from inspect import Parameter
 from typing import Sequence, TypeVar
 
-from typing_extensions import Annotated
+from typing_extensions import Annotated, get_args
 
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
-def get_resource_args(fn) -> Sequence[Parameter]:
+def get_resource_args(fn, err_aggressively: bool = False) -> Sequence[Parameter]:
+    from dagster import DagsterInvalidDefinitionError
+    from dagster._config.structured_config import (
+        ConfigurableResource,
+        ConfigurableResourceFactory,
+        TResValue,
+    )
+    from dagster._config.structured_config.utils import safe_is_subclass
+
+    if err_aggressively:
+        malformed_params = [
+            param
+            for param in get_function_params(fn)
+            if safe_is_subclass(param.annotation, ResourceDefinition)
+            and not safe_is_subclass(param.annotation, ConfigurableResource)
+        ]
+        if len(malformed_params) > 0:
+            malformed_param = malformed_params[0]
+            if safe_is_subclass(malformed_param.annotation, ConfigurableResourceFactory):
+                orig_bases = getattr(malformed_param.annotation, "__orig_bases__", None)
+                output_type = (
+                    get_args(orig_bases[0])[0] if orig_bases and len(orig_bases) > 0 else None
+                )
+                if output_type == TResValue:
+                    output_type = None
+                raise DagsterInvalidDefinitionError(
+                    """Resource param '{param_name}' is annotated as '{annotation_type}', but '{annotation_type}' outputs {value_message} value to user code such as @ops and @assets. This annotation should instead be 'Resource[{output_type}]'""".format(
+                        param_name=malformed_param.name,
+                        annotation_type=malformed_param.annotation,
+                        value_message=f"a '{output_type}'" if output_type else "an unknown",
+                        output_type=output_type.__name__ if output_type else "Any",
+                    )
+                )
+            else:
+                raise DagsterInvalidDefinitionError(
+                    """Resource param '{param_name}' is annotated as '{annotation_type}', but '{param_name}' produces a `Foo` value. This annotation should instead be `Resource[Foo]`"""
+                )
+
     return [param for param in get_function_params(fn) if _is_resource_annotated(param)]
 
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
@@ -7,7 +7,7 @@ from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.resource_definition import ResourceDefinition
 
 
-def get_resource_args(fn, err_aggressively: bool = False) -> Sequence[Parameter]:
+def validate_resource_annotated_function(fn) -> None:
     from dagster import DagsterInvalidDefinitionError
     from dagster._config.structured_config import (
         ConfigurableResource,
@@ -16,34 +16,33 @@ def get_resource_args(fn, err_aggressively: bool = False) -> Sequence[Parameter]
     )
     from dagster._config.structured_config.utils import safe_is_subclass
 
-    if err_aggressively:
-        malformed_params = [
-            param
-            for param in get_function_params(fn)
-            if safe_is_subclass(param.annotation, ResourceDefinition)
-            and not safe_is_subclass(param.annotation, ConfigurableResource)
-        ]
-        if len(malformed_params) > 0:
-            malformed_param = malformed_params[0]
-            output_type = None
-            if safe_is_subclass(malformed_param.annotation, ConfigurableResourceFactory):
-                orig_bases = getattr(malformed_param.annotation, "__orig_bases__", None)
-                output_type = (
-                    get_args(orig_bases[0])[0] if orig_bases and len(orig_bases) > 0 else None
-                )
-                if output_type == TResValue:
-                    output_type = None
-            raise DagsterInvalidDefinitionError(
-                """Resource param '{param_name}' is annotated as '{annotation_type}', but '{annotation_type}' outputs {value_message} value to user code such as @ops and @assets. This annotation should instead be {annotation_suggestion}""".format(
-                    param_name=malformed_param.name,
-                    annotation_type=malformed_param.annotation,
-                    value_message=f"a '{output_type}'" if output_type else "an unknown",
-                    annotation_suggestion=f"'Resource[{output_type.__name__}]'"
-                    if output_type
-                    else "'Resource[Any]' or 'Resource[<output type>]'",
-                )
+    malformed_params = [
+        param
+        for param in get_function_params(fn)
+        if safe_is_subclass(param.annotation, ResourceDefinition)
+        and not safe_is_subclass(param.annotation, ConfigurableResource)
+    ]
+    if len(malformed_params) > 0:
+        malformed_param = malformed_params[0]
+        output_type = None
+        if safe_is_subclass(malformed_param.annotation, ConfigurableResourceFactory):
+            orig_bases = getattr(malformed_param.annotation, "__orig_bases__", None)
+            output_type = get_args(orig_bases[0])[0] if orig_bases and len(orig_bases) > 0 else None
+            if output_type == TResValue:
+                output_type = None
+        raise DagsterInvalidDefinitionError(
+            """Resource param '{param_name}' is annotated as '{annotation_type}', but '{annotation_type}' outputs {value_message} value to user code such as @ops and @assets. This annotation should instead be {annotation_suggestion}""".format(
+                param_name=malformed_param.name,
+                annotation_type=malformed_param.annotation,
+                value_message=f"a '{output_type}'" if output_type else "an unknown",
+                annotation_suggestion=f"'Resource[{output_type.__name__}]'"
+                if output_type
+                else "'Resource[Any]' or 'Resource[<output type>]'",
             )
+        )
 
+
+def get_resource_args(fn) -> Sequence[Parameter]:
     return [param for param in get_function_params(fn) if _is_resource_annotated(param)]
 
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -558,7 +558,9 @@ class SensorDefinition:
         self._asset_selection = check.opt_inst_param(
             asset_selection, "asset_selection", AssetSelection
         )
-        resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(self._raw_fn)}
+        resource_arg_names: Set[str] = {
+            arg.name for arg in get_resource_args(self._raw_fn, err_aggressively=True)
+        }
 
         check.param_invariant(
             len(required_resource_keys or []) == 0 or len(resource_arg_names) == 0,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -29,7 +29,10 @@ from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.partition import (
     CachingDynamicPartitionsLoader,
 )
-from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.resource_annotation import (
+    get_resource_args,
+    validate_resource_annotated_function,
+)
 from dagster._core.definitions.resource_definition import (
     Resources,
 )
@@ -558,9 +561,8 @@ class SensorDefinition:
         self._asset_selection = check.opt_inst_param(
             asset_selection, "asset_selection", AssetSelection
         )
-        resource_arg_names: Set[str] = {
-            arg.name for arg in get_resource_args(self._raw_fn, err_aggressively=True)
-        }
+        validate_resource_annotated_function(self._raw_fn)
+        resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(self._raw_fn)}
 
         check.param_invariant(
             len(required_resource_keys or []) == 0 or len(resource_arg_names) == 0,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -31,7 +31,6 @@ from dagster._core.definitions.partition import (
 )
 from dagster._core.definitions.resource_annotation import (
     get_resource_args,
-    validate_resource_annotated_function,
 )
 from dagster._core.definitions.resource_definition import (
     Resources,
@@ -498,6 +497,8 @@ class SensorDefinition:
         asset_selection: Optional[AssetSelection] = None,
         required_resource_keys: Optional[Set[str]] = None,
     ):
+        from dagster._config.structured_config import validate_resource_annotated_function
+
         if evaluation_fn is None:
             raise DagsterInvalidDefinitionError("Must provide evaluation_fn to SensorDefinition.")
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_parameters.py
@@ -204,7 +204,7 @@ def test_resource_class():
             resource_called["called"] = True
 
     @op
-    def do_something_op(my_resource: MyResource):
+    def do_something_op(my_resource: Resource[MyResource]):
         my_resource.do_something()
 
     @job(resource_defs={"my_resource": MyResource()})
@@ -216,7 +216,7 @@ def test_resource_class():
 
     @asset
     def consumes_nonexistent_resource_class(
-        not_provided: MyResource,
+        not_provided: Resource[MyResource],
     ):
         pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -753,7 +753,7 @@ def test_nested_function_resource():
             return output
 
     @asset
-    def my_asset(writer: PostfixWriterResource):
+    def my_asset(writer: Resource[Callable[[str], None]]):
         writer("foo")
         writer("bar")
 
@@ -791,7 +791,7 @@ def test_nested_function_resource_configured():
             return output
 
     @asset
-    def my_asset(writer: PostfixWriterResource):
+    def my_asset(writer: Resource[Callable[[str], None]]):
         writer("foo")
         writer("bar")
 
@@ -843,7 +843,7 @@ def test_nested_function_resource_runtime_config():
             return output
 
     @asset
-    def my_asset(writer: PostfixWriterResource):
+    def my_asset(writer: Resource[Callable[[str], None]]):
         writer("foo")
         writer("bar")
 


### PR DESCRIPTION
## Summary

Throws an error early if the user annotates an op, asset, schedule, or sensor function param with a `ConfigurableResourceFactory` or bare `ResourceDefinition` that is not a `ConfigurableResource`, e.g.


```python
class MyFactory(ConfigurableResourceFactory[str]):
    ...


# should be my_resource: Resource[str]!

@op
def my_op(my_resource: MyFactory):
    ...
```

## Test PLan

unit tests