### PR TITLE
[ui] Reduce virtualized table cell spacing

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagit/packages/core/src/ui/VirtualizedTable.tsx
@@ -3,25 +3,35 @@ import * as React from 'react';
 import styled from 'styled-components/macro';
 
 export const HeaderCell = ({children}: {children?: React.ReactNode}) => (
-  <Box
-    padding={{vertical: 8, horizontal: 24}}
+  <CellBox
+    padding={{vertical: 8, horizontal: 12}}
     border={{side: 'right', width: 1, color: Colors.KeylineGray}}
     style={{whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}
   >
     {children}
-  </Box>
+  </CellBox>
 );
 
 export const RowCell = ({children}: {children?: React.ReactNode}) => (
-  <Box
-    padding={{horizontal: 24, vertical: 12}}
+  <CellBox
+    padding={12}
     flex={{direction: 'column', justifyContent: 'flex-start'}}
     style={{color: Colors.Gray500, overflow: 'hidden'}}
     border={{side: 'right', width: 1, color: Colors.KeylineGray}}
   >
     {children}
-  </Box>
+  </CellBox>
 );
+
+const CellBox = styled(Box)`
+  :first-child {
+    padding-left: 24px;
+  }
+
+  :last-child {
+    padding-right: 24px;
+  }
+`;
 
 export const Container = styled.div`
   height: 100%;


### PR DESCRIPTION
## Summary & Motivation

Reclaim some horizontal space in virtualized table rows.

Before:

<img width="1373" alt="Screenshot 2023-04-14 at 11 01 43 AM" src="https://user-images.githubusercontent.com/2823852/232096381-5d7eeaea-f9d9-4d6c-a284-a5ed9a31f91a.png">

After:

<img width="1373" alt="Screenshot 2023-04-14 at 11 01 25 AM" src="https://user-images.githubusercontent.com/2823852/232096399-fbc144ea-824d-43e0-8c65-78d08e991d3e.png">

## How I Tested These Changes

View virtualized tables in app. Verify reduced horizontal whitespace.
