### PR TITLE
add fetch depth 1000 so that the mdx preview link does not fail

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000
 
       - name: Get changed docs files
         if: ${{ github.event.pull_request }}

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guides | Dagster Docs
+title: Guides | Dagster Docs WAHWAH
 ---
 
 # Guides

--- a/docs/content/guides.mdx
+++ b/docs/content/guides.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guides | Dagster Docs WAHWAH
+title: Guides | Dagster Docs
 ---
 
 # Guides


### PR DESCRIPTION
## Summary & Motivation
We compare the head to the branch base to get a list of links to generate.

If there are more than one commits in the branch, this command will fail (see https://github.com/dagster-io/dagster/actions/runs/4734422024).

This PR sets the depth to 1000, which I think is the standard with the original checkout anyway ( how github actions powers the `on: paths:` directive.

## How I Tested These Changes
This very PR