### PR TITLE
[pythonic config] Add ability to create int EnvVars

### DIFF
--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -469,6 +469,10 @@ def _config_dictionary_from_values_inner(obj: Any):
         return [_config_dictionary_from_values_inner(v) for v in obj]
     elif isinstance(obj, EnvVar):
         return {"env": str(obj)}
+    elif isinstance(obj, IntEnvVar):
+        return {"env": obj.name}
+    elif isinstance(obj, FloatEnvVar):
+        return {"env": obj.name}
     elif isinstance(obj, Config):
         return {
             k: _config_dictionary_from_values_inner(v)
@@ -492,5 +496,49 @@ def config_dictionary_from_values(
     return check.is_dict(_config_dictionary_from_values_inner(values))
 
 
+class IntEnvVar(int):
+    """Class used to represent an environment variable in the Dagster config system.
+
+    The environment variable will be resolved to an int value when the config is
+    loaded.
+    """
+
+    name: str
+
+    @classmethod
+    def create(cls, name: str) -> "IntEnvVar":
+        var = IntEnvVar(0)
+        var.name = name
+        return var
+
+
+class FloatEnvVar(float):
+    """Class used to represent an environment variable in the Dagster config system.
+
+    The environment variable will be resolved to an float value when the config is
+    loaded.
+    """
+
+    name: str
+
+    @classmethod
+    def create(cls, name: str) -> "FloatEnvVar":
+        var = FloatEnvVar(0)
+        var.name = name
+        return var
+
+
 class EnvVar(str):
-    pass
+    """Class used to represent an environment variable in the Dagster config system.
+
+    The environment variable will be resolved to a string value when the config is
+    loaded.
+    """
+
+    @classmethod
+    def int(cls, name: str) -> "IntEnvVar":
+        return IntEnvVar.create(name=name)
+
+    @classmethod
+    def float(cls, name: str) -> "FloatEnvVar":
+        return FloatEnvVar.create(name=name)

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -471,8 +471,6 @@ def _config_dictionary_from_values_inner(obj: Any):
         return {"env": str(obj)}
     elif isinstance(obj, IntEnvVar):
         return {"env": obj.name}
-    elif isinstance(obj, FloatEnvVar):
-        return {"env": obj.name}
     elif isinstance(obj, Config):
         return {
             k: _config_dictionary_from_values_inner(v)
@@ -512,22 +510,6 @@ class IntEnvVar(int):
         return var
 
 
-class FloatEnvVar(float):
-    """Class used to represent an environment variable in the Dagster config system.
-
-    The environment variable will be resolved to an float value when the config is
-    loaded.
-    """
-
-    name: str
-
-    @classmethod
-    def create(cls, name: str) -> "FloatEnvVar":
-        var = FloatEnvVar(0)
-        var.name = name
-        return var
-
-
 class EnvVar(str):
     """Class used to represent an environment variable in the Dagster config system.
 
@@ -538,7 +520,3 @@ class EnvVar(str):
     @classmethod
     def int(cls, name: str) -> "IntEnvVar":
         return IntEnvVar.create(name=name)
-
-    @classmethod
-    def float(cls, name: str) -> "FloatEnvVar":
-        return FloatEnvVar.create(name=name)

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -652,8 +652,9 @@ def construct_config_type_dictionary(
 
 
 def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
+    from dagster._config.pythonic_config import config_dictionary_from_values
     return {
-        k: {"config": v._as_config_dict() if isinstance(v, Config) else v}  # noqa: SLF001
+        k: {"config": config_dictionary_from_values(v._as_config_dict(), v.to_config_schema().as_field()) if isinstance(v, Config) else v}  # noqa: SLF001
         for k, v in configs.items()
     }
 

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -25,7 +25,7 @@ from dagster._config import (
     Selector,
     Shape,
 )
-from dagster._config.pythonic_config import Config
+from dagster._config.pythonic_config import Config, config_dictionary_from_values
 from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.executor_definition import (
     ExecutorDefinition,
@@ -652,9 +652,14 @@ def construct_config_type_dictionary(
 
 
 def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
-    from dagster._config.pythonic_config import config_dictionary_from_values
     return {
-        k: {"config": config_dictionary_from_values(v._as_config_dict(), v.to_config_schema().as_field()) if isinstance(v, Config) else v}  # noqa: SLF001
+        k: {
+            "config": config_dictionary_from_values(
+                v._as_config_dict(), v.to_config_schema().as_field()  # noqa: SLF001
+            )
+            if isinstance(v, Config)
+            else v
+        }
         for k, v in configs.items()
     }
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -1,0 +1,93 @@
+from dagster import Definitions, EnvVar, RunConfig, asset
+from dagster._config.pythonic_config import Config
+from dagster._core.test_utils import environ
+
+
+def test_str_env_var() -> None:
+    executed = {}
+
+    class AStringConfig(Config):
+        a_str: str
+
+    @asset
+    def a_string_asset(config: AStringConfig):
+        assert config.a_str == "foo"
+        executed["a_string_asset"] = True
+
+    defs = Definitions(assets=[a_string_asset])
+
+    with environ({"A_STR": "foo"}):
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            run_config=RunConfig(ops={"a_string_asset": AStringConfig(a_str=EnvVar("A_STR"))})
+        )
+    assert executed["a_string_asset"]
+
+
+def test_str_env_var_nested() -> None:
+    executed = {}
+
+    class AStringConfig(Config):
+        a_str: str
+
+    class AnOuterConfig(Config):
+        inner: AStringConfig
+
+    @asset
+    def a_string_asset(config: AnOuterConfig):
+        assert config.inner.a_str == "bar"
+        executed["a_string_asset"] = True
+
+    defs = Definitions(assets=[a_string_asset])
+
+    with environ({"A_STR": "bar"}):
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            run_config=RunConfig(
+                ops={"a_string_asset": AnOuterConfig(inner=AStringConfig(a_str=EnvVar("A_STR")))}
+            )
+        )
+    assert executed["a_string_asset"]
+
+
+def test_int_env_var() -> None:
+    executed = {}
+
+    class AnIntConfig(Config):
+        an_int: int
+
+    @asset
+    def an_int_asset(config: AnIntConfig):
+        assert config.an_int == 5
+        executed["an_int_asset"] = True
+
+    defs = Definitions(assets=[an_int_asset])
+
+    with environ({"AN_INT": "5"}):
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            run_config=RunConfig(ops={"an_int_asset": AnIntConfig(an_int=EnvVar.int("AN_INT"))})
+        )
+    assert executed["an_int_asset"]
+
+
+def test_int_env_var_nested() -> None:
+    executed = {}
+
+    class AnIntConfig(Config):
+        a_int: int
+
+    class AnOuterConfig(Config):
+        inner: AnIntConfig
+
+    @asset
+    def a_int_asset(config: AnOuterConfig):
+        assert config.inner.a_int == 10
+        executed["a_int_asset"] = True
+
+    defs = Definitions(assets=[a_int_asset])
+
+    with environ({"AN_INT": "10"}):
+        defs.get_implicit_global_asset_job_def().execute_in_process(
+            run_config=RunConfig(
+                ops={"a_int_asset": AnOuterConfig(inner=AnIntConfig(a_int=EnvVar.int("AN_INT")))}
+            )
+        )
+    assert executed["a_int_asset"]


### PR DESCRIPTION
## Summary

Introduces a way to use `EnvVar` values with int fields:


```python
class MyIntConfig(Config):
  an_int: int


MyIntConfig(an_int=EnvVar.int("AN_INT_ENV"))
```

There is not an immediate analogue for float (since we have no `FloatSource`) or bool (since `bool` is final and cannot be extended - needs some cleverness).


## Test Plan

New unit tests.
