### PR TITLE
[ui] Virtualize left nav

### DIFF
--- a/js_modules/dagit/packages/core/package.json
+++ b/js_modules/dagit/packages/core/package.json
@@ -148,6 +148,7 @@
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "react-router-dom-v5-compat": "^6.3.0",
+    "resize-observer-polyfill": "^1.5.1",
     "rgb-hex": "^4.0.0",
     "styled-components": "^5.3.3",
     "ts-node": "9.1.1",

--- a/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagit/packages/core/src/nav/LeftNavRepositorySection.tsx
@@ -16,7 +16,11 @@ const LoadedRepositorySection: React.FC<{
 }> = ({allRepos, visibleRepos, toggleVisible}) => {
   const listContent = () => {
     if (visibleRepos.length) {
-      return <SectionedLeftNav />;
+      return (
+        <div style={{overflow: 'hidden'}}>
+          <SectionedLeftNav />
+        </div>
+      );
     }
 
     if (allRepos.length > 0) {

--- a/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
+++ b/js_modules/dagit/packages/core/src/nav/getLeftNavItemsForOption.tsx
@@ -38,7 +38,7 @@ export const getAssetGroupItemsForOption = (option: DagsterRepoOption) => {
   return items.sort((a, b) => a.name.localeCompare(b.name));
 };
 
-export const gettopLevelResourceDetailsItemsForOption = (option: DagsterRepoOption) => {
+export const getTopLevelResourceDetailsItemsForOption = (option: DagsterRepoOption) => {
   const items: LeftNavItemType[] = [];
 
   const {repository, repositoryLocation} = option;

--- a/js_modules/dagit/packages/core/src/setupTests.ts
+++ b/js_modules/dagit/packages/core/src/setupTests.ts
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom';
 import 'jest-canvas-mock';
+import ResizeObserver from 'resize-observer-polyfill';
 
 // react-markdown and its dependencies are ESM-only, which Jest can't
 // currently accommodate. Mock markdown components/functions entirely to
 // avoid any imports.
 jest.mock('./ui/Markdown');
 jest.mock('./ui/markdownToPlaintext');
+
+global.ResizeObserver = ResizeObserver;

--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -1,4 +1,5 @@
 import {BaseTag, Box, Colors, Icon, IconWrapper, MiddleTruncate, StyledTag} from '@dagster-io/ui';
+import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -12,22 +13,40 @@ import {LeftNavItemType} from '../nav/LeftNavItemType';
 import {
   getAssetGroupItemsForOption,
   getJobItemsForOption,
-  gettopLevelResourceDetailsItemsForOption,
+  getTopLevelResourceDetailsItemsForOption,
 } from '../nav/getLeftNavItemsForOption';
 import {explorerPathFromString} from '../pipelines/PipelinePathUtils';
-import {DagsterRepoOption, WorkspaceContext} from '../workspace/WorkspaceContext';
+import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress, DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString, repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
+import {Inner, Row} from './VirtualizedTable';
+
 const validateExpandedKeys = (parsed: unknown) => (Array.isArray(parsed) ? parsed : []);
 const EXPANDED_REPO_KEYS = 'dagit.expanded-repo-keys';
+
+type ItemType = 'asset-group' | 'job' | 'resource';
+
+type RowType =
+  | {type: 'code-location'; repoAddress: RepoAddress; itemCount: number}
+  | {type: 'item-type'; itemType: ItemType; isFirst: boolean}
+  | {
+      type: 'item';
+      repoAddress: RepoAddress;
+      item: LeftNavItemType;
+      itemType: ItemType;
+      isFirst: boolean;
+      isLast: boolean;
+    };
 
 export const SectionedLeftNav = () => {
   const {loading, visibleRepos} = React.useContext(WorkspaceContext);
   const {basePath} = React.useContext(AppContext);
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
 
+  const {flagSidebarResources} = useFeatureFlags();
   const match = usePathMatch();
 
   const [expandedKeys, setExpandedKeys] = useStateWithStorage<string[]>(
@@ -58,9 +77,12 @@ export const SectionedLeftNav = () => {
         repo,
         repoAddress,
         key: repoAddressAsHumanString(repoAddress),
+        jobItems: getJobItemsForOption(repo),
+        assetGroupItems: getAssetGroupItemsForOption(repo),
+        resourceItems: flagSidebarResources ? getTopLevelResourceDetailsItemsForOption(repo) : [],
       };
     });
-  }, [visibleRepos]);
+  }, [flagSidebarResources, visibleRepos]);
 
   const duplicateRepoNames = React.useMemo(() => {
     const uniques = new Set<string>();
@@ -94,114 +116,214 @@ export const SectionedLeftNav = () => {
     return [...reposWithJobs, ...reposWithoutJobs];
   }, [visibleReposAndKeys]);
 
+  const flattened: RowType[] = React.useMemo(() => {
+    const flat: RowType[] = [];
+    for (const repoWithKey of sortedRepos) {
+      const {repoAddress, key, jobItems, assetGroupItems, resourceItems} = repoWithKey;
+      if (!repoAddress) {
+        continue;
+      }
+
+      const jobCount = jobItems.length;
+      const assetGroupCount = assetGroupItems.length;
+      const resourceCount = resourceItems.length;
+
+      const itemCount = jobCount + assetGroupCount + resourceCount;
+      const showTypeLabels =
+        itemCount > jobCount && itemCount > assetGroupCount && itemCount > resourceCount;
+
+      flat.push({type: 'code-location', repoAddress, itemCount});
+
+      if (expandedKeys.includes(key) || sortedRepos.length === 1) {
+        if (jobItems.length) {
+          if (showTypeLabels) {
+            flat.push({type: 'item-type', itemType: 'job', isFirst: true});
+          }
+          jobItems.forEach((item, ii) => {
+            flat.push({
+              type: 'item',
+              repoAddress,
+              itemType: 'job',
+              item,
+              isFirst: !showTypeLabels && ii === 0,
+              isLast: ii === jobItems.length - 1,
+            });
+          });
+        }
+
+        if (assetGroupItems.length) {
+          if (showTypeLabels) {
+            flat.push({type: 'item-type', itemType: 'asset-group', isFirst: !jobCount});
+          }
+          assetGroupItems.forEach((item, ii) => {
+            flat.push({
+              type: 'item',
+              repoAddress,
+              itemType: 'asset-group',
+              item,
+              isFirst: !showTypeLabels && ii === 0,
+              isLast: ii === assetGroupItems.length - 1,
+            });
+          });
+        }
+
+        if (resourceItems.length) {
+          if (showTypeLabels) {
+            flat.push({
+              type: 'item-type',
+              itemType: 'resource',
+              isFirst: !jobCount && !assetGroupCount,
+            });
+          }
+          resourceItems.forEach((item, ii) => {
+            flat.push({
+              type: 'item',
+              repoAddress,
+              itemType: 'resource',
+              item,
+              isFirst: !showTypeLabels && ii === 0,
+              isLast: ii === resourceItems.length - 1,
+            });
+          });
+        }
+      }
+    }
+
+    return flat;
+  }, [expandedKeys, sortedRepos]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: flattened.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (index: number) => {
+      const item = flattened[index];
+      switch (item.type) {
+        case 'code-location':
+          return 48;
+        case 'item-type':
+          return item.isFirst ? 32 : 28;
+        case 'item': {
+          let height = 30;
+          if (item.isFirst) {
+            height += 4;
+          }
+          if (item.isLast) {
+            height += 4;
+          }
+          return height;
+        }
+      }
+    },
+    overscan: 40,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  const collapsible = sortedRepos.length > 1;
+
   if (loading) {
     return <div style={{flex: 1}} />;
   }
 
   return (
-    <Container>
-      {sortedRepos.map(({repo, repoAddress, key}) => {
-        const {name} = repoAddress;
-        const addressAsString = repoAddressAsURLString(repoAddress);
-        return (
-          <Section
-            key={key}
-            onToggle={onToggle}
-            option={repo}
-            repoAddress={repoAddress}
-            expanded={sortedRepos.length === 1 || expandedKeys.includes(addressAsString)}
-            collapsible={sortedRepos.length > 1}
-            showRepoLocation={duplicateRepoNames.has(name) && name !== DUNDER_REPO_NAME}
-            match={match?.repoAddress === repoAddress ? match : null}
-          />
-        );
-      })}
+    <Container ref={parentRef}>
+      <Inner $totalHeight={totalHeight}>
+        {items.map(({index, key, size, start}) => {
+          const row: RowType = flattened[index];
+          const type = row!.type;
+
+          if (type === 'code-location') {
+            const repoAddress = row.repoAddress;
+            const addressAsString = repoAddressAsURLString(repoAddress);
+            const expanded = sortedRepos.length === 1 || expandedKeys.includes(addressAsString);
+            return (
+              <CodeLocationNameRow
+                key={key}
+                height={size}
+                start={start}
+                repoAddress={repoAddress}
+                itemCount={row.itemCount}
+                collapsible={collapsible}
+                showRepoLocation={
+                  duplicateRepoNames.has(addressAsString) && addressAsString !== DUNDER_REPO_NAME
+                }
+                expanded={expanded}
+                onToggle={onToggle}
+              />
+            );
+          }
+
+          if (type === 'item-type') {
+            return (
+              <ItemTypeLabelRow
+                key={key}
+                height={size}
+                start={start}
+                itemType={row.itemType}
+                isFirst={row.isFirst}
+              />
+            );
+          }
+
+          const isMatch =
+            match?.repoAddress === row.repoAddress &&
+            match?.itemType === row.itemType &&
+            match?.itemName === row.item.name;
+
+          return (
+            <ItemRow
+              key={key}
+              height={size}
+              start={start}
+              item={row.item}
+              isMatch={isMatch}
+              isFirst={row.isFirst}
+              isLast={row.isLast}
+            />
+          );
+        })}
+      </Inner>
     </Container>
   );
 };
 
-const HEADER_HEIGHT = 48;
-const HEADER_HEIGHT_WITH_LOCATION = 64;
+const Container = styled.div`
+  height: 100%;
+  overflow: auto;
+  background-color: ${Colors.Gray100};
+`;
 
-// Note: This component uses React.memo so that it only re-renders when it's props change.
-// This means opening/closing a collapsed section doesn't re-render other sections (a nice
-// perf win) but more importantly opening a section doesn't cause the view to scroll back
-// to the selected item, which could be offscreen.
-//
-interface SectionProps {
+interface CodeLocationNameRowProps {
+  height: number;
+  start: number;
   expanded: boolean;
   collapsible: boolean;
+  itemCount: number;
   onToggle: (repoAddress: RepoAddress) => void;
-  option: DagsterRepoOption;
-  match: {itemName: string; itemType: 'asset-group' | 'job' | 'resource'} | null;
   repoAddress: RepoAddress;
   showRepoLocation: boolean;
 }
 
-const Section: React.FC<SectionProps> = React.memo((props) => {
-  const {expanded, collapsible, onToggle, option, match, repoAddress, showRepoLocation} = props;
-  const matchRef = React.useRef<HTMLDivElement>(null);
+const CodeLocationNameRow = (props: CodeLocationNameRowProps) => {
+  const {
+    height,
+    start,
+    expanded,
+    collapsible,
+    onToggle,
+    itemCount,
+    repoAddress,
+    showRepoLocation,
+  } = props;
 
-  const jobItems = React.useMemo(() => getJobItemsForOption(option), [option]);
-  const assetGroupItems = React.useMemo(() => getAssetGroupItemsForOption(option), [option]);
-
-  const {flagSidebarResources} = useFeatureFlags();
-  const resourceItems = React.useMemo(
-    () => (flagSidebarResources ? gettopLevelResourceDetailsItemsForOption(option) : []),
-    [option, flagSidebarResources],
-  );
-
-  const empty = jobItems.length === 0 && assetGroupItems.length === 0 && resourceItems.length === 0;
-  const showTypeLabels =
-    expanded &&
-    [jobItems.length > 0, assetGroupItems.length > 0, resourceItems.length > 0].filter(Boolean)
-      .length > 1;
-
-  React.useEffect(() => {
-    if (match && matchRef.current) {
-      matchRef.current.scrollIntoView({block: 'nearest'});
-    }
-  }, [match]);
-
-  const visibleItems = ({
-    items,
-    type,
-  }: {
-    items: LeftNavItemType[];
-    type: 'job' | 'asset-group' | 'resource';
-  }) => {
-    const matchItem =
-      match?.itemType === type ? items.find((i) => i.name === match.itemName) : null;
-
-    const shownItems = expanded ? items : matchItem ? [matchItem] : [];
-    if (!shownItems.length) {
-      return null;
-    }
-
-    return (
-      <Box padding={{vertical: 8, horizontal: 12}}>
-        {showTypeLabels && (
-          <ItemTypeLabel>
-            {type === 'asset-group' ? 'Asset Groups' : type === 'resource' ? 'Resources' : 'Jobs'}
-          </ItemTypeLabel>
-        )}
-        {shownItems.map((item) => (
-          <LeftNavItem
-            item={item}
-            key={item.path}
-            ref={item === matchItem ? matchRef : undefined}
-            active={item === matchItem}
-          />
-        ))}
-      </Box>
-    );
-  };
+  const codeLocationLabel = repoAddressAsHumanString(repoAddress);
+  const empty = itemCount === 0;
 
   return (
-    <Box background={Colors.Gray100} border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
+    <Row $height={height} $start={start}>
       <SectionHeader
         $open={expanded && !empty}
-        $showTypeLabels={showTypeLabels}
         $showRepoLocation={showRepoLocation}
         disabled={empty}
         onClick={collapsible ? () => onToggle(repoAddress) : undefined}
@@ -215,17 +337,17 @@ const Section: React.FC<SectionProps> = React.memo((props) => {
           </Box>
           <RepoNameContainer>
             <RepoName
-              data-tooltip={repoAddressAsHumanString(repoAddress)}
+              data-tooltip={codeLocationLabel}
               data-tooltip-style={CodeLocationTooltipStyles}
             >
-              <MiddleTruncate text={repoAddressAsHumanString(repoAddress)} showTitle={false} />
+              <MiddleTruncate text={codeLocationLabel} showTitle={false} />
             </RepoName>
             {/* Wrapper div to prevent tag from stretching vertically */}
             <div>
               <BaseTag
                 fillColor={Colors.Gray10}
                 textColor={Colors.Dark}
-                label={(jobItems.length + assetGroupItems.length).toLocaleString()}
+                label={itemCount.toLocaleString()}
               />
             </div>
           </RepoNameContainer>
@@ -236,12 +358,70 @@ const Section: React.FC<SectionProps> = React.memo((props) => {
           )}
         </Box>
       </SectionHeader>
-      {visibleItems({type: 'job', items: jobItems})}
-      {visibleItems({type: 'asset-group', items: assetGroupItems})}
-      {visibleItems({type: 'resource', items: resourceItems})}
-    </Box>
+    </Row>
   );
-});
+};
+
+interface ItemTypeLabelRowProps {
+  height: number;
+  start: number;
+  itemType: ItemType;
+  isFirst: boolean;
+}
+
+const ItemTypeLabelRow = (props: ItemTypeLabelRowProps) => {
+  const {height, start, itemType, isFirst} = props;
+  const label = React.useMemo(() => {
+    switch (itemType) {
+      case 'asset-group':
+        return 'Asset groups';
+      case 'job':
+        return 'Jobs';
+      case 'resource':
+        return 'Resources';
+    }
+  }, [itemType]);
+  return (
+    <Row $height={height} $start={start}>
+      <Box padding={{top: isFirst ? 12 : 8, horizontal: 12}}>
+        <ItemTypeLabel>{label}</ItemTypeLabel>
+      </Box>
+    </Row>
+  );
+};
+
+interface ItemRowProps {
+  height: number;
+  start: number;
+  item: LeftNavItemType;
+  isMatch: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+const ItemRow = (props: ItemRowProps) => {
+  const {height, start, item, isMatch, isFirst, isLast} = props;
+  const matchRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (isMatch && matchRef.current) {
+      matchRef.current.scrollIntoView({block: 'nearest'});
+    }
+  }, [isMatch]);
+
+  return (
+    <Row $height={height} $start={start}>
+      <Box padding={{horizontal: 12, top: isFirst ? 4 : 0, bottom: isLast ? 4 : 0}}>
+        <LeftNavItem
+          item={item}
+          key={item.path}
+          ref={isMatch ? matchRef : undefined}
+          active={isMatch}
+        />
+      </Box>
+    </Row>
+  );
+};
 
 const CodeLocationTooltipStyles = JSON.stringify({
   background: Colors.Gray100,
@@ -308,15 +488,8 @@ const ItemTypeLabel = styled.div`
   font-size: 12px;
 `;
 
-const Container = styled.div`
-  background-color: ${Colors.Gray100};
-  overflow-y: auto;
-  overflow-x: hidden;
-`;
-
 const SectionHeader = styled.button<{
   $open: boolean;
-  $showTypeLabels: boolean;
   $showRepoLocation: boolean;
 }>`
   background: ${Colors.Gray100};
@@ -327,18 +500,15 @@ const SectionHeader = styled.button<{
   align-items: center;
   font-size: 14px;
   gap: 12px;
-  padding: 0 12px 0 24px;
+  padding: 12px 12px 12px 24px;
   text-align: left;
   user-select: none;
   white-space: nowrap;
 
-  height: ${({$showRepoLocation}) =>
-    $showRepoLocation ? HEADER_HEIGHT_WITH_LOCATION : HEADER_HEIGHT}px;
   width: 100%;
   margin: 0;
-  margin-bottom: ${({$showTypeLabels}) => ($showTypeLabels ? '8px' : 0)};
   
-  box-shadow: inset 0px -1px 0 ${Colors.KeylineGray};
+  box-shadow: inset 0px 1px 0 ${Colors.KeylineGray}, inset 0px -1px 0 ${Colors.KeylineGray};
 
   :disabled {
     cursor: default;

--- a/js_modules/dagit/yarn.lock
+++ b/js_modules/dagit/yarn.lock
@@ -6425,6 +6425,7 @@ __metadata:
     remark: ^14.0.2
     remark-gfm: 3.0.1
     remark-plain-text: ^0.2.0
+    resize-observer-polyfill: ^1.5.1
     rgb-hex: ^4.0.0
     styled-components: ^5.3.3
     subscriptions-transport-ws: ^0.9.15
@@ -28448,6 +28449,13 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
+  languageName: node
+  linkType: hard
+
+"resize-observer-polyfill@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 57e7f79489867b00ba43c9c051524a5c8f162a61d5547e99333549afc23e15c44fd43f2f318ea0261ea98c0eb3158cca261e6f48d66e1ed1cd1f340a43977094
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Virtualize the left nav. Users with a high volume of jobs or asset groups see sluggish performance on rendering the left nav. This should improve things dramatically.

## How I Tested These Changes

Load the app with a very large number of jobs (many thousands). Verify that the left nav loads quickly and scrolls smoothly, that repository collapse/expand behavior works correctly, and that hiding/showing repos also works correctly.

Load an empty workspace, verify correct rendering of left nav empty state. Load a single repo, verify that it is expanded by default and renders correctly.

Test "highlight" of active matched nav item, and that the nav scrolls to that item correctly if it is initially out of view.
