### PR TITLE
[pythonic resources] Add from_resource_context utility

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -144,9 +144,9 @@ class Config(MakeConfigCacheable):
         return output
 
     @classmethod
-    def to_config_field(cls) -> Field:
-        """Converts the config structure represented by this class into a Dagster config field."""
-        return infer_schema_from_config_class(cls)
+    def to_config_schema(cls) -> DefinitionConfigSchema:
+        """Converts the config structure represented by this class into a DefinitionConfigSchema."""
+        return DefinitionConfigSchema(infer_schema_from_config_class(cls))
 
 
 @experimental

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -143,6 +143,11 @@ class Config(MakeConfigCacheable):
                 output[key] = value
         return output
 
+    @classmethod
+    def to_config_field(cls) -> Field:
+        """Converts the config structure represented by this class into a Dagster config field."""
+        return infer_schema_from_config_class(cls)
+
 
 @experimental
 class PermissiveConfig(Config):

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -567,6 +567,26 @@ class ConfigurableResourceFactory(
     def _create_object_fn(self, context: InitResourceContext) -> TResValue:
         return self.create_resource(context)
 
+    @classmethod
+    def from_resource_context(cls, context: InitResourceContext) -> TResValue:
+        """Creates a new instance of this resource from a populated InitResourceContext.
+        Useful when creating a resource from a function-based resource, for backwards
+        compatibility purposes.
+
+        Example usage:
+
+        .. code-block:: python
+
+            class MyResource(ConfigurableResource):
+                my_str: str
+
+            @resource(config_schema={"my_str": str})
+            def my_resource(context: InitResourceContext) -> MyResource:
+                return MyResource.from_resource_context(context)
+
+        """
+        return cls(**context.resource_config).create_resource(context)
+
 
 @experimental
 class ConfigurableResource(ConfigurableResourceFactory[TResValue]):

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -585,7 +585,7 @@ class ConfigurableResourceFactory(
             class MyResource(ConfigurableResource):
                 my_str: str
 
-            @resource(config_schema={"my_str": str})
+            @resource(config_schema=MyResource.to_config_schema())
             def my_resource(context: InitResourceContext) -> MyResource:
                 return MyResource.from_resource_context(context)
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -2244,7 +2244,7 @@ def test_from_resource_context_and_to_config_field() -> None:
         def create_resource(self, context) -> str:
             return self.a_string + "bar"
 
-    @resource(config_schema=StringResource.to_config_field())
+    @resource(config_schema=StringResource.to_config_schema())
     def string_resource_function_style(context: InitResourceContext) -> str:
         return StringResource.from_resource_context(context)
 
@@ -2259,7 +2259,7 @@ def test_from_resource_context_and_to_config_field_complex() -> None:
         a_list_of_ints: List[int]
         a_map_of_lists_of_maps_of_floats: Mapping[str, List[Mapping[str, float]]]
 
-    @resource(config_schema=MyComplexConfigResource.to_config_field())
+    @resource(config_schema=MyComplexConfigResource.to_config_schema())
     def complex_config_resource_function_style(
         context: InitResourceContext,
     ) -> MyComplexConfigResource:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -2237,16 +2237,49 @@ def test_direct_asset_invocation_with_inputs() -> None:
     assert my_wacky_addition_asset_no_context(y=1, x=2, my_resource=MyResource(z=3)) == 6
 
 
-
-def test_from_resource_context() -> None:
+def test_from_resource_context_and_to_config_field() -> None:
     class StringResource(ConfigurableResourceFactory[str]):
         a_string: str
 
         def create_resource(self, context) -> str:
             return self.a_string + "bar"
-    
-    @resource(config_schema={"a_string": str})
+
+    @resource(config_schema=StringResource.to_config_field())
     def string_resource_function_style(context: InitResourceContext) -> str:
         return StringResource.from_resource_context(context)
-    
-    assert string_resource_function_style(build_init_resource_context({"a_string": "foo"})) == "foobar"
+
+    assert (
+        string_resource_function_style(build_init_resource_context({"a_string": "foo"})) == "foobar"
+    )
+
+
+def test_from_resource_context_and_to_config_field_complex() -> None:
+    class MyComplexConfigResource(ConfigurableResource):
+        a_string: str
+        a_list_of_ints: List[int]
+        a_map_of_lists_of_maps_of_floats: Mapping[str, List[Mapping[str, float]]]
+
+    @resource(config_schema=MyComplexConfigResource.to_config_field())
+    def complex_config_resource_function_style(
+        context: InitResourceContext,
+    ) -> MyComplexConfigResource:
+        return MyComplexConfigResource.from_resource_context(context)
+
+    complex_config_resource = complex_config_resource_function_style(
+        build_init_resource_context(
+            {
+                "a_string": "foo",
+                "a_list_of_ints": [1, 2, 3],
+                "a_map_of_lists_of_maps_of_floats": {
+                    "a": [{"b": 1.0}, {"c": 2.0}],
+                    "d": [{"e": 3.0}, {"f": 4.0}],
+                },
+            }
+        )
+    )
+    assert complex_config_resource.a_string == "foo"
+    assert complex_config_resource.a_list_of_ints == [1, 2, 3]
+    assert complex_config_resource.a_map_of_lists_of_maps_of_floats == {
+        "a": [{"b": 1.0}, {"c": 2.0}],
+        "d": [{"e": 3.0}, {"f": 4.0}],
+    }


### PR DESCRIPTION
## Summary

Adds a small utility which helps building resources from `ConfigurableResourceFactory` classes by taking an init context and returning the output resource value.

Based on discussion in https://github.com/dagster-io/dagster/pull/12978#discussion_r1159066432

## Test Plan

Small unit test.
