### PR TITLE
[pythonic config] Fix passing struct. Config values for graphs to RunConfig

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -613,17 +613,24 @@ def construct_config_type_dictionary(
     return type_dict_by_name, type_dict_by_key
 
 
-def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
+def _convert_config_classes_inner(configs: Any) -> Any:
+    if not isinstance(configs, dict):
+        return configs
+
     return {
         k: {
             "config": config_dictionary_from_values(
                 v._as_config_dict(), v.to_config_schema().as_field()  # noqa: SLF001
             )
-            if isinstance(v, Config)
-            else v
         }
+        if isinstance(v, Config)
+        else _convert_config_classes_inner(v)
         for k, v in configs.items()
     }
+
+
+def _convert_config_classes(configs: Dict[str, Any]) -> Dict[str, Any]:
+    return _convert_config_classes_inner(configs)
 
 
 class RunConfig:

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_basic_pythonic_config.py
@@ -424,7 +424,7 @@ def test_validate_run_config():
     }
 
     result_with_runconfig = validate_run_config(
-        job_requires_config, RunConfig(ops={"requires_config": {"foo": "bar"}})
+        job_requires_config, RunConfig(ops={"requires_config": {"config": {"foo": "bar"}}})
     )
     assert result_with_runconfig == result
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_graphs.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_graphs.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict
 
 import pytest
-from dagster import Config, RunConfig, config_mapping, graph, job, op
+from dagster import Config, RunConfig, config_mapping, graph, graph_asset, job, materialize, op
 from dagster._check import CheckError
 
 
@@ -210,3 +210,89 @@ def test_config_mapping_return_run_config_nested() -> None:
     )
     assert result.success
     assert result.output_for_node("do_it_all_with_simplified_config.do_something") == "foo"
+
+
+def test_graph_no_mapping() -> None:
+    executed = {}
+
+    class MyOpConfig(Config):
+        foo_str: str
+
+    @op
+    def my_op(config: MyOpConfig):
+        assert config.foo_str == "foo"
+        executed["my_op"] = True
+
+    class MyOtherOpConfig(Config):
+        bar_int: int
+
+    @op
+    def my_other_op(config: MyOtherOpConfig):
+        assert config.bar_int == 2
+        executed["my_other_op"] = True
+
+    @graph
+    def my_graph():
+        my_op()
+        my_other_op()
+
+    @job
+    def my_job():
+        my_graph()
+
+    assert my_job.execute_in_process(
+        run_config=RunConfig(
+            ops={
+                "my_graph": {
+                    "ops": {
+                        "my_op": MyOpConfig(foo_str="foo"),
+                        "my_other_op": MyOtherOpConfig(bar_int=2),
+                    }
+                }
+            }
+        )
+    ).success
+    assert executed == {"my_op": True, "my_other_op": True}
+
+
+def test_graph_asset() -> None:
+    executed = {}
+
+    class MyOpConfig(Config):
+        foo_str: str
+
+    @op
+    def my_op(config: MyOpConfig) -> int:
+        assert config.foo_str == "foo"
+        executed["my_op"] = True
+        return len(config.foo_str)
+
+    class MyOtherOpConfig(Config):
+        bar_int: int
+
+    @op
+    def my_other_op(my_in: int, config: MyOtherOpConfig) -> int:
+        assert config.bar_int == 2
+        executed["my_other_op"] = True
+        return my_in + config.bar_int
+
+    @graph_asset
+    def my_graph_asset() -> int:
+        return my_other_op(my_op())
+
+    result = materialize(
+        assets=[my_graph_asset],
+        run_config=RunConfig(
+            ops={
+                "my_graph_asset": {
+                    "ops": {
+                        "my_op": MyOpConfig(foo_str="foo"),
+                        "my_other_op": MyOtherOpConfig(bar_int=2),
+                    }
+                }
+            }
+        ),
+    )
+    assert result.success
+    assert result.asset_value("my_graph_asset") == 5
+    assert executed == {"my_op": True, "my_other_op": True}


### PR DESCRIPTION
## Summary

Allows users to pass config values to nested ops more easily using `RunConfig`, e.g. for graphs or graph-backed assets. Helps address #13880.

The following invocation is now possible:


```python
class MyOpConfig(Config):
    foo_str: str

@op
def my_op(config: MyOpConfig):
    assert config.foo_str == "foo"

class MyOtherOpConfig(Config):
    bar_int: int

@op
def my_other_op(config: MyOtherOpConfig):
    assert config.bar_int == 2

@graph
def my_graph():
    my_op()
    my_other_op()

@job
def my_job():
    my_graph()

my_job.execute_in_process(
    run_config=RunConfig(
        ops={
            "my_graph": {
                "ops": {
                    "my_op": MyOpConfig(foo_str="foo"),
                    "my_other_op": MyOtherOpConfig(bar_int=2),
                }
            }
        }
    )
)
```

## Test plan

A few new unit tests, more forthcoming
