### PR TITLE
AutoMaterializePolicy edits

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -57,7 +57,7 @@ def get_implicit_auto_materialize_policy(
     if auto_materialize_policy is None:
         return AutoMaterializePolicy(
             on_missing=True,
-            on_upstream_data_newer=not bool(
+            on_new_parent_data=not bool(
                 asset_graph.get_downstream_freshness_policies(asset_key=asset_key)
             ),
             for_freshness=True,
@@ -617,7 +617,7 @@ def determine_asset_partitions_to_reconcile(
             auto_materialize_policy.on_missing
             and not instance_queryer.materialization_exists(asset_partition=candidate)
         ) or (
-            auto_materialize_policy.on_upstream_data_newer
+            auto_materialize_policy.on_new_parent_data
             and not instance_queryer.is_reconciled(
                 asset_partition=candidate, asset_graph=asset_graph
             )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import NamedTuple, Optional
 
-from dagster._annotations import experimental
+from dagster._annotations import experimental, public
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
@@ -39,7 +39,7 @@ class AutoMaterializePolicy(NamedTuple):
     """
 
     on_missing: bool
-    on_upstream_data_newer: bool
+    on_new_parent_data: bool
     for_freshness: bool
     time_window_partition_scope_minutes: Optional[float]
 
@@ -49,20 +49,22 @@ class AutoMaterializePolicy(NamedTuple):
             return None
         return datetime.timedelta(minutes=self.time_window_partition_scope_minutes)
 
+    @public
     @staticmethod
     def eager() -> "AutoMaterializePolicy":
         return AutoMaterializePolicy(
             on_missing=True,
-            on_upstream_data_newer=True,
+            on_new_parent_data=True,
             for_freshness=True,
             time_window_partition_scope_minutes=datetime.timedelta.resolution.total_seconds() / 60,
         )
 
+    @public
     @staticmethod
     def lazy() -> "AutoMaterializePolicy":
         return AutoMaterializePolicy(
             on_missing=True,
-            on_upstream_data_newer=False,
+            on_new_parent_data=False,
             for_freshness=True,
             time_window_partition_scope_minutes=datetime.timedelta.resolution.total_seconds() / 60,
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -70,7 +70,7 @@ partitioned_source = SourceAsset(
     auto_materialize_policy=AutoMaterializePolicy(
         on_missing=True,
         for_freshness=True,
-        on_upstream_data_newer=True,
+        on_new_parent_data=True,
         time_window_partition_scope_minutes=(24 + 7) * 60,
     ),
 )
@@ -264,7 +264,7 @@ def test_auto_materialize_policy():
     ) == AutoMaterializePolicy(
         on_missing=True,
         for_freshness=True,
-        on_upstream_data_newer=True,
+        on_new_parent_data=True,
         time_window_partition_scope_minutes=(24 + 7) * 60,
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/auto_materialize_policy_scenarios.py
@@ -89,7 +89,7 @@ auto_materialize_policy_scenarios = {
             AutoMaterializePolicy(
                 on_missing=True,
                 for_freshness=True,
-                on_upstream_data_newer=True,
+                on_new_parent_data=True,
                 time_window_partition_scope_minutes=24 * 2 * 60,
             ),
         ),
@@ -108,7 +108,7 @@ auto_materialize_policy_scenarios = {
             AutoMaterializePolicy(
                 on_missing=True,
                 for_freshness=True,
-                on_upstream_data_newer=False,
+                on_new_parent_data=False,
                 time_window_partition_scope_minutes=24 * 2 * 60,
             ),
         ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/multi_code_location_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/multi_code_location_scenarios.py
@@ -134,7 +134,7 @@ multi_code_location_scenarios = {
                 AutoMaterializePolicy(
                     for_freshness=True,
                     on_missing=False,
-                    on_upstream_data_newer=False,
+                    on_new_parent_data=False,
                     time_window_partition_scope_minutes=0,
                 ),
             ),
@@ -143,7 +143,7 @@ multi_code_location_scenarios = {
                 AutoMaterializePolicy(
                     for_freshness=True,
                     on_missing=False,
-                    on_upstream_data_newer=False,
+                    on_new_parent_data=False,
                     time_window_partition_scope_minutes=0,
                 ),
             ),
@@ -159,7 +159,7 @@ multi_code_location_scenarios = {
                 AutoMaterializePolicy(
                     for_freshness=True,
                     on_missing=False,
-                    on_upstream_data_newer=False,
+                    on_new_parent_data=False,
                     time_window_partition_scope_minutes=0,
                 ),
             ),
@@ -168,7 +168,7 @@ multi_code_location_scenarios = {
                 AutoMaterializePolicy(
                     for_freshness=True,
                     on_missing=False,
-                    on_upstream_data_newer=False,
+                    on_new_parent_data=False,
                     time_window_partition_scope_minutes=0,
                 ),
             ),


### PR DESCRIPTION
## Summary & Motivation

- Make `lazy` and `eager` public
- `on_upstream_data_newer` -> `on_new_parent_data`, as agreed on in [this discussion](https://github.com/dagster-io/internal/discussions/5381#discussion-5048263)

## How I Tested These Changes
