### PR TITLE
[ui] Cache code location reload errors after mutation

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/types/useRepositoryLocationReload.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/useRepositoryLocationReload.types.ts
@@ -124,5 +124,18 @@ export type ReloadRepositoryLocationMutation = {
         __typename: 'WorkspaceLocationEntry';
         id: string;
         loadStatus: Types.RepositoryLocationLoadStatus;
+        locationOrLoadError:
+          | {
+              __typename: 'PythonError';
+              message: string;
+              stack: Array<string>;
+              errorChain: Array<{
+                __typename: 'ErrorChainLink';
+                isExplicitLink: boolean;
+                error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+              }>;
+            }
+          | {__typename: 'RepositoryLocation'; id: string}
+          | null;
       };
 };

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -277,12 +277,10 @@ const RELOAD_WORKSPACE_MUTATION = gql`
       ... on Workspace {
         id
         locationEntries {
-          __typename
           name
           id
           loadStatus
           locationOrLoadError {
-            __typename
             ... on RepositoryLocation {
               id
               repositories {
@@ -339,10 +337,15 @@ export const buildReloadFnForLocation = (location: string) => {
 const RELOAD_REPOSITORY_LOCATION_MUTATION = gql`
   mutation ReloadRepositoryLocationMutation($location: String!) {
     reloadRepositoryLocation(repositoryLocationName: $location) {
-      __typename
       ... on WorkspaceLocationEntry {
         id
         loadStatus
+        locationOrLoadError {
+          ... on RepositoryLocation {
+            id
+          }
+          ...PythonErrorFragment
+        }
       }
       ... on UnauthorizedError {
         message


### PR DESCRIPTION
## Summary & Motivation

When reloading a code location, cache the mutation response. This should update the UI to show the correct error.

The goal here is to resolve an issue where a code location has multiple errors surfaced when loading it. After fixing one error and reloading, the fixed error doesn't go away. This is because the error is tracked via the top-level workspace query, but not updated by the mutation. By writing to the cache, the error dialog updates with the new (as yet unfixed) error right away.

https://user-images.githubusercontent.com/2823852/232617176-c9515797-7871-49cf-abbd-791e6555525b.mov

## How I Tested These Changes

Raise exceptions from two `@repository` objects in `toys/repo.py`, load UI. Navigate to code locations, open error dialog. Comment out one exception, click "Reload". Verify that the next exception shows up in the dialog. Comment it out, click Reload. Verify that the code location loads successfully.
