### PR TITLE
[bugfix] Allow invalid metadata in {Input,Output}DefSnap

### DIFF
--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -53,7 +53,7 @@ class InputDefSnap(
             dagster_type_key=check.str_param(dagster_type_key, "dagster_type_key"),
             description=check.opt_str_param(description, "description"),
             metadata=normalize_metadata(
-                check.opt_mapping_param(metadata, "metadata", key_type=str)
+                check.opt_mapping_param(metadata, "metadata", key_type=str), allow_invalid=True
             ),
         )
 
@@ -92,7 +92,7 @@ class OutputDefSnap(
             description=check.opt_str_param(description, "description"),
             is_required=check.bool_param(is_required, "is_required"),
             metadata=normalize_metadata(
-                check.opt_mapping_param(metadata, "metadata", key_type=str)
+                check.opt_mapping_param(metadata, "metadata", key_type=str), allow_invalid=True
             ),
             is_dynamic=check.bool_param(is_dynamic, "is_dynamic"),
         )


### PR DESCRIPTION
## Summary & Motivation

Allow invalid metadata when normalizing metadata input to `OutputDefSnap` and `InputDefSnap`. This is beacuse `InputDefinition` and `OutputDefinition` allow invalid metadata. Fixes a bug where arbitrary (non-json-serializable) metadata passed to an `OutputDefinition` (e.g. via an `@asset` would cause an error during snap creation, introduced by #12770 (prior to that PR no normalization occurred at snap creation).

Fixes this: https://elementl-workspace.slack.com/archives/C03D094F23G/p1681416720082509

## How I Tested These Changes

Added new test.
