### PR TITLE
[fix][pythonic config] Fix direct-invocation config behavior with nested Pythonic config

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -295,11 +295,7 @@ def _config_value_to_dict_representation(field: Optional[ModelField], value: Any
     from dagster._config.field_utils import EnvVar, IntEnvVar
 
     if isinstance(value, dict):
-        return {
-            k: _config_value_to_dict_representation(None, v)
-            for k, v in value.items()
-            if v is not None
-        }
+        return {k: _config_value_to_dict_representation(None, v) for k, v in value.items()}
     elif isinstance(value, list):
         return [_config_value_to_dict_representation(None, v) for v in value]
     elif isinstance(value, EnvVar):

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -158,7 +158,7 @@ def op_invocation_result(
         from dagster._config.pythonic_config import Config
 
         context = (context or build_op_context()).replace_config(
-            config_input._get_non_none_public_field_values()  # noqa: SLF001
+            config_input._as_config_dict_deep()  # noqa: SLF001
             if isinstance(config_input, Config)
             else config_input
         )

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -158,7 +158,7 @@ def op_invocation_result(
         from dagster._config.pythonic_config import Config
 
         context = (context or build_op_context()).replace_config(
-            config_input._as_config_dict_deep()  # noqa: SLF001
+            config_input._convert_to_config_dictionary()  # noqa: SLF001
             if isinstance(config_input, Config)
             else config_input
         )

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
@@ -663,6 +663,7 @@ def test_schema_aliased_field():
 
 def test_env_var():
     with environ({"ENV_VARIABLE_FOR_TEST_INT": "2", "ENV_VARIABLE_FOR_TEST": "foo"}):
+
         class AnAssetConfig(Config):
             a_string: str
             an_int: int
@@ -695,7 +696,7 @@ def test_env_var():
         )
 
         assert executed["yes"]
-  
+
 
 def test_structured_run_config_ops():
     class ANewConfigOpConfig(Config):
@@ -961,7 +962,7 @@ def test_direct_op_invocation_kwarg_very_complex() -> None:
                 boolean=False,
             )
         )
-   
+
     assert executed["yes"]
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from typing import List, Optional
 
@@ -32,6 +31,7 @@ from dagster._core.errors import (
     DagsterInvalidPythonicConfigDefinitionError,
 )
 from dagster._core.execution.context.invocation import build_op_context
+from dagster._core.test_utils import environ
 from dagster._utils.cached_method import cached_method
 from pydantic import (
     BaseModel,
@@ -662,10 +662,7 @@ def test_schema_aliased_field():
 
 
 def test_env_var():
-    os.environ["ENV_VARIABLE_FOR_TEST"] = "foo"
-    os.environ["ENV_VARIABLE_FOR_TEST_INT"] = "2"
-    try:
-
+    with environ({"ENV_VARIABLE_FOR_TEST_INT": "2", "ENV_VARIABLE_FOR_TEST": "foo"}):
         class AnAssetConfig(Config):
             a_string: str
             an_int: int
@@ -698,10 +695,7 @@ def test_env_var():
         )
 
         assert executed["yes"]
-    finally:
-        del os.environ["ENV_VARIABLE_FOR_TEST"]
-        del os.environ["ENV_VARIABLE_FOR_TEST_INT"]
-
+  
 
 def test_structured_run_config_ops():
     class ANewConfigOpConfig(Config):
@@ -958,8 +952,7 @@ def test_direct_op_invocation_kwarg_very_complex() -> None:
         assert config.boolean is False
         executed["yes"] = True
 
-    os.environ["ENV_VARIABLE_FOR_TEST_INT"] = "2"
-    try:
+    with environ({"ENV_VARIABLE_FOR_TEST_INT": "2"}):
         an_op(
             config=MyOutermostConfig(
                 inner=MyOuterConfig(
@@ -968,9 +961,7 @@ def test_direct_op_invocation_kwarg_very_complex() -> None:
                 boolean=False,
             )
         )
-    finally:
-        del os.environ["ENV_VARIABLE_FOR_TEST_INT"]
-
+   
     assert executed["yes"]
 
 


### PR DESCRIPTION
## Summary

Fixes direct op/asset invocation behavior when specifying a config class which is more complex (e.g. nested config). Under the hood, this wasn't properly flatting the passed config into a config dictionary, only the top level of config.

The following now works:

```python
class MyConfig(Config):
    num: int

class MyOuterConfig(Config):
    inner: MyConfig
    string: str

executed = {}

@op
def an_op(config: MyOuterConfig) -> None:
    assert config.inner.num == 1
    assert config.string == "foo"
    executed["yes"] = True

an_op(config=MyOuterConfig(inner=MyConfig(num=1), string="foo"))
```

## Test Plan

New unit tests.
