### PR TITLE
Remove parentPipelineSnapshotId field from runs queries

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
@@ -26,9 +26,9 @@ export type RunReExecutionQuery = {
         pipelineName: string;
         solidSelection: Array<string> | null;
         pipelineSnapshotId: string | null;
-        parentPipelineSnapshotId: string | null;
         stepKeysToExecute: Array<string> | null;
         updateTime: number | null;
+        parentPipelineSnapshotId: string | null;
         startTime: number | null;
         endTime: number | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
@@ -56,7 +56,6 @@ export type LaunchedRunListQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
@@ -36,7 +36,6 @@ export type PartitionRunListQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -38,7 +38,6 @@ export type PipelineRunsRootQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -51,7 +51,6 @@ export const RUN_FRAGMENT = gql`
       }
     }
     pipelineSnapshotId
-    parentPipelineSnapshotId
     executionPlan {
       artifactsPersisted
       ...ExecutionPlanToGraphFragment

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -181,7 +181,6 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
     rootRunId
     parentRunId
     pipelineSnapshotId
-    parentPipelineSnapshotId
     pipelineName
     repositoryOrigin {
       id

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
@@ -24,9 +24,9 @@ export type RunActionButtonsTestQuery = {
         pipelineName: string;
         solidSelection: Array<string> | null;
         pipelineSnapshotId: string | null;
-        parentPipelineSnapshotId: string | null;
         stepKeysToExecute: Array<string> | null;
         updateTime: number | null;
+        parentPipelineSnapshotId: string | null;
         startTime: number | null;
         endTime: number | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
@@ -32,9 +32,9 @@ export type RunFragment = {
   pipelineName: string;
   solidSelection: Array<string> | null;
   pipelineSnapshotId: string | null;
-  parentPipelineSnapshotId: string | null;
   stepKeysToExecute: Array<string> | null;
   updateTime: number | null;
+  parentPipelineSnapshotId: string | null;
   startTime: number | null;
   endTime: number | null;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
@@ -26,9 +26,9 @@ export type RunRootQuery = {
         pipelineName: string;
         solidSelection: Array<string> | null;
         pipelineSnapshotId: string | null;
-        parentPipelineSnapshotId: string | null;
         stepKeysToExecute: Array<string> | null;
         updateTime: number | null;
+        parentPipelineSnapshotId: string | null;
         startTime: number | null;
         endTime: number | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;

--- a/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
@@ -16,7 +16,6 @@ export type RunTableRunFragment = {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
-  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   solidSelection: Array<string> | null;
   startTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
@@ -38,7 +38,6 @@ export type RunsRootQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -137,7 +137,6 @@ export type PreviousRunsForScheduleQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -28,7 +28,6 @@ export type PreviousRunsForSensorQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;


### PR DESCRIPTION
Summary:
This field requires fetching the pipeline snapshot from storage for each run, which can be expensive if the job has many assets.

The one place it was being used appears to be to detect a case that seems pretty edge-casey to me and not worth slowing down the whole UI - the pipeline snapshot but the repository origin not matching (maybe after doing a repo rename?) Curious what reviewers think about just taking that out.

Test Plan: Load runs page on a deployment with large pipeline snapshots - runs page now loads in under a second instead of 5-15 seconds

## Summary & Motivation

## How I Tested These Changes
