### PR TITLE
Added get_gcs_keys helper function

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/sensor.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/sensor.py
@@ -1,0 +1,45 @@
+import dagster._check as check
+from google.cloud import storage
+
+MAX_KEYS = 1000
+
+
+def get_gcs_keys(bucket, prefix="", since_key=None, gcs_session=None):
+    check.str_param(bucket, "bucket")
+    check.str_param(prefix, "prefix")
+    check.opt_str_param(since_key, "since_key")
+
+    if not gcs_session:
+        gcs_session = storage.Client()
+
+    cursor = ""
+    contents = []
+
+    while True:
+        response = list(
+            gcs_session.list_blobs(
+                bucket_or_name=bucket,
+                delimiter="",
+                max_results=MAX_KEYS,
+                prefix=prefix,
+                start_offset=cursor,
+            )
+        )
+        contents.extend(response)
+        if len(response) < MAX_KEYS:
+            break
+
+        contents.pop()
+
+        cursor = response[-1].name
+
+    sorted_keys = [obj.name for obj in sorted(contents, key=lambda x: x.updated)]
+
+    if not since_key or since_key not in sorted_keys:
+        return sorted_keys
+
+    for idx, key in enumerate(sorted_keys):
+        if key == since_key:
+            return sorted_keys[idx + 1 :]
+
+    return []


### PR DESCRIPTION
## Summary & Motivation
Added `get_gcs_keys` helper function to the dagster-gcp library for use in detecting when new files have been added to gcs buckets.

In the [Dagster docs](https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors#s3-sensors) there is an example of using sensors for detecting when new files are uploaded into an s3 bucket which makes reference to a get_s3_keys helper function. In my own personal project I needed to use a similar design but for Google Cloud Storage so I have refactored the `get_s3_keys` function found here: [get_s3_keys github](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py). Hopefully this can help other people with similar sensors in the future. 

## How I Tested These Changes
Tested locally to match behaviour of `get_s3_keys` function. 