### PR TITLE
[ui] Move job disambiguation page to /guess

### DIFF
--- a/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
+++ b/js_modules/dagit/packages/core/src/app/ContentRoot.tsx
@@ -16,6 +16,7 @@ const RunRoot = React.lazy(() => import('../runs/RunRoot'));
 const RunsRoot = React.lazy(() => import('../runs/RunsRoot'));
 const ScheduledRunListRoot = React.lazy(() => import('../runs/ScheduledRunListRoot'));
 const SnapshotRoot = React.lazy(() => import('../snapshots/SnapshotRoot'));
+const GuessJobLocationRoot = React.lazy(() => import('../workspace/GuessJobLocationRoot'));
 
 export const ContentRoot = React.memo(() => {
   const {pathname} = useLocation();
@@ -77,6 +78,11 @@ export const ContentRoot = React.memo(() => {
           <Route path="/locations">
             <React.Suspense fallback={<div />}>
               <WorkspaceRoot />
+            </React.Suspense>
+          </Route>
+          <Route path="/guess/:jobPath">
+            <React.Suspense fallback={<div />}>
+              <GuessJobLocationRoot />
             </React.Suspense>
           </Route>
           <Route path="/overview">

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineReference.test.tsx
@@ -49,7 +49,7 @@ describe('PipelineReference', () => {
       await waitFor(() => {
         const link = screen.getByRole('link', {name: /foobar/i});
         expect(link).toBeVisible();
-        expect(link.getAttribute('href')).toBe('/locations/jobs/foobar/');
+        expect(link.getAttribute('href')).toBe('/guess/jobs/foobar');
       });
     });
 
@@ -58,7 +58,7 @@ describe('PipelineReference', () => {
       await waitFor(() => {
         const link = screen.getByRole('link', {name: /foobar/i});
         expect(link).toBeVisible();
-        expect(link.getAttribute('href')).toBe('/locations/lorem@ipsum/jobs/foobar/');
+        expect(link.getAttribute('href')).toBe('/locations/lorem@ipsum/jobs/foobar');
       });
     });
 

--- a/js_modules/dagit/packages/core/src/workspace/GuessJobLocationRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/GuessJobLocationRoot.tsx
@@ -11,19 +11,19 @@ import {buildRepoPathForHuman} from './buildRepoAddress';
 import {findRepoContainingPipeline} from './findRepoContainingPipeline';
 import {workspacePath, workspacePathFromAddress} from './workspacePath';
 
-export const WorkspacePipelineRoot = () => {
+export const GuessJobLocationRoot = () => {
   useTrackPageView();
 
-  const params = useParams<{pipelinePath: string}>();
-  const {pipelinePath} = params;
+  const params = useParams<{jobPath: string}>();
+  const {jobPath} = params;
 
-  const entireMatch = useRouteMatch(['/locations/pipelines/(/?.*)', '/locations/jobs/(/?.*)']);
+  const entireMatch = useRouteMatch('/guess/(/?.*)');
   const location = useLocation();
 
   const toAppend = (entireMatch!.params as any)[0];
   const {search} = location;
 
-  const {pipelineName} = explorerPathFromString(pipelinePath);
+  const {pipelineName} = explorerPathFromString(jobPath);
   const {loading, options} = useRepositoryOptions();
 
   if (loading) {
@@ -42,7 +42,7 @@ export const WorkspacePipelineRoot = () => {
               <div>
                 <strong>{pipelineName}</strong>
               </div>
-              was not found in any repositories in this workspace.
+              was not found in any of your definitions.
             </div>
           }
         />
@@ -131,3 +131,7 @@ export const WorkspacePipelineRoot = () => {
     </Page>
   );
 };
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default GuessJobLocationRoot;

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceRoot.tsx
@@ -15,7 +15,6 @@ import {WorkspaceContext} from './WorkspaceContext';
 import {WorkspaceGraphsRoot} from './WorkspaceGraphsRoot';
 import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
 import {WorkspaceOpsRoot} from './WorkspaceOpsRoot';
-import {WorkspacePipelineRoot} from './WorkspacePipelineRoot';
 import {WorkspaceSchedulesRoot} from './WorkspaceSchedulesRoot';
 import {WorkspaceSensorsRoot} from './WorkspaceSensorsRoot';
 import {repoAddressAsHumanString} from './repoAddressAsString';
@@ -146,9 +145,6 @@ export const WorkspaceRoot = () => {
   return (
     <MainContent>
       <Switch>
-        <Route path={['/locations/pipelines/:pipelinePath', '/locations/jobs/:pipelinePath']}>
-          <WorkspacePipelineRoot />
-        </Route>
         <Route path="/locations/:repoPath">
           <RepoRouteContainer />
         </Route>

--- a/js_modules/dagit/packages/core/src/workspace/workspacePath.ts
+++ b/js_modules/dagit/packages/core/src/workspace/workspacePath.ts
@@ -21,15 +21,15 @@ export const workspacePipelinePath = ({
   isJob,
   path = '',
 }: PathConfig) => {
-  const finalPath = path.startsWith('/') ? path : `/${path}`;
+  const finalPath = path === '' ? '' : path.startsWith('/') ? path : `/${path}`;
   return `/locations/${buildRepoPathForURL(repoName, repoLocation)}/${
     isJob ? 'jobs' : 'pipelines'
   }/${pipelineName}${finalPath}`;
 };
 
 export const workspacePipelinePathGuessRepo = (pipelineName: string, isJob = false, path = '') => {
-  const finalPath = path.startsWith('/') ? path : `/${path}`;
-  return `/locations/${isJob ? 'jobs' : 'pipelines'}/${pipelineName}${finalPath}`;
+  const finalPath = path === '' ? '' : path.startsWith('/') ? path : `/${path}`;
+  return `/guess/${isJob ? 'jobs' : 'pipelines'}/${pipelineName}${finalPath}`;
 };
 
 export const workspacePathFromAddress = (repoAddress: RepoAddress, path = '') => {


### PR DESCRIPTION
## Summary & Motivation

Resolves #13258. Resolves #12793.

Move the job/pipeline disambiguation route to `/guess/:jobName`, which frees up `jobs` and `pipelines` to be used as code location names under `/location` paths.

## How I Tested These Changes

Go to `/guess/log_asset_sensor_job` locally, verify that it correctly identifies the code location and redirects me to the right path.

Force disambiguation table to appear, verify that it loads correctly and shows appropriate information to display matching jobs.
