### PR TITLE
[docs] hackernews_assets -> all_assets

### DIFF
--- a/docs/content/tutorial/saving-your-data.mdx
+++ b/docs/content/tutorial/saving-your-data.mdx
@@ -60,7 +60,7 @@ Next, update your `Definitions` (shown below) to attach the I/O manager to your 
 
 ```python file=/tutorial/saving/add_fs_io_manager.py startafter=start_update_defs endbefore=end_update_defs
 defs = Definitions(
-    assets=hackernews_assets,
+    assets=all_assets,
     schedules=[hackernews_schedule],
     resources={
         "io_manager": io_manager,
@@ -115,7 +115,7 @@ database_io_manager = duckdb_pandas_io_manager.configured(
 
 # Update your Definitions
 defs = Definitions(
-    assets=hackernews_assets,
+    assets=all_assets,
     schedules=[hackernews_schedule],
     resources={
         "io_manager": io_manager,

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/add_db_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/add_db_io_manager.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-hackernews_assets = None
+all_assets = None
 hackernews_schedule = None
 
 from dagster import (
@@ -36,7 +36,7 @@ database_io_manager = duckdb_pandas_io_manager.configured(
 
 # Update your Definitions
 defs = Definitions(
-    assets=hackernews_assets,
+    assets=all_assets,
     schedules=[hackernews_schedule],
     resources={
         "io_manager": io_manager,

--- a/examples/docs_snippets/docs_snippets/tutorial/saving/add_fs_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/saving/add_fs_io_manager.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-hackernews_assets = None
+all_assets = None
 
 # start_imports_and_definitions
 from dagster import (
@@ -26,7 +26,7 @@ io_manager = fs_io_manager.configured(
 
 # start_update_defs
 defs = Definitions(
-    assets=hackernews_assets,
+    assets=all_assets,
     schedules=[hackernews_schedule],
     resources={
         "io_manager": io_manager,


### PR DESCRIPTION
## Summary & Motivation

In `Tutorial, part six: Saving your data` the assets were called `hackernews_assets`, however. in previous parts they were called `all_assets`

## How I Tested These Changes

Locally on my PC
