### PR TITLE
[pythonic config] Correctly handle Falsey config defaults

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -937,6 +937,7 @@ def _convert_pydantic_field(pydantic_field: ModelField, model_cls: Optional[Type
         wrapped_config_type = _wrap_config_type(
             shape_type=pydantic_field.shape, config_type=config_type, key_type=key_type
         )
+
         return Field(
             config=Noneable(wrapped_config_type)
             if pydantic_field.allow_none
@@ -944,7 +945,7 @@ def _convert_pydantic_field(pydantic_field: ModelField, model_cls: Optional[Type
             description=pydantic_field.field_info.description,
             is_required=_is_pydantic_field_required(pydantic_field),
             default_value=pydantic_field.default
-            if pydantic_field.default
+            if pydantic_field.default is not None
             else FIELD_NO_DEFAULT_PROVIDED,
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
@@ -956,3 +956,23 @@ def test_direct_op_invocation_kwarg_with_config_and_context_err() -> None:
         DagsterInvalidInvocationError, match="Cannot provide config in both context and kwargs"
     ):
         an_op(context=build_op_context(config={"num": 2}), config=MyConfig(num=1))
+
+
+def test_truthy_and_falsey_defaults() -> None:
+    class ConfigClassToConvertTrue(Config):
+        bool_with_default_true_value: bool = PyField(default=True)
+
+    fields = ConfigClassToConvertTrue.to_fields_dict()
+    true_default_field = fields["bool_with_default_true_value"]
+    assert true_default_field.is_required is False
+    assert true_default_field.default_provided is True
+    assert true_default_field.default_value is True
+
+    class ConfigClassToConvertFalse(Config):
+        bool_with_default_false_value: bool = PyField(default=False)
+
+    fields = ConfigClassToConvertFalse.to_fields_dict()
+    false_default_field = fields["bool_with_default_false_value"]
+    assert false_default_field.is_required is False
+    assert false_default_field.default_provided is True
+    assert false_default_field.default_value is False


### PR DESCRIPTION
## Summary

Fixes a bug where Pydantic config defaults which were falsey (e.g. evaluate to `False` when casted to bool) were not correctly set in the underlying Dagster config type.

## Test Plan

Previously failing test 