### PR TITLE
[ui] Restore static contextType on ErrorBoundary

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/ErrorBoundary.tsx
+++ b/js_modules/dagit/packages/ui/src/components/ErrorBoundary.tsx
@@ -36,6 +36,8 @@ interface ErrorBoundaryState {
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = {error: null, errorResetPropsValue: null};
 
+  static contextType = ErrorCollectionContext;
+
   componentDidUpdate() {
     if (
       this.state.error &&
@@ -46,7 +48,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   }
 
   componentDidCatch(error: Error, info: any) {
-    (this.context as ErrorCollectionContextValue).onReportError(error, {
+    this.context.onReportError(error, {
       info,
       region: this.props.region,
     });


### PR DESCRIPTION
## Summary & Motivation

ErrorBoundary is broken without the `static contextType` defined. We'll have to fix this for React 18, but I'll just restore it for now.

## How I Tested These Changes

Surface an error in `RunsRoot`, verify that the ErrorBoundary catches it and renders appropriately.
