### PR TITLE
Make rules in MakeConfigCacheable much more strict

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -83,6 +83,10 @@ from .utils import safe_is_subclass
 
 Self = TypeVar("Self", bound="ConfigurableResourceFactory")
 
+INTERNAL_MARKER = "__internal__"
+
+assert CACHED_METHOD_FIELD_SUFFIX.endswith(INTERNAL_MARKER)
+
 
 class MakeConfigCacheable(BaseModel):
     """This class centralizes and implements all the chicanery we need in order
@@ -113,7 +117,7 @@ class MakeConfigCacheable(BaseModel):
         return super().__setattr__(name, value)
 
     def _is_field_internal(self, name: str) -> bool:
-        return name.endswith("__internal__") or name.endswith(CACHED_METHOD_FIELD_SUFFIX)
+        return name.endswith(INTERNAL_MARKER)
 
 
 class Config(MakeConfigCacheable):

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -85,6 +85,7 @@ Self = TypeVar("Self", bound="ConfigurableResourceFactory")
 
 INTERNAL_MARKER = "__internal__"
 
+# ensure that this ends with the internal marker so we can do a single check
 assert CACHED_METHOD_FIELD_SUFFIX.endswith(INTERNAL_MARKER)
 
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -497,7 +497,7 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
 class ConfigurableResourceFactoryState(NamedTuple):
     nested_partial_resources: Mapping[str, CoercibleToResource]
     resolved_config_dict: Dict[str, Any]
-    config_schema: DagsterField
+    config_schema: DefinitionConfigSchema
     schema: DagsterField
     nested_resources: Dict[str, CoercibleToResource]
 
@@ -966,11 +966,11 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
 
     def get_resource_definition(self) -> ConfigurableIOManagerFactoryResourceDefinition:
         return ConfigurableIOManagerFactoryResourceDefinition(
-            resource_fn=self._resource_fn,
-            config_schema=self._config_schema,
-            description=self._description,
+            resource_fn=self._state__internal__.resource_fn,
+            config_schema=self._state__internal__.config_schema,
+            description=self._state__internal__.description,
             resolve_resource_keys=self._resolve_required_resource_keys,
-            nested_resources=self.nested_resources,
+            nested_resources=self._state__internal__.nested_resources,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

MakeConfigCacheable is a class that allows us attach variables directly to Pydantic classes that are otherwise immutable. Before we had a fairly blanket policy of allowing any variable starting with "_" to be set on these classes. That was very broad and it would be easier for our users to get themselves into trouble.

Here we make this much more strict and only fields ending in `__internal__` can be set on these classes. For the classes the depend on this behavior I extracted out a separate class so that only these variables exist per class.

## How I Tested These Changes

BK
