### PR TITLE
[dagit] If there is no asset selection, don’t fetch any asset partition definitions

### DIFF
--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -165,7 +165,9 @@ const ConfigEditorPartitionPicker: React.FC<ConfigEditorPartitionPickerProps> = 
       variables: {
         repositorySelector,
         partitionSetName,
-        assetKeys: assetSelection?.map((selection) => ({path: selection.assetKey.path})),
+        assetKeys: assetSelection
+          ? assetSelection.map((selection) => ({path: selection.assetKey.path}))
+          : [],
       },
       fetchPolicy: 'network-only',
     });


### PR DESCRIPTION
## Summary & Motivation

Discussion: https://elementl-workspace.slack.com/archives/C03CA4TVCAW/p1681931733988229

If you open the launchpad with no assetSelection (eg: for a standard non-asset run), we pass `undefined` to the query, which omits the query parameter on `assetNodes(assetKeys: $assetKeys)`, loading ALL asset nodes in the repo.

Note: This is just the front-end fix -- we also need to update the backend to discern between `undefined` and `empty array` and return nothing in the empty array case.

## How I Tested These Changes

I checked in Dagit that opening the launchpad before this change passed no params to `assetNodes()`, and that after this change, it passes `assetNodes(assetKeys: [])`