### PR TITLE
[dagster-pyspark] Rough migration to Pythonic resources

### DIFF
--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/__init__.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/__init__.py
@@ -1,9 +1,15 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from .resources import lazy_pyspark_resource, pyspark_resource
+from .resources import LazyPySparkResource, PySparkResource, lazy_pyspark_resource, pyspark_resource
 from .types import DataFrame
 from .version import __version__
 
 DagsterLibraryRegistry.register("dagster-pyspark", __version__)
 
-__all__ = ["DataFrame", "pyspark_resource", "lazy_pyspark_resource"]
+__all__ = [
+    "DataFrame",
+    "pyspark_resource",
+    "lazy_pyspark_resource",
+    "PySparkResource",
+    "LazyPySparkResource",
+]

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark/resources.py
@@ -1,5 +1,10 @@
+from typing import Any, Dict
+
 import dagster._check as check
-from dagster import resource
+from dagster import ConfigurableResource, IAttachDifferentObjectToOpContext, resource
+from dagster._config.validate import validate_config
+from dagster._core.errors import DagsterInvalidConfigError
+from dagster._utils.cached_method import cached_method
 from dagster_spark.configs_spark import spark_config
 from dagster_spark.utils import flatten_dict
 from pyspark.sql import SparkSession
@@ -15,7 +20,7 @@ def spark_session_from_config(spark_conf=None):
     return builder.getOrCreate()
 
 
-class PySparkResource:
+class PySparkClient:
     def __init__(self, spark_conf):
         self._spark_session = spark_session_from_config(spark_conf)
 
@@ -26,6 +31,48 @@ class PySparkResource:
     @property
     def spark_context(self):
         return self.spark_session.sparkContext
+
+
+class PySparkResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
+    """This resource provides access to a PySpark Session for executing PySpark code within Dagster.
+
+    Example:
+        .. code-block:: python
+
+            @op
+            def my_op(pyspark: PySparkResource)
+                spark_session = pyspark.get_client().spark_session
+                dataframe = spark_session.read.json("examples/src/main/resources/people.json")
+
+
+            @job(
+                resource_defs={
+                    "pyspark": PySparkResource(
+                        spark_config={
+                            "spark.executor.memory": "2g"
+                        }
+                    )
+                }
+            )
+            def my_spark_job():
+                my_op()
+    """
+
+    spark_config: Dict[str, Any]
+
+    @cached_method
+    def get_client(self) -> PySparkClient:
+        result = validate_config(spark_config(), self.spark_config)
+        if not result.success:
+            raise DagsterInvalidConfigError(
+                "Error when processing PySpark resource config ",
+                result.errors,
+                self.spark_config,
+            )
+        return PySparkClient(self.spark_config)
+
+    def get_object_to_set_on_execution_context(self) -> Any:
+        return self.get_client()
 
 
 @resource({"spark_conf": spark_config()})
@@ -48,10 +95,10 @@ def pyspark_resource(init_context):
             def my_spark_job():
                 my_op()
     """
-    return PySparkResource(init_context.resource_config["spark_conf"])
+    return PySparkClient(init_context.resource_config["spark_conf"])
 
 
-class LazyPySparkResource:
+class LazyPySparkClient:
     def __init__(self, spark_conf):
         self._spark_session = None
         self._spark_conf = spark_conf
@@ -69,6 +116,50 @@ class LazyPySparkResource:
     def spark_context(self):
         self._init_session()
         return self._spark_session.sparkContext
+
+
+class LazyPySparkResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
+    """This resource provides access to a lazily-created  PySpark SparkSession for executing PySpark
+    code within Dagster, avoiding the creation of a SparkSession object until the .spark_session attribute
+    of the resource is accessed. This is helpful for avoiding the creation (and startup penalty) of a SparkSession
+    until it is actually needed / accessed by an op or IOManager.
+
+    Example:
+        .. code-block:: python
+
+            @op
+            def my_op(lazy_pyspark: LazyPySparkResource)
+                spark_session = lazy_pyspark.get_client().spark_session
+                dataframe = spark_session.read.json("examples/src/main/resources/people.json")
+
+            @job(
+                resource_defs={
+                    "lazy_pyspark": LazyPySparkResource(
+                        spark_config={
+                            "spark.executor.memory": "2g"
+                        }
+                    )
+                }
+            )
+            def my_spark_job():
+                my_op()
+    """
+
+    spark_config: Dict[str, Any]
+
+    @cached_method
+    def get_client(self) -> LazyPySparkClient:
+        result = validate_config(spark_config(), self.spark_config)
+        if not result.success:
+            raise DagsterInvalidConfigError(
+                "Error when processing PySpark resource config ",
+                result.errors,
+                self.spark_config,
+            )
+        return LazyPySparkClient(self.spark_config)
+
+    def get_object_to_set_on_execution_context(self) -> Any:
+        return self.get_client()
 
 
 @resource({"spark_conf": spark_config()})
@@ -94,4 +185,4 @@ def lazy_pyspark_resource(init_context):
             def my_spark_job():
                 my_op()
     """
-    return LazyPySparkResource(init_context.resource_config["spark_conf"])
+    return LazyPySparkClient(init_context.resource_config["spark_conf"])

--- a/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_resources.py
+++ b/python_modules/libraries/dagster-pyspark/dagster_pyspark_tests/test_resources.py
@@ -1,7 +1,15 @@
+from typing import Any
+
+import pytest
 from dagster import job, multiprocess_executor, op, reconstructable
 from dagster._core.execution.api import execute_job
 from dagster._core.test_utils import instance_for_test
-from dagster_pyspark.resources import lazy_pyspark_resource, pyspark_resource
+from dagster_pyspark import (
+    LazyPySparkResource,
+    PySparkResource,
+    lazy_pyspark_resource,
+    pyspark_resource,
+)
 from pyspark.sql import SparkSession
 
 
@@ -45,23 +53,43 @@ def assert_pipeline_runs_with_lazy_resource(resource_def):
     assert called["yup"]
 
 
-def test_pyspark_resource():
-    pyspark_resource.configured({"spark_conf": {"spark": {"executor": {"memory": "1024MB"}}}})
+@pytest.fixture(name="build_pyspark_resource", params=["pythonic", "legacy"])
+def build_pyspark_resource_fixture(request) -> Any:
+    if request.param == "pythonic":
+        return PySparkResource
+    else:
+        return lambda **kwargs: pyspark_resource.configured(
+            {"spark_conf": kwargs.get("spark_config")}
+        )
+
+
+@pytest.fixture(name="build_lazy_pyspark_resource", params=["pythonic", "legacy"])
+def build_lazy_pyspark_resource_fixture(request) -> Any:
+    if request.param == "pythonic":
+        return LazyPySparkResource
+    else:
+        return lambda **kwargs: lazy_pyspark_resource.configured(
+            {"spark_conf": kwargs.get("spark_config")}
+        )
+
+
+def test_pyspark_resource(build_pyspark_resource):
+    build_pyspark_resource(spark_config={"spark": {"executor": {"memory": "1024MB"}}})
     assert_pipeline_runs_with_resource(pyspark_resource)
 
 
-def test_lazy_pyspark_resource():
-    lazy_pyspark_resource.configured({"spark_conf": {"spark": {"executor": {"memory": "1024MB"}}}})
+def test_lazy_pyspark_resource(build_lazy_pyspark_resource):
+    build_lazy_pyspark_resource(spark_config={"spark": {"executor": {"memory": "1024MB"}}})
     assert_pipeline_runs_with_lazy_resource(lazy_pyspark_resource)
 
 
-def test_pyspark_resource_escape_hatch():
-    pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "1024MB"}})
+def test_pyspark_resource_escape_hatch(build_pyspark_resource):
+    build_pyspark_resource(spark_config={"spark.executor.memory": "1024MB"})
     assert_pipeline_runs_with_resource(pyspark_resource)
 
 
-def test_lazy_pyspark_resource_escape_hatch():
-    lazy_pyspark_resource.configured({"spark_conf": {"spark.executor.memory": "1024MB"}})
+def test_lazy_pyspark_resource_escape_hatch(build_lazy_pyspark_resource):
+    build_lazy_pyspark_resource(spark_config={"spark.executor.memory": "1024MB"})
     assert_pipeline_runs_with_lazy_resource(lazy_pyspark_resource)
 
 


### PR DESCRIPTION
## Summary

Very barebones port of `dagster-pyspark` to Pythonic resources.

Renames the non-exported `PySparkResource` to `PySparkClient`, creates a new `PySparkResource` resource which wraps the client and takes an arbitrary config dict.

This dict is type-checked under the hood when the client is constructed, rather than as part of the config schema itself.

## Test Plan

unit tests.