### PR TITLE
[dagster_gcp] BigQuery resource upgraded to pydantic config

### DIFF
--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -588,15 +588,12 @@ from dagster import Definitions, asset
 @asset
 def small_petals(bigquery: BigQueryResource):
     with bigquery.get_client() as client:
-        return (
-            client.query(
-                (
-                    'SELECT * FROM IRIS.IRIS_DATA WHERE "Petal length (cm)" < 1 AND "Petal'
-                    ' width (cm)" < 1'
-                ),
-            )
-            .result()
-        )
+        return client.query(
+            (
+                'SELECT * FROM IRIS.IRIS_DATA WHERE "Petal length (cm)" < 1 AND "Petal'
+                ' width (cm)" < 1'
+            ),
+        ).result()
 
 
 defs = Definitions(

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -588,15 +588,12 @@ from dagster import Definitions, asset
 @asset
 def small_petals(bigquery: BigQueryResource):
     with bigquery.get_client() as client:
-        return (
-            client.query(
-                (
-                    'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
-                    ' "petal_width_cm" < 1'
-                ),
-            )
-            .result()
-        )
+        return client.query(
+            (
+                'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
+                ' "petal_width_cm" < 1'
+            ),
+        ).result()
 
 
 defs = Definitions(

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -588,12 +588,15 @@ from dagster import Definitions, asset
 @asset
 def small_petals(bigquery: BigQueryResource):
     with bigquery.get_client() as client:
-        return client.query(
-            (
-                'SELECT * FROM IRIS.IRIS_DATA WHERE "Petal length (cm)" < 1 AND "Petal'
-                ' width (cm)" < 1'
-            ),
-        ).result()
+        return (
+            client.query(
+                (
+                    'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
+                    ' "petal_width_cm" < 1'
+                ),
+            )
+            .result()
+        )
 
 
 defs = Definitions(

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -577,7 +577,7 @@ defs = Definitions(
 In addition to the BigQuery I/O manager, Dagster also provides a BigQuery [resource](/concepts/resources) for executing custom SQL queries.
 
 ```python file=/integrations/bigquery/resource.py
-from dagster_gcp import bigquery_resource
+from dagster_gcp import BigQueryResource
 
 from dagster import Definitions, asset
 
@@ -585,24 +585,26 @@ from dagster import Definitions, asset
 # Using Dagster with BigQuery tutorial
 
 
-@asset(required_resource_keys={"bigquery"})
-def small_petals(context):
-    return context.resources.bigquery.query(
-        (
-            'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
-            ' "petal_width_cm" < 1'
-        ),
-    ).result()
+@asset()
+def small_petals(bigquery: BigQueryResource):
+    return (
+        bigquery.get_client()
+        .query(
+            (
+                'SELECT * FROM IRIS.IRIS_DATA WHERE "Petal length (cm)" < 1 AND "Petal'
+                ' width (cm)" < 1'
+            ),
+        )
+        .result()
+    )
 
 
 defs = Definitions(
     assets=[small_petals],
     resources={
-        "bigquery": bigquery_resource.configured(
-            {
-                "project": "my-gcp-project",
-                "location": "us-east5",
-            }
+        "bigquery": BigQueryResource(
+            project="my-gcp-project",
+            location="us-east5",
         )
     },
 )

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -585,18 +585,18 @@ from dagster import Definitions, asset
 # Using Dagster with BigQuery tutorial
 
 
-@asset()
+@asset
 def small_petals(bigquery: BigQueryResource):
-    return (
-        bigquery.get_client()
-        .query(
-            (
-                'SELECT * FROM IRIS.IRIS_DATA WHERE "Petal length (cm)" < 1 AND "Petal'
-                ' width (cm)" < 1'
-            ),
+    with bigquery.get_client() as client:
+        return (
+            client.query(
+                (
+                    'SELECT * FROM IRIS.IRIS_DATA WHERE "Petal length (cm)" < 1 AND "Petal'
+                    ' width (cm)" < 1'
+                ),
+            )
+            .result()
         )
-        .result()
-    )
 
 
 defs = Definitions(

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/resource.py
@@ -9,15 +9,12 @@ from dagster import Definitions, asset
 @asset
 def small_petals(bigquery: BigQueryResource):
     with bigquery.get_client() as client:
-        return (
-            client.query(
-                (
-                    'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
-                    ' "petal_width_cm" < 1'
-                ),
-            )
-            .result()
-        )
+        return client.query(
+            (
+                'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
+                ' "petal_width_cm" < 1'
+            ),
+        ).result()
 
 
 defs = Definitions(

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/resource.py
@@ -6,7 +6,7 @@ from dagster import Definitions, asset
 # Using Dagster with BigQuery tutorial
 
 
-@asset()
+@asset
 def small_petals(bigquery: BigQueryResource):
     with bigquery.get_client() as client:
         return (

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/resource.py
@@ -1,4 +1,4 @@
-from dagster_gcp import bigquery_resource
+from dagster_gcp import BigQueryResource
 
 from dagster import Definitions, asset
 
@@ -6,24 +6,26 @@ from dagster import Definitions, asset
 # Using Dagster with BigQuery tutorial
 
 
-@asset(required_resource_keys={"bigquery"})
-def small_petals(context):
-    return context.resources.bigquery.query(
-        (
-            'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
-            ' "petal_width_cm" < 1'
-        ),
-    ).result()
+@asset()
+def small_petals(bigquery: BigQueryResource):
+    with bigquery.get_client() as client:
+        return (
+            client.query(
+                (
+                    'SELECT * FROM IRIS.IRIS_DATA WHERE "petal_length_cm" < 1 AND'
+                    ' "petal_width_cm" < 1'
+                ),
+            )
+            .result()
+        )
 
 
 defs = Definitions(
     assets=[small_petals],
     resources={
-        "bigquery": bigquery_resource.configured(
-            {
-                "project": "my-gcp-project",
-                "location": "us-east5",
-            }
+        "bigquery": BigQueryResource(
+            project="my-gcp-project",
+            location="us-east5",
         )
     },
 )

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
@@ -12,7 +12,10 @@ from .bigquery.ops import (
     import_file_to_bq as import_file_to_bq,
     import_gcs_paths_to_bq as import_gcs_paths_to_bq,
 )
-from .bigquery.resources import bigquery_resource as bigquery_resource
+from .bigquery.resources import (
+    BigQueryResource as BigQueryResource,
+    bigquery_resource as bigquery_resource,
+)
 from .bigquery.types import BigQueryError as BigQueryError
 from .dataproc.ops import dataproc_op as dataproc_op
 from .dataproc.resources import dataproc_resource as dataproc_resource

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/configs.py
@@ -4,7 +4,7 @@ See the BigQuery Python API documentation for reference:
     https://googleapis.github.io/google-cloud-python/latest/bigquery/reference.html
 """
 
-from dagster import Array, Bool, Field, IntSource, Noneable, String, StringSource
+from dagster import Array, Bool, Field, IntSource, String, StringSource
 
 from .types import (
     BQCreateDisposition,
@@ -16,37 +16,6 @@ from .types import (
     Dataset,
     Table,
 )
-
-
-def bq_resource_config():
-    project = Field(
-        StringSource,
-        description="""Project ID for the project which the client acts on behalf of. Will be passed
-        when creating a dataset / job. If not passed, falls back to the default inferred from the
-        environment.""",
-        is_required=False,
-    )
-
-    location = Field(
-        StringSource,
-        description="(Optional) Default location for jobs / datasets / tables.",
-        is_required=False,
-    )
-
-    gcp_credentials = Field(
-        Noneable(StringSource),
-        is_required=False,
-        default_value=None,
-        description=(
-            "GCP authentication credentials. If provided, a temporary file will be created"
-            " with the credentials and GOOGLE_APPLICATION_CREDENTIALS will be set to the"
-            " temporary file. To avoid issues with newlines in the keys, you must base64"
-            " encode the key. You can retrieve the base64 encoded key with this shell"
-            " command: cat $GOOGLE_AUTH_CREDENTIALS | base64"
-        ),
-    )
-
-    return {"project": project, "location": location, "gcp_credentials": gcp_credentials}
 
 
 def _define_shared_fields():

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,4 +1,5 @@
-from typing import Generator, Optional
+from typing import Optional, Iterator
+from contextlib import contextmanager
 
 from dagster import ConfigurableResource, resource
 from google.cloud import bigquery
@@ -31,7 +32,8 @@ class BigQueryResource(ConfigurableResource):
         ),
     )
 
-    def get_client(self) -> Generator:
+    @contextmanager
+    def get_client(self) -> Iterator[bigquery.Client]:
         if self.gcp_credentials:
             with setup_gcp_creds(self.gcp_credentials):
                 yield bigquery.Client(project=self.project, location=self.location)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -54,4 +54,6 @@ class BigQueryResource(ConfigurableResource):
     description="Dagster resource for connecting to BigQuery",
 )
 def bigquery_resource(context):
-    return BigQueryResource.from_resource_context(context).get_client()
+    bq_resource = BigQueryResource.from_resource_context(context)
+    with bq_resource.setup_credentials():
+        yield bq_resource.get_client()

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,20 +1,51 @@
-from dagster import resource
-from google.cloud import bigquery
+from typing import Generator, Optional
 
-from .configs import bq_resource_config
+from dagster import resource
+from dagster._config.structured_config import (
+    ConfigurableResourceFactory,
+    infer_schema_from_config_class,
+)
+from google.cloud import bigquery
+from pydantic import Field
+
 from .utils import setup_gcp_creds
 
 
+class BigQueryResource(ConfigurableResourceFactory):
+    project: Optional[str] = Field(
+        default=None,
+        description="""Project ID for the project which the client acts on behalf of. Will be passed
+        when creating a dataset / job. If not passed, falls back to the default inferred from the
+        environment.""",
+    )
+
+    location: Optional[str] = Field(
+        default=None,
+        description="Default location for jobs / datasets / tables.",
+    )
+
+    gcp_credentials: Optional[str] = Field(
+        default=None,
+        description=(
+            "GCP authentication credentials. If provided, a temporary file will be created"
+            " with the credentials and GOOGLE_APPLICATION_CREDENTIALS will be set to the"
+            " temporary file. To avoid issues with newlines in the keys, you must base64"
+            " encode the key. You can retrieve the base64 encoded key with this shell"
+            " command: cat $GOOGLE_AUTH_CREDENTIALS | base64"
+        ),
+    )
+
+    def create_resource(self, context) -> Generator:
+        if self.gcp_credentials:
+            with setup_gcp_creds(self.gcp_credentials):
+                yield bigquery.Client(project=self.project, location=self.location)
+        else:
+            yield bigquery.Client(project=self.project, location=self.location)
+
+
 @resource(
-    config_schema=bq_resource_config(), description="Dagster resource for connecting to BigQuery"
+    config_schema=infer_schema_from_config_class(BigQueryResource),
+    description="Dagster resource for connecting to BigQuery",
 )
 def bigquery_resource(context):
-    no_creds_config = {
-        key: value for key, value in context.resource_config.items() if key != "gcp_credentials"
-    }
-
-    if context.resource_config.get("gcp_credentials"):
-        with setup_gcp_creds(context.resource_config.get("gcp_credentials")):
-            yield bigquery.Client(**no_creds_config)
-    else:
-        yield bigquery.Client(**no_creds_config)
+    return BigQueryResource.from_resource_context(context)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,14 +1,14 @@
 from contextlib import contextmanager
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
-from dagster import ConfigurableResource, resource
+from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
 from google.cloud import bigquery
 from pydantic import Field
 
 from .utils import setup_gcp_creds
 
 
-class BigQueryResource(ConfigurableResource):
+class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
     """Resource for interacting with Google BigQuery.
 
     Examples:
@@ -74,6 +74,10 @@ class BigQueryResource(ConfigurableResource):
 
         else:
             yield bigquery.Client(project=self.project, location=self.location)
+
+    def get_object_to_set_on_execution_context(self) -> Any:
+        with self.get_client() as client:
+            yield client
 
 
 @resource(

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -32,9 +32,11 @@ class BigQueryResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
 
     project: Optional[str] = Field(
         default=None,
-        description="""Project ID for the project which the client acts on behalf of. Will be passed
-        when creating a dataset / job. If not passed, falls back to the default inferred from the
-        environment.""",
+        description=(
+            "Project ID for the project which the client acts on behalf of. Will be passed when"
+            " creating a dataset / job. If not passed, falls back to the default inferred from the"
+            " environment."
+        ),
     )
 
     location: Optional[str] = Field(

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,5 +1,5 @@
-from typing import Optional, Iterator
 from contextlib import contextmanager
+from typing import Iterator, Optional
 
 from dagster import ConfigurableResource, resource
 from google.cloud import bigquery

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/resources.py
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 from typing import Optional, Iterator
 from contextlib import contextmanager
+=======
+from contextlib import contextmanager
+from typing import Optional
+>>>>>>> c19b0a3426 (working...)
 
 from dagster import ConfigurableResource, resource
 from google.cloud import bigquery
@@ -36,9 +41,12 @@ class BigQueryResource(ConfigurableResource):
     def get_client(self) -> Iterator[bigquery.Client]:
         if self.gcp_credentials:
             with setup_gcp_creds(self.gcp_credentials):
-                yield bigquery.Client(project=self.project, location=self.location)
+                yield
         else:
-            yield bigquery.Client(project=self.project, location=self.location)
+            yield
+
+    def get_client(self) -> bigquery.Client:
+        return bigquery.Client(project=self.project, location=self.location)
 
 
 @resource(

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
@@ -97,7 +97,7 @@ def test_pythonic_resource_authenticate_via_config():
 def test_pythonic_resource_authenticate_via_env():
     @asset
     def test_asset(bigquery: BigQueryResource) -> int:
-        with bigquery.setup_credentials():
+        with bigquery.get_client():
             assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None
             return 1
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
@@ -9,7 +9,7 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
-def test_authenticate_via_config():
+def test_old_resource_authenticate_via_config():
     asset_info = dict()
 
     @asset(required_resource_keys={"bigquery"})
@@ -27,32 +27,67 @@ def test_authenticate_via_config():
         with open(old_gcp_creds_file, "r") as f:
             gcp_creds = f.read()
 
-        resources = [
-            BigQueryResource(
-                project=EnvVar("GCP_PROJECT_ID"),
-                gcp_credentials=base64.b64encode(str.encode(gcp_creds)).decode(),
-            ),
-            bigquery_resource.configured(
+        resource_defs = {
+            "bigquery": bigquery_resource.configured(
                 {
                     "project": os.getenv("GCP_PROJECT_ID"),
                     "gcp_credentials": base64.b64encode(str.encode(gcp_creds)).decode(),
                 }
-            ),
-        ]
-
-        for r in resources:
-            resource_defs = {"bigquery": r}
-
-            assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
-
-            result = materialize(
-                [test_asset],
-                resources=resource_defs,
             )
-            passed = result.success
+        }
 
-            assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
-            assert not os.path.exists(asset_info["gcp_creds_file"])
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
+
+        result = materialize(
+            [test_asset],
+            resources=resource_defs,
+        )
+        passed = result.success
+
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
+        assert not os.path.exists(asset_info["gcp_creds_file"])
+    finally:
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = old_gcp_creds_file
+        assert passed
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
+def test_pythonic_resource_authenticate_via_config():
+    asset_info = dict()
+
+    @asset
+    def test_asset(bigquery: BigQueryResource) -> int:
+        bq = bigquery.get_client()  # noqa: F841
+        asset_info["gcp_creds_file"] = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None
+        return 1
+
+    old_gcp_creds_file = os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+    assert old_gcp_creds_file is not None
+
+    passed = False
+
+    try:
+        with open(old_gcp_creds_file, "r") as f:
+            gcp_creds = f.read()
+
+        resource_defs = {
+            "bigquery": BigQueryResource(
+                project=EnvVar("GCP_PROJECT_ID"),
+                gcp_credentials=base64.b64encode(str.encode(gcp_creds)).decode(),
+            ),
+        }
+
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
+
+        result = materialize(
+            [test_asset],
+            resources=resource_defs,
+        )
+        passed = result.success
+
+        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is None
+        assert not os.path.exists(asset_info["gcp_creds_file"])
     finally:
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = old_gcp_creds_file
         assert passed

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
@@ -57,10 +57,10 @@ def test_pythonic_resource_authenticate_via_config():
 
     @asset
     def test_asset(bigquery: BigQueryResource) -> int:
-        bq = bigquery.get_client()  # noqa: F841
-        asset_info["gcp_creds_file"] = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-        assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None
-        return 1
+        with bigquery.get_client():
+            asset_info["gcp_creds_file"] = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None
+            return 1
 
     old_gcp_creds_file = os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
     assert old_gcp_creds_file is not None


### PR DESCRIPTION
## Summary & Motivation
Updates the BigQuery resource to use pydantic config.

One main issue with this resource is handling authentication via config values. In order to support serverless users, we need to allow them to pass GCP creds as configuration. In the "old" version i could setup credentials on resource init, but that doesn't work in the pydantic resource. Instead I've made a context manager that the users can call to set up the credentials (if there is no credential config passed, the context manager does nothing. So if in local dev they have GOOGLE_APPLICATION_CREDENTIALS set, the asset will still work). See the test file for how this will look in an asset. IMO it's a fine pattern, but not great. However, I'm not sure what our other options are. if you have ideas, let me know!

I believe this is a pattern we will need to include for all GCP resources (GCS, Dataproc) so we should make sure we like it. 

## How I Tested These Changes
