### PR TITLE
Enables multi asset sensor partitions methods to work for source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -247,15 +247,19 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             self._monitored_asset_keys = monitored_assets
 
         self._assets_by_key: Dict[AssetKey, Optional[AssetsDefinition]] = {}
+        self._partitions_def_by_asset_key: Dict[AssetKey, Optional[PartitionsDefinition]] = {}
         for asset_key in self._monitored_asset_keys:
             assets_def = self._repository_def.assets_defs_by_key.get(asset_key)
             self._assets_by_key[asset_key] = assets_def
 
-        self._partitions_def_by_asset_key = {
-            asset_key: asset_def.partitions_def
-            for asset_key, asset_def in self._assets_by_key.items()
-            if asset_def is not None
-        }
+            source_asset_def = self._repository_def.source_assets_by_key.get(asset_key)
+            self._partitions_def_by_asset_key[asset_key] = (
+                assets_def.partitions_def
+                if assets_def
+                else source_asset_def.partitions_def
+                if source_asset_def
+                else None
+            )
 
         # Cursor object with utility methods for updating and retrieving cursor information.
         # At the end of each tick, must call update_cursor_after_evaluation to update the serialized

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Iterator, Optional, cast
+from typing import Iterator, List, Optional, cast
 from unittest import mock
 
 import pytest
@@ -25,6 +25,7 @@ from dagster import (
     RunConfig,
     RunRequest,
     SkipReason,
+    SourceAsset,
     StaticPartitionsDefinition,
     asset,
     build_freshness_policy_sensor_context,
@@ -321,6 +322,52 @@ def test_multi_asset_sensor_invocation_resources() -> None:
             resources={"my_resource": MyResource(a_str="bar")},
         )
         assert cast(RunRequest, a_and_b_sensor(ctx)).run_config == {"foo": "bar"}
+
+
+def test_multi_asset_sensor_with_source_assets() -> None:
+    # upstream_asset1 exists in another repository
+    @asset(partitions_def=DailyPartitionsDefinition(start_date="2023-03-01"))
+    def upstream_asset1():
+        ...
+
+    upstream_asset1_source = SourceAsset(
+        key=upstream_asset1.key,
+        partitions_def=DailyPartitionsDefinition(start_date="2023-03-01"),
+    )
+
+    @asset()
+    def downstream_asset(upstream_asset1):
+        ...
+
+    @multi_asset_sensor(
+        monitored_assets=[
+            upstream_asset1.key,
+        ],
+        job=define_asset_job("foo", selection=[downstream_asset]),
+    )
+    def my_sensor(context):
+        run_requests = []
+        for partition, record in context.latest_materialization_records_by_partition(
+            AssetKey("upstream_asset1")
+        ).items():
+            context.advance_cursor({upstream_asset1.key: record})
+            run_requests.append(RunRequest(partition_key=partition))
+        return run_requests
+
+    @repository
+    def my_repo():
+        return [upstream_asset1_source, downstream_asset, my_sensor]
+
+    with instance_for_test() as instance:
+        materialize([upstream_asset1], instance=instance, partition_key="2023-03-01")
+        ctx = build_multi_asset_sensor_context(
+            monitored_assets=[AssetKey("upstream_asset1")],
+            instance=instance,
+            repository_def=my_repo,
+        )
+        run_requests = cast(List[RunRequest], my_sensor(ctx))
+        assert len(run_requests) == 1
+        assert run_requests[0].partition_key == "2023-03-01"
 
 
 def test_freshness_policy_sensor_invocation_resources() -> None:


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/13834

The multi asset sensor context partition methods currently don't work for source assets since we only fetch existent partitions defs for derived assets. This PR updates this functionality to also fetch partitions definitions for source assets.