### PR TITLE
Move kvs access to DaemonCursorStorage

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_event_log_consumer.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_event_log_consumer.py
@@ -105,12 +105,12 @@ SUCCESS_KEY = "EVENT_LOG_CONSUMER_CURSOR-PIPELINE_SUCCESS"
 
 
 def test_cursors(instance: DagsterInstance, empty_workspace_context):
-    assert instance.run_storage.kvs_get({FAILURE_KEY, SUCCESS_KEY}) == {}
+    assert instance.run_storage.get_cursor_values({FAILURE_KEY, SUCCESS_KEY}) == {}
 
     daemon = TestEventLogConsumerDaemon()
     list(daemon.run_iteration(empty_workspace_context))
 
-    assert instance.run_storage.kvs_get({FAILURE_KEY, SUCCESS_KEY}) == {
+    assert instance.run_storage.get_cursor_values({FAILURE_KEY, SUCCESS_KEY}) == {
         FAILURE_KEY: str(0),
         SUCCESS_KEY: str(0),
     }
@@ -124,17 +124,17 @@ def test_cursors(instance: DagsterInstance, empty_workspace_context):
     list(daemon.run_iteration(empty_workspace_context))
     assert len(daemon.run_records) == 2
 
-    cursors = instance.run_storage.kvs_get({FAILURE_KEY, SUCCESS_KEY})
+    cursors = instance.run_storage.get_cursor_values({FAILURE_KEY, SUCCESS_KEY})
 
     list(daemon.run_iteration(empty_workspace_context))
-    assert instance.run_storage.kvs_get({FAILURE_KEY, SUCCESS_KEY}) == cursors
+    assert instance.run_storage.get_cursor_values({FAILURE_KEY, SUCCESS_KEY}) == cursors
 
     for _ in range(5):
         instance.report_engine_event("foo", run1)
         instance.report_engine_event("foo", run2)
 
     list(daemon.run_iteration(empty_workspace_context))
-    assert instance.run_storage.kvs_get({FAILURE_KEY, SUCCESS_KEY}) == {
+    assert instance.run_storage.get_cursor_values({FAILURE_KEY, SUCCESS_KEY}) == {
         FAILURE_KEY: str(int(cursors[FAILURE_KEY]) + 10),
         SUCCESS_KEY: str(int(cursors[SUCCESS_KEY]) + 10),
     }

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -423,13 +423,6 @@ class DagsterInstance(DynamicPartitionsStore):
 
         if self.run_retries_enabled:
             check.invariant(
-                self.run_storage.supports_kvs(),
-                (
-                    "Run retries are enabled, but the configured run storage does not support them."
-                    " Consider switching to Postgres or Mysql."
-                ),
-            )
-            check.invariant(
                 self.event_log_storage.supports_event_consumer_queries(),
                 (
                     "Run retries are enabled, but the configured event log storage does not support"

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
     from dagster._core.secrets import SecretsLoader
     from dagster._core.snap import ExecutionPlanSnapshot, PipelineSnapshot
     from dagster._core.storage.compute_log_manager import ComputeLogManager
+    from dagster._core.storage.daemon_cursor import DaemonCursorStorage
     from dagster._core.storage.event_log import EventLogStorage
     from dagster._core.storage.event_log.base import (
         AssetRecord,
@@ -664,6 +665,10 @@ class DagsterInstance(DynamicPartitionsStore):
     @property
     def event_log_storage(self) -> "EventLogStorage":
         return self._event_storage
+
+    @property
+    def daemon_cursor_storage(self) -> "DaemonCursorStorage":
+        return self._run_storage
 
     # schedule storage
 

--- a/python_modules/dagster/dagster/_core/storage/daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/storage/daemon_cursor.py
@@ -1,0 +1,12 @@
+from abc import abstractmethod
+from typing import Mapping, Set
+
+
+class DaemonCursorStorage:
+    @abstractmethod
+    def kvs_get(self, keys: Set[str]) -> Mapping[str, str]:
+        """Retrieve the value for a given key in the current deployment."""
+
+    @abstractmethod
+    def kvs_set(self, pairs: Mapping[str, str]) -> None:
+        """Set the value for a given key in the current deployment."""

--- a/python_modules/dagster/dagster/_core/storage/daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/storage/daemon_cursor.py
@@ -4,9 +4,9 @@ from typing import Mapping, Set
 
 class DaemonCursorStorage:
     @abstractmethod
-    def kvs_get(self, keys: Set[str]) -> Mapping[str, str]:
+    def get_cursor_values(self, keys: Set[str]) -> Mapping[str, str]:
         """Retrieve the value for a given key in the current deployment."""
 
     @abstractmethod
-    def kvs_set(self, pairs: Mapping[str, str]) -> None:
+    def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         """Set the value for a given key in the current deployment."""

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -327,11 +327,11 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def get_run_partition_data(self, runs_filter: "RunsFilter") -> Sequence["RunPartitionData"]:
         return self._storage.run_storage.get_run_partition_data(runs_filter)
 
-    def kvs_get(self, keys: Set[str]) -> Mapping[str, str]:
-        return self._storage.run_storage.kvs_get(keys)
+    def get_cursor_values(self, keys: Set[str]) -> Mapping[str, str]:
+        return self._storage.run_storage.get_cursor_values(keys)
 
-    def kvs_set(self, pairs: Mapping[str, str]) -> None:
-        return self._storage.run_storage.kvs_set(pairs)
+    def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
+        return self._storage.run_storage.set_cursor_values(pairs)
 
     def replace_job_origin(self, run: "DagsterRun", job_origin: "ExternalPipelineOrigin") -> None:
         return self._storage.run_storage.replace_job_origin(run, job_origin)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -403,9 +403,6 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def alembic_version(self) -> Optional[AlembicVersion]:
         return None
 
-    def supports_kvs(self) -> bool:
-        return True
-
     @abstractmethod
     def replace_job_origin(self, run: "DagsterRun", job_origin: "ExternalPipelineOrigin") -> None:
         ...

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -19,6 +19,8 @@ from dagster._core.storage.sql import AlembicVersion
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._utils import PrintFn
 
+from ..daemon_cursor import DaemonCursorStorage
+
 if TYPE_CHECKING:
     from dagster._core.host_representation.origin import ExternalPipelineOrigin
 
@@ -28,7 +30,7 @@ class RunGroupInfo(TypedDict):
     runs: Sequence[DagsterRun]
 
 
-class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
+class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorStorage):
     """Abstract base class for storing pipeline run history.
 
     Note that run storages using SQL databases as backing stores should implement
@@ -401,21 +403,8 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def alembic_version(self) -> Optional[AlembicVersion]:
         return None
 
-    # Key Value Storage
-    #
-    # Stores arbitrary key-value pairs. Currently used for the cursor for the auto-reexecution
-    # deamon. Bundled into run storage for convenience.
-
     def supports_kvs(self) -> bool:
         return True
-
-    @abstractmethod
-    def kvs_get(self, keys: Set[str]) -> Mapping[str, str]:
-        """Retrieve the value for a given key in the current deployment."""
-
-    @abstractmethod
-    def kvs_set(self, pairs: Mapping[str, str]) -> None:
-        """Set the value for a given key in the current deployment."""
 
     @abstractmethod
     def replace_job_origin(self, run: "DagsterRun", job_origin: "ExternalPipelineOrigin") -> None:

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -1137,10 +1137,7 @@ class SqlRunStorage(RunStorage):
                 )
             )
 
-    def supports_kvs(self) -> bool:
-        return True
-
-    def kvs_get(self, keys: Set[str]) -> Mapping[str, str]:
+    def get_cursor_values(self, keys: Set[str]) -> Mapping[str, str]:
         check.set_param(keys, "keys", of_type=str)
 
         with self.connect() as conn:
@@ -1151,7 +1148,7 @@ class SqlRunStorage(RunStorage):
             )
             return {row.key: row.value for row in rows}
 
-    def kvs_set(self, pairs: Mapping[str, str]) -> None:
+    def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         check.mapping_param(pairs, "pairs", key_type=str, value_type=str)
         db_values = [{"key": k, "value": v} for k, v in pairs.items()]
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -40,7 +40,9 @@ class AssetDaemon(IntervalDaemon):
             yield
             return
 
-        raw_cursor = instance.daemon_cursor_storage.kvs_get({CURSOR_NAME}).get(CURSOR_NAME)
+        raw_cursor = instance.daemon_cursor_storage.get_cursor_values({CURSOR_NAME}).get(
+            CURSOR_NAME
+        )
         cursor = (
             AssetReconciliationCursor.from_serialized(raw_cursor, asset_graph)
             if raw_cursor
@@ -118,4 +120,4 @@ class AssetDaemon(IntervalDaemon):
             )
             instance.submit_run(run.run_id, workspace)
 
-        instance.daemon_cursor_storage.kvs_set({CURSOR_NAME: new_cursor.serialize()})
+        instance.daemon_cursor_storage.set_cursor_values({CURSOR_NAME: new_cursor.serialize()})

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -40,7 +40,7 @@ class AssetDaemon(IntervalDaemon):
             yield
             return
 
-        raw_cursor = instance.run_storage.kvs_get({CURSOR_NAME}).get(CURSOR_NAME)
+        raw_cursor = instance.daemon_cursor_storage.kvs_get({CURSOR_NAME}).get(CURSOR_NAME)
         cursor = (
             AssetReconciliationCursor.from_serialized(raw_cursor, asset_graph)
             if raw_cursor
@@ -118,4 +118,4 @@ class AssetDaemon(IntervalDaemon):
             )
             instance.submit_run(run.run_id, workspace)
 
-        instance.run_storage.kvs_set({CURSOR_NAME: new_cursor.serialize()})
+        instance.daemon_cursor_storage.kvs_set({CURSOR_NAME: new_cursor.serialize()})

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -107,7 +107,7 @@ def _fetch_persisted_cursors(
     check.sequence_param(event_types, "event_types", of_type=DagsterEventType)
 
     # get the persisted cursor for each event type
-    persisted_cursors = instance.run_storage.kvs_get(
+    persisted_cursors = instance.daemon_cursor_storage.kvs_get(
         {_create_cursor_key(event_type) for event_type in event_types}
     )
 
@@ -134,7 +134,7 @@ def _persist_cursors(instance: DagsterInstance, cursors: Mapping[DagsterEventTyp
     check.mapping_param(cursors, "cursors", key_type=DagsterEventType, value_type=int)
 
     if cursors:
-        instance.run_storage.kvs_set(
+        instance.daemon_cursor_storage.kvs_set(
             {
                 _create_cursor_key(event_type): str(cursor_value)
                 for event_type, cursor_value in cursors.items()

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -107,7 +107,7 @@ def _fetch_persisted_cursors(
     check.sequence_param(event_types, "event_types", of_type=DagsterEventType)
 
     # get the persisted cursor for each event type
-    persisted_cursors = instance.daemon_cursor_storage.kvs_get(
+    persisted_cursors = instance.daemon_cursor_storage.get_cursor_values(
         {_create_cursor_key(event_type) for event_type in event_types}
     )
 
@@ -134,7 +134,7 @@ def _persist_cursors(instance: DagsterInstance, cursors: Mapping[DagsterEventTyp
     check.mapping_param(cursors, "cursors", key_type=DagsterEventType, value_type=int)
 
     if cursors:
-        instance.daemon_cursor_storage.kvs_set(
+        instance.daemon_cursor_storage.set_cursor_values(
             {
                 _create_cursor_key(event_type): str(cursor_value)
                 for event_type, cursor_value in cursors.items()

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -286,7 +286,9 @@ def test_using_repository_data():
         repository_load_data = repository_def.repository_load_data
 
         assert (
-            instance.run_storage.kvs_get({"get_definitions_called"}).get("get_definitions_called")
+            instance.run_storage.get_cursor_values({"get_definitions_called"}).get(
+                "get_definitions_called"
+            )
             == "1"
         )
 
@@ -300,7 +302,9 @@ def test_using_repository_data():
 
         # need to get the definitions from metadata when creating the plan
         assert (
-            instance.run_storage.kvs_get({"get_definitions_called"}).get("get_definitions_called")
+            instance.run_storage.get_cursor_values({"get_definitions_called"}).get(
+                "get_definitions_called"
+            )
             == "2"
         )
 
@@ -314,14 +318,16 @@ def test_using_repository_data():
         )
 
         assert (
-            instance.run_storage.kvs_get({"compute_cacheable_data_called"}).get(
+            instance.run_storage.get_cursor_values({"compute_cacheable_data_called"}).get(
                 "compute_cacheable_data_called"
             )
             == "1"
         )
         # should not have needed to get_definitions again after creating the plan
         assert (
-            instance.run_storage.kvs_get({"get_definitions_called"}).get("get_definitions_called")
+            instance.run_storage.get_cursor_values({"get_definitions_called"}).get(
+                "get_definitions_called"
+            )
             == "2"
         )
 
@@ -334,9 +340,9 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         instance = DagsterInstance.get()
         kvs_key = "compute_cacheable_data_called"
         compute_cacheable_data_called = int(
-            instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0")
+            instance.run_storage.get_cursor_values({kvs_key}).get(kvs_key, "0")
         )
-        instance.run_storage.kvs_set({kvs_key: str(compute_cacheable_data_called + 1)})
+        instance.run_storage.set_cursor_values({kvs_key: str(compute_cacheable_data_called + 1)})
         return [self._cacheable_data]
 
     def build_definitions(self, data):
@@ -346,8 +352,10 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         # used for tracking how many times this function gets called over an execution
         instance = DagsterInstance.get()
         kvs_key = "get_definitions_called"
-        get_definitions_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
-        instance.run_storage.kvs_set({kvs_key: str(get_definitions_called + 1)})
+        get_definitions_called = int(
+            instance.run_storage.get_cursor_values({kvs_key}).get(kvs_key, "0")
+        )
+        instance.run_storage.set_cursor_values({kvs_key: str(get_definitions_called + 1)})
 
         @op
         def _op():

--- a/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/dynamic_tests/test_reexecute.py
@@ -363,9 +363,9 @@ def fail_once(context: OpExecutionContext, x):
     map_key = context.get_mapping_key()
     if map_key:
         key += f"[{map_key}]"
-    if context.instance.run_storage.kvs_get({key}).get(key):
+    if context.instance.run_storage.get_cursor_values({key}).get(key):
         return x
-    context.instance.run_storage.kvs_set({key: "true"})
+    context.instance.run_storage.set_cursor_values({key: "true"})
     raise Exception("failed (just this once)")
 
 
@@ -484,11 +484,11 @@ def fail_n(context: OpExecutionContext, x):
     assert map_key
     key = f"{context.op_handle.name}[{map_key}]"
 
-    fails = int(context.instance.run_storage.kvs_get({key}).get(key, "0"))
+    fails = int(context.instance.run_storage.get_cursor_values({key}).get(key, "0"))
     if fails >= int(map_key):
         return x
     fails += 1
-    context.instance.run_storage.kvs_set({key: str(fails)})
+    context.instance.run_storage.set_cursor_values({key: str(fails)})
     raise Exception(f"failed {fails} out of {map_key}")
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -350,7 +350,7 @@ def test_execute_using_repository_data():
             recon_job,
             instance=instance,
         ) as result:
-            call_counts = instance.run_storage.kvs_get(
+            call_counts = instance.run_storage.get_cursor_values(
                 {"compute_cacheable_data_called", "get_definitions_called"}
             )
             assert call_counts.get("compute_cacheable_data_called") == "1"
@@ -382,7 +382,7 @@ def test_execute_using_repository_data():
             assert result.success
             # we do not attempt to fetch the previous repository load data off of the execution plan
             # from the previous run, so the reexecution will require us to fetch the metadata again
-            call_counts = instance.run_storage.kvs_get(
+            call_counts = instance.run_storage.get_cursor_values(
                 {"compute_cacheable_data_called", "get_definitions_called"}
             )
             assert call_counts.get("compute_cacheable_data_called") == "2"
@@ -397,8 +397,8 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         # used for tracking how many times this function gets called over an execution
         instance = DagsterInstance.get()
         kvs_key = "compute_cacheable_data_called"
-        num_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
-        instance.run_storage.kvs_set({kvs_key: str(num_called + 1)})
+        num_called = int(instance.run_storage.get_cursor_values({kvs_key}).get(kvs_key, "0"))
+        instance.run_storage.set_cursor_values({kvs_key: str(num_called + 1)})
         return [self._cacheable_data]
 
     def build_definitions(self, data):
@@ -407,8 +407,8 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         # used for tracking how many times this function gets called over an execution
         instance = DagsterInstance.get()
         kvs_key = "get_definitions_called"
-        num_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
-        instance.run_storage.kvs_set({kvs_key: str(num_called + 1)})
+        num_called = int(instance.run_storage.get_cursor_values({kvs_key}).get(kvs_key, "0"))
+        instance.run_storage.set_cursor_values({kvs_key: str(num_called + 1)})
 
         @op
         def _op():

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_external_step.py
@@ -611,7 +611,7 @@ def test_multiproc_launcher_with_repository_load_data():
             }
         }
         with instance_for_test() as instance:
-            instance.run_storage.kvs_set({"val": "INITIAL_VALUE"})
+            instance.run_storage.set_cursor_values({"val": "INITIAL_VALUE"})
             recon_repo = ReconstructableRepository.for_file(
                 file_relative_path(__file__, "test_external_step.py"),
                 fn_name="pending_repo",
@@ -626,7 +626,7 @@ def test_multiproc_launcher_with_repository_load_data():
                 instance=instance,
             ) as result:
                 assert result.success
-                assert instance.run_storage.kvs_get({"val"}).get("val") == "NEW_VALUE"
+                assert instance.run_storage.get_cursor_values({"val"}).get("val") == "NEW_VALUE"
 
 
 class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
@@ -638,9 +638,9 @@ class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
         # and assert that this pre-populated value is present, to ensure that we'll error if this
         # gets called in a child process
         instance = DagsterInstance.get()
-        val = instance.run_storage.kvs_get({"val"}).get("val")
+        val = instance.run_storage.get_cursor_values({"val"}).get("val")
         assert val == "INITIAL_VALUE"
-        instance.run_storage.kvs_set({"val": "NEW_VALUE"})
+        instance.run_storage.set_cursor_values({"val": "NEW_VALUE"})
         return [self._cacheable_data]
 
     def build_definitions(self, data):

--- a/python_modules/dagster/dagster_tests/execution_tests/test_execute_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_execute_job.py
@@ -379,9 +379,9 @@ def echo(x):
 @op
 def fail_once(context: OpExecutionContext, x):
     key = context.op_handle.name
-    if context.instance.run_storage.kvs_get({key}).get(key):
+    if context.instance.run_storage.get_cursor_values({key}).get(key):
         return x
-    context.instance.run_storage.kvs_set({key: "true"})
+    context.instance.run_storage.set_cursor_values({key: "true"})
     raise Exception("failed (just this once)")
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1122,8 +1122,8 @@ def test_add_primary_keys():
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
             assert "id" not in set(get_sqlite3_columns(db_path, "kvs"))
             # trigger insert, and update
-            instance.run_storage.kvs_set({"a": "A"})
-            instance.run_storage.kvs_set({"a": "A"})
+            instance.run_storage.set_cursor_values({"a": "A"})
+            instance.run_storage.set_cursor_values({"a": "A"})
             kvs_row_count = _get_table_row_count(instance.run_storage, KeyValueStoreTable)
             assert kvs_row_count > 0
 

--- a/python_modules/dagster/dagster_tests/launcher_tests/pending_repository.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/pending_repository.py
@@ -22,9 +22,9 @@ class MyAssets(CacheableAssetsDefinition):
         instance = DagsterInstance.get()
         kvs_key = f"compute_cacheable_data_called_{self.unique_id}"
         compute_cacheable_data_called = int(
-            instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0")
+            instance.run_storage.get_cursor_values({kvs_key}).get(kvs_key, "0")
         )
-        instance.run_storage.kvs_set({kvs_key: str(compute_cacheable_data_called + 1)})
+        instance.run_storage.set_cursor_values({kvs_key: str(compute_cacheable_data_called + 1)})
 
         return [
             AssetsDefinitionCacheableData(
@@ -50,8 +50,10 @@ class MyAssets(CacheableAssetsDefinition):
         # used for tracking how many times we've executed this function
         instance = DagsterInstance.get()
         kvs_key = f"get_definitions_called_{self.unique_id}"
-        get_definitions_called = int(instance.run_storage.kvs_get({kvs_key}).get(kvs_key, "0"))
-        instance.run_storage.kvs_set({kvs_key: str(get_definitions_called + 1)})
+        get_definitions_called = int(
+            instance.run_storage.get_cursor_values({kvs_key}).get(kvs_key, "0")
+        )
+        instance.run_storage.set_cursor_values({kvs_key: str(get_definitions_called + 1)})
 
         @op(name=f"my_op_{self.unique_id}", ins={"inp": In(Nothing)})
         def my_op():

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -193,7 +193,7 @@ def test_successful_run_from_pending(
         known_state=None,
     )
 
-    call_counts = instance.run_storage.kvs_get(
+    call_counts = instance.run_storage.get_cursor_values(
         {
             "compute_cacheable_data_called_a",
             "compute_cacheable_data_called_b",
@@ -240,7 +240,7 @@ def test_successful_run_from_pending(
     finished_run = poll_for_finished_run(instance, run_id)
     assert finished_run.status == DagsterRunStatus.SUCCESS
 
-    call_counts = instance.run_storage.kvs_get(
+    call_counts = instance.run_storage.get_cursor_values(
         {
             "compute_cacheable_data_called_a",
             "compute_cacheable_data_called_b",

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -117,7 +117,7 @@ def test_run_from_pending_repository():
                     known_state=None,
                 )
 
-                call_counts = instance.run_storage.kvs_get(
+                call_counts = instance.run_storage.get_cursor_values(
                     {
                         "compute_cacheable_data_called_a",
                         "compute_cacheable_data_called_b",
@@ -176,7 +176,7 @@ def test_run_from_pending_repository():
         server_process.wait()
 
         # should only have had to get the metadata once for each cacheable asset def
-        call_counts = instance.run_storage.kvs_get(
+        call_counts = instance.run_storage.get_cursor_values(
             {
                 "compute_cacheable_data_called_a",
                 "compute_cacheable_data_called_b",

--- a/python_modules/dagster/dagster_tests/storage_tests/test_daemon_cursor_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_daemon_cursor_storage.py
@@ -1,0 +1,26 @@
+import pytest
+
+from .test_run_storage import (
+    create_in_memory_storage,
+    create_legacy_run_storage,
+    create_non_bucket_sqlite_run_storage,
+    create_sqlite_run_storage,
+)
+from .utils.daemon_cursor_storage import TestDaemonCursorStorage
+
+
+class TestDaemonCursorStorages(TestDaemonCursorStorage):
+    __test__ = True
+
+    @pytest.fixture(
+        name="storage",
+        params=[
+            create_in_memory_storage,
+            create_sqlite_run_storage,
+            create_non_bucket_sqlite_run_storage,
+            create_legacy_run_storage,
+        ],
+    )
+    def cursor_storage(self, request):
+        with request.param() as s:
+            yield s

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/daemon_cursor_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/daemon_cursor_storage.py
@@ -14,18 +14,22 @@ class TestDaemonCursorStorage:
             yield s
 
     def test_kvs(self, storage):
-        storage.kvs_set({"key": "value"})
-        assert storage.kvs_get({"key"}) == {"key": "value"}
+        storage.set_cursor_values({"key": "value"})
+        assert storage.get_cursor_values({"key"}) == {"key": "value"}
 
-        storage.kvs_set({"key": "new-value"})
-        assert storage.kvs_get({"key"}) == {"key": "new-value"}
+        storage.set_cursor_values({"key": "new-value"})
+        assert storage.get_cursor_values({"key"}) == {"key": "new-value"}
 
-        storage.kvs_set({"foo": "foo", "bar": "bar"})
-        assert storage.kvs_get({"foo", "bar", "key"}) == {
+        storage.set_cursor_values({"foo": "foo", "bar": "bar"})
+        assert storage.get_cursor_values({"foo", "bar", "key"}) == {
             "key": "new-value",
             "foo": "foo",
             "bar": "bar",
         }
 
-        storage.kvs_set({"foo": "1", "bar": "2", "key": "3"})
-        assert storage.kvs_get({"foo", "bar", "key"}) == {"foo": "1", "bar": "2", "key": "3"}
+        storage.set_cursor_values({"foo": "1", "bar": "2", "key": "3"})
+        assert storage.get_cursor_values({"foo", "bar", "key"}) == {
+            "foo": "1",
+            "bar": "2",
+            "key": "3",
+        }

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/daemon_cursor_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/daemon_cursor_storage.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+class TestDaemonCursorStorage:
+    """You can extend this class to easily run these set of tests on any daemon cursor storage. When extending,
+    you simply need to override the `cursor_storage` fixture.
+    """
+
+    __test__ = False
+
+    @pytest.fixture(name="storage", params=[])
+    def cursor_storage(self, request):
+        with request.param() as s:
+            yield s
+
+    def test_kvs(self, storage):
+        storage.kvs_set({"key": "value"})
+        assert storage.kvs_get({"key"}) == {"key": "value"}
+
+        storage.kvs_set({"key": "new-value"})
+        assert storage.kvs_get({"key"}) == {"key": "new-value"}
+
+        storage.kvs_set({"foo": "foo", "bar": "bar"})
+        assert storage.kvs_get({"foo", "bar", "key"}) == {
+            "key": "new-value",
+            "foo": "foo",
+            "bar": "bar",
+        }
+
+        storage.kvs_set({"foo": "1", "bar": "2", "key": "3"})
+        assert storage.kvs_get({"foo", "bar", "key"}) == {"foo": "1", "bar": "2", "key": "3"}

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1580,25 +1580,6 @@ class TestRunStorage:
                 assert record.start_time == freeze_datetime.timestamp()
                 assert record.end_time == freeze_datetime.timestamp()
 
-    def test_kvs(self, storage):
-        if not storage.supports_kvs():
-            pytest.skip("storage cannot kvs")
-
-        storage.kvs_set({"key": "value"})
-        assert storage.kvs_get({"key"}) == {"key": "value"}
-
-        storage.kvs_set({"key": "new-value"})
-        assert storage.kvs_get({"key"}) == {"key": "new-value"}
-
-        storage.kvs_set({"foo": "foo", "bar": "bar"})
-        assert storage.kvs_get({"foo", "bar", "key"}) == {
-            "key": "new-value",
-            "foo": "foo",
-            "bar": "bar",
-        }
-
-        storage.kvs_set({"foo": "1", "bar": "2", "key": "3"})
-        assert storage.kvs_get({"foo", "bar", "key"}) == {"foo": "1", "bar": "2", "key": "3"}
 
     def test_migrate_repo(self, storage):
         assert storage

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1580,7 +1580,6 @@ class TestRunStorage:
                 assert record.start_time == freeze_datetime.timestamp()
                 assert record.end_time == freeze_datetime.timestamp()
 
-
     def test_migrate_repo(self, storage):
         assert storage
         self._skip_in_memory(storage)

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -189,7 +189,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
                 )
             )
 
-    def kvs_set(self, pairs: Mapping[str, str]) -> None:
+    def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         check.mapping_param(pairs, "pairs", key_type=str, value_type=str)
         db_values = [{"key": k, "value": v} for k, v in pairs.items()]
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -408,8 +408,8 @@ def test_add_primary_keys(backcompat_conn_string):
         with DagsterInstance.from_config(tempdir) as instance:
             assert "id" not in get_columns(instance, "kvs")
             # trigger insert, and update
-            instance.run_storage.kvs_set({"a": "A"})
-            instance.run_storage.kvs_set({"a": "A"})
+            instance.run_storage.set_cursor_values({"a": "A"})
+            instance.run_storage.set_cursor_values({"a": "A"})
 
             kvs_row_count = _get_table_row_count(instance.run_storage, KeyValueStoreTable)
             assert kvs_row_count > 0

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_daemon_cursor_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_daemon_cursor_storage.py
@@ -1,0 +1,13 @@
+import pytest
+from dagster_mysql.run_storage import MySQLRunStorage
+from dagster_tests.storage_tests.utils.daemon_cursor_storage import TestDaemonCursorStorage
+
+
+class TestMySQLDaemonCursorStorage(TestDaemonCursorStorage):
+    __test__ = True
+
+    @pytest.fixture(scope="function", name="storage")
+    def cursor_storage(self, conn_string):
+        storage = MySQLRunStorage.create_clean_storage(conn_string)
+        assert storage
+        return storage

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -196,7 +196,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 )
             )
 
-    def kvs_set(self, pairs: Mapping[str, str]) -> None:
+    def set_cursor_values(self, pairs: Mapping[str, str]) -> None:
         check.mapping_param(pairs, "pairs", key_type=str, value_type=str)
 
         # pg speciic on_conflict_do_update

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -845,8 +845,8 @@ def test_add_primary_keys(hostname, conn_string):
         with DagsterInstance.from_config(tempdir) as instance:
             assert "id" not in get_columns(instance, "kvs")
             # trigger insert, and update
-            instance.run_storage.kvs_set({"a": "A"})
-            instance.run_storage.kvs_set({"a": "A"})
+            instance.run_storage.set_cursor_values({"a": "A"})
+            instance.run_storage.set_cursor_values({"a": "A"})
             kvs_row_count = _get_table_row_count(instance.run_storage, KeyValueStoreTable)
             assert kvs_row_count > 0
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_daemon_cursor_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_daemon_cursor_storage.py
@@ -1,0 +1,13 @@
+import pytest
+from dagster_postgres.run_storage import PostgresRunStorage
+from dagster_tests.storage_tests.utils.daemon_cursor_storage import TestDaemonCursorStorage
+
+
+class TestPostgresDaemonCursorStorage(TestDaemonCursorStorage):
+    __test__ = True
+
+    @pytest.fixture(scope="function", name="storage")
+    def cursor_storage(self, conn_string):
+        storage = PostgresRunStorage.create_clean_storage(conn_string)
+        assert storage
+        return storage


### PR DESCRIPTION
I need something like this to support the AssetDaemon in cloud where the kvs is on cloud storage instead of run storage, and we've talked about moving in this direction anyway

https://github.com/dagster-io/internal/pull/5427