### PR TITLE
[ui] Fix half-clipped headers on repo-scoped asset table

### DIFF
--- a/js_modules/dagit/packages/core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/__tests__/AppTopNav.test.tsx
@@ -22,6 +22,7 @@ describe('AppTopNav', () => {
       repositories: () => [...new Array(1)],
     }),
     Workspace: () => ({
+      id: () => 'my_workspace',
       locationEntries: () => [...new Array(1)],
     }),
     RepositoryOrigin: () => ({

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -7,6 +7,7 @@ import {
   buildAssetNode,
   buildRepositoryLocation,
   buildRepository,
+  buildAssetKey,
 } from '../../graphql/types';
 import {SINGLE_ASSET_QUERY} from '../../workspace/VirtualizedAssetRow';
 import {SingleAssetQuery} from '../../workspace/types/VirtualizedAssetRow.types';
@@ -316,28 +317,19 @@ export const AssetCatalogTableMockAssets: Extract<
   {
     id: '["dashboards", "cost_dashboard"]',
     __typename: 'Asset',
-    key: {
-      path: ['dashboards', 'cost_dashboard'],
-      __typename: 'AssetKey',
-    },
+    key: buildAssetKey({path: ['dashboards', 'cost_dashboard']}),
     definition: null,
   },
   {
     id: '["dashboards", "traffic_dashboard"]',
     __typename: 'Asset',
-    key: {
-      path: ['dashboards', 'traffic_dashboard'],
-      __typename: 'AssetKey',
-    },
+    key: buildAssetKey({path: ['dashboards', 'traffic_dashboard']}),
     definition: null,
   },
   {
     id: 'test.py.repo.["good_asset"]',
     __typename: 'Asset',
-    key: {
-      path: ['good_asset'],
-      __typename: 'AssetKey',
-    },
+    key: buildAssetKey({path: ['good_asset']}),
     definition: buildAssetNode({
       id: 'test.py.repo.["good_asset"]',
       groupName: 'GROUP2',
@@ -346,16 +338,12 @@ export const AssetCatalogTableMockAssets: Extract<
       description:
         'This is a super long description that could involve some level of SQL and is just generally very long',
       repository,
-      __typename: 'AssetNode',
     }),
   },
   {
     id: 'test.py.repo.["late_asset"]',
     __typename: 'Asset',
-    key: {
-      path: ['late_asset'],
-      __typename: 'AssetKey',
-    },
+    key: buildAssetKey({path: ['late_asset']}),
     definition: buildAssetNode({
       id: 'test.py.repo.["late_asset"]',
       groupName: 'GROUP2',
@@ -368,10 +356,7 @@ export const AssetCatalogTableMockAssets: Extract<
   {
     id: 'test.py.repo.["run_failing_asset"]',
     __typename: 'Asset',
-    key: {
-      path: ['run_failing_asset'],
-      __typename: 'AssetKey',
-    },
+    key: buildAssetKey({path: ['run_failing_asset']}),
     definition: buildAssetNode({
       id: 'test.py.repo.["run_failing_asset"]',
       groupName: 'GROUP4',
@@ -379,16 +364,12 @@ export const AssetCatalogTableMockAssets: Extract<
       description: null,
       hasMaterializePermission: true,
       repository,
-      __typename: 'AssetNode',
     }),
   },
   {
     id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
     __typename: 'Asset',
-    key: {
-      path: ['asset_with_a_very_long_key_that_will_require_truncation'],
-      __typename: 'AssetKey',
-    },
+    key: buildAssetKey({path: ['asset_with_a_very_long_key_that_will_require_truncation']}),
     definition: buildAssetNode({
       id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
       groupName: 'GROUP4',

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -309,6 +309,97 @@ export const SingleAssetQueryLastRunFailed: MockedResponse<SingleAssetQuery> = {
   },
 };
 
+export const AssetCatalogTableMockAssets: Extract<
+  AssetCatalogTableQuery['assetsOrError'],
+  {__typename: 'AssetConnection'}
+>['nodes'] = [
+  {
+    id: '["dashboards", "cost_dashboard"]',
+    __typename: 'Asset',
+    key: {
+      path: ['dashboards', 'cost_dashboard'],
+      __typename: 'AssetKey',
+    },
+    definition: null,
+  },
+  {
+    id: '["dashboards", "traffic_dashboard"]',
+    __typename: 'Asset',
+    key: {
+      path: ['dashboards', 'traffic_dashboard'],
+      __typename: 'AssetKey',
+    },
+    definition: null,
+  },
+  {
+    id: 'test.py.repo.["good_asset"]',
+    __typename: 'Asset',
+    key: {
+      path: ['good_asset'],
+      __typename: 'AssetKey',
+    },
+    definition: buildAssetNode({
+      id: 'test.py.repo.["good_asset"]',
+      groupName: 'GROUP2',
+      partitionDefinition: null,
+      hasMaterializePermission: true,
+      description:
+        'This is a super long description that could involve some level of SQL and is just generally very long',
+      repository,
+      __typename: 'AssetNode',
+    }),
+  },
+  {
+    id: 'test.py.repo.["late_asset"]',
+    __typename: 'Asset',
+    key: {
+      path: ['late_asset'],
+      __typename: 'AssetKey',
+    },
+    definition: buildAssetNode({
+      id: 'test.py.repo.["late_asset"]',
+      groupName: 'GROUP2',
+      partitionDefinition: null,
+      hasMaterializePermission: true,
+      description: null,
+      repository,
+    }),
+  },
+  {
+    id: 'test.py.repo.["run_failing_asset"]',
+    __typename: 'Asset',
+    key: {
+      path: ['run_failing_asset'],
+      __typename: 'AssetKey',
+    },
+    definition: buildAssetNode({
+      id: 'test.py.repo.["run_failing_asset"]',
+      groupName: 'GROUP4',
+      partitionDefinition: null,
+      description: null,
+      hasMaterializePermission: true,
+      repository,
+      __typename: 'AssetNode',
+    }),
+  },
+  {
+    id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
+    __typename: 'Asset',
+    key: {
+      path: ['asset_with_a_very_long_key_that_will_require_truncation'],
+      __typename: 'AssetKey',
+    },
+    definition: buildAssetNode({
+      id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
+      groupName: 'GROUP4',
+      partitionDefinition: null,
+      description: null,
+      hasMaterializePermission: true,
+      repository,
+    }),
+  },
+];
+
 export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
   request: {
     query: ASSET_CATALOG_TABLE_QUERY,
@@ -318,93 +409,7 @@ export const AssetCatalogTableMock: MockedResponse<AssetCatalogTableQuery> = {
       __typename: 'DagitQuery',
       assetsOrError: {
         __typename: 'AssetConnection',
-        nodes: [
-          {
-            id: '["dashboards", "cost_dashboard"]',
-            __typename: 'Asset',
-            key: {
-              path: ['dashboards', 'cost_dashboard'],
-              __typename: 'AssetKey',
-            },
-            definition: null,
-          },
-          {
-            id: '["dashboards", "traffic_dashboard"]',
-            __typename: 'Asset',
-            key: {
-              path: ['dashboards', 'traffic_dashboard'],
-              __typename: 'AssetKey',
-            },
-            definition: null,
-          },
-          {
-            id: 'test.py.repo.["good_asset"]',
-            __typename: 'Asset',
-            key: {
-              path: ['good_asset'],
-              __typename: 'AssetKey',
-            },
-            definition: buildAssetNode({
-              id: 'test.py.repo.["good_asset"]',
-              groupName: 'GROUP2',
-              partitionDefinition: null,
-              hasMaterializePermission: true,
-              description:
-                'This is a super long description that could involve some level of SQL and is just generally very long',
-              repository,
-              __typename: 'AssetNode',
-            }),
-          },
-          {
-            id: 'test.py.repo.["late_asset"]',
-            __typename: 'Asset',
-            key: {
-              path: ['late_asset'],
-              __typename: 'AssetKey',
-            },
-            definition: buildAssetNode({
-              id: 'test.py.repo.["late_asset"]',
-              groupName: 'GROUP2',
-              partitionDefinition: null,
-              hasMaterializePermission: true,
-              description: null,
-              repository,
-            }),
-          },
-          {
-            id: 'test.py.repo.["run_failing_asset"]',
-            __typename: 'Asset',
-            key: {
-              path: ['run_failing_asset'],
-              __typename: 'AssetKey',
-            },
-            definition: buildAssetNode({
-              id: 'test.py.repo.["run_failing_asset"]',
-              groupName: 'GROUP4',
-              partitionDefinition: null,
-              description: null,
-              hasMaterializePermission: true,
-              repository,
-              __typename: 'AssetNode',
-            }),
-          },
-          {
-            id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
-            __typename: 'Asset',
-            key: {
-              path: ['asset_with_a_very_long_key_that_will_require_truncation'],
-              __typename: 'AssetKey',
-            },
-            definition: buildAssetNode({
-              id: 'test.py.repo.["asset_with_a_very_long_key_that_will_require_truncation"]',
-              groupName: 'GROUP4',
-              partitionDefinition: null,
-              description: null,
-              hasMaterializePermission: true,
-              repository,
-            }),
-          },
-        ],
+        nodes: AssetCatalogTableMockAssets,
       },
     },
   },

--- a/js_modules/dagit/packages/core/src/assets/__stories__/AssetTables.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/AssetTables.stories.tsx
@@ -1,16 +1,19 @@
 import {MockedProvider} from '@apollo/client/testing';
+import {Box} from '@dagster-io/ui';
 import React from 'react';
 
 import {StorybookProvider} from '../../testing/StorybookProvider';
+import {VirtualizedRepoAssetTable} from '../../workspace/VirtualizedRepoAssetTable';
 import {AssetsCatalogTable} from '../AssetsCatalogTable';
 import {
   AssetCatalogGroupTableMock,
   AssetCatalogTableMock,
+  AssetCatalogTableMockAssets,
   SingleAssetQueryLastRunFailed,
   SingleAssetQueryMaterializedStaleAndLate,
   SingleAssetQueryMaterializedWithLatestRun,
   SingleAssetQueryTrafficDashboard,
-} from '../__fixtures__/AssetsCatalogTable.fixtures';
+} from '../__fixtures__/AssetTables.fixtures';
 
 // eslint-disable-next-line import/no-default-export
 export default {component: AssetsCatalogTable};
@@ -24,7 +27,7 @@ const MOCKS = [
   SingleAssetQueryLastRunFailed,
 ];
 
-export const NoPrefixPath = () => {
+export const GlobalCatalogNoPrefix = () => {
   return (
     <StorybookProvider routerProps={{initialEntries: ['/']}}>
       <MockedProvider mocks={MOCKS}>
@@ -34,11 +37,30 @@ export const NoPrefixPath = () => {
   );
 };
 
-export const WithinAssetPath = () => {
+export const GlobalCatalogWithPrefix = () => {
   return (
     <StorybookProvider routerProps={{initialEntries: ['/']}}>
       <MockedProvider mocks={MOCKS}>
         <AssetsCatalogTable prefixPath={['dashboards']} setPrefixPath={() => {}} />
+      </MockedProvider>
+    </StorybookProvider>
+  );
+};
+
+export const RepoAssets = () => {
+  return (
+    <StorybookProvider routerProps={{initialEntries: ['/']}}>
+      <MockedProvider mocks={MOCKS}>
+        <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+          <VirtualizedRepoAssetTable
+            repoAddress={{name: 'repo', location: 'test.py'}}
+            assets={AssetCatalogTableMockAssets.filter((a) => !!a.definition).map((a) => ({
+              id: a.id,
+              assetKey: a.key,
+              groupName: a.definition!.groupName,
+            }))}
+          />
+        </Box>
       </MockedProvider>
     </StorybookProvider>
   );

--- a/js_modules/dagit/packages/core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagit/packages/core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -77,6 +77,7 @@ describe('Repository options', () => {
   describe('localStorage', () => {
     const mocksWithOne = {
       Workspace: () => ({
+        id: 'workspace',
         locationEntries: () => [
           {
             locationOrLoadError: {
@@ -91,6 +92,7 @@ describe('Repository options', () => {
 
     const mocksWithThree = {
       Workspace: () => ({
+        id: 'workspace',
         locationEntries: () => [
           {
             locationOrLoadError: {
@@ -274,6 +276,7 @@ describe('Repository options', () => {
     it('initializes empty, then shows options when they are added', async () => {
       const initialMocks = {
         Workspace: () => ({
+          id: 'workspace',
           locationEntries: () => [],
         }),
       };
@@ -326,6 +329,7 @@ describe('Repository options', () => {
     it('initializes with options, then shows empty if they are removed', async () => {
       const mocksAfterRemoval = {
         Workspace: () => ({
+          id: 'workspace',
           locationEntries: () => [],
         }),
       };
@@ -379,6 +383,7 @@ describe('Repository options', () => {
         isAssetJob: () => false,
       }),
       Workspace: () => ({
+        id: 'workspace',
         locationEntries: () => [
           {
             locationOrLoadError: {

--- a/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
+++ b/js_modules/dagit/packages/core/src/testing/defaultMocks.ts
@@ -54,6 +54,7 @@ export const defaultMocks = {
     name: hyphenatedName,
   }),
   Workspace: () => ({
+    id: 'workspace',
     locationEntries: () => [...new Array(1)],
   }),
   WorkspaceLocationEntry: () => ({

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -26,7 +26,7 @@ import {RepoAddress} from './types';
 import {SingleAssetQuery, SingleAssetQueryVariables} from './types/VirtualizedAssetRow.types';
 import {workspacePathFromAddress} from './workspacePath';
 
-const TEMPLATE_COLUMNS = '1.3fr 1.3fr 80px';
+const TEMPLATE_COLUMNS = '1.3fr 1fr 80px';
 const TEMPLATE_COLUMNS_FOR_CATALOG = '76px 1.3fr 1.3fr 1.3fr 80px';
 
 interface AssetRowProps {
@@ -260,8 +260,7 @@ export const VirtualizedAssetHeader: React.FC<{
       }}
     >
       <HeaderCell>{nameLabel}</HeaderCell>
-      <HeaderCell>Materialized</HeaderCell>
-      <HeaderCell>Latest run</HeaderCell>
+      <HeaderCell>Status</HeaderCell>
       <HeaderCell></HeaderCell>
     </Box>
   );


### PR DESCRIPTION
## Summary & Motivation

This PR renames the asset catalog table stories and adds a story for the repo-scoped asset table, which has slightly different columns and folding behavior. It fixes an issue with the repo-scoped asset table defining one too many columns and adjusts the column widths slightly.

Thankfully these use the same virtualized rows and the storybooks are almost the same.

Note:  I also added an "id" value to some Workspace mocks, because the storybook was throwing exceptions without an id. I'm not 100% sure all of the places I added it are required, but I think specifying a constant value is correct and we shouldn't let our old faker-based Apollo mocks randomize the value.

## How I Tested These Changes

![image](https://user-images.githubusercontent.com/1037212/232147007-8fac39c3-6e67-4665-850a-f36109e5fec1.png)
![image](https://user-images.githubusercontent.com/1037212/232147025-0507aa79-83ee-4bbd-9dc0-edc68904a31c.png)
