### PR TITLE
Change `AssetsDefinition._from_node()` to use output prefixes globally

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -327,7 +327,7 @@ class AssetsDefinition(ResourceAddable):
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
                 asset.
-            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
+            freshness_policies_by_output_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.
@@ -407,7 +407,7 @@ class AssetsDefinition(ResourceAddable):
                 be associated with each of the output assets for this node. Keys are names of the
                 outputs, and values are dictionaries of metadata to be associated with the related
                 asset.
-            freshness_policies_by_output_name_ouptut_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
+            freshness_policies_by_output_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
                 FreshnessPolicy to be associated with some or all of the output assets for this node.
                 Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
                 to the associated asset.

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -526,21 +526,21 @@ class AssetsDefinition(ResourceAddable):
             if partition_mappings
             else None,
             metadata_by_key={
-                keys_by_output_name[output_name]: metadata
+                keys_by_output_name_with_prefix[output_name]: metadata
                 for output_name, metadata in metadata_by_output_name.items()
                 if metadata is not None
             }
             if metadata_by_output_name
             else None,
             freshness_policies_by_key={
-                keys_by_output_name[output_name]: freshness_policy
+                keys_by_output_name_with_prefix[output_name]: freshness_policy
                 for output_name, freshness_policy in freshness_policies_by_output_name.items()
                 if freshness_policy is not None
             }
             if freshness_policies_by_output_name
             else None,
             descriptions_by_key={
-                keys_by_output_name[output_name]: description
+                keys_by_output_name_with_prefix[output_name]: description
                 for output_name, description in descriptions_by_output_name.items()
                 if description is not None
             }

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -719,11 +719,18 @@ def test_from_graph_w_key_prefix():
     def silly_graph():
         return bar(foo())
 
+    freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
+    description = "This is a description!"
+    metadata = {"test_metadata": "This is some metadata"}
+
     the_asset = AssetsDefinition.from_graph(
         graph_def=silly_graph,
         keys_by_input_name={},
         keys_by_output_name={"result": AssetKey(["the", "asset"])},
         key_prefix=["this", "is", "a", "prefix"],
+        freshness_policies_by_output_name={"result": freshness_policy},
+        descriptions_by_output_name={"result": description},
+        metadata_by_output_name={"result": metadata},
         group_name="abc",
     )
     assert the_asset.keys_by_output_name["result"].path == [
@@ -737,6 +744,18 @@ def test_from_graph_w_key_prefix():
 
     assert the_asset.group_names_by_key == {
         AssetKey(["this", "is", "a", "prefix", "the", "asset"]): "abc"
+    }
+
+    assert the_asset.freshness_policies_by_key == {
+        AssetKey(["this", "is", "a", "prefix", "the", "asset"]): freshness_policy
+    }
+
+    assert the_asset.descriptions_by_key == {
+        AssetKey(["this", "is", "a", "prefix", "the", "asset"]): description
+    }
+
+    assert the_asset.metadata_by_key == {
+        AssetKey(["this", "is", "a", "prefix", "the", "asset"]): metadata
     }
 
     str_prefix = AssetsDefinition.from_graph(
@@ -758,11 +777,18 @@ def test_from_op_w_key_prefix():
     def foo():
         return 1
 
+    freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
+    description = "This is a description!"
+    metadata = {"test_metadata": "This is some metadata"}
+
     the_asset = AssetsDefinition.from_op(
         op_def=foo,
         keys_by_input_name={},
         keys_by_output_name={"result": AssetKey(["the", "asset"])},
         key_prefix=["this", "is", "a", "prefix"],
+        freshness_policies_by_output_name={"result": freshness_policy},
+        descriptions_by_output_name={"result": description},
+        metadata_by_output_name={"result": metadata},
         group_name="abc",
     )
 
@@ -777,6 +803,18 @@ def test_from_op_w_key_prefix():
 
     assert the_asset.group_names_by_key == {
         AssetKey(["this", "is", "a", "prefix", "the", "asset"]): "abc"
+    }
+
+    assert the_asset.freshness_policies_by_key == {
+        AssetKey(["this", "is", "a", "prefix", "the", "asset"]): freshness_policy
+    }
+
+    assert the_asset.descriptions_by_key == {
+        AssetKey(["this", "is", "a", "prefix", "the", "asset"]): description
+    }
+
+    assert the_asset.metadata_by_key == {
+        AssetKey(["this", "is", "a", "prefix", "the", "asset"]): metadata
     }
 
     str_prefix = AssetsDefinition.from_op(


### PR DESCRIPTION
## Summary & Motivation

We are trying to use Freshness Policies to make our pipelines easier to manage, but were running into issues where they were not being applied to specific assets.  After investigating, I narrowed down the issue to the `key_prefix` parameter in `AssetsDefinition.from_op()` and opened up issue #13450.

I looked into the underlying code a bit, and it seems like this is a very straightforward fix, so I threw together a PR.

## How I Tested These Changes

Using the following test file, I verified that `test_table_wo_freshness` doesn't show a freshness policy with Dagster v1.2.6, but does with this patch.

```python
from dagster import AssetsDefinition, FreshnessPolicy, Out, op

@op(out={"test_table_w_freshness": Out()})
def test_table_w_freshness():
    return ""

@op(out={"test_table_wo_freshness": Out()})
def test_table_wo_freshness():
    return ""

# Freshness policy correctly applies to this asset
asset_w_freshness_policy = AssetsDefinition.from_op(
    op_def=test_table_w_freshness,
    freshness_policies_by_output_name={
        "test_table_w_freshness": FreshnessPolicy(maximum_lag_minutes=60)
    },
)

# This asset doesn't have a freshness policy in dagit
asset_wo_freshness_policy = AssetsDefinition.from_op(
    op_def=test_table_wo_freshness,
    key_prefix=["test"],
    freshness_policies_by_output_name={
        "test_table_wo_freshness": FreshnessPolicy(maximum_lag_minutes=60)
    },
)
```