### PR TITLE
Separate serdes NamedTuple serializer and deserializer registries

### DIFF
--- a/python_modules/dagster/dagster/_serdes/utils.py
+++ b/python_modules/dagster/dagster/_serdes/utils.py
@@ -1,11 +1,12 @@
 import hashlib
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
-from .serdes import serialize_value
+from .serdes import WhitelistMap, serialize_value
 
 
-def create_snapshot_id(snapshot: NamedTuple) -> str:
-    json_rep = serialize_value(snapshot)
+def create_snapshot_id(snapshot: NamedTuple, whitelist_map: Optional[WhitelistMap] = None) -> str:
+    kwargs = dict(whitelist_map=whitelist_map) if whitelist_map else {}
+    json_rep = serialize_value(snapshot, **kwargs)
     return hash_str(json_rep)
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -634,7 +634,7 @@ def test_external_job_origin_instigator_origin():
             namedtuple("_ExternalJobOrigin", "external_repository_origin job_name")
         ):
             def get_id(self):
-                return create_snapshot_id(self)
+                return create_snapshot_id(self, legacy_env)
 
         @_whitelist_for_serdes(legacy_env)
         class ExternalRepositoryOrigin(


### PR DESCRIPTION
## Summary & Motivation

This is a minor change to the internals of `WhitelistMap` to separate the registries used to look up serializer classes used during serialization and deserialization.

The impetus for this is that we need to rename `ExternalPipelineOrigin` to `ExternalJobOrigin`, but `ExternalInstigatorOrigin` used to be called `ExternalJobOrigin` and is serialized under this name for backcompat. Without this change, the name collision causes a breakage.

## How I Tested These Changes

Modified `storage_name` unit test.
