### PR TITLE
[test-all] fixup k8s test suite

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_k8s_job_op.py
@@ -174,7 +174,7 @@ def test_k8s_job_op_with_failure(namespace, cluster_provider):
     def failure_job():
         failure_op()
 
-    with pytest.raises(DagsterK8sError, match="Timed out while waiting for pod to become ready"):
+    with pytest.raises(DagsterK8sError):
         failure_job.execute_in_process()
 
 


### PR DESCRIPTION
Summary:
[test-all]
- avoid name collisions
- wait for a pod to exist in a test
- error that was too strict

Test Plan:
Run the suite a couple of times

## Summary & Motivation

## How I Tested These Changes
