### PR TITLE
Better error handling for serdes failures during grpc calls

### DIFF
--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -10,11 +10,14 @@ from dagster._api.snapshot_partition import (
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.host_representation import (
     ExternalPartitionConfigData,
+    ExternalPartitionExecutionErrorData,
     ExternalPartitionNamesData,
     ExternalPartitionSetExecutionParamData,
     ExternalPartitionTagsData,
 )
 from dagster._core.instance import DagsterInstance
+from dagster._grpc.types import PartitionArgs, PartitionNamesArgs, PartitionSetExecutionParamArgs
+from dagster._serdes import deserialize_value
 
 from .utils import get_bar_repo_code_location
 
@@ -27,6 +30,24 @@ def test_external_partition_names_grpc(instance: DagsterInstance):
         )
         assert isinstance(data, ExternalPartitionNamesData)
         assert data.partition_names == list(string.ascii_lowercase)
+
+
+def test_external_partition_names_deserialize_error_grpc(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        api_client = code_location.client
+
+        repository_handle = code_location.get_repository("bar_repo").handle
+        repository_origin = repository_handle.get_external_origin()
+
+        result = deserialize_value(
+            api_client.external_partition_names(
+                partition_names_args=PartitionNamesArgs(
+                    repository_origin=repository_origin,
+                    partition_set_name="foo",
+                )._replace(repository_origin="INVALID"),
+            )
+        )
+        assert isinstance(result, ExternalPartitionExecutionErrorData)
 
 
 def test_external_partitions_config_grpc(instance: DagsterInstance):
@@ -55,6 +76,26 @@ def test_external_partitions_config_error_grpc(instance: DagsterInstance):
             )
 
 
+def test_external_partition_config_deserialize_error_grpc(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        repository_handle = code_location.get_repository("bar_repo").handle
+
+        api_client = code_location.client
+
+        result = deserialize_value(
+            api_client.external_partition_config(
+                partition_args=PartitionArgs(
+                    repository_origin=repository_handle.get_external_origin(),
+                    partition_set_name="foo",
+                    partition_name="bar",
+                    instance_ref=instance.get_ref(),
+                )._replace(repository_origin="INVALID"),
+            )
+        )
+
+        assert isinstance(result, ExternalPartitionExecutionErrorData)
+
+
 def test_external_partitions_tags_grpc(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
         repository_handle = code_location.get_repository("bar_repo").handle
@@ -65,6 +106,26 @@ def test_external_partitions_tags_grpc(instance: DagsterInstance):
         assert isinstance(data, ExternalPartitionTagsData)
         assert data.tags
         assert data.tags["foo"] == "bar"
+
+
+def test_external_partitions_tags_deserialize_error_grpc(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        repository_handle = code_location.get_repository("bar_repo").handle
+        repository_origin = repository_handle.get_external_origin()
+
+        api_client = code_location.client
+
+        result = deserialize_value(
+            api_client.external_partition_tags(
+                partition_args=PartitionArgs(
+                    repository_origin=repository_origin,
+                    partition_set_name="fooba",
+                    partition_name="c",
+                    instance_ref=instance.get_ref(),
+                )._replace(repository_origin="INVALID"),
+            )
+        )
+        assert isinstance(result, ExternalPartitionExecutionErrorData)
 
 
 def test_external_partitions_tags_error_grpc(instance: DagsterInstance):
@@ -90,6 +151,28 @@ def test_external_partition_set_execution_params_grpc(instance: DagsterInstance)
         )
         assert isinstance(data, ExternalPartitionSetExecutionParamData)
         assert len(data.partition_data) == 3
+
+
+def test_external_partition_set_execution_params_deserialize_error_grpc(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        repository_handle = code_location.get_repository("bar_repo").handle
+
+        repository_origin = repository_handle.get_external_origin()
+
+        api_client = code_location.client
+
+        result = deserialize_value(
+            api_client.external_partition_set_execution_params(
+                partition_set_execution_param_args=PartitionSetExecutionParamArgs(
+                    repository_origin=repository_origin,
+                    partition_set_name="baz_partition_set",
+                    partition_names=["a", "b", "c"],
+                    instance_ref=instance.get_ref(),
+                )._replace(repository_origin="INVALID"),
+            )
+        )
+
+        assert isinstance(result, ExternalPartitionExecutionErrorData)
 
 
 def test_dynamic_partition_set_grpc(instance: DagsterInstance):

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -2,6 +2,10 @@ import pytest
 from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_ephemeral_grpc
 from dagster._core.definitions.sensor_definition import SensorExecutionData
 from dagster._core.errors import DagsterUserCodeProcessError, DagsterUserCodeUnreachableError
+from dagster._core.host_representation.external_data import ExternalSensorExecutionErrorData
+from dagster._grpc.client import ephemeral_grpc_api_client
+from dagster._grpc.types import SensorExecutionArgs
+from dagster._serdes import deserialize_value
 
 from .utils import get_bar_repo_handle
 
@@ -24,6 +28,27 @@ def test_external_sensor_error(instance):
             sync_get_external_sensor_execution_data_ephemeral_grpc(
                 instance, repository_handle, "sensor_error", None, None, None
             )
+
+
+def test_external_sensor_deserialize_error(instance):
+    with get_bar_repo_handle(instance) as repository_handle:
+        origin = repository_handle.get_external_origin()
+        with ephemeral_grpc_api_client(
+            origin.code_location_origin.loadable_target_origin
+        ) as api_client:
+            result = deserialize_value(
+                api_client.external_sensor_execution(
+                    sensor_execution_args=SensorExecutionArgs(
+                        repository_origin=origin,
+                        instance_ref=instance.get_ref(),
+                        sensor_name="foo",
+                        last_completion_time=None,
+                        last_run_key=None,
+                        cursor=None,
+                    )
+                )
+            )
+            assert isinstance(result, ExternalSensorExecutionErrorData)
 
 
 def test_external_sensor_raises_dagster_error(instance):


### PR DESCRIPTION
Summary:
In a few different api calls here we were try catching the inner impl method, but not catching the exception and serializing it up if there was an error during the resulting serialize_value call itself. Add some additional try/catch wrappers for that.

## Summary & Motivation

## How I Tested These Changes
