### PR TITLE
Calculate PR branch fetch depth instead of hard-coding to 1000

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - 'release-*'
     paths:
       - docs/**
   pull_request:
@@ -17,10 +16,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/checkout@v3
+
+      - name: 'Get PR fetch depth'
+        if: ${{ github.event.pull_request }}
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: 'Checkout PR branch'
+        uses: actions/checkout@v3
+        if: ${{ github.event.pull_request }}
         with:
-          fetch-depth: 1000
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
       - name: Get changed docs files
         if: ${{ github.event.pull_request }}


### PR DESCRIPTION
## Summary & Motivation
Based off of https://github.com/actions/checkout/issues/552

We should limit the fetch depth of the PR branch checkout to the bare minimum of what we need.

## How I Tested These Changes
Applied script to local repository, made sure that the main branch checkout happened and the PR checkout happened with the calculated fetch depth.