### PR TITLE
Disable run_request_for_partition with dynamic partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -6,7 +6,6 @@ import dagster._check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._core.instance import DagsterInstance
 from dagster._utils.backcompat import deprecation_warning
 
 from .asset_layer import build_asset_selection_job
@@ -83,7 +82,6 @@ class UnresolvedAssetJobDefinition(
         tags: Optional[Mapping[str, str]] = None,
         asset_selection: Optional[Sequence[AssetKey]] = None,
         run_config: Optional[Mapping[str, Any]] = None,
-        instance: Optional[DagsterInstance] = None,
         current_time: Optional[datetime] = None,
     ) -> RunRequest:
         """Creates a RunRequest object for a run that processes the given partition.
@@ -126,27 +124,32 @@ class UnresolvedAssetJobDefinition(
         if (
             isinstance(self.partitions_def, DynamicPartitionsDefinition)
             and self.partitions_def.name
-            and not instance
         ):
+            # Do not support using run_request_for_partition with dynamic partitions,
+            # since this requires querying the instance once per run request for the
+            # existent dynamic partitions
             check.failed(
-                "Must provide a dagster instance when calling run_request_for_partition on a "
-                "dynamic partition set"
+                "run_request_for_partition is not supported for dynamic partitions. Instead, use"
+                " RunRequest(partition_key=...)"
             )
 
         partition = self.partitions_def.get_partition(
-            partition_key, dynamic_partitions_store=instance, current_time=current_time
+            partition_key, dynamic_partitions_store=None, current_time=current_time
         )
         run_config = (
             run_config
             if run_config is not None
             else partitioned_config.get_run_config_for_partition_key(
-                partition.name, dynamic_partitions_store=instance, current_time=current_time
+                partition.name, dynamic_partitions_store=None, current_time=current_time
             )
         )
         run_request_tags = {
             **(tags or {}),
             **partitioned_config.get_tags_for_partition_key(
-                partition_key, instance, current_time=current_time, job_name=self.name
+                partition_key,
+                dynamic_partitions_store=None,
+                current_time=current_time,
+                job_name=self.name,
             ),
         }
 


### PR DESCRIPTION
Each call of `run_request_for_partition` for a dynamic partition requires querying the instance for the existent dynamic partitions, which is expensive and can overwhelm the db. 

This PR disables this behavior by removing the instance arg and throwing an error. I wish initially I'd added an `experimental` tag to the instance arg, but I think only dynamic partitions users should be passing in an instance and thus will encounter this breaking change.

If we don't feel comfortable directly removing the instance arg, I'm happy to add the arg back and just not pass the instance through to the `get_partition` method.