### PR TITLE
[docs] Add migration guide link to config, resources, io manager pages

### DIFF
--- a/docs/content/concepts/configuration/config-schema-legacy.mdx
+++ b/docs/content/concepts/configuration/config-schema-legacy.mdx
@@ -11,7 +11,9 @@ description: Job run configuration allows providing parameters to jobs at the ti
   <a href="/concepts/configuration/config-schema">
     updated configuration guide
   </a>
-  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
+  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">
+    migrating to Pythonic resources and config
+  </a> guide.
 </Note>
 
 Run configuration allows providing parameters to jobs at the time they're executed.

--- a/docs/content/concepts/configuration/config-schema-legacy.mdx
+++ b/docs/content/concepts/configuration/config-schema-legacy.mdx
@@ -11,7 +11,7 @@ description: Job run configuration allows providing parameters to jobs at the ti
   <a href="/concepts/configuration/config-schema">
     updated configuration guide
   </a>
-  .
+  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
 </Note>
 
 Run configuration allows providing parameters to jobs at the time they're executed.

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -11,7 +11,9 @@ description: Job run configuration allows providing parameters to jobs at the ti
   <a href="/concepts/configuration/config-schema-legacy">
     legacy configuration guide
   </a>
-  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
+  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">
+    migrating to Pythonic resources and config
+  </a> guide.
 </Note>
 
 Run configuration allows providing parameters to jobs at the time they're executed.

--- a/docs/content/concepts/configuration/config-schema.mdx
+++ b/docs/content/concepts/configuration/config-schema.mdx
@@ -11,7 +11,7 @@ description: Job run configuration allows providing parameters to jobs at the ti
   <a href="/concepts/configuration/config-schema-legacy">
     legacy configuration guide
   </a>
-  .
+  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
 </Note>
 
 Run configuration allows providing parameters to jobs at the time they're executed.

--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -8,7 +8,12 @@ description: IO Managers determine how to store asset/op outputs and load asset/
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the
   new Pythonic resource system introduced in Dagster 1.3, see the{" "}
-  <a href="/concepts/io-management/io-managers">updated I/O managers guide</a>. To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
+  <a href="/concepts/io-management/io-managers">updated I/O managers guide</a>.
+  To migrate your code, refer to the{" "}
+  <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">
+    migrating to Pythonic resources and config
+  </a>{" "}
+  guide.
 </Note>
 
 IO Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.

--- a/docs/content/concepts/io-management/io-managers-legacy.mdx
+++ b/docs/content/concepts/io-management/io-managers-legacy.mdx
@@ -8,7 +8,7 @@ description: IO Managers determine how to store asset/op outputs and load asset/
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the
   new Pythonic resource system introduced in Dagster 1.3, see the{" "}
-  <a href="/concepts/io-management/io-managers">updated I/O managers guide</a>.
+  <a href="/concepts/io-management/io-managers">updated I/O managers guide</a>. To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
 </Note>
 
 IO Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -11,7 +11,7 @@ description: I/O Managers determine how to store asset/op outputs and load asset
   <a href="/concepts/io-management/io-managers-legacy">
     legacy I/O managers guide
   </a>
-  .
+  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
 </Note>
 
 I/O Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -11,7 +11,9 @@ description: I/O Managers determine how to store asset/op outputs and load asset
   <a href="/concepts/io-management/io-managers-legacy">
     legacy I/O managers guide
   </a>
-  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
+  . To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">
+    migrating to Pythonic resources and config
+  </a> guide.
 </Note>
 
 I/O Managers are user-provided objects that store asset and op outputs and load them as inputs to downstream assets and ops.

--- a/docs/content/concepts/resources-legacy.mdx
+++ b/docs/content/concepts/resources-legacy.mdx
@@ -8,7 +8,7 @@ description: Resources enable you to separate graph logic from environment, and 
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the
   new Pythonic resource system introduced in Dagster 1.3, see the{" "}
-  <a href="/concepts/resources">updated resources guide</a>.
+  <a href="/concepts/resources">updated resources guide</a>. To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
 </Note>
 
 Resources are objects that are shared across the implementations of multiple [software-defined assets](/concepts/assets/software-defined-assets) and [ops](/concepts/ops-jobs-graphs/ops) and that can be plugged in after defining those ops and assets.

--- a/docs/content/concepts/resources-legacy.mdx
+++ b/docs/content/concepts/resources-legacy.mdx
@@ -8,7 +8,12 @@ description: Resources enable you to separate graph logic from environment, and 
 <Note>
   This guide covers using the legacy Dagster resource system. For docs on the
   new Pythonic resource system introduced in Dagster 1.3, see the{" "}
-  <a href="/concepts/resources">updated resources guide</a>. To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
+  <a href="/concepts/resources">updated resources guide</a>. To migrate your
+  code, refer to the{" "}
+  <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">
+    migrating to Pythonic resources and config
+  </a>{" "}
+  guide.
 </Note>
 
 Resources are objects that are shared across the implementations of multiple [software-defined assets](/concepts/assets/software-defined-assets) and [ops](/concepts/ops-jobs-graphs/ops) and that can be plugged in after defining those ops and assets.

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -8,7 +8,12 @@ description: Resources enable you to separate graph logic from environment, and 
 <Note>
   This guide covers using the new Pythonic resources system introduced in
   Dagster 1.3. If your code is still using the legacy resources system, see the{" "}
-  <a href="/concepts/resources-legacy">legacy resources guide</a>. To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
+  <a href="/concepts/resources-legacy">legacy resources guide</a>. To migrate
+  your code, refer to the{" "}
+  <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">
+    migrating to Pythonic resources and config
+  </a>{" "}
+  guide.
 </Note>
 
 Resources are objects that are shared across the implementations of multiple [software-defined assets](/concepts/assets/software-defined-assets), [ops](/concepts/ops-jobs-graphs/ops), [schedules](/concepts/partitions-schedules-sensors/schedules), and [sensors](/concepts/partitions-schedules-sensors/sensors). These resources can be plugged in after the definitions of your assets or ops, and can be easily swapped out.

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -8,7 +8,7 @@ description: Resources enable you to separate graph logic from environment, and 
 <Note>
   This guide covers using the new Pythonic resources system introduced in
   Dagster 1.3. If your code is still using the legacy resources system, see the{" "}
-  <a href="/concepts/resources-legacy">legacy resources guide</a>.
+  <a href="/concepts/resources-legacy">legacy resources guide</a>. To migrate your code, refer to the <a href="/guides/dagster/migrating-to-pythonic-resources-and-config">migrating to Pythonic resources and config</a> guide.
 </Note>
 
 Resources are objects that are shared across the implementations of multiple [software-defined assets](/concepts/assets/software-defined-assets), [ops](/concepts/ops-jobs-graphs/ops), [schedules](/concepts/partitions-schedules-sensors/schedules), and [sensors](/concepts/partitions-schedules-sensors/sensors). These resources can be plugged in after the definitions of your assets or ops, and can be easily swapped out.


### PR DESCRIPTION
## Summary

Adds links to the migration guide from the infobox at the top of the config/resources/io managers pages.