### PR TITLE
Disable partitioned observables

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -155,9 +155,9 @@ def test_partitioned_self_dep():
 
 
 def get_observable_source_asset_repo():
-    @observable_source_asset(partitions_def=StaticPartitionsDefinition(["1"]))
+    @asset(partitions_def=StaticPartitionsDefinition(["1"]))
     def foo():
-        return DataVersion("1")
+        return 1
 
     @observable_source_asset
     def bar():

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -6,7 +6,6 @@ from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.metadata import (
     MetadataUserInput,
 )
-from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.source_asset import SourceAsset, SourceAssetObserveFunction
@@ -27,7 +26,6 @@ def observable_source_asset(
     io_manager_key: Optional[str] = None,
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
     group_name: Optional[str] = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -45,7 +43,6 @@ def observable_source_asset(
     io_manager_key: Optional[str] = None,
     io_manager_def: Optional[IOManagerDefinition] = None,
     description: Optional[str] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
     group_name: Optional[str] = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -71,8 +68,6 @@ def observable_source_asset(
         io_manager_def (Optional[IOManagerDefinition]): (Experimental) The definition of the IOManager that will be used to load the contents of
             the source asset when it's used as an input to other assets inside a job.
         description (Optional[str]): The description of the asset.
-        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
-            compose the source asset.
         group_name (Optional[str]): A string name used to organize multiple assets into groups. If not provided,
             the name "default" is used.
         required_resource_keys (Optional[Set[str]]): Set of resource keys required by the observe op.
@@ -91,7 +86,6 @@ def observable_source_asset(
         io_manager_key,
         io_manager_def,
         description,
-        partitions_def,
         group_name,
         required_resource_keys,
         resource_defs,
@@ -107,7 +101,6 @@ class _ObservableSourceAsset:
         io_manager_key: Optional[str] = None,
         io_manager_def: Optional[IOManagerDefinition] = None,
         description: Optional[str] = None,
-        partitions_def: Optional[PartitionsDefinition] = None,
         group_name: Optional[str] = None,
         required_resource_keys: Optional[AbstractSet[str]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -122,7 +115,6 @@ class _ObservableSourceAsset:
         self.io_manager_key = io_manager_key
         self.io_manager_def = io_manager_def
         self.description = description
-        self.partitions_def = partitions_def
         self.group_name = group_name
         self.required_resource_keys = required_resource_keys
         self.resource_defs = resource_defs
@@ -148,7 +140,6 @@ class _ObservableSourceAsset:
             io_manager_key=self.io_manager_key,
             io_manager_def=self.io_manager_def,
             description=self.description,
-            partitions_def=self.partitions_def,
             group_name=self.group_name,
             _required_resource_keys=resolved_resource_keys,
             resource_defs=self.resource_defs,

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -106,6 +106,11 @@ class SourceAsset(ResourceAddable):
     ):
         from dagster._core.execution.build_resources import wrap_resources_for_execution
 
+        if partitions_def is not None and observe_fn is not None:
+            raise DagsterInvalidDefinitionError(
+                "Cannot specify a `partitions_def` for an observable source asset."
+            )
+
         if resource_defs is not None:
             experimental_arg_warning("resource_defs", "SourceAsset.__new__")
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset.py
@@ -1,6 +1,10 @@
+import pytest
+from dagster import DataVersion
 from dagster._core.definitions import ResourceDefinition, SourceAsset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
+from dagster._core.definitions.partition import StaticPartitionsDefinition
+from dagster._core.errors import DagsterInvalidDefinitionError
 
 
 def test_source_asset_metadata():
@@ -23,3 +27,12 @@ def test_source_asset_with_bare_resource():
     source_asset = SourceAsset(key="foo", resource_defs={"bare_resource": BareResourceObject()})
 
     assert isinstance(source_asset.resource_defs["bare_resource"], ResourceDefinition)
+
+
+def test_partitioned_observable():
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        def foo():
+            return DataVersion("1")
+
+        SourceAsset(partitions_def=StaticPartitionsDefinition(["1"]), key="foo", observe_fn=foo)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -56,6 +56,7 @@ def test_execute_source_asset_observation_job():
     assert _get_current_data_version(AssetKey("bar"), instance) == DataVersion("beta")
 
 
+@pytest.mark.skip("Temporarily disabling this feature pending GQL UI work")
 def test_partitioned_observable_source_asset():
     partitions_def_a = StaticPartitionsDefinition(["A"])
     partitions_def_b = StaticPartitionsDefinition(["B"])

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset.py
@@ -11,7 +11,7 @@ from dagster._core.storage.io_manager import io_manager
 
 
 def test_all_fields():
-    partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
+    StaticPartitionsDefinition(["a", "b", "c", "d"])
 
     @io_manager(required_resource_keys={"baz"})
     def foo_manager():
@@ -24,7 +24,6 @@ def test_all_fields():
         metadata={"epsilon": "gamma"},
         io_manager_key="lambda",
         io_manager_def=foo_manager,
-        partitions_def=partitions_def,
         group_name="rho",
     )
     def foo_source_asset(context):
@@ -33,7 +32,6 @@ def test_all_fields():
     assert foo_source_asset.key == AssetKey(["delta", "alpha"])
     assert foo_source_asset.description == "beta"
     assert foo_source_asset.io_manager_key == "lambda"
-    assert foo_source_asset.partitions_def == partitions_def
     assert foo_source_asset.group_name == "rho"
     assert foo_source_asset.resource_defs == {"lambda": foo_manager}
     assert foo_source_asset.io_manager_def == foo_manager


### PR DESCRIPTION
## Summary & Motivation

Currently the backend works for partitioned observables but the UI has problems due to differences between source assets and regular assets at the GQL level. Therefore we are disabling until 1.3.1. Partitioned observables did not work at all until very recently and observables are experimental, so there is no issue removing the `partitions_def` arg.

## How I Tested These Changes

New test
