### PR TITLE
[graphql] Remove `Run.runId` from the GraphQL API in favor of `Run.id`

### DIFF
--- a/examples/deploy_docker/tests/test_deploy_docker.py
+++ b/examples/deploy_docker/tests/test_deploy_docker.py
@@ -77,7 +77,7 @@ mutation($executionParams: ExecutionParams!) {
     __typename
     ... on LaunchRunSuccess {
       run {
-        runId
+        id
         status
       }
     }
@@ -99,17 +99,17 @@ mutation($runId: String!) {
     __typename
     ... on TerminateRunSuccess{
       run {
-        runId
+        id
       }
     }
     ... on TerminateRunFailure {
       run {
-        runId
+        id
       }
       message
     }
     ... on RunNotFoundError {
-      runId
+      id
     }
     ... on PythonError {
       message
@@ -182,7 +182,7 @@ def test_deploy_docker():
         assert launch_res["data"]["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run = launch_res["data"]["launchPipelineExecution"]["run"]
-        run_id = run["runId"]
+        run_id = run["id"]
         assert run["status"] == "QUEUED"
 
         _wait_for_run_status(run_id, dagit_host, DagsterRunStatus.SUCCESS)
@@ -211,7 +211,7 @@ def test_deploy_docker():
         assert launch_res["data"]["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run = launch_res["data"]["launchPipelineExecution"]["run"]
-        run_id = run["runId"]
+        run_id = run["id"]
         assert run["status"] == "QUEUED"
 
         _wait_for_run_status(run_id, dagit_host, DagsterRunStatus.SUCCESS)
@@ -239,7 +239,7 @@ def test_deploy_docker():
         assert launch_res["data"]["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run = launch_res["data"]["launchPipelineExecution"]["run"]
-        hanging_run_id = run["runId"]
+        hanging_run_id = run["id"]
 
         _wait_for_run_status(hanging_run_id, dagit_host, DagsterRunStatus.STARTED)
 

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -61,7 +61,7 @@ mutation($executionParams: ExecutionParams!) {
     __typename
     ... on LaunchPipelineRunSuccess {
       run {
-        runId
+        id
         status
       }
     }
@@ -105,17 +105,17 @@ mutation($runId: String!, $terminatePolicy: TerminateRunPolicy) {
     __typename
     ... on TerminateRunSuccess{
       run {
-        runId
+        id
       }
     }
     ... on TerminateRunFailure {
       run {
-        runId
+        id
       }
       message
     }
     ... on RunNotFoundError {
-      runId
+      id
     }
     ... on PythonError {
       message
@@ -175,7 +175,7 @@ def launch_run_over_graphql(
         and result["data"]["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
     )
 
-    return result["data"]["launchPipelineExecution"]["run"]["runId"]
+    return result["data"]["launchPipelineExecution"]["run"]["id"]
 
 
 def can_terminate_run_over_graphql(

--- a/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AllIndividualEventsLink.tsx
@@ -252,8 +252,8 @@ const EventGroupRow: React.FC<{
       </td>
       <td>
         <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-          <RunStatusWithStats runId={run.runId} status={run.status} />
-          <Link to={`/runs/${run.runId}?timestamp=${timestamp}`}>
+          <RunStatusWithStats runId={run.id} status={run.status} />
+          <Link to={`/runs/${run.id}?timestamp=${timestamp}`}>
             <Mono>{titleForRun(run)}</Mono>
           </Link>
         </Box>

--- a/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventDetail.tsx
@@ -72,7 +72,7 @@ export const AssetEventDetail: React.FC<{
           <Subheading>Run</Subheading>
           {run ? (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <RunStatusWithStats runId={run.runId} status={run.status} />
+              <RunStatusWithStats runId={run.id} status={run.status} />
               <Link to={linkToRunEvent(run, event)}>
                 <Mono>{titleForRun(run)}</Mono>
               </Link>

--- a/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetEventList.tsx
@@ -152,11 +152,11 @@ const AssetEventListEventRow: React.FC<{group: AssetEventGroup}> = ({group}) => 
         {latest && run && (
           <Tag>
             <AssetRunLink
-              runId={run.runId}
+              runId={run.id}
               event={{stepKey: latest.stepKey, timestamp: latest.timestamp}}
             >
               <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
-                <RunStatusWithStats runId={run.runId} status={run.status} size={8} />
+                <RunStatusWithStats runId={run.id} status={run.status} size={8} />
                 {titleForRun(run)}
               </Box>
             </AssetRunLink>

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -123,7 +123,6 @@ export const ASSET_PARTITION_DETAIL_QUERY = gql`
   fragment AssetPartitionLatestRunFragment on Run {
     __typename
     id
-    runId
     status
     endTime
   }
@@ -206,7 +205,7 @@ export const AssetPartitionDetail: React.FC<{
           icon={<Spinner purpose="body-text" />}
           title={
             <div style={{fontWeight: 400}}>
-              Run <Link to={`/runs/${currentRun.runId}`}>{titleForRun(currentRun)}</Link>{' '}
+              Run <Link to={`/runs/${currentRun.id}`}>{titleForRun(currentRun)}</Link>{' '}
               {currentRunStatusMessage}
             </div>
           }
@@ -252,7 +251,7 @@ export const AssetPartitionDetail: React.FC<{
           <Subheading>Run</Subheading>
           {latestEventRun && latest ? (
             <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <RunStatusWithStats runId={latestEventRun.runId} status={latestEventRun.status} />
+              <RunStatusWithStats runId={latestEventRun.id} status={latestEventRun.status} />
               <Link to={linkToRunEvent(latestEventRun, latest)}>
                 <Mono>{titleForRun(latestEventRun)}</Mono>
               </Link>

--- a/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LastMaterializationMetadata.tsx
@@ -55,7 +55,7 @@ export const LatestMaterializationMetadata: React.FC<{
                 <Box>
                   {'Run '}
                   <Link to={`/runs/${latestEvent.runId}?timestamp=${latestEvent.timestamp}`}>
-                    <Mono>{titleForRun({runId: latestEvent.runId})}</Mono>
+                    <Mono>{titleForRun({id: latestEvent.runId})}</Mono>
                   </Link>
                 </Box>
                 {!isHiddenAssetGroupJob(latestRun.pipelineName) && (
@@ -156,7 +156,6 @@ export const LATEST_MATERIALIZATION_METADATA_FRAGMENT = gql`
     runOrError {
       ... on PipelineRun {
         id
-        runId
         mode
         pipelineName
         pipelineSnapshotId

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.mocks.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetEventDetail.mocks.ts
@@ -31,7 +31,6 @@ export const MaterializationEventOlder: AssetMaterializationFragment = {
   ],
   runOrError: {
     id: '0b847814-4e03-82a6-cfab-d9431369974d',
-    runId: '0b847814-4e03-82a6-cfab-d9431369974d',
     mode: 'default',
     repositoryOrigin: {
       id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -79,7 +78,6 @@ export const MaterializationEventMinimal: AssetMaterializationFragment = {
   tags: [],
   runOrError: {
     id: '1369974d-cfab-4e03-82a6-d9430b847814',
-    runId: '1369974d-cfab-4e03-82a6-d9430b847814',
     mode: 'default',
     repositoryOrigin: {
       id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -133,7 +131,6 @@ export const MaterializationEventFull: AssetMaterializationFragment = {
   ],
   runOrError: {
     id: '1369974d-cfab-4e03-82a6-d9430b847814',
-    runId: '1369974d-cfab-4e03-82a6-d9430b847814',
     mode: 'default',
     repositoryOrigin: {
       id: 'c22d9677b8089be89b1e014b9de34284962f83a7',
@@ -186,7 +183,6 @@ export const BasicObservationEvent: AssetObservationFragment = {
   ],
   runOrError: {
     id: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
-    runId: '01e455fc-9ea5-4d45-92d6-a997b9e4bf60',
     mode: 'default',
     repositoryOrigin: {
       id: 'cc94e313d9025bbc796a3e7e46487eb305969b68',
@@ -304,7 +300,6 @@ export const buildAssetPartitionDetailMock = (
           ? {
               __typename: 'Run',
               id: '123456',
-              runId: '123456',
               status: currentRunStatus,
               endTime: null,
             }

--- a/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetPartitionDetail.types.ts
@@ -16,7 +16,6 @@ export type AssetPartitionDetailQuery = {
         latestRunForPartition: {
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           endTime: number | null;
         } | null;
@@ -34,7 +33,6 @@ export type AssetPartitionDetailQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;
@@ -190,7 +188,6 @@ export type AssetPartitionDetailQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;
@@ -334,7 +331,6 @@ export type AssetPartitionDetailQuery = {
 export type AssetPartitionLatestRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   endTime: number | null;
 };

--- a/js_modules/dagit/packages/core/src/assets/types/LastMaterializationMetadata.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LastMaterializationMetadata.types.ts
@@ -14,7 +14,6 @@ export type LatestMaterializationMetadataFragment = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         mode: string;
         pipelineName: string;
         pipelineSnapshotId: string | null;

--- a/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/useRecentAssetEvents.types.ts
@@ -16,7 +16,6 @@ export type AssetMaterializationFragment = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         mode: string;
         status: Types.RunStatus;
         pipelineName: string;
@@ -153,7 +152,6 @@ export type AssetObservationFragment = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         mode: string;
         status: Types.RunStatus;
         pipelineName: string;
@@ -299,7 +297,6 @@ export type AssetEventsQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;
@@ -450,7 +447,6 @@ export type AssetEventsQuery = {
             | {
                 __typename: 'Run';
                 id: string;
-                runId: string;
                 mode: string;
                 status: Types.RunStatus;
                 pipelineName: string;

--- a/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagit/packages/core/src/assets/useRecentAssetEvents.tsx
@@ -92,7 +92,6 @@ export const ASSET_MATERIALIZATION_FRAGMENT = gql`
     runOrError {
       ... on PipelineRun {
         id
-        runId
         mode
         repositoryOrigin {
           id
@@ -131,7 +130,6 @@ export const ASSET_OBSERVATION_FRAGMENT = gql`
     runOrError {
       ... on PipelineRun {
         id
-        runId
         mode
         repositoryOrigin {
           id

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -98,7 +98,7 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
       <>
         {runs.map((g, idx) =>
           g ? (
-            <RunGroupRun key={g.runId} to={`/runs/${g.runId}`} selected={g.runId === runId}>
+            <RunGroupRun key={g.id} to={`/runs/${g.id}`} selected={g.id === runId}>
               {idx < runs.length - 1 && <ThinLine style={{height: 36}} />}
               <Box padding={{top: 4}}>
                 <RunStatusIndicator status={g.status} />
@@ -113,7 +113,7 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
               >
                 <div style={{display: 'flex', justifyContent: 'space-between'}}>
                   <RunTitle>
-                    {g.runId.split('-')[0]}
+                    {g.id.split('-')[0]}
                     {idx === 0 && RootTag}
                   </RunTitle>
                   <RunTime run={g} />
@@ -154,7 +154,6 @@ const RUN_GROUP_PANEL_QUERY = gql`
 
   fragment RunGroupPanelRun on Run {
     id
-    runId
     parentRunId
     status
     stepKeysToExecute

--- a/js_modules/dagit/packages/core/src/gantt/types/RunGroupPanel.types.ts
+++ b/js_modules/dagit/packages/core/src/gantt/types/RunGroupPanel.types.ts
@@ -25,7 +25,6 @@ export type RunGroupPanelQuery = {
         runs: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           parentRunId: string | null;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
@@ -42,7 +41,6 @@ export type RunGroupPanelQuery = {
 export type RunGroupPanelRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   parentRunId: string | null;
   status: Types.RunStatus;
   stepKeysToExecute: Array<string> | null;

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -983,7 +983,6 @@ interface PipelineReference {
 
 interface PipelineRun {
   id: ID!
-  runId: String!
   pipelineSnapshotId: String
   repositoryOrigin: RepositoryOrigin
   status: RunStatus!
@@ -1209,7 +1208,6 @@ type RuntimeMismatchConfigError implements PipelineConfigValidationError {
 
 type Run implements PipelineRun {
   id: ID!
-  runId: String!
   pipelineSnapshotId: String
   repositoryOrigin: RepositoryOrigin
   status: RunStatus!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2556,7 +2556,6 @@ export type PipelineRun = {
   rootRunId: Maybe<Scalars['String']>;
   runConfig: Scalars['RunConfigData'];
   runConfigYaml: Scalars['String'];
-  runId: Scalars['String'];
   solidSelection: Maybe<Array<Scalars['String']>>;
   stats: RunStatsSnapshotOrError;
   status: RunStatus;
@@ -3017,7 +3016,6 @@ export type Run = PipelineRun & {
   rootRunId: Maybe<Scalars['String']>;
   runConfig: Scalars['RunConfigData'];
   runConfigYaml: Scalars['String'];
-  runId: Scalars['String'];
   solidSelection: Maybe<Array<Scalars['String']>>;
   startTime: Maybe<Scalars['Float']>;
   stats: RunStatsSnapshotOrError;
@@ -9500,7 +9498,6 @@ export const buildPipelineRun = (
       overrides && overrides.hasOwnProperty('runConfig') ? overrides.runConfig! : 'aspernatur',
     runConfigYaml:
       overrides && overrides.hasOwnProperty('runConfigYaml') ? overrides.runConfigYaml! : 'facere',
-    runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'tenetur',
     solidSelection:
       overrides && overrides.hasOwnProperty('solidSelection') ? overrides.solidSelection! : ['quo'],
     stats:
@@ -10716,7 +10713,6 @@ export const buildRun = (
     runConfig: overrides && overrides.hasOwnProperty('runConfig') ? overrides.runConfig! : 'quas',
     runConfigYaml:
       overrides && overrides.hasOwnProperty('runConfigYaml') ? overrides.runConfigYaml! : 'eveniet',
-    runId: overrides && overrides.hasOwnProperty('runId') ? overrides.runId! : 'fuga',
     solidSelection:
       overrides && overrides.hasOwnProperty('solidSelection')
         ? overrides.solidSelection!

--- a/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/JobMenu.types.ts
@@ -15,7 +15,6 @@ export type RunReExecutionQuery = {
         id: string;
         parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
-        runId: string;
         canTerminate: boolean;
         hasReExecutePermission: boolean;
         hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationTick.tsx
@@ -230,7 +230,6 @@ const LAUNCHED_RUN_LIST_QUERY = gql`
         results {
           ...RunTableRunFragment
           id
-          runId
         }
       }
       ... on InvalidPipelineRunsFilterError {

--- a/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/InstigationUtils.tsx
@@ -23,8 +23,8 @@ export const InstigatedRunStatus: React.FC<{
 export const RunStatusLink: React.FC<{run: RunStatusFragment}> = ({run}) => (
   <Group direction="row" spacing={4} alignItems="center">
     <RunStatusIndicator status={run.status} />
-    <Link to={`/runs/${run.runId}`} target="_blank" rel="noreferrer">
-      <Mono>{titleForRun({runId: run.runId})}</Mono>
+    <Link to={`/runs/${run.id}`} target="_blank" rel="noreferrer">
+      <Mono>{titleForRun({id: run.id})}</Mono>
     </Link>
   </Group>
 );
@@ -32,7 +32,6 @@ export const RunStatusLink: React.FC<{run: RunStatusFragment}> = ({run}) => (
 export const RUN_STATUS_FRAGMENT = gql`
   fragment RunStatusFragment on Run {
     id
-    runId
     status
   }
 `;

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationTick.types.ts
@@ -45,7 +45,6 @@ export type LaunchedRunListQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/instigation/types/InstigationUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/InstigationUtils.types.ts
@@ -2,12 +2,7 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunStatusFragment = {
-  __typename: 'Run';
-  id: string;
-  runId: string;
-  status: Types.RunStatus;
-};
+export type RunStatusFragment = {__typename: 'Run'; id: string; status: Types.RunStatus};
 
 export type InstigationStateFragment = {
   __typename: 'InstigationState';
@@ -28,7 +23,6 @@ export type InstigationStateFragment = {
   runs: Array<{
     __typename: 'Run';
     id: string;
-    runId: string;
     status: Types.RunStatus;
     startTime: number | null;
     endTime: number | null;

--- a/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagit/packages/core/src/instigation/types/TickHistory.types.ts
@@ -29,7 +29,7 @@ export type TickHistoryQuery = {
           originRunIds: Array<string>;
           logKey: Array<string> | null;
           runKeys: Array<string>;
-          runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus; runId: string}>;
+          runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus}>;
           error: {
             __typename: 'PythonError';
             message: string;
@@ -71,7 +71,7 @@ export type HistoryTickFragment = {
   originRunIds: Array<string>;
   logKey: Array<string> | null;
   runKeys: Array<string>;
-  runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus; runId: string}>;
+  runs: Array<{__typename: 'Run'; id: string; status: Types.RunStatus}>;
   error: {
     __typename: 'PythonError';
     message: string;

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
@@ -60,7 +60,6 @@ export type JobMetadataQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
-          runId: string;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
@@ -117,7 +116,6 @@ export type RunMetadataFragment = {
   __typename: 'Run';
   id: string;
   status: Types.RunStatus;
-  runId: string;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagit/packages/core/src/nav/types/LatestRunTag.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/LatestRunTag.types.ts
@@ -17,7 +17,6 @@ export type LatestRunTagQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
-          runId: string;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
@@ -112,7 +112,6 @@ export type UnloadableSchedulesQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
@@ -113,7 +113,6 @@ export type UnloadableSensorsQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/PartitionRunList.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/PartitionRunList.tsx
@@ -56,7 +56,6 @@ const PARTITION_RUN_LIST_QUERY = gql`
         results {
           ...RunTableRunFragment
           id
-          runId
         }
       }
       ... on InvalidPipelineRunsFilterError {

--- a/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/PartitionRunList.types.ts
@@ -25,7 +25,6 @@ export type PartitionRunListQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/partitions/types/useMatrixData.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/useMatrixData.types.ts
@@ -5,7 +5,6 @@ import * as Types from '../../graphql/types';
 export type PartitionMatrixStepRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   startTime: number | null;
   endTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/types/usePartitionStepQuery.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/usePartitionStepQuery.types.ts
@@ -27,7 +27,6 @@ export type PartitionStepLoaderQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;

--- a/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/useMatrixData.tsx
@@ -223,7 +223,6 @@ export const useMatrixData = (inputs: MatrixDataInputs) => {
 export const PARTITION_MATRIX_STEP_RUN_FRAGMENT = gql`
   fragment PartitionMatrixStepRunFragment on Run {
     id
-    runId
     status
     startTime
     endTime

--- a/js_modules/dagit/packages/core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/usePartitionStepQuery.tsx
@@ -165,7 +165,7 @@ export function usePartitionStepQuery({
         );
         setDataState((state) => {
           const updated = state.runs
-            .filter((r) => !relevant.some((o) => o.runId === r.runId))
+            .filter((r) => !relevant.some((o) => o.id === r.id))
             .concat(relevant);
           return {...state, loading: false, runs: updated};
         });

--- a/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/PipelineRunsRoot.tsx
@@ -92,7 +92,7 @@ export const PipelineRunsRoot: React.FC<Props> = (props) => {
       if (runs.pipelineRunsOrError.__typename !== 'Runs') {
         return undefined;
       }
-      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.runId;
+      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.id;
     },
     getResultArray: (data) => {
       if (!data || data.pipelineRunsOrError.__typename !== 'Runs') {

--- a/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -27,7 +27,6 @@ export type PipelineRunsRootQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -385,7 +385,6 @@ const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
 const PIPELINE_RUN_LOGS_SUBSCRIPTION_STATUS_FRAGMENT = gql`
   fragment PipelineRunLogsSubscriptionStatusFragment on Run {
     id
-    runId
     status
     canTerminate
   }
@@ -396,7 +395,6 @@ const RUN_LOGS_QUERY = gql`
     pipelineRunOrError(runId: $runId) {
       ... on Run {
         id
-        runId
         status
         canTerminate
       }

--- a/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ReexecutionDialog.test.tsx
@@ -24,7 +24,6 @@ const buildLaunchPipelineReexecutionSuccessMock = (
         __typename: 'LaunchRunSuccess',
         run: {
           id: '1234',
-          runId: '1234',
           pipelineName: '1234',
           rootRunId: null,
           parentRunId,

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.test.tsx
@@ -23,7 +23,6 @@ describe('RunActionsMenu', () => {
   const runFragment: RunTableRunFragment = {
     __typename: 'Run',
     id: 'run-foo-bar',
-    runId: 'abcdef12',
     status: RunStatus.SUCCESS,
     stepKeysToExecute: null,
     canTerminate: true,

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -71,7 +71,7 @@ export const RunActionsMenu: React.FC<{
     PipelineEnvironmentQuery,
     PipelineEnvironmentQueryVariables
   >(PIPELINE_ENVIRONMENT_QUERY, {
-    variables: {runId: run.runId},
+    variables: {runId: run.id},
   });
 
   const closeDialogs = () => {
@@ -192,7 +192,7 @@ export const RunActionsMenu: React.FC<{
               text="Download debug file"
               icon="download_for_offline"
               download
-              href={`${rootServerURI}/download_debug/${run.runId}`}
+              href={`${rootServerURI}/download_debug/${run.id}`}
             />
             {run.hasDeletePermission ? (
               <MenuItem
@@ -298,7 +298,7 @@ export const RunBulkActionsMenu: React.FC<{
     {},
   );
 
-  const deleteableIDs = selected.map((run) => run.runId);
+  const deleteableIDs = selected.map((run) => run.id);
   const deletionMap = selected.reduce((accum, run) => ({...accum, [run.id]: run.canTerminate}), {});
 
   const reexecuteFromFailureRuns = selected.filter(

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -179,7 +179,7 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
                 <MenuItem
                   text="Download debug file"
                   icon={<Icon name="download_for_offline" />}
-                  onClick={() => window.open(`${rootServerURI}/download_debug/${run.runId}`)}
+                  onClick={() => window.open(`${rootServerURI}/download_debug/${run.id}`)}
                 />
               </Tooltip>
               {run.hasDeletePermission ? (

--- a/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunFragments.tsx
@@ -10,7 +10,6 @@ export const RUN_FRAGMENT = gql`
   fragment RunFragment on Run {
     id
     runConfigYaml
-    runId
     canTerminate
     repositoryOrigin {
       id

--- a/js_modules/dagit/packages/core/src/runs/RunStats.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStats.tsx
@@ -61,7 +61,6 @@ const RUN_STATS_QUERY = gql`
       }
       ... on Run {
         id
-        runId
         pipelineName
         stats {
           ... on RunStatsSnapshot {

--- a/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStatusPez.tsx
@@ -44,7 +44,7 @@ export const RunStatusPezList = (props: ListProps) => {
     <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>
       {runs.map((run, ii) => (
         <Popover
-          key={run.runId}
+          key={run.id}
           position="top"
           interactionKind="hover"
           content={
@@ -55,8 +55,8 @@ export const RunStatusPezList = (props: ListProps) => {
           hoverOpenDelay={100}
         >
           <RunStatusPez
-            key={run.runId}
-            runId={run.runId}
+            key={run.id}
+            runId={run.id}
             status={run.status}
             opacity={fade ? MAX_OPACITY - (count - ii - 1) * step : 1.0}
           />
@@ -78,7 +78,7 @@ export const RunStatusOverlay = ({name, run}: OverlayProps) => {
       <RunRow>
         <Box flex={{alignItems: 'center', direction: 'row', gap: 8}}>
           <RunStatusIndicator status={run.status} />
-          <Link to={`/runs/${run.runId}`}>
+          <Link to={`/runs/${run.id}`}>
             <Mono style={{fontSize: '14px'}}>{titleForRun(run)}</Mono>
           </Link>
         </Box>

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -45,7 +45,7 @@ interface RunTableProps {
 
 export const RunTable = (props: RunTableProps) => {
   const {runs, filter, onAddTag, highlightedIds, actionBarComponents} = props;
-  const allIds = runs.map((r) => r.runId);
+  const allIds = runs.map((r) => r.id);
 
   const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(allIds);
 
@@ -110,7 +110,7 @@ export const RunTable = (props: RunTableProps) => {
     }
   }
 
-  const selectedFragments = runs.filter((run) => checkedIds.has(run.runId));
+  const selectedFragments = runs.filter((run) => checkedIds.has(run.id));
 
   return (
     <>
@@ -153,12 +153,12 @@ export const RunTable = (props: RunTableProps) => {
             <RunRow
               canTerminateOrDelete={run.hasTerminatePermission || run.hasDeletePermission}
               run={run}
-              key={run.runId}
+              key={run.id}
               onAddTag={onAddTag}
-              checked={checkedIds.has(run.runId)}
+              checked={checkedIds.has(run.id)}
               additionalColumns={props.additionalColumnsForRow?.(run)}
-              onToggleChecked={onToggleFactory(run.runId)}
-              isHighlighted={highlightedIds && highlightedIds.includes(run.runId)}
+              onToggleChecked={onToggleFactory(run.id)}
+              isHighlighted={highlightedIds && highlightedIds.includes(run.id)}
             />
           ))}
         </tbody>
@@ -170,7 +170,6 @@ export const RunTable = (props: RunTableProps) => {
 export const RUN_TABLE_RUN_FRAGMENT = gql`
   fragment RunTableRunFragment on Run {
     id
-    runId
     status
     stepKeysToExecute
     canTerminate
@@ -250,10 +249,10 @@ const RunRow: React.FC<{
         ) : null}
       </td>
       <td>
-        <RunStatusTagWithStats status={run.status} runId={run.runId} />
+        <RunStatusTagWithStats status={run.status} runId={run.id} />
       </td>
       <td>
-        <Link to={`/runs/${run.runId}`}>
+        <Link to={`/runs/${run.id}`}>
           <Mono>{titleForRun(run)}</Mono>
         </Link>
       </td>

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -19,8 +19,8 @@ import {RunFragment} from './types/RunFragments.types';
 import {RunTableRunFragment} from './types/RunTable.types';
 import {LaunchPipelineExecutionMutation, RunTimeFragment} from './types/RunUtils.types';
 
-export function titleForRun(run: {runId: string}) {
-  return run.runId.split('-').shift();
+export function titleForRun(run: {id: string}) {
+  return run.id.split('-').shift();
 }
 
 export function assetKeysForRun(run: {
@@ -34,10 +34,10 @@ export function assetKeysForRun(run: {
 }
 
 export function linkToRunEvent(
-  run: {runId: string},
+  run: {id: string},
   event: {timestamp?: string; stepKey: string | null},
 ) {
-  return `/runs/${run.runId}?${qs.stringify({
+  return `/runs/${run.id}?${qs.stringify({
     focusedTime: event.timestamp ? Number(event.timestamp) : undefined,
     selection: event.stepKey,
     logs: `step:${event.stepKey}`,
@@ -74,7 +74,7 @@ export function handleLaunchResult(
   }
 
   if (result.__typename === 'LaunchRunSuccess') {
-    const pathname = `/runs/${result.run.runId}`;
+    const pathname = `/runs/${result.run.id}`;
     const search = options.preserveQuerystring ? history.location.search : '';
     const openInNewTab = () => window.open(history.createHref({pathname, search}), '_blank');
     const openInSameTab = () => history.push({pathname, search});
@@ -88,7 +88,7 @@ export function handleLaunchResult(
         intent: 'success',
         message: (
           <div>
-            Launched run <Mono>{result.run.runId.slice(0, 8)}</Mono>
+            Launched run <Mono>{result.run.id.slice(0, 8)}</Mono>
           </div>
         ),
         action: {
@@ -122,8 +122,8 @@ function getBaseExecutionMetadata(run: RunFragment | RunTableRunFragment) {
   const hiddenTagKeys: string[] = [DagsterTag.IsResumeRetry, DagsterTag.StepSelection];
 
   return {
-    parentRunId: run.runId,
-    rootRunId: run.rootRunId ? run.rootRunId : run.runId,
+    parentRunId: run.id,
+    rootRunId: run.rootRunId ? run.rootRunId : run.id,
     tags: [
       // Clean up tags related to run grouping once we decide its persistence
       // https://github.com/dagster-io/dagster/issues/2495
@@ -137,11 +137,11 @@ function getBaseExecutionMetadata(run: RunFragment | RunTableRunFragment) {
       // pass run group info via tags
       {
         key: DagsterTag.ParentRunId,
-        value: run.runId,
+        value: run.id,
       },
       {
         key: DagsterTag.RootRunId,
-        value: run.rootRunId ? run.rootRunId : run.runId,
+        value: run.rootRunId ? run.rootRunId : run.id,
       },
     ],
   };
@@ -204,7 +204,6 @@ export const LAUNCH_PIPELINE_EXECUTION_MUTATION = gql`
       ... on LaunchRunSuccess {
         run {
           id
-          runId
           pipelineName
         }
       }
@@ -256,7 +255,6 @@ export const TERMINATE_MUTATION = gql`
       ... on TerminateRunSuccess {
         run {
           id
-          runId
           canTerminate
         }
       }
@@ -283,7 +281,6 @@ export const LAUNCH_PIPELINE_REEXECUTION_MUTATION = gql`
       ... on LaunchRunSuccess {
         run {
           id
-          runId
           pipelineName
           rootRunId
           parentRunId
@@ -349,7 +346,6 @@ export const RunStateSummary: React.FC<RunTimeProps> = React.memo(({run}) => {
 export const RUN_TIME_FRAGMENT = gql`
   fragment RunTimeFragment on Run {
     id
-    runId
     status
     startTime
     endTime

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -57,7 +57,7 @@ export const RunsRoot = () => {
       if (runs.pipelineRunsOrError.__typename !== 'Runs') {
         return undefined;
       }
-      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.runId;
+      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.id;
     },
     getResultArray: (data) => {
       if (!data || data.pipelineRunsOrError.__typename !== 'Runs') {

--- a/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
@@ -4865,7 +4865,6 @@ export type RunLogsSubscriptionSuccessFragment = {
 export type PipelineRunLogsSubscriptionStatusFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   canTerminate: boolean;
 };
@@ -4880,7 +4879,7 @@ export type RunLogsQuery = {
   __typename: 'DagitQuery';
   pipelineRunOrError:
     | {__typename: 'PythonError'}
-    | {__typename: 'Run'; id: string; runId: string; status: Types.RunStatus; canTerminate: boolean}
+    | {__typename: 'Run'; id: string; status: Types.RunStatus; canTerminate: boolean}
     | {__typename: 'RunNotFoundError'};
   logsForRun:
     | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunActionButtons.test.types.ts
@@ -13,7 +13,6 @@ export type RunActionButtonsTestQuery = {
         id: string;
         parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
-        runId: string;
         canTerminate: boolean;
         hasReExecutePermission: boolean;
         hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
@@ -6,7 +6,6 @@ export type RunFragment = {
   __typename: 'Run';
   id: string;
   runConfigYaml: string;
-  runId: string;
   canTerminate: boolean;
   hasReExecutePermission: boolean;
   hasTerminatePermission: boolean;
@@ -2243,7 +2242,6 @@ export type RunPageFragment = {
   id: string;
   parentPipelineSnapshotId: string | null;
   runConfigYaml: string;
-  runId: string;
   canTerminate: boolean;
   hasReExecutePermission: boolean;
   hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunRoot.types.ts
@@ -15,7 +15,6 @@ export type RunRootQuery = {
         id: string;
         parentPipelineSnapshotId: string | null;
         runConfigYaml: string;
-        runId: string;
         canTerminate: boolean;
         hasReExecutePermission: boolean;
         hasTerminatePermission: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunStats.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunStats.types.ts
@@ -22,7 +22,6 @@ export type RunStatsQuery = {
     | {
         __typename: 'Run';
         id: string;
-        runId: string;
         pipelineName: string;
         stats:
           | {

--- a/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTable.types.ts
@@ -5,7 +5,6 @@ import * as Types from '../../graphql/types';
 export type RunTableRunFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   stepKeysToExecute: Array<string> | null;
   canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunUtils.types.ts
@@ -13,10 +13,7 @@ export type LaunchPipelineExecutionMutation = {
     | {__typename: 'InvalidOutputError'}
     | {__typename: 'InvalidStepError'}
     | {__typename: 'InvalidSubsetError'; message: string}
-    | {
-        __typename: 'LaunchRunSuccess';
-        run: {__typename: 'Run'; id: string; runId: string; pipelineName: string};
-      }
+    | {__typename: 'LaunchRunSuccess'; run: {__typename: 'Run'; id: string; pipelineName: string}}
     | {__typename: 'NoModeProvidedError'}
     | {__typename: 'PipelineNotFoundError'; message: string}
     | {__typename: 'PresetNotFoundError'}
@@ -89,7 +86,7 @@ export type TerminateMutation = {
     | {__typename: 'TerminateRunFailure'; message: string}
     | {
         __typename: 'TerminateRunSuccess';
-        run: {__typename: 'Run'; id: string; runId: string; canTerminate: boolean};
+        run: {__typename: 'Run'; id: string; canTerminate: boolean};
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
@@ -111,7 +108,6 @@ export type LaunchPipelineReexecutionMutation = {
         run: {
           __typename: 'Run';
           id: string;
-          runId: string;
           pipelineName: string;
           rootRunId: string | null;
           parentRunId: string | null;
@@ -148,7 +144,6 @@ export type LaunchPipelineReexecutionMutation = {
 export type RunTimeFragment = {
   __typename: 'Run';
   id: string;
-  runId: string;
   status: Types.RunStatus;
   startTime: number | null;
   endTime: number | null;

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
@@ -27,7 +27,6 @@ export type RunsRootQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
@@ -20,7 +20,6 @@ export type RunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;
@@ -42,7 +41,6 @@ export type RunTimelineQuery = {
           __typename: 'Run';
           id: string;
           pipelineName: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -49,7 +49,6 @@ export type ScheduleRootQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;
@@ -126,7 +125,6 @@ export type PreviousRunsForScheduleQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleUtils.types.ts
@@ -32,7 +32,6 @@ export type ScheduleFragment = {
     runs: Array<{
       __typename: 'Run';
       id: string;
-      runId: string;
       status: Types.RunStatus;
       startTime: number | null;
       endTime: number | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorFragment.types.ts
@@ -30,7 +30,6 @@ export type SensorFragment = {
     runs: Array<{
       __typename: 'Run';
       id: string;
-      runId: string;
       status: Types.RunStatus;
       startTime: number | null;
       endTime: number | null;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -17,7 +17,6 @@ export type PreviousRunsForSensorQuery = {
         results: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           canTerminate: boolean;

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
@@ -47,7 +47,6 @@ export type SensorRootQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -19,7 +19,6 @@ export type SingleJobQuery = {
         runs: Array<{
           __typename: 'Run';
           id: string;
-          runId: string;
           status: Types.RunStatus;
           startTime: number | null;
           endTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -46,7 +46,6 @@ export type SingleScheduleQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -50,7 +50,6 @@ export type SingleSensorQuery = {
           runs: Array<{
             __typename: 'Run';
             id: string;
-            runId: string;
             status: Types.RunStatus;
             startTime: number | null;
             endTime: number | null;

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -195,7 +195,7 @@ class DagsterGraphQLClient:
             query_result_type == "LaunchRunSuccess"
             or query_result_type == "LaunchPipelineRunSuccess"
         ):
-            return query_result["run"]["runId"]
+            return query_result["run"]["id"]
         elif query_result_type == "InvalidStepError":
             raise DagsterGraphQLClientError(query_result_type, query_result["invalidStepKey"])
         elif query_result_type == "InvalidOutputError":

--- a/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client_queries.py
@@ -12,7 +12,7 @@ mutation($executionParams: ExecutionParams!) {
     }
     ... on LaunchPipelineRunSuccess {
       run {
-        runId
+        id
       }
     }
     ... on ConflictingExecutionParamsError {
@@ -130,7 +130,7 @@ mutation TerminateRun($runId: String!) {
     __typename
     ... on TerminateRunSuccess{
       run {
-        runId
+        id
       }
     }
     ... on TerminateRunFailure {

--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -230,7 +230,7 @@ subscription subscribeTest($runId: ID!) {
     __typename
     ... on PipelineRunLogsSubscriptionSuccess {
       run {
-        runId
+        id
       }
       messages {
         ...messageEventFragment
@@ -280,7 +280,7 @@ mutation($executionParams: ExecutionParams!) {
     }
     ... on LaunchRunSuccess {
       run {
-        runId
+        id
         pipeline {
           name
         }
@@ -335,7 +335,7 @@ mutation($executionParams: ExecutionParams, $reexecutionParams: ReexecutionParam
     }
     ... on LaunchRunSuccess {
       run {
-        runId
+        id
         status
         pipeline {
           name

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -277,7 +277,6 @@ class GrapheneEventConnectionOrError(graphene.Union):
 
 class GraphenePipelineRun(graphene.Interface):
     id = graphene.NonNull(graphene.ID)
-    runId = graphene.NonNull(graphene.String)
     # Nullable because of historical runs
     pipelineSnapshotId = graphene.String()
     repositoryOrigin = graphene.Field(GrapheneRepositoryOrigin)
@@ -323,7 +322,6 @@ class GraphenePipelineRun(graphene.Interface):
 
 class GrapheneRun(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
-    runId = graphene.NonNull(graphene.String)
     # Nullable because of historical runs
     pipelineSnapshotId = graphene.String()
     parentPipelineSnapshotId = graphene.String()
@@ -374,7 +372,7 @@ class GrapheneRun(graphene.ObjectType):
         check.inst_param(record, "record", RunRecord)
         pipeline_run = record.dagster_run
         super().__init__(
-            runId=pipeline_run.run_id,
+            id=pipeline_run.run_id,
             status=pipeline_run.status.value,
             mode=pipeline_run.mode,
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_status.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_get_run_status.py
@@ -71,7 +71,7 @@ class TestGetRunStatusWithClient(ExecutingGraphQLContextTestMatrix):
         assert not result.errors
         assert result.data
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
         start_time = time.time()
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -9,7 +9,7 @@ EXPECTED_RUN_ID = "foo"
 launch_pipeline_success_response = {
     "launchPipelineExecution": {
         "__typename": "LaunchRunSuccess",
-        "run": {"runId": EXPECTED_RUN_ID},
+        "run": {"id": EXPECTED_RUN_ID},
     }
 }
 
@@ -92,7 +92,7 @@ def test_complex_tags_success(mock_client: MockClient):
     response = {
         "launchPipelineExecution": {
             "__typename": "LaunchRunSuccess",
-            "run": {"runId": EXPECTED_RUN_ID},
+            "run": {"id": EXPECTED_RUN_ID},
         }
     }
     mock_client.mock_gql_client.execute.return_value = response
@@ -163,7 +163,7 @@ def test_no_location_or_repo_provided_success(mock_client: MockClient):
     submit_execution_response = {
         "launchPipelineExecution": {
             "__typename": "LaunchRunSuccess",
-            "run": {"runId": EXPECTED_RUN_ID},
+            "run": {"id": EXPECTED_RUN_ID},
         }
     }
     mock_client.mock_gql_client.execute.side_effect = [
@@ -209,7 +209,7 @@ def no_location_or_repo_provided_duplicate_pipeline_mock_config(mock_client: Moc
     submit_execution_response = {
         "launchPipelineExecution": {
             "__typename": "LaunchRunSuccess",
-            "run": {"runId": EXPECTED_RUN_ID},
+            "run": {"id": EXPECTED_RUN_ID},
         }
     }
     mock_client.mock_gql_client.execute.side_effect = [
@@ -260,7 +260,7 @@ def no_location_or_repo_provided_mock_config(mock_client):
     submit_execution_response = {
         "launchPipelineExecution": {
             "__typename": "LaunchRunSuccess",
-            "run": {"runId": EXPECTED_RUN_ID},
+            "run": {"id": EXPECTED_RUN_ID},
         }
     }
     mock_client.mock_gql_client.execute.side_effect = [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
@@ -14,7 +14,7 @@ query RunsQuery {
     __typename
     ... on PipelineRuns {
       results {
-        runId
+        id
         pipelineName
         status
         runConfigYaml
@@ -40,7 +40,7 @@ query PaginatedRunsQuery($cursor: String!, $limit: Int) {
     __typename
     ... on PipelineRuns {
       results {
-        runId
+        id
         pipelineName
         status
         runConfigYaml
@@ -63,7 +63,7 @@ query FilteredRunsQuery {
     __typename
     ... on PipelineRuns {
       results {
-        runId
+        id
         pipelineName
         status
         runConfigYaml
@@ -137,7 +137,7 @@ mutation ExecutePipeline(
     __typename
     ... on LaunchPipelineRunSuccess {
       run {
-        runId
+        id
       }
     }
     ... on PipelineConfigValidationInvalid {
@@ -191,7 +191,7 @@ def test_runs_query():
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
             result = execute_dagster_graphql(context, RUNS_QUERY)
             assert result.data
-            run_ids = [run["runId"] for run in result.data["pipelineRunsOrError"]["results"]]
+            run_ids = [run["id"] for run in result.data["pipelineRunsOrError"]["results"]]
             assert len(run_ids) == 2
             assert run_ids[0] == run_id_2
             assert run_ids[1] == run_id_1
@@ -216,7 +216,7 @@ def test_paginated_runs_query():
                 variables={"cursor": run_id_3, "limit": 1},
             )
             assert result.data
-            run_ids = [run["runId"] for run in result.data["pipelineRunsOrError"]["results"]]
+            run_ids = [run["id"] for run in result.data["pipelineRunsOrError"]["results"]]
             assert len(run_ids) == 1
             assert run_ids[0] == run_id_2
 
@@ -236,7 +236,7 @@ def test_filtered_runs_query():
         with define_out_of_process_context(__file__, "get_repo", instance) as context:
             result = execute_dagster_graphql(context, FILTERED_RUNS_QUERY)
             assert result.data
-            run_ids = [run["runId"] for run in result.data["pipelineRunsOrError"]["results"]]
+            run_ids = [run["id"] for run in result.data["pipelineRunsOrError"]["results"]]
             assert len(run_ids) == 1
             assert run_ids[0] == run_id_2
 
@@ -286,7 +286,7 @@ def test_launch_mutation():
             assert not result.errors
             assert result.data
             run = result.data["launchPipelineExecution"]["run"]
-            assert run and run["runId"]
+            assert run and run["id"]
 
 
 def test_launch_mutation_error():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -562,7 +562,7 @@ def _create_run(
         },
     )
     assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-    run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+    run_id = result.data["launchPipelineExecution"]["run"]["id"]
     poll_for_finished_run(graphql_context.instance, run_id)
     return run_id
 
@@ -908,7 +908,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
             variables={"pipelineSelector": selector, "partition": "a"},
         )
         assert result.data
-        assert result.data["assetNodes"][0]["latestRunForPartition"]["runId"] == run_id
+        assert result.data["assetNodes"][0]["latestRunForPartition"]["id"] == run_id
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -1522,7 +1522,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
                 },
             },
         )
-        run_id = result.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineReexecution"]["run"]["id"]
         poll_for_finished_run(graphql_context.instance, run_id)
 
         run = graphql_context.instance.get_run_by_id(run_id)
@@ -2061,7 +2061,7 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
             assert not result.errors
             assert result.data
 
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             # ensure the execution has happened
             while not os.path.exists(path):
@@ -2124,7 +2124,7 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
             assert not result.errors
             assert result.data
 
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             # ensure the execution has happened
             while not os.path.exists(path):
@@ -2182,7 +2182,7 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
             assert not result.errors
             assert result.data
 
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             # ensure the execution has happened
             while not os.path.exists(path):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
@@ -36,7 +36,7 @@ class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
             context=graphql_context,
             variables={"executionParams": {"selector": selector, "mode": "default"}},
         )
-        run_id = payload["run"]["runId"]
+        run_id = payload["run"]["id"]
 
         logs = graphql_context.instance.all_logs(run_id, of_type=DagsterEventType.LOGS_CAPTURED)
         assert len(logs) == 1
@@ -57,7 +57,7 @@ class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
             context=graphql_context,
             variables={"executionParams": {"selector": selector, "mode": "default"}},
         )
-        run_id = payload["run"]["runId"]
+        run_id = payload["run"]["id"]
         logs = graphql_context.instance.all_logs(run_id, of_type=DagsterEventType.LOGS_CAPTURED)
         assert len(logs) == 1
         entry = logs[0]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_compute_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_compute_logs.py
@@ -12,7 +12,7 @@ COMPUTE_LOGS_QUERY = """
   query ComputeLogsQuery($runId: ID!, $stepKey: String!) {
     pipelineRunOrError(runId: $runId) {
       ... on PipelineRun {
-        runId
+        id
         computeLogs(stepKey: $stepKey) {
           stdout {
             data
@@ -38,7 +38,7 @@ class TestComputeLogs(ExecutingGraphQLContextTestMatrix):
             context=graphql_context,
             variables={"executionParams": {"selector": selector, "mode": "default"}},
         )
-        run_id = payload["run"]["runId"]
+        run_id = payload["run"]["id"]
         logs = graphql_context.instance.all_logs(run_id, of_type=DagsterEventType.LOGS_CAPTURED)
         assert len(logs) == 1
         entry = logs[0]
@@ -57,7 +57,7 @@ class TestComputeLogs(ExecutingGraphQLContextTestMatrix):
             context=graphql_context,
             variables={"executionParams": {"selector": selector, "mode": "default"}},
         )
-        run_id = payload["run"]["runId"]
+        run_id = payload["run"]["id"]
         logs = graphql_context.instance.all_logs(run_id, of_type=DagsterEventType.LOGS_CAPTURED)
         assert len(logs) == 1
         entry = logs[0]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dynamic_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dynamic_pipeline.py
@@ -38,7 +38,7 @@ def test_dynamic_resume_reexecution(graphql_context: WorkspaceRequestContext):
     assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
     assert result.data["launchPipelineExecution"]["run"]["pipeline"]["name"] == "dynamic_job"
 
-    parent_run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+    parent_run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
     logs = get_all_logs_for_finished_run_via_subscription(graphql_context, parent_run_id)[
         "pipelineRunLogs"
@@ -74,7 +74,7 @@ def test_dynamic_resume_reexecution(graphql_context: WorkspaceRequestContext):
         retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
     ), retry_one.data["launchPipelineReexecution"].get("message")
 
-    run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+    run_id = retry_one.data["launchPipelineReexecution"]["run"]["id"]
 
     logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
         "pipelineRunLogs"
@@ -111,7 +111,7 @@ def test_dynamic_full_reexecution(graphql_context: WorkspaceRequestContext):
     assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
     assert result.data["launchPipelineExecution"]["run"]["pipeline"]["name"] == "dynamic_job"
 
-    parent_run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+    parent_run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
     logs = get_all_logs_for_finished_run_via_subscription(graphql_context, parent_run_id)[
         "pipelineRunLogs"
@@ -147,7 +147,7 @@ def test_dynamic_full_reexecution(graphql_context: WorkspaceRequestContext):
         retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
     ), retry_one.data["launchPipelineReexecution"].get("message")
 
-    run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+    run_id = retry_one.data["launchPipelineReexecution"]["run"]["id"]
 
     logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
         "pipelineRunLogs"
@@ -184,7 +184,7 @@ def test_dynamic_subset(graphql_context: WorkspaceRequestContext):
     assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
     assert result.data["launchPipelineExecution"]["run"]["pipeline"]["name"] == "dynamic_job"
 
-    parent_run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+    parent_run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
     logs = get_all_logs_for_finished_run_via_subscription(graphql_context, parent_run_id)[
         "pipelineRunLogs"
@@ -226,7 +226,7 @@ def test_dynamic_subset(graphql_context: WorkspaceRequestContext):
         retry_one.data["launchPipelineReexecution"]["__typename"] == "LaunchRunSuccess"
     ), retry_one.data["launchPipelineReexecution"].get("message")
 
-    run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+    run_id = retry_one.data["launchPipelineReexecution"]["run"]["id"]
 
     logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
         "pipelineRunLogs"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_execute_pipeline.py
@@ -94,7 +94,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
 
         # just test existence
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-        assert uuid.UUID(result.data["launchPipelineExecution"]["run"]["runId"])
+        assert uuid.UUID(result.data["launchPipelineExecution"]["run"]["id"])
         assert (
             result.data["launchPipelineExecution"]["run"]["pipeline"]["name"] == "csv_hello_world"
         )
@@ -119,7 +119,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
 
         # just test existence
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-        assert uuid.UUID(result.data["launchPipelineExecution"]["run"]["runId"])
+        assert uuid.UUID(result.data["launchPipelineExecution"]["run"]["id"])
         assert (
             result.data["launchPipelineExecution"]["run"]["pipeline"]["name"] == "csv_hello_world"
         )
@@ -168,7 +168,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
 
         # just test existence
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-        assert uuid.UUID(result.data["launchPipelineExecution"]["run"]["runId"])
+        assert uuid.UUID(result.data["launchPipelineExecution"]["run"]["id"])
         assert (
             result.data["launchPipelineExecution"]["run"]["pipeline"]["name"]
             == "hello_world_with_tags"
@@ -374,7 +374,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         events_result = execute_dagster_graphql(
             graphql_context,
             RUN_EVENTS_QUERY,
-            variables={"runId": exc_result.data["launchPipelineExecution"]["run"]["runId"]},
+            variables={"runId": exc_result.data["launchPipelineExecution"]["run"]["id"]},
         )
 
         assert not events_result.errors
@@ -419,7 +419,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
                 graphql_context,
                 RUN_EVENTS_QUERY,
                 variables={
-                    "runId": exc_result.data["launchPipelineExecution"]["run"]["runId"],
+                    "runId": exc_result.data["launchPipelineExecution"]["run"]["id"],
                     "cursor": cursor,
                 },
             )
@@ -474,7 +474,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess", str(
             result.data
         )
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
         wait_for_runs_to_finish(graphql_context.instance)
 
@@ -610,7 +610,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
         run = result.data["launchPipelineExecution"]["run"]
-        run_id = run["runId"]
+        run_id = run["id"]
         assert len(run["tags"]) > 0
         assert any(
             [x["key"] == "dagster/test_key" and x["value"] == "test_value" for x in run["tags"]]
@@ -704,7 +704,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
             },
         )
         run = result.data["launchPipelineExecution"]["run"]
-        run_id = run["runId"]
+        run_id = run["id"]
 
         wait_for_runs_to_finish(graphql_context.instance)
 
@@ -729,7 +729,7 @@ class TestExecutePipeline(ExecutingGraphQLContextTestMatrix):
             },
         )
         run = result.data["launchPipelineExecution"]["run"]
-        run_id = run["runId"]
+        run_id = run["id"]
 
         wait_for_runs_to_finish(graphql_context.instance)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reexecution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reexecution.py
@@ -40,7 +40,7 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
         assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
-        result_one.data["launchPipelineExecution"]["run"]["runId"] = "<runId dummy value>"
+        result_one.data["launchPipelineExecution"]["run"]["id"] = "<runId dummy value>"
         result_one.data["launchPipelineExecution"]["run"][
             "runConfigYaml"
         ] = "<runConfigYaml dummy value>"
@@ -90,7 +90,7 @@ class TestReexecution(ExecutingGraphQLContextTestMatrix):
 
         assert result_one.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
 
-        result_one.data["launchPipelineExecution"]["run"]["runId"] = "<runId dummy value>"
+        result_one.data["launchPipelineExecution"]["run"]["id"] = "<runId dummy value>"
         result_one.data["launchPipelineExecution"]["run"][
             "runConfigYaml"
         ] = "<runConfigYaml dummy value>"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -110,7 +110,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -138,7 +138,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry_one.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -165,7 +165,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = retry_two.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry_two.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -193,7 +193,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = retry_three.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry_three.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -218,7 +218,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(context, run_id)["pipelineRunLogs"][
             "messages"
         ]
@@ -239,7 +239,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
                 }
             },
         )
-        run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry_one.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(context, run_id)["pipelineRunLogs"][
             "messages"
         ]
@@ -256,7 +256,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(context, run_id)["pipelineRunLogs"][
             "messages"
         ]
@@ -277,7 +277,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = retry_one.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry_one.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(context, run_id)["pipelineRunLogs"][
             "messages"
         ]
@@ -298,7 +298,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = retry_two.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry_two.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(context, run_id)["pipelineRunLogs"][
             "messages"
         ]
@@ -480,7 +480,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -505,7 +505,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry.data["launchPipelineReexecution"]["run"]["id"]
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
             "pipelineRunLogs"
         ]["messages"]
@@ -536,7 +536,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         finally:
             os.remove(output_file)
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run and run.status == DagsterRunStatus.FAILURE
 
@@ -549,7 +549,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         assert retry.data["launchPipelineReexecution"].get("run"), retry.data[
             "launchPipelineReexecution"
         ]
-        run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry.data["launchPipelineReexecution"]["run"]["id"]
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run and run.status == DagsterRunStatus.SUCCESS
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[
@@ -583,7 +583,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         finally:
             os.remove(output_file)
 
-        parent_run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        parent_run_id = result.data["launchPipelineExecution"]["run"]["id"]
         parent_run = graphql_context.instance.get_run_by_id(parent_run_id)
         assert parent_run
         assert parent_run.status == DagsterRunStatus.FAILURE
@@ -625,7 +625,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
         finally:
             os.remove(output_file)
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run and run.status == DagsterRunStatus.FAILURE
 
@@ -635,7 +635,7 @@ class TestHardFailures(ExecutingGraphQLContextTestMatrix):
             variables={"reexecutionParams": {"parentRunId": run_id, "strategy": "FROM_FAILURE"}},
         )
 
-        run_id = retry.data["launchPipelineReexecution"]["run"]["runId"]
+        run_id = retry.data["launchPipelineReexecution"]["run"]["id"]
         run = graphql_context.instance.get_run_by_id(run_id)
         assert run and run.status == DagsterRunStatus.SUCCESS
         logs = get_all_logs_for_finished_run_via_subscription(graphql_context, run_id)[

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_cancellation.py
@@ -25,12 +25,12 @@ mutation($runId: String!, $terminatePolicy: TerminateRunPolicy) {
     __typename
     ... on TerminateRunSuccess{
       run {
-        runId
+        id
       }
     }
     ... on TerminateRunFailure {
       run {
-        runId
+        id
       }
       message
     }
@@ -52,7 +52,7 @@ mutation TerminatePipeline($runId: String!) {
     __typename
     ... on TerminatePipelineExecutionSuccess{
       run {
-        runId
+        id
       }
     }
     ... on TerminatePipelineExecutionFailure {
@@ -96,7 +96,7 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
 
             # just test existence
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             run = graphql_context.instance.get_run_by_id(run_id)
             assert run and run.status == DagsterRunStatus.QUEUED
@@ -128,7 +128,7 @@ class TestQueuedRunTermination(QueuedRunCoordinatorTestSuite):
 
             # just test existence
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             run = graphql_context.instance.get_run_by_id(run_id)
             assert run and run.status == DagsterRunStatus.QUEUED
@@ -191,7 +191,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
 
             # just test existence
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             assert run_id
 
@@ -224,7 +224,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
 
             # just test existence
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             assert run_id
 
@@ -286,7 +286,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
 
             # just test existence
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
             # ensure the execution has happened
             while not os.path.exists(path):
                 time.sleep(0.1)
@@ -309,7 +309,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
 
             assert result.data["terminatePipelineExecution"]["__typename"] == "TerminateRunSuccess"
 
-            assert result.data["terminatePipelineExecution"]["run"]["runId"] == run_id
+            assert result.data["terminatePipelineExecution"]["run"]["id"] == run_id
 
             graphql_context.instance.run_launcher.terminate = old_terminate
 
@@ -382,7 +382,7 @@ class TestRunVariantTermination(RunTerminationTestSuite):
 
             # just test existence
             assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
-            run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
             assert run_id
 
@@ -395,4 +395,4 @@ class TestRunVariantTermination(RunTerminationTestSuite):
                 BACKCOMPAT_LEGACY_TERMINATE_PIPELINE,
                 variables={"runId": run_id},
             )
-            assert result.data["terminatePipelineExecution"]["run"]["runId"] == run_id
+            assert result.data["terminatePipelineExecution"]["run"]["id"] == run_id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_run_launcher.py
@@ -43,7 +43,7 @@ class TestBasicLaunch(BaseTestSuite):
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
         assert result.data["launchPipelineExecution"]["run"]["status"] == "STARTING"
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
         wait_for_runs_to_finish(graphql_context.instance)
 
@@ -69,7 +69,7 @@ class TestBasicLaunch(BaseTestSuite):
         assert result.data["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
         assert result.data["launchPipelineExecution"]["run"]["status"] == "STARTING"
 
-        run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+        run_id = result.data["launchPipelineExecution"]["run"]["id"]
 
         wait_for_runs_to_finish(graphql_context.instance)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -260,7 +260,6 @@ query RepositorySchedulesQuery($repositorySelector: RepositorySelector!) {
                     id
                     runs(limit: 1) {
                       id
-                      runId
                     }
                     ticks(limit: 1) {
                       id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -59,7 +59,6 @@ query SensorsQuery($repositorySelector: RepositorySelector!) {
           status
           runs {
               id
-              runId
           }
           runsCount
           ticks {
@@ -124,7 +123,6 @@ query SensorQuery($sensorSelector: SensorSelector!) {
         status
         runs {
           id
-          runId
         }
         runsCount
         ticks {
@@ -329,7 +327,6 @@ query RepositorySensorsQuery($repositorySelector: RepositorySelector!) {
                     id
                     runs(limit: 1) {
                       id
-                      runId
                     }
                     ticks(limit: 1) {
                       id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/utils.py
@@ -56,7 +56,7 @@ def sync_execute_get_payload(variables, context):
 
     wait_for_runs_to_finish(context.instance)
 
-    run_id = result.data["launchPipelineExecution"]["run"]["runId"]
+    run_id = result.data["launchPipelineExecution"]["run"]["id"]
     return get_all_logs_for_finished_run_via_subscription(context, run_id)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
@@ -109,7 +109,7 @@ mutation ($executionParams: ExecutionParams!) {
         __typename
         ... on LaunchRunSuccess {
             run {
-                runId
+                id
                 pipeline { ...on PipelineReference { name } }
             }
         }
@@ -302,7 +302,7 @@ def test_logs_in_start_execution_predefined():
             assert (
                 result_data["data"]["launchPipelineExecution"]["__typename"] == "LaunchRunSuccess"
             )
-            run_id = result_data["data"]["launchPipelineExecution"]["run"]["runId"]
+            run_id = result_data["data"]["launchPipelineExecution"]["run"]["id"]
 
             # allow FS events to flush
             retries = 5

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/hooks/dagster_hook.py
@@ -259,7 +259,6 @@ mutation Terminate($runId: String!, $terminatePolicy: TerminateRunPolicy) {
     ... on TerminateRunSuccess {
       run {
         id
-        runId
         canTerminate
         __typename
       }

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
@@ -42,7 +42,7 @@ def test_execute_hammer_through_dagit():
             if start_pipeline_result.errors:
                 raise Exception(f"{start_pipeline_result.errors}")
 
-            run_id = start_pipeline_result.data["launchPipelineExecution"]["run"]["runId"]
+            run_id = start_pipeline_result.data["launchPipelineExecution"]["run"]["id"]
 
             context.instance.run_launcher.join(timeout=60)
 


### PR DESCRIPTION
## Summary & Motivation

This is a follow-up to https://github.com/dagster-io/dagster/pull/13578.

Our GraphQL API exposes both `Run.id` and `Run.runId`.  In general, consumers of the GraphQL API should be using Run.id because the id field is understood to be a unique key in Apollo and other client libraries. #13578 removes all usage of `Run.runId` in Dagit, and this PR removes it from the GraphQL layer tests.

## How I Tested These Changes

- Viewed, started, cancelled runs in Dagit
- Verified that all tests still pass