### PR TITLE
[3/n][dagster-aws] Port S3Resource, S3IOManager to Pythonic resources

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
@@ -5,6 +5,7 @@ from .file_manager import (
 )
 from .io_manager import (
     PickledObjectS3IOManager as PickledObjectS3IOManager,
+    S3PickleIOManager as S3PickleIOManager,
     s3_pickle_io_manager as s3_pickle_io_manager,
 )
 from .ops import (
@@ -12,6 +13,8 @@ from .ops import (
     file_handle_to_s3 as file_handle_to_s3,
 )
 from .resources import (
+    S3FileManagerResource as S3FileManagerResource,
+    S3Resource as S3Resource,
     s3_file_manager as s3_file_manager,
     s3_resource as s3_resource,
 )

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
@@ -5,7 +5,7 @@ from .file_manager import (
 )
 from .io_manager import (
     PickledObjectS3IOManager as PickledObjectS3IOManager,
-    S3PickleIOManager as S3PickleIOManager,
+    S3IOManagerResource as S3IOManagerResource,
     s3_pickle_io_manager as s3_pickle_io_manager,
 )
 from .ops import (

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
@@ -4,8 +4,8 @@ from .file_manager import (
     S3FileManager as S3FileManager,
 )
 from .io_manager import (
+    ConfigurablePickledObjectS3IOManager as ConfigurablePickledObjectS3IOManager,
     PickledObjectS3IOManager as PickledObjectS3IOManager,
-    PickledObjectS3IOManagerResource as PickledObjectS3IOManagerResource,
     s3_pickle_io_manager as s3_pickle_io_manager,
 )
 from .ops import (

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/__init__.py
@@ -5,7 +5,7 @@ from .file_manager import (
 )
 from .io_manager import (
     PickledObjectS3IOManager as PickledObjectS3IOManager,
-    S3IOManagerResource as S3IOManagerResource,
+    PickledObjectS3IOManagerResource as PickledObjectS3IOManagerResource,
     s3_pickle_io_manager as s3_pickle_io_manager,
 )
 from .ops import (

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -157,18 +157,18 @@ class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
     )
 
     @cached_method
-    def inner_db_io_manager(self) -> PickledObjectS3IOManager:
+    def inner_io_manager(self) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(
             s3_bucket=self.s3_bucket,
-            s3_session=self.s3_resource,
+            s3_session=self.s3_resource.create_client(),
             s3_prefix=self.s3_prefix,
         )
 
     def load_input(self, context: InputContext) -> Any:
-        return self.inner_db_io_manager().load_input(context)
+        return self.inner_io_manager().load_input(context)
 
     def handle_output(self, context: OutputContext, obj: Any) -> None:
-        return self.inner_db_io_manager().handle_output(context, obj)
+        return self.inner_io_manager().handle_output(context, obj)
 
 
 @io_manager(

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -104,7 +104,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         context.add_output_metadata({"uri": MetadataValue.path(path)})
 
 
-class S3IOManagerResource(ConfigurableIOManager):
+class PickledObjectS3IOManagerResource(ConfigurableIOManager):
     """Persistent IO manager using S3 for storage.
 
     Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
@@ -125,7 +125,7 @@ class S3IOManagerResource(ConfigurableIOManager):
     .. code-block:: python
 
         from dagster import asset, Definitions
-        from dagster_aws.s3 import S3PickleIOManager, S3Resource
+        from dagster_aws.s3 import PickledObjectS3IOManagerResource, S3Resource
 
 
         @asset
@@ -140,7 +140,7 @@ class S3IOManagerResource(ConfigurableIOManager):
         defs = Definitions(
             assets=[asset1, asset2],
             resources={
-                "io_manager": S3PickleIOManager(
+                "io_manager": PickledObjectS3IOManagerResource(
                     s3_resource=S3Resource(),
                     s3_bucket="my-cool-bucket",
                     s3_prefix="my-cool-prefix",
@@ -172,7 +172,7 @@ class S3IOManagerResource(ConfigurableIOManager):
 
 
 @io_manager(
-    config_schema=S3IOManagerResource.to_config_schema(),
+    config_schema=PickledObjectS3IOManagerResource.to_config_schema(),
     required_resource_keys={"s3"},
 )
 def s3_pickle_io_manager(init_context):

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -3,8 +3,8 @@ import pickle
 from typing import Sequence, Union
 
 from dagster import (
-    ConfigurableIOManagerFactory,
     InputContext,
+    IOManagerFactoryResource,
     MemoizableIOManager,
     MetadataValue,
     OutputContext,
@@ -103,7 +103,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         context.add_output_metadata({"uri": MetadataValue.path(path)})
 
 
-class S3IOManagerResource(ConfigurableIOManagerFactory):
+class S3IOManagerResource(IOManagerFactoryResource[PickledObjectS3IOManager]):
     """Persistent IO manager using S3 for storage.
 
     Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
@@ -155,7 +155,7 @@ class S3IOManagerResource(ConfigurableIOManagerFactory):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
-    def create_io_manager(self, context) -> PickledObjectS3IOManager:
+    def provide_object_for_execution(self, context) -> PickledObjectS3IOManager:
         return PickledObjectS3IOManager(
             s3_bucket=self.s3_bucket,
             s3_session=self.s3_resource,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -103,7 +103,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         context.add_output_metadata({"uri": MetadataValue.path(path)})
 
 
-class S3PickleIOManager(ConfigurableIOManagerFactory):
+class S3IOManagerResource(ConfigurableIOManagerFactory):
     """Persistent IO manager using S3 for storage.
 
     Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
@@ -164,7 +164,7 @@ class S3PickleIOManager(ConfigurableIOManagerFactory):
 
 
 @io_manager(
-    config_schema=S3PickleIOManager.to_config_schema(),
+    config_schema=S3IOManagerResource.to_config_schema(),
     required_resource_keys={"s3"},
 )
 def s3_pickle_io_manager(init_context):

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -104,7 +104,7 @@ class PickledObjectS3IOManager(MemoizableIOManager):
         context.add_output_metadata({"uri": MetadataValue.path(path)})
 
 
-class PickledObjectS3IOManagerResource(ConfigurableIOManager):
+class ConfigurablePickledObjectS3IOManager(ConfigurableIOManager):
     """Persistent IO manager using S3 for storage.
 
     Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
@@ -125,7 +125,7 @@ class PickledObjectS3IOManagerResource(ConfigurableIOManager):
     .. code-block:: python
 
         from dagster import asset, Definitions
-        from dagster_aws.s3 import PickledObjectS3IOManagerResource, S3Resource
+        from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 
         @asset
@@ -140,7 +140,7 @@ class PickledObjectS3IOManagerResource(ConfigurableIOManager):
         defs = Definitions(
             assets=[asset1, asset2],
             resources={
-                "io_manager": PickledObjectS3IOManagerResource(
+                "io_manager": ConfigurablePickledObjectS3IOManager(
                     s3_resource=S3Resource(),
                     s3_bucket="my-cool-bucket",
                     s3_prefix="my-cool-prefix",
@@ -172,7 +172,7 @@ class PickledObjectS3IOManagerResource(ConfigurableIOManager):
 
 
 @io_manager(
-    config_schema=PickledObjectS3IOManagerResource.to_config_schema(),
+    config_schema=ConfigurablePickledObjectS3IOManager.to_config_schema(),
     required_resource_keys={"s3"},
 )
 def s3_pickle_io_manager(init_context):

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -1,6 +1,6 @@
 import io
 import pickle
-from typing import Any, Sequence, Union
+from typing import Sequence, Union
 
 from dagster import (
     ConfigurableIOManagerFactory,
@@ -14,6 +14,8 @@ from dagster import (
 )
 from dagster._utils import PICKLE_PROTOCOL
 from pydantic import Field
+
+from .resources import S3Resource
 
 
 class PickledObjectS3IOManager(MemoizableIOManager):
@@ -121,7 +123,7 @@ class S3PickleIOManager(ConfigurableIOManagerFactory):
 
     .. code-block:: python
 
-        from dagster import asset, repository, with_resources
+        from dagster import asset, Definitions
         from dagster_aws.s3 import S3PickleIOManager, S3Resource
 
 
@@ -134,23 +136,20 @@ class S3PickleIOManager(ConfigurableIOManagerFactory):
         def asset2(asset1):
             return asset1[:5]
 
-        @repository
-        def repo():
-            return with_resources(
-                [asset1, asset2],
-                resource_defs={
-                    "io_manager": S3PickleIOManager(
-                        s3_resource=S3Resource(),
-                        s3_bucket="my-cool-bucket",
-                        s3_prefix="my-cool-prefix",
-                    )
-                },
-            )
-
+        defs = Definitions(
+            assets=[asset1, asset2],
+            resources={
+                "io_manager": S3PickleIOManager(
+                    s3_resource=S3Resource(),
+                    s3_bucket="my-cool-bucket",
+                    s3_prefix="my-cool-prefix",
+                )
+            }
+        )
 
     """
 
-    s3_resource: ResourceDependency[Any]
+    s3_resource: ResourceDependency[S3Resource]
     s3_bucket: str = Field(description="S3 bucket to use for the file manager.")
     s3_prefix: str = Field(
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/ops.py
@@ -67,21 +67,11 @@ def last_key(key: str) -> str:
     required_resource_keys={"s3", "file_manager"},
 )
 def file_handle_to_s3(context, file_handle) -> Generator[Any, None, None]:
-    from .resources import S3FileManager, S3FileManagerResource, S3Resource
-
     bucket = context.op_config["Bucket"]
     key = context.op_config["Key"]
 
-    file_manager_resource = context.resources.file_manager
-    s3_resource = context.resources.s3
-
-    # Extract clients from new Pythonic resource types, if needed
-    file_manager: S3FileManager = file_manager_resource
-    if isinstance(file_manager_resource, S3FileManagerResource):
-        file_manager = file_manager_resource.create_client()
-    s3 = s3_resource
-    if isinstance(s3_resource, S3Resource):
-        s3 = s3_resource.create_client()
+    file_manager = context.resources.file_manager
+    s3 = context.resources.s3
 
     with file_manager.read(file_handle, "rb") as fileobj:
         s3.upload_fileobj(fileobj, bucket, key)

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, TypeVar
 
 from dagster import (
-    ConfigurableResourceFactory,
+    FactoryResource,
     InitResourceContext,
     resource,
 )
@@ -13,7 +13,7 @@ from .utils import construct_s3_client
 T = TypeVar("T")
 
 
-class ResourceWithS3Configuration(ConfigurableResourceFactory[T]):
+class ResourceWithS3Configuration(FactoryResource[T]):
     use_unsigned_session: bool = Field(
         default=False, description="Specifiesw whether to use an unsigned S3 session."
     )
@@ -86,7 +86,7 @@ class S3Resource(ResourceWithS3Configuration[Any]):
 
     """
 
-    def create_resource(self, context: InitResourceContext) -> Any:
+    def provide_object_for_execution(self, context: InitResourceContext) -> Any:
         return construct_s3_client(
             max_attempts=self.max_attempts,
             region_name=self.region_name,
@@ -180,7 +180,7 @@ class S3FileManagerResource(ResourceWithS3Configuration[S3FileManager]):
         default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
 
-    def create_resource(self, context: InitResourceContext) -> S3FileManager:
+    def provide_object_for_execution(self, context: InitResourceContext) -> S3FileManager:
         return S3FileManager(
             s3_session=construct_s3_client(
                 max_attempts=self.max_attempts,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -1,77 +1,107 @@
-from dagster import Field, Noneable, StringSource, resource
-from dagster._utils.merger import merge_dicts
+from typing import Any, Optional, TypeVar
+
+from dagster import (
+    ConfigurableResourceFactory,
+    InitResourceContext,
+    resource,
+)
+from pydantic import Field
 
 from .file_manager import S3FileManager
 from .utils import construct_s3_client
 
-S3_SESSION_CONFIG = {
-    "use_unsigned_session": Field(
-        bool,
-        description="Specifies whether to use an unsigned S3 session",
-        is_required=False,
-        default_value=False,
-    ),
-    "region_name": Field(
-        str, description="Specifies a custom region for the S3 session", is_required=False
-    ),
-    "endpoint_url": Field(
-        StringSource,
-        description="Specifies a custom endpoint for the S3 session",
-        is_required=False,
-    ),
-    "max_attempts": Field(
-        int,
+T = TypeVar("T")
+
+
+class S3ResourceBase(ConfigurableResourceFactory[T]):
+    use_unsigned_session: bool = Field(
+        default=False, description="Specifiesw whether to use an unsigned S3 session."
+    )
+    region_name: Optional[str] = Field(
+        default=None, description="Specifies a custom region for the S3 session."
+    )
+    endpoint_url: Optional[str] = Field(
+        default=None, description="Specifies a custom endpoint for the S3 session."
+    )
+    max_attempts: int = Field(
+        default=5,
         description=(
-            "This provides Boto3's retry handler with a value of maximum retry attempts, "
-            "where the initial call counts toward the max_attempts value that you provide"
+            "This provides Boto3's retry handler with a value of maximum retry attempts, where the"
+            " initial call counts toward the max_attempts value that you provide."
         ),
-        is_required=False,
-        default_value=5,
-    ),
-    "profile_name": Field(
-        str,
-        description="Specifies a profile to connect that session",
-        is_required=False,
-    ),
-    "use_ssl": Field(
-        bool,
-        description="Whether or not to use SSL. By default, SSL is used.",
-        is_required=False,
-        default_value=True,
-    ),
-    "verify": Field(
-        Noneable(str),
+    )
+    profile_name: Optional[str] = Field(
+        default=None, description="Specifies a profile to connect that session."
+    )
+    use_ssl: bool = Field(
+        default=True, description="Whether or not to use SSL. By default, SSL is used."
+    )
+    verify: Optional[str] = Field(
+        default=None,
         description=(
             "Whether or not to verify SSL certificates. By default SSL certificates are verified."
             " You can also specify this argument if you want to use a different CA cert bundle than"
             " the one used by botocore."
         ),
-        is_required=False,
-        default_value=None,
-    ),
-    "aws_access_key_id": Field(
-        Noneable(StringSource),
-        description="The access key to use when creating the client.",
-        is_required=False,
-        default_value=None,
-    ),
-    "aws_secret_access_key": Field(
-        Noneable(StringSource),
-        description="The secret key to use when creating the client.",
-        is_required=False,
-        default_value=None,
-    ),
-    "aws_session_token": Field(
-        Noneable(StringSource),
-        description="The session token to use when creating the client.",
-        is_required=False,
-        default_value=None,
-    ),
-}
+    )
+    aws_access_key_id: Optional[str] = Field(
+        default=None, description="AWS access key ID to use when creating the boto3 session."
+    )
+    aws_secret_access_key: Optional[str] = Field(
+        default=None, description="AWS secret access key to use when creating the boto3 session."
+    )
+    aws_session_token: str = Field(
+        default=None, description="AWS session token to use when creating the boto3 session."
+    )
 
 
-@resource(S3_SESSION_CONFIG)
-def s3_resource(context):
+class S3Resource(S3ResourceBase[Any]):
+    """Resource that gives access to S3.
+
+    The underlying S3 session is created by calling
+    :py:func:`boto3.session.Session(profile_name) <boto3:boto3.session>`.
+    The returned resource object is an S3 client, an instance of `botocore.client.S3`.
+
+    Example:
+        .. code-block:: python
+
+            from dagster import build_op_context, job, op
+            from dagster_aws.s3 import S3Resource
+
+            @op(required_resource_keys={'s3'})
+            def example_s3_op(context):
+                return context.resources.s3.list_objects_v2(
+                    Bucket='my-bucket',
+                    Prefix='some-key'
+                )
+
+            @job(resource_defs={
+                's3': S3Resource(region_name='us-west-1')
+            })
+            def example_job():
+                example_s3_op()
+
+            example_job.execute_in_process()
+
+    """
+
+    def create_resource(self, context: InitResourceContext) -> Any:
+        return construct_s3_client(
+            max_attempts=self.max_attempts,
+            region_name=self.region_name,
+            endpoint_url=self.endpoint_url,
+            use_unsigned_session=self.use_unsigned_session,
+            profile_name=self.profile_name,
+            use_ssl=self.use_ssl,
+            verify=self.verify,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
+        )
+
+
+@resource(config_schema=S3Resource.to_config_schema())
+def s3_resource(context) -> Any:
     """Resource that gives access to S3.
 
     The underlying S3 session is created by calling
@@ -140,47 +170,40 @@ def s3_resource(context):
               aws_session_token: None
               # Optional[str]:  The session token to use when creating the client.
     """
-    return construct_s3_client(
-        max_attempts=context.resource_config["max_attempts"],
-        region_name=context.resource_config.get("region_name"),
-        endpoint_url=context.resource_config.get("endpoint_url"),
-        use_unsigned_session=context.resource_config["use_unsigned_session"],
-        profile_name=context.resource_config.get("profile_name"),
-        use_ssl=context.resource_config.get("use_ssl"),
-        verify=context.resource_config.get("verify"),
-        aws_access_key_id=context.resource_config.get("aws_access_key_id"),
-        aws_secret_access_key=context.resource_config.get("aws_secret_access_key"),
-        aws_session_token=context.resource_config.get("aws_session_token"),
+    return S3Resource.from_resource_context(context)
+
+
+class S3FileManagerResource(S3ResourceBase[S3FileManager]):
+    s3_bucket: str = Field(description="S3 bucket to use for the file manager.")
+    s3_prefix: str = Field(
+        default="dagster", description="Prefix to use for the S3 bucket for this file manager."
     )
+
+    def create_resource(self, context: InitResourceContext) -> S3FileManager:
+        return S3FileManager(
+            s3_session=construct_s3_client(
+                max_attempts=self.max_attempts,
+                region_name=self.region_name,
+                endpoint_url=self.endpoint_url,
+                use_unsigned_session=self.use_unsigned_session,
+                profile_name=self.profile_name,
+                use_ssl=self.use_ssl,
+                verify=self.verify,
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                aws_session_token=self.aws_session_token,
+            ),
+            s3_bucket=self.s3_bucket,
+            s3_base_key=self.s3_prefix,
+        )
 
 
 @resource(
-    merge_dicts(
-        S3_SESSION_CONFIG,
-        {
-            "s3_bucket": Field(StringSource),
-            "s3_prefix": Field(StringSource, is_required=False, default_value="dagster"),
-        },
-    )
+    config_schema=S3FileManagerResource.to_config_schema(),
 )
-def s3_file_manager(context):
+def s3_file_manager(context) -> S3FileManager:
     """FileManager that provides abstract access to S3.
 
     Implements the :py:class:`~dagster._core.storage.file_manager.FileManager` API.
     """
-    return S3FileManager(
-        s3_session=construct_s3_client(
-            max_attempts=context.resource_config["max_attempts"],
-            region_name=context.resource_config.get("region_name"),
-            endpoint_url=context.resource_config.get("endpoint_url"),
-            use_unsigned_session=context.resource_config["use_unsigned_session"],
-            profile_name=context.resource_config.get("profile_name"),
-            use_ssl=context.resource_config.get("use_ssl"),
-            verify=context.resource_config.get("verify"),
-            aws_access_key_id=context.resource_config.get("aws_access_key_id"),
-            aws_secret_access_key=context.resource_config.get("aws_secret_access_key"),
-            aws_session_token=context.resource_config.get("aws_session_token"),
-        ),
-        s3_bucket=context.resource_config["s3_bucket"],
-        s3_base_key=context.resource_config["s3_prefix"],
-    )
+    return S3FileManagerResource.from_resource_context(context)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_file_handle_to_s3.py
@@ -1,27 +1,55 @@
-from dagster import DagsterEventType, job, op
+import pytest
+from dagster import DagsterEventType, ResourceDefinition, job, op
 from dagster._core.definitions.metadata import MetadataValue
-from dagster_aws.s3 import S3FileHandle, file_handle_to_s3, s3_file_manager, s3_resource
+from dagster_aws.s3 import (
+    S3FileHandle,
+    S3FileManagerResource,
+    S3Resource,
+    file_handle_to_s3,
+    s3_file_manager,
+    s3_resource,
+)
 
 
-def create_file_handle_job(temp_file_handle):
+@pytest.fixture(name="s3_resource_type", params=[True, False])
+def s3_resource_type_fixture(request) -> ResourceDefinition:
+    if request.param:
+        return s3_resource
+    else:
+        return S3Resource.configure_at_launch()
+
+
+@pytest.fixture(name="s3_file_manager_resource_type", params=[True, False])
+def s3_file_manager_resource_type_fixture(request) -> ResourceDefinition:
+    if request.param:
+        return s3_file_manager
+    else:
+        return S3FileManagerResource.configure_at_launch()
+
+
+def create_file_handle_job(temp_file_handle, s3_resource_type, s3_file_manager_resource_type):
     @op
     def emit_temp_handle(_):
         return temp_file_handle
 
-    @job(resource_defs={"s3": s3_resource, "file_manager": s3_file_manager})
+    @job(resource_defs={"s3": s3_resource_type, "file_manager": s3_file_manager_resource_type})
     def test():
         file_handle_to_s3(emit_temp_handle())
 
     return test
 
 
-def test_successful_file_handle_to_s3(mock_s3_bucket):
+def test_successful_file_handle_to_s3(
+    mock_s3_bucket, s3_resource_type, s3_file_manager_resource_type
+):
     foo_bytes = b"foo"
     remote_s3_object = mock_s3_bucket.Object("some-key/foo")
     remote_s3_object.put(Body=foo_bytes)
 
     file_handle = S3FileHandle(mock_s3_bucket.name, "some-key/foo")
-    result = create_file_handle_job(file_handle).execute_in_process(
+    result = create_file_handle_job(
+        file_handle, s3_resource_type, s3_file_manager_resource_type
+    ).execute_in_process(
         run_config={
             "ops": {
                 "file_handle_to_s3": {"config": {"Bucket": mock_s3_bucket.name, "Key": "some-key"}}

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -22,7 +22,7 @@ from dagster import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import build_assets_job
-from dagster_aws.s3.io_manager import S3IOManagerResource, s3_pickle_io_manager
+from dagster_aws.s3.io_manager import PickledObjectS3IOManagerResource, s3_pickle_io_manager
 from dagster_aws.s3.utils import construct_s3_client
 
 
@@ -31,7 +31,7 @@ def s3_io_manager_builder_fixture(request) -> Callable[[Any], ResourceDefinition
     if request.param:
         return lambda _: s3_pickle_io_manager
     else:
-        return lambda s3: S3IOManagerResource.configure_at_launch(s3_resource=s3)
+        return lambda s3: PickledObjectS3IOManagerResource.configure_at_launch(s3_resource=s3)
 
 
 @resource

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -22,7 +22,7 @@ from dagster import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import build_assets_job
-from dagster_aws.s3.io_manager import S3PickleIOManager, s3_pickle_io_manager
+from dagster_aws.s3.io_manager import S3IOManagerResource, s3_pickle_io_manager
 from dagster_aws.s3.utils import construct_s3_client
 
 
@@ -31,7 +31,7 @@ def s3_io_manager_builder_fixture(request) -> Callable[[Any], ResourceDefinition
     if request.param:
         return lambda _: s3_pickle_io_manager
     else:
-        return lambda s3: S3PickleIOManager.configure_at_launch(s3_resource=s3)
+        return lambda s3: S3IOManagerResource.configure_at_launch(s3_resource=s3)
 
 
 @resource

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -22,7 +22,7 @@ from dagster import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.test_utils import instance_for_test
 from dagster._legacy import build_assets_job
-from dagster_aws.s3.io_manager import PickledObjectS3IOManagerResource, s3_pickle_io_manager
+from dagster_aws.s3.io_manager import ConfigurablePickledObjectS3IOManager, s3_pickle_io_manager
 from dagster_aws.s3.utils import construct_s3_client
 
 
@@ -31,7 +31,7 @@ def s3_io_manager_builder_fixture(request) -> Callable[[Any], ResourceDefinition
     if request.param:
         return lambda _: s3_pickle_io_manager
     else:
-        return lambda s3: PickledObjectS3IOManagerResource.configure_at_launch(s3_resource=s3)
+        return lambda s3: ConfigurablePickledObjectS3IOManager.configure_at_launch(s3_resource=s3)
 
 
 @resource


### PR DESCRIPTION
## Summary

Finishes off the `dagster-aws` migration by migrating the `S3IOManager` and `S3Resource` over.

## Test Plan

Add new resources to existing unit tests.
