### PR TITLE
[configurable resources] Update dataclass_transform annotation to support aliases

### DIFF
--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, Union, cast
 
 import pydantic
+from pydantic import Field
+from pydantic.fields import FieldInfo
 from typing_extensions import dataclass_transform, get_origin
 
 from .utils import safe_is_subclass
@@ -49,7 +51,7 @@ class LateBoundTypesForResourceTypeChecking:
         )
 
 
-@dataclass_transform()
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field, FieldInfo))
 class BaseResourceMeta(pydantic.main.ModelMetaclass):
     """Custom metaclass for Resource and PartialResource. This metaclass is responsible for
     transforming the type annotations on the class so that Pydantic constructor-time validation

--- a/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/structured_config/typing_utils.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, Union, 
 
 import pydantic
 from pydantic import Field
-from pydantic.fields import FieldInfo
 from typing_extensions import dataclass_transform, get_origin
 
 from .utils import safe_is_subclass
@@ -51,7 +50,7 @@ class LateBoundTypesForResourceTypeChecking:
         )
 
 
-@dataclass_transform(kw_only_default=True, field_specifiers=(Field, FieldInfo))
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class BaseResourceMeta(pydantic.main.ModelMetaclass):
     """Custom metaclass for Resource and PartialResource. This metaclass is responsible for
     transforming the type annotations on the class so that Pydantic constructor-time validation

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -1004,6 +1004,32 @@ reveal_type(my_str_resource.a_string)
         assert mypy_out[1] == "builtins.str"
 
 
+@pytest.mark.typesignature
+def test_type_signatures_alias():
+    with tempfile.TemporaryDirectory() as tempdir:
+        filename = os.path.join(tempdir, "test.py")
+
+        with open(filename, "w") as f:
+            f.write(
+                """
+from dagster._config.structured_config import ConfigurableResource
+from pydantic import Field
+
+class ResourceWithAlias(ConfigurableResource):
+    _schema: str = Field(alias="schema")
+
+reveal_type(ResourceWithAlias.__init__)
+
+my_resource = ResourceWithAlias(schema="foo")
+"""
+            )
+
+        pyright_out = get_pyright_reveal_type_output(filename)
+
+        # Ensure constructor signature shows schema as the alias
+        assert pyright_out[0] == "(self: ResourceWithAlias, *, schema: str) -> None"
+
+
 def test_nested_config_class() -> None:
     # Validate that we can nest Config classes in a pythonic resource
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_struct_config_resources.py
@@ -931,10 +931,10 @@ reveal_type(my_outer.inner)
         mypy_out = get_mypy_type_output(filename)
 
         # Ensure constructor signature is correct (mypy doesn't yet support Pydantic model constructor type hints)
-        assert pyright_out[0] == "(self: InnerResource, a_string: str) -> None"
+        assert pyright_out[0] == "(self: InnerResource, *, a_string: str) -> None"
         assert (
             pyright_out[1]
-            == "(self: OuterResource, inner: InnerResource | PartialResource[InnerResource],"
+            == "(self: OuterResource, *, inner: InnerResource | PartialResource[InnerResource],"
             " a_bool: bool) -> None"
         )
 
@@ -995,7 +995,7 @@ reveal_type(my_str_resource.a_string)
         # resource function that returns a str
         assert (
             pyright_out[0]
-            == "(self: StringDependentResource, a_string: ConfigurableResourceFactory[str] |"
+            == "(self: StringDependentResource, *, a_string: ConfigurableResourceFactory[str] |"
             " PartialResource[str] | ResourceDefinition | str) -> None"
         )
 


### PR DESCRIPTION
## Summary

Updates the [`__dataclass_transform__`](https://peps.python.org/pep-0681/) decorator on our custom `ConfigurableResource` metaclass to point to Pydantic Field classes as field specifiers. This helps Pyright and other type checking tools recognize aliases.

## Test Plan

Tested in editor manually to verify that alias was respected.

Added pyright type signature unit test.
