### PR TITLE
Add `node_info_to_auto_materialize_policy_fn` to `load_assets_from_dbt_*`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -20,6 +20,7 @@ import dateutil
 from dagster import (
     AssetKey,
     AssetsDefinition,
+    AutoMaterializePolicy,
     FreshnessPolicy,
     In,
     OpExecutionContext,
@@ -31,7 +32,6 @@ from dagster import (
 )
 from dagster._config.field import Field
 from dagster._config.field_utils import Permissive
-from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.events import (
     AssetMaterialization,
     AssetObservation,
@@ -497,7 +497,7 @@ def load_assets_from_dbt_project(
             `dagster_freshness_policy={"maximum_lag_minutes": 60, "cron_schedule": "0 9 * * *"}`
             will result in that model being assigned
             `FreshnessPolicy(maximum_lag_minutes=60, cron_schedule="0 9 * * *")`
-        node_info_to_auto_materialize_policy_fn (Dict[str, Any] -> Optional[FreshnessPolicy]):
+        node_info_to_auto_materialize_policy_fn (Dict[str, Any] -> Optional[AutoMaterializePolicy]):
             A function that takes a dictionary of dbt node info and optionally returns a AutoMaterializePolicy
             that should be applied to this node. By default, AutoMaterializePolicies will be created from
             config applied to dbt models, i.e.:
@@ -619,7 +619,7 @@ def load_assets_from_dbt_manifest(
             `dagster_freshness_policy={"maximum_lag_minutes": 60, "cron_schedule": "0 9 * * *"}`
             will result in that model being assigned
             `FreshnessPolicy(maximum_lag_minutes=60, cron_schedule="0 9 * * *")`
-        node_info_to_auto_materialize_policy_fn (Dict[str, Any] -> Optional[FreshnessPolicy]):
+        node_info_to_auto_materialize_policy_fn (Dict[str, Any] -> Optional[AutoMaterializePolicy]):
             A function that takes a dictionary of dbt node info and optionally returns a AutoMaterializePolicy
             that should be applied to this node. By default, AutoMaterializePolicies will be created from
             config applied to dbt models, i.e.:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -40,6 +40,7 @@ from dbt.main import parse_args as dbt_parse_args
 
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,
+    default_auto_materialize_policy_fn,
     default_freshness_policy_fn,
     default_group_fn,
     default_metadata_fn,
@@ -311,6 +312,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             asset_outs,
             group_names_by_key,
             freshness_policies_by_key,
+            auto_materialize_policies_by_key,
             fqns_by_output_name,
             metadata_by_output_name,
         ) = get_asset_deps(
@@ -320,6 +322,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
             node_info_to_group_fn=self._node_info_to_group_fn,
             node_info_to_freshness_policy_fn=self._node_info_to_freshness_policy_fn,
             # TODO: In the future, allow this function to be specified
+            node_info_to_auto_materialize_policy_fn=default_auto_materialize_policy_fn,
             node_info_to_definition_metadata_fn=default_metadata_fn,
             # TODO: In the future, allow the IO manager to be specified.
             io_manager_key=None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_defs.py
@@ -6,6 +6,7 @@ import pytest
 from dagster import (
     AssetIn,
     AssetKey,
+    AutoMaterializePolicy,
     DailyPartitionsDefinition,
     FreshnessPolicy,
     ResourceDefinition,
@@ -272,6 +273,21 @@ def test_custom_freshness_policy():
 
     assert dbt_assets[0].freshness_policies_by_key == {
         key: FreshnessPolicy(maximum_lag_minutes=len(key.path[-1])) for key in dbt_assets[0].keys
+    }
+
+
+def test_custom_auto_materialize_policy():
+    manifest_path = file_relative_path(__file__, "sample_manifest.json")
+    with open(manifest_path, "r", encoding="utf8") as f:
+        manifest_json = json.load(f)
+
+    dbt_assets = load_assets_from_dbt_manifest(
+        manifest_json=manifest_json,
+        node_info_to_auto_materialize_policy_fn=lambda _: AutoMaterializePolicy.lazy(),
+    )
+
+    assert dbt_assets[0].auto_materialize_policies_by_key == {
+        key: AutoMaterializePolicy.lazy() for key in dbt_assets[0].keys
     }
 
 


### PR DESCRIPTION
## Summary & Motivation
With the launch of `AutoMaterializePolicy`s, I had an immediate use case to implement them into my dbt assets. The proposed solution follows the same pattern as the `node_info_to_freshness_policy_fn`, where users can specify the auto materialization policy by default by adding it to the dbt model config under `dagster_auto_materialize_policy: {"type": "eager" | "lazy"}`.

## How I Tested These Changes
Added unit test and tested locally, run was successfully kicked off. Granted, I'm not sure this small test will be enough, but happy to add more if necessary.