### PR TITLE
Fix docs build RunFailureSensorContext error

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -258,7 +258,6 @@ class RunFailureSensorContext(RunStatusSensorContext):
     Attributes:
         sensor_name (str): the name of the sensor.
         dagster_run (DagsterRun): the failed run.
-        failure_event (DagsterEvent): the failure event.
     """
 
     @public


### PR DESCRIPTION
## Summary & Motivation

#13719 introduced a new docstring that conflicted with an existing one, which caused BK docs build to emit a warning leading to a failing BK step. This fixes that.

## How I Tested These Changes

BK
