### PR TITLE
convert assets_pandas_type_metadata to pydantic config and resources

### DIFF
--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/__init__.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/__init__.py
@@ -4,8 +4,8 @@ from . import (
     assets,
     lib as lib,
 )
-from .resources.csv_io_manager import local_csv_io_manager
+from .resources.csv_io_manager import LocalCsvIOManager
 
 defs = Definitions(
-    assets=load_assets_from_package_module(assets), resources={"io_manager": local_csv_io_manager}
+    assets=load_assets_from_package_module(assets), resources={"io_manager": LocalCsvIOManager()}
 )

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/assets/bollinger_analysis.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata/assets/bollinger_analysis.py
@@ -1,4 +1,5 @@
-from dagster import Field, asset
+from dagster import Config, asset
+from pydantic import Field
 
 from ..lib import (
     AnomalousEventsDgType,
@@ -19,21 +20,18 @@ def sp500_prices():
     return load_sp500_prices()
 
 
+class BollingerBandsConfig(Config):
+    rate: int = Field(default=30, description="Size of sliding window in days")
+    sigma: float = Field(default=2.0, description="Width of envelope in standard deviations")
+
+
 @asset(
     dagster_type=BollingerBandsDgType,
-    config_schema={
-        "rate": Field(int, default_value=30, description="Size of sliding window in days"),
-        "sigma": Field(
-            float, default_value=2.0, description="Width of envelope in standard deviations"
-        ),
-    },
     metadata={"owner": "alice@example.com"},
 )
-def sp500_bollinger_bands(context, sp500_prices):
+def sp500_bollinger_bands(config: BollingerBandsConfig, sp500_prices):
     """Bollinger bands for the S&amp;P 500 stock prices."""
-    return compute_bollinger_bands_multi(
-        sp500_prices, rate=context.op_config["rate"], sigma=context.op_config["sigma"]
-    )
+    return compute_bollinger_bands_multi(sp500_prices, rate=config.rate, sigma=config.sigma)
 
 
 @asset(

--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_bollinger_analysis.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_bollinger_analysis.py
@@ -3,7 +3,7 @@ from assets_pandas_type_metadata.assets.bollinger_analysis import (
     sp500_bollinger_bands,
     sp500_prices,
 )
-from assets_pandas_type_metadata.resources.csv_io_manager import local_csv_io_manager
+from assets_pandas_type_metadata.resources.csv_io_manager import LocalCsvIOManager
 from dagster import AssetSelection, define_asset_job, with_resources
 
 
@@ -14,7 +14,7 @@ def test_bollinger_analysis():
     ).resolve(
         with_resources(
             [sp500_anomalous_events, sp500_bollinger_bands, sp500_prices],
-            {"io_manager": local_csv_io_manager},
+            {"io_manager": LocalCsvIOManager()},
         ),
         [],
     )


### PR DESCRIPTION
## Summary & Motivation
converts the `assets_pandas_type_metadata` example to use pydantic resources and config 

## How I Tested These Changes
ran locally