### PR TITLE
respect AutoMaterializePolicies

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -22,6 +22,7 @@ import pendulum
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -42,6 +43,70 @@ from .utils import check_valid_name
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
     from dagster._utils.caching_instance_queryer import CachingInstanceQueryer  # expensive import
+
+
+def get_implicit_auto_materialize_policy(
+    asset_graph: AssetGraph, asset_key: AssetKey
+) -> Optional[AutoMaterializePolicy]:
+    """For backcompat with pre-auto materialize policy graphs, assume a default scope of 1 day."""
+    auto_materialize_policy = asset_graph.get_auto_materialize_policy(asset_key)
+    if auto_materialize_policy is None:
+        return AutoMaterializePolicy(
+            on_missing=True,
+            on_upstream_data_newer=not bool(
+                asset_graph.get_downstream_freshness_policies(asset_key=asset_key)
+            ),
+            for_freshness=True,
+            time_window_partition_scope_minutes=24 * 60,
+        )
+    return auto_materialize_policy
+
+
+def reconciliation_window_for_time_window_partitions(
+    partitions_def: TimeWindowPartitionsDefinition,
+    time_window_partition_scope: Optional[datetime.timedelta],
+    current_time: datetime.datetime,
+) -> Optional[TimeWindow]:
+    latest_partition_window = partitions_def.get_last_partition_window(current_time=current_time)
+    earliest_partition_window = partitions_def.get_first_partition_window(current_time=current_time)
+    if latest_partition_window is None or earliest_partition_window is None:
+        return None
+
+    allowable_start_time = (
+        max(
+            earliest_partition_window.start,
+            latest_partition_window.start
+            - time_window_partition_scope
+            + datetime.timedelta.resolution,
+        )
+        if time_window_partition_scope is not None
+        else earliest_partition_window.start
+    )
+    return TimeWindow(allowable_start_time, latest_partition_window.end)
+
+
+def can_reconcile_time_window_partition(
+    partitions_def: TimeWindowPartitionsDefinition,
+    partition_key: Optional[str],
+    time_window_partition_scope: Optional[datetime.timedelta],
+    current_time: datetime.datetime,
+) -> bool:
+    if partition_key is None:
+        return False
+    if time_window_partition_scope is None:
+        return True
+    reconciliation_window = reconciliation_window_for_time_window_partitions(
+        partitions_def=partitions_def,
+        time_window_partition_scope=time_window_partition_scope,
+        current_time=current_time,
+    )
+    if reconciliation_window is None:
+        return False
+    key_window = partitions_def.time_window_for_partition_key(partition_key)
+    return (
+        key_window.start >= reconciliation_window.start
+        and key_window.end <= reconciliation_window.end
+    )
 
 
 class AssetReconciliationCursor(NamedTuple):
@@ -68,7 +133,8 @@ class AssetReconciliationCursor(NamedTuple):
         asset_key: AssetKey,
         asset_graph,
         dynamic_partitions_store: "DynamicPartitionsStore",
-        evaluation_time: datetime.datetime,
+        current_time: datetime.datetime,
+        time_window_partition_scope: Optional[datetime.timedelta],
     ) -> Iterable[str]:
         partitions_def = asset_graph.get_partitions_def(asset_key)
 
@@ -79,16 +145,19 @@ class AssetReconciliationCursor(NamedTuple):
         )
 
         if isinstance(partitions_def, TimeWindowPartitionsDefinition):
-            allowable_time_window = allowable_time_window_for_partitions_def(
-                partitions_def, evaluation_time
+            # for performance, only iterate over keys within the allowable time window
+            reconciliation_window = reconciliation_window_for_time_window_partitions(
+                partitions_def=partitions_def,
+                time_window_partition_scope=time_window_partition_scope,
+                current_time=current_time,
             )
-            if allowable_time_window is None:
+            if reconciliation_window is None:
                 return []
             # for performance, only iterate over keys within the allowable time window
             return [
                 partition_key
                 for partition_key in partitions_def.get_partition_keys_in_time_window(
-                    allowable_time_window
+                    reconciliation_window
                 )
                 if partition_key not in materialized_or_requested_subset
             ]
@@ -243,6 +312,7 @@ def find_parent_materialized_asset_partitions(
     instance_queryer: "CachingInstanceQueryer",
     latest_storage_id: Optional[int],
     target_asset_keys: AbstractSet[AssetKey],
+    target_asset_keys_and_parents: AbstractSet[AssetKey],
     asset_graph: AssetGraph,
     can_reconcile_fn: Callable[[AssetKeyPartitionKey], bool] = lambda _: True,
 ) -> Tuple[AbstractSet[AssetKeyPartitionKey], Optional[int]]:
@@ -257,14 +327,7 @@ def find_parent_materialized_asset_partitions(
     result_asset_partitions: Set[AssetKeyPartitionKey] = set()
     result_latest_storage_id = latest_storage_id
 
-    # set of all parents of all target assets using asset_graph.get_parents(key)
-    target_parent_asset_keys = {
-        parent
-        for target_asset_key in target_asset_keys
-        for parent in asset_graph.get_parents(target_asset_key)
-    }
-
-    for asset_key in target_parent_asset_keys:
+    for asset_key in target_asset_keys_and_parents:
         if asset_graph.is_source(asset_key):
             continue
 
@@ -349,7 +412,7 @@ def find_never_materialized_or_requested_root_asset_partitions(
     cursor: AssetReconciliationCursor,
     target_asset_keys: AbstractSet[AssetKey],
     asset_graph: AssetGraph,
-    evaluation_time: datetime.datetime,
+    current_time: datetime.datetime,
 ) -> Tuple[
     Iterable[AssetKeyPartitionKey], AbstractSet[AssetKey], Mapping[AssetKey, AbstractSet[str]]
 ]:
@@ -369,8 +432,15 @@ def find_never_materialized_or_requested_root_asset_partitions(
 
     for asset_key in target_asset_keys & asset_graph.root_asset_keys:
         if asset_graph.is_partitioned(asset_key):
+            auto_materialize_policy = check.not_none(
+                get_implicit_auto_materialize_policy(asset_graph, asset_key)
+            )
             for partition_key in cursor.get_never_requested_never_materialized_partitions(
-                asset_key, asset_graph, instance_queryer, evaluation_time
+                asset_key,
+                asset_graph,
+                instance_queryer,
+                current_time,
+                time_window_partition_scope=auto_materialize_policy.time_window_partition_scope,
             ):
                 asset_partition = AssetKeyPartitionKey(asset_key, partition_key)
                 if instance_queryer.get_latest_materialization_record(asset_partition, None):
@@ -392,75 +462,13 @@ def find_never_materialized_or_requested_root_asset_partitions(
     )
 
 
-def allowable_time_window_for_partitions_def(
-    partitions_def: TimeWindowPartitionsDefinition,
-    evaluation_time: datetime.datetime,
-) -> Optional[TimeWindow]:
-    """Returns a time window encompassing the partitions that the reconciliation sensor is currently
-    allowed to materialize for this partitions_def.
-    """
-    latest_partition_window = partitions_def.get_last_partition_window(current_time=evaluation_time)
-    if latest_partition_window is None:
-        return None
-
-    earliest_partition_window = partitions_def.get_first_partition_window(
-        current_time=evaluation_time
-    )
-    if earliest_partition_window is None:
-        return None
-
-    start = max(
-        earliest_partition_window.start,
-        # we add datetime.timedelta.resolution because if the latest partition starts at 2023-01-02,
-        # then we don't want 2023-01-01 to be within the allowable time window
-        latest_partition_window.start - datetime.timedelta(days=1) + datetime.timedelta.resolution,
-    )
-
-    return TimeWindow(
-        start=start,
-        end=latest_partition_window.end,
-    )
-
-
-def candidates_unit_within_allowable_time_window(
-    asset_graph: AssetGraph,
-    candidates_unit: Iterable[AssetKeyPartitionKey],
-    evaluation_time: datetime.datetime,
-):
-    """A given time-window partition may only be materialized if its window ends within 1 day of the
-    latest window for that partition.
-    """
-    representative_candidate = next(iter(candidates_unit), None)
-    if not representative_candidate:
-        return True
-
-    partitions_def = asset_graph.get_partitions_def(representative_candidate.asset_key)
-    partition_key = representative_candidate.partition_key
-    if not isinstance(partitions_def, TimeWindowPartitionsDefinition) or not partition_key:
-        return True
-
-    partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
-
-    allowable_time_window = allowable_time_window_for_partitions_def(
-        partitions_def, evaluation_time
-    )
-    if allowable_time_window is None:
-        return False
-
-    candidate_partition_window = partitions_def.time_window_for_partition_key(partition_key)
-    return (
-        candidate_partition_window.start >= allowable_time_window.start
-        and candidate_partition_window.end <= allowable_time_window.end
-    )
-
-
 def determine_asset_partitions_to_reconcile(
     instance_queryer: "CachingInstanceQueryer",
     cursor: AssetReconciliationCursor,
     target_asset_keys: AbstractSet[AssetKey],
+    target_asset_keys_and_parents: AbstractSet[AssetKey],
     asset_graph: AssetGraph,
-    eventual_asset_partitions_to_reconcile_for_freshness: AbstractSet[AssetKeyPartitionKey],
-    evaluation_time: datetime.datetime,
+    current_time: datetime.datetime,
 ) -> Tuple[
     AbstractSet[AssetKeyPartitionKey],
     AbstractSet[AssetKey],
@@ -476,25 +484,44 @@ def determine_asset_partitions_to_reconcile(
         cursor=cursor,
         target_asset_keys=target_asset_keys,
         asset_graph=asset_graph,
-        evaluation_time=evaluation_time,
+        current_time=current_time,
     )
 
-    # a quick filter for eliminating some stale candidates
-    def can_reconcile_fn(candidate: AssetKeyPartitionKey) -> bool:
-        if candidate.partition_key is None:
-            return True
-        return candidates_unit_within_allowable_time_window(
-            asset_graph=asset_graph,
-            candidates_unit=[candidate],
-            evaluation_time=evaluation_time,
+    # a filter for eliminating candidates
+    def can_reconcile_candidate(candidate: AssetKeyPartitionKey) -> bool:
+        auto_materialize_policy = get_implicit_auto_materialize_policy(
+            asset_graph=asset_graph, asset_key=candidate.asset_key
         )
+        partitions_def = asset_graph.get_partitions_def(candidate.asset_key)
+
+        # no policy means no reconciliation
+        if auto_materialize_policy is None:
+            return False
+        # the partition is too old to reconcile
+        elif isinstance(
+            partitions_def, TimeWindowPartitionsDefinition
+        ) and not can_reconcile_time_window_partition(
+            partitions_def=partitions_def,
+            partition_key=candidate.partition_key,
+            time_window_partition_scope=auto_materialize_policy.time_window_partition_scope,
+            current_time=current_time,
+        ):
+            return False
+        # the policy does not allow for materializing missing partitions and it's missing
+        elif not auto_materialize_policy.on_missing and not instance_queryer.materialization_exists(
+            candidate
+        ):
+            return False
+
+        return True
 
     stale_candidates, latest_storage_id = find_parent_materialized_asset_partitions(
         instance_queryer=instance_queryer,
         latest_storage_id=cursor.latest_storage_id,
         target_asset_keys=target_asset_keys,
+        target_asset_keys_and_parents=target_asset_keys_and_parents,
         asset_graph=asset_graph,
-        can_reconcile_fn=can_reconcile_fn,
+        can_reconcile_fn=can_reconcile_candidate,
     )
 
     backfill_target_asset_graph_subset = get_active_backfill_target_asset_graph_subset(
@@ -525,18 +552,30 @@ def determine_asset_partitions_to_reconcile(
             )
         )
 
+    def should_reconcile_candidate(candidate: AssetKeyPartitionKey) -> bool:
+        auto_materialize_policy = get_implicit_auto_materialize_policy(
+            asset_graph=asset_graph, asset_key=candidate.asset_key
+        )
+        if auto_materialize_policy is None:
+            return False
+
+        return (
+            auto_materialize_policy.on_missing
+            and not instance_queryer.materialization_exists(asset_partition=candidate)
+        ) or (
+            auto_materialize_policy.on_upstream_data_newer
+            and not instance_queryer.is_reconciled(
+                asset_partition=candidate, asset_graph=asset_graph
+            )
+        )
+
     def should_reconcile(
         candidates_unit: Iterable[AssetKeyPartitionKey],
         to_reconcile: AbstractSet[AssetKeyPartitionKey],
     ) -> bool:
-        if not candidates_unit_within_allowable_time_window(
-            asset_graph, candidates_unit, evaluation_time
-        ):
-            return False
-
         if any(
-            # do not reconcile assets if the freshness system will update them
-            candidate in eventual_asset_partitions_to_reconcile_for_freshness
+            # do not reconcile assets if they are not reconcilable
+            not can_reconcile_candidate(candidate)
             # do not reconcile assets if an active backfill will update them
             or candidate in backfill_target_asset_graph_subset
             # do not reconcile assets if they are not in the target selection
@@ -547,10 +586,7 @@ def determine_asset_partitions_to_reconcile(
 
         return all(
             parents_will_be_reconciled(candidate, to_reconcile) for candidate in candidates_unit
-        ) and any(
-            not instance_queryer.is_reconciled(asset_partition=candidate, asset_graph=asset_graph)
-            for candidate in candidates_unit
-        )
+        ) and any(should_reconcile_candidate(candidate) for candidate in candidates_unit)
 
     to_reconcile = asset_graph.bfs_filter_asset_partitions(
         instance_queryer,
@@ -569,14 +605,14 @@ def determine_asset_partitions_to_reconcile(
 def get_execution_period_for_policy(
     freshness_policy: FreshnessPolicy,
     effective_data_time: Optional[datetime.datetime],
-    evaluation_time: datetime.datetime,
+    current_time: datetime.datetime,
 ) -> pendulum.Period:
     if effective_data_time is None:
-        return pendulum.Period(start=evaluation_time, end=evaluation_time)
+        return pendulum.Period(start=current_time, end=current_time)
 
     if freshness_policy.cron_schedule:
         tick_iterator = cron_string_iterator(
-            start_timestamp=evaluation_time.timestamp(),
+            start_timestamp=current_time.timestamp(),
             cron_string=freshness_policy.cron_schedule,
             execution_timezone=freshness_policy.cron_schedule_timezone,
         )
@@ -593,14 +629,14 @@ def get_execution_period_for_policy(
         return pendulum.Period(
             # we don't want to execute this too frequently
             start=effective_data_time + 0.9 * freshness_policy.maximum_lag_delta,
-            end=max(effective_data_time + freshness_policy.maximum_lag_delta, evaluation_time),
+            end=max(effective_data_time + freshness_policy.maximum_lag_delta, current_time),
         )
 
 
 def get_execution_period_for_policies(
     policies: AbstractSet[FreshnessPolicy],
     effective_data_time: Optional[datetime.datetime],
-    evaluation_time: datetime.datetime,
+    current_time: datetime.datetime,
 ) -> Optional[pendulum.Period]:
     """Determines a range of times for which you can kick off an execution of this asset to solve
     the most pressing constraint, alongside a maximum number of additional constraints.
@@ -608,7 +644,7 @@ def get_execution_period_for_policies(
     merged_period = None
     for period in sorted(
         (
-            get_execution_period_for_policy(policy, effective_data_time, evaluation_time)
+            get_execution_period_for_policy(policy, effective_data_time, current_time)
             for policy in policies
         ),
         # sort execution periods by most pressing
@@ -631,8 +667,9 @@ def determine_asset_partitions_to_reconcile_for_freshness(
     data_time_resolver: "CachingDataTimeResolver",
     asset_graph: AssetGraph,
     target_asset_keys: AbstractSet[AssetKey],
-    evaluation_time: datetime.datetime,
-) -> Tuple[AbstractSet[AssetKeyPartitionKey], AbstractSet[AssetKeyPartitionKey]]:
+    target_asset_keys_and_parents: AbstractSet[AssetKey],
+    current_time: datetime.datetime,
+) -> AbstractSet[AssetKeyPartitionKey]:
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies, as well as a set of AssetKeyPartitionKeys which will be materialized at
     some point within the plan window.
@@ -641,17 +678,19 @@ def determine_asset_partitions_to_reconcile_for_freshness(
     """
     # now we have a full set of constraints, we can find solutions for them as we move down
     to_materialize: Set[AssetKeyPartitionKey] = set()
-    eventually_materialize: Set[AssetKeyPartitionKey] = set()
     expected_data_time_by_key: Dict[AssetKey, Optional[datetime.datetime]] = {}
+
     for level in asset_graph.toposort_asset_keys():
         for key in level:
-            if asset_graph.is_source(key) or not asset_graph.get_downstream_freshness_policies(
-                asset_key=key
+            if (
+                key not in target_asset_keys_and_parents
+                or key not in asset_graph.all_asset_keys
+                or not asset_graph.get_downstream_freshness_policies(asset_key=key)
             ):
                 continue
 
             # figure out the current contents of this asset with respect to its constraints
-            current_data_time = data_time_resolver.get_current_data_time(key, evaluation_time)
+            current_data_time = data_time_resolver.get_current_data_time(key, current_time)
 
             # figure out the expected data time of this asset if it were to be executed on this tick
             expected_data_time = min(
@@ -660,19 +699,19 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                     for k in asset_graph.get_parents(key)
                     if k in expected_data_time_by_key and expected_data_time_by_key[k] is not None
                 ),
-                default=evaluation_time,
+                default=current_time,
             )
 
             if key in target_asset_keys:
                 # calculate the data times you would expect after all currently-executing runs
                 # were to successfully complete
                 in_progress_data_time = data_time_resolver.get_in_progress_data_time(
-                    key, evaluation_time
+                    key, current_time
                 )
 
                 # calculate the data times you would have expected if the most recent run succeeded
                 failed_data_time = data_time_resolver.get_ignored_failure_data_time(
-                    key, evaluation_time
+                    key, current_time
                 )
 
                 effective_data_time = max(
@@ -685,11 +724,8 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 execution_period = get_execution_period_for_policies(
                     policies=asset_graph.get_downstream_freshness_policies(asset_key=key),
                     effective_data_time=effective_data_time,
-                    evaluation_time=evaluation_time,
+                    current_time=current_time,
                 )
-                if execution_period:
-                    eventually_materialize.add(AssetKeyPartitionKey(key, None))
-
             else:
                 execution_period = None
 
@@ -700,7 +736,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 expected_data_time_by_key[key] = expected_data_time
             elif (
                 execution_period is not None
-                and execution_period.start <= evaluation_time
+                and execution_period.start <= current_time
                 and expected_data_time is not None
                 and expected_data_time >= execution_period.start
             ):
@@ -714,7 +750,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 # current time for this asset, as it's not going to be updated
                 expected_data_time_by_key[key] = current_data_time
 
-    return to_materialize, eventually_materialize
+    return to_materialize
 
 
 def reconcile(
@@ -730,29 +766,41 @@ def reconcile(
 
     instance_queryer = CachingInstanceQueryer(instance=instance)
 
-    # fetch some data in advance to batch together some queries
-    target_parent_asset_keys = list(
-        {
-            parent
-            for target_asset_key in target_asset_keys
-            for parent in asset_graph.get_parents(target_asset_key)
+    # if there is a auto materialize policy set in the selection, use that
+    if any(
+        asset_graph.get_auto_materialize_policy(target_key) is not None
+        for target_key in target_asset_keys
+    ):
+        target_asset_keys = {
+            target_key
+            for target_key in target_asset_keys
+            if asset_graph.get_auto_materialize_policy(target_key) is not None
         }
-    )
-    instance_queryer.prefetch_asset_records(target_parent_asset_keys)
+
+    target_parent_asset_keys = {
+        parent
+        for target_asset_key in target_asset_keys
+        for parent in asset_graph.get_parents(target_asset_key)
+    }
+    target_asset_keys_and_parents = target_asset_keys | target_parent_asset_keys
+
+    # fetch some data in advance to batch some queries
+    target_asset_keys_and_parents_list = list(target_asset_keys_and_parents)
+    instance_queryer.prefetch_asset_records(target_asset_keys_and_parents_list)
     instance_queryer.prefetch_asset_partition_counts(
-        target_parent_asset_keys, after_cursor=cursor.latest_storage_id
+        target_asset_keys_and_parents_list, after_cursor=cursor.latest_storage_id
     )
 
-    (
-        asset_partitions_to_reconcile_for_freshness,
-        eventual_asset_partitions_to_reconcile_for_freshness,
-    ) = determine_asset_partitions_to_reconcile_for_freshness(
-        data_time_resolver=CachingDataTimeResolver(
-            instance_queryer=instance_queryer, asset_graph=asset_graph
-        ),
-        asset_graph=asset_graph,
-        target_asset_keys=target_asset_keys,
-        evaluation_time=current_time,
+    asset_partitions_to_reconcile_for_freshness = (
+        determine_asset_partitions_to_reconcile_for_freshness(
+            data_time_resolver=CachingDataTimeResolver(
+                instance_queryer=instance_queryer, asset_graph=asset_graph
+            ),
+            asset_graph=asset_graph,
+            target_asset_keys=target_asset_keys,
+            target_asset_keys_and_parents=target_asset_keys_and_parents,
+            current_time=current_time,
+        )
     )
 
     (
@@ -765,8 +813,8 @@ def reconcile(
         asset_graph=asset_graph,
         cursor=cursor,
         target_asset_keys=target_asset_keys,
-        eventual_asset_partitions_to_reconcile_for_freshness=eventual_asset_partitions_to_reconcile_for_freshness,
-        evaluation_time=current_time,
+        target_asset_keys_and_parents=target_asset_keys_and_parents,
+        current_time=current_time,
     )
 
     run_requests = build_run_requests(

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -410,6 +410,7 @@ class UpstreamAssetSelection(AssetSelection):
                     )
                     for asset_key in selection
                 ],
+                set(),
             ),
             selection if not self.include_self else set(),
         )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -40,13 +40,13 @@ class AutoMaterializePolicy(NamedTuple):
     on_missing: bool
     on_upstream_data_newer: bool
     for_freshness: bool
-    time_window_partition_scope_minutes: Optional[int]
+    time_window_partition_scope_minutes: Optional[float]
 
     @property
     def time_window_partition_scope(self) -> Optional[datetime.timedelta]:
         if self.time_window_partition_scope_minutes is None:
             return None
-        return datetime.timedelta(seconds=self.time_window_partition_scope_minutes)
+        return datetime.timedelta(minutes=self.time_window_partition_scope_minutes)
 
     @staticmethod
     def eager(
@@ -56,9 +56,7 @@ class AutoMaterializePolicy(NamedTuple):
             on_missing=True,
             on_upstream_data_newer=True,
             for_freshness=True,
-            time_window_partition_scope_minutes=int(
-                time_window_partition_scope.total_seconds() / 60
-            )
+            time_window_partition_scope_minutes=time_window_partition_scope.total_seconds() / 60
             if time_window_partition_scope is not None
             else None,
         )
@@ -71,9 +69,7 @@ class AutoMaterializePolicy(NamedTuple):
             on_missing=True,
             on_upstream_data_newer=False,
             for_freshness=True,
-            time_window_partition_scope_minutes=int(
-                time_window_partition_scope.total_seconds() / 60
-            )
+            time_window_partition_scope_minutes=time_window_partition_scope.total_seconds() / 60
             if time_window_partition_scope is not None
             else None,
         )

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -468,6 +468,14 @@ def execute_asset_backfill_iteration_inner(
         updated_materialized_subset = AssetGraphSubset(asset_graph)
         failed_and_downstream_subset = AssetGraphSubset(asset_graph)
     else:
+        target_parent_asset_keys = {
+            parent
+            for target_asset_key in asset_backfill_data.target_subset.asset_keys
+            for parent in asset_graph.get_parents(target_asset_key)
+        }
+        target_asset_keys_and_parents = (
+            asset_backfill_data.target_subset.asset_keys | target_parent_asset_keys
+        )
         (
             parent_materialized_asset_partitions,
             next_latest_storage_id,
@@ -475,6 +483,7 @@ def execute_asset_backfill_iteration_inner(
             asset_graph=asset_graph,
             instance_queryer=instance_queryer,
             target_asset_keys=asset_backfill_data.target_subset.asset_keys,
+            target_asset_keys_and_parents=target_asset_keys_and_parents,
             latest_storage_id=asset_backfill_data.latest_storage_id,
         )
         initial_candidates.update(parent_materialized_asset_partitions)

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.asset_reconciliation_sensor import (
     AssetReconciliationCursor,
     reconcile,
 )
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.partition import (
@@ -268,6 +269,7 @@ def asset_def(
     deps: Optional[Union[List[str], Mapping[str, PartitionMapping]]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
+    auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
 ) -> AssetsDefinition:
     if deps is None:
         non_argument_deps = set()
@@ -289,6 +291,7 @@ def asset_def(
         ins=ins,
         config_schema={"fail": Field(bool, default_value=False)},
         freshness_policy=freshness_policy,
+        auto_materialize_policy=auto_materialize_policy,
     )
     def _asset(context, **kwargs):
         del kwargs

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -1,0 +1,115 @@
+import copy
+import datetime
+from typing import Sequence
+
+from dagster import (
+    AssetsDefinition,
+    PartitionKeyRange,
+)
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._seven.compat.pendulum import create_pendulum_time
+
+from .asset_reconciliation_scenario import (
+    AssetReconciliationScenario,
+    run,
+    run_request,
+    single_asset_run,
+)
+from .freshness_policy_scenarios import overlapping_freshness_inf
+from .partition_scenarios import (
+    hourly_partitions_def,
+    hourly_to_daily_partitions,
+    two_assets_in_sequence_one_partition,
+)
+
+
+def with_auto_materialize_policy(
+    assets_defs: Sequence[AssetsDefinition], auto_materialize_policy: AutoMaterializePolicy
+) -> Sequence[AssetsDefinition]:
+    """Note: this should be implemented in core dagster at some point, and this implementation is
+    a lazy hack.
+    """
+    ret = []
+    for assets_def in assets_defs:
+        new_assets_def = copy.copy(assets_def)
+        new_assets_def._auto_materialize_policies_by_key = {  # noqa: SLF001
+            asset_key: auto_materialize_policy for asset_key in new_assets_def.asset_keys
+        }
+        ret.append(new_assets_def)
+    return ret
+
+
+# auto materialization policies
+auto_materialize_policy_scenarios = {
+    "auto_materialize_policy_eager_with_freshness_policies": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            overlapping_freshness_inf, AutoMaterializePolicy.eager()
+        ),
+        cursor_from=AssetReconciliationScenario(
+            assets=overlapping_freshness_inf,
+            unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4", "asset5", "asset6"])],
+        ),
+        # change at the top, should be immediately propagated as all assets have eager reconciliation
+        unevaluated_runs=[run(["asset1"])],
+        expected_run_requests=[
+            run_request(asset_keys=["asset2", "asset3", "asset4", "asset5", "asset6"])
+        ],
+    ),
+    "auto_materialize_policy_with_default_scope_hourly_to_daily_partitions_never_materialized": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            hourly_to_daily_partitions,
+            AutoMaterializePolicy.eager(),
+        ),
+        unevaluated_runs=[],
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        expected_run_requests=[
+            # with default scope, only the last partition is materialized
+            run_request(
+                asset_keys=["hourly"],
+                partition_key=hourly_partitions_def.get_last_partition_key(
+                    current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4)
+                ),
+            )
+        ],
+    ),
+    "auto_materialize_policy_with_custom_scope_hourly_to_daily_partitions_never_materialized": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            hourly_to_daily_partitions,
+            AutoMaterializePolicy.eager(time_window_partition_scope=datetime.timedelta(days=2)),
+        ),
+        unevaluated_runs=[],
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        expected_run_requests=[
+            run_request(asset_keys=["hourly"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-05-04:00", end="2013-01-07-03:00")
+            )
+        ],
+    ),
+    "auto_materialize_policy_with_custom_scope_hourly_to_daily_partitions_never_materialized2": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            hourly_to_daily_partitions,
+            AutoMaterializePolicy.lazy(time_window_partition_scope=datetime.timedelta(days=2)),
+        ),
+        unevaluated_runs=[],
+        current_time=create_pendulum_time(year=2013, month=1, day=7, hour=4),
+        expected_run_requests=[
+            run_request(asset_keys=["hourly"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2013-01-05-04:00", end="2013-01-07-03:00")
+            )
+        ],
+    ),
+    "auto_materialize_policy_lazy_parent_rematerialized_one_partition": AssetReconciliationScenario(
+        assets=with_auto_materialize_policy(
+            two_assets_in_sequence_one_partition,
+            AutoMaterializePolicy.lazy(),
+        ),
+        unevaluated_runs=[
+            run(["asset1", "asset2"], partition_key="a"),
+            single_asset_run(asset_key="asset1", partition_key="a"),
+        ],
+        # no need to rematerialize as this is a lazy policy
+        expected_run_requests=[],
+    ),
+}

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/scenarios.py
@@ -1,5 +1,6 @@
 from dagster import Definitions
 
+from .auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
 from .basic_scenarios import basic_scenarios
 from .exotic_partition_mapping_scenarios import exotic_partition_mapping_scenarios
 from .freshness_policy_scenarios import freshness_policy_scenarios
@@ -10,6 +11,7 @@ ASSET_RECONCILIATION_SCENARIOS = {
     **partition_scenarios,
     **basic_scenarios,
     **freshness_policy_scenarios,
+    **auto_materialize_policy_scenarios,
 }
 
 # put repos in the global namespace so that the daemon can load them with LoadableTargetOrigin

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_materialize_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_materialize_daemon.py
@@ -3,17 +3,11 @@ from dagster import DagsterInstance
 
 from .scenarios import ASSET_RECONCILIATION_SCENARIOS
 
-AUTO_MATERIALIZE_DAEMON_SCENARIOS = ASSET_RECONCILIATION_SCENARIOS.copy()
-
-# These cases use asset_selections, which the daemon does not support
-AUTO_MATERIALIZE_DAEMON_SCENARIOS.pop("freshness_many_to_one_roots_unselectable")
-AUTO_MATERIALIZE_DAEMON_SCENARIOS.pop("freshness_complex_subsettable")
-
 
 @pytest.mark.parametrize(
     "scenario_item",
-    list(AUTO_MATERIALIZE_DAEMON_SCENARIOS.items()),
-    ids=list(AUTO_MATERIALIZE_DAEMON_SCENARIOS.keys()),
+    list(ASSET_RECONCILIATION_SCENARIOS.items()),
+    ids=list(ASSET_RECONCILIATION_SCENARIOS.keys()),
 )
 def test_daemon(scenario_item):
     scenario_name, scenario = scenario_item


### PR DESCRIPTION
Rebasing in the last of https://github.com/dagster-io/dagster/pull/13205/files#diff-e551658986bbfd44b318278ce049a89b449d0b89bd8fb6552500c2b7ac617b30

For the sensor, if no AutoMaterializePolicies are set on the targeted assets, then maintain the prior behavior. If it exists on any of them, then fully switch to the new api (don't reconcile any without a policy set, etc.)

The latter will be the only mode for the daemon.