### PR TITLE
[asyncio] dont use asyncio.run

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -117,11 +117,17 @@ def _validate_event(event: Any, step_context: StepExecutionContext) -> OpOutputU
 
 
 def gen_from_async_gen(async_gen: AsyncIterator[T]) -> Iterator[T]:
-    while True:
-        try:
-            yield asyncio.run(async_gen.__anext__())  # type: ignore # subtle awaitable vs coroutine issue
-        except StopAsyncIteration:
-            return
+    # prime use for asyncio.Runner, but new in 3.11 and did not find appealing backport
+    loop = asyncio.new_event_loop()
+    try:
+        while True:
+            try:
+                yield loop.run_until_complete(async_gen.__anext__())
+            except StopAsyncIteration:
+                return
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
 
 
 def _yield_compute_results(

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -424,10 +424,16 @@ def test_async_op():
 
 
 def test_async_gen_invocation():
-    @op
-    async def aio_gen(_):
+    async def make_outputs():
         await asyncio.sleep(0.01)
-        yield Output("done")
+        yield Output("first", output_name="first")
+        await asyncio.sleep(0.01)
+        yield Output("second", output_name="second")
+
+    @op(out={"first": Out(), "second": Out()})
+    async def aio_gen(_):
+        async for v in make_outputs():
+            yield v
 
     context = build_op_context()
 
@@ -437,8 +443,18 @@ def test_async_gen_invocation():
             res.append(output)
         return res
 
-    output = asyncio.run(get_results())[0]
-    assert output.value == "done"
+    results = asyncio.run(get_results())
+    assert results[0].value == "first"
+    assert results[1].value == "second"
+
+    @graph
+    def aio():
+        aio_gen()
+
+    result = aio.execute_in_process()
+    assert result.success
+    assert result.output_for_node("aio_gen", "first") == "first"
+    assert result.output_for_node("aio_gen", "second") == "second"
 
 
 def test_multiple_outputs_iterator():


### PR DESCRIPTION
Overlooked in #12785, was the fact that that `run` finalizes async generators which in our use case may still be active. 

https://docs.python.org/3/library/asyncio-runner.html#asyncio.run


## How I Tested These Changes

added tests that were failing
