### PR TITLE
Allow @job resources_def argument to take any object, not just a ResourceDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -119,7 +119,7 @@ def job(
     *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
+    resource_defs: Optional[Mapping[str, object]] = ...,
     config: Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"] = ...,
     tags: Optional[Mapping[str, Any]] = ...,
     metadata: Optional[Mapping[str, RawMetadataValue]] = ...,
@@ -139,7 +139,7 @@ def job(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+    resource_defs: Optional[Mapping[str, object]] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"]] = None,
     tags: Optional[Mapping[str, Any]] = None,
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
@@ -162,7 +162,7 @@ def job(
             functions, does not accept a context argument.
         name (Optional[str]):
             The name for the Job. Defaults to the name of the this graph.
-        resource_defs (Optional[Mapping[str, ResourceDefinition]]):
+        resource_defs (Optional[Mapping[str, object]]):
             Resources that are required by this graph for execution.
             If not defined, `io_manager` will default to filesystem.
         config:
@@ -224,14 +224,17 @@ def job(
             def job1():
                 add_one(return_one())
     """
+
     if compose_fn is not None:
         check.invariant(description is None)
         return _Job()(compose_fn)
 
+    from dagster._core.execution.build_resources import wrap_resources_for_execution
+
     return _Job(
         name=name,
         description=description,
-        resource_defs=resource_defs,
+        resource_defs=wrap_resources_for_execution(resource_defs),
         config=config,
         tags=tags,
         metadata=metadata,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -224,7 +224,6 @@ def job(
             def job1():
                 add_one(return_one())
     """
-
     if compose_fn is not None:
         check.invariant(description is None)
         return _Job()(compose_fn)

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -223,3 +223,22 @@ def test_subset_job_with_config():
         run_config={"ops": {"echo": {"inputs": {"x": 1}}}}
     )
     assert result.success
+
+
+def test_coerce_resource_job_decorator() -> None:
+    executed = {}
+
+    class BareResourceObject:
+        pass
+
+    @op(required_resource_keys={"bare_resource"})
+    def an_op(context) -> None:
+        assert context.resources.bare_resource
+        executed["yes"] = True
+
+    @job(resource_defs={"bare_resource": BareResourceObject()})
+    def a_job() -> None:
+        an_op()
+
+    assert a_job.execute_in_process().success
+    assert executed["yes"]


### PR DESCRIPTION
## Summary & Motivation

Now that Definitions resources automatically bind resources to jobs, it makes sense to have the behavior between them consistent, including automatic coercion. Without this change one cannot pass the same dictionary of objects to `Definitions` and `job`, which doesn't make too much sense.

This is also important for setting up a change needed to ConfigurableResource and friends in order to make them not inherit from ResourceDefinition.

## How I Tested These Changes

BK and included test.