### PR TITLE
[dagit] Use `Run.id` instead of `Run.runId` everywhere in Dagit

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
@@ -33,10 +33,10 @@ export const AssetRunLink: React.FC<{
   event?: Parameters<typeof linkToRunEvent>[1];
 }> = ({runId, children, event}) => (
   <Link
-    to={event ? linkToRunEvent({runId}, event) : `/runs/${runId}`}
+    to={event ? linkToRunEvent({id: runId}, event) : `/runs/${runId}`}
     target="_blank"
     rel="noreferrer"
   >
-    {children || <CaptionMono>{titleForRun({runId})}</CaptionMono>}
+    {children || <CaptionMono>{titleForRun({id: runId})}</CaptionMono>}
   </Link>
 );

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -98,7 +98,7 @@ export const SidebarAssetInfo: React.FC<{
         assetKey={assetKey}
         assetLastMaterializedAt={lastMaterialization?.timestamp}
         assetHasDefinedPartitions={!!asset.partitionDefinition}
-        isSourceAsset={assetNode.definition.isSource}
+        isSourceAsset={definition.isSource}
         liveData={liveData}
       />
 

--- a/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -165,7 +165,6 @@ const EventsMock: MockedResponse<AssetEventsQuery> = {
               pipelineSnapshotId: null,
               id: '12345',
               status: RunStatus.SUCCESS,
-              runId: '12345',
               repositoryOrigin: {
                 __typename: 'RepositoryOrigin',
                 id: 'test.py',
@@ -193,7 +192,6 @@ const EventsMock: MockedResponse<AssetEventsQuery> = {
               pipelineSnapshotId: null,
               id: '12345',
               status: RunStatus.SUCCESS,
-              runId: '12345',
               repositoryOrigin: {
                 __typename: 'RepositoryOrigin',
                 id: 'test.py',

--- a/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
@@ -132,7 +132,7 @@ const MetadataEntriesRow: React.FC<{
                           <span>
                             {`${obs.stepKey} in `}
                             <Link to={`/runs/${obs.runId}?timestamp=${obs.timestamp}`}>
-                              <Mono>{titleForRun({runId: obs.runId})}</Mono>
+                              <Mono>{titleForRun({id: obs.runId})}</Mono>
                             </Link>
                             {` (${dayjs(Number(obs.timestamp)).from(
                               Number(timestamp),
@@ -252,8 +252,8 @@ const EventGroupRow: React.FC<{
       </td>
       <td>
         <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-          <RunStatusWithStats runId={run.runId} status={run.status} />
-          <Link to={`/runs/${run.runId}?timestamp=${timestamp}`}>
+          <RunStatusWithStats runId={run.id} status={run.status} />
+          <Link to={`/runs/${run.id}?timestamp=${timestamp}`}>
             <Mono>{titleForRun(run)}</Mono>
           </Link>
         </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
@@ -72,7 +72,7 @@ export const AssetEventDetail: React.FC<{
           <Subheading>Run</Subheading>
           {run ? (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <RunStatusWithStats runId={run.runId} status={run.status} />
+              <RunStatusWithStats runId={run.id} status={run.status} />
               <Link to={linkToRunEvent(run, event)}>
                 <Mono>{titleForRun(run)}</Mono>
               </Link>

--- a/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
@@ -152,11 +152,11 @@ const AssetEventListEventRow: React.FC<{group: AssetEventGroup}> = ({group}) => 
         {latest && run && (
           <Tag>
             <AssetRunLink
-              runId={run.runId}
+              runId={run.id}
               event={{stepKey: latest.stepKey, timestamp: latest.timestamp}}
             >
               <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
-                <RunStatusWithStats runId={run.runId} status={run.status} size={8} />
+                <RunStatusWithStats runId={run.id} status={run.status} size={8} />
                 {titleForRun(run)}
               </Box>
             </AssetRunLink>

--- a/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -66,7 +66,7 @@ export const AssetEventMetadataEntriesTable: React.FC<{
                 <Box>
                   {`Observed in run `}
                   <Link to={`/runs/${obv.runId}?timestamp=${timestamp}`}>
-                    <Mono>{titleForRun({runId: obv.runId})}</Mono>
+                    <Mono>{titleForRun({id: obv.runId})}</Mono>
                   </Link>
                 </Box>
                 <Caption>

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -123,7 +123,6 @@ export const ASSET_PARTITION_DETAIL_QUERY = gql`
   fragment AssetPartitionLatestRunFragment on Run {
     __typename
     id
-    runId
     status
     endTime
   }
@@ -206,7 +205,7 @@ export const AssetPartitionDetail: React.FC<{
           icon={<Spinner purpose="body-text" />}
           title={
             <div style={{fontWeight: 400}}>
-              Run <Link to={`/runs/${currentRun.runId}`}>{titleForRun(currentRun)}</Link>{' '}
+              Run <Link to={`/runs/${currentRun.id}`}>{titleForRun(currentRun)}</Link>{' '}
               {currentRunStatusMessage}
             </div>
           }
@@ -252,7 +251,7 @@ export const AssetPartitionDetail: React.FC<{
           <Subheading>Run</Subheading>
           {latestEventRun && latest ? (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <RunStatusWithStats runId={latestEventRun.runId} status={latestEventRun.status} />
+              <RunStatusWithStats runId={latestEventRun.id} status={latestEventRun.status} />
               <Link to={linkToRunEvent(latestEventRun, latest)}>
                 <Mono>{titleForRun(latestEventRun)}</Mono>
               </Link>

--- a/js_modules/dagit/packages/core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagit/packages/core/src/assets/CurrentRunsBanner.tsx
@@ -24,14 +24,9 @@ export const CurrentRunsBanner: React.FC<{liveData?: LiveDataForNode; border: Bo
           <div style={{fontWeight: 400}}>
             {inProgressRunIds.length > 0 && (
               <>
-                {inProgressRunIds.map((runId) => (
-                  <React.Fragment key={runId}>
-                    Run{' '}
-                    <Link to={`/runs/${runId}`}>
-                      {titleForRun({
-                        runId,
-                      })}
-                    </Link>
+                {inProgressRunIds.map((id) => (
+                  <React.Fragment key={id}>
+                    Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
                   </React.Fragment>
                 ))}{' '}
                 {inProgressRunIds.length === 1 ? 'is' : 'are'} currently refreshing this asset.
@@ -39,14 +34,9 @@ export const CurrentRunsBanner: React.FC<{liveData?: LiveDataForNode; border: Bo
             )}
             {unstartedRunIds.length > 0 && (
               <>
-                {unstartedRunIds.map((runId) => (
-                  <React.Fragment key={runId}>
-                    Run{' '}
-                    <Link to={`/runs/${runId}`}>
-                      {titleForRun({
-                        runId,
-                      })}
-                    </Link>
+                {unstartedRunIds.map((id) => (
+                  <React.Fragment key={id}>
+                    Run <Link to={`/runs/${id}`}>{titleForRun({id})}</Link>
                   </React.Fragment>
                 ))}{' '}
                 {unstartedRunIds.length === 1 ? 'has' : 'have'} started and will refresh this asset.

--- a/js_modules/dagit/packages/core/src/assets/FailedRunSinceMaterializationBanner.tsx
+++ b/js_modules/dagit/packages/core/src/assets/FailedRunSinceMaterializationBanner.tsx
@@ -18,8 +18,8 @@ export const FailedRunSinceMaterializationBanner: React.FC<{
           intent="error"
           title={
             <div style={{fontWeight: 400}}>
-              Run <Link to={`/runs/${run.id}`}>{titleForRun({runId: run.id})}</Link> failed to
-              materialize this asset.
+              Run <Link to={`/runs/${run.id}`}>{titleForRun(run)}</Link> failed to materialize this
+              asset.
             </div>
           }
         />

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -24,7 +24,6 @@ export const LatestMaterializationMetadata: React.FC<{
   latest: AssetObservationFragment | AssetMaterializationFragment | undefined;
   liveData: LiveDataForNode | undefined;
 }> = ({assetKey, latest, liveData}) => {
-  console.log(latest);
   const latestRun = latest?.runOrError.__typename === 'Run' ? latest?.runOrError : null;
   const repositoryOrigin = latestRun?.repositoryOrigin;
   const repoAddress = repositoryOrigin
@@ -59,7 +58,7 @@ export const LatestMaterializationMetadata: React.FC<{
                 <Box>
                   {'Run '}
                   <Link to={`/runs/${latestEvent.runId}?timestamp=${latestEvent.timestamp}`}>
-                    <Mono>{titleForRun({runId: latestEvent.runId})}</Mono>
+                    <Mono>{titleForRun({id: latestEvent.runId})}</Mono>
                   </Link>
                 </Box>
                 {!isHiddenAssetGroupJob(latestRun.pipelineName) && (

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.mocks.ts
@@ -31,7 +31,6 @@ export const MaterializationEventOlder: AssetMaterializationFragment = {
   ],
   runOrError: {
     id: '0b847814-4e03-82a6-cfab-d9431369974d',
-    runId: '0b847814-4e03-82a6-cfab-d9431369974d',
     mode: 'default',
     repositoryOrigin: {
       id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -79,7 +78,6 @@ export const MaterializationEventMinimal: AssetMaterializationFragment = {
   tags: [],
   runOrError: {
     id: '1369974d-cfab-4e03-82a6-d9430b847814',
-    runId: '1369974d-cfab-4e03-82a6-d9430b847814',
     mode: 'default',
     repositoryOrigin: {
       id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -133,7 +131,6 @@ export const MaterializationEventFull: AssetMaterializationFragment = {
   ],
   runOrError: {
     id: '1369974d-cfab-4e03-82a6-d9430b847814',
-    runId: '1369974d-cfab-4e03-82a6-d9430b847814',
     mode: 'default',
     repositoryOrigin: {
       id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -186,7 +183,6 @@ export const BasicObservationEvent: AssetObservationFragment = {
   ],
   runOrError: {
     id: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
-    runId: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
     mode: 'default',
     repositoryOrigin: {
       id: 'cc94e313d9025bbc796a3e7e46487eb305969b68',
@@ -304,7 +300,6 @@ export const buildAssetPartitionDetailMock = (
           ? {
               __typename: 'Run',
               id: '123456',
-              runId: '123456',
               status: currentRunStatus,
               endTime: null,
             }

--- a/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
@@ -16,7 +16,6 @@ export type AssetPartitionDetailQuery = {
         latestRunForPartition: {
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           endTime: number | null;
         } | null;
@@ -34,7 +33,6 @@ export type AssetPartitionDetailQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;
@@ -190,7 +188,6 @@ export type AssetPartitionDetailQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;
@@ -334,7 +331,6 @@ export type AssetPartitionDetailQuery = {
 export type AssetPartitionLatestRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   endTime: number | null;
 };

--- a/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
@@ -16,7 +16,6 @@ export type AssetMaterializationFragment = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         mode: string;
         status: Types.RunStatus;
         pipelineName: string;
@@ -153,7 +152,6 @@ export type AssetObservationFragment = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         mode: string;
         status: Types.RunStatus;
         pipelineName: string;
@@ -299,7 +297,6 @@ export type AssetEventsQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;
@@ -450,7 +447,6 @@ export type AssetEventsQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;

--- a/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
@@ -92,7 +92,6 @@ export const ASSET_MATERIALIZATION_FRAGMENT = gql`
     runOrError {
       ... on PipelineRun {
         id
-        runId
         mode
         repositoryOrigin {
           id
@@ -131,7 +130,6 @@ export const ASSET_OBSERVATION_FRAGMENT = gql`
     runOrError {
       ... on PipelineRun {
         id
-        runId
         mode
         repositoryOrigin {
           id

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -98,7 +98,7 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
       <>
         {runs.map((g, idx) =>
           g ? (
-            <RunGroupRun key={g.runId} to={`/runs/${g.runId}`} selected={g.runId === runId}>
+            <RunGroupRun key={g.id} to={`/runs/${g.id}`} selected={g.id === runId}>
               {idx < runs.length - 1 && <ThinLine style={{height: 36}} />}
               <Box padding={{top: 4}}>
                 <RunStatusIndicator status={g.status} />
@@ -113,7 +113,7 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
               >
                 <div style={{display: 'flex', justifyContent: 'space-between'}}>
                   <RunTitle>
-                    {g.runId.split('-')[0]}
+                    {g.id.split('-')[0]}
                     {idx === 0 && RootTag}
                   </RunTitle>
                   <RunTime run={g} />
@@ -154,7 +154,6 @@ const RUN_GROUP_PANEL_QUERY = gql`
 
   fragment RunGroupPanelRun on Run {
     id
-    runId
     parentRunId
     status
     stepKeysToExecute

--- a/js_modules/dagit/packages/core/src/gantt/types/RunGroupPanel.types.ts
+++ b/js_modules/dagit/packages/core/src/gantt/types/RunGroupPanel.types.ts
@@ -25,7 +25,6 @@ export type RunGroupPanelQuery = {
         runs: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           parentRunId: string | null;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
@@ -42,7 +41,6 @@ export type RunGroupPanelQuery = {
 export type RunGroupPanelRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   parentRunId: string | null;
   status: Types.RunStatus;
   stepKeysToExecute: Array<string> | null;

--- a/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
@@ -15,7 +15,6 @@ export type RunReExecutionQuery = {
         id: string;
         parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
-        runId: string;
         canTerminate: boolean;
         hasReExecutePermission: boolean;
         hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -230,7 +230,6 @@ const LAUNCHED_RUN_LIST_QUERY = gql`
         results {
           ...RunTableRunFragment
           id
-          runId
         }
       }
       ... on InvalidPipelineRunsFilterError {

--- a/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
@@ -23,8 +23,8 @@ export const InstigatedRunStatus: React.FC<{
 export const RunStatusLink: React.FC<{run: RunStatusFragment}> = ({run}) => (
   <Group direction="row" spacing={4} alignItems="center">
     <RunStatusIndicator status={run.status} />
-    <Link to={`/runs/${run.runId}`} target="_blank" rel="noreferrer">
-      <Mono>{titleForRun({runId: run.runId})}</Mono>
+    <Link to={`/runs/${run.id}`} target="_blank" rel="noreferrer">
+      <Mono>{titleForRun({id: run.id})}</Mono>
     </Link>
   </Group>
 );
@@ -32,7 +32,6 @@ export const RunStatusLink: React.FC<{run: RunStatusFragment}> = ({run}) => (
 export const RUN_STATUS_FRAGMENT = gql`
   fragment RunStatusFragment on Run {
     id
-    runId
     status
   }
 `;

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
@@ -45,7 +45,6 @@ export type LaunchedRunListQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationUtils.types.ts
@@ -2,12 +2,7 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunStatusFragment = {
-  __typename: 'Run';
-  id: string;
-  runId: string;
-  status: Types.RunStatus;
-};
+export type RunStatusFragment = {__typename: 'Run'; id: string; status: Types.RunStatus};
 
 export type InstigationStateFragment = {
   __typename: 'InstigationState';
@@ -28,7 +23,6 @@ export type InstigationStateFragment = {
   runs: Array<{
     __typename: 'Run';
     id: string;
-    runId: string;
     status: Types.RunStatus;
     startTime: number | null;
     endTime: number | null;

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
@@ -29,7 +29,7 @@ export type TickHistoryQuery = {
           originRunIds: Array<string>;
           logKey: Array<string> | null;
           runKeys: Array<string>;
-          runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus; runId: string}>;
+          runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus}>;
           error: {
             __typename: 'PythonError';
             message: string;
@@ -71,7 +71,7 @@ export type HistoryTickFragment = {
   originRunIds: Array<string>;
   logKey: Array<string> | null;
   runKeys: Array<string>;
-  runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus; runId: string}>;
+  runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus}>;
   error: {
     __typename: 'PythonError';
     message: string;

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
@@ -60,7 +60,6 @@ export type JobMetadataQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
-          runId: string;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
@@ -117,7 +116,6 @@ export type RunMetadataFragment = {
   __typename: 'Run';
   id: string;
   status: Types.RunStatus;
-  runId: string;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagit/packages/core/src/nav/types/LatestRunTag.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/LatestRunTag.types.ts
@@ -17,7 +17,6 @@ export type LatestRunTagQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
-          runId: string;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
@@ -112,7 +112,6 @@ export type UnloadableSchedulesQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
@@ -113,7 +113,6 @@ export type UnloadableSensorsQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunList.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunList.tsx
@@ -56,7 +56,6 @@ const PARTITION_RUN_LIST_QUERY = gql`
         results {
           ...RunTableRunFragment
           id
-          runId
         }
       }
       ... on InvalidPipelineRunsFilterError {

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
@@ -25,7 +25,6 @@ export type PartitionRunListQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/partitions/types/useMatrixData.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/useMatrixData.types.ts
@@ -5,7 +5,6 @@ import * as Types from '../../graphql/types';
 export type PartitionMatrixStepRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   startTime: number | null;
   endTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/usePartitionStepQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/usePartitionStepQuery.types.ts
@@ -27,7 +27,6 @@ export type PartitionStepLoaderQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
@@ -223,7 +223,6 @@ export const useMatrixData = (inputs: MatrixDataInputs) => {
 export const PARTITION_MATRIX_STEP_RUN_FRAGMENT = gql`
   fragment PartitionMatrixStepRunFragment on Run {
     id
-    runId
     status
     startTime
     endTime

--- a/js_modules/dagit/packages/core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/usePartitionStepQuery.tsx
@@ -165,7 +165,7 @@ export function usePartitionStepQuery({
         );
         setDataState((state) => {
           const updated = state.runs
-            .filter((r) => !relevant.some((o) => o.runId === r.runId))
+            .filter((r) => !relevant.some((o) => o.id === r.id))
             .concat(relevant);
           return {...state, loading: false, runs: updated};
         });

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -92,7 +92,7 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
       if (runs.pipelineRunsOrError.__typename !== 'Runs') {
         return undefined;
       }
-      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.runId;
+      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.id;
     },
     getResultArray: (data) => {
       if (!data || data.pipelineRunsOrError.__typename !== 'Runs') {

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -110,7 +110,7 @@ export const SidebarOpExecutionGraphs: React.FC<{
                   placement="bottom-end"
                   content={`View Run ${runId.slice(0, 8)} →`}
                 >
-                  <Link to={linkToRunEvent({runId}, {stepKey: solidName})}>
+                  <Link to={linkToRunEvent({id: runId}, {stepKey: solidName})}>
                     <StepStatusDot
                       onMouseEnter={() => startTime && setHighlightedStartTime(startTime * 1000)}
                       onMouseLeave={() => setHighlightedStartTime(null)}

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -27,7 +27,6 @@ export type PipelineRunsRootQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -385,7 +385,6 @@ const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
 const PIPELINE_RUN_LOGS_SUBSCRIPTION_STATUS_FRAGMENT = gql`
   fragment PipelineRunLogsSubscriptionStatusFragment on Run {
     id
-    runId
     status
     canTerminate
   }
@@ -396,7 +395,6 @@ const RUN_LOGS_QUERY = gql`
     pipelineRunOrError(runId: $runId) {
       ... on Run {
         id
-        runId
         status
         canTerminate
       }

--- a/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
@@ -24,7 +24,6 @@ const buildLaunchPipelineReexecutionSuccessMock = (
         __typename: 'LaunchRunSuccess',
         run: {
           id: '1234',
-          runId: '1234',
           pipelineName: '1234',
           rootRunId: null,
           parentRunId,

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
@@ -23,7 +23,6 @@ describe('RunActionsMenu', () => {
   const runFragment: RunTableRunFragment = {
     __typename: 'Run',
     id: 'run-foo-bar',
-    runId: 'abcdef12',
     status: RunStatus.SUCCESS,
     stepKeysToExecute: null,
     canTerminate: true,

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -71,7 +71,7 @@ export const RunActionsMenu: React.FC<{
     PipelineEnvironmentQuery,
     PipelineEnvironmentQueryVariables
   >(PIPELINE_ENVIRONMENT_QUERY, {
-    variables: {runId: run.runId},
+    variables: {runId: run.id},
   });
 
   const closeDialogs = () => {
@@ -192,7 +192,7 @@ export const RunActionsMenu: React.FC<{
               text="Download debug file"
               icon="download_for_offline"
               download
-              href={`${rootServerURI}/download_debug/${run.runId}`}
+              href={`${rootServerURI}/download_debug/${run.id}`}
             />
             {run.hasDeletePermission ? (
               <MenuItem
@@ -298,7 +298,7 @@ export const RunBulkActionsMenu: React.FC<{
     {},
   );
 
-  const deleteableIDs = selected.map((run) => run.runId);
+  const deleteableIDs = selected.map((run) => run.id);
   const deletionMap = selected.reduce((accum, run) => ({...accum, [run.id]: run.canTerminate}), {});
 
   const reexecuteFromFailureRuns = selected.filter(

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -179,7 +179,7 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
                 <MenuItem
                   text="Download debug file"
                   icon={<Icon name="download_for_offline" />}
-                  onClick={() => window.open(`${rootServerURI}/download_debug/${run.runId}`)}
+                  onClick={() => window.open(`${rootServerURI}/download_debug/${run.id}`)}
                 />
               </Tooltip>
               {run.hasDeletePermission ? (

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -10,7 +10,6 @@ export const RUN_FRAGMENT = gql`
   fragment RunFragment on Run {
     id
     runConfigYaml
-    runId
     canTerminate
     repositoryOrigin {
       id

--- a/js_modules/dagit/packages/core/src/runs/RunStats.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStats.tsx
@@ -61,7 +61,6 @@ const RUN_STATS_QUERY = gql`
       }
       ... on Run {
         id
-        runId
         pipelineName
         stats {
           ... on RunStatsSnapshot {

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -44,7 +44,7 @@ export const RunStatusPezList = (props: ListProps) => {
     <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>
       {runs.map((run, ii) => (
         <Popover
-          key={run.runId}
+          key={run.id}
           position="top"
           interactionKind="hover"
           content={
@@ -55,8 +55,8 @@ export const RunStatusPezList = (props: ListProps) => {
           hoverOpenDelay={100}
         >
           <RunStatusPez
-            key={run.runId}
-            runId={run.runId}
+            key={run.id}
+            runId={run.id}
             status={run.status}
             opacity={fade ? MAX_OPACITY - (count - ii - 1) * step : 1.0}
           />
@@ -78,7 +78,7 @@ export const RunStatusOverlay = ({name, run}: OverlayProps) => {
       <RunRow>
         <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
           <RunStatusIndicator status={run.status} />
-          <Link to={`/runs/${run.runId}`}>
+          <Link to={`/runs/${run.id}`}>
             <Mono style={{fontSize: '14px'}}>{titleForRun(run)}</Mono>
           </Link>
         </Box>

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -45,7 +45,7 @@ interface RunTableProps {
 
 export const RunTable = (props: RunTableProps) => {
   const {runs, filter, onAddTag, highlightedIds, actionBarComponents} = props;
-  const allIds = runs.map((r) => r.runId);
+  const allIds = runs.map((r) => r.id);
 
   const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(allIds);
 
@@ -110,7 +110,7 @@ export const RunTable = (props: RunTableProps) => {
     }
   }
 
-  const selectedFragments = runs.filter((run) => checkedIds.has(run.runId));
+  const selectedFragments = runs.filter((run) => checkedIds.has(run.id));
 
   return (
     <>
@@ -153,12 +153,12 @@ export const RunTable = (props: RunTableProps) => {
             <RunRow
               canTerminateOrDelete={run.hasTerminatePermission || run.hasDeletePermission}
               run={run}
-              key={run.runId}
+              key={run.id}
               onAddTag={onAddTag}
-              checked={checkedIds.has(run.runId)}
+              checked={checkedIds.has(run.id)}
               additionalColumns={props.additionalColumnsForRow?.(run)}
-              onToggleChecked={onToggleFactory(run.runId)}
-              isHighlighted={highlightedIds && highlightedIds.includes(run.runId)}
+              onToggleChecked={onToggleFactory(run.id)}
+              isHighlighted={highlightedIds && highlightedIds.includes(run.id)}
             />
           ))}
         </tbody>
@@ -170,7 +170,6 @@ export const RunTable = (props: RunTableProps) => {
 export const RUN_TABLE_RUN_FRAGMENT = gql`
   fragment RunTableRunFragment on Run {
     id
-    runId
     status
     stepKeysToExecute
     canTerminate
@@ -250,10 +249,10 @@ const RunRow: React.FC<{
         ) : null}
       </td>
       <td>
-        <RunStatusTagWithStats status={run.status} runId={run.runId} />
+        <RunStatusTagWithStats status={run.status} runId={run.id} />
       </td>
       <td>
-        <Link to={`/runs/${run.runId}`}>
+        <Link to={`/runs/${run.id}`}>
           <Mono>{titleForRun(run)}</Mono>
         </Link>
       </td>

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -19,8 +19,8 @@ import {RunFragment} from './types/RunFragments.types';
 import {RunTableRunFragment} from './types/RunTable.types';
 import {LaunchPipelineExecutionMutation, RunTimeFragment} from './types/RunUtils.types';
 
-export function titleForRun(run: {runId: string}) {
-  return run.runId.split('-').shift();
+export function titleForRun(run: {id: string}) {
+  return run.id.split('-').shift();
 }
 
 export function assetKeysForRun(run: {
@@ -34,10 +34,10 @@ export function assetKeysForRun(run: {
 }
 
 export function linkToRunEvent(
-  run: {runId: string},
+  run: {id: string},
   event: {timestamp?: string; stepKey: string | null},
 ) {
-  return `/runs/${run.runId}?${qs.stringify({
+  return `/runs/${run.id}?${qs.stringify({
     focusedTime: event.timestamp ? Number(event.timestamp) : undefined,
     selection: event.stepKey,
     logs: `step:${event.stepKey}`,
@@ -74,7 +74,7 @@ export function handleLaunchResult(
   }
 
   if (result.__typename === 'LaunchRunSuccess') {
-    const pathname = `/runs/${result.run.runId}`;
+    const pathname = `/runs/${result.run.id}`;
     const search = options.preserveQuerystring ? history.location.search : '';
     const openInNewTab = () => window.open(history.createHref({pathname, search}), '_blank');
     const openInSameTab = () => history.push({pathname, search});
@@ -88,7 +88,7 @@ export function handleLaunchResult(
         intent: 'success',
         message: (
           <div>
-            Launched run <Mono>{result.run.runId.slice(0, 8)}</Mono>
+            Launched run <Mono>{result.run.id.slice(0, 8)}</Mono>
           </div>
         ),
         action: {
@@ -122,8 +122,8 @@ function getBaseExecutionMetadata(run: RunFragment | RunTableRunFragment) {
   const hiddenTagKeys: string[] = [DagsterTag.IsResumeRetry, DagsterTag.StepSelection];
 
   return {
-    parentRunId: run.runId,
-    rootRunId: run.rootRunId ? run.rootRunId : run.runId,
+    parentRunId: run.id,
+    rootRunId: run.rootRunId ? run.rootRunId : run.id,
     tags: [
       // Clean up tags related to run grouping once we decide its persistence
       // https://github.com/dagster-io/dagster/issues/2495
@@ -137,11 +137,11 @@ function getBaseExecutionMetadata(run: RunFragment | RunTableRunFragment) {
       // pass run group info via tags
       {
         key: DagsterTag.ParentRunId,
-        value: run.runId,
+        value: run.id,
       },
       {
         key: DagsterTag.RootRunId,
-        value: run.rootRunId ? run.rootRunId : run.runId,
+        value: run.rootRunId ? run.rootRunId : run.id,
       },
     ],
   };
@@ -204,7 +204,6 @@ export const LAUNCH_PIPELINE_EXECUTION_MUTATION = gql`
       ... on LaunchRunSuccess {
         run {
           id
-          runId
           pipelineName
         }
       }
@@ -256,7 +255,6 @@ export const TERMINATE_MUTATION = gql`
       ... on TerminateRunSuccess {
         run {
           id
-          runId
           canTerminate
         }
       }
@@ -283,7 +281,6 @@ export const LAUNCH_PIPELINE_REEXECUTION_MUTATION = gql`
       ... on LaunchRunSuccess {
         run {
           id
-          runId
           pipelineName
           rootRunId
           parentRunId
@@ -349,7 +346,6 @@ export const RunStateSummary: React.FC<RunTimeProps> = React.memo(({run}) => {
 export const RUN_TIME_FRAGMENT = gql`
   fragment RunTimeFragment on Run {
     id
-    runId
     status
     startTime
     endTime

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -57,7 +57,7 @@ export const RunsRoot = () => {
       if (runs.pipelineRunsOrError.__typename !== 'Runs') {
         return undefined;
       }
-      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.runId;
+      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.id;
     },
     getResultArray: (data) => {
       if (!data || data.pipelineRunsOrError.__typename !== 'Runs') {

--- a/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
@@ -4865,7 +4865,6 @@ export type RunLogsSubscriptionSuccessFragment = {
 export type PipelineRunLogsSubscriptionStatusFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   canTerminate: boolean;
 };
@@ -4880,7 +4879,7 @@ export type RunLogsQuery = {
   __typename: 'DagitQuery';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
-    | {__typename: 'Run'; id: string; runId: string; status: Types.RunStatus; canTerminate: boolean}
+    | {__typename: 'Run'; id: string; status: Types.RunStatus; canTerminate: boolean}
     | {__typename: 'RunNotFoundError'};
   logsForRun:
     | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
@@ -13,7 +13,6 @@ export type RunActionButtonsTestQuery = {
         id: string;
         parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
-        runId: string;
         canTerminate: boolean;
         hasReExecutePermission: boolean;
         hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
@@ -6,7 +6,6 @@ export type RunFragment = {
   __typename: 'Run';
   id: string;
   runConfigYaml: string;
-  runId: string;
   canTerminate: boolean;
   hasReExecutePermission: boolean;
   hasTerminatePermission: boolean;
@@ -2243,7 +2242,6 @@ export type RunPageFragment = {
   id: string;
   parentPipelineSnapshotId: string | null;
   runConfigYaml: string;
-  runId: string;
   canTerminate: boolean;
   hasReExecutePermission: boolean;
   hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
@@ -15,7 +15,6 @@ export type RunRootQuery = {
         id: string;
         parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
-        runId: string;
         canTerminate: boolean;
         hasReExecutePermission: boolean;
         hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunStats.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunStats.types.ts
@@ -22,7 +22,6 @@ export type RunStatsQuery = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         pipelineName: string;
         stats:
           | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
@@ -5,7 +5,6 @@ import * as Types from '../../graphql/types';
 export type RunTableRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   stepKeysToExecute: Array<string> | null;
   canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunUtils.types.ts
@@ -13,10 +13,7 @@ export type LaunchPipelineExecutionMutation = {
     | {__typename: 'InvalidOutputError'}
     | {__typename: 'InvalidStepError'}
     | {__typename: 'InvalidSubsetError'; message: string}
-    | {
-        __typename: 'LaunchRunSuccess';
-        run: {__typename: 'Run'; id: string; runId: string; pipelineName: string};
-      }
+    | {__typename: 'LaunchRunSuccess'; run: {__typename: 'Run'; id: string; pipelineName: string}}
     | {__typename: 'NoModeProvidedError'}
     | {__typename: 'PipelineNotFoundError'; message: string}
     | {__typename: 'PresetNotFoundError'}
@@ -89,7 +86,7 @@ export type TerminateMutation = {
     | {__typename: 'TerminateRunFailure'; message: string}
     | {
         __typename: 'TerminateRunSuccess';
-        run: {__typename: 'Run'; id: string; runId: string; canTerminate: boolean};
+        run: {__typename: 'Run'; id: string; canTerminate: boolean};
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
@@ -111,7 +108,6 @@ export type LaunchPipelineReexecutionMutation = {
         run: {
           __typename: 'Run';
           id: string;
-          runId: string;
           pipelineName: string;
           rootRunId: string | null;
           parentRunId: string | null;
@@ -148,7 +144,6 @@ export type LaunchPipelineReexecutionMutation = {
 export type RunTimeFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   startTime: number | null;
   endTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
@@ -27,7 +27,6 @@ export type RunsRootQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
@@ -20,7 +20,6 @@ export type RunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;
@@ -42,7 +41,6 @@ export type RunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -49,7 +49,6 @@ export type ScheduleRootQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;
@@ -126,7 +125,6 @@ export type PreviousRunsForScheduleQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
@@ -32,7 +32,6 @@ export type ScheduleFragment = {
     runs: Array<{
       __typename: 'Run';
       id: string;
-      runId: string;
       status: Types.RunStatus;
       startTime: number | null;
       endTime: number | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
@@ -30,7 +30,6 @@ export type SensorFragment = {
     runs: Array<{
       __typename: 'Run';
       id: string;
-      runId: string;
       status: Types.RunStatus;
       startTime: number | null;
       endTime: number | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -17,7 +17,6 @@ export type PreviousRunsForSensorQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
@@ -47,7 +47,6 @@ export type SensorRootQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -19,7 +19,6 @@ export type SingleJobQuery = {
         runs: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -46,7 +46,6 @@ export type SingleScheduleQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -50,7 +50,6 @@ export type SingleSensorQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;


### PR DESCRIPTION
## Summary & Motivation

This PR replaces all uses of Run.runId with Run.id in Dagit. I'm assembling a follow-up PR with the GraphQL changes to fully remove `Run.runId`, but doing that separately because I think there could be reasons to leave it in place for longer.

Mutations results ala `LaunchRunSuccess` still return a runId for clarity.

Using a non-standard field name for an object's unique ID causes problems in our Apollo GraphQL library and requires manually telling it what it can use to uniquely key the objects. We've had both `run.runId` and `run.id` for a long time, and we usually request both.

Our goal is to remove all of the non-standard IDs, but it might take a handful of PRs :-)


## How I Tested These Changes

- Run GraphQL tests and confirm they still pass
- View runs 
- View run details view
- Launch runs in Dagit
