### PR TITLE
[graphql] Replace “PartitionBackfill.backfillId” with “id”

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppCache.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppCache.tsx
@@ -22,8 +22,6 @@ export const createAppCache = () =>
         return 'Instance';
       } else if (object.__typename === 'Workspace') {
         return 'Workspace';
-      } else if (object.__typename === 'PartitionBackfill') {
-        return object.backfillId;
       } else {
         return defaultDataIdFromObject(object);
       }

--- a/js_modules/dagit/packages/core/src/assets/RunningBackfillsNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/RunningBackfillsNotice.tsx
@@ -47,8 +47,8 @@ export const RUNNING_BACKFILLS_NOTICE_QUERY = gql`
       __typename
       ... on PartitionBackfills {
         results {
+          id
           partitionSetName
-          backfillId
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/assets/types/RunningBackfillsNotice.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/RunningBackfillsNotice.types.ts
@@ -11,8 +11,8 @@ export type RunningBackfillsNoticeQuery = {
         __typename: 'PartitionBackfills';
         results: Array<{
           __typename: 'PartitionBackfill';
+          id: string;
           partitionSetName: string | null;
-          backfillId: string;
         }>;
       }
     | {__typename: 'PythonError'};

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2386,7 +2386,7 @@ type PartitionRun {
 }
 
 type PartitionBackfill {
-  backfillId: String!
+  id: String!
   status: BulkActionStatus!
   partitionNames: [String!]
   isValidSerialization: Boolean!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2256,12 +2256,12 @@ export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
   assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
-  backfillId: Scalars['String'];
   endTimestamp: Maybe<Scalars['Float']>;
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean'];
   hasCancelPermission: Scalars['Boolean'];
   hasResumePermission: Scalars['Boolean'];
+  id: Scalars['String'];
   isAssetBackfill: Scalars['Boolean'];
   isValidSerialization: Scalars['Boolean'];
   numCancelable: Scalars['Int'];
@@ -8759,8 +8759,6 @@ export const buildPartitionBackfill = (
               ? ({} as AssetKey)
               : buildAssetKey({}, relationshipsToOmit),
           ],
-    backfillId:
-      overrides && overrides.hasOwnProperty('backfillId') ? overrides.backfillId! : 'sint',
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 0.33,
     error:
@@ -8779,6 +8777,7 @@ export const buildPartitionBackfill = (
       overrides && overrides.hasOwnProperty('hasResumePermission')
         ? overrides.hasResumePermission!
         : true,
+    id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'recusandae',
     isAssetBackfill:
       overrides && overrides.hasOwnProperty('isAssetBackfill') ? overrides.isAssetBackfill! : false,
     isValidSerialization:

--- a/js_modules/dagit/packages/core/src/instance/BackfillPartitionsRequestedDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillPartitionsRequestedDialog.tsx
@@ -14,9 +14,7 @@ export const BackfillPartitionsRequestedDialog = ({backfill, onClose}: Props) =>
       title={
         <span>
           Partitions requested for backfill:{' '}
-          <span style={{fontSize: '18px', fontFamily: FontFamily.monospace}}>
-            {backfill?.backfillId}
-          </span>
+          <span style={{fontSize: '18px', fontFamily: FontFamily.monospace}}>{backfill?.id}</span>
         </span>
       }
       onClose={onClose}

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -57,7 +57,7 @@ export const BackfillRow = ({
   const statusDetails = useLazyQuery<SingleBackfillQuery, SingleBackfillQueryVariables>(
     SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
     {
-      variables: {backfillId: backfill.backfillId},
+      variables: {backfillId: backfill.id},
       notifyOnNetworkStatusChange: true,
     },
   );
@@ -65,7 +65,7 @@ export const BackfillRow = ({
   const statusCounts = useLazyQuery<SingleBackfillCountsQuery, SingleBackfillCountsQueryVariables>(
     SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
     {
-      variables: {backfillId: backfill.backfillId},
+      variables: {backfillId: backfill.id},
       notifyOnNetworkStatusChange: true,
     },
   );
@@ -110,16 +110,16 @@ export const BackfillRow = ({
           <Link
             to={
               backfill.isAssetBackfill
-                ? `/overview/backfills/${backfill.backfillId}`
+                ? `/overview/backfills/${backfill.id}`
                 : runsPathWithFilters([
                     {
                       token: 'tag',
-                      value: `dagster/backfill=${backfill.backfillId}`,
+                      value: `dagster/backfill=${backfill.id}`,
                     },
                   ])
             }
           >
-            {backfill.backfillId}
+            {backfill.id}
           </Link>
         </Mono>
       </td>
@@ -190,7 +190,7 @@ const BackfillMenu = ({
   const runsUrl = runsPathWithFilters([
     {
       token: 'tag',
-      value: `dagster/backfill=${backfill.backfillId}`,
+      value: `dagster/backfill=${backfill.id}`,
     },
   ]);
 
@@ -483,7 +483,7 @@ export const SINGLE_BACKFILL_STATUS_COUNTS_QUERY = gql`
   query SingleBackfillCountsQuery($backfillId: String!) {
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
-        backfillId
+        id
         partitionStatusCounts {
           runStatus
           count
@@ -497,7 +497,7 @@ export const SINGLE_BACKFILL_STATUS_DETAILS_QUERY = gql`
   query SingleBackfillQuery($backfillId: String!) {
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
-        backfillId
+        id
         partitionStatuses {
           ...PartitionStatusesForBackfill
         }

--- a/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillStepStatusDialog.tsx
@@ -44,7 +44,7 @@ export const BackfillStepStatusDialog = ({backfill, onClose}: Props) => {
   return (
     <Dialog
       isOpen={!!backfill?.partitionSet}
-      title={`Step status for backfill: ${backfill?.backfillId}`}
+      title={`Step status for backfill: ${backfill?.id}`}
       onClose={onClose}
       style={{width: '80vw'}}
     >
@@ -74,9 +74,9 @@ const BackfillStepStatusDialogContent = ({
   const [offset, setOffset] = React.useState<number>(0);
 
   const runsFilter = React.useMemo(() => {
-    const token: RunFilterToken = {token: 'tag', value: `dagster/backfill=${backfill.backfillId}`};
+    const token: RunFilterToken = {token: 'tag', value: `dagster/backfill=${backfill.id}`};
     return [token];
-  }, [backfill.backfillId]);
+  }, [backfill.id]);
 
   const partitions = usePartitionStepQuery({
     partitionSetName: partitionSet.name,

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.mocks.ts
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.mocks.ts
@@ -32,7 +32,7 @@ function buildTimePartitionNames(start: Date, count: number) {
 
 export const BackfillTableFragmentRequested2000AssetsPure: BackfillTableFragment = buildPartitionBackfill(
   {
-    backfillId: 'qtpussca',
+    id: 'qtpussca',
     status: BulkActionStatus.REQUESTED,
     numPartitions: 2000,
     hasCancelPermission: true,
@@ -63,7 +63,7 @@ export const BackfillTableFragmentRequested2000AssetsPureStatus: MockedResponse<
     data: {
       __typename: 'DagitQuery',
       partitionBackfillOrError: buildPartitionBackfill({
-        backfillId: 'qtpussca',
+        id: 'qtpussca',
         isAssetBackfill: true,
         partitionStatusCounts: [
           buildPartitionStatusCounts({
@@ -86,7 +86,7 @@ export const BackfillTableFragmentRequested2000AssetsPureStatus: MockedResponse<
 
 export const BackfillTableFragmentCancelledAssetsPartitionSet: BackfillTableFragment = buildPartitionBackfill(
   {
-    backfillId: 'tclwoggv',
+    id: 'tclwoggv',
     status: BulkActionStatus.CANCELED,
     isValidSerialization: true,
     numPartitions: 5000,
@@ -130,7 +130,7 @@ export const BackfillTableFragmentCancelledAssetsPartitionSetStatus: MockedRespo
     data: {
       __typename: 'DagitQuery',
       partitionBackfillOrError: buildPartitionBackfill({
-        backfillId: 'tclwoggv',
+        id: 'tclwoggv',
         partitionStatusCounts: [
           {runStatus: RunStatus.NOT_STARTED, count: 6524, __typename: 'PartitionStatusCounts'},
         ],
@@ -140,7 +140,7 @@ export const BackfillTableFragmentCancelledAssetsPartitionSetStatus: MockedRespo
 };
 
 export const BackfillTableFragmentFailedError: BackfillTableFragment = buildPartitionBackfill({
-  backfillId: 'sjqzcfhe',
+  id: 'sjqzcfhe',
   status: BulkActionStatus.FAILED,
   isValidSerialization: true,
   numPartitions: 100,
@@ -175,7 +175,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
     data: {
       __typename: 'DagitQuery',
       partitionBackfillOrError: buildPartitionBackfill({
-        backfillId: 'sjqzcfhe',
+        id: 'sjqzcfhe',
         partitionStatuses: buildPartitionStatuses({
           results: BackfillTableFragmentFailedError.partitionNames!.map((n) =>
             buildPartitionStatus({
@@ -193,7 +193,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
 
 export const BackfillTableFragmentCompletedAssetJob: BackfillTableFragment = buildPartitionBackfill(
   {
-    backfillId: 'pwgcpiwc',
+    id: 'pwgcpiwc',
     status: BulkActionStatus.COMPLETED,
     isValidSerialization: true,
     numPartitions: 11,
@@ -247,7 +247,7 @@ export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<Single
     data: {
       __typename: 'DagitQuery',
       partitionBackfillOrError: {
-        backfillId: 'pwgcpiwc',
+        id: 'pwgcpiwc',
         partitionStatuses: {
           results: [
             {
@@ -337,7 +337,7 @@ export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<Single
 };
 
 export const BackfillTableFragmentCompletedOpJob: BackfillTableFragment = buildPartitionBackfill({
-  backfillId: 'pqdiepuf',
+  id: 'pqdiepuf',
   status: BulkActionStatus.COMPLETED,
   isValidSerialization: true,
   numPartitions: 4,
@@ -373,7 +373,7 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
     data: {
       __typename: 'DagitQuery',
       partitionBackfillOrError: buildPartitionBackfill({
-        backfillId: 'pqdiepuf',
+        id: 'pqdiepuf',
         isAssetBackfill: true,
         partitionStatuses: buildPartitionStatuses({
           results: [
@@ -410,7 +410,7 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
 
 export const BackfillTableFragmentInvalidPartitionSet: BackfillTableFragment = buildPartitionBackfill(
   {
-    backfillId: 'jzduiapb',
+    id: 'jzduiapb',
     status: BulkActionStatus.COMPLETED,
     isValidSerialization: false,
     numPartitions: 0,
@@ -437,7 +437,7 @@ export const BackfillTableFragmentInvalidPartitionSet: BackfillTableFragment = b
 );
 
 export const BackfillTablePureAssetCountsOnly: BackfillTableFragment = buildPartitionBackfill({
-  backfillId: 'likqkgna',
+  id: 'likqkgna',
   status: BulkActionStatus.FAILED,
   isValidSerialization: true,
   numPartitions: 30,
@@ -476,7 +476,7 @@ export const BackfillTablePureAssetCountsOnly: BackfillTableFragment = buildPart
 
 const BackfillTablePureAssetNoCountsOrPartitionNames: BackfillTableFragment = buildPartitionBackfill(
   {
-    backfillId: 'vlpmimsl',
+    id: 'vlpmimsl',
     status: BulkActionStatus.COMPLETED,
     isValidSerialization: true,
     numPartitions: null,

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -36,19 +36,19 @@ export const BackfillTable = ({
     RESUME_BACKFILL_MUTATION,
   );
 
-  const candidateId = terminationBackfill?.backfillId;
+  const candidateId = terminationBackfill?.id;
 
   React.useEffect(() => {
     if (candidateId) {
       const [backfill] = backfills.filter(
-        (backfill) => backfill.backfillId === candidateId && backfill.hasCancelPermission,
+        (backfill) => backfill.id === candidateId && backfill.hasCancelPermission,
       );
       setTerminationBackfill(backfill);
     }
   }, [backfills, candidateId]);
 
   const resume = async (backfill: BackfillTableFragment) => {
-    const {data} = await resumeBackfill({variables: {backfillId: backfill.backfillId}});
+    const {data} = await resumeBackfill({variables: {backfillId: backfill.id}});
     if (data && data.resumePartitionBackfill.__typename === 'ResumeBackfillSuccess') {
       refetch();
     } else if (data && data.resumePartitionBackfill.__typename === 'UnauthorizedError') {
@@ -97,7 +97,7 @@ export const BackfillTable = ({
         <tbody>
           {backfills.map((backfill) => (
             <BackfillRow
-              key={backfill.backfillId}
+              key={backfill.id}
               showBackfillTarget={showBackfillTarget}
               backfill={backfill}
               allPartitions={allPartitions}
@@ -128,7 +128,7 @@ export const BackfillTable = ({
 
 export const BACKFILL_TABLE_FRAGMENT = gql`
   fragment BackfillTableFragment on PartitionBackfill {
-    backfillId
+    id
     status
     isAssetBackfill
     hasCancelPermission

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -28,7 +28,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
     {
       variables: {
-        backfillId: backfill?.backfillId || '',
+        backfillId: backfill?.id || '',
       },
       notifyOnNetworkStatusChange: true,
       skip: !backfill,
@@ -58,7 +58,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
   const numUnscheduled = backfill.numCancelable;
   const cancel = async () => {
     setIsSubmitting(true);
-    await cancelBackfill({variables: {backfillId: backfill.backfillId}});
+    await cancelBackfill({variables: {backfillId: backfill.id}});
     onComplete();
     setIsSubmitting(false);
     onClose();

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -48,7 +48,7 @@ export const InstanceBackfills = () => {
     pageSize: PAGE_SIZE,
     nextCursorForResult: (result) =>
       result.partitionBackfillsOrError.__typename === 'PartitionBackfills'
-        ? result.partitionBackfillsOrError.results[PAGE_SIZE - 1]?.backfillId
+        ? result.partitionBackfillsOrError.results[PAGE_SIZE - 1]?.id
         : undefined,
     getResultArray: (result) =>
       result?.partitionBackfillsOrError.__typename === 'PartitionBackfills'
@@ -125,7 +125,7 @@ const BACKFILLS_QUERY = gql`
     partitionBackfillsOrError(cursor: $cursor, limit: $limit) {
       ... on PartitionBackfills {
         results {
-          backfillId
+          id
           status
           isValidSerialization
           numPartitions

--- a/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
@@ -326,6 +326,7 @@ export const BACKFILL_DETAILS_QUERY = gql`
   }
 
   fragment PartitionBackfillFragment on PartitionBackfill {
+    id
     status
     timestamp
     endTimestamp

--- a/js_modules/dagit/packages/core/src/instance/backfill/__stories__/BackfillPage.stories.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__stories__/BackfillPage.stories.tsx
@@ -50,7 +50,7 @@ export const Canceled = () => {
 const CompletedResponse = buildBackfillDetailsQuery(
   '1',
   buildPartitionBackfill({
-    backfillId: '1',
+    id: '1',
     status: BulkActionStatus.COMPLETED,
     timestamp: Date.now() / 1000 - 10000,
     assetBackfillData: buildAssetBackfillData({
@@ -87,7 +87,7 @@ const CompletedResponse = buildBackfillDetailsQuery(
 const InProgressResponse = buildBackfillDetailsQuery(
   '1',
   buildPartitionBackfill({
-    backfillId: '1',
+    id: '1',
     status: BulkActionStatus.REQUESTED,
     timestamp: Date.now() / 1000 - 10000,
     endTimestamp: Date.now() / 1000 - 10,
@@ -125,7 +125,7 @@ const InProgressResponse = buildBackfillDetailsQuery(
 const CanceledResponse = buildBackfillDetailsQuery(
   '1',
   buildPartitionBackfill({
-    backfillId: '1',
+    id: '1',
     status: BulkActionStatus.CANCELED,
     timestamp: Date.now() / 1000 - 10000,
     endTimestamp: Date.now() / 1000 - 10,
@@ -145,7 +145,7 @@ const CanceledResponse = buildBackfillDetailsQuery(
 const FailedResponse = buildBackfillDetailsQuery(
   '1',
   buildPartitionBackfill({
-    backfillId: '1',
+    id: '1',
     status: BulkActionStatus.FAILED,
     timestamp: Date.now() / 1000 - 10000,
     endTimestamp: Date.now() / 1000 - 10,

--- a/js_modules/dagit/packages/core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/backfill/types/BackfillPage.types.ts
@@ -11,6 +11,7 @@ export type BackfillStatusesByAssetQuery = {
   partitionBackfillOrError:
     | {
         __typename: 'PartitionBackfill';
+        id: string;
         status: Types.BulkActionStatus;
         timestamp: number;
         endTimestamp: number | null;
@@ -47,6 +48,7 @@ export type BackfillStatusesByAssetQuery = {
 
 export type PartitionBackfillFragment = {
   __typename: 'PartitionBackfill';
+  id: string;
   status: Types.BulkActionStatus;
   timestamp: number;
   endTimestamp: number | null;

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
@@ -11,7 +11,7 @@ export type SingleBackfillCountsQuery = {
   partitionBackfillOrError:
     | {
         __typename: 'PartitionBackfill';
-        backfillId: string;
+        id: string;
         partitionStatusCounts: Array<{
           __typename: 'PartitionStatusCounts';
           runStatus: Types.RunStatus;
@@ -30,7 +30,7 @@ export type SingleBackfillQuery = {
   partitionBackfillOrError:
     | {
         __typename: 'PartitionBackfill';
-        backfillId: string;
+        id: string;
         partitionStatuses: {
           __typename: 'PartitionStatuses';
           results: Array<{

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTable.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTable.types.ts
@@ -4,7 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type BackfillTableFragment = {
   __typename: 'PartitionBackfill';
-  backfillId: string;
+  id: string;
   status: Types.BulkActionStatus;
   isAssetBackfill: boolean;
   hasCancelPermission: boolean;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
@@ -46,7 +46,7 @@ export type InstanceBackfillsQuery = {
         __typename: 'PartitionBackfills';
         results: Array<{
           __typename: 'PartitionBackfill';
-          backfillId: string;
+          id: string;
           status: Types.BulkActionStatus;
           isValidSerialization: boolean;
           numPartitions: number | null;

--- a/js_modules/dagit/packages/core/src/instance/types/useDaemonStatus.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useDaemonStatus.types.ts
@@ -35,7 +35,7 @@ export type InstanceWarningQuery = {
   partitionBackfillsOrError:
     | {
         __typename: 'PartitionBackfills';
-        results: Array<{__typename: 'PartitionBackfill'; backfillId: string}>;
+        results: Array<{__typename: 'PartitionBackfill'; id: string}>;
       }
     | {__typename: 'PythonError'};
 };

--- a/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
@@ -102,7 +102,7 @@ const INSTANCE_WARNING_QUERY = gql`
       __typename
       ... on PartitionBackfills {
         results {
-          backfillId
+          id
         }
       }
     }

--- a/js_modules/dagit/packages/core/src/partitions/JobBackfillsTable.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/JobBackfillsTable.tsx
@@ -79,7 +79,7 @@ export const JobBackfillsTable = ({
             if (cursor) {
               setCursorStack((current) => [...current, cursor]);
             }
-            const nextCursor = backfills && backfills[backfills.length - 1].backfillId;
+            const nextCursor = backfills && backfills[backfills.length - 1].id;
             if (!nextCursor) {
               return;
             }
@@ -121,6 +121,7 @@ const JOB_BACKFILLS_QUERY = gql`
         id
         pipelineName
         backfills(cursor: $cursor, limit: $limit) {
+          id
           ...BackfillTableFragment
         }
       }

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
@@ -18,7 +18,7 @@ export type JobBackfillsQuery = {
         pipelineName: string;
         backfills: Array<{
           __typename: 'PartitionBackfill';
-          backfillId: string;
+          id: string;
           status: Types.BulkActionStatus;
           isAssetBackfill: boolean;
           hasCancelPermission: boolean;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -126,7 +126,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     class Meta:
         name = "PartitionBackfill"
 
-    backfillId = graphene.NonNull(graphene.String)
+    id = graphene.NonNull(graphene.String)
     status = graphene.NonNull(GrapheneBulkActionStatus)
     partitionNames = graphene.List(graphene.NonNull(graphene.String))
     isValidSerialization = graphene.NonNull(graphene.Boolean)
@@ -167,7 +167,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         self._partition_run_data = None
 
         super().__init__(
-            backfillId=backfill_job.backfill_id,
+            id=backfill_job.backfill_id,
             partitionSetName=backfill_job.partition_set_name,
             status=backfill_job.status.value,
             fromFailure=bool(backfill_job.from_failure),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -27,7 +27,7 @@ GET_PARTITION_BACKFILLS_QUERY = """
     partitionBackfillsOrError(cursor: $cursor, limit: $limit) {
       ... on PartitionBackfills {
         results {
-          backfillId
+          id
           status
           numPartitions
           timestamp
@@ -193,7 +193,7 @@ def test_launch_asset_backfill():
             backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
             assert len(backfill_results) == 1
             assert backfill_results[0]["numPartitions"] == 2
-            assert backfill_results[0]["backfillId"] == backfill_id
+            assert backfill_results[0]["id"] == backfill_id
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
@@ -248,7 +248,7 @@ def test_remove_partitions_defs_after_backfill():
             backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
             assert len(backfill_results) == 1
             assert backfill_results[0]["numPartitions"] == 0
-            assert backfill_results[0]["backfillId"] == backfill_id
+            assert backfill_results[0]["id"] == backfill_id
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert set(backfill_results[0]["partitionNames"]) == set()
@@ -358,7 +358,7 @@ def test_launch_asset_backfill_with_upstream_anchor_asset():
             backfill_results = get_backfills_result.data["partitionBackfillsOrError"]["results"]
             assert len(backfill_results) == 1
             assert backfill_results[0]["numPartitions"] is None
-            assert backfill_results[0]["backfillId"] == backfill_id
+            assert backfill_results[0]["id"] == backfill_id
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert backfill_results[0]["partitionNames"] is None

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -41,7 +41,7 @@ PARTITION_PROGRESS_QUERY = """
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
         __typename
-        backfillId
+        id
         status
         numCancelable
         partitionNames
@@ -128,7 +128,7 @@ GET_PARTITION_BACKFILLS_QUERY = """
         name
         pipelineName
         backfills {
-          backfillId
+          id
           isAssetBackfill
         }
       }
@@ -315,7 +315,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionSetOrError"]["__typename"] == "PartitionSet"
         assert len(result.data["partitionSetOrError"]["backfills"]) == 1
-        assert result.data["partitionSetOrError"]["backfills"][0]["backfillId"] == backfill_id
+        assert result.data["partitionSetOrError"]["backfills"][0]["id"] == backfill_id
         assert result.data["partitionSetOrError"]["backfills"][0]["isAssetBackfill"] is False
 
     def test_launch_partial_backfill(self, graphql_context):


### PR DESCRIPTION
## Summary & Motivation

This PR replaces `PartitionBackfill.backfillId` with `PartitionBackfill.id`, both in Dagit and in our GraphQL layer.

Mutations like LaunchBackfill still return a `backfillId` for clarity.

Using a non-standard field name for an object's unique ID causes problems in our Apollo GraphQL library and requires manually telling it what it can use to uniquely key the objects. It created such a big problem for runs that we actually have both `runId` and `id` and usually request both.

Our goal is to remove all of the non-standard IDs, but it might take a handful of PRs :-) 

## How I Tested These Changes

- Run GraphQL tests and confirm they still pass
- Launch a backfill in Dagit, view the backfills page