### PR TITLE
[1/n][Runs Table v2] Duplicate RunsRoot and RunsFilterInput so that we can gate new changes

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -168,7 +168,7 @@ export const RunTable = (props: RunTableProps) => {
 };
 
 export const RUN_TABLE_RUN_FRAGMENT = gql`
-  fragment RunTableRunNewFragment on Run {
+  fragment RunTableRunFragment on Run {
     id
     status
     stepKeysToExecute

--- a/js_modules/dagit/packages/core/src/runs/RunTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTable.tsx
@@ -168,7 +168,7 @@ export const RunTable = (props: RunTableProps) => {
 };
 
 export const RUN_TABLE_RUN_FRAGMENT = gql`
-  fragment RunTableRunFragment on Run {
+  fragment RunTableRunNewFragment on Run {
     id
     status
     stepKeysToExecute

--- a/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
@@ -168,7 +168,7 @@ export const RunTable = (props: RunTableProps) => {
 };
 
 export const RUN_TABLE_RUN_FRAGMENT = gql`
-  fragment RunTableRunFragment on Run {
+  fragment RunTableRunFragmentNew on Run {
     id
     status
     stepKeysToExecute

--- a/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
@@ -168,7 +168,7 @@ export const RunTable = (props: RunTableProps) => {
 };
 
 export const RUN_TABLE_RUN_FRAGMENT = gql`
-  fragment RunTableRunFragmentNew on Run {
+  fragment RunTableRunNewFragment on Run {
     id
     status
     stepKeysToExecute

--- a/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
@@ -1,0 +1,317 @@
+import {gql} from '@apollo/client';
+import {Box, Checkbox, Colors, Icon, NonIdealState, Table, Mono} from '@dagster-io/ui';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components/macro';
+
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {RunsFilter} from '../graphql/types';
+import {useSelectionReducer} from '../hooks/useSelectionReducer';
+import {PipelineSnapshotLink} from '../pipelines/PipelinePathUtils';
+import {PipelineReference} from '../pipelines/PipelineReference';
+import {AnchorButton} from '../ui/AnchorButton';
+import {
+  findRepositoryAmongOptions,
+  isThisThingAJob,
+  useRepositoryOptions,
+} from '../workspace/WorkspaceContext';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {useRepositoryForRunWithoutSnapshot} from '../workspace/useRepositoryForRun';
+import {workspacePipelinePath, workspacePipelinePathGuessRepo} from '../workspace/workspacePath';
+
+import {AssetKeyTagCollection} from './AssetKeyTagCollection';
+import {RunActionsMenu, RunBulkActionsMenu} from './RunActionsMenu';
+import {RunStatusTagWithStats} from './RunStatusTag';
+import {RunTags} from './RunTags';
+import {
+  assetKeysForRun,
+  RunStateSummary,
+  RunTime,
+  RUN_TIME_FRAGMENT,
+  titleForRun,
+} from './RunUtils';
+import {RunFilterToken} from './RunsFilterInput';
+import {RunTableRunFragment} from './types/RunTable.types';
+
+interface RunTableProps {
+  runs: RunTableRunFragment[];
+  filter?: RunsFilter;
+  onAddTag?: (token: RunFilterToken) => void;
+  actionBarComponents?: React.ReactNode;
+  highlightedIds?: string[];
+  additionalColumnHeaders?: React.ReactNode[];
+  additionalColumnsForRow?: (run: RunTableRunFragment) => React.ReactNode[];
+}
+
+export const RunTable = (props: RunTableProps) => {
+  const {runs, filter, onAddTag, highlightedIds, actionBarComponents} = props;
+  const allIds = runs.map((r) => r.id);
+
+  const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(allIds);
+
+  const canTerminateOrDeleteAny = React.useMemo(() => {
+    return runs.some((run) => run.hasTerminatePermission || run.hasDeletePermission);
+  }, [runs]);
+
+  const {options} = useRepositoryOptions();
+
+  if (runs.length === 0) {
+    const anyFilter = Object.keys(filter || {}).length;
+    return (
+      <div>
+        {actionBarComponents ? (
+          <Box padding={{vertical: 8, left: 24, right: 12}}>{actionBarComponents}</Box>
+        ) : null}
+        <Box margin={{vertical: 32}}>
+          {anyFilter ? (
+            <NonIdealState
+              icon="run"
+              title="No matching runs"
+              description="No runs were found for this filter."
+            />
+          ) : (
+            <NonIdealState
+              icon="run"
+              title="No runs found"
+              description={
+                <Box flex={{direction: 'column', gap: 12}}>
+                  <div>You have not launched any runs yet.</div>
+                  <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
+                    <AnchorButton icon={<Icon name="add_circle" />} to="/overview/jobs">
+                      Launch a run
+                    </AnchorButton>
+                    <span>or</span>
+                    <AnchorButton icon={<Icon name="materialization" />} to="/asset-groups">
+                      Materialize an asset
+                    </AnchorButton>
+                  </Box>
+                </Box>
+              }
+            />
+          )}
+        </Box>
+      </div>
+    );
+  }
+
+  let anyPipelines = false;
+  for (const run of runs) {
+    const {repositoryOrigin} = run;
+    if (repositoryOrigin) {
+      const repoAddress = buildRepoAddress(
+        repositoryOrigin.repositoryName,
+        repositoryOrigin.repositoryLocationName,
+      );
+      const repo = findRepositoryAmongOptions(options, repoAddress);
+      if (!repo || !isThisThingAJob(repo, run.pipelineName)) {
+        anyPipelines = true;
+        break;
+      }
+    }
+  }
+
+  const selectedFragments = runs.filter((run) => checkedIds.has(run.id));
+
+  return (
+    <>
+      <Box flex={{alignItems: 'center', gap: 12}} padding={{vertical: 8, left: 24, right: 12}}>
+        {actionBarComponents}
+        <div style={{flex: 1}} />
+        <RunBulkActionsMenu
+          selected={selectedFragments}
+          clearSelection={() => onToggleAll(false)}
+        />
+      </Box>
+
+      <Table>
+        <thead>
+          <tr>
+            <th style={{width: 42, paddingTop: 0, paddingBottom: 0}}>
+              {canTerminateOrDeleteAny ? (
+                <Checkbox
+                  indeterminate={checkedIds.size > 0 && checkedIds.size !== runs.length}
+                  checked={checkedIds.size === runs.length}
+                  onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                    if (e.target instanceof HTMLInputElement) {
+                      onToggleAll(e.target.checked);
+                    }
+                  }}
+                />
+              ) : null}
+            </th>
+            <th style={{width: 120}}>Status</th>
+            <th style={{width: 90}}>Run ID</th>
+            <th>{anyPipelines ? 'Job / Pipeline' : 'Job'}</th>
+            <th style={{width: 90}}>Snapshot ID</th>
+            <th style={{width: 190}}>Timing</th>
+            {props.additionalColumnHeaders}
+            <th style={{width: 52}} />
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <RunRow
+              canTerminateOrDelete={run.hasTerminatePermission || run.hasDeletePermission}
+              run={run}
+              key={run.id}
+              onAddTag={onAddTag}
+              checked={checkedIds.has(run.id)}
+              additionalColumns={props.additionalColumnsForRow?.(run)}
+              onToggleChecked={onToggleFactory(run.id)}
+              isHighlighted={highlightedIds && highlightedIds.includes(run.id)}
+            />
+          ))}
+        </tbody>
+      </Table>
+    </>
+  );
+};
+
+export const RUN_TABLE_RUN_FRAGMENT = gql`
+  fragment RunTableRunFragment on Run {
+    id
+    status
+    stepKeysToExecute
+    canTerminate
+    hasReExecutePermission
+    hasTerminatePermission
+    hasDeletePermission
+    mode
+    rootRunId
+    parentRunId
+    pipelineSnapshotId
+    pipelineName
+    repositoryOrigin {
+      id
+      repositoryName
+      repositoryLocationName
+    }
+    solidSelection
+    assetSelection {
+      ... on AssetKey {
+        path
+      }
+    }
+    status
+    tags {
+      key
+      value
+    }
+    ...RunTimeFragment
+  }
+
+  ${RUN_TIME_FRAGMENT}
+`;
+
+const RunRow: React.FC<{
+  run: RunTableRunFragment;
+  canTerminateOrDelete: boolean;
+  onAddTag?: (token: RunFilterToken) => void;
+  checked?: boolean;
+  onToggleChecked?: (values: {checked: boolean; shiftKey: boolean}) => void;
+  additionalColumns?: React.ReactNode[];
+  isHighlighted?: boolean;
+}> = ({
+  run,
+  canTerminateOrDelete,
+  onAddTag,
+  checked,
+  onToggleChecked,
+  additionalColumns,
+  isHighlighted,
+}) => {
+  const {pipelineName} = run;
+  const repo = useRepositoryForRunWithoutSnapshot(run);
+
+  const isJob = React.useMemo(() => {
+    if (repo) {
+      const pipelinesAndJobs = repo.match.repository.pipelines;
+      const match = pipelinesAndJobs.find((pipelineOrJob) => pipelineOrJob.name === pipelineName);
+      return !!match?.isJob;
+    }
+    return false;
+  }, [repo, pipelineName]);
+
+  const onChange = (e: React.FormEvent<HTMLInputElement>) => {
+    if (e.target instanceof HTMLInputElement) {
+      const {checked} = e.target;
+      const shiftKey =
+        e.nativeEvent instanceof MouseEvent && e.nativeEvent.getModifierState('Shift');
+      onToggleChecked && onToggleChecked({checked, shiftKey});
+    }
+  };
+
+  return (
+    <Row highlighted={!!isHighlighted}>
+      <td>
+        {canTerminateOrDelete && onToggleChecked ? (
+          <Checkbox checked={!!checked} onChange={onChange} />
+        ) : null}
+      </td>
+      <td>
+        <RunStatusTagWithStats status={run.status} runId={run.id} />
+      </td>
+      <td>
+        <Link to={`/runs/${run.id}`}>
+          <Mono>{titleForRun(run)}</Mono>
+        </Link>
+      </td>
+      <td>
+        <Box flex={{direction: 'column', gap: 5}}>
+          {isHiddenAssetGroupJob(run.pipelineName) ? (
+            <AssetKeyTagCollection assetKeys={assetKeysForRun(run)} />
+          ) : (
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <PipelineReference
+                isJob={isJob}
+                showIcon
+                pipelineName={run.pipelineName}
+                pipelineHrefContext="no-link"
+              />
+              <Link
+                to={
+                  repo
+                    ? workspacePipelinePath({
+                        repoName: repo.match.repository.name,
+                        repoLocation: repo.match.repositoryLocation.name,
+                        pipelineName: run.pipelineName,
+                        isJob,
+                      })
+                    : workspacePipelinePathGuessRepo(run.pipelineName)
+                }
+                target="_blank"
+              >
+                <Icon name="open_in_new" color={Colors.Blue500} />
+              </Link>
+            </Box>
+          )}
+          <RunTags
+            tags={run.tags}
+            mode={isJob ? (run.mode !== 'default' ? run.mode : null) : run.mode}
+            onAddTag={onAddTag}
+          />
+        </Box>
+      </td>
+      <td>
+        <PipelineSnapshotLink
+          snapshotId={run.pipelineSnapshotId || ''}
+          pipelineName={run.pipelineName}
+          size="normal"
+        />
+      </td>
+      <td>
+        <RunTime run={run} />
+        <RunStateSummary run={run} />
+      </td>
+      {additionalColumns}
+      <td>
+        <RunActionsMenu run={run} />
+      </td>
+    </Row>
+  );
+};
+
+const Row = styled.tr<{highlighted: boolean}>`
+  ${({highlighted}) =>
+    highlighted ? `box-shadow: inset 3px 3px #bfccd6, inset -3px -3px #bfccd6;` : null}
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
@@ -14,10 +14,11 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {DagsterRepoOption, useRepositoryOptions} from '../workspace/WorkspaceContext';
 
 import {
-  RunTagKeysQuery,
-  RunTagValuesQuery,
-  RunTagValuesQueryVariables,
-} from './types/RunsFilterInput.types';
+  RunTagKeysNewQuery,
+  RunTagKeysNewQueryVariables,
+  RunTagValuesNewQuery,
+  RunTagValuesNewQueryVariables,
+} from './types/RunsFilterInputNew.types';
 
 type RunTags = Array<{
   __typename: 'PipelineTagAndValues';
@@ -197,10 +198,13 @@ export const RunsFilterInput: React.FC<RunsFilterInputProps> = ({
 }) => {
   const {options} = useRepositoryOptions();
   const [selectedTagKey, setSelectedTagKey] = React.useState<string | undefined>();
-  const [fetchTagKeys, {data: tagKeyData}] = useLazyQuery<RunTagKeysQuery>(RUN_TAG_KEYS_QUERY);
+  const [fetchTagKeys, {data: tagKeyData}] = useLazyQuery<
+    RunTagKeysNewQuery,
+    RunTagKeysNewQueryVariables
+  >(RUN_TAG_KEYS_QUERY);
   const [fetchTagValues, {data: tagValueData}] = useLazyQuery<
-    RunTagValuesQuery,
-    RunTagValuesQueryVariables
+    RunTagValuesNewQuery,
+    RunTagValuesNewQueryVariables
   >(RUN_TAG_VALUES_QUERY, {
     variables: {tagKeys: selectedTagKey ? [selectedTagKey] : []},
   });
@@ -276,7 +280,7 @@ export const RunsFilterInput: React.FC<RunsFilterInputProps> = ({
 };
 
 const RUN_TAG_KEYS_QUERY = gql`
-  query RunTagKeysQuery {
+  query RunTagKeysNewQuery {
     runTagKeysOrError {
       ... on RunTagKeys {
         keys
@@ -286,7 +290,7 @@ const RUN_TAG_KEYS_QUERY = gql`
 `;
 
 const RUN_TAG_VALUES_QUERY = gql`
-  query RunTagValuesQuery($tagKeys: [String!]!) {
+  query RunTagValuesNewQuery($tagKeys: [String!]!) {
     runTagsOrError(tagKeys: $tagKeys) {
       __typename
       ... on RunTags {

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
@@ -1,0 +1,300 @@
+import {gql, useLazyQuery} from '@apollo/client';
+import {
+  SuggestionProvider,
+  TokenizingField,
+  TokenizingFieldValue,
+  tokensAsStringArray,
+  tokenizedValuesFromStringArray,
+} from '@dagster-io/ui';
+import qs from 'qs';
+import * as React from 'react';
+
+import {RunsFilter, RunStatus} from '../graphql/types';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {DagsterRepoOption, useRepositoryOptions} from '../workspace/WorkspaceContext';
+
+import {
+  RunTagKeysQuery,
+  RunTagValuesQuery,
+  RunTagValuesQueryVariables,
+} from './types/RunsFilterInput.types';
+
+type RunTags = Array<{
+  __typename: 'PipelineTagAndValues';
+  key: string;
+  values: Array<string>;
+}>;
+
+export type RunFilterTokenType = 'id' | 'status' | 'pipeline' | 'job' | 'snapshotId' | 'tag';
+
+export type RunFilterToken = {
+  token?: RunFilterTokenType;
+  value: string;
+};
+
+const RUN_PROVIDERS_EMPTY = [
+  {
+    token: 'id',
+    values: () => [],
+  },
+  {
+    token: 'status',
+    values: () => [],
+  },
+  {
+    token: 'pipeline',
+    values: () => [],
+  },
+  {
+    token: 'job',
+    values: () => [],
+  },
+  {
+    token: 'tag',
+    values: () => [],
+  },
+  {
+    token: 'snapshotId',
+    values: () => [],
+  },
+];
+
+/**
+ * This React hook provides run filtering state similar to React.useState(), but syncs
+ * the value to the URL query string so that reloading the page / navigating "back"
+ * maintains your view as expected.
+ *
+ * @param enabledFilters: This is useful if you want to ignore some filters that could
+ * be provided (eg pipeline:, which is not relevant within pipeline scoped views.)
+ */
+export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[]) {
+  return useQueryPersistedState<RunFilterToken[]>(
+    React.useMemo(
+      () => ({
+        encode: (tokens) => ({q: tokensAsStringArray(tokens), cursor: undefined}),
+        decode: ({q = []}) =>
+          tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY).filter(
+            (t) =>
+              !t.token || !enabledFilters || enabledFilters.includes(t.token as RunFilterTokenType),
+          ) as RunFilterToken[],
+      }),
+      [enabledFilters],
+    ),
+  );
+}
+
+export function runsPathWithFilters(filterTokens: RunFilterToken[]) {
+  return `/runs?${qs.stringify({q: tokensAsStringArray(filterTokens)}, {arrayFormat: 'brackets'})}`;
+}
+
+export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
+  if (!search[0]) {
+    return {};
+  }
+
+  const obj: RunsFilter = {};
+
+  for (const item of search) {
+    if (item.token === 'pipeline' || item.token === 'job') {
+      obj.pipelineName = item.value;
+    } else if (item.token === 'id') {
+      obj.runIds = obj.runIds || [];
+      obj.runIds.push(item.value);
+    } else if (item.token === 'status') {
+      obj.statuses = obj.statuses || [];
+      obj.statuses.push(item.value as RunStatus);
+    } else if (item.token === 'snapshotId') {
+      obj.snapshotId = item.value;
+    } else if (item.token === 'tag') {
+      const [key, value = ''] = item.value.split('=');
+      if (obj.tags) {
+        obj.tags.push({key, value});
+      } else {
+        obj.tags = [{key, value}];
+      }
+    }
+  }
+
+  return obj;
+}
+
+function searchSuggestionsForRuns(
+  repositoryOptions: DagsterRepoOption[],
+  runTagKeys?: string[],
+  selectedRunTagKey?: string,
+  runTagValues?: RunTags,
+  enabledFilters?: RunFilterTokenType[],
+): SuggestionProvider[] {
+  const pipelineNames = new Set<string>();
+  const jobNames = new Set<string>();
+
+  for (const option of repositoryOptions) {
+    const {repository} = option;
+    for (const pipeline of repository.pipelines) {
+      if (pipeline.isJob) {
+        jobNames.add(pipeline.name);
+      } else {
+        pipelineNames.add(pipeline.name);
+      }
+    }
+  }
+
+  const suggestions: {token: RunFilterTokenType; values: () => string[]; textOnly?: boolean}[] = [
+    {
+      token: 'id',
+      values: () => [],
+    },
+    {
+      token: 'status',
+      values: () => Object.keys(RunStatus),
+    },
+    {
+      token: 'pipeline',
+      values: () => Array.from(pipelineNames),
+    },
+    {
+      token: 'job',
+      values: () => Array.from(jobNames),
+    },
+    {
+      token: 'tag',
+      values: () => {
+        if (!selectedRunTagKey) {
+          return (runTagKeys || []).map((key) => `${key}`);
+        }
+        return (runTagValues || [])
+          .filter(({key}) => key === selectedRunTagKey)
+          .map(({values}) => values.map((value) => `${selectedRunTagKey}=${value}`))
+          .flat();
+      },
+      textOnly: !selectedRunTagKey,
+    },
+    {
+      token: 'snapshotId',
+      values: () => [],
+    },
+  ];
+
+  if (enabledFilters) {
+    return suggestions.filter((x) => enabledFilters.includes(x.token));
+  }
+
+  return suggestions;
+}
+
+interface RunsFilterInputProps {
+  loading?: boolean;
+  tokens: RunFilterToken[];
+  onChange: (tokens: RunFilterToken[]) => void;
+  enabledFilters?: RunFilterTokenType[];
+}
+
+export const RunsFilterInput: React.FC<RunsFilterInputProps> = ({
+  loading,
+  tokens,
+  onChange,
+  enabledFilters,
+}) => {
+  const {options} = useRepositoryOptions();
+  const [selectedTagKey, setSelectedTagKey] = React.useState<string | undefined>();
+  const [fetchTagKeys, {data: tagKeyData}] = useLazyQuery<RunTagKeysQuery>(RUN_TAG_KEYS_QUERY);
+  const [fetchTagValues, {data: tagValueData}] = useLazyQuery<
+    RunTagValuesQuery,
+    RunTagValuesQueryVariables
+  >(RUN_TAG_VALUES_QUERY, {
+    variables: {tagKeys: selectedTagKey ? [selectedTagKey] : []},
+  });
+
+  React.useEffect(() => {
+    if (selectedTagKey) {
+      fetchTagValues();
+    }
+  }, [selectedTagKey, fetchTagValues]);
+
+  const suggestions = searchSuggestionsForRuns(
+    options,
+    tagKeyData?.runTagKeysOrError?.__typename === 'RunTagKeys'
+      ? tagKeyData.runTagKeysOrError.keys
+      : [],
+    selectedTagKey,
+    tagValueData?.runTagsOrError?.__typename === 'RunTags' ? tagValueData.runTagsOrError.tags : [],
+    enabledFilters,
+  );
+
+  const search = tokenizedValuesFromStringArray(tokensAsStringArray(tokens), suggestions);
+  const refreshSuggestions = (text: string) => {
+    if (!text.startsWith('tag:')) {
+      return;
+    }
+    const tagKeyText = text.slice(4);
+    if (
+      tagKeyData?.runTagKeysOrError?.__typename === 'RunTagKeys' &&
+      tagKeyData.runTagKeysOrError.keys.includes(tagKeyText)
+    ) {
+      setSelectedTagKey(tagKeyText);
+    }
+  };
+
+  const suggestionProvidersFilter = (
+    suggestionProviders: SuggestionProvider[],
+    values: TokenizingFieldValue[],
+  ) => {
+    const tokens: string[] = [];
+    for (const {token} of values) {
+      if (token) {
+        tokens.push(token);
+      }
+    }
+
+    // If id is set, then no other filters can be set
+    if (tokens.includes('id')) {
+      return [];
+    }
+
+    // Can only have one filter value for pipeline or id
+    const limitedTokens = new Set<string>(['id', 'job', 'pipeline', 'snapshotId']);
+    const presentLimitedTokens = tokens.filter((token) => limitedTokens.has(token));
+
+    return suggestionProviders.filter(
+      (provider) => !provider.token || !presentLimitedTokens.includes(provider.token),
+    );
+  };
+
+  const onFocus = React.useCallback(() => fetchTagKeys(), [fetchTagKeys]);
+
+  return (
+    <TokenizingField
+      values={search}
+      onChange={(values) => onChange(values as RunFilterToken[])}
+      onFocus={onFocus}
+      onTextChange={refreshSuggestions}
+      suggestionProviders={suggestions}
+      suggestionProvidersFilter={suggestionProvidersFilter}
+      loading={loading}
+    />
+  );
+};
+
+const RUN_TAG_KEYS_QUERY = gql`
+  query RunTagKeysQuery {
+    runTagKeysOrError {
+      ... on RunTagKeys {
+        keys
+      }
+    }
+  }
+`;
+
+const RUN_TAG_VALUES_QUERY = gql`
+  query RunTagValuesQuery($tagKeys: [String!]!) {
+    runTagsOrError(tagKeys: $tagKeys) {
+      __typename
+      ... on RunTags {
+        tags {
+          key
+          values
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
@@ -1,0 +1,290 @@
+import {ApolloError, gql, useQuery} from '@apollo/client';
+import {
+  Alert,
+  Box,
+  Colors,
+  CursorHistoryControls,
+  NonIdealState,
+  Page,
+  Tag,
+  tokenToString,
+} from '@dagster-io/ui';
+import partition from 'lodash/partition';
+import * as React from 'react';
+import {Link} from 'react-router-dom';
+
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {useTrackPageView} from '../app/analytics';
+import {InstancePageContext} from '../instance/InstancePageContext';
+import {useCanSeeConfig} from '../instance/useCanSeeConfig';
+import {Loading} from '../ui/Loading';
+import {StickyTableContainer} from '../ui/StickyTableContainer';
+
+import {useSelectedRunsTab} from './RunListTabs';
+import {RunTable, RUN_TABLE_RUN_FRAGMENT} from './RunTable';
+import {RunsQueryRefetchContext} from './RunUtils';
+import {
+  RunFilterTokenType,
+  RunsFilterInput,
+  runsFilterForSearchTokens,
+  useQueryPersistedRunFilters,
+  RunFilterToken,
+} from './RunsFilterInput';
+import {RunsPageHeader} from './RunsPageHeader';
+import {
+  QueueDaemonStatusQuery,
+  QueueDaemonStatusQueryVariables,
+  RunsRootQuery,
+  RunsRootQueryVariables,
+} from './types/RunsRoot.types';
+import {useCursorPaginatedQuery} from './useCursorPaginatedQuery';
+
+const PAGE_SIZE = 25;
+
+export const RunsRoot = () => {
+  useTrackPageView();
+
+  const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
+  const filter = runsFilterForSearchTokens(filterTokens);
+  const canSeeConfig = useCanSeeConfig();
+
+  const {queryResult, paginationProps} = useCursorPaginatedQuery<
+    RunsRootQuery,
+    RunsRootQueryVariables
+  >({
+    nextCursorForResult: (runs) => {
+      if (runs.pipelineRunsOrError.__typename !== 'Runs') {
+        return undefined;
+      }
+      return runs.pipelineRunsOrError.results[PAGE_SIZE - 1]?.id;
+    },
+    getResultArray: (data) => {
+      if (!data || data.pipelineRunsOrError.__typename !== 'Runs') {
+        return [];
+      }
+      return data.pipelineRunsOrError.results;
+    },
+    variables: {
+      filter,
+    },
+    query: RUNS_ROOT_QUERY,
+    pageSize: PAGE_SIZE,
+  });
+
+  const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
+
+  const currentTab = useSelectedRunsTab(filterTokens);
+  const staticStatusTags = currentTab !== 'all';
+  const [statusTokens, nonStatusTokens] = partition(
+    filterTokens,
+    (token) => token.token === 'status',
+  );
+
+  const setFilterTokensWithStatus = React.useCallback(
+    (tokens: RunFilterToken[]) => {
+      if (staticStatusTags) {
+        setFilterTokens([...statusTokens, ...tokens]);
+      } else {
+        setFilterTokens(tokens);
+      }
+    },
+    [setFilterTokens, staticStatusTags, statusTokens],
+  );
+
+  const onAddTag = React.useCallback(
+    (token: RunFilterToken) => {
+      const tokenAsString = tokenToString(token);
+      if (!nonStatusTokens.some((token) => tokenToString(token) === tokenAsString)) {
+        setFilterTokensWithStatus([...nonStatusTokens, token]);
+      }
+    },
+    [nonStatusTokens, setFilterTokensWithStatus],
+  );
+
+  const enabledFilters = React.useMemo(() => {
+    const filters: RunFilterTokenType[] = ['tag', 'snapshotId', 'id', 'job', 'pipeline'];
+
+    if (!staticStatusTags) {
+      filters.push('status');
+    }
+
+    return filters;
+  }, [staticStatusTags]);
+
+  const mutableTokens = React.useMemo(() => {
+    if (staticStatusTags) {
+      return filterTokens.filter((token) => token.token !== 'status');
+    }
+    return filterTokens;
+  }, [filterTokens, staticStatusTags]);
+
+  return (
+    <Page>
+      <RunsPageHeader refreshStates={[refreshState]} />
+      {currentTab === 'queued' && canSeeConfig ? (
+        <Box
+          flex={{direction: 'column', gap: 8}}
+          padding={{horizontal: 24, vertical: 16}}
+          border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+        >
+          <Alert
+            intent="info"
+            title={<Link to="/config#run_coordinator">View queue configuration</Link>}
+          />
+          <QueueDaemonAlert />
+        </Box>
+      ) : null}
+      <RunsQueryRefetchContext.Provider value={{refetch: queryResult.refetch}}>
+        <Loading
+          queryResult={queryResult}
+          allowStaleData
+          renderError={(error: ApolloError) => {
+            // In this case, a 400 is most likely due to invalid run filters, which are a GraphQL
+            // validation error but surfaced as a 400.
+            const badRequest = !!(
+              error?.networkError &&
+              'statusCode' in error.networkError &&
+              error.networkError.statusCode === 400
+            );
+            return (
+              <Box
+                flex={{direction: 'column', gap: 32}}
+                padding={{vertical: 8, left: 24, right: 12}}
+              >
+                <RunsFilterInput
+                  tokens={mutableTokens}
+                  onChange={setFilterTokensWithStatus}
+                  loading={queryResult.loading}
+                  enabledFilters={enabledFilters}
+                />
+                <NonIdealState
+                  icon="warning"
+                  title={badRequest ? 'Invalid run filters' : 'Unexpected error'}
+                  description={
+                    badRequest
+                      ? 'The specified run filters are not valid. Please check the filters and try again.'
+                      : 'An unexpected error occurred. Check the console for details.'
+                  }
+                />
+              </Box>
+            );
+          }}
+        >
+          {({pipelineRunsOrError}) => {
+            if (pipelineRunsOrError.__typename !== 'Runs') {
+              return (
+                <Box padding={{vertical: 64}}>
+                  <NonIdealState
+                    icon="error"
+                    title="Query Error"
+                    description={pipelineRunsOrError.message}
+                  />
+                </Box>
+              );
+            }
+
+            return (
+              <>
+                <StickyTableContainer $top={0}>
+                  <RunTable
+                    runs={pipelineRunsOrError.results.slice(0, PAGE_SIZE)}
+                    onAddTag={onAddTag}
+                    filter={filter}
+                    actionBarComponents={
+                      <Box flex={{direction: 'column', gap: 8}}>
+                        {currentTab !== 'all' ? (
+                          <Box flex={{direction: 'row', gap: 8}}>
+                            {filterTokens
+                              .filter((token) => token.token === 'status')
+                              .map(({token, value}) => (
+                                <Tag key={`${token}:${value}`}>{`${token}:${value}`}</Tag>
+                              ))}
+                          </Box>
+                        ) : null}
+                        <RunsFilterInput
+                          tokens={mutableTokens}
+                          onChange={setFilterTokensWithStatus}
+                          loading={queryResult.loading}
+                          enabledFilters={enabledFilters}
+                        />
+                      </Box>
+                    }
+                  />
+                </StickyTableContainer>
+                {pipelineRunsOrError.results.length > 0 ? (
+                  <div style={{marginTop: '16px'}}>
+                    <CursorHistoryControls {...paginationProps} />
+                  </div>
+                ) : null}
+              </>
+            );
+          }}
+        </Loading>
+      </RunsQueryRefetchContext.Provider>
+    </Page>
+  );
+};
+
+// Imported via React.lazy, which requires a default export.
+// eslint-disable-next-line import/no-default-export
+export default RunsRoot;
+
+const RUNS_ROOT_QUERY = gql`
+  query RunsRootQuery($limit: Int, $cursor: String, $filter: RunsFilter!) {
+    pipelineRunsOrError(limit: $limit, cursor: $cursor, filter: $filter) {
+      ... on Runs {
+        results {
+          id
+          ...RunTableRunFragment
+        }
+      }
+      ... on InvalidPipelineRunsFilterError {
+        message
+      }
+      ...PythonErrorFragment
+    }
+  }
+
+  ${RUN_TABLE_RUN_FRAGMENT}
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
+const QueueDaemonAlert = () => {
+  const {data} = useQuery<QueueDaemonStatusQuery, QueueDaemonStatusQueryVariables>(
+    QUEUE_DAEMON_STATUS_QUERY,
+  );
+  const {pageTitle} = React.useContext(InstancePageContext);
+  const status = data?.instance.daemonHealth.daemonStatus;
+  if (status?.required && !status?.healthy) {
+    return (
+      <Alert
+        intent="warning"
+        title="The queued run coordinator is not healthy."
+        description={
+          <div>
+            View <Link to="/health">{pageTitle}</Link> for details.
+          </div>
+        }
+      />
+    );
+  }
+  return null;
+};
+
+const QUEUE_DAEMON_STATUS_QUERY = gql`
+  query QueueDaemonStatusQuery {
+    instance {
+      id
+      daemonHealth {
+        id
+        daemonStatus(daemonType: "QUEUED_RUN_COORDINATOR") {
+          id
+          daemonType
+          healthy
+          required
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
@@ -22,7 +22,7 @@ import {Loading} from '../ui/Loading';
 import {StickyTableContainer} from '../ui/StickyTableContainer';
 
 import {useSelectedRunsTab} from './RunListTabs';
-import {RunTable, RUN_TABLE_RUN_FRAGMENT} from './RunTable';
+import {RunTable, RUN_TABLE_RUN_FRAGMENT} from './RunTableNew';
 import {RunsQueryRefetchContext} from './RunUtils';
 import {
   RunFilterTokenType,
@@ -33,11 +33,11 @@ import {
 } from './RunsFilterInput';
 import {RunsPageHeader} from './RunsPageHeader';
 import {
-  QueueDaemonStatusQuery,
-  QueueDaemonStatusQueryVariables,
-  RunsRootQuery,
-  RunsRootQueryVariables,
-} from './types/RunsRoot.types';
+  QueueDaemonStatusNewQuery,
+  QueueDaemonStatusNewQueryVariables,
+  RunsRootNewQuery,
+  RunsRootNewQueryVariables,
+} from './types/RunsRootNew.types';
 import {useCursorPaginatedQuery} from './useCursorPaginatedQuery';
 
 const PAGE_SIZE = 25;
@@ -50,8 +50,8 @@ export const RunsRoot = () => {
   const canSeeConfig = useCanSeeConfig();
 
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
-    RunsRootQuery,
-    RunsRootQueryVariables
+    RunsRootNewQuery,
+    RunsRootNewQueryVariables
   >({
     nextCursorForResult: (runs) => {
       if (runs.pipelineRunsOrError.__typename !== 'Runs') {
@@ -231,12 +231,12 @@ export const RunsRoot = () => {
 export default RunsRoot;
 
 const RUNS_ROOT_QUERY = gql`
-  query RunsRootQuery($limit: Int, $cursor: String, $filter: RunsFilter!) {
+  query RunsRootNewQuery($limit: Int, $cursor: String, $filter: RunsFilter!) {
     pipelineRunsOrError(limit: $limit, cursor: $cursor, filter: $filter) {
       ... on Runs {
         results {
           id
-          ...RunTableRunFragment
+          ...RunTableRunNewFragment
         }
       }
       ... on InvalidPipelineRunsFilterError {
@@ -251,7 +251,7 @@ const RUNS_ROOT_QUERY = gql`
 `;
 
 const QueueDaemonAlert = () => {
-  const {data} = useQuery<QueueDaemonStatusQuery, QueueDaemonStatusQueryVariables>(
+  const {data} = useQuery<QueueDaemonStatusNewQuery, QueueDaemonStatusNewQueryVariables>(
     QUEUE_DAEMON_STATUS_QUERY,
   );
   const {pageTitle} = React.useContext(InstancePageContext);
@@ -273,7 +273,7 @@ const QueueDaemonAlert = () => {
 };
 
 const QUEUE_DAEMON_STATUS_QUERY = gql`
-  query QueueDaemonStatusQuery {
+  query QueueDaemonStatusNewQuery {
     instance {
       id
       daemonHealth {

--- a/js_modules/dagit/packages/core/src/runs/types/RunTableNew.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTableNew.types.ts
@@ -2,7 +2,7 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunTableRunFragmentNewFragment = {
+export type RunTableRunNewFragment = {
   __typename: 'Run';
   id: string;
   status: Types.RunStatus;

--- a/js_modules/dagit/packages/core/src/runs/types/RunTableNew.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunTableNew.types.ts
@@ -1,0 +1,31 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type RunTableRunFragmentNewFragment = {
+  __typename: 'Run';
+  id: string;
+  status: Types.RunStatus;
+  stepKeysToExecute: Array<string> | null;
+  canTerminate: boolean;
+  hasReExecutePermission: boolean;
+  hasTerminatePermission: boolean;
+  hasDeletePermission: boolean;
+  mode: string;
+  rootRunId: string | null;
+  parentRunId: string | null;
+  pipelineSnapshotId: string | null;
+  pipelineName: string;
+  solidSelection: Array<string> | null;
+  startTime: number | null;
+  endTime: number | null;
+  updateTime: number | null;
+  repositoryOrigin: {
+    __typename: 'RepositoryOrigin';
+    id: string;
+    repositoryName: string;
+    repositoryLocationName: string;
+  } | null;
+  assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+  tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+};

--- a/js_modules/dagit/packages/core/src/runs/types/RunsFilterInputNew.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsFilterInputNew.types.ts
@@ -1,0 +1,28 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type RunTagKeysNewQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type RunTagKeysNewQuery = {
+  __typename: 'DagitQuery';
+  runTagKeysOrError:
+    | {__typename: 'PythonError'}
+    | {__typename: 'RunTagKeys'; keys: Array<string>}
+    | null;
+};
+
+export type RunTagValuesNewQueryVariables = Types.Exact<{
+  tagKeys: Array<Types.Scalars['String']> | Types.Scalars['String'];
+}>;
+
+export type RunTagValuesNewQuery = {
+  __typename: 'DagitQuery';
+  runTagsOrError:
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'RunTags';
+        tags: Array<{__typename: 'PipelineTagAndValues'; key: string; values: Array<string>}>;
+      }
+    | null;
+};

--- a/js_modules/dagit/packages/core/src/runs/types/RunsRootNew.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsRootNew.types.ts
@@ -1,0 +1,76 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type RunsRootNewQueryVariables = Types.Exact<{
+  limit?: Types.InputMaybe<Types.Scalars['Int']>;
+  cursor?: Types.InputMaybe<Types.Scalars['String']>;
+  filter: Types.RunsFilter;
+}>;
+
+export type RunsRootNewQuery = {
+  __typename: 'DagitQuery';
+  pipelineRunsOrError:
+    | {__typename: 'InvalidPipelineRunsFilterError'; message: string}
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'Runs';
+        results: Array<{
+          __typename: 'Run';
+          id: string;
+          status: Types.RunStatus;
+          stepKeysToExecute: Array<string> | null;
+          canTerminate: boolean;
+          hasReExecutePermission: boolean;
+          hasTerminatePermission: boolean;
+          hasDeletePermission: boolean;
+          mode: string;
+          rootRunId: string | null;
+          parentRunId: string | null;
+          pipelineSnapshotId: string | null;
+          pipelineName: string;
+          solidSelection: Array<string> | null;
+          startTime: number | null;
+          endTime: number | null;
+          updateTime: number | null;
+          repositoryOrigin: {
+            __typename: 'RepositoryOrigin';
+            id: string;
+            repositoryName: string;
+            repositoryLocationName: string;
+          } | null;
+          assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+          tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+        }>;
+      };
+};
+
+export type QueueDaemonStatusNewQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type QueueDaemonStatusNewQuery = {
+  __typename: 'DagitQuery';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    daemonHealth: {
+      __typename: 'DaemonHealth';
+      id: string;
+      daemonStatus: {
+        __typename: 'DaemonStatus';
+        id: string;
+        daemonType: string;
+        healthy: boolean | null;
+        required: boolean;
+      };
+    };
+  };
+};


### PR DESCRIPTION
## Summary & Motivation

We want to gate the new Runs changes being made in https://github.com/dagster-io/dagster/pull/13758/ and https://github.com/dagster-io/dagster/pull/13758/ 

To that end, since all of the changes are in RunsRoot, RunsFilterInput and RunsTable, I'm duplicating these files and will make the changes to these files to make it easier to review what actually changed. 

This is a lot simpler to maintain than adding a ton of conditional branching in the components but it does mean any changes in the mean time need to be made to both. I don't reckon we'll have both versions for long though or that we'll be making other changes to these components soon.

## How I Tested These Changes

Nothing to test these are just carbon copies and I will base my changes on top of these copies to make it easier to review
