### PR TITLE
[pythonic config] Update cached_method field-setting logic

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -42,6 +42,7 @@ from dagster._core.errors import (
     DagsterInvalidPythonicConfigDefinitionError,
 )
 from dagster._core.execution.context.init import InitResourceContext
+from dagster._utils.cached_method import CACHED_METHOD_FIELD_SUFFIX
 
 from .attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
@@ -112,7 +113,7 @@ class MakeConfigCacheable(BaseModel):
         return super().__setattr__(name, value)
 
     def _is_field_internal(self, name: str) -> bool:
-        return name.startswith("_") or name.endswith("_cache")
+        return name.startswith("_") or name.endswith(CACHED_METHOD_FIELD_SUFFIX)
 
 
 class Config(MakeConfigCacheable):

--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -18,6 +18,8 @@ class _Sentinel:
 NO_VALUE_IN_CACHE_SENTINEL: Final = _Sentinel()
 NO_ARGS_HASH_VALUE = 0
 
+CACHED_METHOD_FIELD_SUFFIX = "_cached_method_cache"
+
 
 def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenate[S, P], T]:
     """Caches the results of a method call.
@@ -57,7 +59,7 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
 
     @wraps(method)
     def helper(self: S, *args: P.args, **kwargs: P.kwargs) -> T:
-        cache_attr_name = method.__name__ + "_cache"
+        cache_attr_name = method.__name__ + CACHED_METHOD_FIELD_SUFFIX
         if not hasattr(self, cache_attr_name):
             cache: Dict[Hashable, T] = {}
             setattr(self, cache_attr_name, cache)

--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -18,7 +18,7 @@ class _Sentinel:
 NO_VALUE_IN_CACHE_SENTINEL: Final = _Sentinel()
 NO_ARGS_HASH_VALUE = 0
 
-CACHED_METHOD_FIELD_SUFFIX = "_cached_method_cache"
+CACHED_METHOD_FIELD_SUFFIX = "_cached__internal__"
 
 
 def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenate[S, P], T]:


### PR DESCRIPTION
## Summary

Updates the `@cached_method` caching logic to save in a more specifically named field `field.__name__ + 'cached_method_cache'`. The Pythonic config setter logic is updated to use this more specific suffix, to reduce the chance of it colliding with a user-created field.
