### PR TITLE
[docs] Add section on Serverless page about I/O Managers

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -100,7 +100,12 @@ def downstream_asset(upstream_asset):
 
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
-    resources={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    resources={
+       "io_manager": s3_pickle_io_manager.configured(
+           {"s3_bucket": "my-cool-bucket", "s3_prefix": "my-cool-prefix"}
+       ),
+       "s3": s3_resource,
+    },
 )
 ```
 
@@ -131,7 +136,7 @@ def downstream_asset(upstream_asset):
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
-        "s3_io_manager": s3_pickle_io_manager,
+        "s3_io_manager": s3_pickle_io_manager.configured({"s3_bucket": "my-cool-bucket"}),
         "s3": s3_resource,
         "fs_io_manager": fs_io_manager,
     },
@@ -276,7 +281,7 @@ def op_2(a):
 @job(
     resource_defs={
         "fs": fs_io_manager,
-        "s3_io": s3_pickle_io_manager,
+        "s3_io": s3_pickle_io_manager.configured({"s3_bucket": "my-cool-bucket"}),
         "s3": s3_resource,
     }
 )

--- a/docs/content/dagster-cloud/deployment/serverless.mdx
+++ b/docs/content/dagster-cloud/deployment/serverless.mdx
@@ -297,6 +297,14 @@ Unlike Hybrid, Serverless Deployments on Dagster Cloud require direct access to 
 
 ---
 
+## Data storage and I/O Managers
+
+By default, Serverless Deployments on Dagster Cloud will use <PyObject object="fs_io_manager" /> as their I/O Manager, which is made for development and not recommended for production use. Serverless Deployments will be able to run and save outputs normally using this default, but you will not be able to retrieve the output data of ops or assets until you configure the deployment to save to a storage location which is accessible to you.
+
+To do this, provide an [I/O Manager](/concepts/io-management/io-managers) resource to your assets or ops. Dagster provides out-of-the-box options for saving data to several popular storage systems such as AWS S3; see [the I/O Manager docs](/concepts/io-management/io-managers#built-in-io-managers) for more information and example configurations.
+
+---
+
 ## Run isolation
 
 Dagster Cloud Serverless offers two settings for run isolation: isolated and non-isolated. Non-isolated runs are for iterating quickly and trade off isolation for speed. Isolated runs are for production and compute heavy Assets/Jobs.


### PR DESCRIPTION
## Summary & Motivation

When I setup a Serverless deployment it never occurred to me to set up my own I/O manager, nor that I wouldn't be able to download asset outputs without doing so. After chatting about it with @tacastillo in [this thread in #dagster-support](https://dagster.slack.com/archives/C01U954MEER/p1681336470898429), I learned that setting up an I/O manager is recommended in general for production, and is the best way to ensure I could access the data produced by my assets and/or ops.

I also noticed in the docs for `s3_pickle_io_manager` that the way to configure the bucket it should use is to use its `.configured()` method, but I felt like I had to do more searching than I wanted to discover that fact, so I added calls to `.configured()` with a custom bucket to the example config snippets on the IO Managers page, since I imagine this is the most common use case for the S3 I/O manager.

## How I Tested These Changes

I configured my own Serverless deployment to use the S3 pickle I/O manager, then took what I learned on Slack and from experience to write this note. Then I ran it locally to edit/reword, and now here we are!