### PR TITLE
[db io managers] to_config_schema instead of infer_schema_from_config_class

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -6,7 +6,6 @@ import duckdb
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
     ConfigurableIOManagerFactory,
-    infer_schema_from_config_class,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
@@ -84,7 +83,7 @@ def build_duckdb_io_manager(
 
     """
 
-    @io_manager(config_schema=infer_schema_from_config_class(DuckDBIOManager))
+    @io_manager(config_schema=DuckDBIOManager.to_config_schema())
     def duckdb_io_manager(init_context):
         """IO Manager for storing outputs in a DuckDB database.
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -6,7 +6,6 @@ from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._annotations import experimental
 from dagster._config.structured_config import (
     ConfigurableIOManagerFactory,
-    infer_schema_from_config_class,
 )
 from dagster._core.storage.db_io_manager import (
     DbClient,
@@ -102,7 +101,7 @@ def build_bigquery_io_manager(
         the base64 encoded with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
     """
 
-    @io_manager(config_schema=infer_schema_from_config_class(BigQueryIOManager))
+    @io_manager(config_schema=BigQueryIOManager.to_config_schema())
     def bigquery_io_manager(init_context):
         """I/O Manager for storing outputs in a BigQuery database.
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -5,7 +5,6 @@ from typing import Mapping, Optional, Sequence, Type, cast
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.structured_config import (
     ConfigurableIOManagerFactory,
-    infer_schema_from_config_class,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
@@ -92,7 +91,7 @@ def build_snowflake_io_manager(
 
     """
 
-    @io_manager(config_schema=infer_schema_from_config_class(SnowflakeIOManager))
+    @io_manager(config_schema=SnowflakeIOManager.to_config_schema())
     def snowflake_io_manager(init_context):
         return DbIOManager(
             type_handlers=type_handlers,


### PR DESCRIPTION
## Summary & Motivation
instead of 
```
@io_manager(config_schema=infer_schema_from_config_class(DuckDBIOManager))
```
do 
```
@io_manager(config_schema=DuckDBIOManager.to_config_schema())
```

## How I Tested These Changes
