### PR TITLE
Properly subset external pipeline in auto run retries

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/utils.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/utils.py
@@ -16,9 +16,15 @@ def do_something():
     pass
 
 
+@op
+def do_something_else():
+    pass
+
+
 @job
 def foo():
     do_something()
+    do_something_else()
 
 
 @repository

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -145,6 +145,8 @@ def create_run_for_test(
     parent_pipeline_snapshot=None,
     external_pipeline_origin=None,
     pipeline_code_origin=None,
+    asset_selection=None,
+    solid_selection=None,
 ):
     return instance.create_run(
         pipeline_name=pipeline_name,
@@ -162,8 +164,8 @@ def create_run_for_test(
         parent_pipeline_snapshot=parent_pipeline_snapshot,
         external_pipeline_origin=external_pipeline_origin,
         pipeline_code_origin=pipeline_code_origin,
-        asset_selection=None,
-        solid_selection=None,
+        asset_selection=asset_selection,
+        solid_selection=solid_selection,
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -2,6 +2,7 @@ import sys
 from typing import Iterator, Optional, Sequence, Tuple, cast
 
 from dagster._core.definitions.metadata import MetadataValue
+from dagster._core.definitions.selector import PipelineSelector
 from dagster._core.events import EngineEventData
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
@@ -119,7 +120,17 @@ def retry_run(
         )
         return
 
-    external_pipeline = external_repo.get_full_external_job(failed_run.pipeline_name)
+    external_pipeline = code_location.get_external_pipeline(
+        PipelineSelector(
+            location_name=origin.code_location_origin.location_name,
+            repository_name=repo_name,
+            pipeline_name=failed_run.pipeline_name,
+            solid_selection=failed_run.solid_selection,
+            asset_selection=None
+            if failed_run.asset_selection is None
+            else list(failed_run.asset_selection),
+        )
+    )
 
     strategy = get_reexecution_strategy(failed_run, instance) or DEFAULT_REEXECUTION_POLICY
 


### PR DESCRIPTION
Got the local repro thanks to @sryza, and verified that this fixed it. 

Will also have to apply the fix in cloud since the daemons are forked (maybe I'll take a look at refactoring)