### PR TITLE
Include past k8s terminations in k8s debug info output

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -693,6 +693,7 @@ class DagsterKubernetesClient:
                     container_name,
                     tail_lines=25,
                     timestamps=True,
+                    previous=True,
                 )
                 # Remove trailing newline if present
                 pod_logs = pod_logs[:-1] if pod_logs.endswith("\n") else pod_logs


### PR DESCRIPTION
Summary:
Realized while testing that if a container crashes and restarts its not currently included in the debug info, so you miss useful information about why the crash happened.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
