### PR TITLE
Fix gql FailureMetadata

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -16,9 +16,7 @@ fragment errorFragment on PythonError {
 }
 """
 
-STEP_EVENT_FRAGMENTS = (
-    ERROR_FRAGMENT
-    + """
+METADATA_ENTRY_FRAGMENT = """
 fragment metadataEntryFragment on MetadataEntry {
   __typename
   label
@@ -86,7 +84,12 @@ fragment metadataEntryFragment on MetadataEntry {
     }
   }
 }
+"""
 
+STEP_EVENT_FRAGMENTS = (
+    ERROR_FRAGMENT
+    + METADATA_ENTRY_FRAGMENT
+    + """
 fragment stepEventFragment on StepEvent {
   stepKey
   solidHandleID

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -237,7 +237,7 @@ class GrapheneFailureMetadata(graphene.ObjectType):
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from ...implementation.events import _to_metadata_entries
 
-        return _to_metadata_entries(self.metadata_entries)
+        return _to_metadata_entries(self.metadata)
 
 
 class GrapheneExecutionStepInputEvent(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -71,6 +71,7 @@ from dagster import (
     usable_as_dagster_type,
 )
 from dagster._core.definitions.decorators.sensor_decorator import sensor
+from dagster._core.definitions.events import Failure
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.input import In
@@ -534,7 +535,8 @@ def naughty_programmer_pipeline():
             except Exception as e:
                 raise Exception("Outer exception") from e
         except Exception as e:
-            raise Exception("Even more outer exception") from e
+            # throw a Failure here so we can test metadata
+            raise Failure("Even more outer exception", metadata={"top_level": True}) from e
 
     throw_a_thing()
 


### PR DESCRIPTION
## Summary & Motivation

Fix `failureMetadata` resolution. There was no test coverage for this.

## How I Tested These Changes

Modified existing step failure test to incorporate `failureMetadata`.
