### PR TITLE
[dagit] Ungate resources UI

### DIFF
--- a/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
@@ -13,11 +13,11 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDisableWebsockets,
   },
   {
-    key: 'Experimental schedule/sensor logging view',
-    flagType: FeatureFlag.flagSensorScheduleLogging,
+    key: 'Display resources in sidebar',
+    flagType: FeatureFlag.flagSidebarResources,
   },
   {
-    key: 'Experimental resource view',
-    flagType: FeatureFlag.flagSidebarResources,
+    key: 'Experimental schedule/sensor logging view',
+    flagType: FeatureFlag.flagSensorScheduleLogging,
   },
 ];

--- a/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
@@ -13,7 +13,7 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDisableWebsockets,
   },
   {
-    key: 'Display resources in sidebar',
+    key: 'Display resources in navigation sidebar',
     flagType: FeatureFlag.flagSidebarResources,
   },
   {

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {useFeatureFlags} from '../app/Flags';
 import {ASSET_NODE_CONFIG_FRAGMENT} from '../assets/AssetConfig';
 import {AssetDefinedInMultipleReposNotice} from '../assets/AssetDefinedInMultipleReposNotice';
 import {

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -50,7 +50,6 @@ export const SidebarAssetInfo: React.FC<{
   const {data} = useQuery<SidebarAssetQuery, SidebarAssetQueryVariables>(SIDEBAR_ASSET_QUERY, {
     variables: {assetKey: {path: assetKey.path}},
   });
-  const {flagSidebarResources} = useFeatureFlags();
 
   const {lastMaterialization} = liveData || {};
   const asset = data?.assetNodeOrError.__typename === 'AssetNode' ? data.assetNodeOrError : null;
@@ -131,7 +130,7 @@ export const SidebarAssetInfo: React.FC<{
             {asset.requiredResources.map((resource) => (
               <ResourceContainer key={resource.resourceKey}>
                 <Icon name="resource" color={Colors.Gray700} />
-                {flagSidebarResources && repoAddress ? (
+                {repoAddress ? (
                   <Link
                     to={workspacePathFromAddress(repoAddress, `/resources/${resource.resourceKey}`)}
                   >

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -41,7 +41,6 @@ export const AssetNodeDefinition: React.FC<{
   dependsOnSelf: boolean;
 }> = ({assetNode, upstream, downstream, liveDataByNode, dependsOnSelf}) => {
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
-  const {flagSidebarResources} = useFeatureFlags();
   const liveDataForNode = liveDataByNode[toGraphId(assetNode.assetKey)];
 
   const assetConfigSchema = assetNode.configField?.configType;
@@ -164,7 +163,7 @@ export const AssetNodeDefinition: React.FC<{
                   {assetNode.requiredResources.map((resource) => (
                     <ResourceContainer key={resource.resourceKey}>
                       <Icon name="resource" color={Colors.Gray700} />
-                      {flagSidebarResources && repoAddress ? (
+                      { repoAddress ? (
                         <Link
                           to={workspacePathFromAddress(
                             repoAddress,

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -3,7 +3,6 @@ import {Body, Box, Caption, Colors, ConfigTypeSchema, Icon, Mono, Subheading} fr
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 
-import {useFeatureFlags} from '../app/Flags';
 import {ASSET_NODE_FRAGMENT} from '../asset-graph/AssetNode';
 import {
   displayNameForAssetKey,
@@ -163,7 +162,7 @@ export const AssetNodeDefinition: React.FC<{
                   {assetNode.requiredResources.map((resource) => (
                     <ResourceContainer key={resource.resourceKey}>
                       <Icon name="resource" color={Colors.Gray700} />
-                      { repoAddress ? (
+                      {repoAddress ? (
                         <Link
                           to={workspacePathFromAddress(
                             repoAddress,

--- a/js_modules/dagit/packages/core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewTabs.tsx
@@ -2,7 +2,6 @@ import {QueryResult} from '@apollo/client';
 import {Box, Tabs} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {TabLink} from '../ui/TabLink';
 

--- a/js_modules/dagit/packages/core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewTabs.tsx
@@ -14,7 +14,6 @@ interface Props<TData> {
 
 export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {refreshState, tab} = props;
-  const {flagSidebarResources} = useFeatureFlags();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -23,9 +22,7 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         <TabLink id="jobs" title="Jobs" to="/overview/jobs" />
         <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
         <TabLink id="sensors" title="Sensors" to="/overview/sensors" />
-        {flagSidebarResources && (
-          <TabLink id="resources" title="Resources" to="/overview/resources" />
-        )}
+        <TabLink id="resources" title="Resources" to="/overview/resources" />
         <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
       </Tabs>
       {refreshState ? (

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
@@ -48,8 +48,6 @@ const DEFAULT_INVOCATIONS_SHOWN = 20;
 export const SidebarOpDefinition: React.FC<SidebarOpDefinitionProps> = (props) => {
   const {definition, getInvocations, showingSubgraph, onClickInvocation, repoAddress} = props;
 
-  const {flagSidebarResources} = useFeatureFlags();
-
   const Plugin = pluginForMetadata(definition.metadata);
   const isComposite = definition.__typename === 'CompositeSolidDefinition';
   const configField = definition.__typename === 'SolidDefinition' ? definition.configField : null;
@@ -118,7 +116,7 @@ export const SidebarOpDefinition: React.FC<SidebarOpDefinitionProps> = (props) =
             {[...requiredResources].sort().map((requirement) => (
               <ResourceContainer key={requirement.resourceKey}>
                 <Icon name="resource" color={Colors.Gray700} />
-                {flagSidebarResources && repoAddress ? (
+                {repoAddress ? (
                   <Link
                     to={workspacePathFromAddress(
                       repoAddress,

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {useFeatureFlags} from '../app/Flags';
 import {breakOnUnderscores} from '../app/Util';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -19,11 +19,8 @@ const fuseOptions = {
   useExtendedSearch: true,
 };
 
-const bootstrapDataToSearchResults = (input: {
-  data?: SearchBootstrapQuery;
-  includeResources: boolean;
-}) => {
-  const {data, includeResources} = input;
+const bootstrapDataToSearchResults = (input: {data?: SearchBootstrapQuery}) => {
+  const {data} = input;
 
   if (!data?.workspaceOrError || data?.workspaceOrError?.__typename !== 'Workspace') {
     return new Fuse([]);
@@ -90,15 +87,12 @@ const bootstrapDataToSearchResults = (input: {
           type: SearchResultType.Sensor,
         }));
 
-        const allResources: SearchResult[] = includeResources
-          ? allTopLevelResourceDetails.map((resource) => ({
-              label: resource.name,
-              description: manyRepos ? `Resource in ${repoPath}` : 'Resource',
-              href: workspacePath(repoName, locationName, `/resources/${resource.name}`),
-              type: SearchResultType.Resource,
-            }))
-          : [];
-
+        const allResources: SearchResult[] = allTopLevelResourceDetails.map((resource) => ({
+          label: resource.name,
+          description: manyRepos ? `Resource in ${repoPath}` : 'Resource',
+          href: workspacePath(repoName, locationName, `/resources/${resource.name}`),
+          type: SearchResultType.Resource,
+        }));
         const allPartitionSets: SearchResult[] = partitionSets
           .filter((item) => !isHiddenAssetGroupJob(item.pipelineName))
           .map((partitionSet) => ({
@@ -157,13 +151,9 @@ export const useRepoSearch = () => {
     {data: secondaryData, loading: secondaryLoading, called: secondaryQueryCalled},
   ] = useLazyQuery<SearchSecondaryQuery>(SEARCH_SECONDARY_QUERY);
 
-  const {flagSidebarResources} = useFeatureFlags();
-
-  const bootstrapFuse = React.useMemo(
-    () =>
-      bootstrapDataToSearchResults({data: bootstrapData, includeResources: flagSidebarResources}),
-    [bootstrapData, flagSidebarResources],
-  );
+  const bootstrapFuse = React.useMemo(() => bootstrapDataToSearchResults({data: bootstrapData}), [
+    bootstrapData,
+  ]);
   const secondaryFuse = React.useMemo(() => secondaryDataToSearchResults(secondaryData), [
     secondaryData,
   ]);

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -2,7 +2,6 @@ import {gql, useLazyQuery} from '@apollo/client';
 import Fuse from 'fuse.js';
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
@@ -18,7 +18,6 @@ interface Props<TData> {
 
 export const WorkspaceTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {repoAddress, refreshState, tab} = props;
-  const {flagSidebarResources} = useFeatureFlags();
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -37,13 +36,11 @@ export const WorkspaceTabs = <TData extends Record<string, any>>(props: Props<TD
         />
         <TabLink id="graphs" title="Graphs" to={workspacePathFromAddress(repoAddress, '/graphs')} />
         <TabLink id="ops" title="Ops" to={workspacePathFromAddress(repoAddress, '/ops')} />
-        {flagSidebarResources && (
-          <TabLink
-            id="resources"
-            title="Resources"
-            to={workspacePathFromAddress(repoAddress, '/resources')}
-          />
-        )}
+        <TabLink
+          id="resources"
+          title="Resources"
+          to={workspacePathFromAddress(repoAddress, '/resources')}
+        />
       </Tabs>
       {refreshState ? (
         <Box padding={{bottom: 8}}>

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceTabs.tsx
@@ -2,7 +2,6 @@ import {QueryResult} from '@apollo/client';
 import {Box, Tabs} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {TabLink} from '../ui/TabLink';
 


### PR DESCRIPTION
## Summary

Ungates the Resources UI in Dagit. Leaves the feature flag and turns it into a toggle for showing/hiding resources in the sidebar - now that they're visible in the overview page and deployments page I think this is less necessary and could create clutter. Leaving it as an experiment feels pretty noncommittal, but happy to remove entirely.

## Test Plan

Tested locally.
