### PR TITLE
[bugfix] Fix stale status resolution for no-provenance assets with source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -351,9 +351,11 @@ class CachingStaleStatusResolver:
                             )
                         ],
                     )
-            # if no provenance, then use materialization timestamps instead of versions
-            # this should be removable eventually since provenance is on all newer materializations
-            else:
+            # If no provenance and dep is a materializable asset, then use materialization
+            # timestamps instead of versions this should be removable eventually since
+            # provenance is on all newer materializations. If dep is a source, then we'll never
+            # provide a stale reason here.
+            elif not self.asset_graph.is_source(dep_key):
                 dep_materialization = self._get_latest_materialization_event(key=dep_key)
                 if dep_materialization is None:
                     # The input must be new if it has no materialization

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_data_versions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_data_versions.py
@@ -25,7 +25,7 @@ from dagster._core.events import (
 from dagster._core.events.log import EventLogEntry
 
 
-def _create_test_event_log_entry(event_type: DagsterEventType, data: Any) -> EventLogEntry:
+def create_test_event_log_entry(event_type: DagsterEventType, data: Any) -> EventLogEntry:
     event_specific_data: Union[StepMaterializationData, AssetObservationData]
     if isinstance(data, AssetMaterialization):
         event_specific_data = StepMaterializationData(data, [])
@@ -60,7 +60,7 @@ def test_extract_data_version_and_provenance_from_materialization_entry():
             f"{CODE_VERSION_TAG}": "3",
         },
     )
-    entry = _create_test_event_log_entry(DagsterEventType.ASSET_MATERIALIZATION, materialization)
+    entry = create_test_event_log_entry(DagsterEventType.ASSET_MATERIALIZATION, materialization)
     assert extract_data_version_from_entry(entry) == DataVersion("1")
     assert extract_data_provenance_from_entry(entry) == DataProvenance(
         code_version="3",
@@ -78,7 +78,7 @@ def test_extract_data_version_from_observation_entry():
             DATA_VERSION_TAG: "1",
         },
     )
-    entry = _create_test_event_log_entry(
+    entry = create_test_event_log_entry(
         DagsterEventType.ASSET_OBSERVATION,
         observation,
     )

--- a/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
@@ -33,10 +33,15 @@ from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey, Output
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import StaticPartitionsDefinition
+from dagster._core.events import DagsterEventType
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster._core.instance_for_test import instance_for_test
 from typing_extensions import Literal
+
+from dagster_tests.core_tests.instance_tests.test_instance_data_versions import (
+    create_test_event_log_entry,
+)
 
 # ########################
 # ##### HELPERS
@@ -844,6 +849,22 @@ def test_stale_status_root_causes_dedup() -> None:
         assert status_resolver.get_stale_root_causes(asset4.key) == [
             StaleCause(asset1.key, StaleCauseCategory.CODE, "updated code version"),
         ]
+
+
+def test_no_provenance_stale_status():
+    @asset
+    def foo(bar):
+        return 1
+
+    bar = SourceAsset(AssetKey(["bar"]))
+
+    with instance_for_test() as instance:
+        materialization = AssetMaterialization(asset_key=AssetKey(["foo"]))
+        entry = create_test_event_log_entry(DagsterEventType.ASSET_MATERIALIZATION, materialization)
+        instance.store_event(entry)
+        status_resolver = get_stale_status_resolver(instance, [foo, bar])
+        assert status_resolver.get_status(foo.key) == StaleStatus.FRESH
+        assert status_resolver.get_stale_root_causes(foo.key) == []
 
 
 def test_get_data_provenance_inside_op():


### PR DESCRIPTION
## Summary & Motivation

Fix a bug with stale status resolution for assets where the latest materialization lacks provenance info. Source assets were being handled incorrectly here-- probably this hasn't been noticed until now because in the vast majority of cases there is provenance info on new materializations.

## How I Tested These Changes

New test.
