### PR TITLE
Add stale cause category comparison

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from collections import OrderedDict
 from enum import Enum
 from hashlib import sha256
@@ -229,10 +230,16 @@ class StaleStatus(Enum):
     FRESH = "FRESH"
 
 
+@functools.total_ordering
 class StaleCauseCategory(Enum):
     CODE = "CODE"
     DATA = "DATA"
     DEPENDENCIES = "DEPENDENCIES"
+
+    def __lt__(self, other: "StaleCauseCategory"):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
 
 
 class StaleCause(NamedTuple):

--- a/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_data_versions.py
@@ -933,3 +933,11 @@ def test_legacy_data_version_tags():
             input_data_versions={AssetKey(["foo"]): DataVersion("alpha")},
             is_user_provided=True,
         )
+
+
+def test_stale_cause_comparison():
+    cause_1 = StaleCause(key=AssetKey(["foo"]), category=StaleCauseCategory.CODE, reason="ok")
+
+    cause_2 = StaleCause(key=AssetKey(["foo"]), category=StaleCauseCategory.DATA, reason="ok")
+
+    assert cause_1 < cause_2


### PR DESCRIPTION
## Summary & Motivation

Add comparison functionality to `StaleCauseCategory`-- sometimes an error would get thrown if other fields on `StaleCause` were equal and the categories would get compared.

## How I Tested These Changes

New unit test
