### PR TITLE
Default bind top-level resources to jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -241,7 +241,6 @@ def _create_repository_using_definitions_args(
         schedules_with_resources,
         sensors_with_resources,
     ) = _attach_resources_to_jobs_and_instigator_jobs(jobs, schedules, sensors, resource_defs)
-   
 
     @repository(
         name=name,

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -13,7 +12,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import deprecated, experimental, public
 from dagster._config.pythonic_config import (
     attach_resource_id_to_key_mapping,
 )
@@ -236,40 +235,13 @@ def _create_repository_using_definitions_args(
 
     check.opt_mapping_param(loggers, "loggers", key_type=str, value_type=LoggerDefinition)
 
-    if isinstance(jobs, BindResourcesToJobs):
-        # Binds top-level resources to jobs and any jobs attached to schedules or sensors
-        (
-            jobs_with_resources,
-            schedules_with_resources,
-            sensors_with_resources,
-        ) = _attach_resources_to_jobs_and_instigator_jobs(jobs, schedules, sensors, resource_defs)
-    else:
-        jobs_to_warn = _jobs_which_will_have_io_manager_replaced(jobs, resource_defs)
-        if jobs_to_warn:
-            jobs_text = ", ".join([f"`{job.name}`" for job in jobs_to_warn[:10]])
-            if len(jobs_to_warn) > 10:
-                jobs_text += f", and {len(jobs_to_warn) - 10} others"
-            warnings.warn(
-                f"""You have overridden the default `io_manager` on `Definitions`. One or more jobs utilize the default filesystem I/O manager. In the future, these jobs will use the `Definitions`-level override instead. To silence this warning, explicitly set the `io_manager` on the jobs in question:
-
-@job(resource_defs={{'io_manager': fs_io_manager}})
-def my_job():
-    ...
-    
-Alternatively, wrap the jobs input to `Definitions` with `BindResourceToJobs`:
-
-defs = Definitions(
-    jobs=BindResourcesToJobs([my_job, my_other_job, ...])
-)
-
-In later releases, this will be the default behavior, and `BindResourcesToJobs` will not be required.
-
-The following jobs are affected: {jobs_text}
-                """
-            )
-        jobs_with_resources = jobs or []
-        schedules_with_resources = schedules or []
-        sensors_with_resources = sensors or []
+    # Binds top-level resources to jobs and any jobs attached to schedules or sensors
+    (
+        jobs_with_resources,
+        schedules_with_resources,
+        sensors_with_resources,
+    ) = _attach_resources_to_jobs_and_instigator_jobs(jobs, schedules, sensors, resource_defs)
+   
 
     @repository(
         name=name,
@@ -289,8 +261,11 @@ The following jobs are affected: {jobs_text}
     return created_repo
 
 
+@deprecated
 class BindResourcesToJobs(list):
-    pass
+    """Used to instruct Dagster to bind top-level resources to jobs and any jobs attached to schedules
+    and sensors. Now deprecated since this behavior is the default.
+    """
 
 
 class Definitions:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 from dagster import Definitions, asset, graph, job, op, repository, resource
 from dagster._config.field_utils import EnvVar
 from dagster._config.pythonic_config import Config, ConfigurableResource
-from dagster._core.definitions.definitions_class import BindResourcesToJobs
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
@@ -480,7 +479,7 @@ def test_repository_snap_definitions_resources_job_op_usage() -> None:
         my_op_in_other_job()
 
     defs = Definitions(
-        jobs=BindResourcesToJobs([my_first_job, my_second_job]),
+        jobs=[my_first_job, my_second_job],
         resources={"foo": MyResource(a_str="foo"), "bar": MyResource(a_str="bar")},
     )
 
@@ -540,7 +539,7 @@ def test_repository_snap_definitions_resources_job_op_usage_graph() -> None:
         my_op()
 
     defs = Definitions(
-        jobs=BindResourcesToJobs([my_job]),
+        jobs=[my_job],
         resources={"foo": MyResource(a_str="foo"), "bar": MyResource(a_str="bar")},
     )
 


### PR DESCRIPTION
## Summary

Deprecates `BindResourcesToJobs` and makes its behavior the default behavior for `Definitions`.


## Test Plan

Updates tests which used `BindResourcesToJobs` to omit the wrapper. Left a single test to ensure users who were using `BindResourcesToJobs` are unaffected.