### PR TITLE
[auto-materialization] Fix detection of in-progress runs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -28,7 +28,6 @@ from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
-from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
 from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     TimeWindowPartitionsDefinition,
@@ -422,9 +421,11 @@ def find_parent_materialized_asset_partitions(
                         child_asset_partition = AssetKeyPartitionKey(child, child_partition)
                         if not can_reconcile_fn(child_asset_partition):
                             continue
-                        # cannot materialize in the same run if different partitions defs
-                        elif child_partitions_def != partitions_def or not isinstance(
-                            partition_mapping, IdentityPartitionMapping
+                        # cannot materialize in the same run if different partitions defs or
+                        # different partition keys
+                        elif (
+                            child_partitions_def != partitions_def
+                            or child_partition not in materialized_partitions
                         ):
                             result_asset_partitions.add(child_asset_partition)
                         else:

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -416,7 +416,7 @@ def find_parent_materialized_asset_partitions(
                         )
                     )
                     for child_partition in child_partitions_subset.get_partition_keys():
-                        # we need to see if the child was materialized in the same run, but this is
+                        # we need to see if the child is planned for the same run, but this is
                         # expensive, so we try to avoid doing so in as many situations as possible
                         child_asset_partition = AssetKeyPartitionKey(child, child_partition)
                         if not can_reconcile_fn(child_asset_partition):

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/active_run_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/active_run_scenarios.py
@@ -1,0 +1,80 @@
+import datetime
+from typing import Optional
+
+from dagster import (
+    DailyPartitionsDefinition,
+    PartitionKeyRange,
+)
+from dagster._core.definitions.events import AssetKey, AssetMaterialization
+from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
+from dagster._core.events import DagsterEvent, StepMaterializationData
+from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.pipeline_run import DagsterRun, DagsterRunStatus
+from dagster._seven.compat.pendulum import create_pendulum_time
+
+from .asset_reconciliation_scenario import (
+    AssetReconciliationScenario,
+    asset_def,
+    run_request,
+)
+
+DEFAULT_JOB_NAME = "some_job"
+
+daily_partitions_def = DailyPartitionsDefinition("2020-01-01")
+hourly_partitions_def = HourlyPartitionsDefinition("2020-01-01-00:00")
+
+assets = [
+    asset_def("upstream_daily", partitions_def=daily_partitions_def),
+    asset_def("downstream_daily", ["upstream_daily"], partitions_def=daily_partitions_def),
+    asset_def("downstream_hourly", ["upstream_daily"], partitions_def=hourly_partitions_def),
+]
+
+
+def create_materialization_event_log_entry(
+    asset_key: AssetKey, partition: Optional[str] = None, run_id: str = "1"
+) -> EventLogEntry:
+    return EventLogEntry(
+        pipeline_name=DEFAULT_JOB_NAME,
+        run_id="1",
+        error_info=None,
+        level="INFO",
+        user_message="",
+        timestamp=datetime.datetime.now().timestamp(),
+        dagster_event=DagsterEvent(
+            event_type_value="ASSET_MATERIALIZATION",
+            pipeline_name=DEFAULT_JOB_NAME,
+            event_specific_data=StepMaterializationData(
+                materialization=AssetMaterialization(asset_key=asset_key, partition=partition)
+            ),
+        ),
+    )
+
+
+active_run_scenarios = {
+    "downstream_still_in_progress": AssetReconciliationScenario(
+        assets=assets,
+        unevaluated_runs=[],
+        current_time=create_pendulum_time(year=2020, month=1, day=2, hour=0),
+        # manually populate entries here to create an in-progress run for both daily assets
+        dagster_runs=[
+            DagsterRun(
+                pipeline_name=DEFAULT_JOB_NAME,
+                run_id="1",
+                status=DagsterRunStatus.STARTED,
+                asset_selection={AssetKey("upstream_daily"), AssetKey("downstream_daily")},
+                tags={"dagster/partition": "2020-01-01"},
+            )
+        ],
+        event_log_entries=[
+            create_materialization_event_log_entry(
+                asset_key=AssetKey("upstream_daily"), partition="2020-01-01"
+            ),
+        ],
+        expected_run_requests=[
+            run_request(asset_keys=["downstream_hourly"], partition_key=partition_key)
+            for partition_key in hourly_partitions_def.get_partition_keys_in_range(
+                PartitionKeyRange(start="2020-01-01-00:00", end="2020-01-01-23:00")
+            )
+        ],
+    ),
+}

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -41,9 +41,11 @@ from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
+from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.asset_backfill import AssetBackfillData
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.host_representation.origin import InProcessCodeLocationOrigin
+from dagster._core.storage.pipeline_run import DagsterRun
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,
@@ -68,6 +70,8 @@ class AssetReconciliationScenario(NamedTuple):
     current_time: Optional[datetime.datetime] = None
     asset_selection: Optional[AssetSelection] = None
     active_backfill_targets: Optional[Sequence[Mapping[AssetKey, PartitionsSubset]]] = None
+    dagster_runs: Optional[Sequence[DagsterRun]] = None
+    event_log_entries: Optional[Sequence[EventLogEntry]] = None
     expected_run_requests: Optional[Sequence[RunRequest]] = None
     code_locations: Optional[Mapping[str, Sequence[Union[SourceAsset, AssetsDefinition]]]] = None
 
@@ -96,6 +100,14 @@ class AssetReconciliationScenario(NamedTuple):
             @repository
             def repo():
                 return self.assets
+
+            # add any runs to the instance
+            for dagster_run in self.dagster_runs or []:
+                instance.add_run(dagster_run)
+
+            # add any events to the instance
+            for event_log_entry in self.event_log_entries or []:
+                instance.store_event(event_log_entry)
 
             # add any backfills to the instance
             for i, target in enumerate(self.active_backfill_targets or []):

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/scenarios.py
@@ -1,6 +1,7 @@
 from dagster import Definitions
 from dagster._core.definitions.executor_definition import in_process_executor
 
+from .active_run_scenarios import active_run_scenarios
 from .auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
 from .basic_scenarios import basic_scenarios
 from .definition_change_scenarios import definition_change_scenarios
@@ -18,6 +19,7 @@ ASSET_RECONCILIATION_SCENARIOS = {
     **auto_materialize_policy_scenarios,
     **observable_source_asset_scenarios,
     **definition_change_scenarios,
+    **active_run_scenarios,
 }
 
 # put repos in the global namespace so that the daemon can load them with LoadableTargetOrigin


### PR DESCRIPTION
## Summary & Motivation

We try to be a bit clever when checking if a newly-detected AssetMaterialization is going to be propagated by a currently in-progress run. The naive solution would be to always just query if the run that created that materialization also plans to materialize the child, but this would result in lots and lots of queries, which would be very inefficient.

Instead, we filter out cases where we know for a fact that the child cannot exist in the same run (i.e. they have different partitions definitions or different partition keys).

The old solution skipped over the fact that TimeWindowPartitionsDefinitions <> TimeWindowPartitionsDefinitions will have a TimeWindowPartitionMapping, not an IdentityPartitionMapping.

## How I Tested These Changes
