### PR TITLE
Distinguish between an empty list of asset keys and passing None to the assetKeys parameter

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -742,10 +742,16 @@ class GrapheneDagitQuery(graphene.ObjectType):
         pipeline: Optional[GraphenePipelineSelector] = None,
         assetKeys: Optional[Sequence[GrapheneAssetKeyInput]] = None,
     ) -> Sequence[GrapheneAssetNode]:
-        resolved_asset_keys = set(
-            AssetKey.from_graphql_input(asset_key_input) for asset_key_input in assetKeys or []
-        )
-        use_all_asset_keys = len(resolved_asset_keys) == 0
+        if assetKeys == []:
+            return []
+        elif not assetKeys:
+            use_all_asset_keys = True
+            resolved_asset_keys = None
+        else:
+            use_all_asset_keys = False
+            resolved_asset_keys = set(
+                AssetKey.from_graphql_input(asset_key_input) for asset_key_input in assetKeys or []
+            )
 
         repo = None
 
@@ -794,7 +800,9 @@ class GrapheneDagitQuery(graphene.ObjectType):
 
         # Filter down to requested asset keys
         results = [
-            node for node in results if use_all_asset_keys or node.assetKey in resolved_asset_keys
+            node
+            for node in results
+            if use_all_asset_keys or node.assetKey in check.not_none(resolved_asset_keys)
         ]
 
         if not results:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -1602,6 +1602,30 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert len(counts) == 1
         assert counts.get("DagsterInstance.get_asset_records") == 1
 
+    def test_batch_empty_list(self, graphql_context: WorkspaceRequestContext):
+        traced_counter.set(Counter())
+        result = execute_dagster_graphql(
+            graphql_context,
+            BATCH_LOAD_ASSETS,
+            variables={
+                "assetKeys": [],
+            },
+        )
+        assert result.data
+        assert len(result.data["assetNodes"]) == 0
+
+    def test_batch_null_keys(self, graphql_context: WorkspaceRequestContext):
+        traced_counter.set(Counter())
+        result = execute_dagster_graphql(
+            graphql_context,
+            BATCH_LOAD_ASSETS,
+            variables={
+                "assetKeys": None,
+            },
+        )
+        assert result.data
+        assert len(result.data["assetNodes"]) > 0
+
     def test_get_partitions_by_dimension(self, graphql_context: WorkspaceRequestContext):
         result = execute_dagster_graphql(
             graphql_context,


### PR DESCRIPTION
Summary:
I don't love that this requires callsites to distinguish between an empty list and None, but this makes it so that if you have a query that fetches assetNodes and explicitly passes in [] to the list of asset keys, it will return onone of them instead of all of them.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
