### PR TITLE
[ui] Fix 60s+ countdown display

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/Countdown.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Countdown.stories.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {Button} from './Button';
 import {Countdown, useCountdown} from './Countdown';
 import {Group} from './Group';
+import {secondsToCountdownTime} from './secondsToCountdownTime';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -27,7 +28,7 @@ export const FiveSeconds = () => {
       return <div>Waiting for refresh…</div>;
     }
     const seconds = Math.floor(timeRemaining / 1000);
-    return <div>{`Refresh in 0:${seconds < 10 ? `0${seconds}` : seconds}`}</div>;
+    return <div>{`Refresh in ${secondsToCountdownTime(seconds)}`}</div>;
   };
 
   return (

--- a/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
+++ b/js_modules/dagit/packages/ui/src/components/RefreshableCountdown.tsx
@@ -5,6 +5,7 @@ import {Colors} from './Colors';
 import {Group} from './Group';
 import {Icon, IconWrapper} from './Icon';
 import {Tooltip} from './Tooltip';
+import {secondsToCountdownTime} from './secondsToCountdownTime';
 
 interface Props {
   refreshing: boolean;
@@ -20,9 +21,7 @@ export const RefreshableCountdown = (props: Props) => {
       <span
         style={{color: Colors.Gray400, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap'}}
       >
-        {refreshing
-          ? `Refreshing ${dataDescription}…`
-          : `0:${seconds < 10 ? `0${seconds}` : seconds}`}
+        {refreshing ? `Refreshing ${dataDescription}…` : secondsToCountdownTime(seconds)}
       </span>
       <Tooltip content={<span style={{whiteSpace: 'nowrap'}}>Refresh now</span>} position="top">
         <RefreshButton onClick={onRefresh}>

--- a/js_modules/dagit/packages/ui/src/components/__tests__/secondsToCountdownTime.test.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__tests__/secondsToCountdownTime.test.tsx
@@ -1,0 +1,32 @@
+import {secondsToCountdownTime} from '../secondsToCountdownTime';
+
+describe('secondsToCountdownTime', () => {
+  it('formats seconds-only', () => {
+    expect(secondsToCountdownTime(0)).toBe('0:00');
+    expect(secondsToCountdownTime(8)).toBe('0:08');
+    expect(secondsToCountdownTime(38)).toBe('0:38');
+    expect(secondsToCountdownTime(59)).toBe('0:59');
+  });
+
+  it('formats minutes and seconds', () => {
+    expect(secondsToCountdownTime(60)).toBe('1:00');
+    expect(secondsToCountdownTime(61)).toBe('1:01');
+    expect(secondsToCountdownTime(119)).toBe('1:59');
+    expect(secondsToCountdownTime(120)).toBe('2:00');
+    expect(secondsToCountdownTime(121)).toBe('2:01');
+    expect(secondsToCountdownTime(599)).toBe('9:59');
+    expect(secondsToCountdownTime(600)).toBe('10:00');
+    expect(secondsToCountdownTime(3599)).toBe('59:59');
+  });
+
+  it('formats hours, minutes, and seconds', () => {
+    expect(secondsToCountdownTime(3600)).toBe('1:00:00');
+    expect(secondsToCountdownTime(3601)).toBe('1:00:01');
+    expect(secondsToCountdownTime(3659)).toBe('1:00:59');
+    expect(secondsToCountdownTime(3660)).toBe('1:01:00');
+    expect(secondsToCountdownTime(3600 + 3599)).toBe('1:59:59');
+    expect(secondsToCountdownTime(3600 * 2)).toBe('2:00:00');
+    expect(secondsToCountdownTime(36000 - 1)).toBe('9:59:59');
+    expect(secondsToCountdownTime(36000)).toBe('10:00:00');
+  });
+});

--- a/js_modules/dagit/packages/ui/src/components/secondsToCountdownTime.tsx
+++ b/js_modules/dagit/packages/ui/src/components/secondsToCountdownTime.tsx
@@ -1,0 +1,13 @@
+const ONE_HOUR_SEC = 3600;
+const ONE_MINUTE_SEC = 60;
+
+export const secondsToCountdownTime = (seconds: number) => {
+  const hours = Math.floor(seconds / ONE_HOUR_SEC);
+  const minutes = Math.floor((seconds % ONE_HOUR_SEC) / ONE_MINUTE_SEC);
+  const sec = Math.round(seconds % ONE_MINUTE_SEC);
+
+  const secondsString = sec < 10 ? `0${sec}` : `${sec}`;
+  const minutesString = hours && minutes < 10 ? `0${minutes}` : `${minutes}`;
+  const minutesAndSeconds = `${minutesString}:${secondsString}`;
+  return hours ? `${hours}:${minutesAndSeconds}` : `${minutesAndSeconds}`;
+};


### PR DESCRIPTION
## Summary & Motivation

Repair countdown display in situations where the time is greater than 60s. Right now we're just blindly assuming the countdown will be less than a minute, which isn't true in cases where we adjust for long queries. In those situations, we end up with stuff like `0:167`.

Break the seconds amount up into a hh:mm:ss format.

## How I Tested These Changes

Jest
