### PR TITLE
test dagster-dbt on python 3.11

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -277,19 +277,9 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/assets_dbt_python",
-        unsupported_python_versions=[
-            # dependency on dagster-dbt
-            AvailablePythonVersion.V3_10,
-            AvailablePythonVersion.V3_11,
-        ],
     ),
     PackageSpec(
         "examples/assets_smoke_test",
-        unsupported_python_versions=[
-            # dependency on dagster-dbt
-            AvailablePythonVersion.V3_10,
-            AvailablePythonVersion.V3_11,
-        ],
     ),
     PackageSpec(
         "examples/deploy_docker",
@@ -427,9 +417,13 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "python_modules/libraries/dagster-dbt",
-        unsupported_python_versions=[
-            AvailablePythonVersion.V3_11,
-        ],
+        unsupported_python_versions=lambda tox_factor: (
+            [
+                AvailablePythonVersion.V3_11,
+            ]
+            if tox_factor == "dbt_13X"
+            else []
+        ),
         pytest_tox_factors=[
             "dbt_13X",
             "dbt_14X",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,6 @@
 - [ui] Performance improvement for Runs page for runs that materialize large numbers of assets.
 - [ui] Performance improvements for Run timeline and left navigation for users with large numbers of jobs or assets.
 - [ui] In the run timeline, consolidate “Ad hoc materializations” rows into a single row.
-- [dagster-dbt] Python 3.10 is now supported.
 - [dagster-aws] The `EcsRunLauncher` now allows you to customize volumes and mount points for the launched ECS task. See [the API docs](https://docs.dagster.io/_apidocs/libraries/dagster-aws#dagster_aws.ecs.EcsRunLauncher) for more information.
 - [dagster-duckdb, dagster-duckdb-pandas, dagster-duckdb-pyspark] New `DuckDBPandasIOManager` and `DuckDBPySparkIOManager` follow Pythonic resource system. The existing `duckdb_pandas_io_manager` and `duckdb_pyspark_io_manager` remain supported.
 - [dagster-gcp, dagster-gcp-pandas, dagster-gcp-pyspark] New `BigQueryPandasIOManager` and `BigQueryPySparkIOManager` follow Pythonic resource system. The existing `bigquery_pandas_io_manager` and `bigquery_pyspark_io_manager` remain supported.


### PR DESCRIPTION
- Add test coverage for 3.11 on dbt-core 1.4
- Remove line from changelog that implied that it wasn't working on 3.10 before - it was, we just turned BK back on for that version