### PR TITLE
Revert "Revert "in memory sqlite storage fixes (#13555)" (#13570)"

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/in_memory.py
@@ -1,3 +1,4 @@
+import uuid
 from contextlib import contextmanager
 from typing import Iterator, Optional, Sequence
 
@@ -20,8 +21,23 @@ class InMemoryRunStorage(SqlRunStorage):
     """
 
     def __init__(self, preload: Optional[Sequence[DebugRunPayload]] = None):
-        self._engine = None
-        self._conn = None
+        self._engine = create_engine(
+            create_in_memory_conn_string(f"runs-{uuid.uuid4()}"),
+            poolclass=NullPool,
+        )
+
+        # hold one connection for life of instance, but vend new ones for specific calls
+        self._held_conn = self._engine.connect()
+
+        RunStorageSqlMetadata.create_all(self._held_conn)
+        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
+        stamp_alembic_rev(alembic_config, self._held_conn)
+        table_names = db.inspect(self._held_conn).get_table_names()
+        if "instance_info" not in table_names:
+            InstanceInfo.create(self._held_conn)
+        self.migrate()
+        self.optimize()
+
         if preload:
             for payload in preload:
                 self.add_pipeline_snapshot(
@@ -32,39 +48,17 @@ class InMemoryRunStorage(SqlRunStorage):
                 )
                 self.add_run(payload.pipeline_run)
 
-    def _create_connection(self) -> None:
-        engine = create_engine(create_in_memory_conn_string("runs"), poolclass=NullPool)
-        conn = engine.connect()
-
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys=ON;")
-        RunStorageSqlMetadata.create_all(conn)
-        alembic_config = get_alembic_config(__file__, "sqlite/alembic/alembic.ini")
-        stamp_alembic_rev(alembic_config, conn)
-        table_names = db.inspect(conn).get_table_names()
-        if "instance_info" not in table_names:
-            InstanceInfo.create(conn)
-
-        self._engine = engine
-        self._conn = conn
-
-        self.migrate()
-        self.optimize()
-
     @contextmanager
     def connect(self) -> Iterator[Connection]:
-        if not self._conn:
-            self._create_connection()
+        with self._engine.connect() as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA foreign_keys=ON;")
 
-        yield self._conn  # type: ignore
+            yield conn
 
     def upgrade(self) -> None:
         pass
 
     def dispose(self) -> None:
-        if self._conn:
-            self._conn.close()
-            self._conn = None
-
-        if self._engine:
-            self._engine.dispose()
+        self._held_conn.close()
+        self._engine.dispose()

--- a/python_modules/dagster/dagster/_core/storage/sqlite.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite.py
@@ -18,7 +18,7 @@ def create_in_memory_conn_string(db_name: str) -> str:
     # that multiple instances can share the same logical DB across connections, while maintaining
     # separate DBs for different db names.  The latter is required to have both the run / event_log
     # in-memory implementations within the same process
-    return f"sqlite:///file:{db_name}?mode=memory&uri=true&check_same_thread=false"
+    return f"sqlite:///file:{db_name}?mode=memory&uri=true&cache=shared"
 
 
 def get_sqlite_version() -> str:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_local_instance.py
@@ -28,6 +28,8 @@ from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import environ
+from packaging import version
+from sqlalchemy import __version__ as sqlalchemy_version
 
 
 def test_fs_stores():
@@ -249,20 +251,29 @@ def test_run_step_stats_with_retries():
 
 
 def test_threaded_ephemeral_instance(caplog):
-    def _instantiate_ephemeral_instance():
-        with DagsterInstance.ephemeral() as instance:
-            instance.get_runs_count()  # call run storage
-            instance.all_asset_keys()  # call event log storage
+    n = 5
 
-    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="ephemeral_worker") as executor:
-        executor.submit(_instantiate_ephemeral_instance)
-        executor.submit(_instantiate_ephemeral_instance)
-        executor.submit(_instantiate_ephemeral_instance)
+    with DagsterInstance.ephemeral() as shared_instance:
 
-    assert (
-        "SQLite objects created in a thread can only be used in that same thread."
-        not in caplog.text
-    )
+        def _instantiate_ephemeral_instance(_):
+            with DagsterInstance.ephemeral() as instance:
+                instance.get_runs_count()  # call run storage
+                instance.all_asset_keys()  # call event log storage
+                shared_instance.get_runs_count()
+                shared_instance.all_asset_keys()
+
+            return True
+
+        with ThreadPoolExecutor(max_workers=n, thread_name_prefix="ephemeral_worker") as executor:
+            results = executor.map(_instantiate_ephemeral_instance, range(n))
+            assert all(results)
+
+    # old SQL alchemy has issue that causes warning to fire
+    if version.parse(sqlalchemy_version) > version.parse("1.3.24"):
+        assert (
+            "SQLite objects created in a thread can only be used in that same thread."
+            not in caplog.text
+        )
 
 
 def test_threadsafe_ephemeral_instance():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -39,7 +39,11 @@ class NonBucketQuerySqliteRunStorage(SqliteRunStorage):
 
 @contextmanager
 def create_in_memory_storage():
-    yield InMemoryRunStorage()
+    storage = InMemoryRunStorage()
+    try:
+        yield storage
+    finally:
+        storage.dispose()
 
 
 @contextmanager


### PR DESCRIPTION
#13555 with `uuid` instead of `id(self)` since the latter can get re-used and updated test 

## How I Tested These Changes

ran observed failures repeatedly locally
BK run with `test-all` 