### PR TITLE
[ui] Don't query for parentPipelineSnapshotId unless necessary

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/JobMenu.tsx
+++ b/js_modules/dagit/packages/core/src/instance/JobMenu.tsx
@@ -29,6 +29,7 @@ export const JobMenu = (props: Props) => {
     permissions: {canLaunchPipelineReexecution},
     disabledReasons,
   } = usePermissionsForLocation(repoAddress.location);
+
   const [fetchHasExecutionPlan, {data}] = useLazyQuery<
     RunReExecutionQuery,
     RunReExecutionQueryVariables
@@ -116,6 +117,7 @@ const RUN_RE_EXECUTION_QUERY = gql`
     pipelineRunOrError(runId: $runId) {
       ... on Run {
         id
+        parentPipelineSnapshotId
         ...RunFragment
       }
     }

--- a/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
@@ -13,6 +13,7 @@ export type RunReExecutionQuery = {
     | {
         __typename: 'Run';
         id: string;
+        parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
         runId: string;
         canTerminate: boolean;
@@ -26,11 +27,16 @@ export type RunReExecutionQuery = {
         pipelineName: string;
         solidSelection: Array<string> | null;
         pipelineSnapshotId: string | null;
-        parentPipelineSnapshotId: string | null;
         stepKeysToExecute: Array<string> | null;
         updateTime: number | null;
         startTime: number | null;
         endTime: number | null;
+        repositoryOrigin: {
+          __typename: 'RepositoryOrigin';
+          id: string;
+          repositoryName: string;
+          repositoryLocationName: string;
+        } | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
         assets: Array<{
           __typename: 'Asset';
@@ -68,12 +74,6 @@ export type RunReExecutionQuery = {
             endTime: number | null;
           }>;
         }>;
-        repositoryOrigin: {
-          __typename: 'RepositoryOrigin';
-          id: string;
-          repositoryName: string;
-          repositoryLocationName: string;
-        } | null;
       }
     | {__typename: 'RunNotFoundError'};
 };

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
@@ -56,7 +56,6 @@ export type LaunchedRunListQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
@@ -36,7 +36,6 @@ export type PartitionRunListQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -38,7 +38,6 @@ export type PipelineRunsRootQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -28,13 +28,13 @@ import {LogsToolbar, LogType} from './LogsToolbar';
 import {RunActionButtons} from './RunActionButtons';
 import {RunContext} from './RunContext';
 import {ILogCaptureInfo, IRunMetadataDict, RunMetadataProvider} from './RunMetadataProvider';
-import {RunDagsterRunEventFragment, RunFragment} from './types/RunFragments.types';
+import {RunDagsterRunEventFragment, RunPageFragment} from './types/RunFragments.types';
 import {useJobReExecution} from './useJobReExecution';
 import {useQueryPersistedLogFilter} from './useQueryPersistedLogFilter';
 
 interface RunProps {
   runId: string;
-  run?: RunFragment;
+  run?: RunPageFragment;
 }
 
 const runStatusFavicon = (status: RunStatus) => {
@@ -114,7 +114,7 @@ export const Run: React.FC<RunProps> = (props) => {
 };
 
 interface RunWithDataProps {
-  run?: RunFragment;
+  run?: RunPageFragment;
   runId: string;
   selectionQuery: string;
   logs: LogsProviderLogs;

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.test.tsx
@@ -164,6 +164,7 @@ const RUN_ACTION_BUTTONS_TEST_QUERY = gql`
     pipelineRunOrError(runId: "foo") {
       ... on Run {
         id
+        parentPipelineSnapshotId
         ...RunFragment
       }
     }

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
@@ -34,7 +34,6 @@ describe('RunActionsMenu', () => {
     rootRunId: 'abcdef12',
     parentRunId: null,
     pipelineSnapshotId: 'snapshotID',
-    parentPipelineSnapshotId: 'snapshotID',
     pipelineName: 'job-bar',
     repositoryOrigin: {
       __typename: 'RepositoryOrigin',

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -6,26 +6,17 @@ import {LOGS_SCROLLING_TABLE_MESSAGE_FRAGMENT} from './LogsScrollingTable';
 import {RUN_DETAILS_FRAGMENT} from './RunDetails';
 import {RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT} from './RunMetadataProvider';
 
-export const RUN_FRAGMENT_FOR_REPOSITORY_MATCH = gql`
-  fragment RunFragmentForRepositoryMatch on Run {
-    id
-    pipelineName
-    pipelineSnapshotId
-    parentPipelineSnapshotId
-    repositoryOrigin {
-      id
-      repositoryName
-      repositoryLocationName
-    }
-  }
-`;
-
 export const RUN_FRAGMENT = gql`
   fragment RunFragment on Run {
     id
     runConfigYaml
     runId
     canTerminate
+    repositoryOrigin {
+      id
+      repositoryName
+      repositoryLocationName
+    }
     hasReExecutePermission
     hasTerminatePermission
     hasDeletePermission
@@ -51,7 +42,6 @@ export const RUN_FRAGMENT = gql`
       }
     }
     pipelineSnapshotId
-    parentPipelineSnapshotId
     executionPlan {
       artifactsPersisted
       ...ExecutionPlanToGraphFragment
@@ -72,12 +62,10 @@ export const RUN_FRAGMENT = gql`
         endTime
       }
     }
-    ...RunFragmentForRepositoryMatch
     ...RunDetailsFragment
   }
 
   ${EXECUTION_PLAN_TO_GRAPH_FRAGMENT}
-  ${RUN_FRAGMENT_FOR_REPOSITORY_MATCH}
   ${RUN_DETAILS_FRAGMENT}
 `;
 
@@ -96,4 +84,14 @@ export const RUN_DAGSTER_RUN_EVENT_FRAGMENT = gql`
 
   ${LOGS_SCROLLING_TABLE_MESSAGE_FRAGMENT}
   ${RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT}
+`;
+
+export const RUN_PAGE_FRAGMENT = gql`
+  fragment RunPageFragment on Run {
+    id
+    parentPipelineSnapshotId
+    ...RunFragment
+  }
+
+  ${RUN_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunRoot.tsx
@@ -11,12 +11,12 @@ import {PipelineReference} from '../pipelines/PipelineReference';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {isThisThingAJob} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
+import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
 
 import {AssetKeyTagCollection} from './AssetKeyTagCollection';
 import {Run} from './Run';
 import {RunConfigDialog, RunDetails} from './RunDetails';
-import {RUN_FRAGMENT} from './RunFragments';
+import {RUN_PAGE_FRAGMENT} from './RunFragments';
 import {RunStatusTag} from './RunStatusTag';
 import {assetKeysForRun} from './RunUtils';
 import {RunRootQuery, RunRootQueryVariables} from './types/RunRoot.types';
@@ -35,7 +35,7 @@ export const RunRoot = () => {
   const run = data?.pipelineRunOrError.__typename === 'Run' ? data.pipelineRunOrError : null;
   const snapshotID = run?.pipelineSnapshotId;
 
-  const repoMatch = useRepositoryForRun(run);
+  const repoMatch = useRepositoryForRunWithParentSnapshot(run);
   const repoAddress = repoMatch?.match
     ? buildRepoAddress(repoMatch.match.repository.name, repoMatch.match.repositoryLocation.name)
     : null;
@@ -178,13 +178,12 @@ const RunById: React.FC<{data: RunRootQuery | undefined; runId: string}> = (prop
 const RUN_ROOT_QUERY = gql`
   query RunRootQuery($runId: ID!) {
     pipelineRunOrError(runId: $runId) {
-      __typename
       ... on Run {
         id
-        ...RunFragment
+        ...RunPageFragment
       }
     }
   }
 
-  ${RUN_FRAGMENT}
+  ${RUN_PAGE_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -16,7 +16,7 @@ import {
   useRepositoryOptions,
 } from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
+import {useRepositoryForRunWithoutSnapshot} from '../workspace/useRepositoryForRun';
 import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
 
 import {AssetKeyTagCollection} from './AssetKeyTagCollection';
@@ -181,7 +181,6 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
     rootRunId
     parentRunId
     pipelineSnapshotId
-    parentPipelineSnapshotId
     pipelineName
     repositoryOrigin {
       id
@@ -223,7 +222,7 @@ const RunRow: React.FC<{
   isHighlighted,
 }) => {
   const {pipelineName} = run;
-  const repo = useRepositoryForRun(run);
+  const repo = useRepositoryForRunWithoutSnapshot(run);
 
   const isJob = React.useMemo(() => {
     if (repo) {

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
@@ -11,6 +11,7 @@ export type RunActionButtonsTestQuery = {
     | {
         __typename: 'Run';
         id: string;
+        parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
         runId: string;
         canTerminate: boolean;
@@ -24,11 +25,16 @@ export type RunActionButtonsTestQuery = {
         pipelineName: string;
         solidSelection: Array<string> | null;
         pipelineSnapshotId: string | null;
-        parentPipelineSnapshotId: string | null;
         stepKeysToExecute: Array<string> | null;
         updateTime: number | null;
         startTime: number | null;
         endTime: number | null;
+        repositoryOrigin: {
+          __typename: 'RepositoryOrigin';
+          id: string;
+          repositoryName: string;
+          repositoryLocationName: string;
+        } | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
         assets: Array<{
           __typename: 'Asset';
@@ -66,12 +72,6 @@ export type RunActionButtonsTestQuery = {
             endTime: number | null;
           }>;
         }>;
-        repositoryOrigin: {
-          __typename: 'RepositoryOrigin';
-          id: string;
-          repositoryName: string;
-          repositoryLocationName: string;
-        } | null;
       }
     | {__typename: 'RunNotFoundError'};
 };

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionsMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionsMenu.types.ts
@@ -2,11 +2,11 @@
 
 import * as Types from '../../graphql/types';
 
-export type PipelineEnvironmentYamlQueryVariables = Types.Exact<{
+export type PipelineEnvironmentQueryVariables = Types.Exact<{
   runId: Types.Scalars['ID'];
 }>;
 
-export type PipelineEnvironmentYamlQuery = {
+export type PipelineEnvironmentQuery = {
   __typename: 'DagitQuery';
   pipelineRunOrError:
     | {__typename: 'PythonError'}

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
@@ -2,20 +2,6 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunFragmentForRepositoryMatchFragment = {
-  __typename: 'Run';
-  id: string;
-  pipelineName: string;
-  pipelineSnapshotId: string | null;
-  parentPipelineSnapshotId: string | null;
-  repositoryOrigin: {
-    __typename: 'RepositoryOrigin';
-    id: string;
-    repositoryName: string;
-    repositoryLocationName: string;
-  } | null;
-};
-
 export type RunFragment = {
   __typename: 'Run';
   id: string;
@@ -32,11 +18,16 @@ export type RunFragment = {
   pipelineName: string;
   solidSelection: Array<string> | null;
   pipelineSnapshotId: string | null;
-  parentPipelineSnapshotId: string | null;
   stepKeysToExecute: Array<string> | null;
   updateTime: number | null;
   startTime: number | null;
   endTime: number | null;
+  repositoryOrigin: {
+    __typename: 'RepositoryOrigin';
+    id: string;
+    repositoryName: string;
+    repositoryLocationName: string;
+  } | null;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
   assets: Array<{
     __typename: 'Asset';
@@ -66,12 +57,6 @@ export type RunFragment = {
     attempts: Array<{__typename: 'RunMarker'; startTime: number | null; endTime: number | null}>;
     markers: Array<{__typename: 'RunMarker'; startTime: number | null; endTime: number | null}>;
   }>;
-  repositoryOrigin: {
-    __typename: 'RepositoryOrigin';
-    id: string;
-    repositoryName: string;
-    repositoryLocationName: string;
-  } | null;
 };
 
 export type RunDagsterRunEventFragment_AlertFailureEvent_ = {
@@ -2252,3 +2237,61 @@ export type RunDagsterRunEventFragment =
   | RunDagsterRunEventFragment_StepExpectationResultEvent_
   | RunDagsterRunEventFragment_StepWorkerStartedEvent_
   | RunDagsterRunEventFragment_StepWorkerStartingEvent_;
+
+export type RunPageFragment = {
+  __typename: 'Run';
+  id: string;
+  parentPipelineSnapshotId: string | null;
+  runConfigYaml: string;
+  runId: string;
+  canTerminate: boolean;
+  hasReExecutePermission: boolean;
+  hasTerminatePermission: boolean;
+  hasDeletePermission: boolean;
+  status: Types.RunStatus;
+  mode: string;
+  rootRunId: string | null;
+  parentRunId: string | null;
+  pipelineName: string;
+  solidSelection: Array<string> | null;
+  pipelineSnapshotId: string | null;
+  stepKeysToExecute: Array<string> | null;
+  updateTime: number | null;
+  startTime: number | null;
+  endTime: number | null;
+  repositoryOrigin: {
+    __typename: 'RepositoryOrigin';
+    id: string;
+    repositoryName: string;
+    repositoryLocationName: string;
+  } | null;
+  tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+  assets: Array<{
+    __typename: 'Asset';
+    id: string;
+    key: {__typename: 'AssetKey'; path: Array<string>};
+  }>;
+  assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+  executionPlan: {
+    __typename: 'ExecutionPlan';
+    artifactsPersisted: boolean;
+    steps: Array<{
+      __typename: 'ExecutionStep';
+      key: string;
+      kind: Types.StepKind;
+      inputs: Array<{
+        __typename: 'ExecutionStepInput';
+        dependsOn: Array<{__typename: 'ExecutionStep'; key: string; kind: Types.StepKind}>;
+      }>;
+    }>;
+  } | null;
+  stepStats: Array<{
+    __typename: 'RunStepStats';
+    stepKey: string;
+    status: Types.StepEventStatus | null;
+    startTime: number | null;
+    endTime: number | null;
+    attempts: Array<{__typename: 'RunMarker'; startTime: number | null; endTime: number | null}>;
+    markers: Array<{__typename: 'RunMarker'; startTime: number | null; endTime: number | null}>;
+  }>;
+};

--- a/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
@@ -13,6 +13,7 @@ export type RunRootQuery = {
     | {
         __typename: 'Run';
         id: string;
+        parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
         runId: string;
         canTerminate: boolean;
@@ -26,11 +27,16 @@ export type RunRootQuery = {
         pipelineName: string;
         solidSelection: Array<string> | null;
         pipelineSnapshotId: string | null;
-        parentPipelineSnapshotId: string | null;
         stepKeysToExecute: Array<string> | null;
         updateTime: number | null;
         startTime: number | null;
         endTime: number | null;
+        repositoryOrigin: {
+          __typename: 'RepositoryOrigin';
+          id: string;
+          repositoryName: string;
+          repositoryLocationName: string;
+        } | null;
         tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
         assets: Array<{
           __typename: 'Asset';
@@ -68,12 +74,6 @@ export type RunRootQuery = {
             endTime: number | null;
           }>;
         }>;
-        repositoryOrigin: {
-          __typename: 'RepositoryOrigin';
-          id: string;
-          repositoryName: string;
-          repositoryLocationName: string;
-        } | null;
       }
     | {__typename: 'RunNotFoundError'};
 };

--- a/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
@@ -16,7 +16,6 @@ export type RunTableRunFragment = {
   rootRunId: string | null;
   parentRunId: string | null;
   pipelineSnapshotId: string | null;
-  parentPipelineSnapshotId: string | null;
   pipelineName: string;
   solidSelection: Array<string> | null;
   startTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
@@ -38,7 +38,6 @@ export type RunsRootQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/useJobAvailabilityErrorForRun.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useJobAvailabilityErrorForRun.tsx
@@ -1,0 +1,109 @@
+import {Group, IconName} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {buildRepoAddress, buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {
+  TargetRunWithParentSnapshot,
+  useRepositoryForRunWithParentSnapshot,
+} from '../workspace/useRepositoryForRun';
+
+export const useJobAvailabilityErrorForRun = (
+  run: TargetRunWithParentSnapshot | null | undefined,
+): null | {tooltip?: string | JSX.Element; icon?: IconName; disabled: boolean} => {
+  const repoMatch = useRepositoryForRunWithParentSnapshot(run);
+
+  // The run hasn't loaded, so no error.
+  if (!run) {
+    return null;
+  }
+
+  if (!run.pipelineSnapshotId) {
+    return {
+      icon: 'error',
+      tooltip: `"${run.pipelineName}" could not be found.`,
+      disabled: true,
+    };
+  }
+
+  if (repoMatch) {
+    const {type: matchType} = repoMatch;
+
+    // The run matches the repository and active snapshot ID for the job. This is the best
+    // we can do, so consider it safe to run as-is.
+    if (matchType === 'origin-and-snapshot') {
+      return null;
+    }
+
+    // Beyond this point, we're just trying our best. Warn the user that behavior might not be what
+    // they expect.
+
+    if (matchType === 'origin-only') {
+      // Only the repo is a match.
+      return {
+        icon: 'warning',
+        tooltip: `The loaded version of "${run.pipelineName}" may be different than the one used for the original run.`,
+        disabled: false,
+      };
+    }
+
+    if (matchType === 'snapshot-only') {
+      // Only the snapshot ID matched, but not the repo.
+      const originRepoName = run.repositoryOrigin
+        ? repoAddressAsHumanString(
+            buildRepoAddress(
+              run.repositoryOrigin.repositoryName,
+              run.repositoryOrigin.repositoryLocationName,
+            ),
+          )
+        : null;
+
+      return {
+        icon: 'warning',
+        tooltip: (
+          <Group direction="column" spacing={4}>
+            <div>{`The original run loaded "${run.pipelineName}" from ${
+              originRepoName || 'a different code location'
+            }.`}</div>
+            {originRepoName ? (
+              <div>
+                Original definition in: <strong>{originRepoName}</strong>
+              </div>
+            ) : null}
+          </Group>
+        ),
+        disabled: false,
+      };
+    }
+
+    // Only the job name matched. This could be from any repo in the workspace.
+    return {
+      icon: 'warning',
+      tooltip: `The job "${run.pipelineName}" may be a different version from the original pipeline run.`,
+      disabled: false,
+    };
+  }
+
+  // We could not find a repo that contained this job. Inform the user that they should
+  // load the missing repository.
+  const repoForRun = run.repositoryOrigin?.repositoryName;
+  const repoLocationForRun = run.repositoryOrigin?.repositoryLocationName;
+
+  const tooltip = (
+    <Group direction="column" spacing={8}>
+      <div>{`"${run.pipelineName}" is not available in your definitions.`}</div>
+      {repoForRun && repoLocationForRun ? (
+        <div>{`Load definitions for ${buildRepoPathForHuman(
+          repoForRun,
+          repoLocationForRun,
+        )} and try again.`}</div>
+      ) : null}
+    </Group>
+  );
+
+  return {
+    icon: 'error',
+    tooltip,
+    disabled: true,
+  };
+};

--- a/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useJobReExecution.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {useHistory} from 'react-router';
 
 import {showLaunchError} from '../launchpad/showLaunchError';
-import {useRepositoryForRun} from '../workspace/useRepositoryForRun';
+import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
 
 import {
   getReexecutionVariables,
@@ -11,19 +11,20 @@ import {
   LAUNCH_PIPELINE_REEXECUTION_MUTATION,
   ReExecutionStyle,
 } from './RunUtils';
-import {RunFragment} from './types/RunFragments.types';
+import {RunPageFragment} from './types/RunFragments.types';
 import {
   LaunchPipelineReexecutionMutation,
   LaunchPipelineReexecutionMutationVariables,
 } from './types/RunUtils.types';
 
-export const useJobReExecution = (run: RunFragment | undefined | null) => {
+export const useJobReExecution = (run: RunPageFragment | undefined | null) => {
   const history = useHistory();
   const [launchPipelineReexecution] = useMutation<
     LaunchPipelineReexecutionMutation,
     LaunchPipelineReexecutionMutationVariables
   >(LAUNCH_PIPELINE_REEXECUTION_MUTATION);
-  const repoMatch = useRepositoryForRun(run);
+
+  const repoMatch = useRepositoryForRunWithParentSnapshot(run);
 
   return React.useCallback(
     async (style: ReExecutionStyle) => {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -137,7 +137,6 @@ export type PreviousRunsForScheduleQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -28,7 +28,6 @@ export type PreviousRunsForSensorQuery = {
           rootRunId: string | null;
           parentRunId: string | null;
           pipelineSnapshotId: string | null;
-          parentPipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
           startTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
+++ b/js_modules/dagit/packages/core/src/workspace/useRepositoryForRun.ts
@@ -1,80 +1,129 @@
-import * as React from 'react';
-
-import {RunFragmentForRepositoryMatchFragment} from '../runs/types/RunFragments.types';
-
 import {DagsterRepoOption, useRepositoryOptions} from './WorkspaceContext';
 import {findRepoContainingPipeline, repoContainsPipeline} from './findRepoContainingPipeline';
 
 type MatchType = {
   match: DagsterRepoOption;
+  type: 'origin' | 'pipeline-name-only';
+};
+
+type MatchTypeWithSnapshot = {
+  match: DagsterRepoOption;
   type: 'origin-and-snapshot' | 'origin-only' | 'snapshot-only' | 'pipeline-name-only';
 };
 
+export interface TargetRunWithParentSnapshot extends TargetRun {
+  parentPipelineSnapshotId?: string | null;
+}
+
+interface TargetRun {
+  pipelineName: string;
+  repositoryOrigin: null | {
+    repositoryLocationName: string;
+    repositoryName: string;
+  };
+  pipelineSnapshotId: string | null;
+}
+
+const repoOriginMatchForRun = (options: DagsterRepoOption[], run: TargetRun | null | undefined) => {
+  if (!run) {
+    return null;
+  }
+
+  const pipelineName = run.pipelineName;
+  // Try to match the pipeline name within the specified origin, if possible.
+  const origin = run.repositoryOrigin;
+
+  if (!origin) {
+    return null;
+  }
+
+  const location = origin?.repositoryLocationName;
+  const name = origin?.repositoryName;
+
+  const match = options.find(
+    (option) => option.repository.name === name && option.repositoryLocation.name === location,
+  );
+
+  // The origin repo is loaded. Verify that a pipeline with this name exists and return the match if so.
+  return match && repoContainsPipeline(match, pipelineName) ? match : null;
+};
+
+const jobNameMatchesForRun = (
+  options: DagsterRepoOption[],
+  run: TargetRun | null | undefined,
+): DagsterRepoOption[] | null => {
+  if (!run) {
+    return null;
+  }
+
+  const pipelineName = run.pipelineName;
+
+  // There is no origin repo. Find any repos that might contain a matching pipeline name.
+  const possibleMatches = findRepoContainingPipeline(options, pipelineName);
+  return possibleMatches.length ? possibleMatches : null;
+};
+
+const snapshotMatchesForRun = (
+  options: DagsterRepoOption[],
+  run: TargetRunWithParentSnapshot | null | undefined,
+): DagsterRepoOption[] | null => {
+  if (!run) {
+    return null;
+  }
+
+  const pipelineName = run.pipelineName;
+
+  // When jobs are subsetted (with an opSelection or assetSelection), only their
+  // parentPipelineSnapshotId (the id of the pipelineSnapshot that they were subsetted from) will
+  // be found in the repository, so look for that instead.
+  const snapshotId = run.parentPipelineSnapshotId ?? run.pipelineSnapshotId;
+
+  // Find the repository that contains the specified pipeline name and snapshot ID, if any.
+  if (pipelineName && snapshotId) {
+    const snapshotMatches = findRepoContainingPipeline(options, pipelineName, snapshotId);
+    if (snapshotMatches.length) {
+      return snapshotMatches;
+    }
+  }
+
+  return null;
+};
+
 /**
- * Given a Run fragment, find the repository that contains its pipeline.
+ * The simple case. Find the repo match for this job name, or the first available
+ * repo match for that job name.
  */
-export const useRepositoryForRun = (
-  run: RunFragmentForRepositoryMatchFragment | null | undefined,
+export const useRepositoryForRunWithoutSnapshot = (
+  run: TargetRun | null | undefined,
 ): MatchType | null => {
   const {options} = useRepositoryOptions();
+  const repoMatch = repoOriginMatchForRun(options, run);
+  if (repoMatch) {
+    return {match: repoMatch, type: 'origin'};
+  }
+  const jobNameMatches = jobNameMatchesForRun(options, run);
+  if (jobNameMatches && jobNameMatches.length) {
+    return {match: jobNameMatches[0], type: 'pipeline-name-only'};
+  }
+  return null;
+};
 
-  const repoMatch = React.useMemo(() => {
-    if (!run) {
-      return null;
-    }
+/**
+ * The more complex case, where a parent snapshot has been fetched. Here, use a
+ * repo match and try to pair it with the snapshot ID. If that fails, use any repo
+ * match, then any snapshot ID match, then any job name match.
+ *
+ * Retrieving a parent snapshot ID is expensive, so this should only be used for
+ * one run at a time.
+ */
+export const useRepositoryForRunWithParentSnapshot = (
+  run: TargetRunWithParentSnapshot | null | undefined,
+): MatchTypeWithSnapshot | null => {
+  const {options} = useRepositoryOptions();
 
-    const pipelineName = run.pipelineName;
-    // Try to match the pipeline name within the specified origin, if possible.
-    const origin = run.repositoryOrigin;
-
-    if (!origin) {
-      return null;
-    }
-
-    const location = origin?.repositoryLocationName;
-    const name = origin?.repositoryName;
-
-    const match = options.find(
-      (option) => option.repository.name === name && option.repositoryLocation.name === location,
-    );
-
-    // The origin repo is loaded. Verify that a pipeline with this name exists and return the match if so.
-    return match && repoContainsPipeline(match, pipelineName) ? match : null;
-  }, [options, run]);
-
-  const snapshotMatches = React.useMemo(() => {
-    if (!run) {
-      return null;
-    }
-
-    const pipelineName = run.pipelineName;
-    // When jobs are subsetted (with an opSelection or assetSelection), only their
-    // parentPipelineSnapshotId (the id of the pipelineSnapshot that they were subsetted from) will
-    // be found in the repository, so look for that instead.
-    const snapshotId = run.parentPipelineSnapshotId ?? run.pipelineSnapshotId;
-
-    // Find the repository that contains the specified pipeline name and snapshot ID, if any.
-    if (pipelineName && snapshotId) {
-      const snapshotMatches = findRepoContainingPipeline(options, pipelineName, snapshotId);
-      if (snapshotMatches.length) {
-        return snapshotMatches;
-      }
-    }
-
-    return null;
-  }, [options, run]);
-
-  const pipelineNameMatches = React.useMemo(() => {
-    if (!run) {
-      return null;
-    }
-
-    const pipelineName = run.pipelineName;
-
-    // There is no origin repo. Find any repos that might contain a matching pipeline name.
-    const possibleMatches = findRepoContainingPipeline(options, pipelineName);
-    return possibleMatches.length ? possibleMatches : null;
-  }, [options, run]);
+  const repoMatch = repoOriginMatchForRun(options, run);
+  const snapshotMatches = snapshotMatchesForRun(options, run);
+  const jobNameMatches = jobNameMatchesForRun(options, run);
 
   if (repoMatch) {
     if (snapshotMatches) {
@@ -91,12 +140,12 @@ export const useRepositoryForRun = (
     return {match: repoMatch, type: 'origin-only'};
   }
 
-  if (snapshotMatches) {
+  if (snapshotMatches && snapshotMatches.length) {
     return {match: snapshotMatches[0], type: 'snapshot-only'};
   }
 
-  if (pipelineNameMatches) {
-    return {match: pipelineNameMatches[0], type: 'pipeline-name-only'};
+  if (jobNameMatches && jobNameMatches.length) {
+    return {match: jobNameMatches[0], type: 'pipeline-name-only'};
   }
 
   return null;


### PR DESCRIPTION
## Summary & Motivation

Avoid querying for `parentPipelineSnapshotId` on Runs unless necessary, since it's expensive.

- Query for this field on individual runs, e.g. on the individual Run page or in the run action menu.
- Provide a stripped-down version of the code that hunts for the matching repo, for use in Runs table rows.

Bonus:

- Reuse `useJobAvailabilityErrorForRun` so that disabled states and error messages on re-execution can be used on the Runs table, not just on the Run page.

<img width="548" alt="Screenshot 2023-04-06 at 4 52 04 PM" src="https://user-images.githubusercontent.com/2823852/230501645-61f13d5d-250c-4987-af1a-6411647b0b33.png">

## How I Tested These Changes

TS, lint, jest. The Jest coverage on this isn't great.

Load Dagit, view Runs table.

- Verify via Apollo cache inspection that the `parentPipelineSnapshotId` is not queried until after I open the run action menu.
- Find a run for a pipeline that does not exist in my definitions, open run action menu. Verify that the re-execute item is disabled, with a message.
