### PR TITLE
Hide "materialization in last run" section for partitioned assets in asset sidebar

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetSidebarActivitySummary.tsx
@@ -83,26 +83,28 @@ export const AssetSidebarActivitySummary: React.FC<Props> = ({
         </SidebarSection>
       )}
 
-      <SidebarSection
-        title={!isSourceAsset ? 'Materialization in last run' : 'Observation in last run'}
-      >
-        {displayedEvent ? (
-          <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
-            <LatestMaterializationMetadata
-              assetKey={assetKey}
-              latest={displayedEvent}
-              liveData={liveData}
-            />
-          </div>
-        ) : (
-          <Box
-            margin={{horizontal: 24, vertical: 12}}
-            style={{color: Colors.Gray500, fontSize: '0.8rem'}}
-          >
-            {!isSourceAsset ? `No materializations found` : `No observations found`}
-          </Box>
-        )}
-      </SidebarSection>
+      {loadedPartitionKeys.length > 1 ? null : (
+        <SidebarSection
+          title={!isSourceAsset ? 'Materialization in last run' : 'Observation in last run'}
+        >
+          {displayedEvent ? (
+            <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
+              <LatestMaterializationMetadata
+                assetKey={assetKey}
+                latest={displayedEvent}
+                liveData={liveData}
+              />
+            </div>
+          ) : (
+            <Box
+              margin={{horizontal: 24, vertical: 12}}
+              style={{color: Colors.Gray500, fontSize: '0.8rem'}}
+            >
+              {!isSourceAsset ? `No materializations found` : `No observations found`}
+            </Box>
+          )}
+        </SidebarSection>
+      )}
       <SidebarSection
         title={!isSourceAsset ? 'Materialization system tags' : 'Observation system tags'}
         collapsedByDefault


### PR DESCRIPTION
## Summary & Motivation

closes https://github.com/dagster-io/dagster/issues/13404

## How I Tested These Changes
Section no longer visible:

![Screen Shot 2023-04-20 at 2 16 33 PM](https://user-images.githubusercontent.com/2286579/233453037-b459c269-540f-44c9-b679-ca0ffbbb65db.png)
