### PR TITLE
Support `resource_defs` with `graph_asset` and `graph_multi_asset`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -669,6 +669,7 @@ def graph_asset(
     group_name: Optional[str] = None,
     metadata: Optional[MetadataUserInput] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
+    resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Creates a software-defined asset that's computed using a graph of ops.
 
@@ -722,6 +723,7 @@ def graph_asset(
             group_name=group_name,
             metadata=metadata,
             freshness_policy=freshness_policy,
+            resource_defs=resource_defs,
         )(fn)
 
     return inner
@@ -738,6 +740,7 @@ class _GraphBackedAsset:
         group_name: Optional[str] = None,
         metadata: Optional[MetadataUserInput] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
+        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     ):
         self.name = name
 
@@ -750,6 +753,7 @@ class _GraphBackedAsset:
         self.group_name = group_name
         self.metadata = metadata
         self.freshness_policy = freshness_policy
+        self.resource_defs = resource_defs
 
     def __call__(self, fn: Callable) -> AssetsDefinition:
         asset_name = self.name or fn.__name__
@@ -780,6 +784,7 @@ class _GraphBackedAsset:
             if self.freshness_policy
             else None,
             descriptions_by_output_name={"result": self.description} if self.description else None,
+            resource_defs=self.resource_defs,
         )
 
 
@@ -791,6 +796,7 @@ def graph_multi_asset(
     partitions_def: Optional[PartitionsDefinition[object]] = None,
     group_name: Optional[str] = None,
     can_subset: bool = False,
+    resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same graph of
     ops, and the same upstream assets.
@@ -862,6 +868,7 @@ def graph_multi_asset(
             metadata_by_output_name=metadata_by_output_name,
             freshness_policies_by_output_name=freshness_policies_by_output_name,
             descriptions_by_output_name=descriptions_by_output_name,
+            resource_defs=resource_defs,
         )
 
     return inner

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -826,6 +826,10 @@ def test_graph_asset_decorator_no_args():
 
 
 def test_graph_asset_with_args():
+    @resource
+    def foo_resource():
+        pass
+
     @op
     def my_op1(x):
         return x
@@ -838,6 +842,7 @@ def test_graph_asset_with_args():
         group_name="group1",
         metadata={"my_metadata": "some_metadata"},
         freshness_policy=FreshnessPolicy(maximum_lag_minutes=5),
+        resource_defs={"foo": foo_resource},
     )
     def my_asset(x):
         return my_op2(my_op1(x))
@@ -847,6 +852,7 @@ def test_graph_asset_with_args():
     assert my_asset.freshness_policies_by_key[AssetKey("my_asset")] == FreshnessPolicy(
         maximum_lag_minutes=5
     )
+    assert my_asset.resource_defs['foo'] == foo_resource
 
 
 def test_graph_asset_partitioned():
@@ -916,6 +922,10 @@ def test_graph_asset_w_key_prefix():
 
 
 def test_graph_multi_asset_decorator():
+    @resource
+    def foo_resource():
+        pass
+
     @op(out={"one": Out(), "two": Out()})
     def two_in_two_out(context, in1, in2):
         assert context.asset_key_for_input("in1") == AssetKey("x")
@@ -930,6 +940,7 @@ def test_graph_multi_asset_decorator():
             "second_asset": AssetOut(freshness_policy=FreshnessPolicy(maximum_lag_minutes=5)),
         },
         group_name="grp",
+        resource_defs={"foo": foo_resource},
     )
     def two_assets(x, y):
         one, two = two_in_two_out(x, y)
@@ -947,6 +958,7 @@ def test_graph_multi_asset_decorator():
     assert two_assets.freshness_policies_by_key[AssetKey("second_asset")] == FreshnessPolicy(
         maximum_lag_minutes=5
     )
+    assert two_assets.resource_defs['foo'] == foo_resource
 
     @asset
     def x():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -852,7 +852,7 @@ def test_graph_asset_with_args():
     assert my_asset.freshness_policies_by_key[AssetKey("my_asset")] == FreshnessPolicy(
         maximum_lag_minutes=5
     )
-    assert my_asset.resource_defs['foo'] == foo_resource
+    assert my_asset.resource_defs["foo"] == foo_resource
 
 
 def test_graph_asset_partitioned():
@@ -958,7 +958,7 @@ def test_graph_multi_asset_decorator():
     assert two_assets.freshness_policies_by_key[AssetKey("second_asset")] == FreshnessPolicy(
         maximum_lag_minutes=5
     )
-    assert two_assets.resource_defs['foo'] == foo_resource
+    assert two_assets.resource_defs["foo"] == foo_resource
 
     @asset
     def x():


### PR DESCRIPTION
## Summary & Motivation

`graph_asset` and `graph_multi_asset` did not support the `resource_defs` paramter that `AssetsDefinition` exposes.
This PR adds the above support.

🚀 feat(asset_decorator): add resource_defs parameter to graph_asset and graph_multi_asset
This change adds a new optional parameter `resource_defs` to the `graph_asset` and `graph_multi_asset` decorators. This parameter allows users to specify a dictionary of resource definitions that will be available to the ops in the graph.

🧪 test(asset_decorator): add tests for resource_defs parameter 
This change adds tests for the new `resource_defs` parameter in the `graph_asset` and `graph_multi_asset` decorators. The tests ensure that the resource definitions are correctly passed to the `AssetsDefinition` object.

## How I Tested These Changes

Updated test files, and used a local project to ensure I was not getting errors.
If there is another step you'd like me to take I'd be happy to :)

Let me know if there is anything else you need me to do!

<3 Kyle