### PR TITLE
[dagster-snowflake, dagster-duckdb] add init overrides in IO managers for aliased schema field

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from contextlib import contextmanager
-from typing import Optional, Sequence, Type, cast
+from typing import Optional, Sequence, Type, cast, overload
 
 import duckdb
 from dagster import IOManagerDefinition, OutputContext, io_manager
@@ -161,6 +161,17 @@ class DuckDBIOManager(ConfigurableIOManagerFactory):
     schema_: Optional[str] = Field(
         default=None, alias="schema", description="Name of the schema to use."
     )  # schema is a reserved word for pydantic
+
+    @overload
+    def __init__(self, schema: str, *args, **kwargs):
+        ...
+
+    @overload
+    def __init__(self, *args, **kwargs):
+        ...
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from contextlib import contextmanager
-from typing import Mapping, Optional, Sequence, Type, cast
+from typing import Mapping, Optional, Sequence, Type, cast, overload
 
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
@@ -195,6 +195,17 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
             " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details."
         ),
     )
+
+    @overload
+    def __init__(self, schema: str, *args, **kwargs):
+        ...
+
+    @overload
+    def __init__(self, *args, **kwargs):
+        ...
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod


### PR DESCRIPTION
## Summary & Motivation
Adds init overrides to Snowflake and Duckdb IO managers so that the aliased schema field doesn't cause pyright errors

## How I Tested These Changes
