### PR TITLE
Allow dagster-k8s to be imported in older versions of k8s python client

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -552,6 +552,10 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "AWS_SECRET_ACCESS_KEY",
             "BUILDKITE_SECRETS_BUCKET",
         ],
+        pytest_tox_factors=[
+            "default",
+            "old_kubernetes",
+        ],
         pytest_extra_cmds=k8s_extra_cmds,
         pytest_step_dependencies=test_project_depends_fn,
     ),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_job.py
@@ -42,7 +42,7 @@ def test_user_defined_k8s_config_serialization():
         },
         pod_template_spec_metadata={"namespace": "value"},
         pod_spec_config={"dns_policy": "value"},
-        job_config={"status": {"completed_indexes": "value"}},
+        job_config={"status": {"active": 1}},
         job_metadata={"namespace": "value"},
         job_spec_config={"backoff_limit": 120},
     )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_resource_tags.py
@@ -216,7 +216,7 @@ def test_user_defined_config_from_tags():
         },
         "pod_template_spec_metadata": {"namespace": "pod_template_spec_value"},
         "pod_spec_config": {"dns_policy": "pod_spec_config_value"},
-        "job_config": {"status": {"completed_indexes": "job_config_value"}},
+        "job_config": {"status": {"active": 1}},
         "job_metadata": {"namespace": "job_metadata_value"},
         "job_spec_config": {"backoff_limit": 120},
     }

--- a/python_modules/libraries/dagster-k8s/tox.ini
+++ b/python_modules/libraries/dagster-k8s/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{39,38,37,36}-{unix,windows}
+envlist = py{39,38,37,36}-{unix,windows}-{default,old_kubernetes}
 skipsdist = true
 
 [testenv]
 download = True
 passenv = HOME AWS_* BUILDKITE* CI_* COVERALLS_REPO_TOKEN DAGSTER_* DOCKER_* GOOGLE_* KUBECONFIG
 deps =
+  old_kubernetes: kubernetes==12.0.0
   -e ../../dagster[test]
   -e ../../dagster-graphql
   -e ../../dagster-test


### PR DESCRIPTION
Summary:
New Events API is not available in all k8s versions, but provides useful debug information when it is. Fall back to a warning message when you're on an older version of k8s.

Test Plan: BK (new test suite with older k8s version)

## Summary & Motivation

## How I Tested These Changes
