### PR TITLE
[dagster-gcp] Dataproc resource upgrade to pythonic resource

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/__init__.py
@@ -17,8 +17,15 @@ from .bigquery.resources import (
     bigquery_resource as bigquery_resource,
 )
 from .bigquery.types import BigQueryError as BigQueryError
-from .dataproc.ops import dataproc_op as dataproc_op
-from .dataproc.resources import dataproc_resource as dataproc_resource
+from .dataproc.ops import (
+    DataprocOpConfig as DataprocOpConfig,
+    configurable_dataproc_op as configurable_dataproc_op,
+    dataproc_op as dataproc_op,
+)
+from .dataproc.resources import (
+    DataprocResource as DataprocResource,
+    dataproc_resource as dataproc_resource,
+)
 from .gcs import (
     GCSFileHandle as GCSFileHandle,
     gcs_file_manager as gcs_file_manager,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
@@ -1,14 +1,21 @@
 from typing import Any, Dict
 
-from dagster import Bool, Config, Int, op
+from dagster import (
+    Bool,
+    Config,
+    Field as DagsterField,
+    Int,
+    op,
+)
 from dagster._seven import json
 from pydantic import Field
 
 from .configs import define_dataproc_submit_job_config
 from .resources import TWENTY_MINUTES, DataprocResource
 
+# maintain the old config schema because of the nested job_config schema
 DATAPROC_CONFIG_SCHEMA = {
-    "job_timeout_in_seconds": Field(
+    "job_timeout_in_seconds": DagsterField(
         Int,
         description="""Optional. Maximum time in seconds to wait for the job being
                     completed. Default is set to 1200 seconds (20 minutes).
@@ -17,7 +24,7 @@ DATAPROC_CONFIG_SCHEMA = {
         default_value=TWENTY_MINUTES,
     ),
     "job_config": define_dataproc_submit_job_config(),
-    "job_scoped_cluster": Field(
+    "job_scoped_cluster": DagsterField(
         Bool,
         description="whether to create a cluster or use an existing cluster",
         is_required=False,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/ops.py
@@ -1,8 +1,11 @@
-from dagster import Bool, Field, Int, op
+from typing import Any, Dict
+
+from dagster import Bool, Config, Int, op
 from dagster._seven import json
+from pydantic import Field
 
 from .configs import define_dataproc_submit_job_config
-from .resources import TWENTY_MINUTES
+from .resources import TWENTY_MINUTES, DataprocResource
 
 DATAPROC_CONFIG_SCHEMA = {
     "job_timeout_in_seconds": Field(
@@ -21,6 +24,30 @@ DATAPROC_CONFIG_SCHEMA = {
         default_value=True,
     ),
 }
+
+
+class DataprocOpConfig(Config):
+    job_timeout_in_seconds: int = Field(
+        default=TWENTY_MINUTES,
+        description=(
+            "Maximum time in seconds to wait for the job being completed. Default is set to 1200"
+            " seconds (20 minutes)."
+        ),
+    )
+    job_scoped_cluster: bool = Field(
+        default=True,
+        description="Whether to create a cluster or use an existing cluster. Defaults to True.",
+    )
+    project_id: str = Field(
+        description=(
+            "Required. Project ID for the project which the client acts on behalf of. Will be"
+            " passed when creating a dataset/job."
+        )
+    )
+    region: str = Field(description="The GCP region.")
+    job_config: Dict[str, Any] = Field(
+        description="Python dictionary containing configuration for the Dataproc Job."
+    )
 
 
 def _dataproc_compute(context):
@@ -60,3 +87,35 @@ def dataproc_solid(context):
 @op(required_resource_keys={"dataproc"}, config_schema=DATAPROC_CONFIG_SCHEMA)
 def dataproc_op(context):
     return _dataproc_compute(context)
+
+
+@op
+def configurable_dataproc_op(context, dataproc: DataprocResource, config: DataprocOpConfig):
+    job_config = {"projectId": config.project_id, "region": config.region, "job": config.job_config}
+    job_timeout = config.job_timeout_in_seconds
+
+    context.log.info(
+        "submitting job with config: %s and timeout of: %d seconds"
+        % (str(json.dumps(job_config)), job_timeout)
+    )
+
+    dataproc_client = dataproc.get_client()
+
+    if config.job_scoped_cluster:
+        # Cluster context manager, creates and then deletes cluster
+        with dataproc_client.cluster_context_manager() as cluster:
+            # Submit the job specified by this solid to the cluster defined by the associated resource
+            result = cluster.submit_job(job_config)
+
+            job_id = result["reference"]["jobId"]
+            context.log.info(f"Submitted job ID {job_id}")
+            cluster.wait_for_job(job_id, wait_timeout=job_timeout)
+
+    else:
+        # Submit to an existing cluster
+        # Submit the job specified by this solid to the cluster defined by the associated resource
+        result = dataproc_client.submit_job(job_config)
+
+        job_id = result["reference"]["jobId"]
+        context.log.info(f"Submitted job ID {job_id}")
+        dataproc_client.wait_for_job(job_id, wait_timeout=job_timeout)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/dataproc/resources.py
@@ -12,7 +12,7 @@ TWENTY_MINUTES = 20 * 60
 DEFAULT_ITER_TIME_SEC = 5
 
 
-class DataprocResource:
+class DataprocClient:
     """Builds a client to the dataproc API."""
 
     def __init__(self, config):
@@ -68,7 +68,7 @@ class DataprocResource:
             cluster = self.get_cluster()
             return cluster["status"]["state"] in {"RUNNING", "UPDATING"}
 
-        done = DataprocResource._iter_and_sleep_until_ready(iter_fn)
+        done = DataprocClient._iter_and_sleep_until_ready(iter_fn)
         if not done:
             cluster = self.get_cluster()
             raise DataprocError(
@@ -112,7 +112,7 @@ class DataprocResource:
 
             return False
 
-        done = DataprocResource._iter_and_sleep_until_ready(iter_fn, max_wait_time_sec=wait_timeout)
+        done = DataprocClient._iter_and_sleep_until_ready(iter_fn, max_wait_time_sec=wait_timeout)
         if not done:
             job = self.get_job(job_id)
             raise DataprocError("Job run timed out: %s" % str(job["status"]))
@@ -154,4 +154,4 @@ class DataprocResource:
     description="Manage a Dataproc cluster resource",
 )
 def dataproc_resource(context):
-    return DataprocResource(context.resource_config)
+    return DataprocClient(context.resource_config)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
@@ -202,22 +202,67 @@ def test_pydantic_dataproc_resource():
             configurable_dataproc_op()
 
         result = test_dataproc.execute_in_process(
-            run_config={
-                "ops": {
-                    "dataproc_op": RunConfig(
-                        DataprocOpConfig(
+            run_config=RunConfig(
+                ops={
+                    "configurable_dataproc_op": DataprocOpConfig(
+                        job_scoped_cluster=True,
+                        project_id=PROJECT_ID,
+                        region=REGION,
+                        job_config={
+                            "reference": {"projectId": PROJECT_ID},
+                            "placement": {"clusterName": CLUSTER_NAME},
+                            "hiveJob": {"queryList": {"queries": ["SHOW DATABASES"]}},
+                        },
+                    )
+                },
+            ),
+            resources={
+                "dataproc": DataprocResource(
+                    project_id=PROJECT_ID,
+                    cluster_name=CLUSTER_NAME,
+                    region=REGION,
+                    cluster_config_dict={
+                        "softwareConfig": {
+                            "properties": {
+                                # Create a single-node cluster
+                                # This needs to be the string "true" when
+                                # serialized, not a boolean true
+                                "dataproc:dataproc.allow.zero.workers": "true"
+                            }
+                        }
+                    },
+                )
+            },
+        )
+        assert result.success
+
+
+def test_wait_for_job_with_timeout_pydantic():
+    """Test submitting a job with timeout of 0 second so that it always fails."""
+    with mock.patch("httplib2.Http", new=HttpSnooper):
+
+        @job
+        def test_dataproc():
+            configurable_dataproc_op()
+
+        try:
+            test_dataproc.execute_in_process(
+                run_config=RunConfig(
+                    ops={
+                        "configurable_dataproc_op": DataprocOpConfig(
                             job_scoped_cluster=True,
                             project_id=PROJECT_ID,
                             region=REGION,
+                            job_timeout_in_seconds=0,
                             job_config={
                                 "reference": {"projectId": PROJECT_ID},
                                 "placement": {"clusterName": CLUSTER_NAME},
                                 "hiveJob": {"queryList": {"queries": ["SHOW DATABASES"]}},
                             },
                         )
-                    )
-                },
-                "resources": {
+                    },
+                ),
+                resources={
                     "dataproc": DataprocResource(
                         project_id=PROJECT_ID,
                         cluster_name=CLUSTER_NAME,
@@ -234,55 +279,6 @@ def test_pydantic_dataproc_resource():
                         },
                     )
                 },
-            }
-        )
-        assert result.success
-
-
-def test_wait_for_job_with_timeout_pydantic():
-    """Test submitting a job with timeout of 0 second so that it always fails."""
-    with mock.patch("httplib2.Http", new=HttpSnooper):
-
-        @job
-        def test_dataproc():
-            configurable_dataproc_op()
-
-        try:
-            test_dataproc.execute_in_process(
-                run_config={
-                    "ops": {
-                        "dataproc_op": RunConfig(
-                            DataprocOpConfig(
-                                job_scoped_cluster=True,
-                                project_id=PROJECT_ID,
-                                region=REGION,
-                                job_timeout_in_seconds=0,
-                                job_config={
-                                    "reference": {"projectId": PROJECT_ID},
-                                    "placement": {"clusterName": CLUSTER_NAME},
-                                    "hiveJob": {"queryList": {"queries": ["SHOW DATABASES"]}},
-                                },
-                            )
-                        )
-                    },
-                    "resources": {
-                        "dataproc": DataprocResource(
-                            project_id=PROJECT_ID,
-                            cluster_name=CLUSTER_NAME,
-                            region=REGION,
-                            cluster_config_dict={
-                                "softwareConfig": {
-                                    "properties": {
-                                        # Create a single-node cluster
-                                        # This needs to be the string "true" when
-                                        # serialized, not a boolean true
-                                        "dataproc:dataproc.allow.zero.workers": "true"
-                                    }
-                                }
-                            },
-                        )
-                    },
-                }
             )
             assert False
         except Exception as e:

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/dataproc_tests/test_resources.py
@@ -4,8 +4,14 @@ import uuid
 from unittest import mock
 
 import httplib2
-from dagster import _seven, job
-from dagster_gcp import dataproc_op, dataproc_resource
+from dagster import RunConfig, _seven, job
+from dagster_gcp import (
+    DataprocOpConfig,
+    DataprocResource,
+    configurable_dataproc_op,
+    dataproc_op,
+    dataproc_resource,
+)
 
 PROJECT_ID = os.getenv("GCP_PROJECT_ID", "default_project")
 CLUSTER_NAME = "test-%s" % uuid.uuid4().hex
@@ -172,6 +178,109 @@ def test_wait_for_job_with_timeout():
                                 },
                             }
                         }
+                    },
+                }
+            )
+            assert False
+        except Exception as e:
+            assert "Job run timed out" in str(e)
+
+
+def test_pydantic_dataproc_resource():
+    """Tests pydantic dataproc cluster creation/deletion. Requests are captured by the responses library, so
+    no actual HTTP requests are made here.
+
+    Note that inspecting the HTTP requests can be useful for debugging, which can be done by adding:
+
+    import httplib2
+    httplib2.debuglevel = 4
+    """
+    with mock.patch("httplib2.Http", new=HttpSnooper):
+
+        @job
+        def test_dataproc():
+            configurable_dataproc_op()
+
+        result = test_dataproc.execute_in_process(
+            run_config={
+                "ops": {
+                    "dataproc_op": RunConfig(
+                        DataprocOpConfig(
+                            job_scoped_cluster=True,
+                            project_id=PROJECT_ID,
+                            region=REGION,
+                            job_config={
+                                "reference": {"projectId": PROJECT_ID},
+                                "placement": {"clusterName": CLUSTER_NAME},
+                                "hiveJob": {"queryList": {"queries": ["SHOW DATABASES"]}},
+                            },
+                        )
+                    )
+                },
+                "resources": {
+                    "dataproc": DataprocResource(
+                        project_id=PROJECT_ID,
+                        cluster_name=CLUSTER_NAME,
+                        region=REGION,
+                        cluster_config_dict={
+                            "softwareConfig": {
+                                "properties": {
+                                    # Create a single-node cluster
+                                    # This needs to be the string "true" when
+                                    # serialized, not a boolean true
+                                    "dataproc:dataproc.allow.zero.workers": "true"
+                                }
+                            }
+                        },
+                    )
+                },
+            }
+        )
+        assert result.success
+
+
+def test_wait_for_job_with_timeout_pydantic():
+    """Test submitting a job with timeout of 0 second so that it always fails."""
+    with mock.patch("httplib2.Http", new=HttpSnooper):
+
+        @job
+        def test_dataproc():
+            configurable_dataproc_op()
+
+        try:
+            test_dataproc.execute_in_process(
+                run_config={
+                    "ops": {
+                        "dataproc_op": RunConfig(
+                            DataprocOpConfig(
+                                job_scoped_cluster=True,
+                                project_id=PROJECT_ID,
+                                region=REGION,
+                                job_timeout_in_seconds=0,
+                                job_config={
+                                    "reference": {"projectId": PROJECT_ID},
+                                    "placement": {"clusterName": CLUSTER_NAME},
+                                    "hiveJob": {"queryList": {"queries": ["SHOW DATABASES"]}},
+                                },
+                            )
+                        )
+                    },
+                    "resources": {
+                        "dataproc": DataprocResource(
+                            project_id=PROJECT_ID,
+                            cluster_name=CLUSTER_NAME,
+                            region=REGION,
+                            cluster_config_dict={
+                                "softwareConfig": {
+                                    "properties": {
+                                        # Create a single-node cluster
+                                        # This needs to be the string "true" when
+                                        # serialized, not a boolean true
+                                        "dataproc:dataproc.allow.zero.workers": "true"
+                                    }
+                                }
+                            },
+                        )
                     },
                 }
             )


### PR DESCRIPTION
## Summary & Motivation
Rough first pass at converting the Dataproc resource to begin gathering feedback. This PR:
- renames `DataprocResource` class to `DataprocClient` (this class was not exported, so i think this should be fine)
- writes a new `DataProcResource` configurable resource
- The new resource can accept cluster config as a yaml file, json file, or python dictionary (we could trim this down to two options if we want)
- the new resource does not do any validation of the cluster config (we could try to add this if it seems valuable)
- the old resource is not updated to use the config of the new resource for 2 reasons: 1 - the config schema names are in camelCase and so a change to snake_case would be breaking, 2- the resource expects cluster config directly in the config schema. We could make the old resource accept the new resource config in addition to the old style config, and put deprecation warnings on old style config 

Lots still to do in this PR, most of which is testing, but i'd like to get a first pass of feedback on the general approach!
## How I Tested These Changes
