### PR TITLE
[ui] Remove custom ID function from Apollo cache setup

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppCache.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppCache.tsx
@@ -1,6 +1,5 @@
-import {InMemoryCache, defaultDataIdFromObject} from '@apollo/client';
+import {InMemoryCache} from '@apollo/client';
 
-// this is a require cause otherwise it breaks
 import possibleTypes from '../graphql/possibleTypes.generated.json';
 
 export const createAppCache = () =>
@@ -11,19 +10,5 @@ export const createAppCache = () =>
       PartitionStatus: {
         keyFields: false,
       },
-    },
-    dataIdFromObject: (object: any) => {
-      if (
-        object.name &&
-        (object.__typename === 'RegularType' || object.__typename === 'CompositeType')
-      ) {
-        return `Type.${object.name}`;
-      } else if (object.__typename === 'Instance') {
-        return 'Instance';
-      } else if (object.__typename === 'Workspace') {
-        return 'Workspace';
-      } else {
-        return defaultDataIdFromObject(object);
-      }
     },
   });

--- a/js_modules/dagit/packages/core/src/app/Permissions.tsx
+++ b/js_modules/dagit/packages/core/src/app/Permissions.tsx
@@ -227,6 +227,7 @@ export const PERMISSIONS_QUERY = gql`
     }
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           name

--- a/js_modules/dagit/packages/core/src/app/types/Permissions.types.ts
+++ b/js_modules/dagit/packages/core/src/app/types/Permissions.types.ts
@@ -16,6 +16,7 @@ export type PermissionsQuery = {
     | {__typename: 'PythonError'}
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;

--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -720,6 +720,7 @@ const UpstreamUnavailableWarning: React.FC<{
 export const LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY = gql`
   query LaunchAssetChoosePartitionsQuery {
     instance {
+      id
       ...DaemonNotRunningAlertInstanceFragment
       ...UsingDefaultLauncherAlertInstanceFragment
     }

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsQuery.fixtures.tsx
@@ -1,5 +1,11 @@
 import {MockedResponse} from '@apollo/client/testing';
 
+import {
+  buildDaemonHealth,
+  buildDaemonStatus,
+  buildInstance,
+  buildRunLauncher,
+} from '../../graphql/types';
 import {LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY} from '../LaunchAssetChoosePartitionsDialog';
 import {LaunchAssetChoosePartitionsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
 
@@ -11,23 +17,19 @@ export const ReleasesWorkspace: MockedResponse<LaunchAssetChoosePartitionsQuery>
   result: {
     data: {
       __typename: 'DagitQuery',
-      instance: {
-        daemonHealth: {
+      instance: buildInstance({
+        daemonHealth: buildDaemonHealth({
           id: 'daemonHealth',
-          daemonStatus: {
+          daemonStatus: buildDaemonStatus({
             id: 'BACKFILL',
             healthy: false,
-            __typename: 'DaemonStatus',
-          },
-          __typename: 'DaemonHealth',
-        },
-        __typename: 'Instance',
+          }),
+        }),
         runQueuingSupported: false,
-        runLauncher: {
+        runLauncher: buildRunLauncher({
           name: 'DefaultRunLauncher',
-          __typename: 'RunLauncher',
-        },
-      },
+        }),
+      }),
     },
   },
 };

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -7,7 +7,11 @@ import {
   LaunchBackfillParams,
   PartitionDefinitionType,
   PartitionRangeStatus,
+  buildDaemonHealth,
+  buildDaemonStatus,
   buildDimensionDefinitionType,
+  buildInstance,
+  buildRunLauncher,
 } from '../../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/BackfillUtils';
 import {LaunchPartitionBackfillMutation} from '../../instance/types/BackfillUtils.types';
@@ -194,16 +198,17 @@ export const LaunchAssetChoosePartitionsMock: MockedResponse<LaunchAssetChoosePa
   result: {
     data: {
       __typename: 'DagitQuery',
-      instance: {
-        daemonHealth: {
+      instance: buildInstance({
+        daemonHealth: buildDaemonHealth({
           id: 'daemonHealth',
-          daemonStatus: {id: 'BACKFILL', healthy: false, __typename: 'DaemonStatus'},
-          __typename: 'DaemonHealth',
-        },
-        __typename: 'Instance',
+          daemonStatus: buildDaemonStatus({
+            id: 'BACKFILL',
+            healthy: false,
+          }),
+        }),
         runQueuingSupported: false,
-        runLauncher: {name: 'DefaultRunLauncher', __typename: 'RunLauncher'},
-      },
+        runLauncher: buildRunLauncher({name: 'DefaultRunLauncher'}),
+      }),
     },
   },
 };

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -8,6 +8,7 @@ export type LaunchAssetChoosePartitionsQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
+    id: string;
     runQueuingSupported: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1341,6 +1341,7 @@ type ReloadWorkspaceMutation {
 union ReloadWorkspaceMutationResult = Workspace | UnauthorizedError | PythonError
 
 type Workspace {
+  id: String!
   locationEntries: [WorkspaceLocationEntry!]!
 }
 
@@ -2116,6 +2117,7 @@ type DaemonStatus {
 }
 
 type Instance {
+  id: String!
   info: String
   runLauncher: RunLauncher
   runQueuingSupported: Boolean!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1564,6 +1564,7 @@ export type Instance = {
   executablePath: Scalars['String'];
   hasCapturedLogManager: Scalars['Boolean'];
   hasInfo: Scalars['Boolean'];
+  id: Scalars['String'];
   info: Maybe<Scalars['String']>;
   runLauncher: Maybe<RunLauncher>;
   runQueuingSupported: Scalars['Boolean'];
@@ -3883,6 +3884,7 @@ export type UsedSolid = {
 
 export type Workspace = {
   __typename: 'Workspace';
+  id: Scalars['String'];
   locationEntries: Array<WorkspaceLocationEntry>;
 };
 
@@ -7062,6 +7064,7 @@ export const buildInstance = (
         ? overrides.hasCapturedLogManager!
         : true,
     hasInfo: overrides && overrides.hasOwnProperty('hasInfo') ? overrides.hasInfo! : true,
+    id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'deleniti',
     info: overrides && overrides.hasOwnProperty('info') ? overrides.info! : 'qui',
     runLauncher:
       overrides && overrides.hasOwnProperty('runLauncher')
@@ -12751,6 +12754,7 @@ export const buildWorkspace = (
   relationshipsToOmit.add('Workspace');
   return {
     __typename: 'Workspace',
+    id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'id',
     locationEntries:
       overrides && overrides.hasOwnProperty('locationEntries')
         ? overrides.locationEntries!

--- a/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceBackfills.tsx
@@ -113,6 +113,7 @@ export const InstanceBackfills = () => {
 const INSTANCE_HEALTH_FOR_BACKFILLS_QUERY = gql`
   query InstanceHealthForBackfillsQuery {
     instance {
+      id
       ...InstanceHealthFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceConfig.tsx
@@ -105,6 +105,7 @@ export const INSTANCE_CONFIG_QUERY = gql`
   query InstanceConfigQuery {
     version
     instance {
+      id
       info
     }
   }

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthFragment.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthFragment.tsx
@@ -4,6 +4,7 @@ import {DAEMON_HEALTH_FRAGMENT} from './DaemonList';
 
 export const INSTANCE_HEALTH_FRAGMENT = gql`
   fragment InstanceHealthFragment on Instance {
+    id
     daemonHealth {
       id
       ...DaemonHealthFragment

--- a/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/InstanceHealthPage.tsx
@@ -60,6 +60,7 @@ export default InstanceHealthPage;
 const INSTANCE_HEALTH_QUERY = gql`
   query InstanceHealthQuery {
     instance {
+      id
       ...InstanceHealthFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
@@ -8,6 +8,7 @@ export type InstanceHealthForBackfillsQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceConfig.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceConfig.types.ts
@@ -7,5 +7,5 @@ export type InstanceConfigQueryVariables = Types.Exact<{[key: string]: never}>;
 export type InstanceConfigQuery = {
   __typename: 'DagitQuery';
   version: string;
-  instance: {__typename: 'Instance'; info: string | null};
+  instance: {__typename: 'Instance'; id: string; info: string | null};
 };

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceHealthFragment.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceHealthFragment.types.ts
@@ -4,6 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type InstanceHealthFragment = {
   __typename: 'Instance';
+  id: string;
   hasInfo: boolean;
   daemonHealth: {
     __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceHealthPage.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceHealthPage.types.ts
@@ -8,6 +8,7 @@ export type InstanceHealthQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/instance/types/useCanSeeConfig.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useCanSeeConfig.types.ts
@@ -6,5 +6,5 @@ export type InstanceConfigHasInfoQueryVariables = Types.Exact<{[key: string]: ne
 
 export type InstanceConfigHasInfoQuery = {
   __typename: 'DagitQuery';
-  instance: {__typename: 'Instance'; hasInfo: boolean};
+  instance: {__typename: 'Instance'; id: string; hasInfo: boolean};
 };

--- a/js_modules/dagit/packages/core/src/instance/types/useDaemonStatus.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useDaemonStatus.types.ts
@@ -8,6 +8,7 @@ export type InstanceWarningQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/instance/types/useSupportsCapturedLogs.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/useSupportsCapturedLogs.types.ts
@@ -6,5 +6,5 @@ export type InstanceSupportsCapturedLogsQueryVariables = Types.Exact<{[key: stri
 
 export type InstanceSupportsCapturedLogsQuery = {
   __typename: 'DagitQuery';
-  instance: {__typename: 'Instance'; hasCapturedLogManager: boolean};
+  instance: {__typename: 'Instance'; id: string; hasCapturedLogManager: boolean};
 };

--- a/js_modules/dagit/packages/core/src/instance/useCanSeeConfig.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useCanSeeConfig.tsx
@@ -15,6 +15,7 @@ export const useCanSeeConfig = () => {
 const INSTANCE_CONFIG_HAS_INFO = gql`
   query InstanceConfigHasInfo {
     instance {
+      id
       hasInfo
     }
   }

--- a/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
@@ -96,6 +96,7 @@ export const useDaemonStatus = (skip = false): StatusAndMessage | null => {
 const INSTANCE_WARNING_QUERY = gql`
   query InstanceWarningQuery {
     instance {
+      id
       ...InstanceHealthFragment
     }
     partitionBackfillsOrError(status: REQUESTED) {

--- a/js_modules/dagit/packages/core/src/instance/useSupportsCapturedLogs.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useSupportsCapturedLogs.tsx
@@ -16,6 +16,7 @@ export const useSupportsCapturedLogs = () => {
 const INSTANCE_SUPPORTS_CAPTURED_LOGS = gql`
   query InstanceSupportsCapturedLogs {
     instance {
+      id
       hasCapturedLogManager
     }
   }

--- a/js_modules/dagit/packages/core/src/nav/__fixtures__/ReloadRepositoryLocationButton.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__fixtures__/ReloadRepositoryLocationButton.fixtures.tsx
@@ -2,6 +2,7 @@ import {MockedResponse} from '@apollo/client/testing';
 
 import {PERMISSIONS_QUERY} from '../../app/Permissions';
 import {PermissionsQuery} from '../../app/types/Permissions.types';
+import {buildPermission, buildWorkspace, buildWorkspaceLocationEntry} from '../../graphql/types';
 
 export const buildPermissionsQuery = (canReload: boolean): MockedResponse<PermissionsQuery> => {
   return {
@@ -12,24 +13,21 @@ export const buildPermissionsQuery = (canReload: boolean): MockedResponse<Permis
       data: {
         __typename: 'DagitQuery',
         unscopedPermissions: [],
-        workspaceOrError: {
-          __typename: 'Workspace',
+        workspaceOrError: buildWorkspace({
           locationEntries: [
-            {
-              __typename: 'WorkspaceLocationEntry',
+            buildWorkspaceLocationEntry({
               id: 'foobar',
               name: 'foobar',
               permissions: [
-                {
-                  __typename: 'Permission',
+                buildPermission({
                   permission: 'reload_repository_location',
                   value: canReload,
                   disabledReason: canReload ? null : 'nope',
-                },
+                }),
               ],
-            },
+            }),
           ],
-        },
+        }),
       },
     },
   };

--- a/js_modules/dagit/packages/core/src/nav/types/useRepositoryLocationReload.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/useRepositoryLocationReload.types.ts
@@ -19,6 +19,7 @@ export type RepositoryLocationStatusQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;
@@ -67,6 +68,7 @@ export type ReloadWorkspaceMutation = {
     | {__typename: 'UnauthorizedError'; message: string}
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           name: string;

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -222,6 +222,7 @@ const REPOSITORY_LOCATION_STATUS_QUERY = gql`
     workspaceOrError {
       __typename
       ... on Workspace {
+        id
         locationEntries {
           __typename
           id
@@ -274,6 +275,7 @@ const RELOAD_WORKSPACE_MUTATION = gql`
   mutation ReloadWorkspaceMutation {
     reloadWorkspace {
       ... on Workspace {
+        id
         locationEntries {
           __typename
           name

--- a/js_modules/dagit/packages/core/src/overview/OverviewJobsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewJobsRoot.tsx
@@ -199,6 +199,7 @@ const OVERVIEW_JOBS_QUERY = gql`
   query OverviewJobsQuery {
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           locationOrLoadError {

--- a/js_modules/dagit/packages/core/src/overview/OverviewResourcesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewResourcesRoot.tsx
@@ -193,6 +193,7 @@ const OVERVIEW_RESOURCES_QUERY = gql`
   query OverviewResourcesQuery {
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           locationOrLoadError {

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -294,6 +294,7 @@ const OVERVIEW_SCHEDULES_QUERY = gql`
   query OverviewSchedulesQuery {
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           locationOrLoadError {
@@ -324,6 +325,7 @@ const OVERVIEW_SCHEDULES_QUERY = gql`
       }
     }
     instance {
+      id
       ...InstanceHealthFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSensorsRoot.tsx
@@ -294,6 +294,7 @@ const OVERVIEW_SENSORS_QUERY = gql`
   query OverviewSensorsQuery {
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           locationOrLoadError {
@@ -325,6 +326,7 @@ const OVERVIEW_SENSORS_QUERY = gql`
       }
     }
     instance {
+      id
       ...InstanceHealthFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewJobsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewJobsRoot.types.ts
@@ -19,6 +19,7 @@ export type OverviewJobsQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewResourcesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewResourcesRoot.types.ts
@@ -19,6 +19,7 @@ export type OverviewResourcesQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
@@ -19,6 +19,7 @@ export type OverviewSchedulesQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;
@@ -60,6 +61,7 @@ export type OverviewSchedulesQuery = {
     | {__typename: 'PythonError'};
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSensorsRoot.types.ts
@@ -19,6 +19,7 @@ export type OverviewSensorsQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;
@@ -61,6 +62,7 @@ export type OverviewSensorsQuery = {
     | {__typename: 'PythonError'};
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
@@ -92,6 +92,7 @@ export function showBackfillSuccessToast(
 
 export const DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT = gql`
   fragment DaemonNotRunningAlertInstanceFragment on Instance {
+    id
     daemonHealth {
       id
       daemonStatus(daemonType: "BACKFILL") {
@@ -129,6 +130,7 @@ export const DaemonNotRunningAlertBody = () => (
 
 export const USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT = gql`
   fragment UsingDefaultLauncherAlertInstanceFragment on Instance {
+    id
     runQueuingSupported
     runLauncher {
       name

--- a/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
@@ -458,6 +458,7 @@ const BACKFILL_SELECTOR_QUERY = gql`
       }
     }
     instance {
+      id
       ...UsingDefaultLauncherAlertInstanceFragment
       ...DaemonNotRunningAlertInstanceFragment
     }

--- a/js_modules/dagit/packages/core/src/partitions/types/BackfillMessaging.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/BackfillMessaging.types.ts
@@ -4,6 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type DaemonNotRunningAlertInstanceFragment = {
   __typename: 'Instance';
+  id: string;
   daemonHealth: {
     __typename: 'DaemonHealth';
     id: string;
@@ -13,6 +14,7 @@ export type DaemonNotRunningAlertInstanceFragment = {
 
 export type UsingDefaultLauncherAlertInstanceFragment = {
   __typename: 'Instance';
+  id: string;
   runQueuingSupported: boolean;
   runLauncher: {__typename: 'RunLauncher'; name: string} | null;
 };

--- a/js_modules/dagit/packages/core/src/partitions/types/BackfillSelector.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/BackfillSelector.types.ts
@@ -160,6 +160,7 @@ export type BackfillSelectorQuery = {
     | {__typename: 'PythonError'};
   instance: {
     __typename: 'Instance';
+    id: string;
     runQueuingSupported: boolean;
     runLauncher: {__typename: 'RunLauncher'; name: string} | null;
     daemonHealth: {

--- a/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRoot.tsx
@@ -275,6 +275,7 @@ const QueueDaemonAlert = () => {
 const QUEUE_DAEMON_STATUS_QUERY = gql`
   query QueueDaemonStatusQuery {
     instance {
+      id
       daemonHealth {
         id
         daemonStatus(daemonType: "QUEUED_RUN_COORDINATOR") {

--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -88,6 +88,7 @@ export default ScheduledRunListRoot;
 const SCHEDULED_RUNS_LIST_QUERY = gql`
   query ScheduledRunsListQuery {
     instance {
+      id
       ...InstanceHealthFragment
     }
     repositoriesOrError {

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRoot.types.ts
@@ -60,6 +60,7 @@ export type QueueDaemonStatusQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
+    id: string;
     daemonHealth: {
       __typename: 'DaemonHealth';
       id: string;

--- a/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ScheduledRunListRoot.types.ts
@@ -8,6 +8,7 @@ export type ScheduledRunsListQuery = {
   __typename: 'DagitQuery';
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/useRunsForTimeline.types.ts
@@ -57,6 +57,7 @@ export type RunTimelineQuery = {
     | {__typename: 'PythonError'}
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;

--- a/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagit/packages/core/src/runs/useRunsForTimeline.tsx
@@ -231,6 +231,7 @@ const RUN_TIMELINE_QUERY = gql`
     }
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           name

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -153,6 +153,7 @@ const SCHEDULE_ROOT_QUERY = gql`
       ...PythonErrorFragment
     }
     instance {
+      id
       daemonHealth {
         id
         daemonStatus(daemonType: "SCHEDULER") {

--- a/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/schedules/types/ScheduleRoot.types.ts
@@ -83,6 +83,7 @@ export type ScheduleRootQuery = {
     | {__typename: 'ScheduleNotFoundError'; message: string};
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/search/types/useRepoSearch.types.ts
+++ b/js_modules/dagit/packages/core/src/search/types/useRepoSearch.types.ts
@@ -19,6 +19,7 @@ export type SearchBootstrapQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;

--- a/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
+++ b/js_modules/dagit/packages/core/src/search/useRepoSearch.tsx
@@ -199,6 +199,7 @@ const SEARCH_BOOTSTRAP_QUERY = gql`
     workspaceOrError {
       __typename
       ... on Workspace {
+        id
         locationEntries {
           __typename
           id

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -103,6 +103,7 @@ const SENSOR_ROOT_QUERY = gql`
       ...PythonErrorFragment
     }
     instance {
+      id
       daemonHealth {
         id
         daemonStatus(daemonType: "SENSOR") {

--- a/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/sensors/types/SensorRoot.types.ts
@@ -88,6 +88,7 @@ export type SensorRootQuery = {
     | {__typename: 'UnauthorizedError'};
   instance: {
     __typename: 'Instance';
+    id: string;
     hasInfo: boolean;
     daemonHealth: {
       __typename: 'DaemonHealth';

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceContext.tsx
@@ -55,6 +55,7 @@ const ROOT_WORKSPACE_QUERY = gql`
   query RootWorkspaceQuery {
     workspaceOrError {
       ... on Workspace {
+        id
         locationEntries {
           id
           ...WorkspaceLocationNode

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceContext.types.ts
@@ -19,6 +19,7 @@ export type RootWorkspaceQuery = {
       }
     | {
         __typename: 'Workspace';
+        id: string;
         locationEntries: Array<{
           __typename: 'WorkspaceLocationEntry';
           id: string;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -370,10 +370,14 @@ class GrapheneRepositoryConnection(graphene.ObjectType):
 
 
 class GrapheneWorkspace(graphene.ObjectType):
+    id = graphene.NonNull(graphene.String)
     locationEntries = non_null_list(GrapheneWorkspaceLocationEntry)
 
     class Meta:
         name = "Workspace"
+
+    def resolve_id(self, _graphene_info: ResolveInfo):
+        return "Workspace"
 
 
 class GrapheneLocationStateChangeEvent(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -89,6 +89,7 @@ class GrapheneDaemonHealth(graphene.ObjectType):
 
 
 class GrapheneInstance(graphene.ObjectType):
+    id = graphene.NonNull(graphene.String)
     info = graphene.Field(graphene.String)
     runLauncher = graphene.Field(GrapheneRunLauncher)
     runQueuingSupported = graphene.NonNull(graphene.Boolean)
@@ -104,6 +105,9 @@ class GrapheneInstance(graphene.ObjectType):
     def __init__(self, instance):
         super().__init__()
         self._instance = check.inst_param(instance, "instance", DagsterInstance)
+
+    def resolve_id(self, _graphene_info: ResolveInfo):
+        return "Instance"
 
     def resolve_hasInfo(self, graphene_info: ResolveInfo) -> bool:
         return graphene_info.context.show_instance_config


### PR DESCRIPTION
## Summary & Motivation

Cleaning up something we should have taken care of a while ago. Instead of defining custom `id` behavior for cached singletons when we define the app cache, just add some `id` fields to the actual GraphQL types.

Also removed a custom branch for `RegularType` and `CompositeType`, neither of which are typenames that seem to exist now.

## How I Tested These Changes

Buildkite. Load app, click around and verify that everything looks fine, including in the cache display in the Apollo dev tools.
