### PR TITLE
[pythonic resources] Update IO-manager class names

### DIFF
--- a/docs/content/guides/dagster/pythonic-resources.mdx
+++ b/docs/content/guides/dagster/pythonic-resources.mdx
@@ -287,10 +287,10 @@ from dagster import (
     AssetKey,
     OutputContext,
     InputContext,
-    ConfigurableIOManager,
+    IOManagerResource,
 )
 
-class MyIOManager(ConfigurableIOManager):
+class MyIOManager(IOManagerResource):
     root_path: str
 
     def _get_path(self, asset_key: AssetKey) -> str:
@@ -374,7 +374,7 @@ from dagster import (
     io_manager,
     IOManager,
     InputContext,
-    ConfigurableLegacyIOManagerAdapter,
+    LegacyIOManagerAdapter,
     OutputContext,
 )
 import os
@@ -407,7 +407,7 @@ def old_file_io_manager(context):
     return OldFileIOManager(base_path)
 
 # New adapter layer
-class MyIOManager(ConfigurableLegacyIOManagerAdapter):
+class MyIOManager(LegacyIOManagerAdapter):
     base_path: str
 
     @property

--- a/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/pythonic_resources/pythonic_resources.py
@@ -398,7 +398,7 @@ def io_adapter() -> None:
         io_manager,
         IOManager,
         InputContext,
-        ConfigurableLegacyIOManagerAdapter,
+        LegacyIOManagerAdapter,
         OutputContext,
     )
     import os
@@ -431,7 +431,7 @@ def io_adapter() -> None:
         return OldFileIOManager(base_path)
 
     # New adapter layer
-    class MyIOManager(ConfigurableLegacyIOManagerAdapter):
+    class MyIOManager(LegacyIOManagerAdapter):
         base_path: str
 
         @property
@@ -501,10 +501,10 @@ def new_io_manager() -> None:
         AssetKey,
         OutputContext,
         InputContext,
-        ConfigurableIOManager,
+        IOManagerResource,
     )
 
-    class MyIOManager(ConfigurableIOManager):
+    class MyIOManager(IOManagerResource):
         root_path: str
 
         def _get_path(self, asset_key: AssetKey) -> str:

--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/common_bucket_s3_pickle_io_manager.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/common_bucket_s3_pickle_io_manager.py
@@ -2,14 +2,14 @@ from typing import Any
 
 from dagster import build_init_resource_context
 from dagster._config.structured_config import (
-    ConfigurableIOManagerFactory,
+    IOManagerFactoryResource,
     ResourceDependency,
 )
 from dagster._core.storage.io_manager import IOManager
 from dagster_aws.s3 import s3_pickle_io_manager
 
 
-class CommonBucketS3PickleIOManager(ConfigurableIOManagerFactory):
+class CommonBucketS3PickleIOManager(IOManagerFactoryResource):
     """A version of the s3_pickle_io_manager that gets its bucket from another resource."""
 
     s3_bucket: str

--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/parquet_io_manager.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/parquet_io_manager.py
@@ -7,13 +7,13 @@ from dagster import (
     OutputContext,
     _check as check,
 )
-from dagster._config.structured_config import ConfigurableIOManager, ResourceDependency
+from dagster._config.structured_config import IOManagerResource, ResourceDependency
 from dagster._seven.temp_dir import get_system_temp_directory
 from dagster_pyspark.resources import PySparkResource
 from pyspark.sql import DataFrame as PySparkDataFrame
 
 
-class PartitionedParquetIOManager(ConfigurableIOManager):
+class PartitionedParquetIOManager(IOManagerResource):
     """This IOManager will take in a pandas or pyspark dataframe and store it in parquet at the
     specified path.
 

--- a/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/snowflake_io_manager.py
+++ b/examples/experimental/project_fully_featured_v2_resources/project_fully_featured_v2_resources/resources/snowflake_io_manager.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
-from dagster._config.structured_config import ConfigurableIOManager
+from dagster._config.structured_config import IOManagerResource
 from pandas import (
     DataFrame as PandasDataFrame,
     read_sql,
@@ -37,7 +37,7 @@ def connect_snowflake(config, schema="public"):
             conn.close()
 
 
-class SnowflakeIOManager(ConfigurableIOManager):
+class SnowflakeIOManager(IOManagerResource):
     """This IOManager can handle outputs that are either Spark or Pandas DataFrames. In either case,
     the data will be written to a Snowflake table specified by metadata on the relevant Out.
     """
@@ -70,7 +70,10 @@ class SnowflakeIOManager(ConfigurableIOManager):
                 df = read_sql(f"SELECT * FROM {context.name} LIMIT 5", con=con)
                 num_rows = con.execute(f"SELECT COUNT(*) FROM {context.name}").fetchone()
 
-            metadata = {"data_sample": MetadataValue.md(df.to_markdown()), "rows": num_rows}
+            metadata = {
+                "data_sample": MetadataValue.md(df.to_markdown()),
+                "rows": num_rows,
+            }
         else:
             raise Exception(
                 "SnowflakeIOManager only supports pandas DataFrames and spark DataFrames"

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -99,10 +99,10 @@ from dagster._config.source import (
 )
 from dagster._config.structured_config import (
     Config as Config,
-    ConfigurableIOManager as ConfigurableIOManager,
-    ConfigurableIOManagerFactory as ConfigurableIOManagerFactory,
-    ConfigurableLegacyIOManagerAdapter as ConfigurableLegacyIOManagerAdapter,
     FactoryResource as FactoryResource,
+    IOManagerFactoryResource as IOManagerFactoryResource,
+    IOManagerResource as IOManagerResource,
+    LegacyIOManagerAdapter as LegacyIOManagerAdapter,
     LegacyResourceAdapter as LegacyResourceAdapter,
     PermissiveConfig as PermissiveConfig,
     Resource as Resource,

--- a/python_modules/dagster/dagster/_config/structured_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/structured_config/__init__.py
@@ -758,7 +758,7 @@ class LegacyResourceAdapter(Resource, ABC):
 
 
 @experimental
-class ConfigurableIOManagerFactory(FactoryResource[TIOManagerValue], IOManagerDefinition):
+class IOManagerFactoryResource(FactoryResource[TIOManagerValue], IOManagerDefinition):
     """Base class for Dagster IO managers that utilize structured config. This base class
     is useful for cases in which the returned IO manager is not the same as the class itself
     (e.g. when it is a wrapper around the actual IO manager implementation).
@@ -804,10 +804,11 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue], IOManager
 
 
 @experimental
-class ConfigurableIOManager(ConfigurableIOManagerFactory, IOManager):
-    """Base class for Dagster IO managers that utilize structured config.
+class IOManagerResource(IOManagerFactoryResource, IOManager):
+    """Base class for Dagster resources which are also IO managers, and which utilize
+    Pythonic config.
 
-    This class is a subclass of both :py:class:`IOManagerDefinition`, :py:class:`Config`,
+    This class is a subclass of both :py:class:`IOManagerDefinition`, :py:class:`Resource`,
     and :py:class:`IOManager`. Implementers must provide an implementation of the
     :py:meth:`handle_output` and :py:meth:`load_input` methods.
     """
@@ -988,7 +989,7 @@ def _is_pydantic_field_required(pydantic_field: ModelField) -> bool:
 
 
 @experimental
-class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
+class LegacyIOManagerAdapter(IOManagerFactoryResource):
     """Adapter base class for wrapping a decorated, function-style I/O manager
     with structured config.
 
@@ -1008,7 +1009,7 @@ class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
 
             return OldIOManager(base_path)
 
-        class MyIOManager(ConfigurableLegacyIOManagerAdapter):
+        class MyIOManager(LegacyIOManagerAdapter):
             base_path: str
 
             @property

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -80,7 +80,7 @@ This config type can be a:
 PYTHONIC_RESOURCE_ADDITIONAL_TYPES = """
 
 If this config type represents a resource dependency, its annotation must either:
-    - Extend dagster.Resource, dagster.ConfigurableIOManager, or
+    - Extend dagster.Resource, dagster.IOManagerResource, or
     - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency[{invalid_type_str}]
 """
 

--- a/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/structured_config_tests/test_errors.py
@@ -94,7 +94,7 @@ This config type can be a:
 
 
 If this config type represents a resource dependency, its annotation must either:
-    - Extend dagster.Resource, dagster.ConfigurableIOManager, or
+    - Extend dagster.Resource, dagster.IOManagerResource, or
     - Be wrapped in a ResourceDependency annotation, e.g. ResourceDependency\\[MyUnsupportedType\\]""",
     ):
         MyBadResource(unsupported_param=MyUnsupportedType())

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence, Type, cast
 import duckdb
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
-    ConfigurableIOManagerFactory,
+    IOManagerFactoryResource,
     infer_schema_from_config_class,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -105,7 +105,7 @@ def build_duckdb_io_manager(
     return duckdb_io_manager
 
 
-class DuckDBIOManager(ConfigurableIOManagerFactory):
+class DuckDBIOManager(IOManagerFactoryResource):
     """Base class for an IO manager definition that reads inputs from and writes outputs to DuckDB.
 
     Examples:

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -5,7 +5,7 @@ from typing import Generator, Optional, Sequence, Type, cast
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._annotations import experimental
 from dagster._config.structured_config import (
-    ConfigurableIOManagerFactory,
+    IOManagerFactoryResource,
     infer_schema_from_config_class,
 )
 from dagster._core.storage.db_io_manager import (
@@ -134,7 +134,7 @@ def build_bigquery_io_manager(
     return bigquery_io_manager
 
 
-class BigQueryIOManager(ConfigurableIOManagerFactory):
+class BigQueryIOManager(IOManagerFactoryResource):
     """Base class for an I/O manager definition that reads inputs from and writes outputs to BigQuery.
 
     Examples:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -4,7 +4,7 @@ from typing import Mapping, Optional, Sequence, Type, cast
 
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
-    ConfigurableIOManagerFactory,
+    IOManagerFactoryResource,
     infer_schema_from_config_class,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -106,7 +106,7 @@ def build_snowflake_io_manager(
     return snowflake_io_manager
 
 
-class SnowflakeIOManager(ConfigurableIOManagerFactory):
+class SnowflakeIOManager(IOManagerFactoryResource):
     """Base class for an IO manager definition that reads inputs from and writes outputs to Snowflake.
 
     Examples:


### PR DESCRIPTION
## Summary & Motivation

Based on offline discussion with @schrockn and stacking on #13458 , we're hoping to make IO Manager Pythonic classes make more sense by creating a better dividing line between the `IOManager` ABC and the resource system.

- `ConfigurableIOManager` -> `IOManagerResource`. This rename is simpler and clearly communicates that this class represents that something is both an IO Manager and a Resource. This is not necessarily true in all cases - some resources produce IO managers which are separate, but subclasses of `IOManagerResource` are both.
- `ConfigurableIOManagerFactory` -> `IOManagerFactoryResource`. This one is ugly, but some behind-the-scenes changes could eliminate the need for it (using `FactoryResource[MyIOManager]` instead). See stacked PR for more.

## How I Tested These Changes

Existing tests
