### PR TITLE
Avoid rebuilding multipartitions subset when time partitions are added

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py
@@ -1,3 +1,4 @@
+import hashlib
 import itertools
 from datetime import datetime
 from functools import reduce
@@ -213,6 +214,20 @@ class MultiPartitionsDefinition(PartitionsDefinition):
     @property
     def partitions_subset_class(self) -> Type["PartitionsSubset"]:
         return MultiPartitionsSubset
+
+    def get_serializable_unique_identifier(
+        self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
+    ) -> str:
+        return hashlib.sha1(
+            str(
+                {
+                    dim_def.name: dim_def.partitions_def.get_serializable_unique_identifier(
+                        dynamic_partitions_store
+                    )
+                    for dim_def in self.partitions_defs
+                }
+            ).encode("utf-8")
+        ).hexdigest()
 
     @property
     def partition_dimension_names(self) -> List[str]:

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -9,6 +9,7 @@ from dagster import (
     DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
     PartitionKeyRange,
     StaticPartitionsDefinition,
 )
@@ -789,6 +790,46 @@ def test_unique_identifier():
         assert identifier1 != dynamic_def.get_serializable_unique_identifier(
             dynamic_partitions_store=instance
         )
+
+        dynamic_dimension_def = DynamicPartitionsDefinition(name="fruits")
+        multipartitions_def = MultiPartitionsDefinition(
+            {"a": StaticPartitionsDefinition(["a", "b", "c"]), "b": dynamic_dimension_def}
+        )
+        serializable_unique_id = multipartitions_def.get_serializable_unique_identifier(instance)
+        instance.add_dynamic_partitions(dynamic_dimension_def.name, ["apple"])
+        assert serializable_unique_id != multipartitions_def.get_serializable_unique_identifier(
+            instance
+        )
+
+    assert (
+        MultiPartitionsDefinition(
+            {
+                "a": StaticPartitionsDefinition(["a", "b", "c"]),
+                "b": StaticPartitionsDefinition(["1"]),
+            }
+        ).get_serializable_unique_identifier()
+        != MultiPartitionsDefinition(
+            {
+                "different_name": StaticPartitionsDefinition(["a", "b", "c"]),
+                "b": StaticPartitionsDefinition(["1"]),
+            }
+        ).get_serializable_unique_identifier()
+    )
+
+    assert (
+        MultiPartitionsDefinition(
+            {
+                "a": StaticPartitionsDefinition(["a", "b", "c"]),
+                "b": StaticPartitionsDefinition(["1"]),
+            }
+        ).get_serializable_unique_identifier()
+        != MultiPartitionsDefinition(
+            {
+                "a": StaticPartitionsDefinition(["a", "b"]),
+                "b": StaticPartitionsDefinition(["1"]),
+            }
+        ).get_serializable_unique_identifier()
+    )
 
 
 def test_static_partitions_subset():


### PR DESCRIPTION
Currently the multipartitions subset serializable unique ID uses the [default implementation](https://github.com/dagster-io/dagster/blob/a26d6c6616451701ad88462b0e497a5e212b92f8/python_modules/dagster/dagster/_core/definitions/partition.py#L322-L329), which hashes a list of all the partition keys.

When the multipartitions def has a time dimension, this means that the serializable unique ID changes whenever new time partition keys exist, which for a `DailyPartitionsDefinition` dimension occurs every day. This causes a rebuild of the partitions status cache every time the serializable unique ID changes.

This PR amends the serializable unique ID for multipartitions defs to be hashed from a mapping of dimension name to serializable unique ID for that dimension definition. This behavior ensures that the serializable ID remains the same when a time dimension partitions def is the same, independent of the existent partition keys. When static partition keys / dynamic partition keys are added and removed from within a dimension, their corresponding serializable IDs will change, causing a rebuild of the cache as desired.

Updating this behavior will speed up page load for users especially cloud customers.