### PR TITLE
Add name field to databricks ops

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/ops.py
@@ -23,6 +23,7 @@ def create_databricks_run_now_op(
     databricks_job_configuration: Optional[dict] = None,
     poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
     max_wait_time_seconds: float = DEFAULT_MAX_WAIT_TIME_SECONDS,
+    name: Optional[str] = None,
 ) -> OpDefinition:
     """Creates an op that launches an existing databricks job.
 
@@ -40,6 +41,8 @@ def create_databricks_run_now_op(
             Databricks job has finished running.
         max_wait_time_seconds (float): How long to wait for the Databricks job to finish running
             before raising an error.
+        name (Optional[str]): The name of the op. If not provided, the name will be
+            _databricks_run_now_op.
 
     Returns:
         OpDefinition: An op definition to run the Databricks Job.
@@ -100,6 +103,7 @@ def create_databricks_run_now_op(
         },
         required_resource_keys={"databricks"},
         tags={"kind": "databricks"},
+        name=name,
     )
     def _databricks_run_now_op(context: OpExecutionContext) -> None:
         databricks: DatabricksClient = context.resources.databricks
@@ -131,6 +135,7 @@ def create_databricks_submit_run_op(
     databricks_job_configuration: dict,
     poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
     max_wait_time_seconds: float = DEFAULT_MAX_WAIT_TIME_SECONDS,
+    name: Optional[str] = None,
 ) -> OpDefinition:
     """Creates an op that submits a one-time run of a set of tasks on Databricks.
 
@@ -145,6 +150,8 @@ def create_databricks_submit_run_op(
             Databricks job has finished running.
         max_wait_time_seconds (float): How long to wait for the Databricks job to finish running
             before raising an error.
+        name (Optional[str]): The name of the op. If not provided, the name will be
+            _databricks_submit_run_op.
 
     Returns:
         OpDefinition: An op definition to submit a one-time run of a set of tasks on Databricks.
@@ -207,6 +214,7 @@ def create_databricks_submit_run_op(
         },
         required_resource_keys={"databricks"},
         tags={"kind": "databricks"},
+        name=name,
     )
     def _databricks_submit_run_op(context: OpExecutionContext) -> None:
         databricks: DatabricksClient = context.resources.databricks

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
@@ -140,3 +140,24 @@ def test_databricks_submit_run_op(mocker: MockerFixture) -> None:
 def test_databricks_submit_run_op_no_job() -> None:
     with pytest.raises(CheckError):
         create_databricks_submit_run_op(databricks_job_configuration={})
+
+
+def test_databricks_op_name():
+    databricks_job_configuration = {
+        "new_cluster": {
+            "spark_version": "2.1.0-db3-scala2.11",
+            "num_workers": 2,
+        },
+        "notebook_task": {
+            "notebook_path": "/Users/dagster@example.com/PrepareData",
+        },
+    }
+
+    @job
+    def databricks_job():
+        create_databricks_run_now_op(
+            databricks_job_id=1,
+        )()
+        create_databricks_run_now_op(databricks_job_id=1, name="other_name")()
+        create_databricks_submit_run_op(databricks_job_configuration)()
+        create_databricks_submit_run_op(databricks_job_configuration, name="other_name_2")()


### PR DESCRIPTION
User reports a `Detected conflicting node definitions with the same name` error when multiple databricks ops exist in the same repository:
https://dagster.slack.com/archives/C01U954MEER/p1681412625636049

This PR threads the `name` arg through to enable this use case.