### PR TITLE
Remove timeWindowMetadata from the GraphenePartitionDefinition class

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -763,7 +763,6 @@ type PartitionDefinition {
   description: String!
   type: PartitionDefinitionType!
   dimensionTypes: [DimensionDefinitionType!]!
-  timeWindowMetadata: TimePartitionsDefinitionMetadata
   name: String
 }
 
@@ -780,13 +779,6 @@ type DimensionDefinitionType {
   type: PartitionDefinitionType!
   isPrimaryDimension: Boolean!
   dynamicPartitionsDefinitionName: String
-}
-
-type TimePartitionsDefinitionMetadata {
-  startTime: Float!
-  endTime: Float!
-  startKey: String!
-  endKey: String!
 }
 
 type DimensionPartitionKeys {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2308,7 +2308,6 @@ export type PartitionDefinition = {
   description: Scalars['String'];
   dimensionTypes: Array<DimensionDefinitionType>;
   name: Maybe<Scalars['String']>;
-  timeWindowMetadata: Maybe<TimePartitionsDefinitionMetadata>;
   type: PartitionDefinitionType;
 };
 
@@ -3841,14 +3840,6 @@ export type TimePartitionRange = {
 export type TimePartitions = {
   __typename: 'TimePartitions';
   ranges: Array<TimePartitionRange>;
-};
-
-export type TimePartitionsDefinitionMetadata = {
-  __typename: 'TimePartitionsDefinitionMetadata';
-  endKey: Scalars['String'];
-  endTime: Scalars['Float'];
-  startKey: Scalars['String'];
-  startTime: Scalars['Float'];
 };
 
 export type TypeCheck = DisplayableEvent & {
@@ -8892,12 +8883,6 @@ export const buildPartitionDefinition = (
               : buildDimensionDefinitionType({}, relationshipsToOmit),
           ],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'facilis',
-    timeWindowMetadata:
-      overrides && overrides.hasOwnProperty('timeWindowMetadata')
-        ? overrides.timeWindowMetadata!
-        : relationshipsToOmit.has('TimePartitionsDefinitionMetadata')
-        ? ({} as TimePartitionsDefinitionMetadata)
-        : buildTimePartitionsDefinitionMetadata({}, relationshipsToOmit),
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
@@ -12641,21 +12626,6 @@ export const buildTimePartitions = (
               ? ({} as TimePartitionRange)
               : buildTimePartitionRange({}, relationshipsToOmit),
           ],
-  };
-};
-
-export const buildTimePartitionsDefinitionMetadata = (
-  overrides?: Partial<TimePartitionsDefinitionMetadata>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'TimePartitionsDefinitionMetadata'} & TimePartitionsDefinitionMetadata => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('TimePartitionsDefinitionMetadata');
-  return {
-    __typename: 'TimePartitionsDefinitionMetadata',
-    endKey: overrides && overrides.hasOwnProperty('endKey') ? overrides.endKey! : 'nobis',
-    endTime: overrides && overrides.hasOwnProperty('endTime') ? overrides.endTime! : 4.51,
-    startKey: overrides && overrides.hasOwnProperty('startKey') ? overrides.startKey! : 'atque',
-    startTime: overrides && overrides.hasOwnProperty('startTime') ? overrides.startTime! : 3.29,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -321,10 +321,6 @@ GET_1D_ASSET_PARTITIONS = """
             }
             partitionDefinition {
                 name
-                timeWindowMetadata {
-                    startTime
-                    startKey
-                }
             }
         }
     }
@@ -1292,14 +1288,6 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert materialized_ranges[0]["endKey"] == time_2
         assert materialized_ranges[0]["startTime"] == _get_datetime_float(time_0)
         assert materialized_ranges[0]["endTime"] == _get_datetime_float(time_3)
-
-        time_partitions_def_metadata = result.data["assetNodes"][0]["partitionDefinition"][
-            "timeWindowMetadata"
-        ]
-        assert time_partitions_def_metadata is not None
-        start_time = "2021-05-05-01:00"
-        assert time_partitions_def_metadata["startTime"] == _get_datetime_float(start_time)
-        assert time_partitions_def_metadata["startKey"] == start_time
 
     def test_asset_observations(self, graphql_context: WorkspaceRequestContext):
         _create_run(graphql_context, "observation_job")


### PR DESCRIPTION
Summary:
This has no callsites and may be expensive since it is initialized in the constructor of the graphql object. Try removing it.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
