### PR TITLE
[wip][pythonic config] Add support for pydantic.SecretStr

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr, SecretField, SecretStr
-from typing_extensions import TypeAlias, TypeGuard, get_args
+from typing_extensions import TypeAlias, TypeGuard, get_args, get_origin
 
 from dagster import (
     Enum as DagsterEnum,
@@ -1421,7 +1421,12 @@ def _config_type_for_type_on_pydantic_field(
         potential_dagster_type (Any): The Python type of the Pydantic field.
     """
     # special case pydantic constrained types to their source equivalents
-    if safe_is_subclass(potential_dagster_type, (ConstrainedStr, SecretStr)):
+
+    if (
+        safe_is_subclass(potential_dagster_type, (ConstrainedStr, SecretStr))
+        or get_origin(potential_dagster_type) == Union
+        and get_args(potential_dagster_type)[0] == SecretStr
+    ):
         return StringSource
     # no FloatSource, so we just return float
     elif safe_is_subclass(potential_dagster_type, ConstrainedFloat):

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, Union, cast
 
 import pydantic
-from pydantic import Field
+from pydantic import Field, SecretStr
 from typing_extensions import dataclass_transform, get_origin
+
+from dagster import EnvVar
 
 from .utils import safe_is_subclass
 
@@ -97,6 +99,8 @@ class BaseResourceMeta(pydantic.main.ModelMetaclass):
                     annotations[field] = Union[
                         LateBoundTypesForResourceTypeChecking.get_partial_resource_type(base), base
                     ]
+                elif annotations[field] == SecretStr:
+                    annotations[field] = Union[SecretStr, EnvVar]
 
         namespaces["__annotations__"] = annotations
         return super().__new__(cls, name, bases, namespaces, **kwargs)

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
@@ -2640,7 +2640,6 @@ def test_secret_str_runtime_config() -> None:
     assert result.output_for_node("my_asset") == "bar"
 
 
-@pytest.xfail("need to fix, hits casting error currently")
 def test_secret_str_from_env() -> None:
     class ResourceWithSecret(ConfigurableResource):
         a_secret: SecretStr

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
@@ -2640,6 +2640,7 @@ def test_secret_str_runtime_config() -> None:
     assert result.output_for_node("my_asset") == "bar"
 
 
+@pytest.xfail("need to fix, hits casting error currently")
 def test_secret_str_from_env() -> None:
     class ResourceWithSecret(ConfigurableResource):
         a_secret: SecretStr


### PR DESCRIPTION
## Summary

Adds support for Pydantic's [`SecretStr`](https://docs.pydantic.dev/usage/types/#secret-types) data type, which when directly accessed or converted to JSON appears as asterisks. 

The config system treats it as a normal string source for purposes of accepting configuration - the only difference here is accessing the value from the config or resource object, in which case the user needs to call `.get_secret_value()` to access the underlying value.

Once we have a generic solution up for "secret" config values, we can make it so `SecretStr` is automatically treated as such.

## Test Plan

New unit tests.

