### PR TITLE
[ui] Fix quick-loading code location toast

### DIFF
--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -156,17 +156,24 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         }
       });
 
+      const toastContent = () => {
+        if (addedEntries.length === 1) {
+          const entryId = addedEntries[0];
+          const locationName = currEntriesById[entryId]?.name;
+          // The entry should be in the entry map, but guard against errors just in case.
+          return (
+            <span>Code location {locationName ? <strong>{locationName}</strong> : ''} added</span>
+          );
+        }
+
+        return <span>{addedEntries.length} code locations added</span>;
+      };
+
       SharedToaster.show({
         intent: 'primary',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
-            {addedEntries.length === 1 ? (
-              <span>
-                Code location <strong>{addedEntries[0]}</strong> added
-              </span>
-            ) : (
-              <span>{addedEntries.length} code locations added</span>
-            )}
+            {toastContent()}
             {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
           </Box>
         ),

--- a/js_modules/dagit/packages/ui/src/components/Toaster.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Toaster.tsx
@@ -28,6 +28,11 @@ export const GlobalToasterStyle = createGlobalStyle`
       gap: 8px;
     }
 
+    .bp4-toast.bp4-intent-primary,
+    .bp4-toast.bp4-intent-primary .bp4-button {
+      background-color: ${Colors.Gray700} !important;
+    }
+
     .bp4-toast.bp4-intent-success,
     .bp4-toast.bp4-intent-success .bp4-button {
       background-color: ${Colors.Blue500} !important;

--- a/js_modules/dagit/packages/ui/src/components/__stories__/Toaster.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/Toaster.stories.tsx
@@ -61,6 +61,18 @@ export const Sizes = () => {
       >
         Error Toast
       </Button>
+      <Button
+        onClick={() =>
+          SharedToaster.show({
+            intent: Intent.PRIMARY,
+            timeout: 5000,
+            message: 'This is a primary toaster',
+            icon: 'account_circle',
+          })
+        }
+      >
+        Primary Toast
+      </Button>
     </Group>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Fix an edge case in monitoring code location status. When a code location is ready so quickly that we never notice it loading, we show a toast indicating that it has been added. However, we were showing the `id` of the status entry object, not the name of the location itself. The result was a weird toast that looked broken:

![image](https://user-images.githubusercontent.com/2823852/232839266-5263ed1c-1e90-4751-8a19-91a42a0de99e.png)


Repair this by getting the location name from the entry map. This codepath is pretty rare, which I guess is why we haven't noticed it before.

<img width="347" alt="Screenshot 2023-04-18 at 11 13 02 AM" src="https://user-images.githubusercontent.com/2823852/232839152-d12f53ef-1925-4142-81cd-38e2c816d827.png">

Also fix the toaster button for the `primary` toast, which is showing up as blue on a gray background since the recent Blueprint v4 upgrade.

## How I Tested These Changes

Force this codepath when loading a new code location to ensure that the toast shows up with the correct location name.

View toaster in Storybook to sanity check color change.
