### PR TITLE
[ui] Consoldiate rendering of graph / op name on details page + sidebar

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetGraphExplorer.tsx
@@ -444,7 +444,7 @@ const AssetGraphExplorerWithData: React.FC<WithDataProps> = ({
             <RightInfoPanelContent>
               <ErrorBoundary region="asset sidebar" resetErrorOnChange={[selectedGraphNodes[0].id]}>
                 <SidebarAssetInfo
-                  assetNode={selectedGraphNodes[0]}
+                  graphNode={selectedGraphNodes[0]}
                   liveData={liveDataByNode[selectedGraphNodes[0].id]}
                 />
               </ErrorBoundary>

--- a/js_modules/dagit/packages/core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -1,12 +1,11 @@
 import {Box} from '@dagster-io/ui';
 import React from 'react';
 
-import {KNOWN_TAGS} from '../graph/OpTags';
-
-import {AssetNode, AssetNodeMinimal} from './AssetNode';
-import * as Mocks from './AssetNode.mocks';
-import {AssetNodeLink} from './ForeignNode';
-import {getAssetNodeDimensions} from './layout';
+import {KNOWN_TAGS} from '../../graph/OpTags';
+import {AssetNode, AssetNodeMinimal} from '../AssetNode';
+import * as Mocks from '../AssetNode.mocks';
+import {AssetNodeLink} from '../ForeignNode';
+import {getAssetNodeDimensions} from '../layout';
 
 // eslint-disable-next-line import/no-default-export
 export default {component: AssetNode};

--- a/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -1,0 +1,261 @@
+import {MockedProvider, MockedResponse} from '@apollo/client/testing';
+import {Box} from '@dagster-io/ui';
+import React from 'react';
+
+import {createAppCache} from '../../app/AppCache';
+import {buildPartitionHealthMock} from '../../assets/__fixtures__/PartitionHealthQuery.fixtures';
+import {AssetEventsQuery} from '../../assets/types/useRecentAssetEvents.types';
+import {ASSET_EVENTS_QUERY} from '../../assets/useRecentAssetEvents';
+import {AssetNode, RunStatus, buildAssetNode} from '../../graphql/types';
+import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
+import {SIDEBAR_ASSET_QUERY, SidebarAssetInfo} from '../SidebarAssetInfo';
+import {GraphNode} from '../Utils';
+import {SidebarAssetQuery} from '../types/SidebarAssetInfo.types';
+
+// eslint-disable-next-line import/no-default-export
+export default {component: SidebarAssetInfo};
+
+const MockRepo = {
+  __typename: 'Repository',
+  id: 'test.py.repo',
+  name: 'test.py',
+  location: {__typename: 'RepositoryLocation', id: 'repo', name: 'repo'},
+} as const;
+
+const MockAssetKey = {__typename: 'AssetKey' as const, path: ['asset1']};
+
+const buildGraphNodeMock = (definitionOverrides: Partial<AssetNode>): GraphNode => ({
+  id: 'test.py.repo.["asset1"]',
+  assetKey: MockAssetKey,
+  definition: buildAssetNode({
+    id: 'test.py.repo.["asset1"]',
+    assetKey: MockAssetKey,
+    jobNames: ['__ASSET_JOB_1'],
+    opNames: ['asset1'],
+    groupName: null,
+    graphName: null,
+    isPartitioned: false,
+    isObservable: false,
+    isSource: false,
+    ...definitionOverrides,
+  }),
+});
+
+const SidebarQueryMock: MockedResponse<SidebarAssetQuery> = {
+  request: {
+    query: SIDEBAR_ASSET_QUERY,
+    variables: {
+      assetKey: {
+        path: ['asset1'],
+      },
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetNodeOrError: {
+        __typename: 'AssetNode',
+        id: 'test.py.repo.["asset1"]',
+        description: null,
+        configField: {
+          name: 'config',
+          isRequired: false,
+          configType: {
+            __typename: 'RegularConfigType',
+            givenName: 'Any',
+            key: 'Any',
+            description: null,
+            isSelector: false,
+            typeParamKeys: [],
+            recursiveConfigTypes: [],
+          },
+          __typename: 'ConfigTypeField',
+        },
+        metadataEntries: [],
+        partitionDefinition: null,
+        assetKey: {
+          path: ['asset1'],
+          __typename: 'AssetKey',
+        },
+        op: {
+          name: 'asset1',
+          description: null,
+          metadata: [
+            {
+              key: 'compute_kind',
+              value: 'pandas',
+              __typename: 'MetadataItemDefinition',
+            },
+            {
+              key: 'kind',
+              value: 'pandas',
+              __typename: 'MetadataItemDefinition',
+            },
+          ],
+          __typename: 'SolidDefinition',
+        },
+        opVersion: null,
+        repository: MockRepo,
+        requiredResources: [],
+        type: {
+          key: 'Any',
+          name: 'Any',
+          displayName: 'Any',
+          description: null,
+          isNullable: false,
+          isList: false,
+          isBuiltin: true,
+          isNothing: false,
+          metadataEntries: [],
+          inputSchemaType: {
+            __typename: 'CompositeConfigType',
+            key: 'Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4',
+            description: null,
+            isSelector: true,
+            typeParamKeys: [],
+            fields: [],
+            recursiveConfigTypes: [],
+          },
+          outputSchemaType: null,
+          __typename: 'RegularDagsterType',
+          innerTypes: [],
+        },
+      },
+    },
+  },
+};
+
+const EventsMock: MockedResponse<AssetEventsQuery> = {
+  request: {
+    query: ASSET_EVENTS_QUERY,
+    variables: {
+      assetKey: {path: ['asset1']},
+      before: undefined,
+      limit: 100,
+    },
+  },
+  result: {
+    data: {
+      __typename: 'DagitQuery',
+      assetOrError: {
+        __typename: 'Asset',
+        key: MockAssetKey,
+        id: '["asset1"]',
+        definition: {
+          __typename: 'AssetNode',
+          id: 'test.py.repo.["asset1"]',
+          partitionKeys: [],
+        },
+        assetMaterializations: [
+          {
+            __typename: 'MaterializationEvent',
+            description: '1234',
+            runId: '12345',
+            metadataEntries: [],
+            partition: null,
+            timestamp: '12345678654',
+            assetLineage: [],
+            label: null,
+            stepKey: 'op',
+            tags: [],
+            runOrError: {
+              __typename: 'Run',
+              pipelineName: '__ASSET_JOB_1',
+              mode: 'default',
+              pipelineSnapshotId: null,
+              id: '12345',
+              status: RunStatus.SUCCESS,
+              runId: '12345',
+              repositoryOrigin: {
+                __typename: 'RepositoryOrigin',
+                id: 'test.py',
+                repositoryLocationName: 'repo',
+                repositoryName: 'test.py',
+              },
+            },
+          },
+        ],
+        assetObservations: [
+          {
+            __typename: 'ObservationEvent',
+            description: '1234',
+            runId: '12345',
+            metadataEntries: [],
+            partition: null,
+            timestamp: '12345678654',
+            label: null,
+            stepKey: 'op',
+            tags: [],
+            runOrError: {
+              __typename: 'Run',
+              pipelineName: '__ASSET_JOB_1',
+              mode: 'default',
+              pipelineSnapshotId: null,
+              id: '12345',
+              status: RunStatus.SUCCESS,
+              runId: '12345',
+              repositoryOrigin: {
+                __typename: 'RepositoryOrigin',
+                id: 'test.py',
+                repositoryLocationName: 'repo',
+                repositoryName: 'test.py',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+const TestContainer: React.FC = ({children}) => (
+  <MockedProvider
+    cache={createAppCache()}
+    mocks={[SidebarQueryMock, EventsMock, buildPartitionHealthMock(MockAssetKey.path[0])]}
+  >
+    <WorkspaceProvider>
+      <Box style={{width: 400}}>{children}</Box>
+    </WorkspaceProvider>
+  </MockedProvider>
+);
+
+export const AssetWithMaterializations = () => {
+  return (
+    <TestContainer>
+      <SidebarAssetInfo graphNode={buildGraphNodeMock({})} liveData={undefined} />
+    </TestContainer>
+  );
+};
+
+export const AssetWithGraphName = () => {
+  return (
+    <TestContainer>
+      <SidebarAssetInfo
+        graphNode={buildGraphNodeMock({graphName: 'op_graph'})}
+        liveData={undefined}
+      />
+    </TestContainer>
+  );
+};
+
+export const AssetWithDifferentOpName = () => {
+  return (
+    <TestContainer>
+      <SidebarAssetInfo
+        graphNode={buildGraphNodeMock({opNames: ['not_asset_name']})}
+        liveData={undefined}
+      />
+    </TestContainer>
+  );
+};
+
+export const ObservableSourceAsset = () => {
+  return (
+    <TestContainer>
+      <SidebarAssetInfo
+        graphNode={buildGraphNodeMock({isObservable: true, isSource: true})}
+        liveData={undefined}
+      />
+    </TestContainer>
+  );
+};

--- a/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
@@ -41,6 +41,7 @@ export const ASSET_NODE_OP_METADATA_FRAGMENT = gql`
       ...MetadataEntryFragment
     }
     type {
+      __typename
       ...DagsterTypeFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -4,12 +4,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {ASSET_NODE_FRAGMENT} from '../asset-graph/AssetNode';
-import {
-  displayNameForAssetKey,
-  isHiddenAssetGroupJob,
-  LiveData,
-  toGraphId,
-} from '../asset-graph/Utils';
+import {isHiddenAssetGroupJob, LiveData, toGraphId} from '../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {Description} from '../pipelines/Description';
@@ -30,6 +25,7 @@ import {
 import {AssetNodeList} from './AssetNodeList';
 import {CurrentMinutesLateTag, freshnessPolicyDescription} from './CurrentMinutesLateTag';
 import {DependsOnSelfBanner} from './DependsOnSelfBanner';
+import {UnderlyingOpsOrGraph} from './UnderlyingOpsOrGraph';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
 
 export const AssetNodeDefinition: React.FC<{
@@ -252,57 +248,12 @@ const DescriptionAnnotations: React.FC<{
           />
         </Mono>
       ))}
-    <OpNamesDisplay assetNode={assetNode} repoAddress={repoAddress} />
+    <UnderlyingOpsOrGraph assetNode={assetNode} repoAddress={repoAddress} />
     {assetNode.isSource && (
       <Caption style={{lineHeight: '16px', marginTop: 2}}>Source Asset</Caption>
     )}
   </Box>
 );
-
-const OpNamesDisplay = (props: {
-  assetNode: AssetNodeDefinitionFragment;
-  repoAddress: RepoAddress;
-}) => {
-  const {assetNode, repoAddress} = props;
-  const {assetKey, graphName, opNames, jobNames} = assetNode;
-  const opCount = opNames.length;
-
-  if (!opCount) {
-    return null;
-  }
-
-  if (!graphName) {
-    const firstOp = opNames[0];
-    if (displayNameForAssetKey(assetKey) === firstOp) {
-      return null;
-    }
-    const opPath = workspacePathFromAddress(repoAddress, `/ops/${firstOp}`);
-    return (
-      <Box flex={{gap: 4, alignItems: 'center'}}>
-        <Icon name="op" size={16} />
-        <Mono>
-          <Link to={opPath}>{firstOp}</Link>
-        </Mono>
-      </Box>
-    );
-  }
-
-  if (!jobNames.length) {
-    return null;
-  }
-
-  return (
-    <Box flex={{gap: 4, alignItems: 'center'}}>
-      <Icon name="schema" size={16} />
-      <Mono>
-        <Link to={workspacePathFromAddress(repoAddress, `/graphs/${jobNames[0]}/${graphName}/`)}>
-          {graphName}
-        </Link>
-        {` (${opCount === 1 ? '1 op' : `${opCount} ops`})`}
-      </Mono>
-    </Box>
-  );
-};
 
 export const ASSET_NODE_DEFINITION_FRAGMENT = gql`
   fragment AssetNodeDefinitionFragment on AssetNode {

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -48,6 +48,7 @@ import {AssetPlots} from './AssetPlots';
 import {CurrentMinutesLateTag} from './CurrentMinutesLateTag';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from './LaunchAssetObservationButton';
+import {UNDERLYING_OPS_ASSET_NODE_FRAGMENT} from './UnderlyingOpsOrGraph';
 import {AssetKey} from './types';
 import {
   AssetViewDefinitionNodeFragment,
@@ -416,10 +417,12 @@ export const ASSET_VIEW_DEFINITION_QUERY = gql`
 
     ...AssetNodeInstigatorsFragment
     ...AssetNodeDefinitionFragment
+    ...UnderlyingOpsAssetNodeFragment
   }
 
   ${ASSET_NODE_INSTIGATORS_FRAGMENT}
   ${ASSET_NODE_DEFINITION_FRAGMENT}
+  ${UNDERLYING_OPS_ASSET_NODE_FRAGMENT}
 `;
 
 const HistoricalViewAlert: React.FC<{

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -22,6 +22,7 @@ export const LatestMaterializationMetadata: React.FC<{
   latest: LatestMaterializationMetadataFragment | undefined;
   liveData: LiveDataForNode | undefined;
 }> = ({assetKey, latest, liveData}) => {
+  console.log(latest);
   const latestRun = latest?.runOrError.__typename === 'Run' ? latest?.runOrError : null;
   const repositoryOrigin = latestRun?.repositoryOrigin;
   const repoAddress = repositoryOrigin

--- a/js_modules/dagit/packages/core/src/assets/UnderlyingOpsOrGraph.tsx
+++ b/js_modules/dagit/packages/core/src/assets/UnderlyingOpsOrGraph.tsx
@@ -1,0 +1,73 @@
+import {gql} from '@apollo/client';
+import {Box, Icon, Mono} from '@dagster-io/ui';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+import {UnderlyingOpsAssetNodeFragment} from './types/UnderlyingOpsOrGraph.types';
+
+export const UnderlyingOpsOrGraph: React.FC<{
+  assetNode: UnderlyingOpsAssetNodeFragment;
+  repoAddress: RepoAddress;
+  minimal?: boolean;
+}> = ({assetNode, repoAddress, minimal}) => {
+  const {assetKey, graphName, opNames, jobNames} = assetNode;
+  const opCount = opNames.length;
+
+  if (!opCount) {
+    return null;
+  }
+
+  if (!graphName) {
+    const firstOp = opNames[0];
+    if (displayNameForAssetKey(assetKey) === firstOp) {
+      return null;
+    }
+    const opPath = workspacePathFromAddress(repoAddress, `/ops/${firstOp}`);
+    return (
+      <Box flex={{gap: 4, alignItems: 'center'}}>
+        <Icon name="op" size={16} />
+        <Mono>
+          <Link to={opPath}>{firstOp}</Link>
+        </Mono>
+      </Box>
+    );
+  }
+
+  if (!jobNames.length) {
+    return null;
+  }
+
+  return (
+    <Box flex={{gap: 4, alignItems: 'center'}}>
+      <Icon name="schema" size={16} />
+      {minimal ? (
+        <Link to={workspacePathFromAddress(repoAddress, `/graphs/${jobNames[0]}/${graphName}/`)}>
+          View graph
+        </Link>
+      ) : (
+        <Mono>
+          <Link to={workspacePathFromAddress(repoAddress, `/graphs/${jobNames[0]}/${graphName}/`)}>
+            {graphName}
+          </Link>
+          {` (${opCount === 1 ? '1 op' : `${opCount} ops`})`}
+        </Mono>
+      )}
+    </Box>
+  );
+};
+
+export const UNDERLYING_OPS_ASSET_NODE_FRAGMENT = gql`
+  fragment UnderlyingOpsAssetNodeFragment on AssetNode {
+    id
+    assetKey {
+      path
+    }
+    graphName
+    opNames
+    jobNames
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetView.types.ts
@@ -67,6 +67,7 @@ export type AssetViewDefinitionQuery = {
             }>;
           }>;
           requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
+          assetKey: {__typename: 'AssetKey'; path: Array<string>};
           configField: {
             __typename: 'ConfigTypeField';
             name: string;
@@ -623,7 +624,6 @@ export type AssetViewDefinitionQuery = {
                   >;
                 };
           } | null;
-          assetKey: {__typename: 'AssetKey'; path: Array<string>};
           metadataEntries: Array<
             | {
                 __typename: 'AssetMetadataEntry';
@@ -15768,6 +15768,7 @@ export type AssetViewDefinitionNodeFragment = {
     }>;
   }>;
   requiredResources: Array<{__typename: 'ResourceRequirement'; resourceKey: string}>;
+  assetKey: {__typename: 'AssetKey'; path: Array<string>};
   configField: {
     __typename: 'ConfigTypeField';
     name: string;
@@ -16320,7 +16321,6 @@ export type AssetViewDefinitionNodeFragment = {
           >;
         };
   } | null;
-  assetKey: {__typename: 'AssetKey'; path: Array<string>};
   metadataEntries: Array<
     | {
         __typename: 'AssetMetadataEntry';

--- a/js_modules/dagit/packages/core/src/assets/types/UnderlyingOpsOrGraph.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/UnderlyingOpsOrGraph.types.ts
@@ -1,0 +1,12 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type UnderlyingOpsAssetNodeFragment = {
+  __typename: 'AssetNode';
+  id: string;
+  graphName: string | null;
+  opNames: Array<string>;
+  jobNames: Array<string>;
+  assetKey: {__typename: 'AssetKey'; path: Array<string>};
+};

--- a/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
@@ -156,7 +156,7 @@ export const ASSET_OBSERVATION_FRAGMENT = gql`
   ${METADATA_ENTRY_FRAGMENT}
 `;
 
-const ASSET_EVENTS_QUERY = gql`
+export const ASSET_EVENTS_QUERY = gql`
   query AssetEventsQuery(
     $assetKey: AssetKeyInput!
     $limit: Int

--- a/js_modules/dagit/packages/core/src/dagstertype/DagsterType.tsx
+++ b/js_modules/dagit/packages/core/src/dagstertype/DagsterType.tsx
@@ -43,7 +43,9 @@ export const DagsterTypeSummary: React.FC<{
   horizontalPadding?: Spacing;
 }> = ({type, horizontalPadding}) => {
   horizontalPadding = horizontalPadding || 0;
-  const tableSchemaEntry = type.metadataEntries.find(gqlTypePredicate('TableSchemaMetadataEntry'));
+  const tableSchemaEntry = (type.metadataEntries || []).find(
+    gqlTypePredicate('TableSchemaMetadataEntry'),
+  );
   return (
     <Box
       flex={{direction: 'column', gap: 8}}
@@ -76,12 +78,15 @@ export const DagsterTypeSummary: React.FC<{
 // NOTE: Because you can't have a recursive fragment, inner types are limited.
 export const DAGSTER_TYPE_FRAGMENT = gql`
   fragment DagsterTypeFragment on DagsterType {
+    __typename
     ..._DagsterTypeFragment
     innerTypes {
+      __typename
       ..._DagsterTypeFragment
     }
   }
   fragment _DagsterTypeFragment on DagsterType {
+    __typename
     key
     name
     displayName


### PR DESCRIPTION
## Summary & Motivation

I noticed a slight bug in the "View graph" link in the asset sidebar showing when an `opName` was present and not specifically a `graphName`. 

The logic is kinda complicated so I pulled the rendering out of the AssetNodeDefinition into a shared component and put that in the asset sidebar.

## How I Tested These Changes

I added a few new storybooks for previewing these different scenarios.

<img width="729" alt="image" src="https://user-images.githubusercontent.com/1037212/231521190-ed3aadb9-0a79-4f51-8b74-1aa969c93218.png">
<img width="712" alt="image" src="https://user-images.githubusercontent.com/1037212/231521210-8ad391bf-0118-4605-86df-37c578ce2c5d.png">
