### PR TITLE
Retry ECS concurrency test on failure

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -275,6 +275,13 @@ def test_register_task_definition(ecs):
                 cpu="256",
             )
 
+        # Infrequently, our concurrent futures don't fire fast enough to hit
+        # our stubbed ECS's lock. We can force this flaky behavior by firing
+        # thousands of futures; by the time the later futures launch, the
+        # earlier futures have already completed and released their lock.
+        #
+        # We've marked this test as flaky and retry it once on failure to
+        # try to mitigate this.
         futures = [executor.submit(task) for i in range(2)]
 
     # We successfully registered only 1 task definition revision

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/test_stubbed_ecs.py
@@ -187,6 +187,7 @@ def test_put_account_setting(ecs):
     assert task_arn_format_setting["value"] == "disabled"
 
 
+@pytest.mark.flaky(reruns=1)
 def test_register_task_definition(ecs):
     # Without memory
     with pytest.raises(ClientError):


### PR DESCRIPTION
Our use of concurrency here makes this occassionally flaky. I think this is pretty rare - I've had it running in a tight loop on my local machine for the past 30 min and I haven't seen it flake yet.

For now, let's just retry on failure using:

https://pypi.org/project/pytest-rerunfailures/

And if it ever re-emerges, we can disable the test or rethink our approach to detect regressions in:

https://github.com/dagster-io/dagster/pull/11192