### PR TITLE
tweak partition_expr error

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -196,9 +196,9 @@ class DbIOManager(IOManager):
                 if partition_expr is None:
                     raise ValueError(
                         f"Asset '{context.asset_key}' has partitions, but no 'partition_expr'"
-                        " metadata value, so we don't know what column to filter it on. Specify"
-                        " which column(s) of the database contains partitioned data as the"
-                        " 'partition_expr' metadata."
+                        " metadata value, so we don't know what column it's partitioned on. To"
+                        " specify a column, set this metadata value. E.g."
+                        ' @asset(metadata={"partition_expr": "your_partition_column"}).'
                     )
 
                 if isinstance(context.asset_partitions_def, MultiPartitionsDefinition):


### PR DESCRIPTION
## Summary & Motivation

I've seen missing `partition_expr` be a stumbling block for a few people who are trying to use a DB IO manager with partitions.

I think the error message is already pretty helpful, but this is an attempt at making the error message as helpful as possible.  I took out "filter it on", because I thought it might not be clear to people why we would need to do filtering at the time that we're writing out data.

Let me know if you thinks this makes it less helpful in some way.

## How I Tested These Changes
