### PR TITLE
[dagit] Expose run.updateTime in the correct timezone

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import List, Optional, Sequence
 
 import dagster._check as check
@@ -573,7 +574,8 @@ class GrapheneRun(graphene.ObjectType):
 
     def resolve_updateTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
-        return datetime_as_float(run_record.update_timestamp)
+        updated = run_record.update_timestamp.timestamp()
+        return datetime_as_float(datetime.datetime.utcfromtimestamp(updated))
 
 
 class GrapheneIPipelineSnapshotMixin:


### PR DESCRIPTION
## Summary & Motivation

Slack discussion: https://elementl-workspace.slack.com/archives/C03CCE471E0/p1681241621839859

When a run is "Starting..." we pull the run.updateTime instead of the run.startTime, which is still null. It appears that this field is applying a timezone offset twice and is four hours early for a user running Dagit locally and in EDT.

This field was the subject of a bug in 0.11.5:

- The `update_timestamp` column in the runs table is now updated with a UTC timezone, making it consistent with the `create_timestamp` column.

I believe that we are correctly transforming a time in the same format to a timestamp here, and I copied this to fix:
https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/data_time.py#L430

## How I Tested These Changes

Before:

<img width="958" alt="image" src="https://user-images.githubusercontent.com/1037212/231490846-5251ed2f-4b67-4983-b24b-6cf383b2ed35.png">


After:

<img width="967" alt="image" src="https://user-images.githubusercontent.com/1037212/231490220-e3e03620-8f47-4ce2-9c4f-e716d3d12b92.png">
