### PR TITLE
Fix schedule evaluation error when `RunRequest(partition_key=...)` provided

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -319,6 +319,7 @@ def get_external_schedule_execution(
             repo_def.name,
             schedule_name,
             resources=resources_to_build,
+            repository_def=repo_def,
         ) as schedule_context:
             with user_code_error_boundary(
                 ScheduleExecutionError,

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -12,6 +12,7 @@ from dagster import (
     job,
     op,
     repository,
+    schedule,
     usable_as_dagster_type,
 )
 from dagster._core.definitions.decorators.sensor_decorator import sensor
@@ -120,6 +121,11 @@ def bar_job():
     fail_subset(one())
 
 
+@schedule(job_name="baz", cron_schedule="* * * * *")
+def partitioned_run_request_schedule():
+    return RunRequest(partition_key="a")
+
+
 def define_bar_schedules():
     return {
         "foo_schedule": ScheduleDefinition(
@@ -145,6 +151,7 @@ def define_bar_schedules():
                 else ""
             },
         ),
+        "partitioned_run_request_schedule": partitioned_run_request_schedule,
     }
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
@@ -51,3 +51,21 @@ def test_include_execution_time_grpc():
             to_launch = execution_data.run_requests[0]
             assert to_launch.run_config == {"passed_in_time": execution_time.isoformat()}
             assert to_launch.tags == {"dagster/schedule_name": "foo_schedule_echo_time"}
+
+
+def test_run_request_partition_key_schedule_grpc():
+    with instance_for_test() as instance:
+        with get_bar_repo_handle(instance) as repository_handle:
+            execution_time = get_current_datetime_in_utc()
+            execution_data = sync_get_external_schedule_execution_data_ephemeral_grpc(
+                instance,
+                repository_handle,
+                "partitioned_run_request_schedule",
+                execution_time,
+            )
+
+            assert isinstance(execution_data, ScheduleExecutionData)
+            assert len(execution_data.run_requests) == 1
+            to_launch = execution_data.run_requests[0]
+            assert to_launch.tags["dagster/schedule_name"] == "partitioned_run_request_schedule"
+            assert to_launch.tags["dagster/partition"] == "a"


### PR DESCRIPTION
Error reported by a user.

This error occurs because the schedule context is constructed without the repository def, which we now need to load in order to validate partition keys for schedule targets that are defined with strings.