### PR TITLE
add `MultiPartitionKey` to `OpExecutionContext.partition_key` return type hint

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1,5 +1,17 @@
 from abc import ABC, abstractmethod
-from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Sequence, Set, Union, cast
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    cast,
+)
 
 from typing_extensions import TypeAlias
 

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Sequence, Set, cast
+from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Sequence, Set, Union, cast
 
 from typing_extensions import TypeAlias
 
@@ -20,6 +20,7 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.mode import ModeDefinition
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionKey
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -289,7 +290,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
     @public
     @property
-    def partition_key(self) -> str:
+    def partition_key(self) -> Union[str, MultiPartitionKey]:
         """The partition key for the current run.
 
         Raises an error if the current run is not a partitioned run.

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -25,7 +25,10 @@ from dagster._core.definitions.dependency import OpNode
 from dagster._core.definitions.events import AssetKey, AssetLineageInfo
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.mode import ModeDefinition
-from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.multi_dimensional_partitions import (
+    MultiPartitionKey,
+    MultiPartitionsDefinition,
+)
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -373,7 +376,7 @@ class PlanExecutionContext(IPlanContext):
         )
 
     @property
-    def partition_key(self) -> str:
+    def partition_key(self) -> Union[str, MultiPartitionKey]:
         from dagster._core.definitions.multi_dimensional_partitions import (
             MultiPartitionsDefinition,
             get_multipartition_key_from_tags,


### PR DESCRIPTION
## Summary & Motivation
Noticed the type hint for `OpExecutionContext.partition_key` is set to only `str`, but it can also return a `MultiPartitionKey`.

## How I Tested These Changes
