### PR TITLE
Make @asset take an arbitrary dictionary of resources

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -65,7 +65,7 @@ def asset(
     description: Optional[str] = ...,
     config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = ...,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
+    resource_defs: Optional[Mapping[str, object]] = ...,
     io_manager_def: Optional[IOManagerDefinition] = ...,
     io_manager_key: Optional[str] = ...,
     compute_kind: Optional[str] = ...,
@@ -93,7 +93,7 @@ def asset(
     description: Optional[str] = None,
     config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[Set[str]] = None,
-    resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
+    resource_defs: Optional[Mapping[str, object]] = None,
     io_manager_def: Optional[IOManagerDefinition] = None,
     io_manager_key: Optional[str] = None,
     compute_kind: Optional[str] = None,
@@ -156,8 +156,8 @@ def asset(
             `json.loads(json.dumps(value)) == value`.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If not provided,
             the name "default" is used.
-        resource_defs (Optional[Mapping[str, ResourceDefinition]]):
-            (Experimental) A mapping of resource keys to resource definitions. These resources
+        resource_defs (Optional[Mapping[str, object]]):
+            (Experimental) A mapping of resource keys to resources. These resources
             will be initialized during execution, and can be accessed from the
             context within the body of the function.
         output_required (bool): Whether the decorated function will always materialize an asset.
@@ -180,6 +180,8 @@ def asset(
     """
 
     def create_asset():
+        from dagster._core.execution.build_resources import wrap_resources_for_execution
+
         return _Asset(
             name=cast(Optional[str], name),  # (mypy bug that it can't infer name is Optional[str])
             key_prefix=key_prefix,
@@ -189,7 +191,7 @@ def asset(
             description=description,
             config_schema=config_schema,
             required_resource_keys=required_resource_keys,
-            resource_defs=resource_defs,
+            resource_defs=wrap_resources_for_execution(resource_defs),
             io_manager=io_manager_def or io_manager_key,
             compute_kind=check.opt_str_param(compute_kind, "compute_kind"),
             dagster_type=dagster_type,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -10,6 +10,7 @@ from dagster import (
     AssetsDefinition,
     DagsterEventType,
     DailyPartitionsDefinition,
+    Definitions,
     EventRecordsFilter,
     FreshnessPolicy,
     GraphOut,
@@ -1363,3 +1364,19 @@ def test_invalid_context_assets_def():
 
     with pytest.raises(DagsterInvalidPropertyError, match="does not have an assets definition"):
         my_job.execute_in_process()
+
+
+def test_asset_takes_bare_resource():
+    class BareObjectResource:
+        pass
+
+    executed = {}
+
+    @asset(resource_defs={"bare_resource": BareObjectResource()})
+    def blah(context):
+        assert context.resources.bare_resource
+        executed["yes"] = True
+
+    defs = Definitions(assets=[blah])
+    defs.get_implicit_global_asset_job_def().execute_in_process()
+    assert executed["yes"]


### PR DESCRIPTION
## Summary & Motivation

Similar to https://github.com/dagster-io/dagster/pull/13556, make `@asset` take an arbitrary dictinoary for the resource_defs argument

## How I Tested These Changes

BK
