### PR TITLE
Allow jobs with unpartitioned assets to be partitioned

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -194,11 +194,6 @@ class UnresolvedAssetJobDefinition(
             if partitions_def is not None:
                 asset_keys_by_partitions_def[partitions_def].add(asset_key)
 
-        if len(asset_keys_by_partitions_def) == 0 and self.partitions_def:
-            raise DagsterInvalidDefinitionError(
-                "Tried to build a partitioned job, but none of the selected assets are partitioned."
-            )
-
         if len(asset_keys_by_partitions_def) > 1:
             keys_by_partitions_def_str = "\n".join(
                 f"{partitions_def}: {asset_keys}"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -709,3 +709,17 @@ def test_job_run_request():
     assert my_job_hardcoded_config.run_request_for_partition(
         partition_key="a", run_config={"a": 5}
     ).run_config == {"a": 5}
+
+
+def test_job_partitions_def_unpartitioned_assets():
+    @asset
+    def my_asset():
+        pass
+
+    my_job = define_asset_job(
+        "my_job", partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")
+    )
+
+    @repository
+    def my_repo():
+        return [my_asset, my_job]


### PR DESCRIPTION
Source assets in the job are not returned as part of the asset selection, which causes the removed error to be raised.

For now, this PR removes the error to unblock users. In the future, we can update the error messaging to handle when partitioned source assets are also selected. 