### PR TITLE
Fix dynamic partitions w/ function in schedule

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -614,7 +614,11 @@ class JobDefinition(PipelineDefinition):
         if not (self.partitions_def and self.partitioned_config):
             check.failed("Called run_request_for_partition on a non-partitioned job")
 
-        if isinstance(self.partitions_def, DynamicPartitionsDefinition) and not instance:
+        if (
+            isinstance(self.partitions_def, DynamicPartitionsDefinition)
+            and self.partitions_def.name
+            and not instance
+        ):
             check.failed(
                 "Must provide a dagster instance when calling run_request_for_partition on a "
                 "dynamic partition set"

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -120,7 +120,11 @@ class UnresolvedAssetJobDefinition(
             self.config, self.partitions_def
         )
 
-        if isinstance(self.partitions_def, DynamicPartitionsDefinition) and not instance:
+        if (
+            isinstance(self.partitions_def, DynamicPartitionsDefinition)
+            and self.partitions_def.name
+            and not instance
+        ):
             check.failed(
                 "Must provide a dagster instance when calling run_request_for_partition on a "
                 "dynamic partition set"


### PR DESCRIPTION
Error reported by a user: https://elementl-workspace.slack.com/archives/C047KSHENRH/p1681135727821259

A new check we added in `run_request_for_partition` doesn't account for the existent dynamic partitions functionality that accepts a function, causing a regression for users.

This PR fixes this issue.