### PR TITLE
[docs][pythonic config] Update IO management page

### DIFF
--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -823,6 +823,5 @@ Additionally, if the handled output is part of a software-defined asset, these m
 For more examples of IO Managers, check out the following in our [Hacker News example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
 
 - [Parquet IO Manager](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py)
-- [S3 IO Manager with custom bucket](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/resources/common_bucket_s3\_pickle_io_manager.py)
 
 Our [Type and Metadata example](https://github.com/dagster-io/dagster/tree/master/examples/assets_pandas_type_metadata) also covers writing custom IO managers.

--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -1,0 +1,829 @@
+---
+title: IO Managers (Legacy) | Dagster
+description: IO Managers determine how to store asset/op outputs and load asset/op inputs.
+---
+
+# IO Managers (Legacy)
+
+
+<Note>
+  This guide covers using the legacy Dagster resource system. For docs on the
+  new Pythonic resource system introduced in Dagster 1.3, see the{" "}
+  <a href="/concepts/io-management/io-managers-legacy">updated I/O managers guide</a>.
+</Note>
+
+IO Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
+
+<center>
+  <Image
+    alt="Diagram of assets and ops with an I/O manager"
+    src="/images/concepts/io-managers.png"
+    width={683}
+    height={410}
+  />
+</center>
+
+## Relevant APIs
+
+| Name                                                        | Description                                                                                                                                                                                                 |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject module="dagster" object="io_manager" decorator /> | A decorator used to define IO managers.                                                                                                                                                                     |
+| <PyObject module="dagster" object="IOManager" />            | Base class for user-provided IO managers.                                                                                                                                                                   |
+| <PyObject object="build_input_context"/>                    | Function for directly constructing a <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |
+| <PyObject object="build_output_context"/>                   | Function for directly constructing a <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |
+
+## Overview
+
+Functions decorated by <PyObject object="asset" decorator/>, <PyObject object="multi_asset" decorator/>, and <PyObject object="op" decorator/> can have parameters and return values that are loaded from and written to persistent storage. <PyObject module="dagster" object="IOManager" pluralize /> let the user control how this data is stored and how it's loaded in downstream ops and assets. For `@asset` and `@multi_asset`, the IO manager effectively determines where the physical asset lives.
+
+The IO manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Software-defined assets and ops can focus on business logic, while IO managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
+
+For non-asset jobs with inputs that aren't connected to upstream outputs, see the [Unconnected Inputs](/concepts/io-management/unconnected-inputs) overview.
+
+### Outputs and downstream inputs
+
+<PyObject module="dagster" object="IOManager" pluralize /> are user-provided objects
+that are responsible for storing the output of an asset or op and loading it as input
+to downstream assets or ops. For example, an IO manager might store and load objects
+from files on a filesystem.
+
+Each software-defined asset can have its own IO manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different IO manager:
+
+<center>
+  <Image
+    alt="Multi-asset with each outputted asset being handled by a different I/O
+  manager"
+    src="/images/concepts/multi-asset-io-manager.png"
+    width={623}
+    height={410}
+  />
+</center>
+
+For ops, each op output can have its own IO manager, or multiple op outputs can share an IO manager. The IO manager that's used for handling a particular op output is automatically used for loading it in downstream ops.
+
+Consider the following diagram. In this example, a job has two IO managers, each of which is shared across a few inputs and outputs:
+
+<center>
+  <Image src="/images/concepts/two-io-managers.png" width={643} height={382} />
+</center>
+
+### Built-in IO managers
+
+The default IO manager, <PyObject module="dagster" object="fs_io_manager" />, stores and retrieves values from pickle files in the local filesystem. If a job is invoked via <PyObject object="JobDefinition" method="execute_in_process" />, the default IO manager is switched to <PyObject module="dagster" object="mem_io_manager"/>, which stores outputs in memory.
+
+Dagster provides out-of-the-box IO managers for popular storage systems: AWS S3 (<PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" />), Azure Blob Storage (<PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager" />), GCS (<PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager" />), and Snowflake (<PyObject module="dagster_snowflake" object="build_snowflake_io_manager" />) - or you can write your own: either from scratch or by extending the `UPathIOManager` if you want to store data in an `fsspec`-supported filesystem.
+
+### IO managers are resources
+
+IO managers are [resources](/concepts/resources), which means users can supply different IO managers for the same assets or ops in different situations. For example, you might use an in-memory IO manager for unit-testing and an S3 IO manager in production.
+
+---
+
+## Using IO managers with software-defined assets
+
+### Applying IO managers to assets
+
+By default, materializing an asset named `my_asset` will pickle it to a local file named `my_asset`. The directory that file lives underneath is determined by the rules in <PyObject object="fs_io_manager" />.
+
+[IO managers](/concepts/io-management/io-managers) enable fully overriding this behavior and storing asset contents in any way you wish - e.g. writing them as tables in a database or as objects in a cloud object store such as s3. You can use one of Dagster's [built-in IO managers](#built-in-io-managers), or you can write your own.
+
+To apply an IO manager to a set of assets, you can use <PyObject object="Definitions" />:
+
+```python file=/concepts/assets/asset_io_manager.py startafter=start_old_marker endbefore=end_old_marker dedent=4
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+from dagster import Definitions, asset
+
+
+@asset
+def upstream_asset():
+    return [1, 2, 3]
+
+
+@asset
+def downstream_asset(upstream_asset):
+    return upstream_asset + [4]
+
+
+defs = Definitions(
+    assets=[upstream_asset, downstream_asset],
+    resources={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+)
+```
+
+This example also includes `"s3": s3_resource` because the <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" /> depends on an S3 resource.
+
+When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and stored in an object on S3. When `downstream_asset` is materialized, the value of `upstream_asset` will be read from S3 and depickled, and `[1, 2, 3, 4]` will be pickled and stored in a different object on S3.
+
+### Per-asset IO manager
+
+Different assets can have different IO managers:
+
+```python file=/concepts/assets/asset_different_io_managers.py startafter=start_old_marker endbefore=end_old_marker dedent=4
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+from dagster import Definitions, asset, fs_io_manager
+
+
+@asset(io_manager_key="s3_io_manager")
+def upstream_asset():
+    return [1, 2, 3]
+
+
+@asset(io_manager_key="fs_io_manager")
+def downstream_asset(upstream_asset):
+    return upstream_asset + [4]
+
+
+defs = Definitions(
+    assets=[upstream_asset, downstream_asset],
+    resources={
+        "s3_io_manager": s3_pickle_io_manager,
+        "s3": s3_resource,
+        "fs_io_manager": fs_io_manager,
+    },
+)
+```
+
+When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and stored in an object on S3. When `downstream_asset` is materialized, the value of `upstream_asset` will be read from S3 and depickled, and `[1, 2, 3, 4]` will be pickled and stored in a file on the local filesystem.
+
+In the multi-asset case, you can customize how each asset is materialized by specifying an `io_manager_key` on each output of the multi-asset.
+
+```python file=/concepts/assets/multi_assets.py startafter=start_io_manager_multi_asset endbefore=end_io_manager_multi_asset
+from dagster import AssetOut, multi_asset
+
+
+@multi_asset(
+    outs={
+        "s3_asset": AssetOut(io_manager_key="s3_io_manager"),
+        "adls_asset": AssetOut(io_manager_key="adls2_io_manager"),
+    },
+)
+def my_assets():
+    return "store_me_on_s3", "store_me_on_adls2"
+```
+
+The same assets can be bound to different resources and IO managers in different environments. For example, for local development, you might want to store assets on your local filesystem while in production, you might want to store the assets in S3.
+
+```python file=/concepts/assets/asset_io_manager_prod_local.py startafter=start_marker endbefore=end_marker
+import os
+
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+from dagster import Definitions, asset, fs_io_manager
+
+
+@asset
+def upstream_asset():
+    return [1, 2, 3]
+
+
+@asset
+def downstream_asset(upstream_asset):
+    return upstream_asset + [4]
+
+
+resources_by_env = {
+    "prod": {"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    "local": {"io_manager": fs_io_manager},
+}
+
+defs = Definitions(
+    assets=[upstream_asset, downstream_asset],
+    resources=resources_by_env[os.getenv("ENV", "local")],
+)
+```
+
+### Asset input IO managers
+
+In some cases you may need to load the input to an asset with different logic than that specified by the upstream asset's IO manager.
+
+To set an IO manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="AssetIn" />.
+
+In this example,`first_asset` and `second_asset` will be stored using the default IO manager, but will be loaded as inputs to `third_asset` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
+
+```python file=/concepts/assets/asset_input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
+@asset
+def first_asset():
+    return [1, 2, 3]
+
+
+@asset
+def second_asset():
+    return [4, 5, 6]
+
+
+@asset(
+    ins={
+        "first_asset": AssetIn(input_manager_key="pandas_series"),
+        "second_asset": AssetIn(input_manager_key="pandas_series"),
+    }
+)
+def third_asset(first_asset, second_asset):
+    return pd.concat([first_asset, second_asset, pd.Series([7, 8])])
+
+
+defs = Definitions(
+    assets=[first_asset, second_asset, third_asset],
+    resources={
+        "pandas_series": pandas_series_io_manager,
+    },
+)
+```
+
+## Using IO managers with non-asset jobs
+
+### Job-wide IO manager
+
+By default, all the inputs and outputs in a job use the same IO manager. This IO manager is determined by the <PyObject module="dagster" object="ResourceDefinition" /> provided for the `"io_manager"` resource key. `"io_manager"` is a resource key that Dagster reserves specifically for this purpose.
+
+Here’s how to specify that all op outputs are stored using the <PyObject module="dagster" object="fs_io_manager" />, which pickles outputs and stores them on the local filesystem. It stores files in a directory with the run ID in the path, so that outputs from prior runs will never be overwritten.
+
+```python file=/concepts/io_management/default_io_manager.py
+from dagster import fs_io_manager, job, op
+
+
+@op
+def op_1():
+    return 1
+
+
+@op
+def op_2(a):
+    return a + 1
+
+
+@job(resource_defs={"io_manager": fs_io_manager})
+def my_job():
+    op_2(op_1())
+```
+
+### Per-output IO manager
+
+Not all the outputs in a job should necessarily be stored the same way. Maybe some of the outputs should live on the filesystem so they can be inspected, and others can be transiently stored in memory.
+
+To select the IO manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting IO managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
+
+```python file=/concepts/io_management/io_manager_per_output.py startafter=start_marker endbefore=end_marker
+from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+from dagster import Out, fs_io_manager, job, op
+
+
+@op(out=Out(io_manager_key="fs"))
+def op_1():
+    return 1
+
+
+@op(out=Out(io_manager_key="s3_io"))
+def op_2(a):
+    return a + 1
+
+
+@job(
+    resource_defs={
+        "fs": fs_io_manager,
+        "s3_io": s3_pickle_io_manager,
+        "s3": s3_resource,
+    }
+)
+def my_job():
+    op_2(op_1())
+```
+
+### Per-input IO manager
+
+Just as with the inputs to assets, the inputs to ops can be loaded using custom logic if you want to override the IO manager of the upstream output. To set an IO manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="In" />.
+
+In this example, the output of `op_1` will be stored using the default IO manager, but will be loaded in `op_2` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
+
+```python file=/concepts/io_management/input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
+@op
+def op_1():
+    return [1, 2, 3]
+
+
+@op(ins={"a": In(input_manager_key="pandas_series")})
+def op_2(a):
+    return pd.concat([a, pd.Series([4, 5, 6])])
+
+
+@job(resource_defs={"pandas_series": pd_series_io_manager})
+def a_job():
+    op_2(op_1())
+```
+
+## Defining an IO manager
+
+If you have specific requirements for where and how your outputs should be stored and retrieved, you can define your own IO manager. This boils down to implementing two functions: one that stores outputs and one that loads inputs.
+
+To define an IO manager, use the <PyObject module="dagster" object="io_manager" displayText="@io_manager" /> decorator.
+
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_marker endbefore=end_io_manager_marker
+from dagster import IOManager, io_manager
+
+
+class MyIOManager(IOManager):
+    def _get_path(self, context) -> str:
+        return "/".join(context.asset_key.path)
+
+    def handle_output(self, context, obj):
+        write_csv(self._get_path(context), obj)
+
+    def load_input(self, context):
+        return read_csv(self._get_path(context))
+
+
+@io_manager
+def my_io_manager():
+    return MyIOManager()
+```
+
+The <PyObject module="dagster" object="io_manager" /> decorator behaves nearly identically to the <PyObject module="dagster" object="resource" /> decorator. It yields an <PyObject module="dagster" object="IOManagerDefinition" />, which is a subclass of <PyObject module="dagster" object="ResourceDefinition" /> that will produce an <PyObject module="dagster" object="IOManager" />.
+
+The provided `context` argument for `handle_output` is an <PyObject module="dagster" object="OutputContext" />. The provided `context` argument for `load_input` is an <PyObject module="dagster" object="InputContext" />. The linked API documentation lists all the fields that are available on these objects.
+
+### Handling partitioned assets
+
+IO managers can be written to handle [partitioned](/concepts/partitions-schedules-sensors/partitions) assets. For a partitioned asset, each invocation of `handle_output` will (over)write a single partition, and each invocation of `load_input` will load one or more partitions. When the IO manager is backed by a filesystem or object store, then each partition will typically correspond to a file or object. When it's backed by a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
+
+The default IO Manager has support for loading a partitioned upstream asset for a downstream asset with matching partitions out of the box (see the section below for loading multiple partitions). The <PyObject module="dagster" object="UPathIOManager" /> can be used to handle partitions in custom filesystem-based IO Managers.
+
+To handle partitions in an custom IO manager, you'll need to determine which partition you're dealing with when you're storing an output or loading an input. For this, <PyObject object="OutputContext" /> and <PyObject object="InputContext" /> have a `asset_partition_key` property:
+
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_partitioned_marker endbefore=end_partitioned_marker
+class MyPartitionedIOManager(IOManager):
+    def _get_path(self, context) -> str:
+        if context.has_partition_key:
+            return "/".join(context.asset_key.path + [context.asset_partition_key])
+        else:
+            return "/".join(context.asset_key.path)
+
+    def handle_output(self, context, obj):
+        write_csv(self._get_path(context), obj)
+
+    def load_input(self, context):
+        return read_csv(self._get_path(context))
+```
+
+If you're working with time window partitions, you can also use the `asset_partitions_time_window` property, which will return a <PyObject object="TimeWindow" /> object.
+
+#### Handling partition mappings
+
+A single partition of one asset might depend on a range of partitions of an upstream asset.
+
+The default IO Manager has support for loading multiple upstream partitions. In this case, the downstream asset should use `Dict[str, ...]` (or leave it blank) type for the upstream `DagsterType`. Here is an example of loading multiple upstream partitions using the default partition mapping:
+
+```python file=/concepts/io_management/loading_multiple_upstream_partitions.py
+from datetime import datetime
+from typing import Dict
+
+import pandas as pd
+
+from dagster import (
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+    OpExecutionContext,
+    asset,
+    materialize,
+)
+
+start = datetime(2022, 1, 1)
+
+hourly_partitions = HourlyPartitionsDefinition(start_date=f"{start:%Y-%m-%d-%H:%M}")
+daily_partitions = DailyPartitionsDefinition(start_date=f"{start:%Y-%m-%d}")
+
+
+@asset(partitions_def=hourly_partitions)
+def upstream_asset(context: OpExecutionContext) -> pd.DataFrame:
+    return pd.DataFrame({"date": [context.partition_key]})
+
+
+@asset(
+    partitions_def=daily_partitions,
+)
+def downstream_asset(upstream_asset: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+    return pd.concat(list(upstream_asset.values()))
+
+
+result = materialize(
+    [*upstream_asset.to_source_assets(), downstream_asset],
+    partition_key=start.strftime(daily_partitions.fmt),
+)
+downstream_asset_data = result.output_for_node("downstream_asset", "result")
+assert (
+    len(downstream_asset_data) == 24
+), "downstream day should map to upstream 24 hours"
+```
+
+The `upstream_asset` becomes a mapping from partition keys to partition values. This is a property of the default IO manager or any IO manager inheriting from the <PyObject module="dagster" object="UPathIOManager" />.
+
+A <PyObject object="PartitionMapping" /> can be provided to <PyObject object="AssetIn" /> to configure the mapped upstream partitions.
+
+When writing a custom IO Manager for loading multiple upstream partitions, the mapped keys can be accessed using <PyObject object="InputContext" method="asset_partition_keys" />, <PyObject object="InputContext" method="asset_partition_key_range" />, or <PyObject object="InputContext" method="asset_partitions_time_window" />.
+
+### Writing a per-input IO Manager
+
+In some cases you may find that you need to load an input in a way other than the `load_input` function of the corresponding output's IO manager. For example, let's say Team A has an op that returns an output as a Pandas DataFrame and specifies an IO manager that knows how to store and load Pandas DataFrames. Your team is interested in using this output for a new op, but you are required to use PySpark to analyze the data. Unfortunately, you don't have permission to modify Team A's IO manager to support this case. Instead, you can specify an input manager on your op that will override some of the behavior of Team A's IO manager.
+
+Since the method for loading an input is directly affected by the way the corresponding output was stored, we recommend defining your input managers as subclasses of existing IO managers and just updating the `load_input` method. In this example, we load an input as a NumPy array rather than a Pandas DataFrame by writing the following:
+
+```python file=/concepts/io_management/input_managers.py startafter=start_plain_input_manager endbefore=end_plain_input_manager
+# in this case PandasIOManager is an existing IO Manager
+class MyNumpyLoader(PandasIOManager):
+    def load_input(self, context):
+        file_path = "path/to/dataframe"
+        array = np.genfromtxt(file_path, delimiter=",", dtype=None)
+        return array
+
+
+@io_manager
+def numpy_io_manager():
+    return MyNumpyLoader()
+
+
+@op(ins={"np_array_input": In(input_manager_key="numpy_manager")})
+def analyze_as_numpy(np_array_input: np.ndarray):
+    assert isinstance(np_array_input, np.ndarray)
+
+
+@job(resource_defs={"numpy_manager": numpy_io_manager, "io_manager": pandas_io_manager})
+def my_job():
+    df = produce_pandas_output()
+    analyze_as_numpy(df)
+```
+
+This may quickly run into issues if the owner of `PandasIOManager` changes the path at which they store outputs. We recommend splitting out path defining logic (or other computations shared by `handle_output` and `load_input`) into new methods that are called when needed.
+
+```python file=/concepts/io_management/input_managers.py startafter=start_better_input_manager endbefore=end_better_input_manager
+# this IO Manager is owned by a different team
+class BetterPandasIOManager(IOManager):
+    def _get_path(self, output_context):
+        return os.path.join(
+            self.base_dir,
+            "storage",
+            f"{output_context.step_key}_{output_context.name}.csv",
+        )
+
+    def handle_output(self, context, obj: pd.DataFrame):
+        file_path = self._get_path(context)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        if obj is not None:
+            obj.to_csv(file_path, index=False)
+
+    def load_input(self, context) -> pd.DataFrame:
+        return pd.read_csv(self._get_path(context.upstream_output))
+
+
+# write a subclass that uses _get_path for your custom loading logic
+class MyBetterNumpyLoader(PandasIOManager):
+    def load_input(self, context):
+        file_path = self._get_path(context.upstream_output)
+        array = np.genfromtxt(file_path, delimiter=",", dtype=None)
+        return array
+
+
+@io_manager
+def better_numpy_io_manager():
+    return MyBetterNumpyLoader()
+
+
+@op(ins={"np_array_input": In(input_manager_key="better_numpy_manager")})
+def better_analyze_as_numpy(np_array_input: np.ndarray):
+    assert isinstance(np_array_input, np.ndarray)
+
+
+@job(
+    resource_defs={
+        "numpy_manager": better_numpy_io_manager,
+        "io_manager": pandas_io_manager,
+    }
+)
+def my_better_job():
+    df = produce_pandas_output()
+    better_analyze_as_numpy(df)
+```
+
+## Examples
+
+### A custom IO manager that stores Pandas DataFrames in tables
+
+If your ops produce Pandas DataFrames that populate tables in a data warehouse, you might write something like the following. This IO manager uses the name assigned to the output as the name of the table to write the output to.
+
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_df_marker endbefore=end_df_marker
+from dagster import IOManager, io_manager
+
+
+class DataframeTableIOManager(IOManager):
+    def handle_output(self, context, obj):
+        # name is the name given to the Out that we're storing for
+        table_name = context.name
+        write_dataframe_to_table(name=table_name, dataframe=obj)
+
+    def load_input(self, context):
+        # upstream_output.name is the name given to the Out that we're loading for
+        table_name = context.upstream_output.name
+        return read_dataframe_from_table(name=table_name)
+
+
+@io_manager
+def df_table_io_manager():
+    return DataframeTableIOManager()
+
+
+@job(resource_defs={"io_manager": df_table_io_manager})
+def my_job():
+    op_2(op_1())
+```
+
+### Custom filesystem-based IO Manager
+
+Dagster provides a feature-rich base class for filesystem-based IO Managers: <PyObject module="dagster" object="UPathIOManager" />. It's compatible with both local and remote filesystems (like S3 or GCS) by using `universal-pathlib` and `fsspec`. The full list of supported filesystems can be found [here](https://github.com/fsspec/universal_pathlib#currently-supported-filesystems-and-schemes). The `UPathIOManager` also has other important features:
+
+- handles partitioned assets
+- handles loading a single upstream partition
+- handles loading multiple upstream partitions (with respect to <PyObject object="PartitionMapping" />)
+- the `get_metadata` method can be customized to add additional metadata to the output
+- the `allow_missing_partitions` metadata value can be set to `True` to skip missing partitions (the default behavior is to raise an error)
+
+The default IO manager inherits from the `UPathIOManager` and therefore has these features too.
+
+The `UPathIOManager` already implements the `load_input` and `handle_output` methods. Instead, <PyObject module="dagster" object="UPathIOManager" method="dump_to_path" /> and <PyObject module="dagster" object="UPathIOManager" method="load_from_path" /> for a given `universal_pathlib.UPath` have to be implemented. Here are some examples:
+
+```python file=/concepts/io_management/filesystem_io_manager.py startafter=start_marker endbefore=end_class_marker
+import pandas as pd
+from upath import UPath
+
+from dagster import (
+    Field,
+    InitResourceContext,
+    InputContext,
+    OutputContext,
+    StringSource,
+    UPathIOManager,
+    io_manager,
+)
+
+
+class PandasParquetIOManager(UPathIOManager):
+    extension: str = ".parquet"
+
+    def dump_to_path(self, context: OutputContext, obj: pd.DataFrame, path: UPath):
+        with path.open("wb") as file:
+            obj.to_parquet(file)
+
+    def load_from_path(self, context: InputContext, path: UPath) -> pd.DataFrame:
+        with path.open("rb") as file:
+            return pd.read_parquet(file)
+```
+
+The extension attribute defines the suffix all the file paths generated by the IOManager will end with.
+
+The io managers defined above will work with partitioned assets on any filesystem:
+
+```python file=/concepts/io_management/filesystem_io_manager.py startafter=start_def_marker endbefore=end_marker
+@io_manager(config_schema={"base_path": Field(str, is_required=False)})
+def local_pandas_parquet_io_manager(
+    init_context: InitResourceContext,
+) -> PandasParquetIOManager:
+    assert init_context.instance is not None  # to please mypy
+    base_path = UPath(
+        init_context.resource_config.get(
+            "base_path", init_context.instance.storage_directory()
+        )
+    )
+    return PandasParquetIOManager(base_path=base_path)
+
+
+@io_manager(
+    config_schema={
+        "base_path": Field(str, is_required=True),
+        "AWS_ACCESS_KEY_ID": StringSource,
+        "AWS_SECRET_ACCESS_KEY": StringSource,
+    }
+)
+def s3_parquet_io_manager(init_context: InitResourceContext) -> PandasParquetIOManager:
+    # `UPath` will read boto env vars.
+    # The credentials can also be taken from the config and passed to `UPath` directly.
+    base_path = UPath(init_context.resource_config.get("base_path"))
+    assert str(base_path).startswith("s3://"), base_path
+    return PandasParquetIOManager(base_path=base_path)
+```
+
+Notice how the local and S3 IO managers are practically the same - the only difference is in the required resources.
+
+### Providing per-output config to an IO manager
+
+When launching a run, you might want to parameterize how particular outputs are stored.
+
+For example, if your job produces DataFrames to populate tables in a data warehouse, you might want to specify the table that each output goes to at run launch time.
+
+To accomplish this, you can define an `output_config_schema` on the IO manager definition. The IO manager methods can access this config when storing or loading data, via the <PyObject module="dagster" object="OutputContext" />.
+
+```python file=/concepts/io_management/output_config.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
+class MyIOManager(IOManager):
+    def handle_output(self, context, obj):
+        table_name = context.config["table"]
+        write_dataframe_to_table(name=table_name, dataframe=obj)
+
+    def load_input(self, context):
+        table_name = context.upstream_output.config["table"]
+        return read_dataframe_from_table(name=table_name)
+
+
+@io_manager(output_config_schema={"table": str})
+def my_io_manager(_):
+    return MyIOManager()
+```
+
+Then, when executing a job, you can pass in this per-output config.
+
+```python file=/concepts/io_management/output_config.py startafter=execute_start_marker endbefore=execute_end_marker
+def execute_my_job_with_config():
+    @job(resource_defs={"io_manager": my_io_manager})
+    def my_job():
+        op_2(op_1())
+
+    my_job.execute_in_process(
+        run_config={
+            "ops": {
+                "op_1": {"outputs": {"result": {"table": "table1"}}},
+                "op_2": {"outputs": {"result": {"table": "table2"}}},
+            }
+        },
+    )
+```
+
+### Providing per-output metadata to an IO manager
+
+You might want to provide static metadata that controls how particular outputs are stored. You don't plan to change the metadata at runtime, so it makes more sense to attach it to a definition rather than expose it as a configuration option.
+
+For example, if your job produces DataFrames to populate tables in a data warehouse, you might want to specify that each output always goes to a particular table. To accomplish this, you can define `metadata` on each <PyObject module="dagster" object="Out" />:
+
+```python file=/concepts/io_management/metadata.py startafter=ops_start_marker endbefore=ops_end_marker
+@op(out=Out(metadata={"schema": "some_schema", "table": "some_table"}))
+def op_1():
+    """Return a Pandas DataFrame."""
+
+
+@op(out=Out(metadata={"schema": "other_schema", "table": "other_table"}))
+def op_2(_input_dataframe):
+    """Return a Pandas DataFrame."""
+```
+
+The IO manager can then access this metadata when storing or retrieving data, via the <PyObject module="dagster" object="OutputContext" />.
+
+In this case, the table names are encoded in the job definition. If, instead, you want to be able to set them at run time, the next section describes how.
+
+```python file=/concepts/io_management/metadata.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
+class MyIOManager(IOManager):
+    def handle_output(self, context, obj):
+        table_name = context.metadata["table"]
+        schema = context.metadata["schema"]
+        write_dataframe_to_table(name=table_name, schema=schema, dataframe=obj)
+
+    def load_input(self, context):
+        table_name = context.upstream_output.metadata["table"]
+        schema = context.upstream_output.metadata["schema"]
+        return read_dataframe_from_table(name=table_name, schema=schema)
+
+
+@io_manager
+def my_io_manager(_):
+    return MyIOManager()
+```
+
+### Per-input loading in assets
+
+Let's say you have an asset that is set to store and load as a Pandas DataFrame, but you want to write a new asset that processes the first asset as a NumPy array. Rather than update the IO manager of the first asset to be able to load as a Pandas DataFrame and a NumPy array, you can write a new loader for the new asset.
+
+In this example, we store `upstream_asset` as a Pandas DataFrame, and we write a new IO manager to load is as a NumPy array in `downstream_asset`
+
+```python file=/concepts/assets/asset_input_managers_numpy.py startafter=start_numpy_example endbefore=end_numpy_example
+class PandasAssetIOManager(IOManager):
+    def handle_output(self, context, obj):
+        file_path = self._get_path(context)
+        store_pandas_dataframe(name=file_path, table=obj)
+
+    def _get_path(self, context):
+        return os.path.join(
+            "storage",
+            f"{context.asset_key.path[-1]}.csv",
+        )
+
+    def load_input(self, context):
+        file_path = self._get_path(context)
+        return load_pandas_dataframe(name=file_path)
+
+
+@io_manager
+def pandas_asset_io_manager():
+    return PandasAssetIOManager()
+
+
+class NumpyAssetIOManager(PandasAssetIOManager):
+    def load_input(self, context):
+        file_path = self._get_path(context)
+        return load_numpy_array(name=file_path)
+
+
+@io_manager
+def numpy_asset_io_manager():
+    return NumpyAssetIOManager()
+
+
+@asset(io_manager_key="pandas_manager")
+def upstream_asset():
+    return pd.DataFrame([1, 2, 3])
+
+
+@asset(
+    ins={"upstream": AssetIn(key_prefix="public", input_manager_key="numpy_manager")}
+)
+def downstream_asset(upstream):
+    return upstream.shape
+
+
+defs = Definitions(
+    assets=[upstream_asset, downstream_asset],
+    resources={
+        "pandas_manager": pandas_asset_io_manager,
+        "numpy_manager": numpy_asset_io_manager,
+    },
+)
+```
+
+## Testing an IO manager
+
+The easiest way to test an IO manager is to construct an <PyObject module="dagster" object="OutputContext" /> or <PyObject module="dagster" object="InputContext" /> and pass it to the `handle_output` or `load_input` method of the IO manager. The <PyObject object="build_output_context" /> and <PyObject object="build_input_context" /> functions allow for easy construction of these contexts.
+
+Here's an example for a simple IO manager that stores outputs in an in-memory dictionary that's keyed on the step and name of the output.
+
+```python file=/concepts/io_management/test_io_manager.py
+from dagster import IOManager, build_input_context, build_output_context, io_manager
+
+
+class MyIOManager(IOManager):
+    def __init__(self):
+        self.storage_dict = {}
+
+    def handle_output(self, context, obj):
+        self.storage_dict[(context.step_key, context.name)] = obj
+
+    def load_input(self, context):
+        return self.storage_dict[
+            (context.upstream_output.step_key, context.upstream_output.name)
+        ]
+
+
+@io_manager
+def my_io_manager(_):
+    return MyIOManager()
+
+
+def test_my_io_manager_handle_output():
+    manager = my_io_manager(None)
+    context = build_output_context(name="abc", step_key="123")
+    manager.handle_output(context, 5)
+    assert manager.storage_dict[("123", "abc")] == 5
+
+
+def test_my_io_manager_load_input():
+    manager = my_io_manager(None)
+    manager.storage_dict[("123", "abc")] = 5
+
+    context = build_input_context(
+        upstream_output=build_output_context(name="abc", step_key="123")
+    )
+    assert manager.load_input(context) == 5
+```
+
+## Recording metadata from an IO Manager
+
+Sometimes, you may want to record some metadata while handling an output in an IO manager. To do this, you can invoke <PyObject object="OutputContext" method="add_output_metadata"/> from within the body of the `handle_output` function. Using this, we can modify one of the [above examples](/concepts/io-management/io-managers#a-custom-io-manager-that-stores-pandas-dataframes-in-tables) to now include some helpful metadata in the log:
+
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_metadata_marker endbefore=end_metadata_marker
+class DataframeTableIOManagerWithMetadata(IOManager):
+    def handle_output(self, context, obj):
+        table_name = context.name
+        write_dataframe_to_table(name=table_name, dataframe=obj)
+
+        context.add_output_metadata({"num_rows": len(obj), "table_name": table_name})
+
+    def load_input(self, context):
+        table_name = context.upstream_output.name
+        return read_dataframe_from_table(name=table_name)
+```
+
+Any entries yielded this way will be attached to the `Handled Output` event for this output.
+
+Additionally, if the handled output is part of a software-defined asset, these metadata entries will also be attached to the materialization event created for that asset and show up on the Asset Details page for the asset.
+
+## See it in action
+
+For more examples of IO Managers, check out the following in our [Hacker News example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
+
+- [Parquet IO Manager](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py)
+- [S3 IO Manager with custom bucket](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/resources/common_bucket_s3\_pickle_io_manager.py)
+
+Our [Type and Metadata example](https://github.com/dagster-io/dagster/tree/master/examples/assets_pandas_type_metadata) also covers writing custom IO managers.

--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -5,11 +5,10 @@ description: IO Managers determine how to store asset/op outputs and load asset/
 
 # IO Managers (Legacy)
 
-
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the
   new Pythonic resource system introduced in Dagster 1.3, see the{" "}
-  <a href="/concepts/io-management/io-managers-legacy">updated I/O managers guide</a>.
+  <a href="/concepts/io-management/io-managers">updated I/O managers guide</a>.
 </Note>
 
 IO Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
@@ -89,7 +88,7 @@ By default, materializing an asset named `my_asset` will pickle it to a local fi
 
 To apply an IO manager to a set of assets, you can use <PyObject object="Definitions" />:
 
-```python file=/concepts/assets/asset_io_manager.py startafter=start_old_marker endbefore=end_old_marker dedent=4
+```python
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 
 from dagster import Definitions, asset
@@ -119,7 +118,7 @@ When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and
 
 Different assets can have different IO managers:
 
-```python file=/concepts/assets/asset_different_io_managers.py startafter=start_old_marker endbefore=end_old_marker dedent=4
+```python
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 
 from dagster import Definitions, asset, fs_io_manager
@@ -149,7 +148,7 @@ When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and
 
 In the multi-asset case, you can customize how each asset is materialized by specifying an `io_manager_key` on each output of the multi-asset.
 
-```python file=/concepts/assets/multi_assets.py startafter=start_io_manager_multi_asset endbefore=end_io_manager_multi_asset
+```python
 from dagster import AssetOut, multi_asset
 
 
@@ -165,7 +164,7 @@ def my_assets():
 
 The same assets can be bound to different resources and IO managers in different environments. For example, for local development, you might want to store assets on your local filesystem while in production, you might want to store the assets in S3.
 
-```python file=/concepts/assets/asset_io_manager_prod_local.py startafter=start_marker endbefore=end_marker
+```python
 import os
 
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
@@ -202,7 +201,7 @@ To set an IO manager for a particular input, use the `input_manager_key` argumen
 
 In this example,`first_asset` and `second_asset` will be stored using the default IO manager, but will be loaded as inputs to `third_asset` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
 
-```python file=/concepts/assets/asset_input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
+```python
 @asset
 def first_asset():
     return [1, 2, 3]
@@ -239,7 +238,7 @@ By default, all the inputs and outputs in a job use the same IO manager. This IO
 
 Here’s how to specify that all op outputs are stored using the <PyObject module="dagster" object="fs_io_manager" />, which pickles outputs and stores them on the local filesystem. It stores files in a directory with the run ID in the path, so that outputs from prior runs will never be overwritten.
 
-```python file=/concepts/io_management/default_io_manager.py
+```python
 from dagster import fs_io_manager, job, op
 
 
@@ -264,7 +263,7 @@ Not all the outputs in a job should necessarily be stored the same way. Maybe so
 
 To select the IO manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting IO managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
 
-```python file=/concepts/io_management/io_manager_per_output.py startafter=start_marker endbefore=end_marker
+```python
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 
 from dagster import Out, fs_io_manager, job, op
@@ -297,7 +296,7 @@ Just as with the inputs to assets, the inputs to ops can be loaded using custom 
 
 In this example, the output of `op_1` will be stored using the default IO manager, but will be loaded in `op_2` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
 
-```python file=/concepts/io_management/input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
+```python
 @op
 def op_1():
     return [1, 2, 3]
@@ -319,7 +318,7 @@ If you have specific requirements for where and how your outputs should be store
 
 To define an IO manager, use the <PyObject module="dagster" object="io_manager" displayText="@io_manager" /> decorator.
 
-```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_marker endbefore=end_io_manager_marker
+```python
 from dagster import IOManager, io_manager
 
 
@@ -351,7 +350,7 @@ The default IO Manager has support for loading a partitioned upstream asset for 
 
 To handle partitions in an custom IO manager, you'll need to determine which partition you're dealing with when you're storing an output or loading an input. For this, <PyObject object="OutputContext" /> and <PyObject object="InputContext" /> have a `asset_partition_key` property:
 
-```python file=/concepts/io_management/custom_io_manager.py startafter=start_partitioned_marker endbefore=end_partitioned_marker
+```python
 class MyPartitionedIOManager(IOManager):
     def _get_path(self, context) -> str:
         if context.has_partition_key:
@@ -374,7 +373,7 @@ A single partition of one asset might depend on a range of partitions of an upst
 
 The default IO Manager has support for loading multiple upstream partitions. In this case, the downstream asset should use `Dict[str, ...]` (or leave it blank) type for the upstream `DagsterType`. Here is an example of loading multiple upstream partitions using the default partition mapping:
 
-```python file=/concepts/io_management/loading_multiple_upstream_partitions.py
+```python
 from datetime import datetime
 from typing import Dict
 
@@ -428,7 +427,7 @@ In some cases you may find that you need to load an input in a way other than th
 
 Since the method for loading an input is directly affected by the way the corresponding output was stored, we recommend defining your input managers as subclasses of existing IO managers and just updating the `load_input` method. In this example, we load an input as a NumPy array rather than a Pandas DataFrame by writing the following:
 
-```python file=/concepts/io_management/input_managers.py startafter=start_plain_input_manager endbefore=end_plain_input_manager
+```python
 # in this case PandasIOManager is an existing IO Manager
 class MyNumpyLoader(PandasIOManager):
     def load_input(self, context):
@@ -455,7 +454,7 @@ def my_job():
 
 This may quickly run into issues if the owner of `PandasIOManager` changes the path at which they store outputs. We recommend splitting out path defining logic (or other computations shared by `handle_output` and `load_input`) into new methods that are called when needed.
 
-```python file=/concepts/io_management/input_managers.py startafter=start_better_input_manager endbefore=end_better_input_manager
+```python
 # this IO Manager is owned by a different team
 class BetterPandasIOManager(IOManager):
     def _get_path(self, output_context):
@@ -510,7 +509,7 @@ def my_better_job():
 
 If your ops produce Pandas DataFrames that populate tables in a data warehouse, you might write something like the following. This IO manager uses the name assigned to the output as the name of the table to write the output to.
 
-```python file=/concepts/io_management/custom_io_manager.py startafter=start_df_marker endbefore=end_df_marker
+```python
 from dagster import IOManager, io_manager
 
 
@@ -550,7 +549,7 @@ The default IO manager inherits from the `UPathIOManager` and therefore has thes
 
 The `UPathIOManager` already implements the `load_input` and `handle_output` methods. Instead, <PyObject module="dagster" object="UPathIOManager" method="dump_to_path" /> and <PyObject module="dagster" object="UPathIOManager" method="load_from_path" /> for a given `universal_pathlib.UPath` have to be implemented. Here are some examples:
 
-```python file=/concepts/io_management/filesystem_io_manager.py startafter=start_marker endbefore=end_class_marker
+```python
 import pandas as pd
 from upath import UPath
 
@@ -581,7 +580,7 @@ The extension attribute defines the suffix all the file paths generated by the I
 
 The io managers defined above will work with partitioned assets on any filesystem:
 
-```python file=/concepts/io_management/filesystem_io_manager.py startafter=start_def_marker endbefore=end_marker
+```python
 @io_manager(config_schema={"base_path": Field(str, is_required=False)})
 def local_pandas_parquet_io_manager(
     init_context: InitResourceContext,
@@ -620,7 +619,7 @@ For example, if your job produces DataFrames to populate tables in a data wareho
 
 To accomplish this, you can define an `output_config_schema` on the IO manager definition. The IO manager methods can access this config when storing or loading data, via the <PyObject module="dagster" object="OutputContext" />.
 
-```python file=/concepts/io_management/output_config.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
+```python
 class MyIOManager(IOManager):
     def handle_output(self, context, obj):
         table_name = context.config["table"]
@@ -638,7 +637,7 @@ def my_io_manager(_):
 
 Then, when executing a job, you can pass in this per-output config.
 
-```python file=/concepts/io_management/output_config.py startafter=execute_start_marker endbefore=execute_end_marker
+```python
 def execute_my_job_with_config():
     @job(resource_defs={"io_manager": my_io_manager})
     def my_job():
@@ -660,7 +659,7 @@ You might want to provide static metadata that controls how particular outputs a
 
 For example, if your job produces DataFrames to populate tables in a data warehouse, you might want to specify that each output always goes to a particular table. To accomplish this, you can define `metadata` on each <PyObject module="dagster" object="Out" />:
 
-```python file=/concepts/io_management/metadata.py startafter=ops_start_marker endbefore=ops_end_marker
+```python
 @op(out=Out(metadata={"schema": "some_schema", "table": "some_table"}))
 def op_1():
     """Return a Pandas DataFrame."""
@@ -675,7 +674,7 @@ The IO manager can then access this metadata when storing or retrieving data, vi
 
 In this case, the table names are encoded in the job definition. If, instead, you want to be able to set them at run time, the next section describes how.
 
-```python file=/concepts/io_management/metadata.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
+```python
 class MyIOManager(IOManager):
     def handle_output(self, context, obj):
         table_name = context.metadata["table"]
@@ -699,7 +698,7 @@ Let's say you have an asset that is set to store and load as a Pandas DataFrame,
 
 In this example, we store `upstream_asset` as a Pandas DataFrame, and we write a new IO manager to load is as a NumPy array in `downstream_asset`
 
-```python file=/concepts/assets/asset_input_managers_numpy.py startafter=start_numpy_example endbefore=end_numpy_example
+```python
 class PandasAssetIOManager(IOManager):
     def handle_output(self, context, obj):
         file_path = self._get_path(context)
@@ -759,7 +758,7 @@ The easiest way to test an IO manager is to construct an <PyObject module="dagst
 
 Here's an example for a simple IO manager that stores outputs in an in-memory dictionary that's keyed on the step and name of the output.
 
-```python file=/concepts/io_management/test_io_manager.py
+```python
 from dagster import IOManager, build_input_context, build_output_context, io_manager
 
 
@@ -802,7 +801,7 @@ def test_my_io_manager_load_input():
 
 Sometimes, you may want to record some metadata while handling an output in an IO manager. To do this, you can invoke <PyObject object="OutputContext" method="add_output_metadata"/> from within the body of the `handle_output` function. Using this, we can modify one of the [above examples](/concepts/io-management/io-managers#a-custom-io-manager-that-stores-pandas-dataframes-in-tables) to now include some helpful metadata in the log:
 
-```python file=/concepts/io_management/custom_io_manager.py startafter=start_metadata_marker endbefore=end_metadata_marker
+```python
 class DataframeTableIOManagerWithMetadata(IOManager):
     def handle_output(self, context, obj):
         table_name = context.name

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -18,12 +18,13 @@ IO Managers are user-provided objects that store asset and op outputs and load t
 
 ## Relevant APIs
 
-| Name                                                        | Description                                                                                                                                                                                                 |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <PyObject module="dagster" object="io_manager" decorator /> | A decorator used to define IO managers.                                                                                                                                                                     |
-| <PyObject module="dagster" object="IOManager" />            | Base class for user-provided IO managers.                                                                                                                                                                   |
-| <PyObject object="build_input_context"/>                    | Function for directly constructing a <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |
-| <PyObject object="build_output_context"/>                   | Function for directly constructing a <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |
+| Name                                                                          | Description                                                                                                                                                                                                 |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject module="dagster" object="ConfigurableIOManager" decorator />        | A base class used to define configurable IO managers which are also resources.                                                                                                                              |
+| <PyObject module="dagster" object="ConfigurableIOManagerFactory" decorator /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                  |
+| <PyObject module="dagster" object="IOManager" />                              | Base class for user-provided IO managers.                                                                                                                                                                   |
+| <PyObject object="build_input_context"/>                                      | Function for directly constructing a <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |
+| <PyObject object="build_output_context"/>                                     | Function for directly constructing a <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |
 
 ## Overview
 
@@ -320,31 +321,59 @@ def a_job():
 
 If you have specific requirements for where and how your outputs should be stored and retrieved, you can define your own IO manager. This boils down to implementing two functions: one that stores outputs and one that loads inputs.
 
-To define an IO manager, use the <PyObject module="dagster" object="io_manager" displayText="@io_manager" /> decorator.
+To define an IO manager, you will want to extend the <PyObject module="dagster" object="IOManager" /> class. Often times, you will want to extend the <PyObject module="dagster" object="ConfigurableIOManager"/> class (which subclasses `IOManager`) to attach a config schema to your IO manager.
+
+Here, we define a simple IO manager that reads and writes CSV values to the filesystem. It takes an optional prefix path through config.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_marker endbefore=end_io_manager_marker
-from dagster import IOManager, io_manager
+from dagster import ConfigurableIOManager
 
 
-class MyIOManager(IOManager):
+class MyIOManager(ConfigurableIOManager):
+    path_prefix: List[str] = []
+
     def _get_path(self, context) -> str:
-        return "/".join(context.asset_key.path)
+        return "/".join(self.path_prefix + context.asset_key.path)
 
     def handle_output(self, context, obj):
         write_csv(self._get_path(context), obj)
 
     def load_input(self, context):
         return read_csv(self._get_path(context))
-
-
-@io_manager
-def my_io_manager():
-    return MyIOManager()
 ```
 
-The <PyObject module="dagster" object="io_manager" /> decorator behaves nearly identically to the <PyObject module="dagster" object="resource" /> decorator. It yields an <PyObject module="dagster" object="IOManagerDefinition" />, which is a subclass of <PyObject module="dagster" object="ResourceDefinition" /> that will produce an <PyObject module="dagster" object="IOManager" />.
-
 The provided `context` argument for `handle_output` is an <PyObject module="dagster" object="OutputContext" />. The provided `context` argument for `load_input` is an <PyObject module="dagster" object="InputContext" />. The linked API documentation lists all the fields that are available on these objects.
+
+### Using an IO manager factory
+
+If your IO manager is more complex, or needs to manage internal state, it may make sense to split out the IO manager definition from its configuration. In this case, you can use `ConfigurableIOManagerFactory`, which specifies config schema and implements a factory function that takes the config and returns an IO manager.
+
+```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_factory_marker endbefore=end_io_manager_factory_marker
+from dagster import IOManager, ConfigurableIOManagerFactory
+import requests
+
+
+class ExternalIOManager(IOManager):
+    def __init__(self, api_token):
+        self._api_token = api_token
+
+    def handle_output(self, context, obj):
+        ...
+
+    def load_input(self, context):
+        ...
+
+
+class ConfigurableExternalIOManager(ConfigurableIOManagerFactory):
+    username: str
+    password: str
+
+    def create_io_manager(self, context) -> ExternalIOManager:
+        api_token = requests.get(
+            "https://my-api.com/token", auth=(self.username, self.password)
+        ).json()
+        return ExternalIOManager(api_token)
+```
 
 ### Handling partitioned assets
 
@@ -440,17 +469,12 @@ class MyNumpyLoader(PandasIOManager):
         return array
 
 
-@io_manager
-def numpy_io_manager():
-    return MyNumpyLoader()
-
-
 @op(ins={"np_array_input": In(input_manager_key="numpy_manager")})
 def analyze_as_numpy(np_array_input: np.ndarray):
     assert isinstance(np_array_input, np.ndarray)
 
 
-@job(resource_defs={"numpy_manager": numpy_io_manager, "io_manager": pandas_io_manager})
+@job(resource_defs={"numpy_manager": MyNumpyLoader(), "io_manager": PandasIOManager()})
 def my_job():
     df = produce_pandas_output()
     analyze_as_numpy(df)
@@ -460,7 +484,7 @@ This may quickly run into issues if the owner of `PandasIOManager` changes the p
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_better_input_manager endbefore=end_better_input_manager
 # this IO Manager is owned by a different team
-class BetterPandasIOManager(IOManager):
+class BetterPandasIOManager(ConfigurableIOManager):
     def _get_path(self, output_context):
         return os.path.join(
             self.base_dir,
@@ -486,11 +510,6 @@ class MyBetterNumpyLoader(PandasIOManager):
         return array
 
 
-@io_manager
-def better_numpy_io_manager():
-    return MyBetterNumpyLoader()
-
-
 @op(ins={"np_array_input": In(input_manager_key="better_numpy_manager")})
 def better_analyze_as_numpy(np_array_input: np.ndarray):
     assert isinstance(np_array_input, np.ndarray)
@@ -498,8 +517,8 @@ def better_analyze_as_numpy(np_array_input: np.ndarray):
 
 @job(
     resource_defs={
-        "numpy_manager": better_numpy_io_manager,
-        "io_manager": pandas_io_manager,
+        "numpy_manager": MyBetterNumpyLoader(),
+        "io_manager": PandasIOManager(),
     }
 )
 def my_better_job():
@@ -514,10 +533,10 @@ def my_better_job():
 If your ops produce Pandas DataFrames that populate tables in a data warehouse, you might write something like the following. This IO manager uses the name assigned to the output as the name of the table to write the output to.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_df_marker endbefore=end_df_marker
-from dagster import IOManager, io_manager
+from dagster import ConfigurableIOManager, io_manager
 
 
-class DataframeTableIOManager(IOManager):
+class DataframeTableIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         # name is the name given to the Out that we're storing for
         table_name = context.name
@@ -529,12 +548,7 @@ class DataframeTableIOManager(IOManager):
         return read_dataframe_from_table(name=table_name)
 
 
-@io_manager
-def df_table_io_manager():
-    return DataframeTableIOManager()
-
-
-@job(resource_defs={"io_manager": df_table_io_manager})
+@job(resource_defs={"io_manager": DataframeTableIOManager()})
 def my_job():
     op_2(op_1())
 ```
@@ -672,7 +686,7 @@ The IO manager can then access this metadata when storing or retrieving data, vi
 In this case, the table names are encoded in the job definition. If, instead, you want to be able to set them at run time, the next section describes how.
 
 ```python file=/concepts/io_management/metadata.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
-class MyIOManager(IOManager):
+class MyIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         table_name = context.metadata["table"]
         schema = context.metadata["schema"]
@@ -682,11 +696,6 @@ class MyIOManager(IOManager):
         table_name = context.upstream_output.metadata["table"]
         schema = context.upstream_output.metadata["schema"]
         return read_dataframe_from_table(name=table_name, schema=schema)
-
-
-@io_manager
-def my_io_manager(_):
-    return MyIOManager()
 ```
 
 ### Per-input loading in assets
@@ -696,7 +705,7 @@ Let's say you have an asset that is set to store and load as a Pandas DataFrame,
 In this example, we store `upstream_asset` as a Pandas DataFrame, and we write a new IO manager to load is as a NumPy array in `downstream_asset`
 
 ```python file=/concepts/assets/asset_input_managers_numpy.py startafter=start_numpy_example endbefore=end_numpy_example
-class PandasAssetIOManager(IOManager):
+class PandasAssetIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         file_path = self._get_path(context)
         store_pandas_dataframe(name=file_path, table=obj)
@@ -712,20 +721,10 @@ class PandasAssetIOManager(IOManager):
         return load_pandas_dataframe(name=file_path)
 
 
-@io_manager
-def pandas_asset_io_manager():
-    return PandasAssetIOManager()
-
-
 class NumpyAssetIOManager(PandasAssetIOManager):
     def load_input(self, context):
         file_path = self._get_path(context)
         return load_numpy_array(name=file_path)
-
-
-@io_manager
-def numpy_asset_io_manager():
-    return NumpyAssetIOManager()
 
 
 @asset(io_manager_key="pandas_manager")
@@ -743,8 +742,8 @@ def downstream_asset(upstream):
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
-        "pandas_manager": pandas_asset_io_manager,
-        "numpy_manager": numpy_asset_io_manager,
+        "pandas_manager": PandasAssetIOManager(),
+        "numpy_manager": NumpyAssetIOManager(),
     },
 )
 ```
@@ -756,7 +755,11 @@ The easiest way to test an IO manager is to construct an <PyObject module="dagst
 Here's an example for a simple IO manager that stores outputs in an in-memory dictionary that's keyed on the step and name of the output.
 
 ```python file=/concepts/io_management/test_io_manager.py
-from dagster import IOManager, build_input_context, build_output_context, io_manager
+from dagster import (
+    IOManager,
+    build_input_context,
+    build_output_context,
+)
 
 
 class MyIOManager(IOManager):
@@ -772,20 +775,15 @@ class MyIOManager(IOManager):
         ]
 
 
-@io_manager
-def my_io_manager(_):
-    return MyIOManager()
-
-
 def test_my_io_manager_handle_output():
-    manager = my_io_manager(None)
+    manager = MyIOManager()
     context = build_output_context(name="abc", step_key="123")
     manager.handle_output(context, 5)
     assert manager.storage_dict[("123", "abc")] == 5
 
 
 def test_my_io_manager_load_input():
-    manager = my_io_manager(None)
+    manager = MyIOManager()
     manager.storage_dict[("123", "abc")] = 5
 
     context = build_input_context(
@@ -799,7 +797,7 @@ def test_my_io_manager_load_input():
 Sometimes, you may want to record some metadata while handling an output in an IO manager. To do this, you can invoke <PyObject object="OutputContext" method="add_output_metadata"/> from within the body of the `handle_output` function. Using this, we can modify one of the [above examples](/concepts/io-management/io-managers#a-custom-io-manager-that-stores-pandas-dataframes-in-tables) to now include some helpful metadata in the log:
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_metadata_marker endbefore=end_metadata_marker
-class DataframeTableIOManagerWithMetadata(IOManager):
+class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
     def handle_output(self, context, obj):
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -1,11 +1,11 @@
 ---
-title: IO Managers | Dagster
-description: IO Managers determine how to store asset/op outputs and load asset/op inputs.
+title: I/O Managers | Dagster
+description: I/O Managers determine how to store asset/op outputs and load asset/op inputs.
 ---
 
-# IO Managers
+# I/O Managers
 
-IO Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
+I/O Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
 
 <center>
   <Image
@@ -18,19 +18,19 @@ IO Managers are user-provided objects that store asset and op outputs and load t
 
 ## Relevant APIs
 
-| Name                                                                          | Description                                                                                                                                                                                                 |
-| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <PyObject module="dagster" object="ConfigurableIOManager" decorator />        | A base class used to define configurable IO managers which are also resources.                                                                                                                              |
-| <PyObject module="dagster" object="ConfigurableIOManagerFactory" decorator /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                  |
-| <PyObject module="dagster" object="IOManager" />                              | Base class for user-provided IO managers.                                                                                                                                                                   |
-| <PyObject object="build_input_context"/>                                      | Function for directly constructing a <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |
-| <PyObject object="build_output_context"/>                                     | Function for directly constructing a <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |
+| Name                                                                          | Description                                                                                                                                                                                                 |   |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | - |
+| <PyObject module="dagster" object="ConfigurableIOManager" decorator />        | A base class used to define configurable I/O managers which are also resources.                                                                                                                             | ƒ |
+| <PyObject module="dagster" object="ConfigurableIOManagerFactory" decorator /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                  |   |
+| <PyObject module="dagster" object="IOManager" />                              | Base class for standalone I/O managers which are constructed by factories.                                                                                                                                  |   |
+| <PyObject object="build_input_context"/>                                      | Function for directly constructing a <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |   |
+| <PyObject object="build_output_context"/>                                     | Function for directly constructing a <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |   |
 
 ## Overview
 
-Functions decorated by <PyObject object="asset" decorator/>, <PyObject object="multi_asset" decorator/>, and <PyObject object="op" decorator/> can have parameters and return values that are loaded from and written to persistent storage. <PyObject module="dagster" object="IOManager" pluralize /> let the user control how this data is stored and how it's loaded in downstream ops and assets. For `@asset` and `@multi_asset`, the IO manager effectively determines where the physical asset lives.
+Functions decorated by <PyObject object="asset" decorator/>, <PyObject object="multi_asset" decorator/>, and <PyObject object="op" decorator/> can have parameters and return values that are loaded from and written to persistent storage. <PyObject module="dagster" object="IOManager" pluralize /> let the user control how this data is stored and how it's loaded in downstream ops and assets. For `@asset` and `@multi_asset`, the I/O manager effectively determines where the physical asset lives.
 
-The IO manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Software-defined assets and ops can focus on business logic, while IO managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
+The I/O manager APIs make it easy to separate code that's responsible for logical data transformation from code that's responsible for reading and writing the results. Software-defined assets and ops can focus on business logic, while I/O managers handle I/O. This separation makes it easier to test the business logic and run it in different environments.
 
 For non-asset jobs with inputs that aren't connected to upstream outputs, see the [Unconnected Inputs](/concepts/io-management/unconnected-inputs) overview.
 
@@ -38,10 +38,10 @@ For non-asset jobs with inputs that aren't connected to upstream outputs, see th
 
 <PyObject module="dagster" object="IOManager" pluralize /> are user-provided objects
 that are responsible for storing the output of an asset or op and loading it as input
-to downstream assets or ops. For example, an IO manager might store and load objects
+to downstream assets or ops. For example, an I/O manager might store and load objects
 from files on a filesystem.
 
-Each software-defined asset can have its own IO manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different IO manager:
+Each software-defined asset can have its own I/O manager. In the [multi-asset](/concepts/assets/multi-assets) case where multiple assets are outputted, each outputted asset can be handled with a different I/O manager:
 
 <center>
   <Image
@@ -53,35 +53,35 @@ Each software-defined asset can have its own IO manager. In the [multi-asset](/c
   />
 </center>
 
-For ops, each op output can have its own IO manager, or multiple op outputs can share an IO manager. The IO manager that's used for handling a particular op output is automatically used for loading it in downstream ops.
+For ops, each op output can have its own I/O manager, or multiple op outputs can share an I/O manager. The I/O manager that's used for handling a particular op output is automatically used for loading it in downstream ops.
 
-Consider the following diagram. In this example, a job has two IO managers, each of which is shared across a few inputs and outputs:
+Consider the following diagram. In this example, a job has two I/O managers, each of which is shared across a few inputs and outputs:
 
 <center>
   <Image src="/images/concepts/two-io-managers.png" width={643} height={382} />
 </center>
 
-### Built-in IO managers
+### Built-in I/O managers
 
-The default IO manager, <PyObject module="dagster" object="fs_io_manager" />, stores and retrieves values from pickle files in the local filesystem. If a job is invoked via <PyObject object="JobDefinition" method="execute_in_process" />, the default IO manager is switched to <PyObject module="dagster" object="mem_io_manager"/>, which stores outputs in memory.
+The default I/O manager, <PyObject module="dagster" object="fs_io_manager" />, stores and retrieves values from pickle files in the local filesystem. If a job is invoked via <PyObject object="JobDefinition" method="execute_in_process" />, the default I/O manager is switched to <PyObject module="dagster" object="mem_io_manager"/>, which stores outputs in memory.
 
-Dagster provides out-of-the-box IO managers for popular storage systems: AWS S3 (<PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" />), Azure Blob Storage (<PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager" />), GCS (<PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager" />), and Snowflake (<PyObject module="dagster_snowflake" object="build_snowflake_io_manager" />) - or you can write your own: either from scratch or by extending the `UPathIOManager` if you want to store data in an `fsspec`-supported filesystem.
+Dagster provides out-of-the-box I/O managers for popular storage systems: AWS S3 (<PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" />), Azure Blob Storage (<PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager" />), GCS (<PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager" />), and Snowflake (<PyObject module="dagster_snowflake" object="build_snowflake_io_manager" />) - or you can write your own: either from scratch or by extending the `UPathIOManager` if you want to store data in an `fsspec`-supported filesystem.
 
-### IO managers are provided by resources
+### I/O managers are resources
 
-IO managers are provided through the [resources](/concepts/resources) system which means users can supply different IO managers for the same assets or ops in different situations. For example, you might use an in-memory IO manager for unit-testing and an S3 IO manager in production.
+I/O managers are provided through the [resources](/concepts/resources) system which means users can supply different I/O managers for the same assets or ops in different situations. For example, you might use an in-memory I/O manager for unit-testing and an S3 I/O manager in production.
 
 ---
 
-## Using IO managers with software-defined assets
+## Using I/O managers with software-defined assets
 
-### Applying IO managers to assets
+### Applying I/O managers to assets
 
 By default, materializing an asset named `my_asset` will pickle it to a local file named `my_asset`. The directory that file lives underneath is determined by the rules in <PyObject object="fs_io_manager" />.
 
-[IO managers](/concepts/io-management/io-managers) enable fully overriding this behavior and storing asset contents in any way you wish - e.g. writing them as tables in a database or as objects in a cloud object store such as s3. You can use one of Dagster's [built-in IO managers](#built-in-io-managers), or you can write your own.
+[I/O managers](/concepts/io-management/io-managers) enable fully overriding this behavior and storing asset contents in any way you wish - e.g. writing them as tables in a database or as objects in a cloud object store such as s3. You can use one of Dagster's [built-in I/O managers](#built-in-io-managers), or you can write your own.
 
-To apply an IO manager to a set of assets, you can use <PyObject object="Definitions" />:
+To apply an I/O manager to a set of assets, you can use <PyObject object="Definitions" />:
 
 ```python file=/concepts/assets/asset_io_manager.py startafter=start_marker endbefore=end_marker
 from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
@@ -109,13 +109,13 @@ defs = Definitions(
 )
 ```
 
-This example also constructs a <PyObject module="dagster_aws.s3" object="S3Resource" /> because the <PyObject module="dagster_aws.s3" object="ConfigurablePickledObjectS3IOManager" /> depends on the S3 resource.
+This example also constructs a <PyObject module="dagster_aws.s3" object="S3Resource" /> because the <PyObject module="dagster_aws.s3" object="ConfigurablePickledObjectS3IOManager" /> depends on the S3 resource. For more information on how these resource-resource dependencies are modeled, refer to the [resources](/concepts/resources#resources-which-depend-on-other-resources) documentation.
 
 When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and stored in an object on S3. When `downstream_asset` is materialized, the value of `upstream_asset` will be read from S3 and depickled, and `[1, 2, 3, 4]` will be pickled and stored in a different object on S3.
 
-### Per-asset IO manager
+### Per-asset I/O manager
 
-Different assets can have different IO managers:
+Different assets can have different I/O managers:
 
 ```python file=/concepts/assets/asset_different_io_managers.py startafter=start_marker endbefore=end_marker
 from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
@@ -162,7 +162,7 @@ def my_assets():
     return "store_me_on_s3", "store_me_on_adls2"
 ```
 
-The same assets can be bound to different resources and IO managers in different environments. For example, for local development, you might want to store assets on your local filesystem while in production, you might want to store the assets in S3.
+The same assets can be bound to different resources and I/O managers in different environments. For example, for local development, you might want to store assets on your local filesystem while in production, you might want to store the assets in S3.
 
 ```python file=/concepts/assets/asset_io_manager_prod_local.py startafter=start_marker endbefore=end_marker
 import os
@@ -197,13 +197,13 @@ defs = Definitions(
 )
 ```
 
-### Asset input IO managers
+### Asset input I/O managers
 
-In some cases you may need to load the input to an asset with different logic than that specified by the upstream asset's IO manager.
+In some cases you may need to load the input to an asset with different logic than that specified by the upstream asset's I/O manager.
 
-To set an IO manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="AssetIn" />.
+To set an I/O manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="AssetIn" />.
 
-In this example,`first_asset` and `second_asset` will be stored using the default IO manager, but will be loaded as inputs to `third_asset` using the logic defined in the `PandasSeriesIOManager` (in this case loading as Pandas Series rather than python lists).
+In this example,`first_asset` and `second_asset` will be stored using the default I/O manager, but will be loaded as inputs to `third_asset` using the logic defined in the `PandasSeriesIOManager` (in this case loading as Pandas Series rather than python lists).
 
 ```python file=/concepts/assets/asset_input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
 @asset
@@ -234,11 +234,11 @@ defs = Definitions(
 )
 ```
 
-## Using IO managers with non-asset jobs
+## Using I/O managers with non-asset jobs
 
-### Job-wide IO manager
+### Job-wide I/O manager
 
-By default, all the inputs and outputs in a job use the same IO manager. This IO manager is determined by the <PyObject module="dagster" object="ResourceDefinition" /> provided for the `"io_manager"` resource key. `"io_manager"` is a resource key that Dagster reserves specifically for this purpose.
+By default, all the inputs and outputs in a job use the same I/O manager. This I/O manager is determined by the <PyObject module="dagster" object="ResourceDefinition" /> provided for the `"io_manager"` resource key. `"io_manager"` is a resource key that Dagster reserves specifically for this purpose.
 
 Here’s how to specify that all op outputs are stored using the <PyObject module="dagster" object="fs_io_manager" />, which pickles outputs and stores them on the local filesystem. It stores files in a directory with the run ID in the path, so that outputs from prior runs will never be overwritten.
 
@@ -261,11 +261,11 @@ def my_job():
     op_2(op_1())
 ```
 
-### Per-output IO manager
+### Per-output I/O manager
 
 Not all the outputs in a job should necessarily be stored the same way. Maybe some of the outputs should live on the filesystem so they can be inspected, and others can be transiently stored in memory.
 
-To select the IO manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting IO managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
+To select the I/O manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting I/O managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
 
 ```python file=/concepts/io_management/io_manager_per_output.py startafter=start_marker endbefore=end_marker
 from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
@@ -295,11 +295,11 @@ def my_job():
     op_2(op_1())
 ```
 
-### Per-input IO manager
+### Per-input I/O manager
 
-Just as with the inputs to assets, the inputs to ops can be loaded using custom logic if you want to override the IO manager of the upstream output. To set an IO manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="In" />.
+Just as with the inputs to assets, the inputs to ops can be loaded using custom logic if you want to override the I/O manager of the upstream output. To set an I/O manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="In" />.
 
-In this example, the output of `op_1` will be stored using the default IO manager, but will be loaded in `op_2` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
+In this example, the output of `op_1` will be stored using the default I/O manager, but will be loaded in `op_2` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
 @op
@@ -317,13 +317,13 @@ def a_job():
     op_2(op_1())
 ```
 
-## Defining an IO manager
+## Defining an I/O manager
 
-If you have specific requirements for where and how your outputs should be stored and retrieved, you can define your own IO manager. This boils down to implementing two functions: one that stores outputs and one that loads inputs.
+If you have specific requirements for where and how your outputs should be stored and retrieved, you can define your own I/O manager. This boils down to implementing two functions: one that stores outputs and one that loads inputs.
 
-To define an IO manager, you will want to extend the <PyObject module="dagster" object="IOManager" /> class. Often times, you will want to extend the <PyObject module="dagster" object="ConfigurableIOManager"/> class (which subclasses `IOManager`) to attach a config schema to your IO manager.
+To define an I/O manager, you will want to extend the <PyObject module="dagster" object="IOManager" /> class. Often times, you will want to extend the <PyObject module="dagster" object="ConfigurableIOManager"/> class (which subclasses `IOManager`) to attach a config schema to your I/O manager.
 
-Here, we define a simple IO manager that reads and writes CSV values to the filesystem. It takes an optional prefix path through config.
+Here, we define a simple I/O manager that reads and writes CSV values to the filesystem. It takes an optional prefix path through config.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_marker endbefore=end_io_manager_marker
 from dagster import ConfigurableIOManager
@@ -344,9 +344,11 @@ class MyIOManager(ConfigurableIOManager):
 
 The provided `context` argument for `handle_output` is an <PyObject module="dagster" object="OutputContext" />. The provided `context` argument for `load_input` is an <PyObject module="dagster" object="InputContext" />. The linked API documentation lists all the fields that are available on these objects.
 
-### Using an IO manager factory
+### Using an I/O manager factory
 
-If your IO manager is more complex, or needs to manage internal state, it may make sense to split out the IO manager definition from its configuration. In this case, you can use `ConfigurableIOManagerFactory`, which specifies config schema and implements a factory function that takes the config and returns an IO manager.
+If your I/O manager is more complex, or needs to manage internal state, it may make sense to split out the I/O manager definition from its configuration. In this case, you can use <PyObject object="ConfigurableIOManagerFactory"/>, which specifies config schema and implements a factory function that takes the config and returns an I/O manager.
+
+In this case, we implement a stateful I/O manager which maintains a cache.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_factory_marker endbefore=end_io_manager_factory_marker
 from dagster import IOManager, ConfigurableIOManagerFactory
@@ -356,32 +358,32 @@ import requests
 class ExternalIOManager(IOManager):
     def __init__(self, api_token):
         self._api_token = api_token
+        # setup stateful cache
+        self._cache = {}
 
     def handle_output(self, context, obj):
         ...
 
     def load_input(self, context):
+        if context.asset_key in self._cache:
+            return self._cache[context.asset_key]
         ...
 
 
 class ConfigurableExternalIOManager(ConfigurableIOManagerFactory):
-    username: str
-    password: str
+    api_token: str
 
     def create_io_manager(self, context) -> ExternalIOManager:
-        api_token = requests.get(
-            "https://my-api.com/token", auth=(self.username, self.password)
-        ).json()
-        return ExternalIOManager(api_token)
+        return ExternalIOManager(self.api_token)
 ```
 
 ### Handling partitioned assets
 
-IO managers can be written to handle [partitioned](/concepts/partitions-schedules-sensors/partitions) assets. For a partitioned asset, each invocation of `handle_output` will (over)write a single partition, and each invocation of `load_input` will load one or more partitions. When the IO manager is backed by a filesystem or object store, then each partition will typically correspond to a file or object. When it's backed by a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
+I/O managers can be written to handle [partitioned](/concepts/partitions-schedules-sensors/partitions) assets. For a partitioned asset, each invocation of `handle_output` will (over)write a single partition, and each invocation of `load_input` will load one or more partitions. When the I/O manager is backed by a filesystem or object store, then each partition will typically correspond to a file or object. When it's backed by a database, then each partition will typically correspond to a range of values in a table that fall within a particular window.
 
-The default IO Manager has support for loading a partitioned upstream asset for a downstream asset with matching partitions out of the box (see the section below for loading multiple partitions). The <PyObject module="dagster" object="UPathIOManager" /> can be used to handle partitions in custom filesystem-based IO Managers.
+The default I/O manager has support for loading a partitioned upstream asset for a downstream asset with matching partitions out of the box (see the section below for loading multiple partitions). The <PyObject module="dagster" object="UPathIOManager" /> can be used to handle partitions in custom filesystem-based I/O managers.
 
-To handle partitions in an custom IO manager, you'll need to determine which partition you're dealing with when you're storing an output or loading an input. For this, <PyObject object="OutputContext" /> and <PyObject object="InputContext" /> have a `asset_partition_key` property:
+To handle partitions in an custom I/O manager, you'll need to determine which partition you're dealing with when you're storing an output or loading an input. For this, <PyObject object="OutputContext" /> and <PyObject object="InputContext" /> have a `asset_partition_key` property:
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_partitioned_marker endbefore=end_partitioned_marker
 class MyPartitionedIOManager(IOManager):
@@ -404,7 +406,7 @@ If you're working with time window partitions, you can also use the `asset_parti
 
 A single partition of one asset might depend on a range of partitions of an upstream asset.
 
-The default IO Manager has support for loading multiple upstream partitions. In this case, the downstream asset should use `Dict[str, ...]` (or leave it blank) type for the upstream `DagsterType`. Here is an example of loading multiple upstream partitions using the default partition mapping:
+The default I/O manager has support for loading multiple upstream partitions. In this case, the downstream asset should use `Dict[str, ...]` (or leave it blank) type for the upstream `DagsterType`. Here is an example of loading multiple upstream partitions using the default partition mapping:
 
 ```python file=/concepts/io_management/loading_multiple_upstream_partitions.py
 from datetime import datetime
@@ -448,17 +450,17 @@ assert (
 ), "downstream day should map to upstream 24 hours"
 ```
 
-The `upstream_asset` becomes a mapping from partition keys to partition values. This is a property of the default IO manager or any IO manager inheriting from the <PyObject module="dagster" object="UPathIOManager" />.
+The `upstream_asset` becomes a mapping from partition keys to partition values. This is a property of the default I/O manager or any I/O manager inheriting from the <PyObject module="dagster" object="UPathIOManager" />.
 
 A <PyObject object="PartitionMapping" /> can be provided to <PyObject object="AssetIn" /> to configure the mapped upstream partitions.
 
-When writing a custom IO Manager for loading multiple upstream partitions, the mapped keys can be accessed using <PyObject object="InputContext" method="asset_partition_keys" />, <PyObject object="InputContext" method="asset_partition_key_range" />, or <PyObject object="InputContext" method="asset_partitions_time_window" />.
+When writing a custom I/O manager for loading multiple upstream partitions, the mapped keys can be accessed using <PyObject object="InputContext" method="asset_partition_keys" />, <PyObject object="InputContext" method="asset_partition_key_range" />, or <PyObject object="InputContext" method="asset_partitions_time_window" />.
 
-### Writing a per-input IO Manager
+### Writing a per-input I/O manager
 
-In some cases you may find that you need to load an input in a way other than the `load_input` function of the corresponding output's IO manager. For example, let's say Team A has an op that returns an output as a Pandas DataFrame and specifies an IO manager that knows how to store and load Pandas DataFrames. Your team is interested in using this output for a new op, but you are required to use PySpark to analyze the data. Unfortunately, you don't have permission to modify Team A's IO manager to support this case. Instead, you can specify an input manager on your op that will override some of the behavior of Team A's IO manager.
+In some cases you may find that you need to load an input in a way other than the `load_input` function of the corresponding output's I/O manager. For example, let's say Team A has an op that returns an output as a Pandas DataFrame and specifies an I/O manager that knows how to store and load Pandas DataFrames. Your team is interested in using this output for a new op, but you are required to use PySpark to analyze the data. Unfortunately, you don't have permission to modify Team A's I/O manager to support this case. Instead, you can specify an input manager on your op that will override some of the behavior of Team A's I/O manager.
 
-Since the method for loading an input is directly affected by the way the corresponding output was stored, we recommend defining your input managers as subclasses of existing IO managers and just updating the `load_input` method. In this example, we load an input as a NumPy array rather than a Pandas DataFrame by writing the following:
+Since the method for loading an input is directly affected by the way the corresponding output was stored, we recommend defining your input managers as subclasses of existing I/O managers and just updating the `load_input` method. In this example, we load an input as a NumPy array rather than a Pandas DataFrame by writing the following:
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_plain_input_manager endbefore=end_plain_input_manager
 # in this case PandasIOManager is an existing IO Manager
@@ -528,9 +530,9 @@ def my_better_job():
 
 ## Examples
 
-### A custom IO manager that stores Pandas DataFrames in tables
+### A custom I/O manager that stores Pandas DataFrames in tables
 
-If your ops produce Pandas DataFrames that populate tables in a data warehouse, you might write something like the following. This IO manager uses the name assigned to the output as the name of the table to write the output to.
+If your ops produce Pandas DataFrames that populate tables in a data warehouse, you might write something like the following. This I/O manager uses the name assigned to the output as the name of the table to write the output to.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_df_marker endbefore=end_df_marker
 from dagster import ConfigurableIOManager, io_manager
@@ -553,9 +555,9 @@ def my_job():
     op_2(op_1())
 ```
 
-### Custom filesystem-based IO Manager
+### Custom filesystem-based I/O manager
 
-Dagster provides a feature-rich base class for filesystem-based IO Managers: <PyObject module="dagster" object="UPathIOManager" />. It's compatible with both local and remote filesystems (like S3 or GCS) by using `universal-pathlib` and `fsspec`. The full list of supported filesystems can be found [here](https://github.com/fsspec/universal_pathlib#currently-supported-filesystems-and-schemes). The `UPathIOManager` also has other important features:
+Dagster provides a feature-rich base class for filesystem-based I/O managers: <PyObject module="dagster" object="UPathIOManager" />. It's compatible with both local and remote filesystems (like S3 or GCS) by using `universal-pathlib` and `fsspec`. The full list of supported filesystems can be found [here](https://github.com/fsspec/universal_pathlib#currently-supported-filesystems-and-schemes). The `UPathIOManager` also has other important features:
 
 - handles partitioned assets
 - handles loading a single upstream partition
@@ -563,7 +565,7 @@ Dagster provides a feature-rich base class for filesystem-based IO Managers: <Py
 - the `get_metadata` method can be customized to add additional metadata to the output
 - the `allow_missing_partitions` metadata value can be set to `True` to skip missing partitions (the default behavior is to raise an error)
 
-The default IO manager inherits from the `UPathIOManager` and therefore has these features too.
+The default I/O manager inherits from the `UPathIOManager` and therefore has these features too.
 
 The `UPathIOManager` already implements the `load_input` and `handle_output` methods. Instead, <PyObject module="dagster" object="UPathIOManager" method="dump_to_path" /> and <PyObject module="dagster" object="UPathIOManager" method="load_from_path" /> for a given `universal_pathlib.UPath` have to be implemented. Here are some examples:
 
@@ -592,7 +594,7 @@ class PandasParquetIOManager(UPathIOManager):
 
 The extension attribute defines the suffix all the file paths generated by the IOManager will end with.
 
-The io managers defined above will work with partitioned assets on any filesystem:
+The i/o managers defined above will work with partitioned assets on any filesystem:
 
 ```python file=/concepts/io_management/filesystem_io_manager.py startafter=start_def_marker endbefore=end_marker
 from typing import Optional
@@ -620,15 +622,15 @@ class S3ParquetIOManager(ConfigurableIOManagerFactory):
         return PandasParquetIOManager(base_path=base_path)
 ```
 
-Notice how the local and S3 IO managers are practically the same - the only difference is in the required resources.
+Notice how the local and S3 I/O managers are practically the same - the only difference is in the required resources.
 
-### Providing per-output config to an IO manager
+### Providing per-output config to an I/O manager
 
 When launching a run, you might want to parameterize how particular outputs are stored.
 
 For example, if your job produces DataFrames to populate tables in a data warehouse, you might want to specify the table that each output goes to at run launch time.
 
-To accomplish this, you can define an `output_config_schema` on the IO manager definition. The IO manager methods can access this config when storing or loading data, via the <PyObject module="dagster" object="OutputContext" />.
+To accomplish this, you can define an `output_config_schema` on the I/O manager definition. The I/O manager methods can access this config when storing or loading data, via the <PyObject module="dagster" object="OutputContext" />.
 
 ```python file=/concepts/io_management/output_config.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
 class MyIOManager(IOManager):
@@ -664,7 +666,7 @@ def execute_my_job_with_config():
     )
 ```
 
-### Providing per-output metadata to an IO manager
+### Providing per-output metadata to an I/O manager
 
 You might want to provide static metadata that controls how particular outputs are stored. You don't plan to change the metadata at runtime, so it makes more sense to attach it to a definition rather than expose it as a configuration option.
 
@@ -681,7 +683,7 @@ def op_2(_input_dataframe):
     """Return a Pandas DataFrame."""
 ```
 
-The IO manager can then access this metadata when storing or retrieving data, via the <PyObject module="dagster" object="OutputContext" />.
+The I/O manager can then access this metadata when storing or retrieving data, via the <PyObject module="dagster" object="OutputContext" />.
 
 In this case, the table names are encoded in the job definition. If, instead, you want to be able to set them at run time, the next section describes how.
 
@@ -700,9 +702,9 @@ class MyIOManager(ConfigurableIOManager):
 
 ### Per-input loading in assets
 
-Let's say you have an asset that is set to store and load as a Pandas DataFrame, but you want to write a new asset that processes the first asset as a NumPy array. Rather than update the IO manager of the first asset to be able to load as a Pandas DataFrame and a NumPy array, you can write a new loader for the new asset.
+Let's say you have an asset that is set to store and load as a Pandas DataFrame, but you want to write a new asset that processes the first asset as a NumPy array. Rather than update the I/O manager of the first asset to be able to load as a Pandas DataFrame and a NumPy array, you can write a new loader for the new asset.
 
-In this example, we store `upstream_asset` as a Pandas DataFrame, and we write a new IO manager to load is as a NumPy array in `downstream_asset`
+In this example, we store `upstream_asset` as a Pandas DataFrame, and we write a new I/O manager to load is as a NumPy array in `downstream_asset`
 
 ```python file=/concepts/assets/asset_input_managers_numpy.py startafter=start_numpy_example endbefore=end_numpy_example
 class PandasAssetIOManager(ConfigurableIOManager):
@@ -748,11 +750,11 @@ defs = Definitions(
 )
 ```
 
-## Testing an IO manager
+## Testing an I/O manager
 
-The easiest way to test an IO manager is to construct an <PyObject module="dagster" object="OutputContext" /> or <PyObject module="dagster" object="InputContext" /> and pass it to the `handle_output` or `load_input` method of the IO manager. The <PyObject object="build_output_context" /> and <PyObject object="build_input_context" /> functions allow for easy construction of these contexts.
+The easiest way to test an I/O manager is to construct an <PyObject module="dagster" object="OutputContext" /> or <PyObject module="dagster" object="InputContext" /> and pass it to the `handle_output` or `load_input` method of the I/O manager. The <PyObject object="build_output_context" /> and <PyObject object="build_input_context" /> functions allow for easy construction of these contexts.
 
-Here's an example for a simple IO manager that stores outputs in an in-memory dictionary that's keyed on the step and name of the output.
+Here's an example for a simple I/O manager that stores outputs in an in-memory dictionary that's keyed on the step and name of the output.
 
 ```python file=/concepts/io_management/test_io_manager.py
 from dagster import (
@@ -792,9 +794,9 @@ def test_my_io_manager_load_input():
     assert manager.load_input(context) == 5
 ```
 
-## Recording metadata from an IO Manager
+## Recording metadata from an I/O manager
 
-Sometimes, you may want to record some metadata while handling an output in an IO manager. To do this, you can invoke <PyObject object="OutputContext" method="add_output_metadata"/> from within the body of the `handle_output` function. Using this, we can modify one of the [above examples](/concepts/io-management/io-managers#a-custom-io-manager-that-stores-pandas-dataframes-in-tables) to now include some helpful metadata in the log:
+Sometimes, you may want to record some metadata while handling an output in an I/O manager. To do this, you can invoke <PyObject object="OutputContext" method="add_output_metadata"/> from within the body of the `handle_output` function. Using this, we can modify one of the [above examples](/concepts/io-management/io-managers#a-custom-io-manager-that-stores-pandas-dataframes-in-tables) to now include some helpful metadata in the log:
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_metadata_marker endbefore=end_metadata_marker
 class DataframeTableIOManagerWithMetadata(ConfigurableIOManager):
@@ -815,8 +817,8 @@ Additionally, if the handled output is part of a software-defined asset, these m
 
 ## See it in action
 
-For more examples of IO Managers, check out the following in our [Hacker News example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
+For more examples of I/O managers, check out the following in our [Hacker News example](https://github.com/dagster-io/dagster/tree/master/examples/project_fully_featured):
 
 - [Parquet IO Manager](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/resources/parquet_io_manager.py)
 
-Our [Type and Metadata example](https://github.com/dagster-io/dagster/tree/master/examples/assets_pandas_type_metadata) also covers writing custom IO managers.
+Our [Type and Metadata example](https://github.com/dagster-io/dagster/tree/master/examples/assets_pandas_type_metadata) also covers writing custom I/O managers.

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -8,7 +8,10 @@ description: I/O Managers determine how to store asset/op outputs and load asset
 <Note>
   This guide covers using the new Pythonic resources system introduced in
   Dagster 1.3. If your code is still using the legacy resources system, see the{" "}
-  <a href="/concepts/io-management/io-managers-legacy">legacy I/O managers guide</a>.
+  <a href="/concepts/io-management/io-managers-legacy">
+    legacy I/O managers guide
+  </a>
+  .
 </Note>
 
 I/O Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
@@ -24,13 +27,13 @@ I/O Managers are user-provided objects that store asset and op outputs and load 
 
 ## Relevant APIs
 
-| Name                                                                          | Description                                                                                                                                                                                                  |   |
-| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | - |
-| <PyObject module="dagster" object="ConfigurableIOManager" />        | A base class used to define configurable I/O managers which are also resources.                                                                                                                              | ƒ |
-| <PyObject module="dagster" object="ConfigurableIOManagerFactory" /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                   |   |
-| <PyObject module="dagster" object="IOManager" />                              | Base class for standalone I/O managers which are constructed by factories.                                                                                                                                   |   |
-| <PyObject object="build_input_context"/>                                      | Function for directly constructing an <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |   |
-| <PyObject object="build_output_context"/>                                     | Function for directly constructing an <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |   |
+| Name                                                                | Description                                                                                                                                                                                                  |   |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | - |
+| <PyObject module="dagster" object="ConfigurableIOManager" />        | A base class used to define configurable I/O managers, which are also configurable resources.                                                                                                                | ƒ |
+| <PyObject module="dagster" object="ConfigurableIOManagerFactory" /> | A base class used to specify configuration for more advanced I/O managers, where configuration is separate from the `IOManager` implementation class.                                                        |   |
+| <PyObject module="dagster" object="IOManager" />                    | Base class for standalone I/O managers which are constructed by `ConfigurableIOManagerFactories`.                                                                                                            |   |
+| <PyObject object="build_input_context"/>                            | Function for directly constructing an <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |   |
+| <PyObject object="build_output_context"/>                           | Function for directly constructing an <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |   |
 
 ## Overview
 
@@ -332,19 +335,20 @@ To define an I/O manager, extend the <PyObject module="dagster" object="IOManage
 Here, we define a simple I/O manager that reads and writes CSV values to the filesystem. It takes an optional prefix path through config.
 
 ```python file=/concepts/io_management/custom_io_manager.py startafter=start_io_manager_marker endbefore=end_io_manager_marker
-from dagster import ConfigurableIOManager
+from dagster import ConfigurableIOManager, InputContext, OutputContext
 
 
 class MyIOManager(ConfigurableIOManager):
+    # specifies an optional string list input, via config system
     path_prefix: List[str] = []
 
     def _get_path(self, context) -> str:
         return "/".join(self.path_prefix + context.asset_key.path)
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         write_csv(self._get_path(context), obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_csv(self._get_path(context))
 ```
 
@@ -629,48 +633,6 @@ class S3ParquetIOManager(ConfigurableIOManagerFactory):
 ```
 
 Notice how the local and S3 I/O managers are practically the same - the only difference is in the required resources.
-
-### Providing per-output config to an I/O manager
-
-When launching a run, you might want to parameterize how particular outputs are stored.
-
-For example, if your job produces DataFrames to populate tables in a data warehouse, you might want to specify the table that each output goes to at run launch time.
-
-To accomplish this, you can define an `output_config_schema` on the I/O manager definition. The I/O manager methods can access this config when storing or loading data, via the <PyObject module="dagster" object="OutputContext" />.
-
-```python file=/concepts/io_management/output_config.py startafter=io_manager_start_marker endbefore=io_manager_end_marker
-class MyIOManager(IOManager):
-    def handle_output(self, context, obj):
-        table_name = context.config["table"]
-        write_dataframe_to_table(name=table_name, dataframe=obj)
-
-    def load_input(self, context):
-        table_name = context.upstream_output.config["table"]
-        return read_dataframe_from_table(name=table_name)
-
-
-@io_manager(output_config_schema={"table": str})
-def my_io_manager(_):
-    return MyIOManager()
-```
-
-Then, when executing a job, you can pass in this per-output config.
-
-```python file=/concepts/io_management/output_config.py startafter=execute_start_marker endbefore=execute_end_marker
-def execute_my_job_with_config():
-    @job(resource_defs={"io_manager": my_io_manager})
-    def my_job():
-        op_2(op_1())
-
-    my_job.execute_in_process(
-        run_config={
-            "ops": {
-                "op_1": {"outputs": {"result": {"table": "table1"}}},
-                "op_2": {"outputs": {"result": {"table": "table2"}}},
-            }
-        },
-    )
-```
 
 ### Providing per-output metadata to an I/O manager
 

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -296,7 +296,7 @@ def op_2(a):
     resource_defs={
         "fs": fs_io_manager,
         "s3_io": ConfigurablePickledObjectS3IOManager(
-            s3_resource=S3Resource(), s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="test-bucket"
         ),
     }
 )

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -5,6 +5,12 @@ description: I/O Managers determine how to store asset/op outputs and load asset
 
 # I/O Managers
 
+<Note>
+  This guide covers using the new Pythonic resources system introduced in
+  Dagster 1.3. If your code is still using the legacy resources system, see the{" "}
+  <a href="/concepts/io-management/io-managers-legacy">legacy I/O managers guide</a>.
+</Note>
+
 I/O Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.
 
 <center>
@@ -20,8 +26,8 @@ I/O Managers are user-provided objects that store asset and op outputs and load 
 
 | Name                                                                          | Description                                                                                                                                                                                                  |   |
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | - |
-| <PyObject module="dagster" object="ConfigurableIOManager" decorator />        | A base class used to define configurable I/O managers which are also resources.                                                                                                                              | ƒ |
-| <PyObject module="dagster" object="ConfigurableIOManagerFactory" decorator /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                   |   |
+| <PyObject module="dagster" object="ConfigurableIOManager" />        | A base class used to define configurable I/O managers which are also resources.                                                                                                                              | ƒ |
+| <PyObject module="dagster" object="ConfigurableIOManagerFactory" /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                   |   |
 | <PyObject module="dagster" object="IOManager" />                              | Base class for standalone I/O managers which are constructed by factories.                                                                                                                                   |   |
 | <PyObject object="build_input_context"/>                                      | Function for directly constructing an <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |   |
 | <PyObject object="build_output_context"/>                                     | Function for directly constructing an <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |   |

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -66,9 +66,9 @@ The default IO manager, <PyObject module="dagster" object="fs_io_manager" />, st
 
 Dagster provides out-of-the-box IO managers for popular storage systems: AWS S3 (<PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" />), Azure Blob Storage (<PyObject module="dagster_azure.adls2" object="adls2_pickle_io_manager" />), GCS (<PyObject module="dagster_gcp.gcs" object="gcs_pickle_io_manager" />), and Snowflake (<PyObject module="dagster_snowflake" object="build_snowflake_io_manager" />) - or you can write your own: either from scratch or by extending the `UPathIOManager` if you want to store data in an `fsspec`-supported filesystem.
 
-### IO managers are resources
+### IO managers are provided by resources
 
-IO managers are [resources](/concepts/resources), which means users can supply different IO managers for the same assets or ops in different situations. For example, you might use an in-memory IO manager for unit-testing and an S3 IO manager in production.
+IO managers are provided through the [resources](/concepts/resources) system which means users can supply different IO managers for the same assets or ops in different situations. For example, you might use an in-memory IO manager for unit-testing and an S3 IO manager in production.
 
 ---
 
@@ -83,7 +83,7 @@ By default, materializing an asset named `my_asset` will pickle it to a local fi
 To apply an IO manager to a set of assets, you can use <PyObject object="Definitions" />:
 
 ```python file=/concepts/assets/asset_io_manager.py startafter=start_marker endbefore=end_marker
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Definitions, asset
 
@@ -98,13 +98,18 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
+s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
-    resources={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    resources={
+        "io_manager": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        ),
+    },
 )
 ```
 
-This example also includes `"s3": s3_resource` because the <PyObject module="dagster_aws.s3" object="s3_pickle_io_manager" /> depends on an S3 resource.
+This example also constructs a <PyObject module="dagster_aws.s3" object="S3Resource" /> because the <PyObject module="dagster_aws.s3" object="ConfigurablePickledObjectS3IOManager" /> depends on the S3 resource.
 
 When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and stored in an object on S3. When `downstream_asset` is materialized, the value of `upstream_asset` will be read from S3 and depickled, and `[1, 2, 3, 4]` will be pickled and stored in a different object on S3.
 
@@ -113,7 +118,7 @@ When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and
 Different assets can have different IO managers:
 
 ```python file=/concepts/assets/asset_different_io_managers.py startafter=start_marker endbefore=end_marker
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Definitions, asset, fs_io_manager
 
@@ -128,11 +133,13 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
+s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
-        "s3_io_manager": s3_pickle_io_manager,
-        "s3": s3_resource,
+        "s3_io_manager": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        ),
         "fs_io_manager": fs_io_manager,
     },
 )
@@ -161,7 +168,7 @@ The same assets can be bound to different resources and IO managers in different
 ```python file=/concepts/assets/asset_io_manager_prod_local.py startafter=start_marker endbefore=end_marker
 import os
 
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Definitions, asset, fs_io_manager
 
@@ -176,8 +183,13 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
+s3_resource = S3Resource()
 resources_by_env = {
-    "prod": {"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    "prod": {
+        "io_manager": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        )
+    },
     "local": {"io_manager": fs_io_manager},
 }
 
@@ -193,7 +205,7 @@ In some cases you may need to load the input to an asset with different logic th
 
 To set an IO manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="AssetIn" />.
 
-In this example,`first_asset` and `second_asset` will be stored using the default IO manager, but will be loaded as inputs to `third_asset` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
+In this example,`first_asset` and `second_asset` will be stored using the default IO manager, but will be loaded as inputs to `third_asset` using the logic defined in the `PandasSeriesIOManager` (in this case loading as Pandas Series rather than python lists).
 
 ```python file=/concepts/assets/asset_input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
 @asset
@@ -219,7 +231,7 @@ def third_asset(first_asset, second_asset):
 defs = Definitions(
     assets=[first_asset, second_asset, third_asset],
     resources={
-        "pandas_series": pandas_series_io_manager,
+        "pandas_series": PandasSeriesIOManager(),
     },
 )
 ```
@@ -258,7 +270,7 @@ Not all the outputs in a job should necessarily be stored the same way. Maybe so
 To select the IO manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting IO managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
 
 ```python file=/concepts/io_management/io_manager_per_output.py startafter=start_marker endbefore=end_marker
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Out, fs_io_manager, job, op
 
@@ -273,11 +285,15 @@ def op_2(a):
     return a + 1
 
 
+s3_resource = S3Resource()
+
+
 @job(
     resource_defs={
         "fs": fs_io_manager,
-        "s3_io": s3_pickle_io_manager,
-        "s3": s3_resource,
+        "s3_io": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        ),
     }
 )
 def my_job():
@@ -548,13 +564,9 @@ import pandas as pd
 from upath import UPath
 
 from dagster import (
-    Field,
-    InitResourceContext,
     InputContext,
     OutputContext,
-    StringSource,
     UPathIOManager,
-    io_manager,
 )
 
 
@@ -575,32 +587,29 @@ The extension attribute defines the suffix all the file paths generated by the I
 The io managers defined above will work with partitioned assets on any filesystem:
 
 ```python file=/concepts/io_management/filesystem_io_manager.py startafter=start_def_marker endbefore=end_marker
-@io_manager(config_schema={"base_path": Field(str, is_required=False)})
-def local_pandas_parquet_io_manager(
-    init_context: InitResourceContext,
-) -> PandasParquetIOManager:
-    assert init_context.instance is not None  # to please mypy
-    base_path = UPath(
-        init_context.resource_config.get(
-            "base_path", init_context.instance.storage_directory()
-        )
-    )
-    return PandasParquetIOManager(base_path=base_path)
+from typing import Optional
+
+from dagster import ConfigurableIOManagerFactory, EnvVar
 
 
-@io_manager(
-    config_schema={
-        "base_path": Field(str, is_required=True),
-        "AWS_ACCESS_KEY_ID": StringSource,
-        "AWS_SECRET_ACCESS_KEY": StringSource,
-    }
-)
-def s3_parquet_io_manager(init_context: InitResourceContext) -> PandasParquetIOManager:
-    # `UPath` will read boto env vars.
-    # The credentials can also be taken from the config and passed to `UPath` directly.
-    base_path = UPath(init_context.resource_config.get("base_path"))
-    assert str(base_path).startswith("s3://"), base_path
-    return PandasParquetIOManager(base_path=base_path)
+class LocalPandasParquetIOManager(ConfigurableIOManagerFactory):
+    base_path: Optional[str] = None
+
+    def create_io_manager(self, context) -> PandasParquetIOManager:
+        base_path = UPath(self.base_path or context.instance.storage_directory())
+        return PandasParquetIOManager(base_path=base_path)
+
+
+class S3ParquetIOManager(ConfigurableIOManagerFactory):
+    base_path: str
+
+    aws_access_key: str = EnvVar("AWS_ACCESS_KEY_ID")
+    aws_secret_key: str = EnvVar("AWS_SECRET_ACCESS_KEY")
+
+    def create_io_manager(self, context) -> PandasParquetIOManager:
+        base_path = UPath(self.base_path)
+        assert str(base_path).startswith("s3://"), base_path
+        return PandasParquetIOManager(base_path=base_path)
 ```
 
 Notice how the local and S3 IO managers are practically the same - the only difference is in the required resources.

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -98,12 +98,11 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
-s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
         "io_manager": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         ),
     },
 )
@@ -133,12 +132,11 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
-s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
         "s3_io_manager": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         ),
         "fs_io_manager": fs_io_manager,
     },
@@ -183,11 +181,10 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
-s3_resource = S3Resource()
 resources_by_env = {
     "prod": {
         "io_manager": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         )
     },
     "local": {"io_manager": fs_io_manager},
@@ -285,14 +282,11 @@ def op_2(a):
     return a + 1
 
 
-s3_resource = S3Resource()
-
-
 @job(
     resource_defs={
         "fs": fs_io_manager,
         "s3_io": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         ),
     }
 )

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -18,13 +18,13 @@ I/O Managers are user-provided objects that store asset and op outputs and load 
 
 ## Relevant APIs
 
-| Name                                                                          | Description                                                                                                                                                                                                 |   |
-| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | - |
-| <PyObject module="dagster" object="ConfigurableIOManager" decorator />        | A base class used to define configurable I/O managers which are also resources.                                                                                                                             | ƒ |
-| <PyObject module="dagster" object="ConfigurableIOManagerFactory" decorator /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                  |   |
-| <PyObject module="dagster" object="IOManager" />                              | Base class for standalone I/O managers which are constructed by factories.                                                                                                                                  |   |
-| <PyObject object="build_input_context"/>                                      | Function for directly constructing a <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |   |
-| <PyObject object="build_output_context"/>                                     | Function for directly constructing a <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |   |
+| Name                                                                          | Description                                                                                                                                                                                                  |   |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | - |
+| <PyObject module="dagster" object="ConfigurableIOManager" decorator />        | A base class used to define configurable I/O managers which are also resources.                                                                                                                              | ƒ |
+| <PyObject module="dagster" object="ConfigurableIOManagerFactory" decorator /> | A base class used to specify configuration for more advanced I/O managers.                                                                                                                                   |   |
+| <PyObject module="dagster" object="IOManager" />                              | Base class for standalone I/O managers which are constructed by factories.                                                                                                                                   |   |
+| <PyObject object="build_input_context"/>                                      | Function for directly constructing an <PyObject object="InputContext"/>, to be passed to the <PyObject object="IOManager" method="load_input"/> method. This is designed primarily for testing purposes.     |   |
+| <PyObject object="build_output_context"/>                                     | Function for directly constructing an <PyObject object="OutputContext"/>, to be passed to the <PyObject object="IOManager" method="handle_output"/> method. This is designed primarily for testing purposes. |   |
 
 ## Overview
 
@@ -69,7 +69,7 @@ Dagster provides out-of-the-box I/O managers for popular storage systems: AWS S3
 
 ### I/O managers are resources
 
-I/O managers are provided through the [resources](/concepts/resources) system which means users can supply different I/O managers for the same assets or ops in different situations. For example, you might use an in-memory I/O manager for unit-testing and an S3 I/O manager in production.
+I/O managers are provided through the [resources](/concepts/resources) system which means you can supply different I/O managers for the same assets or ops in different situations. For example, you might use an in-memory I/O manager for unit-testing and an Amazon S3 I/O manager in production.
 
 ---
 
@@ -109,7 +109,7 @@ defs = Definitions(
 )
 ```
 
-This example also constructs a <PyObject module="dagster_aws.s3" object="S3Resource" /> because the <PyObject module="dagster_aws.s3" object="ConfigurablePickledObjectS3IOManager" /> depends on the S3 resource. For more information on how these resource-resource dependencies are modeled, refer to the [resources](/concepts/resources#resources-which-depend-on-other-resources) documentation.
+This example also constructs an <PyObject module="dagster_aws.s3" object="S3Resource" /> because the <PyObject module="dagster_aws.s3" object="ConfigurablePickledObjectS3IOManager" /> depends on the S3 resource. For more information on how these resource-resource dependencies are modeled, refer to the [resources](/concepts/resources#resources-which-depend-on-other-resources) documentation.
 
 When `upstream_asset` is materialized, the value `[1, 2, 3]` will be pickled and stored in an object on S3. When `downstream_asset` is materialized, the value of `upstream_asset` will be read from S3 and depickled, and `[1, 2, 3, 4]` will be pickled and stored in a different object on S3.
 
@@ -203,7 +203,7 @@ In some cases you may need to load the input to an asset with different logic th
 
 To set an I/O manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="AssetIn" />.
 
-In this example,`first_asset` and `second_asset` will be stored using the default I/O manager, but will be loaded as inputs to `third_asset` using the logic defined in the `PandasSeriesIOManager` (in this case loading as Pandas Series rather than python lists).
+In this example,`first_asset` and `second_asset` will be stored using the default I/O manager, but will be loaded as inputs to `third_asset` using the logic defined in the `PandasSeriesIOManager` (in this case loading as Pandas Series rather than Python lists).
 
 ```python file=/concepts/assets/asset_input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
 @asset
@@ -299,7 +299,7 @@ def my_job():
 
 Just as with the inputs to assets, the inputs to ops can be loaded using custom logic if you want to override the I/O manager of the upstream output. To set an I/O manager for a particular input, use the `input_manager_key` argument on <PyObject module="dagster" object="In" />.
 
-In this example, the output of `op_1` will be stored using the default I/O manager, but will be loaded in `op_2` using the logic defined in the `pandas_series_io_manager` (in this case loading as Pandas Series rather than python lists).
+In this example, the output of `op_1` will be stored using the default I/O manager, but will be loaded in `op_2` using the logic defined in the `PandasSeriesIOManager` (in this case loading as Pandas Series rather than python lists).
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_different_input_managers endbefore=end_different_input_managers
 @op
@@ -321,7 +321,7 @@ def a_job():
 
 If you have specific requirements for where and how your outputs should be stored and retrieved, you can define your own I/O manager. This boils down to implementing two functions: one that stores outputs and one that loads inputs.
 
-To define an I/O manager, you will want to extend the <PyObject module="dagster" object="IOManager" /> class. Often times, you will want to extend the <PyObject module="dagster" object="ConfigurableIOManager"/> class (which subclasses `IOManager`) to attach a config schema to your I/O manager.
+To define an I/O manager, extend the <PyObject module="dagster" object="IOManager" /> class. Oftentimes, you will want to extend the <PyObject module="dagster" object="ConfigurableIOManager"/> class (which subclasses `IOManager`) to attach a config schema to your I/O manager.
 
 Here, we define a simple I/O manager that reads and writes CSV values to the filesystem. It takes an optional prefix path through config.
 

--- a/docs/content/concepts/io-management/unconnected-inputs.mdx
+++ b/docs/content/concepts/io-management/unconnected-inputs.mdx
@@ -169,12 +169,7 @@ class Table1IOManager(TableIOManager):
         return read_dataframe_from_table(name="table_1")
 
 
-@io_manager
-def table_1_io_manager():
-    return Table1IOManager()
-
-
-@job(resource_defs={"load_input_manager": table_1_io_manager})
+@job(resource_defs={"load_input_manager": Table1IOManager()})
 def io_load_table_job():
     my_op()
 ```
@@ -223,18 +218,13 @@ For example, you might have `op1` that normally produces a table that `op2` cons
 To accomplish this, you can set up the `input_manager_key` on `op2`'s `In` to point to an input manager with the desired loading behavior. As in the previous example, setting the `input_manager_key` on an `In` controls how that input is loaded and you can write custom loading logic.
 
 ```python file=/concepts/io_management/input_managers.py startafter=start_load_input_subset endbefore=end_load_input_subset
-class MyIOManager(IOManager):
+class MyIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
     def load_input(self, context):
         return read_dataframe_from_table(name=context.upstream_output.name)
-
-
-@io_manager
-def my_io_manager(_):
-    return MyIOManager()
 
 
 @input_manager
@@ -255,7 +245,7 @@ def op2(dataframe):
 
 @job(
     resource_defs={
-        "io_manager": my_io_manager,
+        "io_manager": MyIOManager(),
         "my_input_manager": my_subselection_input_manager,
     }
 )

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_different_io_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_different_io_managers.py
@@ -14,12 +14,11 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
-s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
         "s3_io_manager": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         ),
         "fs_io_manager": fs_io_manager,
     },

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_different_io_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_different_io_managers.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Definitions, asset, fs_io_manager
 
@@ -14,11 +14,13 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
+s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
-        "s3_io_manager": s3_pickle_io_manager,
-        "s3": s3_resource,
+        "s3_io_manager": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        ),
         "fs_io_manager": fs_io_manager,
     },
 )

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_input_managers.py
@@ -15,7 +15,9 @@ def load_numpy_array(*_args, **_kwargs):
     pass
 
 
-pandas_series_io_manager = None
+class PandasSeriesIOManager:
+    pass
+
 
 # start_different_input_managers
 
@@ -43,7 +45,7 @@ def third_asset(first_asset, second_asset):
 defs = Definitions(
     assets=[first_asset, second_asset, third_asset],
     resources={
-        "pandas_series": pandas_series_io_manager,
+        "pandas_series": PandasSeriesIOManager(),
     },
 )
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
@@ -25,3 +25,26 @@ defs = Definitions(
 
 
 # end_marker
+def old():
+    # start_old_marker
+    from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+
+    from dagster import Definitions, asset
+
+
+    @asset
+    def upstream_asset():
+        return [1, 2, 3]
+
+
+    @asset
+    def downstream_asset(upstream_asset):
+        return upstream_asset + [4]
+
+
+    defs = Definitions(
+        assets=[upstream_asset, downstream_asset],
+        resources={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    )
+
+    # end_old_marker

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
@@ -14,12 +14,11 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
-s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
     resources={
         "io_manager": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         ),
     },
 )

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
@@ -25,26 +25,3 @@ defs = Definitions(
 
 
 # end_marker
-def old():
-    # start_old_marker
-    from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
-
-    from dagster import Definitions, asset
-
-
-    @asset
-    def upstream_asset():
-        return [1, 2, 3]
-
-
-    @asset
-    def downstream_asset(upstream_asset):
-        return upstream_asset + [4]
-
-
-    defs = Definitions(
-        assets=[upstream_asset, downstream_asset],
-        resources={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
-    )
-
-    # end_old_marker

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Definitions, asset
 
@@ -14,9 +14,14 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
+s3_resource = S3Resource()
 defs = Definitions(
     assets=[upstream_asset, downstream_asset],
-    resources={"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    resources={
+        "io_manager": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        ),
+    },
 )
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager_prod_local.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager_prod_local.py
@@ -16,11 +16,10 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
-s3_resource = S3Resource()
 resources_by_env = {
     "prod": {
         "io_manager": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         )
     },
     "local": {"io_manager": fs_io_manager},

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager_prod_local.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_io_manager_prod_local.py
@@ -1,7 +1,7 @@
 # start_marker
 import os
 
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Definitions, asset, fs_io_manager
 
@@ -16,8 +16,13 @@ def downstream_asset(upstream_asset):
     return upstream_asset + [4]
 
 
+s3_resource = S3Resource()
 resources_by_env = {
-    "prod": {"io_manager": s3_pickle_io_manager, "s3": s3_resource},
+    "prod": {
+        "io_manager": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        )
+    },
     "local": {"io_manager": fs_io_manager},
 }
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
@@ -58,23 +58,23 @@ import requests
 class ExternalIOManager(IOManager):
     def __init__(self, api_token):
         self._api_token = api_token
+        # setup stateful cache
+        self._cache = {}
 
     def handle_output(self, context, obj):
         ...
 
     def load_input(self, context):
+        if context.asset_key in self._cache:
+            return self._cache[context.asset_key]
         ...
 
 
 class ConfigurableExternalIOManager(ConfigurableIOManagerFactory):
-    username: str
-    password: str
+    api_token: str
 
     def create_io_manager(self, context) -> ExternalIOManager:
-        api_token = requests.get(
-            "https://my-api.com/token", auth=(self.username, self.password)
-        ).json()
-        return ExternalIOManager(api_token)
+        return ExternalIOManager(self.api_token)
 
 
 # end_io_manager_factory_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/custom_io_manager.py
@@ -31,19 +31,20 @@ def write_csv(_path, _obj):
 
 
 # start_io_manager_marker
-from dagster import ConfigurableIOManager
+from dagster import ConfigurableIOManager, InputContext, OutputContext
 
 
 class MyIOManager(ConfigurableIOManager):
+    # specifies an optional string list input, via config system
     path_prefix: List[str] = []
 
     def _get_path(self, context) -> str:
         return "/".join(self.path_prefix + context.asset_key.path)
 
-    def handle_output(self, context, obj):
+    def handle_output(self, context: OutputContext, obj):
         write_csv(self._get_path(context), obj)
 
-    def load_input(self, context):
+    def load_input(self, context: InputContext):
         return read_csv(self._get_path(context))
 
 

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/filesystem_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/filesystem_io_manager.py
@@ -3,13 +3,9 @@ import pandas as pd
 from upath import UPath
 
 from dagster import (
-    Field,
-    InitResourceContext,
     InputContext,
     OutputContext,
-    StringSource,
     UPathIOManager,
-    io_manager,
 )
 
 
@@ -31,32 +27,29 @@ class PandasParquetIOManager(UPathIOManager):
 
 
 # start_def_marker
-@io_manager(config_schema={"base_path": Field(str, is_required=False)})
-def local_pandas_parquet_io_manager(
-    init_context: InitResourceContext,
-) -> PandasParquetIOManager:
-    assert init_context.instance is not None  # to please mypy
-    base_path = UPath(
-        init_context.resource_config.get(
-            "base_path", init_context.instance.storage_directory()
-        )
-    )
-    return PandasParquetIOManager(base_path=base_path)
+from typing import Optional
+
+from dagster import ConfigurableIOManagerFactory, EnvVar
 
 
-@io_manager(
-    config_schema={
-        "base_path": Field(str, is_required=True),
-        "AWS_ACCESS_KEY_ID": StringSource,
-        "AWS_SECRET_ACCESS_KEY": StringSource,
-    }
-)
-def s3_parquet_io_manager(init_context: InitResourceContext) -> PandasParquetIOManager:
-    # `UPath` will read boto env vars.
-    # The credentials can also be taken from the config and passed to `UPath` directly.
-    base_path = UPath(init_context.resource_config.get("base_path"))
-    assert str(base_path).startswith("s3://"), base_path
-    return PandasParquetIOManager(base_path=base_path)
+class LocalPandasParquetIOManager(ConfigurableIOManagerFactory):
+    base_path: Optional[str] = None
+
+    def create_io_manager(self, context) -> PandasParquetIOManager:
+        base_path = UPath(self.base_path or context.instance.storage_directory())
+        return PandasParquetIOManager(base_path=base_path)
+
+
+class S3ParquetIOManager(ConfigurableIOManagerFactory):
+    base_path: str
+
+    aws_access_key: str = EnvVar("AWS_ACCESS_KEY_ID")
+    aws_secret_key: str = EnvVar("AWS_SECRET_ACCESS_KEY")
+
+    def create_io_manager(self, context) -> PandasParquetIOManager:
+        base_path = UPath(self.base_path)
+        assert str(base_path).startswith("s3://"), base_path
+        return PandasParquetIOManager(base_path=base_path)
 
 
 # end_marker

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -4,10 +4,17 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from dagster import In, InputManager, IOManager, input_manager, io_manager, job, op
+from dagster import (
+    ConfigurableIOManager,
+    In,
+    InputManager,
+    input_manager,
+    job,
+    op,
+)
 
 
-class PandasIOManager(IOManager):
+class PandasIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         pass
 
@@ -15,17 +22,12 @@ class PandasIOManager(IOManager):
         pass
 
 
-class TableIOManager(IOManager):
+class TableIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         pass
 
     def load_input(self, context):
         pass
-
-
-@io_manager
-def pandas_io_manager():
-    return PandasIOManager()
 
 
 @op
@@ -74,17 +76,12 @@ class MyNumpyLoader(PandasIOManager):
         return array
 
 
-@io_manager
-def numpy_io_manager():
-    return MyNumpyLoader()
-
-
 @op(ins={"np_array_input": In(input_manager_key="numpy_manager")})
 def analyze_as_numpy(np_array_input: np.ndarray):
     assert isinstance(np_array_input, np.ndarray)
 
 
-@job(resource_defs={"numpy_manager": numpy_io_manager, "io_manager": pandas_io_manager})
+@job(resource_defs={"numpy_manager": MyNumpyLoader(), "io_manager": PandasIOManager()})
 def my_job():
     df = produce_pandas_output()
     analyze_as_numpy(df)
@@ -97,7 +94,7 @@ def my_job():
 
 
 # this IO Manager is owned by a different team
-class BetterPandasIOManager(IOManager):
+class BetterPandasIOManager(ConfigurableIOManager):
     def _get_path(self, output_context):
         return os.path.join(
             self.base_dir,
@@ -123,11 +120,6 @@ class MyBetterNumpyLoader(PandasIOManager):
         return array
 
 
-@io_manager
-def better_numpy_io_manager():
-    return MyBetterNumpyLoader()
-
-
 @op(ins={"np_array_input": In(input_manager_key="better_numpy_manager")})
 def better_analyze_as_numpy(np_array_input: np.ndarray):
     assert isinstance(np_array_input, np.ndarray)
@@ -135,8 +127,8 @@ def better_analyze_as_numpy(np_array_input: np.ndarray):
 
 @job(
     resource_defs={
-        "numpy_manager": better_numpy_io_manager,
-        "io_manager": pandas_io_manager,
+        "numpy_manager": MyBetterNumpyLoader(),
+        "io_manager": PandasIOManager(),
     }
 )
 def my_better_job():
@@ -195,12 +187,7 @@ class Table1IOManager(TableIOManager):
         return read_dataframe_from_table(name="table_1")
 
 
-@io_manager
-def table_1_io_manager():
-    return Table1IOManager()
-
-
-@job(resource_defs={"load_input_manager": table_1_io_manager})
+@job(resource_defs={"load_input_manager": Table1IOManager()})
 def io_load_table_job():
     my_op()
 
@@ -210,18 +197,13 @@ def io_load_table_job():
 # start_load_input_subset
 
 
-class MyIOManager(IOManager):
+class MyIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         table_name = context.name
         write_dataframe_to_table(name=table_name, dataframe=obj)
 
     def load_input(self, context):
         return read_dataframe_from_table(name=context.upstream_output.name)
-
-
-@io_manager
-def my_io_manager(_):
-    return MyIOManager()
 
 
 @input_manager
@@ -242,7 +224,7 @@ def op2(dataframe):
 
 @job(
     resource_defs={
-        "io_manager": my_io_manager,
+        "io_manager": MyIOManager(),
         "my_input_manager": my_subselection_input_manager,
     }
 )

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
@@ -14,14 +14,11 @@ def op_2(a):
     return a + 1
 
 
-s3_resource = S3Resource()
-
-
 @job(
     resource_defs={
         "fs": fs_io_manager,
         "s3_io": ConfigurablePickledObjectS3IOManager(
-            s3_resource=s3_resource, s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="my-bucket"
         ),
     }
 )

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
@@ -1,5 +1,5 @@
 # start_marker
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource
 
 from dagster import Out, fs_io_manager, job, op
 
@@ -14,11 +14,15 @@ def op_2(a):
     return a + 1
 
 
+s3_resource = S3Resource()
+
+
 @job(
     resource_defs={
         "fs": fs_io_manager,
-        "s3_io": s3_pickle_io_manager,
-        "s3": s3_resource,
+        "s3_io": ConfigurablePickledObjectS3IOManager(
+            s3_resource=s3_resource, s3_bucket="my-bucket"
+        ),
     }
 )
 def my_job():

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/io_manager_per_output.py
@@ -18,7 +18,7 @@ def op_2(a):
     resource_defs={
         "fs": fs_io_manager,
         "s3_io": ConfigurablePickledObjectS3IOManager(
-            s3_resource=S3Resource(), s3_bucket="my-bucket"
+            s3_resource=S3Resource(), s3_bucket="test-bucket"
         ),
     }
 )

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/metadata.py
@@ -1,4 +1,4 @@
-from dagster import IOManager, Out, io_manager, job, op
+from dagster import ConfigurableIOManager, IOManager, Out, io_manager, job, op
 
 
 def connect():
@@ -28,7 +28,7 @@ def op_2(_input_dataframe):
 
 
 # io_manager_start_marker
-class MyIOManager(IOManager):
+class MyIOManager(ConfigurableIOManager):
     def handle_output(self, context, obj):
         table_name = context.metadata["table"]
         schema = context.metadata["schema"]
@@ -40,14 +40,9 @@ class MyIOManager(IOManager):
         return read_dataframe_from_table(name=table_name, schema=schema)
 
 
-@io_manager
-def my_io_manager(_):
-    return MyIOManager()
-
-
 # io_manager_end_marker
 
 
-@job(resource_defs={"io_manager": my_io_manager})
+@job(resource_defs={"io_manager": MyIOManager()})
 def my_job():
     op_2(op_1())

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/test_io_manager.py
@@ -1,4 +1,8 @@
-from dagster import IOManager, build_input_context, build_output_context, io_manager
+from dagster import (
+    IOManager,
+    build_input_context,
+    build_output_context,
+)
 
 
 class MyIOManager(IOManager):
@@ -14,20 +18,15 @@ class MyIOManager(IOManager):
         ]
 
 
-@io_manager
-def my_io_manager(_):
-    return MyIOManager()
-
-
 def test_my_io_manager_handle_output():
-    manager = my_io_manager(None)
+    manager = MyIOManager()
     context = build_output_context(name="abc", step_key="123")
     manager.handle_output(context, 5)
     assert manager.storage_dict[("123", "abc")] == 5
 
 
 def test_my_io_manager_load_input():
-    manager = my_io_manager(None)
+    manager = MyIOManager()
     manager.storage_dict[("123", "abc")] = 5
 
     context = build_input_context(


### PR DESCRIPTION
## Summary

Updates the IO management concepts page to (mostly) use configurable IO managers. Provides some guidance on using ConfigurableIOManager vs the factory.

Doesn't cut over the input/output schema examples, not sure the best way to handle those.