### PR TITLE
Add partition_key field to RunStatusSensorContext

### DIFF
--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -18,6 +18,7 @@ from dagster import (
     AssetSelection,
     CodeLocationSelector,
     DagsterRunStatus,
+    DailyPartitionsDefinition,
     DynamicPartitionsDefinition,
     Field,
     HourlyPartitionsDefinition,
@@ -35,6 +36,7 @@ from dagster import (
     repository,
     run_failure_sensor,
 )
+from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators import op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.decorators.sensor_decorator import asset_sensor, sensor
@@ -565,6 +567,25 @@ def error_on_deleted_dynamic_partitions_run_requests_sensor(context):
     )
 
 
+daily_partitions_def = DailyPartitionsDefinition(start_date="2022-08-01")
+
+
+@asset(partitions_def=daily_partitions_def)
+def partitioned_asset():
+    return 1
+
+
+daily_partitioned_job = define_asset_job(
+    "daily_partitioned_job",
+    partitions_def=daily_partitions_def,
+).resolve(asset_graph=AssetGraph.from_assets([partitioned_asset]))
+
+
+@run_status_sensor(run_status=DagsterRunStatus.SUCCESS, monitored_jobs=[daily_partitioned_job])
+def partitioned_pipeline_success_sensor(_context):
+    assert _context.partition_key == "2022-08-01"
+
+
 @repository
 def the_repo():
     return [
@@ -620,6 +641,8 @@ def the_repo():
         add_dynamic_partitions_sensor,
         quux_asset_job,
         error_on_deleted_dynamic_partitions_run_requests_sensor,
+        partitioned_pipeline_success_sensor,
+        daily_partitioned_job,
     ]
 
 


### PR DESCRIPTION
## Summary & Motivation
Follow up from discussion here: https://github.com/dagster-io/dagster/discussions/13283

This is a very minor change to expose the partition as a top level field in `RunStatusSensorContext`. Previously this information was only available by checking the tags that are available on the `DagsterRun` object within the `RunStatusSensorContext`.

## How I Tested These Changes
Updated unit tests with a scenario that covers the case when a run status sensor is defined on a partitioned job.