### PR TITLE
[ui] Clear old Launchpad sessions when localStorage quota is reached

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagit/packages/core/src/app/ExecutionSessionStorage.tsx
@@ -1,3 +1,4 @@
+import memoize from 'lodash/memoize';
 import * as React from 'react';
 
 import {AssetKeyInput} from '../graphql/types';
@@ -139,10 +140,6 @@ const buildValidator = (initial: Partial<IExecutionSession> = {}) => (json: any)
 export const makeKey = (basePath: string, repoAddress: RepoAddress, pipelineOrJobName: string) =>
   `dagit.v2.${basePath}-${repoAddress.location}-${repoAddress.name}-${pipelineOrJobName}`;
 
-export const makeOldKey = (repoAddress: RepoAddress, pipelineOrJobName: string) =>
-  `dagit.v2.${repoAddress.name}.${pipelineOrJobName}`;
-
-// todo DPE: Clean up the migration logic.
 export function useExecutionSessionStorage(
   repoAddress: RepoAddress,
   pipelineOrJobName: string,
@@ -151,7 +148,6 @@ export function useExecutionSessionStorage(
   const {basePath} = React.useContext(AppContext);
 
   const key = makeKey(basePath, repoAddress, pipelineOrJobName);
-  const oldKey = makeOldKey(repoAddress, pipelineOrJobName);
 
   // Bind the validator function to the provided `initial` value. Convert to a JSON string
   // because we can't trust that the `initial` object is memoized.
@@ -160,23 +156,11 @@ export function useExecutionSessionStorage(
     () => buildValidator(JSON.parse(initialAsJSON) as Partial<IExecutionSession>),
     [initialAsJSON],
   );
-  const [newState, setNewState] = useStateWithStorage(key, validator);
 
-  // Read stored value for the old key. If a value is present, we will use it
-  // for the new key, then remove the old key entirely.
-  const oldValidator = React.useCallback((json: any) => json, []);
-  const [oldState, setOldState] = useStateWithStorage(oldKey, oldValidator);
+  const [state, setState] = useStateWithStorage(key, validator);
+  const wrappedSetState = writeLaunchpadSessionToStorage(setState);
 
-  React.useEffect(() => {
-    if (oldState) {
-      setNewState(oldState);
-
-      // Delete data at old key.
-      setOldState(undefined);
-    }
-  }, [oldState, setNewState, setOldState]);
-
-  return [newState, setNewState];
+  return [state, wrappedSetState];
 }
 
 const writeStorageDataForKey = (key: string, data: IStorageData) => {
@@ -255,4 +239,96 @@ export const useInitialDataForMode = (
 
     return {};
   }, [isAssetJob, isJob, partitionSetsForMode, presets]);
+};
+
+export const allStoredSessions = () => {
+  const storedSessions: [sessionID: string, jobKey: string][] = [];
+  for (let ii = 0; ii < window.localStorage.length; ii++) {
+    const key = window.localStorage.key(ii);
+    if (key) {
+      const value = window.localStorage.getItem(key);
+      if (value) {
+        let parsed;
+
+        // If it's not a parseable object, it's not a launchpad session.
+        try {
+          parsed = JSON.parse(value);
+        } catch (e) {
+          continue;
+        }
+
+        if (
+          parsed &&
+          typeof parsed === 'object' &&
+          parsed.hasOwnProperty('current') &&
+          parsed.hasOwnProperty('sessions')
+        ) {
+          const sessionIDs = Object.keys(parsed.sessions);
+          storedSessions.push(
+            ...sessionIDs.map((sessionID) => [key, sessionID] as [string, string]),
+          );
+        }
+      }
+    }
+  }
+
+  // Order the list of sessions by timestamp.
+  storedSessions.sort(([_aKey, sessionA], [_bKey, sessionB]) => {
+    const timeA = parseInt(sessionA.slice(1), 10);
+    const timeB = parseInt(sessionB.slice(1), 10);
+    return timeA - timeB;
+  });
+
+  return storedSessions;
+};
+
+export const removeSession = (jobKey: string, sessionID: string) => {
+  const item = window.localStorage.getItem(jobKey);
+  if (item) {
+    const data = JSON.parse(item);
+    const updated = applyRemoveSession(data, sessionID);
+    window.localStorage.setItem(jobKey, JSON.stringify(updated));
+  }
+};
+
+export const MAX_SESSION_WRITE_ATTEMPTS = 10;
+
+/**
+ * Try to write this launchpad session to storage. If a quota error occurs because the
+ * user has too much data already in localStorage, clear out old sessions until the
+ * write is successful or we run out of retries.
+ */
+export const writeLaunchpadSessionToStorage = (
+  setState: React.Dispatch<React.SetStateAction<IStorageData | undefined>>,
+) => (data: IStorageData) => {
+  const tryWrite = (data: IStorageData) => {
+    try {
+      setState(data);
+      return true;
+    } catch (e) {
+      // The data could not be written to localStorage. This is probably due to
+      // a QuotaExceededError, but since different browsers use slightly different
+      // objects for this, we don't try to get clever detecting it.
+      return false;
+    }
+  };
+
+  const getInitiallyStoredSessions = memoize(() => allStoredSessions());
+
+  // Track the number of attempts at writing this session to localStorage so that
+  // we eventually give up and don't loop endlessly.
+  let attempts = 1;
+
+  // Attempt to write the session to storage. If an error occurs, delete the oldest
+  // session and try again.
+  while (!tryWrite(data) && attempts < MAX_SESSION_WRITE_ATTEMPTS) {
+    attempts++;
+
+    // Remove the oldest session and try again.
+    const toRemove = getInitiallyStoredSessions().shift();
+    if (toRemove) {
+      const [jobKey, sessionID] = toRemove;
+      removeSession(jobKey, sessionID);
+    }
+  }
 };

--- a/js_modules/dagit/packages/core/src/app/__tests__/ExecutionSessionStorage.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/__tests__/ExecutionSessionStorage.test.tsx
@@ -3,21 +3,20 @@ import * as React from 'react';
 
 import {
   IExecutionSession,
-  makeKey,
-  makeOldKey,
+  IStorageData,
+  MAX_SESSION_WRITE_ATTEMPTS,
+  allStoredSessions,
+  removeSession,
   useExecutionSessionStorage,
+  writeLaunchpadSessionToStorage,
 } from '../ExecutionSessionStorage';
 
 describe('ExecutionSessionStorage', () => {
-  const BASE_PATH = '';
   const REPO_ADDRESS = {
     name: 'test-name',
     location: 'test-location',
   };
   const JOB_NAME = 'test-job';
-
-  const oldKey = makeOldKey(REPO_ADDRESS, JOB_NAME);
-  const newKey = makeKey(BASE_PATH, REPO_ADDRESS, JOB_NAME);
 
   const TestComponent = (props: {initial?: Partial<IExecutionSession>}) => {
     const [data] = useExecutionSessionStorage(REPO_ADDRESS, JOB_NAME, props.initial);
@@ -31,30 +30,6 @@ describe('ExecutionSessionStorage', () => {
 
   beforeEach(() => {
     window.localStorage.clear();
-  });
-
-  describe('Migration', () => {
-    it('Migrates old localStorage data from old format', async () => {
-      const testData = {sessions: {test: 'test'}, current: 'test'};
-      window.localStorage.setItem(oldKey, JSON.stringify(testData));
-
-      const {rerender} = render(<TestComponent />);
-
-      await waitFor(() => {
-        expect(screen.queryByText(/current: test/i)).toBeVisible();
-      });
-
-      // Data is at the new key, and the old key is deleted.
-      expect(JSON.parse(window.localStorage.getItem(newKey) as any)).toEqual(testData);
-      expect(window.localStorage.getItem(oldKey)).toEqual(null);
-
-      // Render it again, expect the data to still be there.
-      rerender(<TestComponent />);
-
-      // Data is at the new key, and the old key remains deleted.
-      expect(JSON.parse(window.localStorage.getItem(newKey) as any)).toEqual(testData);
-      expect(window.localStorage.getItem(oldKey)).toEqual(null);
-    });
   });
 
   describe('Initialization', () => {
@@ -148,6 +123,169 @@ describe('ExecutionSessionStorage', () => {
 
       const storedObjectC = storedObject;
       expect(storedObjectC).toBe(storedObjectA);
+    });
+  });
+
+  describe('localStorage management', () => {
+    beforeEach(() => {
+      window.localStorage.setItem(
+        'abc',
+        JSON.stringify({current: 's0', sessions: {s0: {runConfigYaml: 'foo bar'}}}),
+      );
+
+      window.localStorage.setItem(
+        'def',
+        JSON.stringify({
+          current: 's2',
+          sessions: {s2: {runConfigYaml: 'bar baz'}, s5: {runConfigYaml: 'bar baz borp'}},
+        }),
+      );
+
+      window.localStorage.setItem(
+        'ghi',
+        JSON.stringify({
+          current: 's1',
+          sessions: {
+            s8: {runConfigYaml: 'bar baz derp'},
+            s1: {runConfigYaml: 'gorp baz'},
+            s10: {runConfigYaml: 'gorp baz'},
+          },
+        }),
+      );
+
+      window.localStorage.setItem('not-a-session', '1234');
+      window.localStorage.setItem('my-boolean', 'true');
+    });
+
+    describe('allStoredSessions', () => {
+      it('retrieves tuples for all stored sessions, ordered by session recency', () => {
+        const tuples = allStoredSessions();
+        expect(tuples).toEqual([
+          ['abc', 's0'],
+          ['ghi', 's1'],
+          ['def', 's2'],
+          ['def', 's5'],
+          ['ghi', 's8'],
+          ['ghi', 's10'],
+        ]);
+      });
+    });
+
+    describe('removeSession', () => {
+      it('removes sessions from storage', () => {
+        removeSession('abc', 's0');
+        expect(window.localStorage.getItem('abc')).toBe('{"sessions":{}}');
+
+        expect(() => {
+          removeSession('nothing', 's2');
+        }).not.toThrow();
+
+        removeSession('def', 's2');
+        expect(window.localStorage.getItem('def')).toBe(
+          '{"current":"s5","sessions":{"s5":{"runConfigYaml":"bar baz borp"}}}',
+        );
+      });
+    });
+
+    describe('Handle quota error', () => {
+      it('Clears old sessions when encountering a quota error', () => {
+        const mockSetter = jest
+          .fn()
+          .mockImplementationOnce(() => {
+            throw new Error('Quota error!');
+          })
+          .mockImplementationOnce(() => {
+            throw new Error('Quota error!');
+          })
+          .mockImplementation((data: IStorageData) => {
+            window.localStorage.setItem('xyz', JSON.stringify(data));
+            return true;
+          });
+
+        expect(allStoredSessions()).toEqual([
+          ['abc', 's0'],
+          ['ghi', 's1'],
+          ['def', 's2'],
+          ['def', 's5'],
+          ['ghi', 's8'],
+          ['ghi', 's10'],
+        ]);
+
+        const writeSession = writeLaunchpadSessionToStorage(mockSetter);
+
+        writeSession({
+          current: 's100',
+          sessions: {
+            s100: {
+              key: 'abc',
+              name: 'abc',
+              base: null,
+              mode: 'default',
+              needsRefresh: false,
+              assetSelection: null,
+              solidSelection: null,
+              solidSelectionQuery: '*',
+              flattenGraphs: false,
+              configChangedSinceRun: false,
+              tags: [],
+              runConfigYaml: 'new stuff',
+            },
+          },
+        });
+
+        expect(mockSetter).toHaveBeenCalled();
+
+        // The loop has removed the two oldest sessions, then added in the newest.
+        expect(allStoredSessions()).toEqual([
+          ['def', 's2'],
+          ['def', 's5'],
+          ['ghi', 's8'],
+          ['ghi', 's10'],
+          ['xyz', 's100'],
+        ]);
+      });
+
+      it('Eventually gives up trying to write the session, avoiding an unexpected infinite loop', () => {
+        const mockSetter = jest.fn().mockImplementation(() => {
+          throw new Error('Quota error!');
+        });
+
+        expect(allStoredSessions()).toEqual([
+          ['abc', 's0'],
+          ['ghi', 's1'],
+          ['def', 's2'],
+          ['def', 's5'],
+          ['ghi', 's8'],
+          ['ghi', 's10'],
+        ]);
+
+        const writeSession = writeLaunchpadSessionToStorage(mockSetter);
+
+        writeSession({
+          current: 's100',
+          sessions: {
+            s100: {
+              key: 'abc',
+              name: 'abc',
+              base: null,
+              mode: 'default',
+              needsRefresh: false,
+              assetSelection: null,
+              solidSelection: null,
+              solidSelectionQuery: '*',
+              flattenGraphs: false,
+              configChangedSinceRun: false,
+              tags: [],
+              runConfigYaml: 'new stuff',
+            },
+          },
+        });
+
+        expect(mockSetter).toHaveBeenCalledTimes(MAX_SESSION_WRITE_ATTEMPTS);
+
+        // The loop has correctly removed all of the sessions.
+        expect(allStoredSessions()).toEqual([]);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary & Motivation

Make an attempt to clean up old launchpad sessions when a user encounters a localStorage write error, since this most likely indicates that the localStorage quota has been reached. Sort the existing stored sessions by timestamp, and delete them until the write succeeds.

## How I Tested These Changes

Jest.

Load launchpad, verify that sessions are correctly written to localStorage (and updated correctly) in the normal case.
