### PR TITLE
[cached method] perf optimizations

### DIFF
--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import AbstractSet, Callable, Dict, Hashable, Mapping, Tuple, Type, TypeVar
 
-from typing_extensions import Concatenate, Final, ParamSpec
+from typing_extensions import Concatenate, ParamSpec
 
 from dagster import _check as check
 
@@ -11,11 +11,6 @@ T_Callable = TypeVar("T_Callable", bound=Callable)
 P = ParamSpec("P")
 
 
-class _Sentinel:
-    ...
-
-
-NO_VALUE_IN_CACHE_SENTINEL: Final = _Sentinel()
 NO_ARGS_HASH_VALUE = 0
 
 CACHED_METHOD_FIELD_SUFFIX = "_cached__internal__"
@@ -56,10 +51,10 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
     With this decorator, the first two would point to the same cache entry, and non-kwarg arguments
     are not allowed.
     """
+    cache_attr_name = method.__name__ + CACHED_METHOD_FIELD_SUFFIX
 
     @wraps(method)
-    def helper(self: S, *args: P.args, **kwargs: P.kwargs) -> T:
-        cache_attr_name = method.__name__ + CACHED_METHOD_FIELD_SUFFIX
+    def _cached_method_wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> T:
         if not hasattr(self, cache_attr_name):
             cache: Dict[Hashable, T] = {}
             setattr(self, cache_attr_name, cache)
@@ -67,15 +62,12 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
             cache = getattr(self, cache_attr_name)
 
         key = _make_key(args, kwargs)
-        cached_result = cache.get(key, NO_VALUE_IN_CACHE_SENTINEL)
-        if not isinstance(cached_result, _Sentinel):
-            return cached_result
-        else:
+        if key not in cache:
             result = method(self, *args, **kwargs)
             cache[key] = result
-            return result
+        return cache[key]
 
-    return helper
+    return _cached_method_wrapper
 
 
 class _HashedSeq(list):


### PR DESCRIPTION
some small optimizations observed from profiling
* don't repeatedly concat same string
* remove sentinel & check
* rename inner fn for clarity in stack traces 

## How I Tested These Changes
before
```
10000 iterations of a 1000 @cached_method gets 3576.6234ms
```
after
```
10000 iterations of a 1000 @cached_method gets 2107.8641ms
```


