### PR TITLE
Backfill page dogfooding feedback

### DIFF
--- a/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
@@ -414,7 +414,7 @@ export const PartitionSelection = ({
         <Box flex={{direction: 'column', gap: 8}}>
           {rootAssetTargetedRanges?.map((r) => (
             <div key={`${r.start}:${r.end}`}>
-              {r.start} - {r.end}
+              {r.start}...{r.end}
             </div>
           ))}
         </Box>

--- a/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/BackfillPage.tsx
@@ -22,10 +22,13 @@ import styled from 'styled-components/macro';
 
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
-import {useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {QueryRefreshCountdown, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {useTrackPageView} from '../../app/analytics';
+import {Timestamp} from '../../app/time/Timestamp';
+import {assetDetailsPathForKey} from '../../assets/assetDetailsPathForKey';
 import {BulkActionStatus, RunStatus} from '../../graphql/types';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
+import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
 import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {testId} from '../../testing/testId';
 import {numberFormatter} from '../../ui/formatters';
@@ -58,7 +61,7 @@ export const BackfillPage = () => {
     // for asset backfills, all of the requested runs have concluded in order for the status to be BulkActionStatus.COMPLETED
     isInProgress = backfill.status === BulkActionStatus.REQUESTED;
   }
-  useQueryRefreshAtInterval(queryResult, 5000, isInProgress);
+  const refreshState = useQueryRefreshAtInterval(queryResult, 10000, isInProgress);
 
   function content() {
     if (!backfill || !data) {
@@ -127,7 +130,15 @@ export const BackfillPage = () => {
             alignItems: 'center',
           }}
         >
-          <Detail label="Created" detail="Mar 22, 5:00 PM" />
+          <Detail
+            label="Created"
+            detail={
+              <Timestamp
+                timestamp={{ms: Number(backfill.timestamp * 1000)}}
+                timeFormat={{showSeconds: true, showTimezone: false}}
+              />
+            }
+          />
           <Detail
             label="Duration"
             detail={
@@ -155,10 +166,18 @@ export const BackfillPage = () => {
           <thead>
             <tr>
               <th style={{width: '50%'}}>Asset name</th>
-              <th>Partitions targeted</th>
-              <th>Requested</th>
-              <th>Complete</th>
-              <th>Failed</th>
+              <th>
+                <a href={getRunsUrl('targeted')}>Partitions targeted</a>
+              </th>
+              <th>
+                <a href={getRunsUrl('requested')}>Requested</a>
+              </th>
+              <th>
+                <a href={getRunsUrl('complete')}>Completed</a>
+              </th>
+              <th>
+                <a href={getRunsUrl('failed')}>Failed</a>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -166,7 +185,11 @@ export const BackfillPage = () => {
               <tr key={asset.assetKey.path.join('/')}>
                 <td>
                   <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                    <div>{asset.assetKey.path.join('/')}</div>
+                    <div>
+                      <a href={assetDetailsPathForKey(asset.assetKey)}>
+                        {asset.assetKey.path.join('/')}
+                      </a>
+                    </div>
                     <div>
                       <StatusBar
                         targeted={asset.numPartitionsTargeted}
@@ -177,39 +200,10 @@ export const BackfillPage = () => {
                     </div>
                   </Box>
                 </td>
-                <td>
-                  <a href={getRunsUrl('targeted')}>{asset.numPartitionsTargeted}</a>
-                </td>
-                <td>
-                  <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                    <div>{asset.numPartitionsRequested}</div>
-                    <div>
-                      {asset.numPartitionsRequested ? (
-                        <a href={getRunsUrl('requested')}>View Runs</a>
-                      ) : null}
-                    </div>
-                  </Box>
-                </td>
-                <td>
-                  <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                    <div>{asset.numPartitionsCompleted}</div>
-                    <div>
-                      {asset.numPartitionsCompleted ? (
-                        <a href={getRunsUrl('complete')}>View Runs</a>
-                      ) : null}
-                    </div>
-                  </Box>
-                </td>
-                <td>
-                  <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                    <div>{asset.numPartitionsFailed}</div>
-                    <div>
-                      {asset.numPartitionsFailed ? (
-                        <a href={getRunsUrl('failed')}>View Runs</a>
-                      ) : null}
-                    </div>
-                  </Box>
-                </td>
+                <td>{asset.numPartitionsTargeted}</td>
+                <td>{asset.numPartitionsRequested}</td>
+                <td>{asset.numPartitionsCompleted}</td>
+                <td>{asset.numPartitionsFailed}</td>
               </tr>
             ))}
           </tbody>
@@ -230,6 +224,7 @@ export const BackfillPage = () => {
             {backfillId}
           </div>
         }
+        right={isInProgress ? <QueryRefreshCountdown refreshState={refreshState} /> : null}
       />
       {content()}
     </Page>
@@ -248,13 +243,13 @@ const StatusLabel = ({status}: {status: BulkActionStatus}) => {
     case BulkActionStatus.CANCELED:
       return <Tag intent="warning">Canceled</Tag>;
     case BulkActionStatus.COMPLETED:
-      return <Tag intent="success">Complete</Tag>;
+      return <Tag intent="success">Completed</Tag>;
     case BulkActionStatus.FAILED:
       return <Tag intent="danger">Failed</Tag>;
     case BulkActionStatus.REQUESTED:
       return (
         <Tag intent="primary" icon="spinner">
-          In Progress
+          Requested
         </Tag>
       );
     default:
@@ -313,8 +308,7 @@ const Duration = ({start, end}: {start: number; end?: number | null}) => {
   }, [start, end]);
   const duration = end ? end - start : Date.now() - start;
 
-  const str = dayjs.duration(duration).humanize(false);
-  return <span>{str}</span>;
+  return <span>{formatDuration(duration)}</span>;
 };
 
 export const BACKFILL_DETAILS_QUERY = gql`
@@ -374,7 +368,9 @@ export const PartitionSelection = ({
       dialogContent = (
         <div>
           {rootAssetTargetedPartitions.map((p) => (
-            <div key={p}>{p}</div>
+            <div key={p} style={{maxWidth: '100px'}}>
+              <TruncatedTextWithFullTextOnHover text={p} />
+            </div>
           ))}
         </div>
       );
@@ -401,7 +397,7 @@ export const PartitionSelection = ({
       const {start, end} = rootAssetTargetedRanges[0];
       content = (
         <div>
-          {start} - {end}
+          {start}...{end}
         </div>
       );
     } else {
@@ -437,4 +433,24 @@ export const PartitionSelection = ({
       </Dialog>
     </>
   );
+};
+
+const formatDuration = (duration: number) => {
+  const seconds = Math.floor((duration / 1000) % 60);
+  const minutes = Math.floor((duration / (1000 * 60)) % 60);
+  const hours = Math.floor((duration / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(duration / (1000 * 60 * 60 * 24));
+
+  let result = '';
+  if (days > 0) {
+    result += `${days}d `;
+    result += `${hours}h`;
+  } else if (hours > 0) {
+    result += `${hours}h `;
+    result += `${minutes}m`;
+  } else if (minutes > 0) {
+    result += `${minutes}m `;
+    result += `${seconds}s`;
+  }
+  return result.trim();
 };

--- a/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -187,8 +187,8 @@ describe('PartitionSelection', () => {
 
     fireEvent.click(getByText('2 partitions'));
 
-    expect(getByText('1 - 2')).toBeInTheDocument();
-    expect(getByText('3 - 4')).toBeInTheDocument();
+    expect(getByText('1...2')).toBeInTheDocument();
+    expect(getByText('3...4')).toBeInTheDocument();
   });
 
   it('renders the numPartitions in a ButtonLink when neither rootAssetTargetedPartitions nor rootAssetTargetedRanges are provided', () => {

--- a/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -120,7 +120,7 @@ describe('BackfillPage', () => {
     await waitFor(() => getByText('assetA'));
 
     // Check if the loaded content is displayed
-    expect(getByText('Mar 22, 5:00 PM')).toBeVisible();
+    expect(getByText('Jan 1, 1970, 12:16:40 AM')).toBeVisible();
     expect(getByText('Duration')).toBeVisible();
     expect(getByText('Partition Selection')).toBeVisible();
     expect(getByText('Status')).toBeVisible();

--- a/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -105,7 +105,7 @@ describe('BackfillPage', () => {
   });
 
   it('renders the loaded state', async () => {
-    const {getByText} = render(
+    const {getByText, getAllByText} = render(
       <AnalyticsContext.Provider value={{page: () => {}} as any}>
         <MemoryRouter initialEntries={[`/backfills/${mockBackfillId}`]}>
           <Route path="/backfills/:backfillId">
@@ -126,8 +126,8 @@ describe('BackfillPage', () => {
     expect(getByText('Status')).toBeVisible();
     expect(getByText('Asset name')).toBeVisible();
     expect(getByText('Partitions targeted')).toBeVisible();
-    expect(getByText('Requested')).toBeVisible();
-    expect(getByText('Complete')).toBeVisible();
+    expect(getAllByText('Requested').length).toBe(2);
+    expect(getByText('Completed')).toBeVisible();
     expect(getByText('Failed')).toBeVisible();
 
     // Check if the correct data is displayed

--- a/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -171,7 +171,7 @@ describe('PartitionSelection', () => {
       />,
     );
 
-    expect(getByText('1 - 2')).toBeInTheDocument();
+    expect(getByText('1...2')).toBeInTheDocument();
   });
 
   it('renders the targeted ranges in a dialog when rootAssetTargetedRanges is provided and length > 1', () => {

--- a/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
@@ -78,17 +78,14 @@ export function showBackfillSuccessToast(
     ),
     action: {
       text: 'View',
-      onClick: () =>
-        isAssetBackfill
-          ? history.push(`/overview/backfills/${backfillId}`)
-          : history.push(
-              runsPathWithFilters([
-                {
-                  token: 'tag',
-                  value: `dagster/backfill=${backfillId}`,
-                },
-              ]),
-            ),
+      href: isAssetBackfill
+        ? `/overview/backfills/${backfillId}`
+        : runsPathWithFilters([
+            {
+              token: 'tag',
+              value: `dagster/backfill=${backfillId}`,
+            },
+          ]),
     },
   });
 }


### PR DESCRIPTION
## Summary & Motivation

- Make toast to "View" backfill into an href so that it can be command click opened in a separate tab
- Link to the asset detail page from the asset name in the table
- Add the query refresh countdown component to the right side of the page header
- Change "In Progress" -> "Requested" to keep terminology consistent
- Moved links to view completed/failed/targeted/canceled runs into the table header cells because I don't know of a way that we can filter runs by the assets they materialize 
- Fix partition names being cut off
- Fixed the hardcoded start time
- 

## How I Tested These Changes
<img width="2056" alt="Screen Shot 2023-04-13 at 2 53 06 PM" src="https://user-images.githubusercontent.com/2286579/231855856-349d08e5-4e51-445e-a1d8-d05297041622.png">
