### PR TITLE
in memory sqlite storage fixes

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -1,9 +1,8 @@
 import logging
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Callable, Optional, cast
+from typing import Callable, Optional
 
-from sqlalchemy.engine import Engine
 from sqlalchemy.pool import NullPool
 
 from dagster._core.storage.event_log.base import EventLogCursor
@@ -24,47 +23,44 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     def __init__(self, inst_data: Optional[ConfigurableClassData] = None, preload=None):
         self._inst_data = inst_data
-        self._engine = None
-        self._conn = None
+        self._engine = create_engine(
+            create_in_memory_conn_string(f"events-{id(self)}"),
+            poolclass=NullPool,
+        )
         self._handlers = defaultdict(set)
         self._storage_id = 0  # mirror the storage id, to mimic watching cursors
+
+        # hold one connection for life of instance, but vend new ones for specific calls
+        self._held_conn = self._engine.connect()
+
+        SqlEventLogStorageMetadata.create_all(self._held_conn)
+        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
+        stamp_alembic_rev(alembic_config, self._held_conn)
+        self.reindex_events()
+        self.reindex_assets()
 
         if preload:
             for payload in preload:
                 for event in payload.event_list:
                     self.store_event(event)
 
-    def _create_connection(self):
-        engine = create_engine(create_in_memory_conn_string("event_log"), poolclass=NullPool)
-        conn = engine.connect()
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys=ON;")
-        SqlEventLogStorageMetadata.create_all(conn)
-        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
-        stamp_alembic_rev(alembic_config, conn)
-
-        self._engine = engine
-        self._conn = conn
-        self.reindex_events()
-        self.reindex_assets()
-
     @contextmanager
     def run_connection(self, run_id=None):
-        if not self._conn:
-            self._create_connection()
-        yield self._conn
+        with self._engine.connect() as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA foreign_keys=ON;")
+            yield conn
 
     @contextmanager
     def index_connection(self):
-        if not self._conn:
-            self._create_connection()
-        yield self._conn
+        with self._engine.connect() as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA foreign_keys=ON;")
+            yield conn
 
     def has_table(self, table_name: str) -> bool:
-        if not self._conn:
-            self._create_connection()
-        engine = cast(Engine, self._engine)
-        return bool(engine.dialect.has_table(self._conn, table_name))
+        with self._engine.connect() as conn:
+            return bool(self._engine.dialect.has_table(conn, table_name))
 
     @property
     def inst_data(self):
@@ -104,9 +100,5 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         return False
 
     def dispose(self):
-        if self._conn:
-            self._conn.close()
-            self._conn = None
-
-        if self._engine:
-            self._engine.dispose()
+        self._held_conn.close()
+        self._engine.dispose()

--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -20,8 +20,23 @@ class InMemoryRunStorage(SqlRunStorage):
     """
 
     def __init__(self, preload: Optional[Sequence[DebugRunPayload]] = None):
-        self._engine = None
-        self._conn = None
+        self._engine = create_engine(
+            create_in_memory_conn_string(f"runs-{id(self)}"),
+            poolclass=NullPool,
+        )
+
+        # hold one connection for life of instance, but vend new ones for specific calls
+        self._held_conn = self._engine.connect()
+
+        RunStorageSqlMetadata.create_all(self._held_conn)
+        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
+        stamp_alembic_rev(alembic_config, self._held_conn)
+        table_names = db.inspect(self._held_conn).get_table_names()
+        if "instance_info" not in table_names:
+            InstanceInfo.create(self._held_conn)
+        self.migrate()
+        self.optimize()
+
         if preload:
             for payload in preload:
                 self.add_pipeline_snapshot(
@@ -32,39 +47,17 @@ class InMemoryRunStorage(SqlRunStorage):
                 )
                 self.add_run(payload.pipeline_run)
 
-    def _create_connection(self) -> None:
-        engine = create_engine(create_in_memory_conn_string("runs"), poolclass=NullPool)
-        conn = engine.connect()
-
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys=ON;")
-        RunStorageSqlMetadata.create_all(conn)
-        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
-        stamp_alembic_rev(alembic_config, conn)
-        table_names = db.inspect(conn).get_table_names()
-        if "instance_info" not in table_names:
-            InstanceInfo.create(conn)
-
-        self._engine = engine
-        self._conn = conn
-
-        self.migrate()
-        self.optimize()
-
     @contextmanager
     def connect(self) -> Iterator[Connection]:
-        if not self._conn:
-            self._create_connection()
+        with self._engine.connect() as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA foreign_keys=ON;")
 
-        yield self._conn  # type: ignore
+            yield conn
 
     def upgrade(self) -> None:
         pass
 
     def dispose(self) -> None:
-        if self._conn:
-            self._conn.close()
-            self._conn = None
-
-        if self._engine:
-            self._engine.dispose()
+        self._held_conn.close()
+        self._engine.dispose()

--- a/python_modules/dagster/dagster/_core/storage/sqlite.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite.py
@@ -18,7 +18,7 @@ def create_in_memory_conn_string(db_name: str) -> str:
     # that multiple instances can share the same logical DB across connections, while maintaining
     # separate DBs for different db names.  The latter is required to have both the run / event_log
     # in-memory implementations within the same process
-    return f"sqlite:///file:{db_name}?mode=memory&uri=true&check_same_thread=false"
+    return f"sqlite:///file:{db_name}?mode=memory&uri=true&cache=shared"
 
 
 def get_sqlite_version() -> str:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -39,7 +39,11 @@ class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
 
 @contextmanager
 def create_in_memory_storage():
-    yield InMemoryRunStorage()
+    storage = InMemoryRunStorage()
+    try:
+        yield storage
+    finally:
+        storage.dispose()
 
 
 @contextmanager


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/12229 disabled a warning about same thread use that I thought was fine but turns out with further `dagit-debug` use it was causing `segfault`s.

To address this we
* use `cache=shared` mode on the connection string to allow multiple connections to the same in memory DB
* vend connections on demand, so that they are propery thread scoped like in the context of `dagit-debug`
* since the in memory DB deletes on last connection close, we hold on to one connection for life of instance
* we use the object id of the storage component to scope the in memory DB so concurrent ephemeral instances do not collide


## How I Tested These Changes

bk tests
open the same run many many times in `dagit-debug` which was previously causing `segfault`s 