### PR TITLE
Fix bug when exporting config_dict on config class with cached_method

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -104,11 +104,14 @@ class MakeConfigCacheable(BaseModel):
         # config schema. Pydantic will normally raise an error if you try to set an attribute
         # that is not part of the schema.
 
-        if name.startswith("_") or name.endswith("_cache"):
+        if self._is_field_internal(name):
             object.__setattr__(self, name, value)
             return
 
         return super().__setattr__(name, value)
+
+    def _is_field_internal(self, name: str) -> bool:
+        return name.startswith("_") or name.endswith("_cache")
 
 
 class Config(MakeConfigCacheable):
@@ -143,7 +146,7 @@ class Config(MakeConfigCacheable):
         """
         output = {}
         for key, value in self.__dict__.items():
-            if key.startswith("_"):
+            if self._is_field_internal(key):
                 continue
             field = self.__fields__.get(key)
             if field and value is None and not _is_pydantic_field_required(field):

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -792,3 +792,16 @@ def test_conversion_to_fields() -> None:
     assert not fields["with_default_value"].is_required
     assert fields["optional_str"]
     assert fields["optional_str"].is_required is False
+
+
+def test_to_config_dict_combined_with_cached_method() -> None:
+    class ConfigWithCachedMethod(Config):
+        a_string: str
+
+        @cached_method
+        def a_string_cached(self) -> str:
+            return "foo"
+
+    obj = ConfigWithCachedMethod(a_string="bar")
+    obj.a_string_cached()
+    assert obj._as_config_dict() == {"a_string": "bar"}  # noqa: SLF001


### PR DESCRIPTION
## Summary & Motivation

We were treating internal fields of Config inconsisently in the different classes in the hierarchy. Consolidating logic to check for internal field in one spot

## How I Tested These Changes

Added unit test
