### PR TITLE
Topologically sort assets in asset backfill resolver

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -300,20 +300,20 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             GraphenePartitionKeyRange,
         )
 
-        status_counts_by_asset = (
-            self._backfill_job.get_partitions_status_counts_and_totals_by_asset(
+        status_counts_per_asset = (
+            self._backfill_job.get_partitions_status_counts_and_totals_per_asset(
                 graphene_info.context
             )
         )
 
         asset_partition_status_counts = []
 
-        for asset_key, partitions_counts in status_counts_by_asset.items():
-            counts_by_status = partitions_counts[0]
+        for asset_status in status_counts_per_asset:
+            (asset_key, counts_by_status, total_num_partitions) = asset_status
             asset_partition_status_counts.append(
                 GrapheneAssetPartitionsStatusCounts(
                     assetKey=asset_key,
-                    numPartitionsTargeted=partitions_counts[1],
+                    numPartitionsTargeted=total_num_partitions,
                     numPartitionsRequested=counts_by_status[BackfillPartitionsStatus.REQUESTED],
                     numPartitionsCompleted=counts_by_status[BackfillPartitionsStatus.COMPLETED],
                     numPartitionsFailed=counts_by_status[BackfillPartitionsStatus.FAILED],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -300,16 +300,16 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             GraphenePartitionKeyRange,
         )
 
-        status_counts_per_asset = (
-            self._backfill_job.get_partitions_status_counts_and_totals_per_asset(
+        status_counts_by_asset = (
+            self._backfill_job.get_partitions_status_counts_and_totals_by_asset(
                 graphene_info.context
             )
         )
 
         asset_partition_status_counts = []
 
-        for asset_status in status_counts_per_asset:
-            (asset_key, counts_by_status, total_num_partitions) = asset_status
+        for asset_key, asset_status in status_counts_by_asset.items():
+            (counts_by_status, total_num_partitions) = asset_status
             asset_partition_status_counts.append(
                 GrapheneAssetPartitionsStatusCounts(
                     assetKey=asset_key,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1348,15 +1348,31 @@ def upstream_static_partitioned_asset():
 
 
 @asset(partitions_def=static_partitions_def)
+def middle_static_partitioned_asset_1(upstream_static_partitioned_asset):
+    return 1
+
+
+@asset(partitions_def=static_partitions_def)
+def middle_static_partitioned_asset_2(upstream_static_partitioned_asset):
+    return 1
+
+
+@asset(partitions_def=static_partitions_def)
 def downstream_static_partitioned_asset(
-    upstream_static_partitioned_asset,
+    middle_static_partitioned_asset_1, middle_static_partitioned_asset_2
 ):
-    assert upstream_static_partitioned_asset
+    assert middle_static_partitioned_asset_1
+    assert middle_static_partitioned_asset_2
 
 
 static_partitioned_assets_job = build_assets_job(
     "static_partitioned_assets_job",
-    assets=[upstream_static_partitioned_asset, downstream_static_partitioned_asset],
+    assets=[
+        upstream_static_partitioned_asset,
+        middle_static_partitioned_asset_1,
+        middle_static_partitioned_asset_2,
+        downstream_static_partitioned_asset,
+    ],
 )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_all_snapshot_ids.py
@@ -19719,42 +19719,7 @@ snapshots['test_all_snapshot_ids 129'] = '''{
         "scalar_kind": null,
         "type_param_keys": null
       },
-      "Shape.85dc493a9d77d7093872e3999b6173e59966de08": {
-        "__class__": "ConfigTypeSnap",
-        "description": null,
-        "enum_values": null,
-        "field_aliases": {
-          "ops": "solids"
-        },
-        "fields": [
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "downstream_static_partitioned_asset",
-            "type_key": "Shape.36f967aeb3f6dab9d3a24674eef563a75d431b7f"
-          },
-          {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": true,
-            "default_value_as_json_str": "{}",
-            "description": null,
-            "is_required": false,
-            "name": "upstream_static_partitioned_asset",
-            "type_key": "Shape.36f967aeb3f6dab9d3a24674eef563a75d431b7f"
-          }
-        ],
-        "given_name": null,
-        "key": "Shape.85dc493a9d77d7093872e3999b6173e59966de08",
-        "kind": {
-          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-        },
-        "scalar_kind": null,
-        "type_param_keys": null
-      },
-      "Shape.d800594f7cfe0b0e5d3c1a240c0f186db951d6ec": {
+      "Shape.c82b217e3252b4c1328ebc3077cca608f35b5300": {
         "__class__": "ConfigTypeSnap",
         "description": null,
         "enum_values": null,
@@ -19783,11 +19748,11 @@ snapshots['test_all_snapshot_ids 129'] = '''{
           {
             "__class__": "ConfigFieldSnap",
             "default_provided": true,
-            "default_value_as_json_str": "{\\"downstream_static_partitioned_asset\\": {}, \\"upstream_static_partitioned_asset\\": {}}",
+            "default_value_as_json_str": "{\\"downstream_static_partitioned_asset\\": {}, \\"middle_static_partitioned_asset_1\\": {}, \\"middle_static_partitioned_asset_2\\": {}, \\"upstream_static_partitioned_asset\\": {}}",
             "description": "Configure runtime parameters for ops or assets.",
             "is_required": false,
             "name": "ops",
-            "type_key": "Shape.85dc493a9d77d7093872e3999b6173e59966de08"
+            "type_key": "Shape.cf1286dc4e13bb2f079e3ad9932b61900aba74f3"
           },
           {
             "__class__": "ConfigFieldSnap",
@@ -19800,7 +19765,60 @@ snapshots['test_all_snapshot_ids 129'] = '''{
           }
         ],
         "given_name": null,
-        "key": "Shape.d800594f7cfe0b0e5d3c1a240c0f186db951d6ec",
+        "key": "Shape.c82b217e3252b4c1328ebc3077cca608f35b5300",
+        "kind": {
+          "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+        },
+        "scalar_kind": null,
+        "type_param_keys": null
+      },
+      "Shape.cf1286dc4e13bb2f079e3ad9932b61900aba74f3": {
+        "__class__": "ConfigTypeSnap",
+        "description": null,
+        "enum_values": null,
+        "field_aliases": {
+          "ops": "solids"
+        },
+        "fields": [
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "downstream_static_partitioned_asset",
+            "type_key": "Shape.36f967aeb3f6dab9d3a24674eef563a75d431b7f"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "middle_static_partitioned_asset_1",
+            "type_key": "Shape.36f967aeb3f6dab9d3a24674eef563a75d431b7f"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "middle_static_partitioned_asset_2",
+            "type_key": "Shape.36f967aeb3f6dab9d3a24674eef563a75d431b7f"
+          },
+          {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": true,
+            "default_value_as_json_str": "{}",
+            "description": null,
+            "is_required": false,
+            "name": "upstream_static_partitioned_asset",
+            "type_key": "Shape.36f967aeb3f6dab9d3a24674eef563a75d431b7f"
+          }
+        ],
+        "given_name": null,
+        "key": "Shape.cf1286dc4e13bb2f079e3ad9932b61900aba74f3",
         "kind": {
           "__enum__": "ConfigTypeKind.STRICT_SHAPE"
         },
@@ -19980,6 +19998,39 @@ snapshots['test_all_snapshot_ids 129'] = '''{
         "input_dep_snaps": [
           {
             "__class__": "InputDependencySnap",
+            "input_name": "middle_static_partitioned_asset_1",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": [
+              {
+                "__class__": "OutputHandleSnap",
+                "output_name": "result",
+                "solid_name": "middle_static_partitioned_asset_1"
+              }
+            ]
+          },
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "middle_static_partitioned_asset_2",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": [
+              {
+                "__class__": "OutputHandleSnap",
+                "output_name": "result",
+                "solid_name": "middle_static_partitioned_asset_2"
+              }
+            ]
+          }
+        ],
+        "is_dynamic_mapped": false,
+        "solid_def_name": "downstream_static_partitioned_asset",
+        "solid_name": "downstream_static_partitioned_asset",
+        "tags": {}
+      },
+      {
+        "__class__": "SolidInvocationSnap",
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
             "input_name": "upstream_static_partitioned_asset",
             "is_dynamic_collect": false,
             "upstream_output_snaps": [
@@ -19992,8 +20043,29 @@ snapshots['test_all_snapshot_ids 129'] = '''{
           }
         ],
         "is_dynamic_mapped": false,
-        "solid_def_name": "downstream_static_partitioned_asset",
-        "solid_name": "downstream_static_partitioned_asset",
+        "solid_def_name": "middle_static_partitioned_asset_1",
+        "solid_name": "middle_static_partitioned_asset_1",
+        "tags": {}
+      },
+      {
+        "__class__": "SolidInvocationSnap",
+        "input_dep_snaps": [
+          {
+            "__class__": "InputDependencySnap",
+            "input_name": "upstream_static_partitioned_asset",
+            "is_dynamic_collect": false,
+            "upstream_output_snaps": [
+              {
+                "__class__": "OutputHandleSnap",
+                "output_name": "result",
+                "solid_name": "upstream_static_partitioned_asset"
+              }
+            ]
+          }
+        ],
+        "is_dynamic_mapped": false,
+        "solid_def_name": "middle_static_partitioned_asset_2",
+        "solid_name": "middle_static_partitioned_asset_2",
         "tags": {}
       },
       {
@@ -20046,7 +20118,7 @@ snapshots['test_all_snapshot_ids 129'] = '''{
           "name": "io_manager"
         }
       ],
-      "root_config_key": "Shape.d800594f7cfe0b0e5d3c1a240c0f186db951d6ec"
+      "root_config_key": "Shape.c82b217e3252b4c1328ebc3077cca608f35b5300"
     }
   ],
   "name": "static_partitioned_assets_job",
@@ -20071,10 +20143,84 @@ snapshots['test_all_snapshot_ids 129'] = '''{
             "__class__": "InputDefSnap",
             "dagster_type_key": "Any",
             "description": null,
-            "name": "upstream_static_partitioned_asset"
+            "name": "middle_static_partitioned_asset_1"
+          },
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "name": "middle_static_partitioned_asset_2"
           }
         ],
         "name": "downstream_static_partitioned_asset",
+        "output_def_snaps": [
+          {
+            "__class__": "OutputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "is_dynamic": false,
+            "is_required": true,
+            "name": "result"
+          }
+        ],
+        "required_resource_keys": [],
+        "tags": {}
+      },
+      {
+        "__class__": "SolidDefSnap",
+        "config_field_snap": {
+          "__class__": "ConfigFieldSnap",
+          "default_provided": false,
+          "default_value_as_json_str": null,
+          "description": null,
+          "is_required": false,
+          "name": "config",
+          "type_key": "Any"
+        },
+        "description": null,
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "name": "upstream_static_partitioned_asset"
+          }
+        ],
+        "name": "middle_static_partitioned_asset_1",
+        "output_def_snaps": [
+          {
+            "__class__": "OutputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "is_dynamic": false,
+            "is_required": true,
+            "name": "result"
+          }
+        ],
+        "required_resource_keys": [],
+        "tags": {}
+      },
+      {
+        "__class__": "SolidDefSnap",
+        "config_field_snap": {
+          "__class__": "ConfigFieldSnap",
+          "default_provided": false,
+          "default_value_as_json_str": null,
+          "description": null,
+          "is_required": false,
+          "name": "config",
+          "type_key": "Any"
+        },
+        "description": null,
+        "input_def_snaps": [
+          {
+            "__class__": "InputDefSnap",
+            "dagster_type_key": "Any",
+            "description": null,
+            "name": "upstream_static_partitioned_asset"
+          }
+        ],
+        "name": "middle_static_partitioned_asset_2",
         "output_def_snaps": [
           {
             "__class__": "OutputDefSnap",
@@ -21327,7 +21473,7 @@ snapshots['test_all_snapshot_ids 13'] = '''{
   "tags": {}
 }'''
 
-snapshots['test_all_snapshot_ids 130'] = '635eb1e3540c1be556987dd91de7e792dbc0a625'
+snapshots['test_all_snapshot_ids 130'] = '21734e02964c4cc85ffd0f07bae688038b3c7833'
 
 snapshots['test_all_snapshot_ids 131'] = '''{
   "__class__": "PipelineSnapshot",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_assets.py
@@ -7,6 +7,1101 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_dynamic_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dynamic_in_multipartitions_fail'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dynamic_in_multipartitions_success'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fail_partition_materialization'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_partition_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_fail'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'no_multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_dynamic_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_dynamic_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dynamic_in_multipartitions_fail'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dynamic_in_multipartitions_success'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fail_partition_materialization'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_partition_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_fail'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'no_multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_dynamic_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetsOrError': {
+        '__typename': 'AssetConnection',
+        'nodes': [
+            {
+                'key': {
+                    'path': [
+                        'a'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_one'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_two'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'asset_yields_observation'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'b'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'baz'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'c'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'diamond_source'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_dynamic_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'downstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dummy_source_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dynamic_in_multipartitions_fail'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'dynamic_in_multipartitions_success'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fail_partition_materialization'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'first_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'foo_bar'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_bottom'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_left'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_right'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'fresh_diamond_top'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'grouped_asset_4'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_graph'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'hanging_partition_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'int_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'multipartitions_fail'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'never_runs_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'no_multipartitions_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'str_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'typed_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'unconnected'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_3'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'ungrouped_asset_5'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'untyped_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_dynamic_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_static_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'upstream_time_partitioned_asset'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'yield_partition_materialization'
+                    ]
+                }
+            }
+        ]
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetsOrError': {
         '__typename': 'AssetConnection',
@@ -252,6 +1347,20 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_la
             {
                 'key': {
                     'path': [
+                        'middle_static_partitioned_asset_1'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
+                        'middle_static_partitioned_asset_2'
+                    ]
+                }
+            },
+            {
+                'key': {
+                    'path': [
                         'multipartitions_1'
                     ]
                 }
@@ -358,6 +1467,69 @@ snapshots['TestAssetAwareEventLog.test_all_asset_keys[sqlite_with_default_run_la
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_asset_op[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'definition': {
+            'op': {
+                'description': None,
+                'inputDefinitions': [
+                    {
+                        'name': 'asset_one'
+                    }
+                ],
+                'name': 'asset_two',
+                'outputDefinitions': [
+                    {
+                        'name': 'result'
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_asset_op[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        'definition': {
+            'op': {
+                'description': None,
+                'inputDefinitions': [
+                    {
+                        'name': 'asset_one'
+                    }
+                ],
+                'name': 'asset_two',
+                'outputDefinitions': [
+                    {
+                        'name': 'result'
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'definition': {
+            'op': {
+                'description': None,
+                'inputDefinitions': [
+                    {
+                        'name': 'asset_one'
+                    }
+                ],
+                'name': 'asset_two',
+                'outputDefinitions': [
+                    {
+                        'name': 'result'
+                    }
+                ]
+            }
+        }
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         'definition': {
@@ -377,6 +1549,759 @@ snapshots['TestAssetAwareEventLog.test_asset_op[sqlite_with_default_run_launcher
             }
         }
     }
+}
+
+snapshots['TestAssetAwareEventLog.test_freshness_info[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetNodes': [
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
+        },
+        {
+            'freshnessInfo': {
+                'currentMinutesLate': 0.0,
+                'latestMaterializationMinutesLate': None
+            },
+            'freshnessPolicy': {
+                'cronSchedule': None,
+                'maximumLagMinutes': 30.0
+            },
+            'id': 'test.test_repo.["fresh_diamond_bottom"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_left"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_right"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_top"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["int_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["str_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["no_multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["typed_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["untyped_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_fail"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dynamic_in_multipartitions_fail"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dynamic_in_multipartitions_success"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_dynamic_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_dynamic_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fail_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["baz"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo_bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["unconnected"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_graph"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["first_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["never_runs_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_partition_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_4"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_5"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_yields_observation"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["yield_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_one"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_two"]'
+        }
+    ]
+}
+
+snapshots['TestAssetAwareEventLog.test_freshness_info[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetNodes': [
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
+        },
+        {
+            'freshnessInfo': {
+                'currentMinutesLate': 0.0,
+                'latestMaterializationMinutesLate': None
+            },
+            'freshnessPolicy': {
+                'cronSchedule': None,
+                'maximumLagMinutes': 30.0
+            },
+            'id': 'test.test_repo.["fresh_diamond_bottom"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_left"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_right"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_top"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["int_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["str_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["no_multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["typed_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["untyped_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_fail"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dynamic_in_multipartitions_fail"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dynamic_in_multipartitions_success"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_dynamic_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_dynamic_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fail_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["baz"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo_bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["unconnected"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_graph"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["first_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["never_runs_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_partition_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_4"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_5"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_yields_observation"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["yield_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_one"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_two"]'
+        }
+    ]
+}
+
+snapshots['TestAssetAwareEventLog.test_freshness_info[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetNodes': [
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dummy_source_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["diamond_source"]'
+        },
+        {
+            'freshnessInfo': {
+                'currentMinutesLate': 0.0,
+                'latestMaterializationMinutesLate': None
+            },
+            'freshnessPolicy': {
+                'cronSchedule': None,
+                'maximumLagMinutes': 30.0
+            },
+            'id': 'test.test_repo.["fresh_diamond_bottom"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_left"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_right"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fresh_diamond_top"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["int_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["str_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["no_multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["typed_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["untyped_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["multipartitions_fail"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dynamic_in_multipartitions_fail"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["dynamic_in_multipartitions_success"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_dynamic_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_dynamic_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["fail_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["baz"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["foo_bar"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["unconnected"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_graph"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["first_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["never_runs_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["hanging_partition_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["grouped_asset_4"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_3"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["ungrouped_asset_5"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_yields_observation"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["yield_partition_materialization"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_static_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["downstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["upstream_time_partitioned_asset"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_one"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["asset_two"]'
+        }
+    ]
 }
 
 snapshots['TestAssetAwareEventLog.test_freshness_info[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
@@ -595,6 +2520,16 @@ snapshots['TestAssetAwareEventLog.test_freshness_info[sqlite_with_default_run_la
         {
             'freshnessInfo': None,
             'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_1"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
+            'id': 'test.test_repo.["middle_static_partitioned_asset_2"]'
+        },
+        {
+            'freshnessInfo': None,
+            'freshnessPolicy': None,
             'id': 'test.test_repo.["upstream_static_partitioned_asset"]'
         },
         {
@@ -620,6 +2555,42 @@ snapshots['TestAssetAwareEventLog.test_freshness_info[sqlite_with_default_run_la
     ]
 }
 
+snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'assetLineage': [
+                ],
+                'label': 'a'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'assetLineage': [
+                ],
+                'label': 'a'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'assetLineage': [
+                ],
+                'label': 'a'
+            }
+        ]
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         'assetMaterializations': [
@@ -632,9 +2603,60 @@ snapshots['TestAssetAwareEventLog.test_get_asset_key_materialization[sqlite_with
     }
 }
 
+snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        '__typename': 'AssetNotFoundError'
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        '__typename': 'AssetNotFoundError'
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        '__typename': 'AssetNotFoundError'
+    }
+}
+
 snapshots['TestAssetAwareEventLog.test_get_asset_key_not_found[sqlite_with_default_run_launcher_managed_grpc_env] 1'] = {
     'assetOrError': {
         '__typename': 'AssetNotFoundError'
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'label': 'a',
+                'partition': 'partition_1'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'label': 'a',
+                'partition': 'partition_1'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'assetOrError': {
+        'assetMaterializations': [
+            {
+                'label': 'a',
+                'partition': 'partition_1'
+            }
+        ]
     }
 }
 
@@ -644,6 +2666,60 @@ snapshots['TestAssetAwareEventLog.test_get_partitioned_asset_key_materialization
             {
                 'label': 'a',
                 'partition': 'partition_1'
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_run_materialization[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'runsOrError': {
+        'results': [
+            {
+                'assetMaterializations': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'a'
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_run_materialization[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'runsOrError': {
+        'results': [
+            {
+                'assetMaterializations': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'a'
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_get_run_materialization[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'runsOrError': {
+        'results': [
+            {
+                'assetMaterializations': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'a'
+                            ]
+                        }
+                    }
+                ]
             }
         ]
     }
@@ -664,6 +2740,60 @@ snapshots['TestAssetAwareEventLog.test_get_run_materialization[sqlite_with_defau
                 ]
             }
         ]
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_op_assets[postgres_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'repositoryOrError': {
+        'usedSolid': {
+            'definition': {
+                'assetNodes': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'asset_two'
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_op_assets[postgres_with_default_run_launcher_managed_grpc_env] 1'] = {
+    'repositoryOrError': {
+        'usedSolid': {
+            'definition': {
+                'assetNodes': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'asset_two'
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+
+snapshots['TestAssetAwareEventLog.test_op_assets[sqlite_with_default_run_launcher_deployed_grpc_env] 1'] = {
+    'repositoryOrError': {
+        'usedSolid': {
+            'definition': {
+                'assetNodes': [
+                    {
+                        'assetKey': {
+                            'path': [
+                                'asset_two'
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
 }
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_solids.py
@@ -1045,6 +1045,38 @@ snapshots['test_query_all_solids 1'] = {
             {
                 '__typename': 'UsedSolid',
                 'definition': {
+                    'name': 'middle_static_partitioned_asset_1'
+                },
+                'invocations': [
+                    {
+                        'pipeline': {
+                            'name': 'static_partitioned_assets_job'
+                        },
+                        'solidHandle': {
+                            'handleID': 'middle_static_partitioned_asset_1'
+                        }
+                    }
+                ]
+            },
+            {
+                '__typename': 'UsedSolid',
+                'definition': {
+                    'name': 'middle_static_partitioned_asset_2'
+                },
+                'invocations': [
+                    {
+                        'pipeline': {
+                            'name': 'static_partitioned_assets_job'
+                        },
+                        'solidHandle': {
+                            'handleID': 'middle_static_partitioned_asset_2'
+                        }
+                    }
+                ]
+            },
+            {
+                '__typename': 'UsedSolid',
+                'definition': {
                     'name': 'multi'
                 },
                 'invocations': [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -830,7 +830,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result.data
         assert result.data["assetNodes"]
-        assert len(result.data["assetNodes"]) == 2
+        assert len(result.data["assetNodes"]) == 4
         asset_node = result.data["assetNodes"][0]
         assert asset_node["partitionKeys"] and asset_node["partitionKeys"] == [
             "a",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -535,6 +535,45 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         )
         assert result.data["partitionBackfillOrError"]["status"] == "COMPLETED"
 
+    def test_asset_backfill_stats_in_topological_order(self, graphql_context):
+        asset_key_paths_in_topo_order = [
+            ["upstream_static_partitioned_asset"],
+            ["middle_static_partitioned_asset_1"],
+            ["middle_static_partitioned_asset_2"],
+            ["downstream_static_partitioned_asset"],
+        ]
+
+        partitions = ["a", "b", "c", "d", "e", "f"]
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PARTITION_BACKFILL_MUTATION,
+            variables={
+                "backfillParams": {
+                    "partitionNames": partitions,
+                    "assetSelection": [
+                        AssetKey(path).to_graphql_input() for path in asset_key_paths_in_topo_order
+                    ],
+                }
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
+        backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            BACKFILL_PARTITION_STATUS_COUNTS_BY_ASSET,
+            variables={"backfillId": backfill_id},
+        )
+
+        asset_status_counts = result.data["partitionBackfillOrError"]["assetBackfillData"][
+            "assetPartitionsStatusCounts"
+        ]
+        assert len(asset_status_counts) == 4
+        for i, path in enumerate(asset_key_paths_in_topo_order):
+            assert asset_status_counts[i]["assetKey"]["path"] == path
+
     def test_asset_backfill_partition_stats(self, graphql_context):
         partitions = ["a", "b", "c", "d", "e", "f"]
         result = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -129,6 +129,25 @@ class AssetBackfillData(NamedTuple):
             for asset_key, subset in self.target_subset.partitions_subsets_by_asset_key.items()
         }
 
+    def get_targeted_partitioned_asset_keys_topological_order(self) -> List[AssetKey]:
+        """
+        Returns a topological ordering of partitioned asset keys targeted by the backfill.
+
+        For keys in the same topological level, the order is arbitrary.
+        """
+        toposorted_keys = self.target_subset.asset_graph.toposort_asset_keys()
+
+        targeted_toposorted_keys = []
+        for level_keys in toposorted_keys:
+            for key in level_keys:
+                if (
+                    key in self.target_subset.asset_keys
+                    and self.target_subset.asset_graph.get_partitions_def(key) is not None
+                ):
+                    targeted_toposorted_keys.append(key)
+
+        return targeted_toposorted_keys
+
     def get_partitions_status_counts_by_asset_key(
         self,
     ) -> Mapping[AssetKey, Mapping[BackfillPartitionsStatus, int]]:

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -129,17 +129,16 @@ class AssetBackfillData(NamedTuple):
             for asset_key, subset in self.target_subset.partitions_subsets_by_asset_key.items()
         }
 
-    def get_targeted_partitioned_asset_keys_topological_order(self) -> List[AssetKey]:
-        """
-        Returns a topological ordering of partitioned asset keys targeted by the backfill.
+    def get_targeted_partitioned_asset_keys_topological_order(self) -> Sequence[AssetKey]:
+        """Returns a topological ordering of partitioned asset keys targeted by the backfill.
 
-        For keys in the same topological level, the order is arbitrary.
+        Orders keys in the same topological level alphabetically.
         """
         toposorted_keys = self.target_subset.asset_graph.toposort_asset_keys()
 
         targeted_toposorted_keys = []
         for level_keys in toposorted_keys:
-            for key in level_keys:
+            for key in sorted(level_keys):
                 if (
                     key in self.target_subset.asset_keys
                     and self.target_subset.asset_graph.get_partitions_def(key) is not None

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -127,15 +127,14 @@ class PartitionBackfill(
         else:
             return True
 
-    def get_partitions_status_counts_and_totals_per_asset(
+    def get_partitions_status_counts_and_totals_by_asset(
         self, workspace: IWorkspace
-    ) -> Sequence[Tuple[AssetKey, Mapping[BackfillPartitionsStatus, int], int]]:
-        """
-        Returns a list of tuples of the form (asset_key, partitions_status_counts, total_partitions)
+    ) -> Mapping[AssetKey, Tuple[Mapping[BackfillPartitionsStatus, int], int]]:
+        """Returns a list of tuples of the form (asset_key, partitions_status_counts, total_partitions)
         in topological order of the asset graph. Includes only partitioned assets.
         """
         if not self.is_valid_serialization(workspace):
-            return []
+            return {}
 
         if self.serialized_asset_backfill_data is not None:
             try:
@@ -144,7 +143,7 @@ class PartitionBackfill(
                     ExternalAssetGraph.from_workspace(workspace),
                 )
             except DagsterDefinitionChangedDeserializationError:
-                return []
+                return {}
 
             partitions_status_counts_by_asset_key = (
                 asset_backfill_data.get_partitions_status_counts_by_asset_key()
@@ -164,17 +163,16 @@ class PartitionBackfill(
                 set(partitions_status_counts_by_asset_key.keys()) == set(topological_order)
             )
 
-            return [
-                (
-                    asset_key,
+            return {
+                asset_key: (
                     partitions_status_counts_by_asset_key[asset_key],
                     num_targeted_partitions_by_asset_key[asset_key],
                 )
                 for asset_key in topological_order
-            ]
+            }
 
         else:
-            return []
+            return {}
 
     def get_target_root_partitions_subset(
         self, workspace: IWorkspace


### PR DESCRIPTION
Resolves https://github.com/dagster-io/dagster/issues/13759

Fetches the topological ordering of assets in the asset graph, and returns the targeted partitioned assets in topological order.

Added a test and some additional asset nodes in the graphql repo, not sure how it adds thousands of new lines in the snapshots, but I did at least double check that nothing was unintentionally deleted.