### PR TITLE
Display pure source asset cross-repo dependencies

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/cross_repo_asset_deps.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/cross_repo_asset_deps.py
@@ -2,26 +2,26 @@ from dagster import AssetKey, SourceAsset, asset, repository
 
 
 @asset
-def upstream_asset():
+def derived_asset():
     return 5
 
 
 @repository
 def upstream_assets_repository():
-    return [upstream_asset]
+    return [derived_asset]
 
 
-source_assets = [SourceAsset(AssetKey("upstream_asset"))]
-
-
-@asset
-def downstream_asset1(upstream_asset):
-    assert upstream_asset
+source_assets = [SourceAsset(AssetKey("derived_asset")), SourceAsset("always_source_asset")]
 
 
 @asset
-def downstream_asset2(upstream_asset):
-    assert upstream_asset
+def downstream_asset1(derived_asset, always_source_asset):
+    assert derived_asset
+
+
+@asset
+def downstream_asset2(derived_asset, always_source_asset):
+    assert derived_asset
 
 
 @repository

--- a/python_modules/dagster-test/dagster_test/toys/cross_repo_assets.py
+++ b/python_modules/dagster-test/dagster_test/toys/cross_repo_assets.py
@@ -8,17 +8,22 @@ def upstream_asset():
 
 upstream_repo_assets = [upstream_asset]
 
-source_assets = [SourceAsset(AssetKey("upstream_asset"))]
+source_assets = [
+    SourceAsset(AssetKey("upstream_asset")),
+    SourceAsset(AssetKey("always_source_asset")),
+]
 
 
 @asset
-def downstream_asset1(upstream_asset):
+def downstream_asset1(upstream_asset, always_source_asset):
     assert upstream_asset
+    assert always_source_asset
 
 
 @asset
-def downstream_asset2(upstream_asset):
+def downstream_asset2(upstream_asset, always_source_asset):
     assert upstream_asset
+    assert always_source_asset
 
 
 downstream_repo1_assets = [downstream_asset1, source_assets]


### PR DESCRIPTION
Requested by a user: https://elementl-workspace.slack.com/archives/C0453JAC8KD/p1681818800498509

Currently, we only display cross-repo deps when the asset is defined as a regular asset (non source asset) in another repository. If it's a source asset in all repositories, we don't show the cross-repo deps.

This PR amends this behavior to also display cross-repo deps for source assets that aren't defined as regular assets elsewhere. Also adds this behavior to the toys for ease of testing.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/29110579/233715699-c821fdb3-51a5-49fd-abb0-c1fc4e892580.png">
