### PR TITLE
Improve performance of table slice cleanup in dagster-snowflake

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -284,7 +284,12 @@ class SnowflakeDbClient(DbClient):
     @staticmethod
     def delete_table_slice(context: OutputContext, table_slice: TableSlice, connection) -> None:
         try:
-            connection.execute(_get_cleanup_statement(table_slice))
+            if table_slice.partition_dimensions and len(table_slice.partition_dimensions) > 0:
+                count = connection.execute(_get_count_statement(table_slice))
+                if count.fetchall()[0][0] > 0:
+                    connection.execute(_get_cleanup_statement(table_slice))
+            else:
+                connection.execute(_get_cleanup_statement(table_slice))
         except ProgrammingError:
             # table doesn't exist yet, so ignore the error
             pass

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -312,7 +312,9 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         )
         return query + _partition_where_clause(table_slice.partition_dimensions)
     else:
-        return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
+        return f"TRUNCATE {table_slice.database}.{table_slice.schema}.{table_slice.table}"
+
+
 def _get_count_statement(table_slice: TableSlice) -> str:
     """Returns a SQL Statement that queries the number of rows affected by the delete statement."""
     if table_slice.partition_dimensions and len(table_slice.partition_dimensions) > 0:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -313,6 +313,18 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return query + _partition_where_clause(table_slice.partition_dimensions)
     else:
         return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
+def _get_count_statement(table_slice: TableSlice) -> str:
+    """Returns a SQL Statement that queries the number of rows affected by the delete statement."""
+    if table_slice.partition_dimensions and len(table_slice.partition_dimensions) > 0:
+        query = (
+            "SELECT COUNT(*) FROM"
+            f" {table_slice.database}.{table_slice.schema}.{table_slice.table} WHERE\n"
+        )
+        return query + _partition_where_clause(table_slice.partition_dimensions)
+    else:
+        return (
+            f"SELECT COUNT(*) FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
+        )
 
 
 def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimension]) -> str:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -113,7 +113,7 @@ def test_get_cleanup_statement():
         _get_cleanup_statement(
             TableSlice(database="database_abc", schema="schema1", table="table1")
         )
-        == "DELETE FROM database_abc.schema1.table1"
+        == "TRUNCATE database_abc.schema1.table1"
     )
 
 


### PR DESCRIPTION
## Summary & Motivation

`DELETE FROM` is a particularly expensive command to run in snowflake, especially when there is no partitioning key applied to the table. When rematerialising an asset, an initial cleanup command is run, regardless of whether or not there are any impacted rows, which is fairly time consuming.

These changes improve performance here in two ways:
1) For unpartitioned assets, the `TRUNCATE` command is used for the cleanup statement, which has the same overall effect but is far cheaper to run (even on empty tables). This also does not require a snowflake warehouse to run which is a bonus.

2) For partitioned assets, a `COUNT(*)` type command is first run to ensure that the delete command is necessary (i.e. that there are some rows affected), and only executes if needed. There is a slight trade off here in that if the delete is necessary, you've added some small overhead, but IMO it is a worthwhile tradeoff.

## How I Tested These Changes
Tested locally on a partitioned and unpartitioned table. Ran pytest.