### PR TITLE
[docs] - Fix typo, clean up copy in Databricks guide

### DIFF
--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -5,7 +5,7 @@ description: Dagster can orchestrate Databricks jobs alongside other technologie
 
 # Using Databricks with Dagster
 
-Dagster can orchestrate your Databricks jobs and other Databricks API calls, making it easy to chain together multiple Databricks jobs, as well as orchestrate Databricks alongside your other technologies.
+Dagster can orchestrate your Databricks jobs and other Databricks API calls, making it easy to chain together multiple Databricks jobs and orchestrate Databricks alongside your other technologies.
 
 ---
 
@@ -17,7 +17,7 @@ To get started, you will need to install the `dagster` and `dagster-databricks` 
 pip install dagster dagster-databricks
 ```
 
-You'll also want to have a Databricks workspace with an existing project that is deployed with a Databricks job. If you don't have one already, you can [follow the Databricks quickstart](https://docs.databricks.com/workflows/jobs/jobs-quickstart.html) to set one up.
+You'll also want to have a Databricks workspace with an existing project that is deployed with a Databricks job. If you don't have this, [follow the Databricks quickstart](https://docs.databricks.com/workflows/jobs/jobs-quickstart.html) to set one up.
 
 To manage your Databricks job from Dagster, you'll need three values, which can be set as [environment variables in Dagster](/guides/dagster/using-environment-variables-and-secrets):
 
@@ -31,7 +31,7 @@ You can follow the [Databricks API authentication instructions](https://docs.dat
 
 ## Step 1: Connecting to Databricks
 
-The first step in using Databricks with Dagster is to tell Dagster how to connect to your Databricks workspace using a Databricks [resource](/concepts/resources). This resource contains information on where your Databricks workspace is located and any credentials sourced from environment variables that are needed to access it. By configuring the resource, you can access the underlying [Databricks API client](https://docs.databricks.com/dev-tools/python-api.html) to communicate to your Databricks workspace.
+The first step in using Databricks with Dagster is to tell Dagster how to connect to your Databricks workspace using a Databricks [resource](/concepts/resources). This resource contains information on the location of your Databricks workspace and any credentials sourced from environment variables that are required to access it. You can access the underlying [Databricks API client](https://docs.databricks.com/dev-tools/python-api.html) to communicate to your Databricks workspace by configuring the resource.
 
 For more information about the Databricks resource, see the [API reference](/\_apidocs/libraries/dagster-databricks).
 
@@ -50,18 +50,18 @@ databricks_client_instance = databricks_client.configured(
 
 ## Step 2: Create an op/asset that connects to Databricks
 
-In this step, we show several ways to model a Databricks API call as either a Dagster [op](/concepts/ops-jobs-graphs/ops), or as the computation backing a [software-defined asset](/concepts/assets/software-defined-assets). You can either:
+In this step, we'll demonstrate several ways to model a Databricks API call as either a Dagster [op](/concepts/ops-jobs-graphs/ops) or the computation backing a [Software-defined asset](/concepts/assets/software-defined-assets). You can either:
 
 - Use the `dagster-databricks` op factories, which create ops that invoke the Databricks Jobs' [Run Now](https://docs.databricks.com/api-explorer/workspace/jobs/runnow) ([`create_databricks_run_now_op`](/\_apidocs/libraries/dagster-databricks)) or [Submit Run](https://docs.databricks.com/api-explorer/workspace/jobs/submit) ([`create_databricks_submit_run_op`](/\_apidocs/libraries/dagster-databricks)) APIs, or
 - Manually create a Dagster op or asset that connects to Databricks using the configured Databricks resource.
 
-Afterwards, we create a Dagster [job](/concepts/ops-jobs-graphs/jobs) that either invokes the op or selects the asset in order to run the Databricks API call.
+Afterward, we create a Dagster [job](/concepts/ops-jobs-graphs/jobs) that invokes the op or selects the asset to run the Databricks API call.
 
-For more information on how to decide whether to use an op or asset, see our [guide](/guides/dagster/how-assets-relate-to-ops-and-graphs) to understand how they relate.
+For guidance on deciding whether to use an op or asset, refer to the [Understanding how assets relate to ops guide](/guides/dagster/how-assets-relate-to-ops-and-graphs).
 
 <TabGroup>
 
-<TabItem name="Using the op factories">
+<TabItem name="Using op factories">
 
 ```python startafter=start_define_databricks_op_factories endbefore=end_define_databricks_op_factories file=/integrations/databricks/databricks.py dedent=4
 from dagster_databricks import create_databricks_run_now_op
@@ -135,7 +135,7 @@ materialize_databricks_table = define_asset_job(
 
 ## Step 3: Schedule your Databricks computation
 
-Now that your Databricks API calls are modeled within Dagster, you can [schedule](/concepts/partitions-schedules-sensors/schedules) it to run on a regular cadence.
+Now that your Databricks API calls are modeled within Dagster, you can [schedule](/concepts/partitions-schedules-sensors/schedules) them to run regularly.
 
 In the example below, we schedule the `materialize_databricks_table` and `my_databricks_job` jobs to run daily:
 

--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -137,7 +137,7 @@ materialize_databricks_table = define_asset_job(
 
 Now that your Databricks API calls are modeled within Dagster, you can [schedule](/concepts/partitions-schedules-sensors/schedules) it to run on a regular cadence.
 
-In the example below, we schedule the `materialize_databricks_table` job to run daily, which materiali, and the `my_databricks_job` job to run daily.
+In the example below, we schedule the `materialize_databricks_table` and `my_databricks_job` jobs to run daily:
 
 ```python startafter=start_schedule_databricks endbefore=end_schedule_databricks file=/integrations/databricks/databricks.py dedent=4
 from dagster import (


### PR DESCRIPTION
## Summary & Motivation

This PR fixes a typo I noticed in the Databricks setup guide. It also addresses some other small style/grammar issues in the rest of the copy.

## How I Tested These Changes

local, 👀 
