### PR TITLE
[configurable resources] Attempt removing IOManagerFactoryResource

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -100,7 +100,6 @@ from dagster._config.source import (
 from dagster._config.structured_config import (
     Config as Config,
     FactoryResource as FactoryResource,
-    IOManagerFactoryResource as IOManagerFactoryResource,
     IOManagerResource as IOManagerResource,
     LegacyIOManagerAdapter as LegacyIOManagerAdapter,
     LegacyResourceAdapter as LegacyResourceAdapter,

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence, Type, cast
 import duckdb
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
-    IOManagerFactoryResource,
+    FactoryResource,
     infer_schema_from_config_class,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -105,7 +105,7 @@ def build_duckdb_io_manager(
     return duckdb_io_manager
 
 
-class DuckDBIOManager(IOManagerFactoryResource):
+class DuckDBIOManager(FactoryResource[DbIOManager]):
     """Base class for an IO manager definition that reads inputs from and writes outputs to DuckDB.
 
     Examples:

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -5,7 +5,7 @@ from typing import Generator, Optional, Sequence, Type, cast
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._annotations import experimental
 from dagster._config.structured_config import (
-    IOManagerFactoryResource,
+    FactoryResource,
     infer_schema_from_config_class,
 )
 from dagster._core.storage.db_io_manager import (
@@ -134,7 +134,7 @@ def build_bigquery_io_manager(
     return bigquery_io_manager
 
 
-class BigQueryIOManager(IOManagerFactoryResource):
+class BigQueryIOManager(FactoryResource[DbIOManager]):
     """Base class for an I/O manager definition that reads inputs from and writes outputs to BigQuery.
 
     Examples:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -4,7 +4,7 @@ from typing import Mapping, Optional, Sequence, Type, cast
 
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
-    IOManagerFactoryResource,
+    FactoryResource,
     infer_schema_from_config_class,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -106,7 +106,7 @@ def build_snowflake_io_manager(
     return snowflake_io_manager
 
 
-class SnowflakeIOManager(IOManagerFactoryResource):
+class SnowflakeIOManager(FactoryResource[DbIOManager]):
     """Base class for an IO manager definition that reads inputs from and writes outputs to Snowflake.
 
     Examples:


### PR DESCRIPTION
## Summary

Attempts to eliminate the need for a separate `ConfigurableIOManagerFactory` class, allowing users to simply implement `FactoryResource[MyIOManagerClass]`.

This works by investigating the TypeVar type of a `FactoryResource`-subclassing user class at Definitions-binding time. 

When Pythonic resources are bound at Definitions time, they are already wrapped in a `IOManagerWithKeyMapping` or `ResourceWithKeyMapping` for the purposes of resolving nested resources. This PR adjusts this logic: If the wrapped type is an IO Manager, the resource is wrapped in a `IOManagerWithKeyMapping` rather than a `ResourceWithKeyMapping`.

This works pretty well in the `Definitions` case but won't help us in any cases where IO managers are specified & checked against resource requirements elsewhere (`execute_in_process` etc). Need to investigate if there's a good place to hook in.

## Test Plan

New + existing unit tests.