### PR TITLE
further improvemnts for test_threaded_ephemeral_instance

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sqlite/sqlite_run_storage.py
@@ -90,7 +90,7 @@ class SqliteRunStorage(SqlRunStorage, ConfigurableClass):
             db_revision, head_revision = check_alembic_revision(alembic_config, connection)
             if not (db_revision and head_revision):
                 RunStorageSqlMetadata.create_all(engine)
-                engine.execute("PRAGMA journal_mode=WAL;")
+                connection.execute("PRAGMA journal_mode=WAL;")
                 stamp_alembic_rev(alembic_config, connection)
                 should_mark_indexes = True
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sqlite/sqlite_schedule_storage.py
@@ -67,7 +67,7 @@ class SqliteScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             db_revision, head_revision = check_alembic_revision(alembic_config, connection)
             if not (db_revision and head_revision):
                 ScheduleStorageSqlMetadata.create_all(engine)
-                engine.execute("PRAGMA journal_mode=WAL;")
+                connection.execute("PRAGMA journal_mode=WAL;")
                 stamp_alembic_rev(alembic_config, connection)
                 should_migrate_data = True
 


### PR DESCRIPTION
My best guess for the remaining flakes https://buildkite.com/dagster/dagster/builds/56393#01879468-5c83-4838-819e-24ff92adf248
is that the connection fairy is firing via GC for main thread connections left over from other tests when another thread is running. 


* cleans up calls that were causing GC based connection finalization that i could find by breaking in sqlalchemy/base/pool.py in the debugger (even though they are sqlite)
* pause GC during this test to prevent it from running in a worker thread

## How I Tested These Changes

could never reproduce locally, ran full suite repeatedly as well as the specific test with `--count 1000`

