### PR TITLE
support allPartitions for pure asset backfills

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -134,9 +134,6 @@ def create_and_launch_partition_backfill(
         if backfill_params.get("fromFailure"):
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
-        if backfill_params.get("allPartitions"):
-            raise DagsterError("allPartitions is not supported for pure asset backfills")
-
         asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
 
         location_names = set(
@@ -161,8 +158,9 @@ def create_and_launch_partition_backfill(
             tags=tags,
             backfill_timestamp=backfill_timestamp,
             asset_selection=asset_selection,
-            partition_names=backfill_params["partitionNames"],
+            partition_names=backfill_params.get("partitionNames"),
             dynamic_partitions_store=CachingInstanceQueryer(graphene_info.context.instance),
+            all_partitions=backfill_params.get("allPartitions", False),
         )
     else:
         raise DagsterError(

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -226,10 +226,21 @@ class AssetGraphSubset:
     def all(
         cls, asset_graph: AssetGraph, dynamic_partitions_store: DynamicPartitionsStore
     ) -> "AssetGraphSubset":
+        return cls.from_asset_keys(
+            asset_graph.non_source_asset_keys, asset_graph, dynamic_partitions_store
+        )
+
+    @classmethod
+    def from_asset_keys(
+        cls,
+        asset_keys: Iterable[AssetKey],
+        asset_graph: AssetGraph,
+        dynamic_partitions_store: DynamicPartitionsStore,
+    ) -> "AssetGraphSubset":
         partitions_subsets_by_asset_key: Dict[AssetKey, PartitionsSubset] = {}
         non_partitioned_asset_keys: Set[AssetKey] = set()
 
-        for asset_key in asset_graph.non_source_asset_keys:
+        for asset_key in asset_keys:
             partitions_def = asset_graph.get_partitions_def(asset_key)
             if partitions_def:
                 partitions_subsets_by_asset_key[

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -216,47 +216,63 @@ class AssetBackfillData(NamedTuple):
     def from_asset_partitions(
         cls,
         asset_graph: AssetGraph,
-        partition_names: Sequence[str],
+        partition_names: Optional[Sequence[str]],
         asset_selection: Sequence[AssetKey],
         dynamic_partitions_store: DynamicPartitionsStore,
+        all_partitions: bool,
     ) -> "AssetBackfillData":
-        partitioned_asset_keys = {
-            asset_key
-            for asset_key in asset_selection
-            if asset_graph.get_partitions_def(asset_key) is not None
-        }
-
-        root_partitioned_asset_keys = (
-            AssetSelection.keys(*partitioned_asset_keys).sources().resolve(asset_graph)
+        check.invariant(
+            partition_names is None or all_partitions is False,
+            "Can't provide both a set of partitions and all_partitions=True",
         )
-        root_partitions_defs = {
-            asset_graph.get_partitions_def(asset_key) for asset_key in root_partitioned_asset_keys
-        }
-        if len(root_partitions_defs) > 1:
-            raise DagsterBackfillFailedError(
-                "All the assets at the root of the backfill must have the same PartitionsDefinition"
-            )
 
-        root_partitions_def = next(iter(root_partitions_defs))
-        if not root_partitions_def:
-            raise DagsterBackfillFailedError(
-                "If assets within the backfill have different partitionings, then root assets"
-                " must be partitioned"
+        if all_partitions:
+            target_subset = AssetGraphSubset.from_asset_keys(
+                asset_selection, asset_graph, dynamic_partitions_store
             )
+        elif partition_names is not None:
+            partitioned_asset_keys = {
+                asset_key
+                for asset_key in asset_selection
+                if asset_graph.get_partitions_def(asset_key) is not None
+            }
 
-        root_partitions_subset = root_partitions_def.subset_with_partition_keys(partition_names)
-        target_subset = AssetGraphSubset(
-            asset_graph, non_partitioned_asset_keys=set(asset_selection) - partitioned_asset_keys
-        )
-        for root_asset_key in root_partitioned_asset_keys:
-            target_subset |= asset_graph.bfs_filter_subsets(
-                dynamic_partitions_store,
-                lambda asset_key, _: asset_key in partitioned_asset_keys,
-                AssetGraphSubset(
-                    asset_graph,
-                    partitions_subsets_by_asset_key={root_asset_key: root_partitions_subset},
-                ),
+            root_partitioned_asset_keys = (
+                AssetSelection.keys(*partitioned_asset_keys).sources().resolve(asset_graph)
             )
+            root_partitions_defs = {
+                asset_graph.get_partitions_def(asset_key)
+                for asset_key in root_partitioned_asset_keys
+            }
+            if len(root_partitions_defs) > 1:
+                raise DagsterBackfillFailedError(
+                    "All the assets at the root of the backfill must have the same"
+                    " PartitionsDefinition"
+                )
+
+            root_partitions_def = next(iter(root_partitions_defs))
+            if not root_partitions_def:
+                raise DagsterBackfillFailedError(
+                    "If assets within the backfill have different partitionings, then root assets"
+                    " must be partitioned"
+                )
+
+            root_partitions_subset = root_partitions_def.subset_with_partition_keys(partition_names)
+            target_subset = AssetGraphSubset(
+                asset_graph,
+                non_partitioned_asset_keys=set(asset_selection) - partitioned_asset_keys,
+            )
+            for root_asset_key in root_partitioned_asset_keys:
+                target_subset |= asset_graph.bfs_filter_subsets(
+                    dynamic_partitions_store,
+                    lambda asset_key, _: asset_key in partitioned_asset_keys,
+                    AssetGraphSubset(
+                        asset_graph,
+                        partitions_subsets_by_asset_key={root_asset_key: root_partitions_subset},
+                    ),
+                )
+        else:
+            check.failed("Either partition_names must not be None or all_partitions must be True")
 
         return cls.empty(target_subset)
 

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -321,11 +321,12 @@ class PartitionBackfill(
         cls,
         backfill_id: str,
         asset_graph: AssetGraph,
-        partition_names: Sequence[str],
+        partition_names: Optional[Sequence[str]],
         asset_selection: Sequence[AssetKey],
         backfill_timestamp: float,
         tags: Mapping[str, str],
         dynamic_partitions_store: DynamicPartitionsStore,
+        all_partitions: bool,
     ) -> "PartitionBackfill":
         """If all the selected assets that have PartitionsDefinitions have the same partitioning, then
         the backfill will target the provided partition_names for all those assets.
@@ -347,5 +348,6 @@ class PartitionBackfill(
                 partition_names=partition_names,
                 asset_selection=asset_selection,
                 dynamic_partitions_store=dynamic_partitions_store,
+                all_partitions=all_partitions,
             ).serialize(dynamic_partitions_store=dynamic_partitions_store),
         )

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -32,6 +32,7 @@ from dagster_tests.definitions_tests.asset_reconciliation_tests.asset_reconcilia
 )
 from dagster_tests.definitions_tests.asset_reconciliation_tests.exotic_partition_mapping_scenarios import (
     one_asset_self_dependency,
+    root_assets_different_partitions_same_downstream,
     two_assets_in_sequence_fan_in_partitions,
     two_assets_in_sequence_fan_out_partitions,
 )
@@ -109,6 +110,7 @@ scenarios = {
             "2013-01-06-01:00",
         ],
     ),
+    "root_assets_different_partitions": scenario(root_assets_different_partitions_same_downstream),
 }
 
 
@@ -147,6 +149,7 @@ def test_from_asset_partitions_target_subset(
         asset_graph=asset_graph,
         asset_selection=list(asset_graph.all_asset_keys),
         dynamic_partitions_store=MagicMock(),
+        all_partitions=False,
     )
     assert backfill_data.target_subset == AssetGraphSubset.from_asset_partition_set(
         {

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -711,7 +711,7 @@ def test_backfill_with_asset_selection(
         assert len(instance.run_ids_for_asset_key(asset_key)) == 0
 
 
-def test_pure_asset_backfill_with_multiple_asset_selections(
+def test_pure_asset_backfill_with_multiple_assets_selected(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
     external_repo: ExternalRepository,
@@ -725,16 +725,17 @@ def test_pure_asset_backfill_with_multiple_asset_selections(
             asset_graph=ExternalAssetGraph.from_workspace(
                 workspace_context.create_request_context()
             ),
-            backfill_id="backfill_with_multiple_asset_selections",
+            backfill_id="backfill_with_multiple_assets_selected",
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=pendulum.now().timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_name_list,
             dynamic_partitions_store=instance,
+            all_partitions=False,
         )
     )
     assert instance.get_runs_count() == 0
-    backfill = instance.get_backfill("backfill_with_multiple_asset_selections")
+    backfill = instance.get_backfill("backfill_with_multiple_assets_selected")
     assert backfill
     assert backfill.status == BulkActionStatus.REQUESTED
 
@@ -750,7 +751,7 @@ def test_pure_asset_backfill_with_multiple_asset_selections(
     wait_for_all_runs_to_start(instance, timeout=30)
     wait_for_all_runs_to_finish(instance, timeout=30)
     run = instance.get_runs()[0]
-    assert run.tags[BACKFILL_ID_TAG] == "backfill_with_multiple_asset_selections"
+    assert run.tags[BACKFILL_ID_TAG] == "backfill_with_multiple_assets_selected"
     assert run.tags["custom_tag_key"] == "custom_tag_value"
     assert run.asset_selection == {AssetKey(["asset_a"])}
 
@@ -794,6 +795,7 @@ def test_pure_asset_backfill(
             asset_selection=asset_selection,
             partition_names=partition_name_list,
             dynamic_partitions_store=instance,
+            all_partitions=False,
         )
     )
     assert instance.get_runs_count() == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -367,7 +367,7 @@ def run_request(asset_keys: List[str], partition_key: Optional[str] = None) -> R
 
 def asset_def(
     key: str,
-    deps: Optional[Union[List[str], Mapping[str, PartitionMapping]]] = None,
+    deps: Optional[Union[List[str], Mapping[str, Optional[PartitionMapping]]]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/exotic_partition_mapping_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/exotic_partition_mapping_scenarios.py
@@ -15,7 +15,11 @@ from .asset_reconciliation_scenario import (
     run_request,
     single_asset_run,
 )
-from .partition_scenarios import one_partition_partitions_def
+from .partition_scenarios import (
+    one_partition_partitions_def,
+    other_two_partitions_partitions_def,
+    two_partitions_partitions_def,
+)
 
 fanned_out_partitions_def = StaticPartitionsDefinition(["a_1", "a_2", "a_3"])
 
@@ -53,6 +57,16 @@ one_asset_self_dependency = [
         partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
         deps={"asset1": TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)},
     )
+]
+
+root_assets_different_partitions_same_downstream = [
+    asset_def("root1", partitions_def=two_partitions_partitions_def),
+    asset_def("root2", partitions_def=other_two_partitions_partitions_def),
+    asset_def(
+        "downstream",
+        {"root1": None, "root2": StaticPartitionMapping({"1": "a", "2": "b"})},
+        partitions_def=two_partitions_partitions_def,
+    ),
 ]
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/partition_scenarios.py
@@ -26,6 +26,7 @@ daily_partitions_def = DailyPartitionsDefinition("2013-01-05")
 hourly_partitions_def = HourlyPartitionsDefinition("2013-01-05-00:00")
 one_partition_partitions_def = StaticPartitionsDefinition(["a"])
 two_partitions_partitions_def = StaticPartitionsDefinition(["a", "b"])
+other_two_partitions_partitions_def = StaticPartitionsDefinition(["1", "2"])
 time_multipartitions_def = MultiPartitionsDefinition(
     {"time": daily_partitions_def, "static": two_partitions_partitions_def}
 )


### PR DESCRIPTION
## Summary & Motivation

The backfill graphql mutation has long supported an allPartitions argument that specifies that all partitions of the target job should be included of the backfill.

This argument was not supported for pure asset backfills. This PR adds support for it.

The argument allows requesting a kind of backfill that is not requestable via other parameters: a backfill where root assets have different PartitionsDefinitions.

This is not yet exposed from the UI, but a user wanted to be able to launch graphql requests from a sensor.

## How I Tested These Changes
- GraphQL tests that check that correct backfill object (correct target subset) is created when allPartitions=True is supplied
- Backfill tests that check that backfills with root assets that have different PartitionsDefinitiona can be executed successfully.