### PR TITLE
[pythonic resources] Make init context available in Pythonic resources

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -753,7 +753,7 @@ class ConfigurableResourceFactory(
     def _create_object_fn(self, context: InitResourceContext) -> TResValue:
         return self.create_resource(context)
 
-    def get_context(self) -> InitResourceContext:
+    def get_resource_init_context(self) -> InitResourceContext:
         """Returns the context that this resource was initialized with."""
         return check.not_none(
             self._state__internal__.context,

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
@@ -2464,7 +2464,12 @@ def test_context_on_resource_use_instance() -> None:
         storage_directory.return_value = "/tmp"
 
         with DagsterInstance.ephemeral() as instance:
-            assert OutputDirResource(output_dir=None).with_resource_context(build_init_resource_context(instance=instance)).get_effective_output_dir() == "/tmp"
+            assert (
+                OutputDirResource(output_dir=None)
+                .with_resource_context(build_init_resource_context(instance=instance))
+                .get_effective_output_dir()
+                == "/tmp"
+            )
 
         @asset
         def my_other_output_asset(output_dir: OutputDirResource) -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
@@ -2409,7 +2409,33 @@ def test_from_resource_context_and_to_config_empty() -> None:
     assert string_resource_function_style(build_init_resource_context()) == "foo"
 
 
-def test_context_on_resource() -> None:
+def test_context_on_resource_basic() -> None:
+    executed = {}
+
+    class ContextUsingResource(ConfigurableResource):
+        def access_context(self) -> None:
+            self.get_resource_init_context()
+
+    with pytest.raises(
+        CheckError, match="Attempted to get context before resource was initialized."
+    ):
+        ContextUsingResource().access_context()
+
+    @asset
+    def my_test_asset(context_using: ContextUsingResource) -> None:
+        context_using.access_context()
+        executed["yes"] = True
+
+    defs = Definitions(
+        assets=[my_test_asset],
+        resources={"context_using": ContextUsingResource()},
+    )
+
+    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert executed["yes"]
+
+
+def test_context_on_resource_use_instance() -> None:
     executed = {}
 
     class OutputDirResource(ConfigurableResource):
@@ -2419,7 +2445,7 @@ def test_context_on_resource() -> None:
             if self.output_dir:
                 return self.output_dir
 
-            context = self.get_context()
+            context = self.get_resource_init_context()
             assert context.instance
             return context.instance.storage_directory()
 
@@ -2441,6 +2467,88 @@ def test_context_on_resource() -> None:
         defs = Definitions(
             assets=[my_other_output_asset],
             resources={"output_dir": OutputDirResource()},
+        )
+
+        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert executed["yes"]
+
+
+def test_context_on_resource_runtime_config() -> None:
+    executed = {}
+
+    class OutputDirResource(ConfigurableResource):
+        output_dir: Optional[str] = None
+
+        def get_effective_output_dir(self) -> str:
+            if self.output_dir:
+                return self.output_dir
+
+            context = self.get_resource_init_context()
+            assert context.instance
+            return context.instance.storage_directory()
+
+    with mock.patch(
+        "dagster._core.instance.DagsterInstance.storage_directory"
+    ) as storage_directory:
+        storage_directory.return_value = "/tmp"
+
+        @asset
+        def my_other_output_asset(output_dir: OutputDirResource) -> None:
+            assert output_dir.get_effective_output_dir() == "/tmp"
+            executed["yes"] = True
+
+        defs = Definitions(
+            assets=[my_other_output_asset],
+            resources={"output_dir": OutputDirResource.configure_at_launch()},
+        )
+
+        assert (
+            defs.get_implicit_global_asset_job_def()
+            .execute_in_process(
+                run_config={"resources": {"output_dir": {"config": {"output_dir": None}}}}
+            )
+            .success
+        )
+        assert executed["yes"]
+
+
+def test_context_on_resource_nested() -> None:
+    executed = {}
+
+    class OutputDirResource(ConfigurableResource):
+        output_dir: Optional[str] = None
+
+        def get_effective_output_dir(self) -> str:
+            if self.output_dir:
+                return self.output_dir
+
+            context = self.get_resource_init_context()
+            assert context.instance
+            return context.instance.storage_directory()
+
+    class OutputDirWrapperResource(ConfigurableResource):
+        output_dir: OutputDirResource
+
+    with pytest.raises(
+        CheckError, match="Attempted to get context before resource was initialized."
+    ):
+        OutputDirWrapperResource(
+            output_dir=OutputDirResource(output_dir=None)
+        ).output_dir.get_effective_output_dir()
+
+    with mock.patch(
+        "dagster._core.instance.DagsterInstance.storage_directory"
+    ) as storage_directory:
+        storage_directory.return_value = "/tmp"
+
+        @asset
+        def my_other_output_asset(wrapper: OutputDirWrapperResource) -> None:
+            assert wrapper.output_dir.get_effective_output_dir() == "/tmp"
+            executed["yes"] = True
+
+        defs = Definitions(
+            assets=[my_other_output_asset],
+            resources={"wrapper": OutputDirWrapperResource(output_dir=OutputDirResource())},
         )
 
         assert defs.get_implicit_global_asset_job_def().execute_in_process().success


### PR DESCRIPTION
## Summary

Makes the `InitResourceContext` available to Pythonic resources through a `get_context()` getter. This can be used to retrieve e.g. instance information in the body of a resource.

```python
 class OutputDirResource(ConfigurableResource):
    output_dir: Optional[str] = None

    def get_effective_output_dir(self) -> str:
        if self.output_dir:
            return self.output_dir

        context = self.get_resource_context()
        assert context.instance
        return context.instance.storage_directory()
```

## Test Plan

Added unit test, todo a few more
