### PR TITLE
Better handle ecsrunlauncher with use_current_ecs_task_config=False but no task_definition set

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -84,7 +84,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         self.logs = boto3.client("logs")
 
         self.task_definition = None
-        self.task_definition_dict = None
+        self.task_definition_dict = {}
         if isinstance(task_definition, str):
             self.task_definition = task_definition
         elif task_definition and "env" in task_definition:
@@ -103,7 +103,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                     " set."
                 )
         else:
-            self.task_definition_dict = task_definition
+            self.task_definition_dict = task_definition or {}
 
         self.container_name = container_name
 
@@ -509,7 +509,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         else:
             family = self._get_run_task_definition_family(run)
 
-            if self.task_definition_dict:
+            if self.task_definition_dict or not self.use_current_ecs_task_config:
                 runtime_platform = container_context.runtime_platform
                 is_windows = container_context.runtime_platform.get(
                     "operatingSystemFamily"

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -174,7 +174,7 @@ def instance_with_resources(instance_cm):
 
 
 @pytest.fixture
-def instance_dont_use_current_task(instance_cm, subnet):
+def instance_dont_use_current_task(instance_cm, subnet, monkeypatch):
     with instance_cm(
         config={
             "use_current_ecs_task_config": False,
@@ -189,6 +189,8 @@ def instance_dont_use_current_task(instance_cm, subnet):
             },
         }
     ) as dagster_instance:
+        # Not running in an ECS task
+        monkeypatch.setenv("ECS_CONTAINER_METADATA_URI_V4", None)
         yield dagster_instance
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -155,8 +155,9 @@ def test_launcher_dont_use_current_task(
     assert container_definition["image"] == image
     assert not container_definition.get("entryPoint")
     assert not container_definition.get("dependsOn")
-    # It takes in the environment configured on the instance
-    assert all(item in container_definition["environment"] for item in environment)
+
+    # It does not take in the environment configured on the calling task definition
+    assert not any(item in container_definition["environment"] for item in environment)
     assert {"name": "DAGSTER_RUN_JOB_NAME", "value": "pipeline"} in container_definition[
         "environment"
     ]


### PR DESCRIPTION
Summary:
We were implicitly assuming that if you set use_current_ecs_task_config to False, you must want to configure the task definition in some way, but that is not always the case. Make it possible to launch a run using a 'default' task definition that pulls nothing from the run.

We actually had a test for this case, but it stil had access to the env var that is set when you are inside the ECS task, so the test passed incorrectly.

Test Plan: BK test that would fail before

## Summary & Motivation

## How I Tested These Changes
