### PR TITLE
[docs] Replace `run_request_for_partition` with `RunRequest(partition_key=...)`

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/asset-sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/asset-sensors.mdx
@@ -216,9 +216,7 @@ def trigger_daily_asset_if_both_upstream_partitions_materialized(context):
         materializations_by_asset,
     ) in context.latest_materialization_records_by_partition_and_asset().items():
         if set(materializations_by_asset.keys()) == set(context.asset_keys):
-            run_requests.append(
-                downstream_daily_job.run_request_for_partition(partition)
-            )
+            run_requests.append(RunRequest(partition_key=partition))
             for asset_key, materialization in materializations_by_asset.items():
                 context.advance_cursor({asset_key: materialization})
     return run_requests
@@ -257,9 +255,7 @@ def trigger_daily_asset_when_any_upstream_partitions_have_new_materializations(c
                 for asset_key in context.asset_keys
             ]
         ):
-            run_requests.append(
-                downstream_daily_job.run_request_for_partition(partition)
-            )
+            run_requests.append(RunRequest(partition_key=partition))
             for asset_key, materialization in materializations_by_asset.items():
                 if asset_key in context.asset_keys:
                     context.advance_cursor({asset_key: materialization})
@@ -392,9 +388,9 @@ def trigger_weekly_asset_from_daily_asset(context):
             if context.all_partitions_materialized(
                 AssetKey("upstream_daily_1"), daily_partitions_in_week
             ):
-                run_requests_by_partition[
-                    weekly_partitions[0]
-                ] = weekly_asset_job.run_request_for_partition(weekly_partitions[0])
+                run_requests_by_partition[weekly_partitions[0]] = RunRequest(
+                    partition_key=weekly_partitions[0]
+                )
                 # Advance the cursor so we only check event log records past the cursor
                 context.advance_cursor({AssetKey("upstream_daily_1"): materialization})
     return list(run_requests_by_partition.values())

--- a/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/partitions.mdx
@@ -479,14 +479,13 @@ do_stuff_partitioned_schedule = build_schedule_from_partitioned_job(
 Schedules can also be made from static partitioned jobs. If you wanted to make a schedule for the `continent_job` above that runs each partition, you could write:
 
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_static_partition endbefore=end_static_partition
-from dagster import schedule
+from dagster import schedule, RunRequest
 
 
 @schedule(cron_schedule="0 0 * * *", job=continent_job)
 def continent_schedule():
     for c in CONTINENTS:
-        request = continent_job.run_request_for_partition(partition_key=c, run_key=c)
-        yield request
+        yield RunRequest(run_key=c, partition_key=c)
 ```
 
 Or a schedule that will run a subselection of the partition
@@ -494,10 +493,7 @@ Or a schedule that will run a subselection of the partition
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_single_partition endbefore=end_single_partition
 @schedule(cron_schedule="0 0 * * *", job=continent_job)
 def antarctica_schedule():
-    request = continent_job.run_request_for_partition(
-        partition_key="Antarctica", run_key=None
-    )
-    yield request
+    return RunRequest(partition_key="Antarctica")
 ```
 
 Refer to the [Schedules documentation](/concepts/partitions-schedules-sensors/schedules#schedules-from-partitioned-assets-and-jobs) for more info about constructing both schedule types.

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -188,14 +188,13 @@ def continent_job():
 We can write a schedule that will run this partition:
 
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_static_partition endbefore=end_static_partition
-from dagster import schedule
+from dagster import schedule, RunRequest
 
 
 @schedule(cron_schedule="0 0 * * *", job=continent_job)
 def continent_schedule():
     for c in CONTINENTS:
-        request = continent_job.run_request_for_partition(partition_key=c, run_key=c)
-        yield request
+        yield RunRequest(run_key=c, partition_key=c)
 ```
 
 Or a schedule that will run a subselection of the partition:
@@ -203,10 +202,7 @@ Or a schedule that will run a subselection of the partition:
 ```python file=/concepts/partitions_schedules_sensors/schedule_from_partitions.py startafter=start_single_partition endbefore=end_single_partition
 @schedule(cron_schedule="0 0 * * *", job=continent_job)
 def antarctica_schedule():
-    request = continent_job.run_request_for_partition(
-        partition_key="Antarctica", run_key=None
-    )
-    yield request
+    return RunRequest(partition_key="Antarctica")
 ```
 
 ### Customizing execution times

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedule_from_partitions.py
@@ -45,14 +45,13 @@ asset_partitioned_schedule = build_schedule_from_partitioned_job(
 from .static_partitioned_job import continent_job, CONTINENTS
 
 # start_static_partition
-from dagster import schedule
+from dagster import schedule, RunRequest
 
 
 @schedule(cron_schedule="0 0 * * *", job=continent_job)
 def continent_schedule():
     for c in CONTINENTS:
-        request = continent_job.run_request_for_partition(partition_key=c, run_key=c)
-        yield request
+        yield RunRequest(run_key=c, partition_key=c)
 
 
 # end_static_partition
@@ -62,10 +61,7 @@ def continent_schedule():
 
 @schedule(cron_schedule="0 0 * * *", job=continent_job)
 def antarctica_schedule():
-    request = continent_job.run_request_for_partition(
-        partition_key="Antarctica", run_key=None
-    )
-    yield request
+    return RunRequest(partition_key="Antarctica")
 
 
 # end_single_partition

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
@@ -201,9 +201,9 @@ def trigger_weekly_asset_from_daily_asset(context):
             if context.all_partitions_materialized(
                 AssetKey("upstream_daily_1"), daily_partitions_in_week
             ):
-                run_requests_by_partition[
-                    weekly_partitions[0]
-                ] = weekly_asset_job.run_request_for_partition(weekly_partitions[0])
+                run_requests_by_partition[weekly_partitions[0]] = RunRequest(
+                    partition_key=weekly_partitions[0]
+                )
                 # Advance the cursor so we only check event log records past the cursor
                 context.advance_cursor({AssetKey("upstream_daily_1"): materialization})
     return list(run_requests_by_partition.values())
@@ -228,9 +228,7 @@ def trigger_daily_asset_if_both_upstream_partitions_materialized(context):
         materializations_by_asset,
     ) in context.latest_materialization_records_by_partition_and_asset().items():
         if set(materializations_by_asset.keys()) == set(context.asset_keys):
-            run_requests.append(
-                downstream_daily_job.run_request_for_partition(partition)
-            )
+            run_requests.append(RunRequest(partition_key=partition))
             for asset_key, materialization in materializations_by_asset.items():
                 context.advance_cursor({asset_key: materialization})
     return run_requests
@@ -259,9 +257,7 @@ def trigger_daily_asset_when_any_upstream_partitions_have_new_materializations(c
                 for asset_key in context.asset_keys
             ]
         ):
-            run_requests.append(
-                downstream_daily_job.run_request_for_partition(partition)
-            )
+            run_requests.append(RunRequest(partition_key=partition))
             for asset_key, materialization in materializations_by_asset.items():
                 if asset_key in context.asset_keys:
                     context.advance_cursor({asset_key: materialization})

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/test_asset_sensors.py
@@ -94,7 +94,7 @@ def test_multi_asset_sensor_AND():
             trigger_daily_asset_if_both_upstream_partitions_materialized(and_ctx)
         )
         assert len(run_requests) == 1
-        assert run_requests[0].tags["dagster/partition"] == "2022-08-01"
+        assert run_requests[0].partition_key == "2022-08-01"
 
         materialize([upstream_daily_1], instance=instance, partition_key="2022-08-02")
         assert (
@@ -113,7 +113,7 @@ def test_multi_asset_sensor_AND():
             trigger_daily_asset_if_both_upstream_partitions_materialized(and_ctx)
         )
         assert len(run_requests) == 1
-        assert run_requests[0].tags["dagster/partition"] == "2022-08-02"
+        assert run_requests[0].partition_key == "2022-08-02"
 
 
 def test_multi_asset_sensor_OR():
@@ -137,7 +137,7 @@ def test_multi_asset_sensor_OR():
             )
         )
         assert len(run_requests) == 1
-        assert run_requests[0].tags["dagster/partition"] == "2022-08-01"
+        assert run_requests[0].partition_key == "2022-08-01"
 
         materialize([upstream_daily_1], instance=instance, partition_key="2022-08-01")
         run_requests = list(
@@ -146,7 +146,7 @@ def test_multi_asset_sensor_OR():
             )
         )
         assert len(run_requests) == 1
-        assert run_requests[0].tags["dagster/partition"] == "2022-08-01"
+        assert run_requests[0].partition_key == "2022-08-01"
 
 
 def test_multi_asset_sensor_weekly_from_daily():
@@ -168,7 +168,7 @@ def test_multi_asset_sensor_weekly_from_daily():
         )
         run_requests = list(trigger_weekly_asset_from_daily_asset(ctx))
         assert len(run_requests) == 1
-        assert run_requests[0].tags["dagster/partition"] == "2022-08-14"
+        assert run_requests[0].partition_key == "2022-08-14"
 
         materialize([upstream_daily_1], instance=instance, partition_key="2022-08-21")
         run_requests = list(trigger_weekly_asset_from_daily_asset(ctx))
@@ -177,4 +177,4 @@ def test_multi_asset_sensor_weekly_from_daily():
         materialize([upstream_daily_1], instance=instance, partition_key="2022-08-20")
         run_requests = list(trigger_weekly_asset_from_daily_asset(ctx))
         assert len(run_requests) == 1
-        assert run_requests[0].tags["dagster/partition"] == "2022-08-14"
+        assert run_requests[0].partition_key == "2022-08-14"

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -608,7 +608,7 @@ class DynamicPartitionsDefinition(
             @sensor(job=my_job)
             def my_sensor(context):
                 context.instance.add_dynamic_partitions(fruits.name, [partition_key])
-                return my_job.run_request_for_partition(partition_key, instance=context.instance)
+                return RunRequest(partition_key=partition_key)
 
     """
 


### PR DESCRIPTION
`job.run_request_for_partition` is now deprecated in favor of `RunRequest(partition_key=...)`.

This PR updates the docs references to use the new API.