### PR TITLE
[dagit] Show a checkbox for the new Materializing state, ensure counts add up

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -130,7 +130,7 @@ describe('AssetPartitions', () => {
     );
     await userEvent.click(successCheck);
     expect(screen.getByTestId('router-search')).toHaveTextContent(
-      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MISSING}`,
+      `status=${AssetPartitionStatus.FAILED}%2C${AssetPartitionStatus.MATERIALIZING}%2C${AssetPartitionStatus.MISSING}`,
     );
     expect(screen.getByTestId('partitions-selected')).toHaveTextContent('5,310 Partitions');
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds a new "Materializing" checkbox to the right of this UI for consistency + completeness, and ensures that as a backfill is running and this page is refreshing, the numbers all add up to the total on the left.


<img width="1398" alt="image" src="https://user-images.githubusercontent.com/1037212/231882105-7b32270b-703e-4118-a6a5-72764585f39f.png">

## How I Tested These Changes

I ran backfills and tested that viewing different combinations of the checkboxes for both single- and multi- partitioned assets render as expected. 