### PR TITLE
[quickstart_snowflake] upgrade to pydantic config

### DIFF
--- a/examples/quickstart_snowflake/README.md
+++ b/examples/quickstart_snowflake/README.md
@@ -56,7 +56,7 @@ To connect to Snowflake, you'll need to set up your credentials in Dagster.
 
 Dagster allows using environment variables to handle sensitive information. You can define various configuration options and access environment variables through them. This also allows you to parameterize your pipeline without modifying code.
 
-In this example, we use [snowflake_io_manager](https://docs.dagster.io/_apidocs/libraries/dagster-snowflake#dagster_snowflake.build_snowflake_io_manager) to write outputs to Snowflake and read inputs from it. The configurations of the Snowflake connection are defined [in `quickstart_snowflake/__init__.py`](./quickstart_snowflake/__init__.py), which requires the following environment variables:
+In this example, we use [SnowflakePandasIOManager](https://docs.dagster.io/_apidocs/libraries/dagster-snowflake-pandas#dagster_snowflake_pandas.SnowflakePandasIOManager) to write outputs to Snowflake and read inputs from it. The configurations of the Snowflake connection are defined [in `quickstart_snowflake/__init__.py`](./quickstart_snowflake/__init__.py), which requires the following environment variables:
 - `SNOWFLAKE_ACCOUNT`
 - `SNOWFLAKE_USER`
 - `SNOWFLAKE_PASSWORD`

--- a/examples/quickstart_snowflake/quickstart_snowflake/__init__.py
+++ b/examples/quickstart_snowflake/quickstart_snowflake/__init__.py
@@ -1,10 +1,11 @@
 from dagster import (
     Definitions,
+    EnvVar,
     ScheduleDefinition,
     define_asset_job,
     load_assets_from_package_module,
 )
-from dagster_snowflake_pandas import snowflake_pandas_io_manager
+from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from . import assets
 
@@ -16,17 +17,15 @@ daily_refresh_schedule = ScheduleDefinition(
 defs = Definitions(
     assets=load_assets_from_package_module(assets),
     resources={
-        "io_manager": snowflake_pandas_io_manager.configured(
+        "io_manager": SnowflakePandasIOManager(
             # Read about using environment variables and secrets in Dagster:
             # https://docs.dagster.io/guides/dagster/using-environment-variables-and-secrets
-            {
-                "account": {"env": "SNOWFLAKE_ACCOUNT"},
-                "user": {"env": "SNOWFLAKE_USER"},
-                "password": {"env": "SNOWFLAKE_PASSWORD"},
-                "warehouse": {"env": "SNOWFLAKE_WAREHOUSE"},
-                "database": {"env": "SNOWFLAKE_DATABASE"},
-                "schema": {"env": "SNOWFLAKE_SCHEMA"},
-            }
+            account=EnvVar("SNOWFLAKE_ACCOUNT"),
+            user=EnvVar("SNOWFLAKE_USER"),
+            password=EnvVar("SNOWFLAKE_PASSWORD"),
+            warehouse=EnvVar("SNOWFLAKE_WAREHOUSE"),
+            database=EnvVar("SNOWFLAKE_DATABASE"),
+            schema=EnvVar("SNOWFLAKE_SCHEMA"),
         ),
     },
     schedules=[daily_refresh_schedule],


### PR DESCRIPTION
## Summary & Motivation
Converts the quickstart_snowflake example project to use pydantic SnowflakePandasIOManager

## How I Tested These Changes
ran locally