### PR TITLE
[ui] Visual asset graph tweaks, fix for erroneous “Failed, Overdue” text

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -164,7 +164,7 @@ export function buildAssetNodeStatusContent({
         border: Colors.Gray300,
         content: (
           <>
-            <AssetLatestRunSpinner liveData={liveData} />
+            <AssetLatestRunSpinner liveData={liveData} purpose="caption-text" />
             <span style={{flex: 1}} color={Colors.Gray800}>
               Observing...
             </span>
@@ -238,7 +238,9 @@ export function buildAssetNodeStatusContent({
       border: Colors.Blue500,
       content: (
         <>
-          <AssetLatestRunSpinner liveData={liveData} />
+          <div style={{marginLeft: -1, marginRight: -1}}>
+            <AssetLatestRunSpinner liveData={liveData} purpose="caption-text" />
+          </div>
           <span style={{flex: 1}} color={Colors.Gray800}>
             {numMaterializing === 1
               ? `Materializing 1 partition...`
@@ -320,12 +322,19 @@ export function buildAssetNodeStatusContent({
             />
           )}
 
-          {late ? (
+          {late && runWhichFailedToMaterialize ? (
             <Tooltip
               position="top"
               content={humanizedLateString(liveData.freshnessInfo.currentMinutesLate)}
             >
-              <span style={{color: Colors.Red700}}>{late ? `Failed, Overdue` : 'Overdue'}</span>
+              <span style={{color: Colors.Red700}}>Failed, Overdue</span>
+            </Tooltip>
+          ) : late ? (
+            <Tooltip
+              position="top"
+              content={humanizedLateString(liveData.freshnessInfo.currentMinutesLate)}
+            >
+              <span style={{color: Colors.Red700}}>Overdue</span>
             </Tooltip>
           ) : runWhichFailedToMaterialize ? (
             <span style={{color: Colors.Red700}}>Failed</span>
@@ -407,7 +416,14 @@ export const AssetNodeMinimal: React.FC<{
             $background={background}
             $border={border}
           >
-            <div style={{position: 'absolute', bottom: 6, left: 6}}>
+            <div
+              style={{
+                position: 'absolute',
+                top: '50%',
+                transform: 'translateY(-16px)',
+                left: 8,
+              }}
+            >
               <AssetLatestRunSpinner liveData={liveData} purpose="section" />
             </div>
             <MinimalName style={{fontSize: 30}} $isSource={isSource}>

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -420,8 +420,7 @@ export const AssetNodeMinimal: React.FC<{
               style={{
                 position: 'absolute',
                 top: '50%',
-                transform: 'translateY(-16px)',
-                left: 8,
+                transform: 'translate(8px, -16px)',
               }}
             >
               <AssetLatestRunSpinner liveData={liveData} purpose="section" />

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetRunLinking.tsx
@@ -1,4 +1,4 @@
-import {Tooltip, Spinner, CaptionMono} from '@dagster-io/ui';
+import {Tooltip, Spinner, CaptionMono, FontFamily} from '@dagster-io/ui';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
@@ -37,6 +37,10 @@ export const AssetRunLink: React.FC<{
     target="_blank"
     rel="noreferrer"
   >
-    {children || <CaptionMono>{titleForRun({id: runId})}</CaptionMono>}
+    {children || (
+      <span style={{fontSize: '1.2em', fontFamily: FontFamily.monospace}}>
+        {titleForRun({id: runId})}
+      </span>
+    )}
   </Link>
 );

--- a/js_modules/dagit/packages/core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -278,6 +278,34 @@ export const LiveDataForNodeMaterializedAndOverdue: LiveDataForNode = {
   partitionStats: null,
 };
 
+export const LiveDataForNodeFailedAndOverdue: LiveDataForNode = {
+  stepKey: 'asset1',
+  unstartedRunIds: [],
+  inProgressRunIds: [],
+  lastMaterializationRunStatus: null,
+  lastObservation: null,
+  lastMaterialization: null,
+  runWhichFailedToMaterialize: {
+    __typename: 'Run',
+    id: '123456',
+    status: RunStatus.FAILURE,
+    endTime: 1673301346,
+  },
+  staleStatus: StaleStatus.FRESH,
+  staleCauses: [],
+  freshnessInfo: {
+    __typename: 'AssetFreshnessInfo',
+    currentMinutesLate: 12,
+  },
+  freshnessPolicy: {
+    __typename: 'FreshnessPolicy',
+    maximumLagMinutes: 10,
+    cronSchedule: null,
+    cronScheduleTimezone: null,
+  },
+  partitionStats: null,
+};
+
 export const LiveDataForNodeSourceNeverObserved: LiveDataForNode = {
   stepKey: 'source_asset',
   unstartedRunIds: [],
@@ -625,7 +653,13 @@ export const AssetNodeScenariosBase = [
     title: 'Materialized and Overdue',
     liveData: LiveDataForNodeMaterializedAndOverdue,
     definition: AssetNodeFragmentBasic,
-    expectedText: ['Overdue'],
+    expectedText: ['Overdue', 'Feb'],
+  },
+  {
+    title: 'Materialized and Failed and Overdue',
+    liveData: LiveDataForNodeFailedAndOverdue,
+    definition: AssetNodeFragmentBasic,
+    expectedText: ['Failed, Overdue', 'Jan'],
   },
 ];
 


### PR DESCRIPTION
## Summary & Motivation

- On mini asset nodes, the spinner should be vertically centered

- When an asset is late, show "Failed, Overdue" only if there is also a failed run ID

- Make the "materializing" spinner the same size as the green / red dots and undo it's padding to align it perfectly with the dots.

- Use a relative font size increase (1.2em) to make the monospace text in the asset status the right size. That way, the surrounding font size is not overridden. 

## How I Tested These Changes

- I created a new storybook case

- Visual tests below

<img width="763" alt="image" src="https://user-images.githubusercontent.com/1037212/233154572-99a1d7ed-e7ad-4901-81af-84aecf2ee41c.png">

<img width="201" alt="image" src="https://user-images.githubusercontent.com/1037212/233154636-2f22c7d1-3591-4983-8ac1-22e498caac70.png">

<img width="406" alt="image" src="https://user-images.githubusercontent.com/1037212/233154592-740fd454-d7ba-4069-afbf-37bbe6eb0953.png">

