### PR TITLE
[pythonic config] More explicit error message for setting fields on Config/ConfigurableResource

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -118,19 +118,23 @@ class MakeConfigCacheable(BaseModel):
 
         try:
             return super().__setattr__(name, value)
-        except TypeError as e:
-            if "is immutable and does not support item assignment" in str(e):
+        except (TypeError, ValueError) as e:
+            if "is immutable and does not support item assignment" in str(
+                e
+            ) or "object has no field" in str(e):
                 clsname = self.__class__.__name__
                 if isinstance(self, ConfigurableResourceFactory):
                     raise DagsterInvalidInvocationError(
-                        f"'{clsname}' is a Pythonic resource and does not support item assignment."
-                        " If trying to set state on this resource, consider building a separate,"
-                        " stateful client class."
+                        f"'{clsname}' is a Pythonic resource and does not support item assignment,"
+                        " as it inherits from 'pydantic.BaseModel' with frozen=True. If trying to"
+                        " maintain state on this resource, consider building a separate, stateful"
+                        " client class, and provide a method on the resource to construct and"
+                        " return the stateful client."
                     ) from e
                 else:
                     raise DagsterInvalidInvocationError(
                         f"'{clsname}' is a Pythonic config class and does not support item"
-                        " assignment."
+                        " assignment, as it inherits from 'pydantic.BaseModel' with frozen=True."
                     ) from e
             else:
                 raise

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -13,6 +13,7 @@ from dagster._config.pythonic_config import ConfigurableResource, ConfigurableRe
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
+    DagsterInvalidInvocationError,
     DagsterInvalidPythonicConfigDefinitionError,
 )
 
@@ -355,3 +356,30 @@ def test_using_dagster_field_by_mistake_resource() -> None:
         ),
     ):
         MyResource(my_str="foo")
+
+
+def test_trying_to_set_a_field() -> None:
+    class MyConfig(Config):
+        my_str: str
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match="'MyConfig' is a Pythonic config class and does not support item assignment.",
+    ):
+        my_config = MyConfig(my_str="foo")
+        my_config.my_str = "bar"
+
+
+def test_trying_to_set_a_field_resource() -> None:
+    class MyResource(ConfigurableResource):
+        my_str: str
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=(
+            "'MyResource' is a Pythonic resource and does not support item assignment. If trying"
+            " to set state on this resource, consider building a separate, stateful client class."
+        ),
+    ):
+        my_resource = MyResource(my_str="foo")
+        my_resource.my_str = "bar"

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -395,8 +395,9 @@ def test_trying_to_set_an_undefined_field() -> None:
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "'MyConfig' is a Pythonic config class and does not support item assignment, as it"
-            " inherits from 'pydantic.BaseModel' with frozen=True."
+            "'MyConfig' is a Pythonic config class and does not support manipulating"
+            " undeclared attribute '_my_random_other_field' as it inherits from"
+            " 'pydantic.BaseModel' without extra=\\\"allow\\\"."
         ),
     ):
         my_config = MyConfig(my_str="foo")
@@ -410,11 +411,12 @@ def test_trying_to_set_an_undefined_field_resource() -> None:
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "'MyResource' is a Pythonic resource and does not support item assignment, as it"
-            " inherits from 'pydantic.BaseModel' with frozen=True. If trying to"
-            " maintain state on this resource, consider building a separate, stateful"
-            " client class, and provide a method on the resource to construct and"
-            " return the stateful client."
+            "'MyResource' is a Pythonic resource and does not support manipulating"
+            " undeclared attribute '_my_random_other_field' as it inherits from"
+            " 'pydantic.BaseModel' without extra=\\\"allow\\\". If trying to maintain"
+            " state on this resource, consider building a separate, stateful client"
+            " class, and provide a method on the resource to construct and return the"
+            " stateful client."
         ),
     ):
         my_resource = MyResource(my_str="foo")

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -377,9 +377,45 @@ def test_trying_to_set_a_field_resource() -> None:
     with pytest.raises(
         DagsterInvalidInvocationError,
         match=(
-            "'MyResource' is a Pythonic resource and does not support item assignment. If trying"
-            " to set state on this resource, consider building a separate, stateful client class."
+            "'MyResource' is a Pythonic resource and does not support item assignment, as it"
+            " inherits from 'pydantic.BaseModel' with frozen=True. If trying to"
+            " maintain state on this resource, consider building a separate, stateful"
+            " client class, and provide a method on the resource to construct and"
+            " return the stateful client."
         ),
     ):
         my_resource = MyResource(my_str="foo")
         my_resource.my_str = "bar"
+
+
+def test_trying_to_set_an_undefined_field() -> None:
+    class MyConfig(Config):
+        my_str: str
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=(
+            "'MyConfig' is a Pythonic config class and does not support item assignment, as it"
+            " inherits from 'pydantic.BaseModel' with frozen=True."
+        ),
+    ):
+        my_config = MyConfig(my_str="foo")
+        my_config._my_random_other_field = "bar"  # noqa: SLF001
+
+
+def test_trying_to_set_an_undefined_field_resource() -> None:
+    class MyResource(ConfigurableResource):
+        my_str: str
+
+    with pytest.raises(
+        DagsterInvalidInvocationError,
+        match=(
+            "'MyResource' is a Pythonic resource and does not support item assignment, as it"
+            " inherits from 'pydantic.BaseModel' with frozen=True. If trying to"
+            " maintain state on this resource, consider building a separate, stateful"
+            " client class, and provide a method on the resource to construct and"
+            " return the stateful client."
+        ),
+    ):
+        my_resource = MyResource(my_str="foo")
+        my_resource._my_random_other_field = "bar"  # noqa: SLF001


### PR DESCRIPTION
## Summary

Adds a more explicit/actionable error message for trying to set fields on a `ConfigurableResource`. Here, we prompt users to build a separate, stateful client class.

Previously, users would see the Pydantic error:
```
E   TypeError: "MyResource" is immutable and does not support item assignment
```


Now, they see

```
E   DagsterInvalidInvocationError: 'MyResource' is a Pythonic resource and does not support item assignment. 
    If trying to set state on this resource, consider building a separate, stateful client class.
```