### PR TITLE
[pythonic resources] Add support for input, output config in ConfigurableIOManagers

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -33,6 +33,7 @@ from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.validate import process_config, validate_config
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.definition_config_schema import (
+    CoercableToConfigSchema,
     ConfiguredDefinitionConfigSchema,
     DefinitionConfigSchema,
 )
@@ -515,9 +516,26 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         description: Optional[str],
         resolve_resource_keys: Callable[[Mapping[int, str]], AbstractSet[str]],
         nested_resources: Mapping[str, CoercibleToResource],
+        input_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
+        output_config_schema: Optional[Union[CoercableToConfigSchema, Type[Config]]] = None,
     ):
+        input_config_schema_resolved: CoercableToConfigSchema = (
+            cast(Type[Config], input_config_schema).to_config_schema()
+            if safe_is_subclass(input_config_schema, Config)
+            else cast(CoercableToConfigSchema, input_config_schema)
+        )
+        output_config_schema_resolved: CoercableToConfigSchema = (
+            cast(Type[Config], output_config_schema).to_config_schema()
+            if safe_is_subclass(output_config_schema, Config)
+            else cast(CoercableToConfigSchema, output_config_schema)
+        )
+        print(input_config_schema_resolved)
         super().__init__(
-            resource_fn=resource_fn, config_schema=config_schema, description=description
+            resource_fn=resource_fn,
+            config_schema=config_schema,
+            description=description,
+            input_config_schema=input_config_schema_resolved,
+            output_config_schema=output_config_schema_resolved,
         )
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
@@ -1023,7 +1041,17 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
             description=self.__doc__,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self.nested_resources,
+            input_config_schema=self.__class__.input_config_schema(),
+            output_config_schema=self.__class__.output_config_schema(),
         )
+
+    @classmethod
+    def input_config_schema(cls) -> Optional[Union[CoercableToConfigSchema, Type[Config]]]:
+        return None
+
+    @classmethod
+    def output_config_schema(cls) -> Optional[Union[CoercableToConfigSchema, Type[Config]]]:
+        return None
 
 
 class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
@@ -1033,12 +1061,23 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
         PartialResource.__init__(self, resource_cls, data)
 
     def get_resource_definition(self) -> ConfigurableIOManagerFactoryResourceDefinition:
+        input_config_schema = None
+        output_config_schema = None
+        if safe_is_subclass(self.resource_cls, ConfigurableIOManagerFactory):
+            factory_cls: Type[ConfigurableIOManagerFactory] = cast(
+                Type[ConfigurableIOManagerFactory], self.resource_cls
+            )
+            input_config_schema = factory_cls.input_config_schema()
+            output_config_schema = factory_cls.output_config_schema()
+
         return ConfigurableIOManagerFactoryResourceDefinition(
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
             resolve_resource_keys=self._resolve_required_resource_keys,
             nested_resources=self._state__internal__.nested_resources,
+            input_config_schema=input_config_schema,
+            output_config_schema=output_config_schema,
         )
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
@@ -1,5 +1,22 @@
-from dagster import Definitions, In, asset, job, op
+from typing import Type
+
+from dagster import (
+    Config,
+    Definitions,
+    In,
+    IOManagerDefinition,
+    StringSource,
+    asset,
+    io_manager,
+    job,
+    op,
+)
 from dagster._config.pythonic_config import ConfigurableIOManager, ConfigurableResource
+from dagster._config.type_printer import print_config_type_to_string
+
+
+def type_string_from_config_schema(config_schema):
+    return print_config_type_to_string(config_schema.config_type)
 
 
 def test_load_input_handle_output():
@@ -156,3 +173,211 @@ def test_nested_resources_runtime_config():
         .success
     )
     assert out_txt == ["greeting: hello, world!"]
+
+
+def test_config_schemas() -> None:
+    # Decorator-based IO manager definition
+    @io_manager(
+        config_schema={"base_dir": StringSource},
+        output_config_schema={"path": StringSource},
+        input_config_schema={"format": StringSource},
+    )
+    def an_io_manager():
+        pass
+
+    class OutputConfigSchema(Config):
+        path: str
+
+    class InputConfigSchema(Config):
+        format: str
+
+    class MyIOManager(ConfigurableIOManager):
+        base_dir: str
+
+        @classmethod
+        def input_config_schema(cls) -> Type[Config]:
+            return InputConfigSchema
+
+        @classmethod
+        def output_config_schema(cls) -> Type[Config]:
+            return OutputConfigSchema
+
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            pass
+
+    configured_io_manager = MyIOManager(base_dir="/a/b/c").get_resource_definition()
+
+    # Check that the config schemas are the same
+    assert isinstance(configured_io_manager, IOManagerDefinition)
+    assert type_string_from_config_schema(
+        configured_io_manager.output_config_schema
+    ) == type_string_from_config_schema(an_io_manager.output_config_schema)
+    assert type_string_from_config_schema(
+        configured_io_manager.input_config_schema
+    ) == type_string_from_config_schema(an_io_manager.input_config_schema)
+
+    class MyIOManagerNonPythonicSchemas(ConfigurableIOManager):
+        base_dir: str
+
+        @classmethod
+        def input_config_schema(cls):
+            return {"format": StringSource}
+
+        @classmethod
+        def output_config_schema(cls):
+            return {"path": StringSource}
+
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            pass
+
+    configured_io_manager_non_pythonic = MyIOManagerNonPythonicSchemas(
+        base_dir="/a/b/c"
+    ).get_resource_definition()
+
+    # Check that the config schemas are the same
+    assert isinstance(configured_io_manager_non_pythonic, IOManagerDefinition)
+    assert type_string_from_config_schema(
+        configured_io_manager_non_pythonic.output_config_schema
+    ) == type_string_from_config_schema(an_io_manager.output_config_schema)
+    assert type_string_from_config_schema(
+        configured_io_manager_non_pythonic.input_config_schema
+    ) == type_string_from_config_schema(an_io_manager.input_config_schema)
+
+
+import pytest
+from dagster import InputContext, Out, OutputContext
+from dagster._core.errors import DagsterInvalidConfigError
+
+
+def test_load_input_handle_output_input_config() -> None:
+    class MyIOManager(ConfigurableIOManager):
+        def handle_output(self, context, obj):
+            pass
+
+        def load_input(self, context):
+            assert False, "should not be called"
+
+    class InputConfigSchema(Config):
+        config_value: int
+
+    class MyInputManager(MyIOManager):
+        def load_input(self, context):
+            if context.upstream_output is None:
+                assert False, "upstream output should not be None"
+            else:
+                return context.config["config_value"]
+
+        @classmethod
+        def input_config_schema(cls) -> Type[Config]:
+            return InputConfigSchema
+
+    did_run = {}
+
+    @op
+    def first_op():
+        did_run["first_op"] = True
+        return 1
+
+    @op(ins={"an_input": In(input_manager_key="my_input_manager")})
+    def second_op(an_input):
+        assert an_input == 6
+        did_run["second_op"] = True
+
+    @job(
+        resource_defs={
+            "io_manager": MyIOManager(),
+            "my_input_manager": MyInputManager(),
+        }
+    )
+    def check_input_managers():
+        out = first_op()
+        second_op(out)
+
+    check_input_managers.execute_in_process(
+        run_config={"ops": {"second_op": {"inputs": {"an_input": {"config_value": 6}}}}}
+    )
+    assert did_run["first_op"]
+    assert did_run["second_op"]
+
+    with pytest.raises(DagsterInvalidConfigError):
+        check_input_managers.execute_in_process(
+            run_config={
+                "ops": {"second_op": {"inputs": {"an_input": {"config_value": "a_string"}}}}
+            }
+        )
+
+
+def test_config_param_load_input_handle_output_config() -> None:
+    storage = {}
+
+    class InputConfigSchema(Config):
+        prefix_input: str
+
+    class OutputConfigSchema(Config):
+        postfix_output: str
+
+    class MyIOManager(ConfigurableIOManager):
+        prefix_output: str
+
+        @classmethod
+        def input_config_schema(cls) -> Type[Config]:
+            return InputConfigSchema
+
+        @classmethod
+        def output_config_schema(cls) -> Type[Config]:
+            return OutputConfigSchema
+
+        def load_input(self, context: InputContext):
+            return f"{context.config['prefix_input']}{storage[context.name]}"
+
+        def handle_output(self, context: OutputContext, obj: str):
+            storage[context.name] = f"{self.prefix_output}{obj}{context.config['postfix_output']}"
+
+    did_run = {}
+
+    @op(out={"first_op": Out(io_manager_key="io_manager")})
+    def first_op():
+        did_run["first_op"] = True
+        return "foo"
+
+    @op(
+        ins={"first_op": In(input_manager_key="io_manager")},
+        out={"second_op": Out(io_manager_key="io_manager")},
+    )
+    def second_op(first_op):
+        assert first_op == "barprefoopost"
+        did_run["second_op"] = True
+        return first_op
+
+    @job(
+        resource_defs={
+            "io_manager": MyIOManager(
+                prefix_output="pre",
+            ),
+        }
+    )
+    def check_input_managers():
+        out = first_op()
+        second_op(out)
+
+    check_input_managers.execute_in_process(
+        run_config={
+            "ops": {
+                "first_op": {"outputs": {"first_op": {"postfix_output": "post"}}},
+                "second_op": {
+                    "inputs": {"first_op": {"prefix_input": "bar"}},
+                    "outputs": {"second_op": {"postfix_output": "post"}},
+                },
+            }
+        }
+    )
+    assert did_run["first_op"]
+    assert did_run["second_op"]
+    assert storage["first_op"] == "prefoopost"
+    assert storage["second_op"] == "prebarprefoopostpost"


### PR DESCRIPTION
## Summary

Adds support for specifying input and output config types for `ConfigurableIOManager`s and `ConfigurableIOManagerFactory`s, loosely based on #11346.

These schemas can be either old-style config dicts or `Config` classes. The raw config data passed to input/output functions is a config dict, but we could instead support passing the config directly as in #11346.

```python
class OutputConfigSchema(Config):
    path: str

class InputConfigSchema(Config):
    format: str

class MyIOManager(ConfigurableIOManager):
    base_dir: str

    @classmethod
    def input_config_schema(cls) -> Type[Config]:
        return InputConfigSchema

    @classmethod
    def output_config_schema(cls) -> Type[Config]:
        return OutputConfigSchema

    def handle_output(self, context, obj):
        ...

    def load_input(self, context):
        ...
```

## Test Plan

New tests.