### PR TITLE
Add `StaleStatusCategory`

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -1,4 +1,4 @@
-import {RunStatus, StaleStatus, StaleCause} from '../graphql/types';
+import {RunStatus, StaleStatus, StaleCause, StaleCauseCategory} from '../graphql/types';
 
 import {LiveDataForNode} from './Utils';
 import {AssetNodeFragment} from './types/AssetNode.types';
@@ -10,6 +10,7 @@ export const MockStaleReason: StaleCause = {
     __typename: 'AssetKey',
   },
   reason: 'stale input',
+  category: StaleCauseCategory.DATA,
   dependency: {
     path: ['asset0'],
     __typename: 'AssetKey',

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -803,8 +803,15 @@ enum StaleStatus {
 
 type StaleCause {
   key: AssetKey!
+  category: StaleCauseCategory!
   reason: String!
   dependency: AssetKey
+}
+
+enum StaleCauseCategory {
+  CODE
+  DATA
+  DEPENDENCIES
 }
 
 enum EvaluationErrorReason {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3587,10 +3587,17 @@ export type SolidStepStatusUnavailableError = Error & {
 
 export type StaleCause = {
   __typename: 'StaleCause';
+  category: StaleCauseCategory;
   dependency: Maybe<AssetKey>;
   key: AssetKey;
   reason: Scalars['String'];
 };
+
+export enum StaleCauseCategory {
+  CODE = 'CODE',
+  DATA = 'DATA',
+  DEPENDENCIES = 'DEPENDENCIES',
+}
 
 export enum StaleStatus {
   FRESH = 'FRESH',
@@ -12033,6 +12040,10 @@ export const buildStaleCause = (
   relationshipsToOmit.add('StaleCause');
   return {
     __typename: 'StaleCause',
+    category:
+      overrides && overrides.hasOwnProperty('category')
+        ? overrides.category!
+        : StaleCauseCategory.CODE,
     dependency:
       overrides && overrides.hasOwnProperty('dependency')
         ? overrides.dependency!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -8,6 +8,7 @@ from dagster import (
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import (
     NULL_DATA_VERSION,
+    StaleCauseCategory,
     StaleStatus,
 )
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
@@ -84,10 +85,14 @@ if TYPE_CHECKING:
     from .external import GrapheneRepository
 
 GrapheneAssetStaleStatus = graphene.Enum.from_enum(StaleStatus, name="StaleStatus")
+GrapheneAssetStaleCauseCategory = graphene.Enum.from_enum(
+    StaleCauseCategory, name="StaleCauseCategory"
+)
 
 
 class GrapheneAssetStaleCause(graphene.ObjectType):
     key = graphene.NonNull(GrapheneAssetKey)
+    category = graphene.NonNull(GrapheneAssetStaleCauseCategory)
     reason = graphene.NonNull(graphene.String)
     dependency = graphene.Field(GrapheneAssetKey)
 
@@ -578,6 +583,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return [
             GrapheneAssetStaleCause(
                 GrapheneAssetKey(path=cause.key.path),
+                cause.category,
                 cause.reason,
                 GrapheneAssetKey(path=cause.dependency.path) if cause.dependency else None,
             )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -154,6 +154,7 @@ GET_ASSET_DATA_VERSIONS = """
             staleStatus
             staleCauses {
                 key { path }
+                category
                 reason
                 dependency { path }
             }


### PR DESCRIPTION
## Summary & Motivation

Add `StaleStatusCategory` of `CODE`/`DATA`/`DEPENDENCIES` at the Python and GQL levels. This should facilitate our new asset graph status tags.

## How I Tested These Changes

Modified existing tests to check for correct category.