### PR TITLE
Clean up is_job fields and references

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -871,7 +871,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         ]
 
     def resolve_isJob(self, _graphene_info: ResolveInfo):
-        return self._external_pipeline.is_job
+        return True
 
     def resolve_isAssetJob(self, graphene_info: ResolveInfo):
         handle = self._external_pipeline.repository_handle

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -314,13 +314,11 @@ class ExternalPipeline(RepresentedPipeline):
         if external_pipeline_data:
             self._active_preset_dict = {ap.name: ap for ap in external_pipeline_data.active_presets}
             self._name = external_pipeline_data.name
-            self._is_job = external_pipeline_data.is_job
             self._snapshot_id = self._pipeline_index.pipeline_snapshot_id
 
         elif external_job_ref:
             self._active_preset_dict = {ap.name: ap for ap in external_job_ref.active_presets}
             self._name = external_job_ref.name
-            self._is_job = not external_job_ref.is_legacy_pipeline
             if ref_to_data_fn is None:
                 check.failed("ref_to_data_fn must be passed when using deferred snapshots")
             self._snapshot_id = external_job_ref.snapshot_id

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -251,7 +251,7 @@ class ExternalPipelineSubsetResult(
         )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(old_fields={"is_job": True})
 class ExternalPipelineData(
     NamedTuple(
         "_ExternalPipelineData",
@@ -260,7 +260,6 @@ class ExternalPipelineData(
             ("pipeline_snapshot", PipelineSnapshot),
             ("active_presets", Sequence["ExternalPresetData"]),
             ("parent_pipeline_snapshot", Optional[PipelineSnapshot]),
-            ("is_job", bool),
         ],
     )
 ):
@@ -270,7 +269,6 @@ class ExternalPipelineData(
         pipeline_snapshot: PipelineSnapshot,
         active_presets: Sequence["ExternalPresetData"],
         parent_pipeline_snapshot: Optional[PipelineSnapshot],
-        is_job: bool = False,
     ):
         return super(ExternalPipelineData, cls).__new__(
             cls,
@@ -284,7 +282,6 @@ class ExternalPipelineData(
             active_presets=check.sequence_param(
                 active_presets, "active_presets", of_type=ExternalPresetData
             ),
-            is_job=check.bool_param(is_job, "is_job"),
         )
 
 
@@ -311,7 +308,7 @@ class NestedResource(NamedTuple):
     name: str
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(old_fields={"is_legacy_pipeline": False})
 class ExternalJobRef(
     NamedTuple(
         "_ExternalJobRef",
@@ -320,7 +317,6 @@ class ExternalJobRef(
             ("snapshot_id", str),
             ("active_presets", Sequence["ExternalPresetData"]),
             ("parent_snapshot_id", Optional[str]),
-            ("is_legacy_pipeline", bool),
         ],
     )
 ):
@@ -330,7 +326,6 @@ class ExternalJobRef(
         snapshot_id: str,
         active_presets: Sequence["ExternalPresetData"],
         parent_snapshot_id: Optional[str],
-        is_legacy_pipeline: bool = False,
     ):
         return super(ExternalJobRef, cls).__new__(
             cls,
@@ -340,7 +335,6 @@ class ExternalJobRef(
                 active_presets, "active_presets", of_type=ExternalPresetData
             ),
             parent_snapshot_id=check.opt_str_param(parent_snapshot_id, "parent_snapshot_id"),
-            is_legacy_pipeline=check.bool_param(is_legacy_pipeline, "is_legacy"),
         )
 
 
@@ -1485,26 +1479,17 @@ def external_pipeline_data_from_def(pipeline_def: JobDefinition) -> ExternalPipe
         pipeline_snapshot=pipeline_def.get_pipeline_snapshot(),
         parent_pipeline_snapshot=pipeline_def.get_parent_pipeline_snapshot(),
         active_presets=active_presets_from_job_def(pipeline_def),
-        is_job=True,
     )
 
 
 def external_job_ref_from_def(pipeline_def: JobDefinition) -> ExternalJobRef:
     check.inst_param(pipeline_def, "pipeline_def", JobDefinition)
 
-    parent_snapshot_id = None
-    # parent = pipeline_def.parent_pipeline_def
-    # if parent:
-    #     parent_snapshot_id = parent.get_pipeline_snapshot_id()
-    # else:
-    #     parent_snapshot_id = None
-
     return ExternalJobRef(
         name=pipeline_def.name,
         snapshot_id=pipeline_def.get_pipeline_snapshot_id(),
-        parent_snapshot_id=parent_snapshot_id,
+        parent_snapshot_id=None,
         active_presets=active_presets_from_job_def(pipeline_def),
-        is_legacy_pipeline=False,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -40,7 +40,7 @@ def create_creation_data(job_def):
         logger_defs=default_loggers(),
         ignored_nodes=[],
         required_resources=set(),
-        direct_inputs=job_def._input_values if job_def.is_job else {},  # noqa: SLF001
+        direct_inputs=job_def._input_values,  # noqa: SLF001
         asset_layer=job_def.asset_layer,
     )
 


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5496

Clean up some lingering job/pipeline branching code after removal of `PipelineDefinition`. In the process, fix a GQL bug where the now non-existent property `is_job` is accessed.

## How I Tested These Changes

Existing test suite, verifying dagit works for executing basic jobs.
