### PR TITLE
[1/2] Create ScheduledRunListRoot.new 

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunsListRoot.new.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunsListRoot.new.tsx
@@ -3,7 +3,6 @@ import {Page, Alert, ButtonLink, Colors, Group} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
@@ -17,18 +16,12 @@ import {
 import {Loading} from '../ui/Loading';
 
 import {RunsPageHeader} from './RunsPageHeader';
-import {ScheduledRunListRoot as ScheduledRunListRootNew} from './ScheduledRunsListRoot.new';
 import {
   ScheduledRunsListQuery,
   ScheduledRunsListQueryVariables,
 } from './types/ScheduledRunListRoot.types';
 
 export const ScheduledRunListRoot = () => {
-  const {flagRunsTableFiltering} = useFeatureFlags();
-  return flagRunsTableFiltering ? <ScheduledRunListRootNew /> : <ScheduledRunListRootImpl />;
-};
-
-export const ScheduledRunListRootImpl = () => {
   useTrackPageView();
   useDocumentTitle('Runs | Scheduled');
 
@@ -93,7 +86,7 @@ export const ScheduledRunListRootImpl = () => {
 export default ScheduledRunListRoot;
 
 const SCHEDULED_RUNS_LIST_QUERY = gql`
-  query ScheduledRunsListQuery {
+  query ScheduledRunsListNewQuery {
     instance {
       id
       ...InstanceHealthFragment

--- a/js_modules/dagit/packages/core/src/runs/types/ScheduledRunsListRoot.new.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/ScheduledRunsListRoot.new.types.ts
@@ -1,0 +1,74 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type ScheduledRunsListNewQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type ScheduledRunsListNewQuery = {
+  __typename: 'DagitQuery';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    hasInfo: boolean;
+    daemonHealth: {
+      __typename: 'DaemonHealth';
+      id: string;
+      allDaemonStatuses: Array<{
+        __typename: 'DaemonStatus';
+        id: string;
+        daemonType: string;
+        required: boolean;
+        healthy: boolean | null;
+        lastHeartbeatTime: number | null;
+        lastHeartbeatErrors: Array<{
+          __typename: 'PythonError';
+          message: string;
+          stack: Array<string>;
+          errorChain: Array<{
+            __typename: 'ErrorChainLink';
+            isExplicitLink: boolean;
+            error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+          }>;
+        }>;
+      }>;
+    };
+  };
+  repositoriesOrError:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'RepositoryConnection';
+        nodes: Array<{
+          __typename: 'Repository';
+          id: string;
+          name: string;
+          location: {__typename: 'RepositoryLocation'; id: string; name: string};
+          schedules: Array<{
+            __typename: 'Schedule';
+            id: string;
+            name: string;
+            executionTimezone: string | null;
+            mode: string;
+            solidSelection: Array<string | null> | null;
+            pipelineName: string;
+            scheduleState: {
+              __typename: 'InstigationState';
+              id: string;
+              status: Types.InstigationStatus;
+            };
+            futureTicks: {
+              __typename: 'DryRunInstigationTicks';
+              results: Array<{__typename: 'DryRunInstigationTick'; timestamp: number | null}>;
+            };
+          }>;
+        }>;
+      };
+};


### PR DESCRIPTION
## Summary & Motivation

The "Scheduled" tab on the Runs page has its own root: `ScheduledRunListRoot`. We need to update this root to look similar to RunsRootNew.tsx. To prepare for that and to make it easier to review what actually changed this PR creates a carbon copy of `ScheduledRunListRoot` which will contain the new changes from the Runs page redesigns. It's a lot simpler to create a new file than to conditionally call hooks / add conditional logic everywhere depending on the feature flag. After we decide to ship these features I'll copy the contents of the "new" files to the original which will allow us to preserve commit history.

## How I Tested These Changes

Load dagit successfully.