### PR TITLE
[ui] Allow bulk start/stop of schedules

### DIFF
--- a/js_modules/dagit/packages/core/src/hooks/__tests__/useSelectionReducer.test.tsx
+++ b/js_modules/dagit/packages/core/src/hooks/__tests__/useSelectionReducer.test.tsx
@@ -1,0 +1,105 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {useSelectionReducer} from '../useSelectionReducer';
+
+describe('useSelectionReducer', () => {
+  const Test = ({ids}: {ids: string[]}) => {
+    const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(ids);
+
+    return (
+      <div>
+        <input
+          type="checkbox"
+          aria-label="check-all"
+          checked={checkedIds.size === ids.length}
+          onChange={(e) => onToggleAll(e.target.checked)}
+        />
+        {ids.map((id) => (
+          <input
+            key={id}
+            type="checkbox"
+            onChange={(e: React.FormEvent<HTMLInputElement>) => {
+              if (e.target instanceof HTMLInputElement) {
+                const onToggleChecked = onToggleFactory(id);
+                const {checked} = e.target;
+                const shiftKey =
+                  e.nativeEvent instanceof MouseEvent && e.nativeEvent.getModifierState('Shift');
+                onToggleChecked({checked, shiftKey});
+              }
+            }}
+            aria-label={`checkbox-${id}`}
+            checked={checkedIds.has(id)}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  it('checks individual items', () => {
+    render(<Test ids={['a', 'b', 'c', 'd']} />);
+    const checkA = screen.getByRole('checkbox', {name: /checkbox-a/i});
+    expect(checkA).not.toBeChecked();
+    userEvent.click(checkA);
+    expect(checkA).toBeChecked();
+    userEvent.click(checkA);
+    expect(checkA).not.toBeChecked();
+  });
+
+  it('checks slices of items', () => {
+    render(<Test ids={['a', 'b', 'c', 'd']} />);
+    const checkA = screen.getByRole('checkbox', {name: /checkbox-a/i});
+    const checkB = screen.getByRole('checkbox', {name: /checkbox-b/i});
+    const checkC = screen.getByRole('checkbox', {name: /checkbox-c/i});
+    const checkD = screen.getByRole('checkbox', {name: /checkbox-d/i});
+
+    expect(checkA).not.toBeChecked();
+    expect(checkB).not.toBeChecked();
+    expect(checkC).not.toBeChecked();
+    expect(checkD).not.toBeChecked();
+
+    userEvent.click(checkA);
+    expect(checkA).toBeChecked();
+    userEvent.click(checkC, {shiftKey: true});
+
+    expect(checkA).toBeChecked();
+    expect(checkB).toBeChecked();
+    expect(checkC).toBeChecked();
+    expect(checkD).not.toBeChecked();
+
+    userEvent.click(checkB, {shiftKey: true});
+    expect(checkA).toBeChecked();
+    expect(checkB).not.toBeChecked();
+    expect(checkC).not.toBeChecked();
+    expect(checkD).not.toBeChecked();
+  });
+
+  it('allows toggle-all', () => {
+    render(<Test ids={['a', 'b', 'c', 'd']} />);
+    const checkAll = screen.getByRole('checkbox', {name: /check-all/i});
+    const checkA = screen.getByRole('checkbox', {name: /checkbox-a/i});
+    const checkB = screen.getByRole('checkbox', {name: /checkbox-b/i});
+    const checkC = screen.getByRole('checkbox', {name: /checkbox-c/i});
+    const checkD = screen.getByRole('checkbox', {name: /checkbox-d/i});
+
+    expect(checkA).not.toBeChecked();
+    expect(checkB).not.toBeChecked();
+    expect(checkC).not.toBeChecked();
+    expect(checkD).not.toBeChecked();
+
+    userEvent.click(checkAll);
+
+    expect(checkA).toBeChecked();
+    expect(checkB).toBeChecked();
+    expect(checkC).toBeChecked();
+    expect(checkD).toBeChecked();
+
+    userEvent.click(checkAll);
+
+    expect(checkA).not.toBeChecked();
+    expect(checkB).not.toBeChecked();
+    expect(checkC).not.toBeChecked();
+    expect(checkD).not.toBeChecked();
+  });
+});

--- a/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
+++ b/js_modules/dagit/packages/core/src/overview/OverviewSchedulesRoot.tsx
@@ -11,6 +11,7 @@ import {
   PageHeader,
   Spinner,
   TextInput,
+  Tooltip,
 } from '@dagster-io/ui';
 import * as React from 'react';
 
@@ -20,19 +21,26 @@ import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {RepoFilterButton} from '../instance/RepoFilterButton';
 import {INSTIGATION_STATE_FRAGMENT} from '../instigation/InstigationUtils';
 import {UnloadableSchedules} from '../instigation/Unloadable';
+import {ScheduleBulkActionMenu} from '../schedules/ScheduleBulkActionMenu';
 import {SchedulerInfo} from '../schedules/SchedulerInfo';
+import {SchedulesCheckAll} from '../schedules/SchedulesCheckAll';
+import {filterPermissionedSchedules} from '../schedules/filterPermissionedSchedules';
+import {makeScheduleKey} from '../schedules/makeScheduleKey';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 
+import {BASIC_INSTIGATION_STATE_FRAGMENT} from './BasicInstigationStateFragment';
 import {OverviewScheduleTable} from './OverviewSchedulesTable';
 import {OverviewTabs} from './OverviewTabs';
 import {sortRepoBuckets} from './sortRepoBuckets';
+import {BasicInstigationStateFragment} from './types/BasicInstigationStateFragment.types';
 import {
   OverviewSchedulesQuery,
   OverviewSchedulesQueryVariables,
@@ -78,10 +86,62 @@ export const OverviewSchedulesRoot = () => {
     return repoBuckets
       .map(({repoAddress, schedules}) => ({
         repoAddress,
-        schedules: schedules.filter((name) => name.toLocaleLowerCase().includes(searchToLower)),
+        schedules: schedules.filter(({name}) => name.toLocaleLowerCase().includes(searchToLower)),
       }))
       .filter(({schedules}) => schedules.length > 0);
   }, [repoBuckets, sanitizedSearch]);
+
+  // Collect all schedules across visible code locations that the viewer has permission
+  // to start or stop.
+  const allPermissionedSchedules = React.useMemo(() => {
+    return repoBuckets
+      .map(({repoAddress, schedules}) => {
+        return schedules.filter(filterPermissionedSchedules).map(({name, scheduleState}) => ({
+          repoAddress,
+          scheduleName: name,
+          scheduleState,
+        }));
+      })
+      .flat();
+  }, [repoBuckets]);
+
+  // Build a list of keys from the permissioned schedules for use in checkbox state.
+  // This includes collapsed code locations.
+  const allPermissionedScheduleKeys = React.useMemo(() => {
+    return allPermissionedSchedules.map(({repoAddress, scheduleName}) =>
+      makeScheduleKey(repoAddress, scheduleName),
+    );
+  }, [allPermissionedSchedules]);
+
+  const [{checkedIds: checkedKeys}, {onToggleFactory, onToggleAll}] = useSelectionReducer(
+    allPermissionedScheduleKeys,
+  );
+
+  // Filter to find keys that are visible given any text search.
+  const permissionedKeysOnScreen = React.useMemo(() => {
+    const filteredKeys = new Set(
+      filteredBySearch
+        .map(({repoAddress, schedules}) => {
+          return schedules.map(({name}) => makeScheduleKey(repoAddress, name));
+        })
+        .flat(),
+    );
+    return allPermissionedScheduleKeys.filter((key) => filteredKeys.has(key));
+  }, [allPermissionedScheduleKeys, filteredBySearch]);
+
+  // Determine the list of schedule objects that have been checked by the viewer.
+  // These are the schedules that will be operated on by the bulk start/stop action.
+  const checkedSchedules = React.useMemo(() => {
+    const checkedKeysOnScreen = new Set(
+      permissionedKeysOnScreen.filter((key: string) => checkedKeys.has(key)),
+    );
+    return allPermissionedSchedules.filter(({repoAddress, scheduleName}) => {
+      return checkedKeysOnScreen.has(makeScheduleKey(repoAddress, scheduleName));
+    });
+  }, [permissionedKeysOnScreen, allPermissionedSchedules, checkedKeys]);
+
+  const viewerHasAnyInstigationPermission = allPermissionedScheduleKeys.length > 0;
+  const checkedCount = checkedSchedules.length;
 
   const content = () => {
     if (loading && !data) {
@@ -137,7 +197,22 @@ export const OverviewSchedulesRoot = () => {
       );
     }
 
-    return <OverviewScheduleTable repos={filteredBySearch} />;
+    return (
+      <OverviewScheduleTable
+        headerCheckbox={
+          viewerHasAnyInstigationPermission ? (
+            <SchedulesCheckAll
+              checkedCount={checkedCount}
+              totalCount={permissionedKeysOnScreen.length}
+              onToggleAll={onToggleAll}
+            />
+          ) : undefined
+        }
+        repos={filteredBySearch}
+        checkedKeys={checkedKeys}
+        onToggleCheckFactory={onToggleFactory}
+      />
+    );
   };
 
   return (
@@ -148,16 +223,32 @@ export const OverviewSchedulesRoot = () => {
       />
       <Box
         padding={{horizontal: 24, vertical: 16}}
-        flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
       >
-        {repoCount > 0 ? <RepoFilterButton /> : null}
-        <TextInput
-          icon="search"
-          value={searchValue}
-          onChange={(e) => setSearchValue(e.target.value)}
-          placeholder="Filter by schedule name…"
-          style={{width: '340px'}}
-        />
+        <Box flex={{direction: 'row', gap: 12}}>
+          {repoCount > 0 ? <RepoFilterButton /> : null}
+          <TextInput
+            icon="search"
+            value={searchValue}
+            onChange={(e) => {
+              setSearchValue(e.target.value);
+              onToggleAll(false);
+            }}
+            placeholder="Filter by schedule name…"
+            style={{width: '340px'}}
+          />
+        </Box>
+        <Tooltip
+          content="You do not have permission to start or stop these schedules"
+          canShow={!viewerHasAnyInstigationPermission}
+          placement="top-end"
+          useDisabledButtonTooltipFix
+        >
+          <ScheduleBulkActionMenu
+            schedules={checkedSchedules}
+            onDone={() => refreshState.refetch()}
+          />
+        </Tooltip>
       </Box>
       {loading && !repoCount ? (
         <Box padding={64}>
@@ -256,7 +347,7 @@ const UnloadableScheduleDialog: React.FC = () => {
 
 type RepoBucket = {
   repoAddress: RepoAddress;
-  schedules: string[];
+  schedules: {name: string; scheduleState: BasicInstigationStateFragment}[];
 };
 
 const buildBuckets = (data?: OverviewSchedulesQuery): RepoBucket[] => {
@@ -276,7 +367,7 @@ const buildBuckets = (data?: OverviewSchedulesQuery): RepoBucket[] => {
     for (const repo of entry.repositories) {
       const {name, schedules} = repo;
       const repoAddress = buildRepoAddress(name, entry.name);
-      const scheduleNames = schedules.map(({name}) => name);
+      const scheduleNames = schedules.map(({name, scheduleState}) => ({name, scheduleState}));
 
       if (scheduleNames.length > 0) {
         buckets.push({
@@ -308,6 +399,10 @@ const OVERVIEW_SCHEDULES_QUERY = gql`
                   id
                   name
                   description
+                  scheduleState {
+                    id
+                    ...BasicInstigationStateFragment
+                  }
                 }
               }
             }
@@ -330,6 +425,7 @@ const OVERVIEW_SCHEDULES_QUERY = gql`
     }
   }
 
+  ${BASIC_INSTIGATION_STATE_FRAGMENT}
   ${PYTHON_ERROR_FRAGMENT}
   ${INSTANCE_HEALTH_FRAGMENT}
 `;

--- a/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/overview/types/OverviewSchedulesRoot.types.ts
@@ -47,6 +47,14 @@ export type OverviewSchedulesQuery = {
                     id: string;
                     name: string;
                     description: string | null;
+                    scheduleState: {
+                      __typename: 'InstigationState';
+                      id: string;
+                      selectorId: string;
+                      status: Types.InstigationStatus;
+                      hasStartPermission: boolean;
+                      hasStopPermission: boolean;
+                    };
                   }>;
                 }>;
               }

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleBulkActionMenu.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleBulkActionMenu.tsx
@@ -1,0 +1,81 @@
+import {Button, Icon, Menu, MenuItem, Popover} from '@dagster-io/ui';
+import * as React from 'react';
+
+import {InstigationStatus} from '../graphql/types';
+
+import {OpenWithIntent, ScheduleInfo, ScheduleStateChangeDialog} from './ScheduleStateChangeDialog';
+
+interface Props {
+  schedules: ScheduleInfo[];
+  onDone: () => void;
+}
+
+export const ScheduleBulkActionMenu = (props: Props) => {
+  const {schedules, onDone} = props;
+  const count = schedules.length;
+
+  const [openWithIntent, setOpenWithIntent] = React.useState<OpenWithIntent>('not-open');
+
+  const {anyOff, anyOn} = React.useMemo(() => {
+    let anyOff = false;
+    let anyOn = false;
+
+    for (const schedule of schedules) {
+      const {
+        scheduleState: {status},
+      } = schedule;
+      if (status === InstigationStatus.RUNNING) {
+        anyOn = true;
+      } else if (status === InstigationStatus.STOPPED) {
+        anyOff = true;
+      }
+      if (anyOn && anyOff) {
+        break;
+      }
+    }
+
+    return {anyOff, anyOn};
+  }, [schedules]);
+
+  return (
+    <>
+      <Popover
+        content={
+          <Menu>
+            <MenuItem
+              text={`Start ${count === 1 ? '1 schedule' : `${count} schedules`}`}
+              disabled={!anyOff}
+              aria-disabled={!anyOff}
+              icon="toggle_on"
+              onClick={() => {
+                setOpenWithIntent('start');
+              }}
+            />
+            <MenuItem
+              text={`Stop ${count === 1 ? '1 schedule' : `${count} schedules`}`}
+              disabled={!anyOn}
+              aria-disabled={!anyOn}
+              icon="toggle_off"
+              onClick={() => {
+                setOpenWithIntent('stop');
+              }}
+            />
+          </Menu>
+        }
+        placement="bottom-end"
+      >
+        <Button disabled={!count} intent="primary" rightIcon={<Icon name="expand_more" />}>
+          Actions
+        </Button>
+      </Popover>
+      <ScheduleStateChangeDialog
+        openWithIntent={openWithIntent}
+        schedules={schedules}
+        onClose={() => setOpenWithIntent('not-open')}
+        onComplete={() => {
+          onDone();
+        }}
+      />
+    </>
+  );
+};

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleStateChangeDialog.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleStateChangeDialog.tsx
@@ -22,7 +22,7 @@ export type ScheduleInfo = {
   scheduleState: BasicInstigationStateFragment;
 };
 
-export type OpenWithIntent = 'not-open' | 'turn-on' | 'turn-off';
+export type OpenWithIntent = 'not-open' | 'start' | 'stop';
 
 export interface Props {
   openWithIntent: OpenWithIntent;
@@ -158,7 +158,7 @@ export const ScheduleStateChangeDialog = (props: Props) => {
     dispatch({type: 'start'});
     for (let ii = 0; ii < schedules.length; ii++) {
       const schedule = schedules[ii];
-      if (openWithIntent === 'turn-on') {
+      if (openWithIntent === 'start') {
         await start(schedule);
       } else {
         await stop(schedule);
@@ -176,12 +176,12 @@ export const ScheduleStateChangeDialog = (props: Props) => {
 
     switch (state.step) {
       case 'initial':
-        if (openWithIntent === 'turn-on') {
+        if (openWithIntent === 'stop') {
           return (
             <div>
               {`${count} ${
                 count === 1 ? 'schedule' : 'schedules'
-              } will be turned on. Do you wish to continue?`}
+              } will be stopped. Do you want to continue?`}
             </div>
           );
         }
@@ -189,7 +189,7 @@ export const ScheduleStateChangeDialog = (props: Props) => {
           <div>
             {`${count} ${
               count === 1 ? 'schedule' : 'schedules'
-            } will be turned off. Do you wish to continue?`}
+            } will be started. Do you want to continue?`}
           </div>
         );
       case 'updating':
@@ -216,9 +216,9 @@ export const ScheduleStateChangeDialog = (props: Props) => {
     switch (state.step) {
       case 'initial': {
         const label =
-          openWithIntent === 'turn-on'
-            ? `Turn on ${count === 1 ? '1 schedule' : `${count} schedules`}`
-            : `Turn off ${count === 1 ? '1 schedule' : `${count} schedules`}`;
+          openWithIntent === 'start'
+            ? `Start ${count === 1 ? '1 schedule' : `${count} schedules`}`
+            : `Stop ${count === 1 ? '1 schedule' : `${count} schedules`}`;
         return (
           <>
             <Button intent="none" onClick={onClose}>
@@ -232,9 +232,9 @@ export const ScheduleStateChangeDialog = (props: Props) => {
       }
       case 'updating': {
         const label =
-          openWithIntent === 'turn-on'
-            ? `Turning on ${count === 1 ? '1 schedule' : `${count} schedules`}`
-            : `Turning off ${count === 1 ? '1 schedule' : `${count} schedules`}`;
+          openWithIntent === 'start'
+            ? `Starting ${count === 1 ? '1 schedule' : `${count} schedules`}`
+            : `Stopping ${count === 1 ? '1 schedule' : `${count} schedules`}`;
         return (
           <Button intent="primary" disabled>
             {label}
@@ -273,11 +273,11 @@ export const ScheduleStateChangeDialog = (props: Props) => {
           <Group direction="row" spacing={8} alignItems="flex-start">
             <Icon name="check_circle" color={Colors.Green500} />
             <div>
-              {openWithIntent === 'turn-on'
-                ? `Successfully turned on ${
+              {openWithIntent === 'start'
+                ? `Successfully started ${
                     successCount === 1 ? '1 schedule' : `${successCount} schedules`
                   }.`
-                : `Successfully turned off ${
+                : `Successfully stopped ${
                     successCount === 1 ? '1 schedule' : `${successCount} schedules`
                   }.`}
             </div>
@@ -288,11 +288,11 @@ export const ScheduleStateChangeDialog = (props: Props) => {
             <Group direction="row" spacing={8} alignItems="flex-start">
               <Icon name="warning" color={Colors.Yellow500} />
               <div>
-                {openWithIntent === 'turn-on'
-                  ? `Could not turn on ${
+                {openWithIntent === 'start'
+                  ? `Could not start ${
                       errorCount === 1 ? '1 schedule' : `${errorCount} schedules`
                     }.`
-                  : `Could not turn off ${
+                  : `Could not stop ${
                       errorCount === 1 ? '1 schedule' : `${errorCount} schedules`
                     }.`}
               </div>
@@ -318,7 +318,7 @@ export const ScheduleStateChangeDialog = (props: Props) => {
   return (
     <Dialog
       isOpen={openWithIntent !== 'not-open'}
-      title={openWithIntent === 'turn-on' ? 'Turn on schedules' : 'Turn off schedules'}
+      title={openWithIntent === 'start' ? 'Start schedules' : 'Stop schedules'}
       canEscapeKeyClose={canQuicklyClose}
       canOutsideClickClose={canQuicklyClose}
       onClose={onClose}

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesCheckAll.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesCheckAll.tsx
@@ -1,0 +1,24 @@
+import {Checkbox, Tooltip} from '@dagster-io/ui';
+import * as React from 'react';
+
+interface Props {
+  checkedCount: number;
+  totalCount: number;
+  onToggleAll: (checked: boolean) => void;
+}
+
+export const SchedulesCheckAll = ({checkedCount, totalCount, onToggleAll}: Props) => {
+  return (
+    <Tooltip content={`${checkedCount} of ${totalCount} selected`} placement="top">
+      <Checkbox
+        indeterminate={checkedCount > 0 && checkedCount !== totalCount}
+        checked={checkedCount > 0 && checkedCount === totalCount}
+        onChange={(e) => {
+          if (e.target instanceof HTMLInputElement) {
+            onToggleAll(checkedCount !== totalCount);
+          }
+        }}
+      />
+    </Tooltip>
+  );
+};

--- a/js_modules/dagit/packages/core/src/schedules/__fixtures__/ScheduleState.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/__fixtures__/ScheduleState.fixtures.tsx
@@ -12,7 +12,7 @@ import {StartThisScheduleMutation, StopScheduleMutation} from '../types/Schedule
 
 const repoAddress = buildRepoAddress('foo', 'bar');
 
-export const scheduleAlaskaCurrentlyOff = {
+export const scheduleAlaskaCurrentlyStopped = {
   repoAddress,
   scheduleName: 'alaska',
   scheduleState: buildInstigationState({
@@ -22,7 +22,7 @@ export const scheduleAlaskaCurrentlyOff = {
   }),
 };
 
-export const scheduleColoradoCurrentlyOff = {
+export const scheduleColoradoCurrentlyStopped = {
   repoAddress,
   scheduleName: 'colorado',
   scheduleState: buildInstigationState({
@@ -30,7 +30,7 @@ export const scheduleColoradoCurrentlyOff = {
   }),
 };
 
-export const scheduleDelawareCurrentlyOn = {
+export const scheduleDelawareCurrentlyRunning = {
   repoAddress,
   scheduleName: 'delaware',
   scheduleState: buildInstigationState({
@@ -40,7 +40,7 @@ export const scheduleDelawareCurrentlyOn = {
   }),
 };
 
-export const scheduleHawaiiCurrentlyOn = {
+export const scheduleHawaiiCurrentlyRunning = {
   repoAddress,
   scheduleName: 'hawaii',
   scheduleState: buildInstigationState({
@@ -50,7 +50,7 @@ export const scheduleHawaiiCurrentlyOn = {
   }),
 };
 
-export const buildTurnOnAlaskaSuccess = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
+export const buildStartAlaskaSuccess = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
   return {
     request: {
       query: START_SCHEDULE_MUTATION,
@@ -76,9 +76,7 @@ export const buildTurnOnAlaskaSuccess = (delay = 0): MockedResponse<StartThisSch
   };
 };
 
-export const buildTurnOnColoradoSuccess = (
-  delay = 0,
-): MockedResponse<StartThisScheduleMutation> => {
+export const buildStartColoradoSuccess = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
   return {
     request: {
       query: START_SCHEDULE_MUTATION,
@@ -104,7 +102,7 @@ export const buildTurnOnColoradoSuccess = (
   };
 };
 
-export const buildTurnOnColoradoError = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
+export const buildStartColoradoError = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
   return {
     request: {
       query: START_SCHEDULE_MUTATION,
@@ -128,7 +126,7 @@ export const buildTurnOnColoradoError = (delay = 0): MockedResponse<StartThisSch
   };
 };
 
-export const buildTurnOffDelawareSuccess = (delay = 0): MockedResponse<StopScheduleMutation> => {
+export const buildStopDelawareSuccess = (delay = 0): MockedResponse<StopScheduleMutation> => {
   return {
     request: {
       query: STOP_SCHEDULE_MUTATION,
@@ -151,7 +149,7 @@ export const buildTurnOffDelawareSuccess = (delay = 0): MockedResponse<StopSched
   };
 };
 
-export const buildTurnOffHawaiiSuccess = (delay = 0): MockedResponse<StopScheduleMutation> => {
+export const buildStopHawaiiSuccess = (delay = 0): MockedResponse<StopScheduleMutation> => {
   return {
     request: {
       query: STOP_SCHEDULE_MUTATION,
@@ -174,7 +172,7 @@ export const buildTurnOffHawaiiSuccess = (delay = 0): MockedResponse<StopSchedul
   };
 };
 
-export const buildTurnOffHawaiiError = (delay = 0): MockedResponse<StopScheduleMutation> => {
+export const buildStopHawaiiError = (delay = 0): MockedResponse<StopScheduleMutation> => {
   return {
     request: {
       query: STOP_SCHEDULE_MUTATION,

--- a/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleBulkActionMenu.test.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleBulkActionMenu.test.tsx
@@ -1,0 +1,91 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {ScheduleBulkActionMenu} from '../ScheduleBulkActionMenu';
+import {
+  scheduleAlaskaCurrentlyStopped,
+  scheduleColoradoCurrentlyStopped,
+  scheduleDelawareCurrentlyRunning,
+  scheduleHawaiiCurrentlyRunning,
+} from '../__fixtures__/ScheduleState.fixtures';
+
+jest.mock('../ScheduleStateChangeDialog', () => ({
+  ScheduleStateChangeDialog: () => <div />,
+}));
+
+describe('ScheduleBulkActionMenu', () => {
+  const expectAriaEnabled = (node: HTMLElement) => {
+    expect(node).toHaveAttribute('aria-disabled', 'false');
+  };
+
+  const expectAriaDisabled = (node: HTMLElement) => {
+    expect(node).toHaveAttribute('aria-disabled', 'true');
+  };
+
+  it('renders button and menu items for stopped schedules', () => {
+    render(
+      <ScheduleBulkActionMenu
+        schedules={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
+        onDone={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole('button', {name: /actions/i});
+    expect(button).toBeVisible();
+    expect(button).toBeEnabled();
+
+    userEvent.click(button);
+
+    const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
+    expectAriaEnabled(startItem);
+    const stopItem = screen.getByRole('menuitem', {name: /stop 2 schedules/i});
+    expectAriaDisabled(stopItem);
+  });
+
+  it('renders button and menu items for running schedules', () => {
+    render(
+      <ScheduleBulkActionMenu
+        schedules={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
+        onDone={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole('button', {name: /actions/i});
+    expect(button).toBeVisible();
+    expect(button).toBeEnabled();
+
+    userEvent.click(button);
+
+    const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
+    expectAriaDisabled(startItem);
+    const stopItem = screen.getByRole('menuitem', {name: /stop 2 schedules/i});
+    expectAriaEnabled(stopItem);
+  });
+
+  it('renders button and menu items for mixture of statuses', () => {
+    render(
+      <ScheduleBulkActionMenu
+        schedules={[
+          scheduleAlaskaCurrentlyStopped,
+          scheduleColoradoCurrentlyStopped,
+          scheduleDelawareCurrentlyRunning,
+          scheduleHawaiiCurrentlyRunning,
+        ]}
+        onDone={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole('button', {name: /actions/i});
+    expect(button).toBeVisible();
+    expect(button).toBeEnabled();
+
+    userEvent.click(button);
+
+    // Both options enabled
+    const startItem = screen.getByRole('menuitem', {name: /start 4 schedules/i});
+    expectAriaEnabled(startItem);
+    const stopItem = screen.getByRole('menuitem', {name: /stop 4 schedules/i});
+    expectAriaEnabled(stopItem);
+  });
+});

--- a/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleStateChangeDialog.test.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/__tests__/ScheduleStateChangeDialog.test.tsx
@@ -5,16 +5,16 @@ import * as React from 'react';
 
 import {ScheduleStateChangeDialog} from '../ScheduleStateChangeDialog';
 import {
-  buildTurnOffDelawareSuccess,
-  buildTurnOffHawaiiError,
-  buildTurnOffHawaiiSuccess,
-  buildTurnOnAlaskaSuccess,
-  buildTurnOnColoradoError,
-  buildTurnOnColoradoSuccess,
-  scheduleAlaskaCurrentlyOff,
-  scheduleColoradoCurrentlyOff,
-  scheduleDelawareCurrentlyOn,
-  scheduleHawaiiCurrentlyOn,
+  buildStopDelawareSuccess,
+  buildStopHawaiiError,
+  buildStopHawaiiSuccess,
+  buildStartAlaskaSuccess,
+  buildStartColoradoError,
+  buildStartColoradoSuccess,
+  scheduleAlaskaCurrentlyStopped,
+  scheduleColoradoCurrentlyStopped,
+  scheduleDelawareCurrentlyRunning,
+  scheduleHawaiiCurrentlyRunning,
 } from '../__fixtures__/ScheduleState.fixtures';
 
 jest.mock('../..//runs/NavigationBlock', () => ({
@@ -23,12 +23,12 @@ jest.mock('../..//runs/NavigationBlock', () => ({
 
 describe('ScheduleStateChangeDialog', () => {
   describe('Initial rendering', () => {
-    it('shows content when turning on single schedule', () => {
+    it('shows content when starting single schedule', () => {
       render(
         <MockedProvider>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-on"
-            schedules={[scheduleAlaskaCurrentlyOff]}
+            openWithIntent="start"
+            schedules={[scheduleAlaskaCurrentlyStopped]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
@@ -36,18 +36,18 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       expect(
-        screen.getByText(/1 schedule will be turned on\. do you wish to continue\?/i),
+        screen.getByText(/1 schedule will be started\. do you want to continue\?/i),
       ).toBeVisible();
 
-      expect(screen.getByRole('button', {name: /turn on 1 schedule/i})).toBeVisible();
+      expect(screen.getByRole('button', {name: /start 1 schedule/i})).toBeVisible();
     });
 
-    it('shows content when turning on multiple schedules', () => {
+    it('shows content when starting multiple schedules', () => {
       render(
         <MockedProvider>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-on"
-            schedules={[scheduleAlaskaCurrentlyOff, scheduleColoradoCurrentlyOff]}
+            openWithIntent="start"
+            schedules={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
@@ -55,18 +55,18 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       expect(
-        screen.getByText(/2 schedules will be turned on\. do you wish to continue\?/i),
+        screen.getByText(/2 schedules will be started\. do you want to continue\?/i),
       ).toBeVisible();
 
-      expect(screen.getByRole('button', {name: /turn on 2 schedules/i})).toBeVisible();
+      expect(screen.getByRole('button', {name: /start 2 schedules/i})).toBeVisible();
     });
 
-    it('shows content when turning off single schedule', () => {
+    it('shows content when stopping single schedule', () => {
       render(
         <MockedProvider>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-off"
-            schedules={[scheduleDelawareCurrentlyOn]}
+            openWithIntent="stop"
+            schedules={[scheduleDelawareCurrentlyRunning]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
@@ -74,18 +74,18 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       expect(
-        screen.getByText(/1 schedule will be turned off\. do you wish to continue\?/i),
+        screen.getByText(/1 schedule will be stopped\. do you want to continue\?/i),
       ).toBeVisible();
 
-      expect(screen.getByRole('button', {name: /turn off 1 schedule/i})).toBeVisible();
+      expect(screen.getByRole('button', {name: /stop 1 schedule/i})).toBeVisible();
     });
 
-    it('shows content when turning off multiple schedules', () => {
+    it('shows content when stopping multiple schedules', () => {
       render(
         <MockedProvider>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-off"
-            schedules={[scheduleDelawareCurrentlyOn, scheduleHawaiiCurrentlyOn]}
+            openWithIntent="stop"
+            schedules={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
@@ -93,70 +93,70 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       expect(
-        screen.getByText(/2 schedules will be turned off\. do you wish to continue\?/i),
+        screen.getByText(/2 schedules will be stopped\. do you want to continue\?/i),
       ).toBeVisible();
 
-      expect(screen.getByRole('button', {name: /turn off 2 schedules/i})).toBeVisible();
+      expect(screen.getByRole('button', {name: /stop 2 schedules/i})).toBeVisible();
     });
   });
 
-  describe('Mutation: turn on', () => {
-    it('turns on schedules', async () => {
-      const mocks = [buildTurnOnAlaskaSuccess(100), buildTurnOnColoradoSuccess(100)];
+  describe('Mutation: start', () => {
+    it('starts schedules', async () => {
+      const mocks = [buildStartAlaskaSuccess(100), buildStartColoradoSuccess(100)];
 
       render(
         <MockedProvider mocks={mocks}>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-on"
-            schedules={[scheduleAlaskaCurrentlyOff, scheduleColoradoCurrentlyOff]}
+            openWithIntent="start"
+            schedules={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
         </MockedProvider>,
       );
 
-      const confirmButton = screen.getByRole('button', {name: /turn on/i});
+      const confirmButton = screen.getByRole('button', {name: /start/i});
       userEvent.click(confirmButton);
 
       await waitFor(() => {
-        const button = screen.getByRole('button', {name: /turning on/i});
+        const button = screen.getByRole('button', {name: /starting/i});
         expect(button).toBeVisible();
         expect(button).toBeDisabled();
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/successfully turned on 2 schedules/i)).toBeVisible();
+        expect(screen.getByText(/successfully started 2 schedules/i)).toBeVisible();
       });
     });
 
-    it('shows error when turning on a schedule fails', async () => {
-      const mocks = [buildTurnOnAlaskaSuccess(100), buildTurnOnColoradoError(100)];
+    it('shows error when starting a schedule fails', async () => {
+      const mocks = [buildStartAlaskaSuccess(100), buildStartColoradoError(100)];
 
       render(
         <MockedProvider mocks={mocks}>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-on"
-            schedules={[scheduleAlaskaCurrentlyOff, scheduleColoradoCurrentlyOff]}
+            openWithIntent="start"
+            schedules={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
         </MockedProvider>,
       );
 
-      const confirmButton = screen.getByRole('button', {name: /turn on/i});
+      const confirmButton = screen.getByRole('button', {name: /start/i});
       userEvent.click(confirmButton);
 
       await waitFor(() => {
-        const button = screen.getByRole('button', {name: /turning on/i});
+        const button = screen.getByRole('button', {name: /starting/i});
         expect(button).toBeVisible();
         expect(button).toBeDisabled();
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/successfully turned on 1 schedule/i)).toBeVisible();
+        expect(screen.getByText(/successfully started 1 schedule/i)).toBeVisible();
       });
 
-      expect(screen.getByText(/could not turn on 1 schedule/i)).toBeVisible();
+      expect(screen.getByText(/could not start 1 schedule/i)).toBeVisible();
       const errorItem = screen.getByRole('listitem');
 
       expect(errorItem.textContent).toMatch(/colorado/i);
@@ -164,63 +164,63 @@ describe('ScheduleStateChangeDialog', () => {
     });
   });
 
-  describe('Mutation: turn off', () => {
-    it('turns off schedules', async () => {
-      const mocks = [buildTurnOffDelawareSuccess(100), buildTurnOffHawaiiSuccess(100)];
+  describe('Mutation: stop', () => {
+    it('stops schedules', async () => {
+      const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiSuccess(100)];
 
       render(
         <MockedProvider mocks={mocks}>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-off"
-            schedules={[scheduleDelawareCurrentlyOn, scheduleHawaiiCurrentlyOn]}
+            openWithIntent="stop"
+            schedules={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
         </MockedProvider>,
       );
 
-      const confirmButton = screen.getByRole('button', {name: /turn off/i});
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
       userEvent.click(confirmButton);
 
       await waitFor(() => {
-        const button = screen.getByRole('button', {name: /turning off/i});
+        const button = screen.getByRole('button', {name: /stopping/i});
         expect(button).toBeVisible();
         expect(button).toBeDisabled();
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/successfully turned off 2 schedules/i)).toBeVisible();
+        expect(screen.getByText(/successfully stopped 2 schedules/i)).toBeVisible();
       });
     });
 
-    it('shows error when turning off a schedule fails', async () => {
-      const mocks = [buildTurnOffDelawareSuccess(100), buildTurnOffHawaiiError(100)];
+    it('shows error when stopping a schedule fails', async () => {
+      const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiError(100)];
 
       render(
         <MockedProvider mocks={mocks}>
           <ScheduleStateChangeDialog
-            openWithIntent="turn-off"
-            schedules={[scheduleDelawareCurrentlyOn, scheduleHawaiiCurrentlyOn]}
+            openWithIntent="stop"
+            schedules={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
             onClose={jest.fn()}
             onComplete={jest.fn()}
           />
         </MockedProvider>,
       );
 
-      const confirmButton = screen.getByRole('button', {name: /turn off/i});
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
       userEvent.click(confirmButton);
 
       await waitFor(() => {
-        const button = screen.getByRole('button', {name: /turning off/i});
+        const button = screen.getByRole('button', {name: /stopping/i});
         expect(button).toBeVisible();
         expect(button).toBeDisabled();
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/successfully turned off 1 schedule/i)).toBeVisible();
+        expect(screen.getByText(/successfully stopped 1 schedule/i)).toBeVisible();
       });
 
-      expect(screen.getByText(/could not turn off 1 schedule/i)).toBeVisible();
+      expect(screen.getByText(/could not stop 1 schedule/i)).toBeVisible();
       const errorItem = screen.getByRole('listitem');
 
       expect(errorItem.textContent).toMatch(/hawaii/i);

--- a/js_modules/dagit/packages/core/src/schedules/filterPermissionedSchedules.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/filterPermissionedSchedules.tsx
@@ -1,0 +1,12 @@
+import {InstigationStatus} from '../graphql/types';
+import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
+
+export const filterPermissionedSchedules = (schedule: {
+  scheduleState: BasicInstigationStateFragment;
+}) => {
+  const {scheduleState} = schedule;
+  return (
+    (scheduleState.hasStartPermission && scheduleState.status === InstigationStatus.STOPPED) ||
+    (scheduleState.hasStopPermission && scheduleState.status === InstigationStatus.RUNNING)
+  );
+};

--- a/js_modules/dagit/packages/core/src/schedules/makeScheduleKey.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/makeScheduleKey.tsx
@@ -1,0 +1,6 @@
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+export const makeScheduleKey = (repoAddress: RepoAddress, scheduleName: string) => {
+  return `${repoAddressAsHumanString(repoAddress)}-${scheduleName}`;
+};

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleRow.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Caption,
+  Checkbox,
   Colors,
   Icon,
   Menu,
@@ -18,6 +19,7 @@ import {useQueryRefreshAtInterval, FIFTEEN_SECONDS} from '../app/QueryRefresh';
 import {InstigationStatus, InstigationType} from '../graphql/types';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {TickTag, TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
+import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {ScheduleSwitch, SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
@@ -36,17 +38,31 @@ import {
 } from './types/VirtualizedScheduleRow.types';
 import {workspacePathFromAddress} from './workspacePath';
 
-const TEMPLATE_COLUMNS = '76px 1fr 1fr 148px 210px 92px';
+const TEMPLATE_COLUMNS_WITH_CHECKBOX = '60px 1fr 1fr 76px 148px 210px 92px';
+const TEMPLATE_COLUMNS = '1fr 1fr 76px 148px 210px 92px';
 
 interface ScheduleRowProps {
   name: string;
   repoAddress: RepoAddress;
+  checked: boolean;
+  onToggleChecked: (values: {checked: boolean; shiftKey: boolean}) => void;
+  showCheckboxColumn: boolean;
+  scheduleState: BasicInstigationStateFragment;
   height: number;
   start: number;
 }
 
 export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
-  const {name, repoAddress, start, height} = props;
+  const {
+    name,
+    repoAddress,
+    checked,
+    onToggleChecked,
+    showCheckboxColumn,
+    scheduleState,
+    start,
+    height,
+  } = props;
 
   const repo = useRepository(repoAddress);
 
@@ -83,21 +99,43 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
     ? humanCronString(scheduleData.cronSchedule, scheduleData.executionTimezone || 'UTC')
     : '';
 
+  const onChange = (e: React.FormEvent<HTMLInputElement>) => {
+    if (onToggleChecked && e.target instanceof HTMLInputElement) {
+      const {checked} = e.target;
+      const shiftKey =
+        e.nativeEvent instanceof MouseEvent && e.nativeEvent.getModifierState('Shift');
+      onToggleChecked({checked, shiftKey});
+    }
+  };
+
+  const checkboxState = React.useMemo(() => {
+    const {hasStartPermission, hasStopPermission, status} = scheduleState;
+    if (status === InstigationStatus.RUNNING && !hasStopPermission) {
+      return {disabled: true, message: 'You do not have permission to stop this schedule'};
+    }
+    if (status === InstigationStatus.STOPPED && !hasStartPermission) {
+      return {disabled: true, message: 'You do not have permission to start this schedule'};
+    }
+    return {disabled: false};
+  }, [scheduleState]);
+
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}>
-        <RowCell>
-          {scheduleData ? (
-            <Box flex={{direction: 'column', gap: 4}}>
-              {/* Keyed so that a new switch is always rendered, otherwise it's reused and animates on/off */}
-              <ScheduleSwitch key={name} repoAddress={repoAddress} schedule={scheduleData} />
-              {errorDisplay(
-                scheduleData.scheduleState.status,
-                scheduleData.scheduleState.runningCount,
-              )}
-            </Box>
-          ) : null}
-        </RowCell>
+      <RowGrid
+        border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        $showCheckboxColumn={showCheckboxColumn}
+      >
+        {showCheckboxColumn ? (
+          <RowCell>
+            <Tooltip
+              canShow={checkboxState.disabled}
+              content={checkboxState.message || ''}
+              placement="top"
+            >
+              <Checkbox disabled={checkboxState.disabled} checked={checked} onChange={onChange} />
+            </Tooltip>
+          </RowCell>
+        ) : null}
         <RowCell>
           <Box flex={{direction: 'column', gap: 4}}>
             <span style={{fontWeight: 500}}>
@@ -163,6 +201,18 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
           )}
         </RowCell>
         <RowCell>
+          {scheduleData ? (
+            <Box flex={{direction: 'column', gap: 4}}>
+              {/* Keyed so that a new switch is always rendered, otherwise it's reused and animates on/off */}
+              <ScheduleSwitch key={name} repoAddress={repoAddress} schedule={scheduleData} />
+              {errorDisplay(
+                scheduleData.scheduleState.status,
+                scheduleData.scheduleState.runningCount,
+              )}
+            </Box>
+          ) : null}
+        </RowCell>
+        <RowCell>
           {scheduleData?.scheduleState.ticks.length ? (
             <div>
               <TickTag
@@ -225,21 +275,27 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
   );
 };
 
-export const VirtualizedScheduleHeader = () => {
+export const VirtualizedScheduleHeader = (props: {checkbox: React.ReactNode}) => {
+  const {checkbox} = props;
   return (
     <Box
       border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
       style={{
         display: 'grid',
-        gridTemplateColumns: TEMPLATE_COLUMNS,
+        gridTemplateColumns: checkbox ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS,
         height: '32px',
         fontSize: '12px',
         color: Colors.Gray600,
       }}
     >
-      <HeaderCell />
+      {checkbox ? (
+        <HeaderCell>
+          <div style={{position: 'relative', top: '-1px'}}>{checkbox}</div>
+        </HeaderCell>
+      ) : null}
       <HeaderCell>Schedule name</HeaderCell>
       <HeaderCell>Schedule</HeaderCell>
+      <HeaderCell>Running</HeaderCell>
       <HeaderCell>Last tick</HeaderCell>
       <HeaderCell>Last run</HeaderCell>
       <HeaderCell>Actions</HeaderCell>
@@ -247,9 +303,10 @@ export const VirtualizedScheduleHeader = () => {
   );
 };
 
-const RowGrid = styled(Box)`
+const RowGrid = styled(Box)<{$showCheckboxColumn: boolean}>`
   display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
+  grid-template-columns: ${({$showCheckboxColumn}) =>
+    $showCheckboxColumn ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS};
   height: 100%;
 `;
 

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedScheduleTable.tsx
@@ -1,19 +1,30 @@
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
+import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
+import {makeScheduleKey} from '../schedules/makeScheduleKey';
 import {Container, Inner} from '../ui/VirtualizedTable';
 
 import {VirtualizedScheduleHeader, VirtualizedScheduleRow} from './VirtualizedScheduleRow';
 import {RepoAddress} from './types';
 
-type Schedule = {name: string};
+type ScheduleInfo = {name: string; scheduleState: BasicInstigationStateFragment};
 
 interface Props {
   repoAddress: RepoAddress;
-  schedules: Schedule[];
+  schedules: ScheduleInfo[];
+  headerCheckbox: React.ReactNode;
+  checkedKeys: Set<string>;
+  onToggleCheckFactory: (path: string) => (values: {checked: boolean; shiftKey: boolean}) => void;
 }
 
-export const VirtualizedScheduleTable: React.FC<Props> = ({repoAddress, schedules}) => {
+export const VirtualizedScheduleTable = ({
+  repoAddress,
+  schedules,
+  headerCheckbox,
+  checkedKeys,
+  onToggleCheckFactory,
+}: Props) => {
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 
   const rowVirtualizer = useVirtualizer({
@@ -28,17 +39,22 @@ export const VirtualizedScheduleTable: React.FC<Props> = ({repoAddress, schedule
 
   return (
     <>
-      <VirtualizedScheduleHeader />
+      <VirtualizedScheduleHeader checkbox={headerCheckbox} />
       <div style={{overflow: 'hidden'}}>
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
-              const row: Schedule = schedules[index];
+              const row: ScheduleInfo = schedules[index];
+              const scheduleKey = makeScheduleKey(repoAddress, row.name);
               return (
                 <VirtualizedScheduleRow
                   key={key}
                   name={row.name}
                   repoAddress={repoAddress}
+                  scheduleState={row.scheduleState}
+                  checked={checkedKeys.has(scheduleKey)}
+                  showCheckboxColumn={!!headerCheckbox}
+                  onToggleChecked={onToggleCheckFactory(scheduleKey)}
                   height={size}
                   start={start}
                 />

--- a/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/workspace/types/WorkspaceSchedulesRoot.types.ts
@@ -28,6 +28,14 @@ export type WorkspaceSchedulesQuery = {
           id: string;
           name: string;
           description: string | null;
+          scheduleState: {
+            __typename: 'InstigationState';
+            id: string;
+            selectorId: string;
+            status: Types.InstigationStatus;
+            hasStartPermission: boolean;
+            hasStopPermission: boolean;
+          };
         }>;
       }
     | {__typename: 'RepositoryNotFoundError'};


### PR DESCRIPTION
## Summary & Motivation

Add bulk start/stop to virtualized schedule tables in Overview and Code location views.

https://user-images.githubusercontent.com/2823852/232147144-199caa31-d19f-4427-a6e3-5b36fc0b4255.mov

## How I Tested These Changes

View Overview > Schedules. Check some schedules, then start them, then stop them. Verify that I can select a slice of schedules with shift+click.

Repeat on the code location schedules page.
