### PR TITLE
improvements to automated docs screenshotting

### DIFF
--- a/docs/dagit-screenshot/README.md
+++ b/docs/dagit-screenshot/README.md
@@ -27,7 +27,7 @@ screenshot specs.
 
 Specs have the following fields. Only the `id` field requires explicit specification for all specs:
 
-- `id`: Relative identifier for the spec, unique within the defining YAML file. The full ID of the spec is formed by joining the (extensionless) path to the defining YAML file with the relative ID. For the special name `index.yaml`, the `index` part is dropped. For example, a spec with `id` field "baz.png" stored in either `screenshots/foo/bar.yaml` or `screenshots/foo/bar/index.yaml` has the full ID `foo/bar/baz.png`. The full ID can be treated as a relative path that, when further qualified with an output root directory, specifies the path to an image file. The default output root is `next/public/images`, so by default the spec with ID `foo/bar/baz.png` corresponds to an image in `next/public/images/foo/bar/baz.png`.
+- `id`: E.g. `a/b/c.png`, for a screenshot with id "c.png" in `docs/screenshots/a/b.yaml`. The full ID of the spec is formed by joining the (extensionless) path to the defining YAML file with the relative ID. For the special name `index.yaml`, the `index` part is dropped. For example, a spec with `id` field "baz.png" stored in either `screenshots/foo/bar.yaml` or `screenshots/foo/bar/index.yaml` has the full ID `foo/bar/baz.png`. The full ID can be treated as a relative path that, when further qualified with an output root directory, specifies the path to an image file. The default output root is `next/public/images`, so by default the spec with ID `foo/bar/baz.png` corresponds to an image in `next/public/images/foo/bar/baz.png`.
 - `route (optional)` Dagit route (i.e. path part of the URL) that will be loaded before taking a screenshot. Defaults to `/`.
 - `workspace` (optional): path (relative to the repo root) to a python or workspace YAML file that defines the workspace that should be loaded before attempting screenshot capture. The script will pass the path to `dagit --python-file` or `dagit --workspace` (depending on file type) to load a set of Dagster definitions. This is required for screenshots generated from a local Dagit instance, can should be omitted for screenshots generated from a remote Dagit (e.g. at `demo.elementl.show`).
 - `base_url (optional)`: Base url (protocol and host) of a Dagit instance to be targeted for a screenshot. Can point to a local or remote host. Defaults to `http://localhost:3000`.
@@ -41,7 +41,12 @@ Install `dagit-screenshot` into your environment with `pip install -e
 dagit-screenshot`-- this will make the `dagit-screenshot` executable available
 on your path. 
 
-To generate the screenshot for a spec, run `dagit-screenshot capture <id>`.
+To generate the screenshot for a spec, run
+
+```
+dagit-screenshot capture <id>`
+```
+
 This will attempt to render the specified Dagit view using the browser
 automation tool [Selenium](https://www.selenium.dev). If no `steps` are
 specified in the target spec, the screenshot will be automatically captured. If

--- a/docs/dagit-screenshot/dagit_screenshot/commands/capture.py
+++ b/docs/dagit-screenshot/dagit_screenshot/commands/capture.py
@@ -28,15 +28,21 @@ def capture(spec: ScreenshotSpec, output_path: str) -> None:
         assert "workspace" in spec, 'spec must define a "workspace"'
         workspace = spec["workspace"]
         if workspace.endswith(".py"):
-            command = ["dagit", "-f", workspace]
+            command = ["dagster", "dev", "-f", workspace]
         elif workspace.endswith(".yaml"):
-            command = ["dagit", "-w", workspace]
+            command = ["dagster", "dev", "-w", workspace]
         else:
             raise Exception("'workspace' must be a .py or .yaml file.")
 
-        print("Starting dagit:")
+        print("Running `dagster dev`:")
         print("  " + " ".join(command))
-        dagit_process = subprocess.Popen(command)
+        try:
+            prev_dagster_home = os.environ["DAGSTER_HOME"]
+            os.environ["DAGSTER_HOME"] = ""
+            dagit_process = subprocess.Popen(command)
+        finally:
+            os.environ["DAGSTER_HOME"] = prev_dagster_home
+
         sleep(DAGIT_STARTUP_TIME)  # Wait for the dagit server to start up
 
         driver = webdriver.Chrome()

--- a/docs/dagit-screenshot/dagit_screenshot/utils.py
+++ b/docs/dagit-screenshot/dagit_screenshot/utils.py
@@ -17,6 +17,7 @@ class RawScreenshotSpec(TypedDict):
     width: NotRequired[int]
     height: NotRequired[int]
 
+
 class ScreenshotSpec(TypedDict):
     id: str
     base_url: str
@@ -26,7 +27,6 @@ class ScreenshotSpec(TypedDict):
     vetted: NotRequired[bool]
     width: NotRequired[int]
     height: NotRequired[int]
-
 
 
 SpecDB: TypeAlias = Sequence[ScreenshotSpec]
@@ -49,7 +49,6 @@ def _normalize_path(path: str, root: str):
 
 
 def load_spec(spec_id: str, spec_db_path: str) -> ScreenshotSpec:
-
     if _is_single_file_spec_db(spec_db_path):
         raw_spec = _load_spec_from_yaml(spec_id, spec_db_path)
     else:
@@ -57,7 +56,7 @@ def load_spec(spec_id: str, spec_db_path: str) -> ScreenshotSpec:
         db_nested_path = os.path.join(spec_db_path, *id_parts[:-1]) + ".yaml"
         if os.path.exists(db_nested_path):
             relative_id = id_parts[-1]
-            raw_spec =_load_spec_from_yaml(relative_id, db_nested_path)
+            raw_spec = _load_spec_from_yaml(relative_id, db_nested_path)
         else:
             db_index_path = os.path.join(spec_db_path, "index.yaml")
             raw_spec = _load_spec_from_yaml(spec_id, db_index_path)
@@ -71,7 +70,8 @@ def load_spec_db(spec_db_path: str) -> SpecDB:
         db += _load_yaml(spec_db_path)
     else:
         yaml_files = [
-            os.path.relpath(p, start=spec_db_path) for p in glob(f"{spec_db_path}/**/*.yaml", recursive=True)
+            os.path.relpath(p, start=spec_db_path)
+            for p in glob(f"{spec_db_path}/**/*.yaml", recursive=True)
         ]
 
         for p in yaml_files:
@@ -81,21 +81,29 @@ def load_spec_db(spec_db_path: str) -> SpecDB:
 
     return db
 
+
 def _normalize_spec(raw_spec: RawScreenshotSpec, filepath: str) -> ScreenshotSpec:
-    if filepath != '_global.yaml':
+    if filepath != "_global.yaml":
         raw_id_parts = os.path.splitext(filepath)[0]
-        id_parts = os.path.dirname(raw_id_parts) if os.path.basename(raw_id_parts) == 'index' else raw_id_parts
+        id_parts = (
+            os.path.dirname(raw_id_parts)
+            if os.path.basename(raw_id_parts) == "index"
+            else raw_id_parts
+        )
         raw_spec["id"] = os.path.join(id_parts, raw_spec["id"])
 
     spec = _apply_defaults(raw_spec)
     return spec
 
+
 def _is_single_file_spec_db(spec_db_path: str) -> bool:
     return not os.path.isdir(spec_db_path)
+
 
 def _load_yaml(path: str):
     with open(path, "r", encoding="utf8") as f:
         return yaml.safe_load(f)
+
 
 def _load_spec_from_yaml(spec_id: str, yaml_path: str) -> RawScreenshotSpec:
     specs = _load_yaml(yaml_path)
@@ -105,6 +113,7 @@ def _load_spec_from_yaml(spec_id: str, yaml_path: str) -> RawScreenshotSpec:
     elif len(matches) > 1:
         raise Exception(f"Multiple matches for spec [{spec_id}] found in {yaml_path}.")
     return matches[0]
+
 
 def _apply_defaults(raw_spec: RawScreenshotSpec) -> ScreenshotSpec:
     raw_spec.setdefault("base_url", "http://localhost:3000")


### PR DESCRIPTION
## Summary & Motivation

- Use `dagster dev` instead of `dagit` (otherwise runs don't ever get launched, because Dagster uses the queued run coordinator by default)
- Make the docs a little clearer
- Auto-format `dagit_screenshot/utils`
- Ignore DAGSTER_HOME in the environment

## How I Tested These Changes

Updated some screenshots on https://docs.dagster.io/guides/dagster/asset-versioning-and-caching#asset-versioning-and-caching