### PR TITLE
[docs][pythonic config] Update ops page

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/ops.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/ops.mdx
@@ -164,9 +164,9 @@ While many use cases can be served using built-in python annotations, <PyObject 
 
 ### Op Configuration
 
-Ops in Dagster can specify a config schema which makes them configurable and parameterizable. The configuration system is explained in detail in the [Config schema documentation](/concepts/configuration/config-schema).
+Ops in Dagster can specify a config schema which makes them configurable and parameterizable at execution time. The configuration system is explained in detail in the [Config schema documentation](/concepts/configuration/config-schema).
 
-Op functions can specify an annotated `config` parameter for the op's configuration. The config class, which subclasses <PyObject object="Config"/>, specifies the configuration schema for the op. Op configuration can be used to specify op behavior at runtime, making ops more flexible and reusable.
+Op functions can specify an annotated `config` parameter for the op's configuration. The config class, which subclasses <PyObject object="Config"/> (which wraps [`pydantic.BaseModel`](https://docs.pydantic.dev/usage/models/#basic-model-usage)) specifies the configuration schema for the op. Op configuration can be used to specify op behavior at runtime, making ops more flexible and reusable.
 
 For example, we can define an op where the API endpoint it queries is defined through its configuration:
 

--- a/docs/content/concepts/ops-jobs-graphs/ops.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/ops.mdx
@@ -162,33 +162,38 @@ Like inputs, outputs can also have [Dagster Types](/concepts/types).
 
 While many use cases can be served using built-in python annotations, <PyObject object="Output"/> and <PyObject object="DynamicOutput"/> objects unlock additional functionality. Check out the docs on [Op Outputs](/concepts/ops-jobs-graphs/op-events#output-objects) to learn more.
 
-### Op Context
-
-When writing an op, users can optionally provide a first parameter, `context`. When this parameter is supplied, Dagster will supply a context object to the body of the op. The context provides access to system information like op configuration, loggers, resources, and the current run id. See <PyObject object="OpExecutionContext"/> for the full list of properties accessible from the op context.
-
-For example, to access the logger and log a info message:
-
-```python file=/concepts/ops_jobs_graphs/ops.py startafter=start_op_context_marker endbefore=end_op_context_marker
-@op(config_schema={"name": str})
-def context_op(context):
-    name = context.op_config["name"]
-    context.log.info(f"My name is {name}")
-```
-
 ### Op Configuration
 
-All definitions in dagster expose a `config_schema`, making them configurable and parameterizable. The configuration system is explained in detail on [Config Schema](/concepts/configuration/config-schema).
+Ops in Dagster can specify a config schema which makes them configurable and parameterizable. The configuration system is explained in detail in the [Config schema documentation](/concepts/configuration/config-schema).
 
-Op definitions can specify a `config_schema` for the op's configuration. The configuration is accessible through the [op context](#op-context) at runtime. Therefore, op configuration can be used to specify op behavior at runtime, making ops more flexible and reusable.
+Op functions can specify an annotated `config` parameter for the op's configuration. The config class, which subclasses <PyObject object="Config"/>, specifies the configuration schema for the op. Op configuration can be used to specify op behavior at runtime, making ops more flexible and reusable.
 
 For example, we can define an op where the API endpoint it queries is defined through its configuration:
 
 ```python file=/concepts/ops_jobs_graphs/ops.py startafter=start_configured_op_marker endbefore=end_configured_op_marker
-@op(config_schema={"api_endpoint": str})
-def my_configurable_op(context):
-    api_endpoint = context.op_config["api_endpoint"]
-    data = requests.get(f"{api_endpoint}/data").json()
+from dagster import Config
+
+
+class MyOpConfig(Config):
+    api_endpoint: str
+
+
+@op
+def my_configurable_op(config: MyOpConfig):
+    data = requests.get(f"{config.api_endpoint}/data").json()
     return data
+```
+
+### Op Context
+
+When writing an op, users can optionally provide a first parameter, `context`. When this parameter is supplied, Dagster will supply a context object to the body of the op. The context provides access to system information like loggers and the current run id. See <PyObject object="OpExecutionContext"/> for the full list of properties accessible from the op context.
+
+For example, to access the logger and log a info message:
+
+```python file=/concepts/ops_jobs_graphs/ops.py startafter=start_op_context_marker endbefore=end_op_context_marker
+@op
+def context_op(context: OpExecutionContext):
+    context.log.info(f"My run ID is {context.run_id}")
 ```
 
 ## Using an op

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/ops.py
@@ -3,7 +3,7 @@
 
 import requests
 
-from dagster import DagsterType, In, Nothing, Out, op
+from dagster import DagsterType, In, Nothing, Out, op, OpExecutionContext, Config
 
 
 class MockResponse:
@@ -30,10 +30,16 @@ def my_op():
 
 
 # start_configured_op_marker
-@op(config_schema={"api_endpoint": str})
-def my_configurable_op(context):
-    api_endpoint = context.op_config["api_endpoint"]
-    data = requests.get(f"{api_endpoint}/data").json()
+from dagster import Config
+
+
+class MyOpConfig(Config):
+    api_endpoint: str
+
+
+@op
+def my_configurable_op(config: MyOpConfig):
+    data = requests.get(f"{config.api_endpoint}/data").json()
     return data
 
 
@@ -88,10 +94,9 @@ def my_multi_output_op():
 
 
 # start_op_context_marker
-@op(config_schema={"name": str})
-def context_op(context):
-    name = context.op_config["name"]
-    context.log.info(f"My name is {name}")
+@op
+def context_op(context: OpExecutionContext):
+    context.log.info(f"My run ID is {context.run_id}")
 
 
 # end_op_context_marker


### PR DESCRIPTION
## Summary

Small update to the ops docs page.

Updates the op config section to use Pythonic config. Deprioritizes the op context section, since it's less useful now that resources and config are moved to their own params.
