### PR TITLE
Revert "Use specific events to trigger a "Preparing" state instead of assuming that any logged event means that the step has started (#13182)"

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChart.tsx
@@ -812,7 +812,6 @@ export const GanttChartLoadingState = ({runId}: {runId: string}) => (
       firstInitialPercent={70}
       second={
         <GanttStatusPanel
-          graph={[]}
           metadata={EMPTY_RUN_METADATA}
           selection={{keys: [], query: '*'}}
           runId={runId}
@@ -846,7 +845,6 @@ export const QueuedState = ({run}: {run: RunFragment}) => (
       firstInitialPercent={70}
       second={
         <GanttStatusPanel
-          graph={[]}
           metadata={EMPTY_RUN_METADATA}
           selection={{keys: [], query: '*'}}
           runId={run.id}

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -40,7 +40,7 @@ export interface IStepAttempt {
 
 export interface IStepMetadata {
   // current state
-  state?: IStepState;
+  state: IStepState;
 
   // execution start and stop (user-code) inclusive of all retries
   start?: number;
@@ -262,9 +262,14 @@ export function extractMetadataFromLogs(
       const step =
         metadata.steps[stepKey] ||
         ({
-          state: undefined,
+          state: IStepState.PREPARING,
           attempts: [],
-          transitions: [],
+          transitions: [
+            {
+              state: IStepState.PREPARING,
+              time: timestamp,
+            },
+          ],
           start: undefined,
           end: undefined,
           markers: [],
@@ -280,9 +285,7 @@ export function extractMetadataFromLogs(
         }
       }
 
-      if (log.__typename === 'StepWorkerStartingEvent') {
-        upsertState(step, timestamp, IStepState.PREPARING);
-      } else if (log.__typename === 'ExecutionStepStartEvent') {
+      if (log.__typename === 'ExecutionStepStartEvent') {
         upsertState(step, timestamp, IStepState.RUNNING);
         step.start = timestamp;
       } else if (log.__typename === 'ExecutionStepSuccessEvent') {


### PR DESCRIPTION
This reverts commit 1ecd600325479e96f720bfd19418582ee42b5662. It seems to be struggling with dynamic outputs and incorrectly including them as "Not executed".

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
