### PR TITLE
added `AutoMaterializePolicy` to `AssetsDefinitionCacheableData` and `load_assets_from_dbt_cloud_job`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -32,6 +32,10 @@ class AssetsDefinitionCacheableData(
             ("can_subset", bool),
             ("extra_metadata", Optional[Mapping[Any, Any]]),
             ("freshness_policies_by_output_name", Optional[Mapping[str, FreshnessPolicy]]),
+            (
+                "auto_materialize_policies_by_output_name",
+                Optional[Mapping[str, AutoMaterializePolicy]],
+            ),
         ],
     )
 ):
@@ -50,6 +54,9 @@ class AssetsDefinitionCacheableData(
         can_subset: bool = False,
         extra_metadata: Optional[Mapping[Any, Any]] = None,
         freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
+        auto_materialize_policies_by_output_name: Optional[
+            Mapping[str, AutoMaterializePolicy]
+        ] = None,
     ):
         extra_metadata = check.opt_nullable_mapping_param(extra_metadata, "extra_metadata")
         try:
@@ -86,6 +93,12 @@ class AssetsDefinitionCacheableData(
                 "freshness_policies_by_output_name",
                 key_type=str,
                 value_type=FreshnessPolicy,
+            ),
+            auto_materialize_policies_by_output_name=check.opt_nullable_mapping_param(
+                auto_materialize_policies_by_output_name,
+                "auto_materialize_policies_by_output_name",
+                key_type=str,
+                value_type=AutoMaterializePolicy,
             ),
         )
 


### PR DESCRIPTION
## Summary & Motivation
As discussed with @OwenKephart and on #13794, this PR adds AMPs to `AssetsDefinitionCacheableData` so dbt cloud jobs can also benefit from the functionality. dbt cloud now follows the same pattern as dbt core assets, where users can define custom functions under `node_info_to_auto_materialize_policy_fn`.

## How I Tested These Changes
Unit test for `load_assets_from_dbt_cloud_job`.