### PR TITLE
with_resources can also take any object, not just resource defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -119,7 +119,7 @@ def job(
     *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
+    resource_defs: Optional[Mapping[str, object]] = ...,
     config: Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"] = ...,
     tags: Optional[Mapping[str, Any]] = ...,
     metadata: Optional[Mapping[str, RawMetadataValue]] = ...,
@@ -139,7 +139,7 @@ def job(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+    resource_defs: Optional[Mapping[str, object]] = None,
     config: Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig[object]"]] = None,
     tags: Optional[Mapping[str, Any]] = None,
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
@@ -162,7 +162,7 @@ def job(
             functions, does not accept a context argument.
         name (Optional[str]):
             The name for the Job. Defaults to the name of the this graph.
-        resource_defs (Optional[Mapping[str, ResourceDefinition]]):
+        resource_defs (Optional[Mapping[str, object]]):
             Resources that are required by this graph for execution.
             If not defined, `io_manager` will default to filesystem.
         config:
@@ -224,14 +224,17 @@ def job(
             def job1():
                 add_one(return_one())
     """
+
     if compose_fn is not None:
         check.invariant(description is None)
         return _Job()(compose_fn)
 
+    from dagster._core.execution.build_resources import wrap_resources_for_execution
+
     return _Job(
         name=name,
         description=description,
-        resource_defs=resource_defs,
+        resource_defs=wrap_resources_for_execution(resource_defs),
         config=config,
         tags=tags,
         metadata=metadata,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -224,7 +224,6 @@ def job(
             def job1():
                 add_one(return_one())
     """
-
     if compose_fn is not None:
         check.invariant(description is None)
         return _Job()(compose_fn)

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -114,7 +114,7 @@ def build_resources(
 
 def wrap_resources_for_execution(
     resources: Optional[Mapping[str, Any]] = None
-) -> Mapping[str, ResourceDefinition]:
+) -> Dict[str, ResourceDefinition]:
     resources = check.opt_mapping_param(resources, "resources", key_type=str)
     resource_defs = {}
     # Wrap instantiated resource values in a resource definition.

--- a/python_modules/dagster/dagster/_core/execution/with_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/with_resources.py
@@ -1,10 +1,10 @@
 from typing import Any, Iterable, List, Mapping, Optional, Sequence, TypeVar, cast
 
 from dagster import _check as check
+from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._utils.merger import merge_dicts
 
 from ..._config import Shape
-from ..definitions import ResourceDefinition
 from ..definitions.resource_requirement import ResourceAddable
 from ..definitions.utils import DEFAULT_IO_MANAGER_KEY
 from ..errors import DagsterInvalidConfigError, DagsterInvalidInvocationError
@@ -14,7 +14,7 @@ T = TypeVar("T", bound=ResourceAddable)
 
 def with_resources(
     definitions: Iterable[T],
-    resource_defs: Mapping[str, ResourceDefinition],
+    resource_defs: Mapping[str, object],
     resource_config_by_key: Optional[Mapping[str, Any]] = None,
 ) -> Sequence[T]:
     """Adds dagster resources to copies of resource-requiring dagster definitions.
@@ -27,8 +27,8 @@ def with_resources(
 
     Args:
         definitions (Iterable[ResourceAddable]): Dagster definitions to provide resources to.
-        resource_defs (Mapping[str, ResourceDefinition]):
-            Mapping of resource keys to ResourceDefinition objects to satisfy
+        resource_defs (Mapping[str, object]):
+            Mapping of resource keys to objects to satisfy
             resource requirements of provided dagster definitions.
         resource_config_by_key (Optional[Mapping[str, Any]]):
             Specifies config for provided resources. The key in this dictionary
@@ -73,8 +73,11 @@ def with_resources(
         resource_config_by_key, "resource_config_by_key"
     )
 
-    resource_defs = merge_dicts(
-        {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema}, resource_defs
+    resource_defs = wrap_resources_for_execution(
+        merge_dicts(
+            {DEFAULT_IO_MANAGER_KEY: default_job_io_manager_with_fs_io_manager_schema},
+            resource_defs,
+        )
     )
 
     for key, resource_def in resource_defs.items():

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -223,3 +223,22 @@ def test_subset_job_with_config():
         run_config={"ops": {"echo": {"inputs": {"x": 1}}}}
     )
     assert result.success
+
+
+def test_coerce_resource_job_decorator() -> None:
+    executed = {}
+
+    class BareResourceObject:
+        pass
+
+    @op(required_resource_keys={"bare_resource"})
+    def an_op(context) -> None:
+        assert context.resources.bare_resource
+        executed["yes"] = True
+
+    @job(resource_defs={"bare_resource": BareResourceObject()})
+    def a_job() -> None:
+        an_op()
+
+    assert a_job.execute_in_process().success
+    assert executed["yes"]


### PR DESCRIPTION
## Summary & Motivation

Similar to https://github.com/dagster-io/dagster/pull/13556, we want the `with_resources` behavior to match the `Definitions` behavior.

## How I Tested These Changes

BK
