### PR TITLE
[ui] Add asset groups to global search

### DIFF
--- a/js_modules/dagit/packages/core/src/search/SearchResults.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchResults.tsx
@@ -10,6 +10,8 @@ const iconForType = (type: SearchResultType): IconName => {
   switch (type) {
     case SearchResultType.Asset:
       return 'asset';
+    case SearchResultType.AssetGroup:
+      return 'asset_group';
     case SearchResultType.PartitionSet:
     case SearchResultType.Schedule:
       return 'schedule';

--- a/js_modules/dagit/packages/core/src/search/types.ts
+++ b/js_modules/dagit/packages/core/src/search/types.ts
@@ -1,4 +1,5 @@
 export enum SearchResultType {
+  AssetGroup,
   Asset,
   Page,
   PartitionSet,

--- a/js_modules/dagit/packages/core/src/search/types/useRepoSearch.types.ts
+++ b/js_modules/dagit/packages/core/src/search/types/useRepoSearch.types.ts
@@ -32,6 +32,7 @@ export type SearchBootstrapQuery = {
                   __typename: 'Repository';
                   id: string;
                   name: string;
+                  assetGroups: Array<{__typename: 'AssetGroup'; groupName: string}>;
                   pipelines: Array<{
                     __typename: 'Pipeline';
                     id: string;


### PR DESCRIPTION
## Summary & Motivation

Resolves #13231.

Add asset groups to global search, and repair the "many locations" check that determines whether to show the code location name with the result.

## How I Tested These Changes

Load app, open search. Type the name of an asset group, verify that it appears. Navigate to it, verify success. Verify that the code location names also appear correctly even though there are many repositories in a single location -- they are treated like separate code locations.
