### PR TITLE
[ui] Performance improvements for global search

### DIFF
--- a/js_modules/dagit/packages/core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagit/packages/core/src/app/__tests__/AppTopNav.test.tsx
@@ -9,6 +9,11 @@ import {
 import {TestProvider} from '../../testing/TestProvider';
 import {AppTopNav} from '../AppTopNav';
 
+// We don't need to render the search input here.
+jest.mock('../../search/SearchDialog', () => ({
+  SearchDialog: () => <div />,
+}));
+
 describe('AppTopNav', () => {
   const defaultMocks = {
     Repository: () => ({

--- a/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
+++ b/js_modules/dagit/packages/core/src/search/SearchDialog.tsx
@@ -2,6 +2,7 @@
 import {Overlay} from '@blueprintjs/core';
 import {Box, Colors, Icon, Spinner, FontFamily} from '@dagster-io/ui';
 import Fuse from 'fuse.js';
+import debounce from 'lodash/debounce';
 import * as React from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
 import styled from 'styled-components/macro';
@@ -11,7 +12,7 @@ import {useTrackEvent} from '../app/analytics';
 
 import {SearchResults} from './SearchResults';
 import {SearchResult} from './types';
-import {useRepoSearch} from './useRepoSearch';
+import {useGlobalSearch} from './useGlobalSearch';
 
 const MAX_DISPLAYED_RESULTS = 50;
 
@@ -19,7 +20,8 @@ type State = {
   shown: boolean;
   queryString: string;
   searching: boolean;
-  results: Fuse.FuseResult<SearchResult>[];
+  primaryResults: Fuse.FuseResult<SearchResult>[];
+  secondaryResults: Fuse.FuseResult<SearchResult>[];
   highlight: number;
   loaded: boolean;
 };
@@ -29,20 +31,29 @@ type Action =
   | {type: 'hide-dialog'}
   | {type: 'highlight'; highlight: number}
   | {type: 'change-query'; queryString: string}
-  | {type: 'complete-search'; results: Fuse.FuseResult<SearchResult>[]};
+  | {type: 'complete-primary'; queryString: string; results: Fuse.FuseResult<SearchResult>[]}
+  | {type: 'complete-secondary'; queryString: string; results: Fuse.FuseResult<SearchResult>[]};
 
 const reducer = (state: State, action: Action) => {
   switch (action.type) {
     case 'show-dialog':
       return {...state, shown: true, loaded: true};
     case 'hide-dialog':
-      return {...state, shown: false, queryString: ''};
+      return {...state, shown: false, queryString: '', primaryResults: [], secondaryResults: []};
     case 'highlight':
       return {...state, highlight: action.highlight};
     case 'change-query':
       return {...state, queryString: action.queryString, searching: true, highlight: 0};
-    case 'complete-search':
-      return {...state, results: action.results, searching: false};
+    case 'complete-primary':
+      // If the received results match the current querystring, use them. Otherwise discard.
+      const primaryResults =
+        action.queryString === state.queryString ? action.results : state.primaryResults;
+      return {...state, primaryResults, searching: false};
+    case 'complete-secondary':
+      // If the received results match the current querystring, use them. Otherwise discard.
+      const secondaryResults =
+        action.queryString === state.queryString ? action.results : state.secondaryResults;
+      return {...state, secondaryResults, searching: false};
     default:
       return state;
   }
@@ -52,37 +63,61 @@ const initialState: State = {
   shown: false,
   queryString: '',
   searching: false,
-  results: [],
+  primaryResults: [],
+  secondaryResults: [],
   highlight: 0,
   loaded: false,
 };
 
+const DEBOUNCE_MSEC = 100;
+
 export const SearchDialog: React.FC<{searchPlaceholder: string}> = ({searchPlaceholder}) => {
   const location = useLocation();
   const history = useHistory();
-  const {performBootstrapQuery, loading, performSearch} = useRepoSearch();
+  const {initialize, loading, searchPrimary, searchSecondary} = useGlobalSearch();
   const trackEvent = useTrackEvent();
 
   const [state, dispatch] = React.useReducer(reducer, initialState);
-  const {shown, queryString, results, highlight, loaded} = state;
+  const {shown, queryString, primaryResults, secondaryResults, highlight} = state;
 
+  const results = [...primaryResults, ...secondaryResults];
   const renderedResults = results.slice(0, MAX_DISPLAYED_RESULTS);
   const numRenderedResults = renderedResults.length;
 
   const openSearch = React.useCallback(() => {
     trackEvent('searchOpen');
-    performBootstrapQuery();
+    initialize();
     dispatch({type: 'show-dialog'});
-  }, [performBootstrapQuery, trackEvent]);
+  }, [initialize, trackEvent]);
 
-  const onChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch({type: 'change-query', queryString: e.target.value});
-  }, []);
+  const searchAndHandlePrimary = React.useCallback(
+    async (queryString: string) => {
+      const {queryString: queryStringForResults, results} = await searchPrimary(queryString);
+      dispatch({type: 'complete-primary', queryString: queryStringForResults, results});
+    },
+    [searchPrimary],
+  );
 
-  React.useEffect(() => {
-    const results = performSearch(queryString, loaded);
-    dispatch({type: 'complete-search', results});
-  }, [queryString, performSearch, loaded]);
+  const searchAndHandleSecondary = React.useCallback(
+    async (queryString: string) => {
+      const {queryString: queryStringForResults, results} = await searchSecondary(queryString);
+      dispatch({type: 'complete-secondary', queryString: queryStringForResults, results});
+    },
+    [searchSecondary],
+  );
+
+  const debouncedSearch = React.useMemo(() => {
+    return debounce(async (queryString: string) => {
+      searchAndHandlePrimary(queryString);
+      searchAndHandleSecondary(queryString);
+    }, DEBOUNCE_MSEC);
+  }, [searchAndHandlePrimary, searchAndHandleSecondary]);
+
+  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    dispatch({type: 'change-query', queryString: newValue});
+    debouncedSearch(newValue);
+  };
 
   React.useEffect(() => {
     dispatch({type: 'hide-dialog'});

--- a/js_modules/dagit/packages/core/src/search/__fixtures__/Search.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/search/__fixtures__/Search.fixtures.tsx
@@ -1,0 +1,227 @@
+import {MockedResponse} from '@apollo/client/testing';
+import faker from 'faker';
+
+import {
+  buildAsset,
+  buildAssetConnection,
+  buildAssetGroup,
+  buildAssetKey,
+  buildPipeline,
+  buildRepository,
+  buildRepositoryLocation,
+  buildSchedule,
+  buildSensor,
+  buildWorkspace,
+  buildWorkspaceLocationEntry,
+} from '../../graphql/types';
+import {SearchPrimaryQuery, SearchSecondaryQuery} from '../types/useGlobalSearch.types';
+import {SEARCH_PRIMARY_QUERY, SEARCH_SECONDARY_QUERY} from '../useGlobalSearch';
+
+export const buildPrimarySearch = (delay = 0): MockedResponse<SearchPrimaryQuery> => {
+  return {
+    delay,
+    request: {
+      query: SEARCH_PRIMARY_QUERY,
+      variables: {},
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        workspaceOrError: buildWorkspace({
+          locationEntries: [
+            buildWorkspaceLocationEntry({
+              locationOrLoadError: buildRepositoryLocation({
+                id: 'my-location',
+                name: 'my-location',
+                repositories: [
+                  buildRepository({
+                    id: 'foo',
+                    name: 'foo',
+                    assetGroups: new Array(10).fill(null).map((_) =>
+                      buildAssetGroup({
+                        groupName: faker.random.word(),
+                      }),
+                    ),
+                    pipelines: new Array(10).fill(null).map((_) => {
+                      const id = faker.company.catchPhrase().toLowerCase();
+                      return buildPipeline({
+                        id,
+                        name: id,
+                        isJob: true,
+                      });
+                    }),
+                    schedules: new Array(10).fill(null).map((_) => {
+                      const id = faker.company.catchPhrase().toLowerCase();
+                      return buildSchedule({
+                        id,
+                        name: id,
+                      });
+                    }),
+                    sensors: new Array(10).fill(null).map((_) => {
+                      const id = faker.company.catchPhrase().toLowerCase();
+                      return buildSensor({
+                        id,
+                        name: id,
+                      });
+                    }),
+                  }),
+                ],
+              }),
+            }),
+          ],
+        }),
+      },
+    },
+  };
+};
+
+export const buildPrimarySearchStatic = (delay = 0): MockedResponse<SearchPrimaryQuery> => {
+  return {
+    delay,
+    request: {
+      query: SEARCH_PRIMARY_QUERY,
+      variables: {},
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        workspaceOrError: buildWorkspace({
+          locationEntries: [
+            buildWorkspaceLocationEntry({
+              locationOrLoadError: buildRepositoryLocation({
+                id: 'my-location',
+                name: 'my-location',
+                repositories: [
+                  buildRepository({
+                    id: 'foo',
+                    name: 'foo',
+                    assetGroups: [
+                      buildAssetGroup({
+                        groupName: 'asset-group-one',
+                      }),
+                      buildAssetGroup({
+                        groupName: 'asset-group-two',
+                      }),
+                    ],
+                    pipelines: [
+                      buildPipeline({
+                        id: 'job-one',
+                        name: 'job-one',
+                        isJob: true,
+                      }),
+                      buildPipeline({
+                        id: 'job-two',
+                        name: 'job-two',
+                        isJob: true,
+                      }),
+                    ],
+                    schedules: [
+                      buildSchedule({
+                        id: 'schedule-one',
+                        name: 'schedule-one',
+                      }),
+                      buildSchedule({
+                        id: 'schedule-two',
+                        name: 'schedule-two',
+                      }),
+                    ],
+                    sensors: [
+                      buildSensor({
+                        id: 'sensor-one',
+                        name: 'sensor-one',
+                      }),
+                      buildSensor({
+                        id: 'sensor-two',
+                        name: 'sensor-two',
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            }),
+          ],
+        }),
+      },
+    },
+  };
+};
+
+export const buildSecondarySearch = (
+  size = 100,
+  delay = 0,
+): MockedResponse<SearchSecondaryQuery> => {
+  return {
+    delay,
+    request: {
+      query: SEARCH_SECONDARY_QUERY,
+      variables: {},
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        assetsOrError: buildAssetConnection({
+          // This array manually builds up `Asset` objects because it is too expensive
+          // to run the builders for many thousands of objects.
+          nodes: new Array(size).fill(null).map((_) => {
+            const path = faker.random.words(3);
+            const id = path.replace(' ', '-');
+            return {
+              __typename: 'Asset',
+              id,
+              definition: null,
+              assetMaterializations: [],
+              assetObservations: [],
+              key: {
+                __typename: 'AssetKey',
+                path: path.split(' '),
+              },
+            };
+          }),
+        }),
+      },
+    },
+  };
+};
+
+export const buildSecondarySearchStatic = (delay = 0): MockedResponse<SearchSecondaryQuery> => {
+  return {
+    delay,
+    request: {
+      query: SEARCH_SECONDARY_QUERY,
+      variables: {},
+    },
+    result: {
+      data: {
+        __typename: 'DagitQuery',
+        assetsOrError: buildAssetConnection({
+          nodes: [
+            buildAsset({
+              id: 'asset-one',
+              key: buildAssetKey({
+                path: ['asset-one'],
+              }),
+            }),
+            buildAsset({
+              id: 'asset-two',
+              key: buildAssetKey({
+                path: ['asset-two'],
+              }),
+            }),
+            buildAsset({
+              id: 'asset-three',
+              key: buildAssetKey({
+                path: ['asset-three'],
+              }),
+            }),
+            buildAsset({
+              id: 'asset-four',
+              key: buildAssetKey({
+                path: ['asset-four'],
+              }),
+            }),
+          ],
+        }),
+      },
+    },
+  };
+};

--- a/js_modules/dagit/packages/core/src/search/__stories__/SearchDialog.stories.tsx
+++ b/js_modules/dagit/packages/core/src/search/__stories__/SearchDialog.stories.tsx
@@ -1,8 +1,15 @@
-import {Story, Meta} from '@storybook/react/types-6-0';
+import {MockedProvider} from '@apollo/client/testing';
+import {Meta} from '@storybook/react/types-6-0';
 import * as React from 'react';
 
-import {StorybookProvider} from '../../testing/StorybookProvider';
+import {AnalyticsContext, dummyAnalytics} from '../../app/analytics';
 import {SearchDialog} from '../SearchDialog';
+import {
+  buildPrimarySearch,
+  buildPrimarySearchStatic,
+  buildSecondarySearch,
+  buildSecondarySearchStatic,
+} from '../__fixtures__/Search.fixtures';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -10,10 +17,26 @@ export default {
   component: SearchDialog,
 } as Meta;
 
-const Template: Story = (props) => (
-  <StorybookProvider>
-    <SearchDialog searchPlaceholder="" {...props} />
-  </StorybookProvider>
+export const BasicSearch = () => (
+  <AnalyticsContext.Provider value={dummyAnalytics()}>
+    <MockedProvider mocks={[buildPrimarySearchStatic(), buildSecondarySearchStatic()]}>
+      <SearchDialog searchPlaceholder="" />
+    </MockedProvider>
+  </AnalyticsContext.Provider>
 );
 
-export const Simple = Template.bind({});
+export const SlowSecondaryQuerySearch = () => (
+  <AnalyticsContext.Provider value={dummyAnalytics()}>
+    <MockedProvider mocks={[buildPrimarySearchStatic(), buildSecondarySearchStatic(10000)]}>
+      <SearchDialog searchPlaceholder="" />
+    </MockedProvider>
+  </AnalyticsContext.Provider>
+);
+
+export const LotsOfAssetsSearch = () => (
+  <AnalyticsContext.Provider value={dummyAnalytics()}>
+    <MockedProvider mocks={[buildPrimarySearch(), buildSecondarySearch(10000)]}>
+      <SearchDialog searchPlaceholder="" />
+    </MockedProvider>
+  </AnalyticsContext.Provider>
+);

--- a/js_modules/dagit/packages/core/src/search/createSearchWorker.tsx
+++ b/js_modules/dagit/packages/core/src/search/createSearchWorker.tsx
@@ -1,0 +1,80 @@
+import Fuse from 'fuse.js';
+import memoize from 'lodash/memoize';
+
+import {ResultResponse, SearchResult} from './types';
+
+const spawnSearchWorker = memoize(
+  (_key: string) => new Worker(new URL('../workers/fuseSearch.worker', import.meta.url)),
+);
+
+type QueryListener = {
+  queryString: string;
+  listener: (response: QueryResponse) => void;
+};
+
+type QueryResponse = {queryString: string; results: Fuse.FuseResult<SearchResult>[]};
+
+export type WorkerSearchResult = {
+  update: (results: SearchResult[]) => void;
+  search: (queryString: string) => Promise<QueryResponse>;
+  terminate: () => void;
+};
+
+/**
+ * Create a queryable search worker.
+ *
+ * @param key - Unique identifier for the memoized Web Worker
+ * @param fuseOptions - Options to pass to the Fuse constructor
+ */
+export const createSearchWorker = (
+  key: string,
+  fuseOptions: Fuse.IFuseOptions<SearchResult>,
+): WorkerSearchResult => {
+  const searchWorker = spawnSearchWorker(key);
+  const listeners: Set<QueryListener> = new Set();
+
+  searchWorker.addEventListener('message', (event) => {
+    const {data} = event;
+    if (data.type === 'results') {
+      const {queryString, results} = data as ResultResponse;
+
+      // Inform listeners for this querystring. Remove them after they're done.
+      for (const listener of listeners) {
+        if (listener.queryString === queryString) {
+          listener.listener({queryString, results});
+          listeners.delete(listener);
+        }
+      }
+    }
+  });
+
+  /**
+   * Set the results for the worker, either for initialization or to update them.
+   *
+   * @param results - Prepackaged search results, supplied via GraphQL or otherwise
+   */
+  const update = (results: SearchResult[]) => {
+    searchWorker.postMessage({type: 'set-results', results, fuseOptions});
+  };
+
+  /**
+   * Perform a search on the worker. Resolves with the list of matching results.
+   *
+   * @param queryString
+   */
+  const search = async (queryString: string): Promise<QueryResponse> => {
+    return new Promise((resolve) => {
+      listeners.add({
+        queryString,
+        listener: (response) => resolve(response),
+      });
+
+      // Query worker for results.
+      searchWorker.postMessage({type: 'query', queryString});
+    });
+  };
+
+  const terminate = () => searchWorker.terminate();
+
+  return {update, search, terminate};
+};

--- a/js_modules/dagit/packages/core/src/search/types.ts
+++ b/js_modules/dagit/packages/core/src/search/types.ts
@@ -1,3 +1,5 @@
+import Fuse from 'fuse.js';
+
 export enum SearchResultType {
   AssetGroup,
   Asset,
@@ -19,3 +21,12 @@ export type SearchResult = {
   type: SearchResultType;
   tags?: string;
 };
+
+export type ReadyResponse = {type: 'ready'};
+export type ResultResponse = {
+  type: 'results';
+  queryString: string;
+  results: Fuse.FuseResult<SearchResult>[];
+};
+
+export type WorkerSearchResponse = ReadyResponse | ResultResponse;

--- a/js_modules/dagit/packages/core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagit/packages/core/src/search/types/useGlobalSearch.types.ts
@@ -2,9 +2,9 @@
 
 import * as Types from '../../graphql/types';
 
-export type SearchBootstrapQueryVariables = Types.Exact<{[key: string]: never}>;
+export type SearchPrimaryQueryVariables = Types.Exact<{[key: string]: never}>;
 
-export type SearchBootstrapQuery = {
+export type SearchPrimaryQuery = {
   __typename: 'DagitQuery';
   workspaceOrError:
     | {

--- a/js_modules/dagit/packages/core/src/workers/fuseSearch.worker.ts
+++ b/js_modules/dagit/packages/core/src/workers/fuseSearch.worker.ts
@@ -1,0 +1,36 @@
+import Fuse from 'fuse.js';
+
+import {SearchResult} from '../search/types';
+
+/**
+ * A Web Worker that creates and queries a Fuse object.
+ */
+
+let fuseObject: null | Fuse<SearchResult[]> = null;
+
+self.addEventListener('message', (event) => {
+  const {data} = event;
+
+  switch (data.type) {
+    case 'set-results': {
+      if (!fuseObject) {
+        fuseObject = new Fuse(data.results, data.fuseOptions);
+      } else {
+        fuseObject.setCollection(data.results);
+      }
+      self.postMessage({type: 'ready'});
+      break;
+    }
+    case 'query': {
+      if (fuseObject) {
+        const {queryString} = data;
+
+        // Consider the empty string as returning no results.
+        const results = queryString ? fuseObject.search(queryString) : [];
+        self.postMessage({type: 'results', queryString, results});
+      }
+    }
+  }
+});
+
+export {};


### PR DESCRIPTION
## Summary & Motivation

Introduce a couple of performance improvements on global search.

- Debounce queries while typing.
  - This delays actually executing the search so that we avoid expensive searches that we don't need.
- Move Fuse.js searching into Web Workers.
  - For very large data collections, Fuse.js is pretty slow. By pushing the cost to a worker thread, we avoid letting Fuse block the main thread.
  - Use two of these Web Workers for global search, one for the "primary" query (most of the defined objects: jobs, schedules, etc.) and one for the "secondary" query (currently assets).
    - Since most definitions should be available soon after the page loads, the primary query should (hopefully) be ready soon after search is opened.
    - With separate threads for these data collections, we can start showing primary results even before the secondary GraphQL query is complete, or before the secondary Fuse query is complete.

Each of these improvements helps a bit on their own, but they work best in conjunction, so I'm adding both in this PR.

When the user opens search:

- Two lazy GraphQL queries are started, primary and secondary.
- When a GraphQL query completes, create a search worker and populate it with the results. The GraphQL query results may be cached initially, in which case the worker should already have a collection to search on.
- While either GraphQL query is loading, a loading spinner appears in the search input.
- When the user types, perform a debounced search. Results arrive async from the worker. If results arrive that don't match the user's current querystring, discard them.

I also made some tweaks to the Fuse options to improve surfacing exact matches.

Since we have other searchable pages throughout the app, we can use search workers elsewhere as well and get Fuse fuzzy searching in a bunch of places.

## How I Tested These Changes

Created Storybook stories to simulate:

- Basic search with not-too-many objects
- Fast primary query, slow secondary query
- Normal primary query, seconcary query with tens of thousands of objects

In each case, open search and verify (visually and with Performance profiling in dev tools) that querying and rendering are snappy.

Repeat search in app to sanity check.
