### PR TITLE
Fixing CI after merging the IO Manager Tutorial

### DIFF
--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -25,6 +25,7 @@ setup(
         "dagster-celery",
         "dagster-dbt",
         "dagster-dask",
+        "dagster-duckdb-pandas",
         "dagster-fivetran",
         "dagster-gcp",
         "dagster-graphql",

--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -25,6 +25,7 @@ setup(
         "dagster-celery",
         "dagster-dbt",
         "dagster-dask",
+        "dagster-duckdb",
         "dagster-duckdb-pandas",
         "dagster-fivetran",
         "dagster-gcp",

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -15,6 +15,7 @@ deps =
   -e ../../python_modules/libraries/dagster-celery
   -e ../../python_modules/libraries/dagster-dbt
   -e ../../python_modules/libraries/dagster-dask
+  -e ../../python_modules/libraries/dagster-duckdb
   -e ../../python_modules/libraries/dagster-duckdb-pandas
   -e ../../python_modules/libraries/dagster-fivetran
   -e ../../python_modules/libraries/dagster-gcp

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -15,6 +15,7 @@ deps =
   -e ../../python_modules/libraries/dagster-celery
   -e ../../python_modules/libraries/dagster-dbt
   -e ../../python_modules/libraries/dagster-dask
+  -e ../../python_modules/libraries/dagster-duckdb-pandas
   -e ../../python_modules/libraries/dagster-fivetran
   -e ../../python_modules/libraries/dagster-gcp
   -e ../../python_modules/libraries/dagster-k8s


### PR DESCRIPTION
## Summary & Motivation
BK broke because the IO Manager Tutorial used dagster_duckdb_pandas but the doc_snippets project didn't have it added as a dependency.

Made another PR because some weird branch voodoo happened when I pushed up to the old one.

## How I Tested These Changes
Ran it locally, gonna wait until BK passes before merging this time.