### PR TITLE
[docs] Apply max width to docs pages

### DIFF
--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -220,10 +220,7 @@ const RightSidebar = ({editMode, navigationItems, githubLink, toggleFeedback}) =
 
 export const VersionedContentLayout = ({children, asPath = null}) => {
   return (
-    <div
-      className="flex-1 w-full min-w-0 relative z-0 focus:outline-none flex-col flex items-center"
-      tabIndex={0}
-    >
+    <div className="flex-1 w-full min-w-0 relative z-0 focus:outline-none" tabIndex={0}>
       <div className="flex flex-col lg:mt-5 max-w-7xl">
         <div className="flex justify-between px-4 mb-4">
           <div className="flex justify-start flex-col lg:flex-row lg:px-4 w-full">
@@ -281,11 +278,11 @@ export function UnversionedMDXRenderer({
           description: frontMatter.description,
         }}
       />
-      <div
-        className="flex-1 min-w-0 relative z-0 focus:outline-none pt-4 flex-col flex items-center"
-        tabIndex={0}
-      >
-        <div className="flex flex-row pb-8 max-w-7xl">
+      <div className="flex-1 min-w-0 relative z-0 focus:outline-none pt-4" tabIndex={0}>
+        <div
+          className="flex flex-row pb-8 max-w-7xl"
+          style={{marginLeft: 'auto', marginRight: 'auto'}}
+        >
           {/* Start main area*/}
 
           <div className="py-4 px-4 sm:px-6 lg:px-8 w-full">

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -220,8 +220,11 @@ const RightSidebar = ({editMode, navigationItems, githubLink, toggleFeedback}) =
 
 export const VersionedContentLayout = ({children, asPath = null}) => {
   return (
-    <div className="flex-1 w-full min-w-0 relative z-0 focus:outline-none" tabIndex={0}>
-      <div className="flex flex-col lg:mt-5">
+    <div
+      className="flex-1 w-full min-w-0 relative z-0 focus:outline-none flex-col flex items-center"
+      tabIndex={0}
+    >
+      <div className="flex flex-col lg:mt-5 max-w-7xl">
         <div className="flex justify-between px-4 mb-4">
           <div className="flex justify-start flex-col lg:flex-row lg:px-4 w-full">
             <div className="flex">
@@ -278,8 +281,11 @@ export function UnversionedMDXRenderer({
           description: frontMatter.description,
         }}
       />
-      <div className="flex-1 min-w-0 relative z-0 focus:outline-none pt-4" tabIndex={0}>
-        <div className="flex flex-row pb-8">
+      <div
+        className="flex-1 min-w-0 relative z-0 focus:outline-none pt-4 flex-col flex items-center"
+        tabIndex={0}
+      >
+        <div className="flex flex-row pb-8 max-w-7xl">
           {/* Start main area*/}
 
           <div className="py-4 px-4 sm:px-6 lg:px-8 w-full">

--- a/docs/next/components/mdx/MDXRenderer.tsx
+++ b/docs/next/components/mdx/MDXRenderer.tsx
@@ -221,7 +221,10 @@ const RightSidebar = ({editMode, navigationItems, githubLink, toggleFeedback}) =
 export const VersionedContentLayout = ({children, asPath = null}) => {
   return (
     <div className="flex-1 w-full min-w-0 relative z-0 focus:outline-none" tabIndex={0}>
-      <div className="flex flex-col lg:mt-5 max-w-7xl">
+      <div
+        className="flex flex-col lg:mt-5 max-w-7xl"
+        style={{marginLeft: 'auto', marginRight: 'auto'}}
+      >
         <div className="flex justify-between px-4 mb-4">
           <div className="flex justify-start flex-col lg:flex-row lg:px-4 w-full">
             <div className="flex">


### PR DESCRIPTION
## Summary

Proposal stemming from #13780 which adds a max width to main docs body content. Currently uses 1280px (`max-w-7xl`), which reads nicely in my subjective opinion.

A few comparisons

Unaltered
![Screen Shot 2023-04-19 at 2 17 16 PM](https://user-images.githubusercontent.com/10215173/233203166-8b4ecd66-595d-441f-afd8-c7c370973082.png)


5xl
![Screen Shot 2023-04-19 at 2 17 44 PM](https://user-images.githubusercontent.com/10215173/233203180-a7ac19c8-acae-45e9-ae6d-684ec091b20b.png)


7xl (in this PR)
![Screen Shot 2023-04-19 at 2 17 59 PM](https://user-images.githubusercontent.com/10215173/233203202-f1e054c5-8d71-40ef-a85f-c313e0c70105.png)
