### PR TITLE
Revert opening each dagster subprocess in its own process group

### DIFF
--- a/python_modules/dagit/dagit/app.py
+++ b/python_modules/dagit/dagit/app.py
@@ -15,6 +15,7 @@ from .webserver import DagitWebserver
 def create_app_from_workspace_process_context(
     workspace_process_context: WorkspaceProcessContext,
     path_prefix: str = "",
+    **kwargs,
 ) -> Starlette:
     check.inst_param(
         workspace_process_context, "workspace_process_context", WorkspaceProcessContext
@@ -36,7 +37,7 @@ def create_app_from_workspace_process_context(
     return DagitWebserver(
         workspace_process_context,
         path_prefix,
-    ).create_asgi_app()
+    ).create_asgi_app(**kwargs)
 
 
 def default_app(debug=False):

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -739,6 +739,9 @@ def grpc_command(
 
         try:
             server.serve()
+        except KeyboardInterrupt:
+            # Terminate cleanly on interrupt
+            logger.info("Code server was interrupted")
         finally:
             logger.info("Shutting down %s", server_desc)
 

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -197,31 +197,17 @@ def ipc_read_event_stream(
 # https://stefan.sofa-rockers.org/2013/08/15/handling-sub-process-hierarchies-python-linux-os-x/
 
 
-def _preexec_fn():
-    # See: https://bugs.python.org/issue14892 - prevent lines like "import readline" from hanging
-    # in the subprocess
-    signal.signal(signal.SIGTTOU, signal.SIG_IGN)
-
-    # the new subprocess will be in its own process group so that CTRL-Cing the parent process
-    # doesn't immediately interrupt the child process as well.
-    os.setpgrp()
-
-
 def open_ipc_subprocess(parts: Sequence[str], **kwargs: object) -> Popen[bytes]:
     """Sets the correct flags to support graceful termination."""
     check.list_param(parts, "parts", str)
 
     creationflags = 0
-    preexec_fn = None
     if sys.platform == "win32":
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
-    else:
-        # Works on all UNIX systems (but not WASI, see: https://docs.python.org/3/library/os.html#os.setpgrp)
-        preexec_fn = _preexec_fn
+
     return subprocess.Popen(
         parts,
         creationflags=creationflags,
-        preexec_fn=preexec_fn,
         **kwargs,
     )
 


### PR DESCRIPTION
Summary:
This reverts open_ipc_subprocess to its original state before I messed with its subprocess lifecycle - I thought that it would be desirable in general to run grpc servers in their own process groups as well, but that seems to have opened up a whole host of sketchy issues related to stdin.

Instead, add a hook to dagit so that even if it spins down a bit messily, it doesn't log an unsightly CancelledError to the terminal

