### PR TITLE
RFC: Convert ConfigurableIOManagerFactory usage to ConfigurableIOManager

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -249,6 +249,7 @@ class BigQueryIOManager(ConfigurableIOManagerFactory):
     def default_load_type() -> Optional[Type]:
         return None
 
+    # NOTE to reviewers. This is where having the factory comes in hand to do the with block.
     def create_io_manager(self, context) -> Generator:
         mgr = DbIOManager(
             db_client=BigQueryClient(),


### PR DESCRIPTION
## Summary & Motivation

This demonstrates a world where we don't use ConfigurableIOManagerFactories. Some are easy to convert. Others that do cleanup in context managers are harder to deal with.

The pattern here is instead of the DBIOManager frontend classes implementing ConfigurableIOManagerFactory, they just implement ConfigurableIOManager. They then create the IOManager they actually delegate to.

The Snowflake and DuckDb ones were straightforward to convert (even though it offends my programming sensibilities to some degree). However the BigQuery one is more challenging as there is now no longer place to hook into where you can manage the lifecycle of other resources that in turn controlled by other context managers. cc: @sryza these are one of the type of uses cases where I think separation of concerns of the initialization pathways and object itself are useful.

## How I Tested These Changes

BK
