### PR TITLE
[fix] Fix late-resource binding error related to sensors with multiple jobs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -177,8 +177,8 @@ def _attach_resources_to_jobs_and_instigator_jobs(
         for schedule in schedules
     ]
     updated_sensors = [
-        sensor.with_updated_job(unsatisfied_job_to_resource_bound_job[id(sensor.job)])
-        if sensor.has_loadable_targets() and sensor.job in unsatisfied_jobs
+        sensor.with_updated_jobs([unsatisfied_job_to_resource_bound_job[id(job)] if job in unsatisfied_jobs else job for job in sensor.jobs])
+        if sensor.has_loadable_targets() and any(job in unsatisfied_jobs for job in sensor.jobs)
         else sensor
         for sensor in sensors
     ]

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -177,7 +177,12 @@ def _attach_resources_to_jobs_and_instigator_jobs(
         for schedule in schedules
     ]
     updated_sensors = [
-        sensor.with_updated_jobs([unsatisfied_job_to_resource_bound_job[id(job)] if job in unsatisfied_jobs else job for job in sensor.jobs])
+        sensor.with_updated_jobs(
+            [
+                unsatisfied_job_to_resource_bound_job[id(job)] if job in unsatisfied_jobs else job
+                for job in sensor.jobs
+            ]
+        )
         if sensor.has_loadable_targets() and any(job in unsatisfied_jobs for job in sensor.jobs)
         else sensor
         for sensor in sensors

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -510,7 +510,6 @@ class ScheduleDefinition:
             job=new_job,
             default_status=self.default_status,
         )
-        
 
     def __init__(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -510,6 +510,7 @@ class ScheduleDefinition:
             job=new_job,
             default_status=self.default_status,
         )
+        
 
     def __init__(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -461,8 +461,8 @@ class SensorDefinition:
             the sensor condition is met. This can be provided instead of specifying a job.
     """
 
-    def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":
-        """Returns a copy of this schedule with the job replaced.
+    def with_updated_jobs(self, new_jobs: Sequence[ExecutableDefinition]) -> "SensorDefinition":
+        """Returns a copy of this sensor with the jobs replaced.
 
         Args:
             job (ExecutableDefinition): The job that should execute when this
@@ -473,10 +473,20 @@ class SensorDefinition:
             evaluation_fn=self._evaluation_fn,
             minimum_interval_seconds=self.minimum_interval_seconds,
             description=self.description,
-            job=new_job,
+            jobs=new_jobs if len(new_jobs) > 1 else None,
+            job=new_jobs[0] if len(new_jobs) == 1 else None,
             default_status=self.default_status,
             asset_selection=self.asset_selection,
         )
+
+    def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":
+        """Returns a copy of this sensor with the job replaced.
+
+        Args:
+            job (ExecutableDefinition): The job that should execute when this
+                schedule runs.
+        """
+        return self.with_updated_jobs([new_job])
 
     def __init__(
         self,
@@ -618,6 +628,13 @@ class SensorDefinition:
                 raise DagsterInvalidDefinitionError(
                     "Job property not available when SensorDefinition has multiple jobs."
                 )
+        raise DagsterInvalidDefinitionError("No job was provided to SensorDefinition.")
+
+    @public
+    @property
+    def jobs(self) -> List[Union[JobDefinition, GraphDefinition, UnresolvedAssetJobDefinition]]:
+        if self._targets and all(isinstance(target, DirectTarget) for target in self._targets):
+            return [target.target for target in self._targets]
         raise DagsterInvalidDefinitionError("No job was provided to SensorDefinition.")
 
     @property

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_pythonic_config_resources.py
@@ -2568,7 +2568,7 @@ def test_context_on_resource_nested() -> None:
         assert executed["yes"]
 
 
-def bind_top_level_resource_sensor_multi_job() -> None:
+def test_bind_top_level_resource_sensor_multi_job() -> None:
     executed = {}
 
     class FooResource(ConfigurableResource):


### PR DESCRIPTION
## Summary

Fixes an issue where the late-binding top level resource logic was throwing errors by accessing `sensor.job`. This property getter errors when sensors are bound to many jobs.

This PR updates this logic to work against multiple jobs.

https://elementl-workspace.slack.com/archives/C04J8BRN9ST/p1681959401886829


## Test Plan

New test case, more todo.