### PR TITLE
[pythonic config][fix] Fix directly constructing config w/ discriminated union

### DIFF
--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -470,7 +470,7 @@ def config_dictionary_from_values(
 
     from dagster._config.pythonic_config import _config_value_to_dict_representation
 
-    return check.is_dict(_config_value_to_dict_representation(None, None, values))
+    return check.is_dict(_config_value_to_dict_representation(None, values))
 
 
 class IntEnvVar(int):

--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 import hashlib
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Sequence
 
 import dagster._check as check
@@ -460,28 +459,6 @@ def _convert_potential_field(
     return Field(_convert_potential_type(original_root, potential_field, stack))
 
 
-def _config_dictionary_from_values_inner(obj: Any):
-    from dagster._config.pythonic_config import Config
-
-    if isinstance(obj, dict):
-        return {k: _config_dictionary_from_values_inner(v) for k, v in obj.items() if v is not None}
-    elif isinstance(obj, list):
-        return [_config_dictionary_from_values_inner(v) for v in obj]
-    elif isinstance(obj, EnvVar):
-        return {"env": str(obj)}
-    elif isinstance(obj, IntEnvVar):
-        return {"env": obj.name}
-    elif isinstance(obj, Config):
-        return {
-            k: _config_dictionary_from_values_inner(v)
-            for k, v in obj._as_config_dict().items()  # noqa: SLF001
-        }
-    elif isinstance(obj, Enum):
-        return obj.name
-
-    return obj
-
-
 def config_dictionary_from_values(
     values: Mapping[str, Any], config_field: "Field"
 ) -> Dict[str, Any]:
@@ -491,7 +468,9 @@ def config_dictionary_from_values(
     """
     assert ConfigTypeKind.is_shape(config_field.config_type.kind)
 
-    return check.is_dict(_config_dictionary_from_values_inner(values))
+    from dagster._config.pythonic_config import _config_value_to_dict_representation
+
+    return check.is_dict(_config_value_to_dict_representation(None, None, values))
 
 
 class IntEnvVar(int):

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -295,11 +295,7 @@ def _config_value_to_dict_representation(field: Optional[ModelField], value: Any
     from dagster._config.field_utils import EnvVar, IntEnvVar
 
     if isinstance(value, dict):
-        return {
-            k: _config_value_to_dict_representation(None, v)
-            for k, v in value.items()
-            if v is not None
-        }
+        return {k: _config_value_to_dict_representation(None, v) for k, v in value.items()}
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -205,7 +205,7 @@ class Config(MakeConfigCacheable):
 
                 discriminator_key = check.not_none(field.discriminator_key)
                 if isinstance(value, Config):
-                    value_dict = value.dict()
+                    value_dict = value._as_config_dict()  # noqa: SLF001
                     value_discriminator = check.not_none(value_dict.get(discriminator_key))
                     values_without_key = {
                         k: v for k, v in value_dict.items() if k != discriminator_key

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -158,7 +158,7 @@ def op_invocation_result(
         from dagster._config.pythonic_config import Config
 
         context = (context or build_op_context()).replace_config(
-            config_input._get_non_none_public_field_values()  # noqa: SLF001
+            config_input._convert_to_config_dictionary()  # noqa: SLF001
             if isinstance(config_input, Config)
             else config_input
         )

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -158,7 +158,7 @@ def op_invocation_result(
         from dagster._config.pythonic_config import Config
 
         context = (context or build_op_context()).replace_config(
-            config_input._as_config_dict()  # noqa: SLF001
+            config_input._as_config_dict_shallow()  # noqa: SLF001
             if isinstance(config_input, Config)
             else config_input
         )

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -158,7 +158,7 @@ def op_invocation_result(
         from dagster._config.pythonic_config import Config
 
         context = (context or build_op_context()).replace_config(
-            config_input._as_config_dict_shallow()  # noqa: SLF001
+            config_input._get_non_none_public_field_values()  # noqa: SLF001
             if isinstance(config_input, Config)
             else config_input
         )

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -24,7 +24,7 @@ from dagster._config import (
     Selector,
     Shape,
 )
-from dagster._config.pythonic_config import Config, config_dictionary_from_values
+from dagster._config.pythonic_config import Config
 from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.executor_definition import (
     ExecutorDefinition,
@@ -618,11 +618,7 @@ def _convert_config_classes_inner(configs: Any) -> Any:
         return configs
 
     return {
-        k: {
-            "config": config_dictionary_from_values(
-                v._as_config_dict_shallow(), v.to_config_schema().as_field()  # noqa: SLF001
-            )
-        }
+        k: {"config": v._convert_to_config_dictionary()}  # noqa: SLF001
         if isinstance(v, Config)
         else _convert_config_classes_inner(v)
         for k, v in configs.items()

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -620,7 +620,7 @@ def _convert_config_classes_inner(configs: Any) -> Any:
     return {
         k: {
             "config": config_dictionary_from_values(
-                v._as_config_dict(), v.to_config_schema().as_field()  # noqa: SLF001
+                v._as_config_dict_shallow(), v.to_config_schema().as_field()  # noqa: SLF001
             )
         }
         if isinstance(v, Config)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from typing import List, Optional
 
@@ -7,6 +6,7 @@ import pydantic
 import pytest
 from dagster import (
     AssetOut,
+    EnvVar,
     _check as check,
     asset,
     job,
@@ -31,6 +31,7 @@ from dagster._core.errors import (
     DagsterInvalidPythonicConfigDefinitionError,
 )
 from dagster._core.execution.context.invocation import build_op_context
+from dagster._core.test_utils import environ
 from dagster._utils.cached_method import cached_method
 from pydantic import (
     BaseModel,
@@ -661,9 +662,7 @@ def test_schema_aliased_field():
 
 
 def test_env_var():
-    os.environ["ENV_VARIABLE_FOR_TEST"] = "foo"
-    os.environ["ENV_VARIABLE_FOR_TEST_INT"] = "2"
-    try:
+    with environ({"ENV_VARIABLE_FOR_TEST_INT": "2", "ENV_VARIABLE_FOR_TEST": "foo"}):
 
         class AnAssetConfig(Config):
             a_string: str
@@ -697,9 +696,6 @@ def test_env_var():
         )
 
         assert executed["yes"]
-    finally:
-        del os.environ["ENV_VARIABLE_FOR_TEST"]
-        del os.environ["ENV_VARIABLE_FOR_TEST_INT"]
 
 
 def test_structured_run_config_ops():
@@ -890,6 +886,82 @@ def test_direct_op_invocation_kwarg_with_config() -> None:
         executed["yes"] = True
 
     an_op(config=MyConfig(num=1))
+
+    assert executed["yes"]
+
+
+def test_direct_op_invocation_arg_complex() -> None:
+    class MyConfig(Config):
+        num: int
+
+    class MyOuterConfig(Config):
+        inner: MyConfig
+        string: str
+
+    executed = {}
+
+    @op
+    def an_op(config: MyOuterConfig) -> None:
+        assert config.inner.num == 1
+        assert config.string == "foo"
+        executed["yes"] = True
+
+    an_op(MyOuterConfig(inner=MyConfig(num=1), string="foo"))
+
+    assert executed["yes"]
+
+
+def test_direct_op_invocation_kwarg_complex() -> None:
+    class MyConfig(Config):
+        num: int
+
+    class MyOuterConfig(Config):
+        inner: MyConfig
+        string: str
+
+    executed = {}
+
+    @op
+    def an_op(config: MyOuterConfig) -> None:
+        assert config.inner.num == 1
+        assert config.string == "foo"
+        executed["yes"] = True
+
+    an_op(config=MyOuterConfig(inner=MyConfig(num=1), string="foo"))
+
+    assert executed["yes"]
+
+
+def test_direct_op_invocation_kwarg_very_complex() -> None:
+    class MyConfig(Config):
+        num: int
+
+    class MyOuterConfig(Config):
+        inner: MyConfig
+        string: str
+
+    class MyOutermostConfig(Config):
+        inner: MyOuterConfig
+        boolean: bool
+
+    executed = {}
+
+    @op
+    def an_op(config: MyOutermostConfig) -> None:
+        assert config.inner.inner.num == 2
+        assert config.inner.string == "foo"
+        assert config.boolean is False
+        executed["yes"] = True
+
+    with environ({"ENV_VARIABLE_FOR_TEST_INT": "2"}):
+        an_op(
+            config=MyOutermostConfig(
+                inner=MyOuterConfig(
+                    inner=MyConfig(num=EnvVar.int("ENV_VARIABLE_FOR_TEST_INT")), string="foo"
+                ),
+                boolean=False,
+            )
+        )
 
     assert executed["yes"]
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -11,7 +11,7 @@ from dagster import (
     op,
 )
 from dagster._config.config_type import ConfigTypeKind, Noneable
-from dagster._config.pythonic_config import Config, PermissiveConfig
+from dagster._config.pythonic_config import Config, ConfigurableResource, PermissiveConfig
 from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.cached_method import cached_method
@@ -418,7 +418,7 @@ def test_struct_config_map_different_key_type(key_type: Type, keys: List[Any]):
     assert executed["yes"]
 
 
-def test_descriminated_unions() -> None:
+def test_discriminated_unions() -> None:
     class Cat(Config):
         pet_type: Literal["cat"]
         meows: int
@@ -555,7 +555,7 @@ def test_nested_discriminated_unions() -> None:
     assert executed["yes"]
 
 
-def test_descriminated_unions_direct_instantiation() -> None:
+def test_discriminated_unions_direct_instantiation() -> None:
     class Cat(Config):
         pet_type: Literal["cat"] = "cat"
         meows: int
@@ -600,6 +600,37 @@ def test_nested_discriminated_config_instantiation() -> None:
         n: int
 
     config = OpConfigWithUnion(pet=Dog(barks=5.5, breed=Poodle(fluffy=True)), n=3)
+    assert isinstance(config.pet, Dog)
+    assert config.pet.barks == 5.5
+    assert config.pet.pet_type == "dog"
+    assert isinstance(config.pet.breed, Poodle)
+    assert config.pet.breed.fluffy
+    assert config.pet.breed.breed_type == "poodle"
+
+
+def test_nested_discriminated_resource_instantiation() -> None:
+    class Poodle(Config):
+        breed_type: Literal["poodle"] = "poodle"
+        fluffy: bool
+
+    class Dachshund(Config):
+        breed_type: Literal["dachshund"] = "dachshund"
+        long: bool
+
+    class Cat(Config):
+        pet_type: Literal["cat"] = "cat"
+        meows: int
+
+    class Dog(Config):
+        pet_type: Literal["dog"] = "dog"
+        barks: float
+        breed: Union[Poodle, Dachshund] = Field(..., discriminator="breed_type")
+
+    class ResourceWithUnion(ConfigurableResource):
+        pet: Union[Cat, Dog] = Field(..., discriminator="pet_type")
+        n: int
+
+    config = ResourceWithUnion(pet=Dog(barks=5.5, breed=Poodle(fluffy=True)), n=3)
     assert isinstance(config.pet, Dog)
     assert config.pet.barks == 5.5
     assert config.pet.pet_type == "dog"
@@ -857,4 +888,4 @@ def test_to_config_dict_combined_with_cached_method() -> None:
 
     obj = ConfigWithCachedMethod(a_string="bar")
     obj.a_string_cached()
-    assert obj._as_config_dict() == {"a_string": "bar"}  # noqa: SLF001
+    assert obj._as_config_dict_shallow() == {"a_string": "bar"}  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -500,6 +500,28 @@ def test_descriminated_unions() -> None:
         )
 
 
+def test_descriminated_unions_initialization() -> None:
+    class Cat(Config):
+        pet_type: Literal["cat"] = "cat"
+        meows: int
+
+    class Dog(Config):
+        pet_type: Literal["dog"] = "dog"
+        barks: float
+
+    class Lizard(Config):
+        pet_type: Literal["reptile", "lizard"] = "reptile"
+        scales: bool
+
+    class OpConfigWithUnion(Config):
+        pet: Union[Cat, Dog, Lizard] = Field(..., discriminator="pet_type")
+        n: int
+
+    config = OpConfigWithUnion(pet=Cat(meows=3), n=5)
+    assert isinstance(config.pet, Cat)
+    assert config.pet.meows == 3
+
+
 def test_nested_discriminated_unions() -> None:
     class Poodle(Config):
         breed_type: Literal["poodle"]

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -909,4 +909,4 @@ def test_to_config_dict_combined_with_cached_method() -> None:
 
     obj = ConfigWithCachedMethod(a_string="bar")
     obj.a_string_cached()
-    assert obj._as_config_dict_shallow() == {"a_string": "bar"}  # noqa: SLF001
+    assert obj._convert_to_config_dictionary() == {"a_string": "bar"}  # noqa: SLF001

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources.py
@@ -480,7 +480,9 @@ class DbtCliClientResource(ConfigurableResourceWithCliFlags, IAttachDifferentObj
     def get_dbt_client(self) -> DbtCliClient:
         context = self.get_resource_context()
         default_flags = {
-            k: v for k, v in self._as_config_dict().items() if k not in COMMON_OPTION_KEYS
+            k: v
+            for k, v in self._get_non_none_public_field_values().items()
+            if k not in COMMON_OPTION_KEYS
         }
 
         return DbtCliClient(


### PR DESCRIPTION
## Summary

Addresses #13875.

Fixes direct construction of discriminated unions, which currently errors:

```python

class Cat(Config):
    pet_type: Literal["cat"] = "cat"
    meows: int

class Dog(Config):
    pet_type: Literal["dog"] = "dog"
    barks: float

class ConfigWithUnion(Config):
    pet: Union[Cat, Dog] = Field(discriminator="pet_type")
    
config = ConfigWithUnion(pet=Cat(meows=10))
```

This behavior was only tested in the "unstructured config" case, so it wasn't caught.

## Test Plan

A few new unit tests
