### PR TITLE
[dagit] Fix long “overdue” text overflowing asset nodes

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -605,7 +605,7 @@ export const AssetNodeScenariosBase = [
     title: 'Materialized and Stale and Overdue',
     liveData: LiveDataForNodeMaterializedAndStaleAndOverdue,
     definition: AssetNodeFragmentBasic,
-    expectedText: ['Code version', '12 minutes overdue', 'Feb'],
+    expectedText: ['Code version', 'Overdue', 'Feb'],
   },
 
   {
@@ -626,7 +626,7 @@ export const AssetNodeScenariosBase = [
     title: 'Materialized and Overdue',
     liveData: LiveDataForNodeMaterializedAndOverdue,
     definition: AssetNodeFragmentBasic,
-    expectedText: ['12 minutes overdue'],
+    expectedText: ['Overdue'],
   },
 ];
 
@@ -714,7 +714,7 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Partitioned Asset - Overdue',
     liveData: LiveDataForNodePartitionedOverdue,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['All', '12 minutes overdue'],
+    expectedText: ['All', 'Overdue'],
   },
 
   {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.mocks.ts
@@ -707,7 +707,7 @@ export const AssetNodeScenariosPartitioned = [
     title: 'Materializing...',
     liveData: LiveDataForNodePartitionedMaterializing,
     definition: AssetNodeFragmentPartitioned,
-    expectedText: ['Materializing 5 partitions', 'ABCDEF'],
+    expectedText: ['Materializing 5 partitions'],
   },
 
   {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -183,7 +183,7 @@ export function buildAssetNodeStatusContent({
             {expanded && <AssetPartitionStatusDot status={[AssetPartitionStatus.MISSING]} />}
             <span>Observed</span>
             {expanded && <SpacerDot />}
-            <span style={{textAlign: 'right'}}>
+            <span style={{textAlign: 'right', overflow: 'hidden'}}>
               <AssetRunLink
                 runId={liveData.lastObservation.runId}
                 event={{
@@ -265,23 +265,29 @@ export function buildAssetNodeStatusContent({
       background,
       border,
       content: (
-        <span style={{color: foreground}}>
-          <Link
-            to={assetDetailsPathForKey(definition.assetKey, {view: 'partitions'})}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {late
-              ? humanizedLateString(liveData.freshnessInfo.currentMinutesLate)
-              : partitionCountString(numPartitions)}
-          </Link>
-        </span>
+        <Link
+          to={assetDetailsPathForKey(definition.assetKey, {view: 'partitions'})}
+          style={{color: foreground}}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {late ? (
+            <Tooltip
+              position="top"
+              content={humanizedLateString(liveData.freshnessInfo.currentMinutesLate)}
+            >
+              Overdue
+            </Tooltip>
+          ) : (
+            partitionCountString(numPartitions)
+          )}
+        </Link>
       ),
     };
   }
 
   const lastMaterializationLink = lastMaterialization ? (
-    <span>
+    <span style={{overflow: 'hidden'}}>
       <AssetRunLink
         runId={lastMaterialization.runId}
         event={{stepKey: getStepKey(definition), timestamp: lastMaterialization.timestamp}}
@@ -309,18 +315,21 @@ export function buildAssetNodeStatusContent({
             />
           )}
 
-          <span style={{color: Colors.Red700}}>
-            {runWhichFailedToMaterialize && late
-              ? `Failed (Overdue)`
-              : late
-              ? humanizedLateString(liveData.freshnessInfo.currentMinutesLate)
-              : 'Failed'}
-          </span>
+          {late ? (
+            <Tooltip
+              position="top"
+              content={humanizedLateString(liveData.freshnessInfo.currentMinutesLate)}
+            >
+              <span style={{color: Colors.Red700}}>{late ? `Failed, Overdue` : 'Overdue'}</span>
+            </Tooltip>
+          ) : runWhichFailedToMaterialize ? (
+            <span style={{color: Colors.Red700}}>Failed</span>
+          ) : undefined}
 
           {expanded && <SpacerDot />}
 
           {runWhichFailedToMaterialize ? (
-            <span>
+            <span style={{overflow: 'hidden'}}>
               <AssetRunLink runId={runWhichFailedToMaterialize.id}>
                 <TimestampDisplay
                   timestamp={Number(runWhichFailedToMaterialize.endTime)}

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -230,6 +230,9 @@ export function buildAssetNodeStatusContent({
   }
 
   if (materializingRunId) {
+    // Note: this value is undefined for unpartitioned assets
+    const numMaterializing = liveData.partitionStats?.numMaterializing;
+
     return {
       background: Colors.Blue50,
       border: Colors.Blue500,
@@ -237,14 +240,16 @@ export function buildAssetNodeStatusContent({
         <>
           <AssetLatestRunSpinner liveData={liveData} />
           <span style={{flex: 1}} color={Colors.Gray800}>
-            {liveData.partitionStats?.numMaterializing === 1
+            {numMaterializing === 1
               ? `Materializing 1 partition...`
-              : liveData.partitionStats?.numMaterializing
-              ? `Materializing ${liveData.partitionStats.numMaterializing} partitions...`
+              : numMaterializing
+              ? `Materializing ${numMaterializing} partitions...`
               : `Materializing...`}
           </span>
           {expanded && <SpacerDot />}
-          <AssetRunLink runId={materializingRunId} />
+          {!numMaterializing || numMaterializing === 1 ? (
+            <AssetRunLink runId={materializingRunId} />
+          ) : undefined}
         </>
       ),
     };

--- a/js_modules/dagit/packages/core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -14,9 +14,14 @@ export const LiveStates = () => {
   const caseWithLiveData = (scenario: typeof Mocks.AssetNodeScenariosBase[0]) => {
     const dimensions = getAssetNodeDimensions(scenario.definition);
     return (
-      <Box flex={{direction: 'column', gap: 0, alignItems: 'flex-start'}}>
+      <Box flex={{direction: 'column', gap: 8, alignItems: 'flex-start'}}>
         <div
-          style={{position: 'relative', width: 280, height: dimensions.height, overflowY: 'hidden'}}
+          style={{
+            position: 'relative',
+            width: dimensions.width,
+            height: dimensions.height,
+            overflowY: 'hidden',
+          }}
         >
           <AssetNode
             definition={scenario.definition}
@@ -24,8 +29,8 @@ export const LiveStates = () => {
             selected={false}
           />
         </div>
-        <div style={{position: 'relative', width: 280, height: 82}}>
-          <div style={{position: 'absolute', width: 280, height: 82}}>
+        <div style={{position: 'relative', width: dimensions.width, height: 82}}>
+          <div style={{position: 'absolute', width: dimensions.width, height: 82}}>
             <AssetNodeMinimal
               definition={scenario.definition}
               liveData={scenario.liveData}

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -162,7 +162,7 @@ export const layoutAssetGraph = (graphData: GraphData): AssetGraphLayout => {
       }
     }
     for (const group of Object.values(groups)) {
-      group.bounds = padBounds(group.bounds, {x: 15, top: 80, bottom: 15});
+      group.bounds = padBounds(group.bounds, {x: 15, top: 70, bottom: -10});
     }
   }
 

--- a/js_modules/dagit/packages/core/src/asset-graph/layout.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/layout.ts
@@ -237,7 +237,7 @@ export const getAssetNodeDimensions = (def: {
   description?: string | null;
   computeKind: string | null;
 }) => {
-  const width = 255;
+  const width = 265;
 
   if (def.isSource && !def.isObservable) {
     return {width, height: 102};


### PR DESCRIPTION
## Summary & Motivation

This PR moves the actual time overdue to a tooltip and changes the text from `Failed (Overdue)` to `Failed, Overdue`, which is one character shorter. It also makes asset nodes 10px wider, allowing the full timestamp with the year to fit:

Before:
![image](https://user-images.githubusercontent.com/1037212/231817664-9cf7f5e7-4cb5-4ebe-9ee8-0c1a504b370b.png)

After:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/1037212/231817487-5530dcf9-47c6-487c-8240-8f30d6f1a4ca.png">
<img width="353" alt="image" src="https://user-images.githubusercontent.com/1037212/231817740-512d1f7c-5e97-4cd0-81ae-f715b2502712.png">

This PR also tweaks the text color of the "1500 partitions" label in the picture below to match the text color used for other bottom-left labels:

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/1037212/231818018-d7475e3f-747e-4070-849c-905061ef2514.png">


## How I Tested These Changes

We have storybooks for all these cases, so I previewed those to make sure the changes don't have any unexpected rendering consequences: