### PR TITLE
Fix forward test_logging_run_status_sensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -139,7 +139,7 @@ class RunStatusSensorContext:
         self._dagster_run = check.inst_param(dagster_run, "dagster_run", DagsterRun)
         self._dagster_event = check.inst_param(dagster_event, "dagster_event", DagsterEvent)
         self._instance = check.inst_param(instance, "instance", DagsterInstance)
-        self._logger: Optional[logging.Logger] = logger or context.log if context else None
+        self._logger: Optional[logging.Logger] = logger or (context.log if context else None)
 
         # Wait to set resources unless they're accessed
         self._resource_defs = resource_defs

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -1182,7 +1182,6 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
 
 
 @pytest.mark.parametrize("executor", get_sensor_executors())
-@pytest.mark.skip(reason="#13367 caused this and we are going to fix forward")
 def test_logging_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,


### PR DESCRIPTION
## Summary

Fix forward for a test disabled in #13576.

This was a silly boolean logic error, which is now fixed.

## Test Plan

Ran test locally, BK
