### PR TITLE
Enable observations on partitioned source assets

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
@@ -1,6 +1,8 @@
 from dagster import repository
 from dagster._core.definitions.assets_job import build_assets_job
-from dagster._core.definitions.data_version import extract_data_version_from_entry
+from dagster._core.definitions.data_version import (
+    extract_data_version_from_entry,
+)
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.instance_for_test import instance_for_test
 from docs_snippets.concepts.assets.observable_source_assets import (

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -299,7 +299,12 @@ class RepositoryDefinition:
             i = 0
             while self.has_job(f"{ASSET_BASE_JOB_PREFIX}_{i}"):
                 base_job = self.get_job(f"{ASSET_BASE_JOB_PREFIX}_{i}")
-                if all(key in base_job.asset_layer.assets_defs_by_key for key in asset_keys):
+
+                if all(
+                    key in base_job.asset_layer.assets_defs_by_key
+                    or base_job.asset_layer.is_observable_for_asset(key)
+                    for key in asset_keys
+                ):
                     return base_job
 
                 i += 1


### PR DESCRIPTION
## Summary & Motivation

This fixes a bug with performing on observations on source assets. The bug arose from the fact that defining "job_names" for source assets was done via a different code path than the per-partitions-def "base asset job" calculation.

## How I Tested These Changes

New unit test
