### PR TITLE
[docs] Update state-in-resources docs to include lifecycle hooks

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -402,16 +402,11 @@ Below is a test for the `process_data_schedule` that we defined in the [Using re
 from dagster import build_schedule_context, validate_run_config
 
 def test_process_data_schedule():
-    context = build_schedule_context(
-        scheduled_execution_time=datetime.datetime(2020, 1, 1)
-    )
+    context = build_schedule_context(scheduled_execution_time=datetime.datetime(2020, 1, 1))
     run_request = process_data_schedule(
         context, date_formatter=DateFormatter(format="%Y-%m-%d")
     )
-    assert (
-        run_request.run_config["ops"]["fetch_data"]["config"]["date"]
-        == "2020-01-01"
-    )
+    assert run_request.run_config["ops"]["fetch_data"]["config"]["date"] == "2020-01-01"
 ```
 
 </TabItem>

--- a/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/schedules.mdx
@@ -402,11 +402,16 @@ Below is a test for the `process_data_schedule` that we defined in the [Using re
 from dagster import build_schedule_context, validate_run_config
 
 def test_process_data_schedule():
-    context = build_schedule_context(scheduled_execution_time=datetime.datetime(2020, 1, 1))
+    context = build_schedule_context(
+        scheduled_execution_time=datetime.datetime(2020, 1, 1)
+    )
     run_request = process_data_schedule(
         context, date_formatter=DateFormatter(format="%Y-%m-%d")
     )
-    assert run_request.run_config["ops"]["fetch_data"]["config"]["date"] == "2020-01-01"
+    assert (
+        run_request.run_config["ops"]["fetch_data"]["config"]["date"]
+        == "2020-01-01"
+    )
 ```
 
 </TabItem>

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -200,9 +200,7 @@ Then, configuration for the resource can be provided at launch time in the launc
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_runtime_launch endbefore=end_new_resource_runtime_launch dedent=4
 from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-update_data_job = define_asset_job(
-    name="update_data_job", selection=[data_from_database]
-)
+update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
 
 @sensor(job=update_data_job)
 def table_update_sensor():
@@ -245,9 +243,7 @@ defs = Definitions(
     assets=[my_asset],
     resources={
         "bucket": FileStoreBucket(
-            credentials=CredentialsResource(
-                username="my_user", password="my_password"
-            ),
+            credentials=CredentialsResource(username="my_user", password="my_password"),
             region="us-east-1",
         ),
     },
@@ -277,7 +273,7 @@ defs = Definitions(
 
 ## Defining resources which require state
 
-Once a resource reaches a certain complexity, it may be desirable to manage the state of the resource over its lifetime. This is useful for resources which require special initilization or cleanup such as database connections or file handles. Since `ConfigurableResource` is a dataclass meant to encapsulate config, it is not a good fit for managing state. The recommended pattern in this case is to build a separate class which manages the state of the resource which is provided by the `ConfigurableResource` class.
+Once a resource reaches a certain complexity, it may be desirable to manage the state of the resource over its lifetime. This is useful for resources which require special initilization or cleanup such as database connections or file handles. `ConfigurableResource` is a dataclass meant to encapsulate config, but can also be used to set up basic state.
 
 In this instance, we have a client which generates an API token from user-supplied credentials. This client class is provided by the resource, which handles config.
 
@@ -285,14 +281,18 @@ In this instance, we have a client which generates an API token from user-suppli
 from dagster import ConfigurableResource, asset
 import requests
 
-class MyClient:
-    """Client class with mutable state."""
+from pydantic import PrivateAttr
 
-    def __init__(self, username: str, password: str):
-        self.username = username
-        self.password = password
+class MyClientResource(ConfigurableResource):
+    username: str
+    password: str
+
+    _api_token: str = PrivateAttr()
+
+    def __post_init__(self):
+        # Fetch and set up an API token based on the username and password
         self._api_token = requests.get(
-            "https://my-api.com/token", auth=(username, password)
+            "https://my-api.com/token", auth=(self.username, self.password)
         ).text
 
     def query(self, body: str):
@@ -302,16 +302,35 @@ class MyClient:
             data=body,
         )
 
+@asset
+def my_asset(client: MyClientResource):
+    return client.query("foobar")
+```
+
+If more complex state management is required, such as setup and teardown of a temporary connection, the recommended pattern is to provide a context manager on the resource class which can be entered in a `with` block in an op or asset body:
+
+```python file=/concepts/resources/pythonic_resources.py startafter=start_with_complex_state_example endbefore=end_with_complex_state_example dedent=4
+from dagster import ConfigurableResource, asset
+from contextlib import contextmanager
+
+@contextmanager
+def get_database_connection(username: str, password: str):
+    ...
+
 class MyClientResource(ConfigurableResource):
     username: str
     password: str
 
-    def get_client(self):
-        return MyClient(self.username, self.password)
+    # Setup and teardown occurs in the asset or op body
+    @contextmanager
+    def get_connection(self):
+        with get_database_connection(self.username, self.password) as conn:
+            yield conn
 
 @asset
 def my_asset(client: MyClientResource):
-    return client.get_client().query("SELECT * FROM my_table")
+    with client.get_connection() as conn:
+        conn.query("SELECT * FROM my_table")
 ```
 
 For more information on the recommended way to test with resources which require state, see the [testing section](#testing-resources-with-state).

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -200,7 +200,9 @@ Then, configuration for the resource can be provided at launch time in the launc
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_runtime_launch endbefore=end_new_resource_runtime_launch dedent=4
 from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
+update_data_job = define_asset_job(
+    name="update_data_job", selection=[data_from_database]
+)
 
 @sensor(job=update_data_job)
 def table_update_sensor():
@@ -243,7 +245,9 @@ defs = Definitions(
     assets=[my_asset],
     resources={
         "bucket": FileStoreBucket(
-            credentials=CredentialsResource(username="my_user", password="my_password"),
+            credentials=CredentialsResource(
+                username="my_user", password="my_password"
+            ),
             region="us-east-1",
         ),
     },
@@ -350,8 +354,7 @@ class MyClientResource(ConfigurableResource):
 
 @asset
 def my_asset(client: MyClientResource):
-    with client.get_connection() as conn:
-        conn.query("SELECT * FROM my_table")
+    client.query("SELECT * FROM my_table")
 ```
 
 ---

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -200,7 +200,9 @@ Then, configuration for the resource can be provided at launch time in the launc
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_runtime_launch endbefore=end_new_resource_runtime_launch dedent=4
 from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
+update_data_job = define_asset_job(
+    name="update_data_job", selection=[data_from_database]
+)
 
 @sensor(job=update_data_job)
 def table_update_sensor():
@@ -243,7 +245,9 @@ defs = Definitions(
     assets=[my_asset],
     resources={
         "bucket": FileStoreBucket(
-            credentials=CredentialsResource(username="my_user", password="my_password"),
+            credentials=CredentialsResource(
+                username="my_user", password="my_password"
+            ),
             region="us-east-1",
         ),
     },
@@ -273,9 +277,11 @@ defs = Definitions(
 
 ## Defining resources which require state
 
-Once a resource reaches a certain complexity, it may be desirable to manage the state of the resource over its lifetime. This is useful for resources which require special initilization or cleanup such as database connections or file handles. `ConfigurableResource` is a dataclass meant to encapsulate config, but can also be used to set up basic state.
+Once a resource reaches a certain complexity, it may be desirable to manage the state of the resource over its lifetime. This is useful for resources which require special initilization or cleanup. `ConfigurableResource` is a dataclass meant to encapsulate config, but can also be used to set up basic state.
 
-In this instance, we have a client which generates an API token from user-supplied credentials. This client class is provided by the resource, which handles config.
+The `setup_for_execution` and `teardown_after_execution` methods can be overridden to initialize or teardown a resource before each run execution.
+
+In this instance, we can setup an API token for a client resource based on the username and password provided in the config. We then use that API token to query an API in our asset body.
 
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_with_state_example endbefore=end_with_state_example dedent=4
 from dagster import ConfigurableResource, asset
@@ -289,29 +295,37 @@ class MyClientResource(ConfigurableResource):
 
     _api_token: str = PrivateAttr()
 
-    def __post_init__(self):
+    def setup_for_execution(self, context) -> None:
         # Fetch and set up an API token based on the username and password
         self._api_token = requests.get(
             "https://my-api.com/token", auth=(self.username, self.password)
         ).text
 
-    def query(self, body: str):
+    def get_all_users(self):
         return requests.get(
-            "https://my-api.com/query",
+            "https://my-api.com/users",
             headers={"Authorization": self._api_token},
-            data=body,
         )
 
 @asset
 def my_asset(client: MyClientResource):
-    return client.query("foobar")
+    return client.get_all_users()
 ```
 
-If more complex state management is required, such as setup and teardown of a temporary connection, the recommended pattern is to provide a context manager on the resource class which can be entered in a `with` block in an op or asset body:
+`setup_for_execution` and `teardown_after_execution` are each called once per run, per process. When using the in-process executor, this means that they will be called once per run. When using the multiprocess executor, each process' instance of the resource will be initialized and torn down.
+
+For more complex use-cases, you may instead override the `yield_for_execution`. By default, this context manager will call `setup_for_execution`, yield the resource, and then call `teardown_after_execution`, but you can override it to provide any custom behavior. This is useful for resources which require a context to be open for the duration of a run, such as database connections or file handles.
 
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_with_complex_state_example endbefore=end_with_complex_state_example dedent=4
 from dagster import ConfigurableResource, asset
 from contextlib import contextmanager
+from pydantic import PrivateAttr
+
+class DBConnection:
+    ...
+
+    def query(self, body: str):
+        ...
 
 @contextmanager
 def get_database_connection(username: str, password: str):
@@ -321,11 +335,20 @@ class MyClientResource(ConfigurableResource):
     username: str
     password: str
 
-    # Setup and teardown occurs in the asset or op body
+    _db_connection: DBConnection = PrivateAttr()
+
     @contextmanager
-    def get_connection(self):
+    def yield_for_execution(self, context):
+        # keep connection open for the duration of the execution
         with get_database_connection(self.username, self.password) as conn:
-            yield conn
+            # set up the connection attribute so it can be used in the execution
+            self._db_connection = conn
+
+            # yield, allowing execution to occur
+            yield self
+
+    def query(self, body: str):
+        return self._db_connection.query(body)
 
 @asset
 def my_asset(client: MyClientResource):

--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -200,9 +200,7 @@ Then, configuration for the resource can be provided at launch time in the launc
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_runtime_launch endbefore=end_new_resource_runtime_launch dedent=4
 from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-update_data_job = define_asset_job(
-    name="update_data_job", selection=[data_from_database]
-)
+update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
 
 @sensor(job=update_data_job)
 def table_update_sensor():
@@ -245,9 +243,7 @@ defs = Definitions(
     assets=[my_asset],
     resources={
         "bucket": FileStoreBucket(
-            credentials=CredentialsResource(
-                username="my_user", password="my_password"
-            ),
+            credentials=CredentialsResource(username="my_user", password="my_password"),
             region="us-east-1",
         ),
     },
@@ -275,11 +271,13 @@ defs = Definitions(
 
 ---
 
-## Defining resources which require state
+## Managing state in resources
 
 Once a resource reaches a certain complexity, it may be desirable to manage the state of the resource over its lifetime. This is useful for resources which require special initilization or cleanup. `ConfigurableResource` is a dataclass meant to encapsulate config, but can also be used to set up basic state.
 
-The `setup_for_execution` and `teardown_after_execution` methods can be overridden to initialize or teardown a resource before each run execution.
+You can mark any private state attributes using Pydantic's [`PrivateAttr`](https://docs.pydantic.dev/latest/usage/models/#private-model-attributes). These attributes, which must start with an underscore, will not be included in the resource's config.
+
+The `setup_for_execution` and `teardown_after_execution` methods can be overridden to initialize or teardown a resource before each run execution, and are free to modify any private state attributes.
 
 In this instance, we can setup an API token for a client resource based on the username and password provided in the config. We then use that API token to query an API in our asset body.
 
@@ -355,8 +353,6 @@ def my_asset(client: MyClientResource):
     with client.get_connection() as conn:
         conn.query("SELECT * FROM my_table")
 ```
-
-For more information on the recommended way to test with resources which require state, see the [testing section](#testing-resources-with-state).
 
 ---
 
@@ -453,43 +449,6 @@ def test_my_resource_with_nesting():
     resource = MyResourceRequiresAnother(foo=string_holder, bar="bar")
     assert resource.foo.value == "foo"
     assert resource.bar == "bar"
-```
-
-### Testing resources with state
-
-If you have separated out a stateful client class from your resource class as detailed above in the [Defining resources which require state](#defining-resources-which-require-state) section, you can use tools such as the `mock` library to easily fake your resource and associated client.
-
-```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_testing_with_state endbefore=end_new_resource_testing_with_state dedent=4
-from dagster import ConfigurableResource, asset
-import mock
-
-class MyClient:
-    ...
-
-    def query(self, body: str):
-        ...
-
-class MyClientResource(ConfigurableResource):
-    username: str
-    password: str
-
-    def get_client(self):
-        return MyClient(self.username, self.password)
-
-@asset
-def my_asset(client: MyClientResource):
-    return client.get_client().query("SELECT * FROM my_table")
-
-def test_my_asset():
-    class FakeClient:
-        def query(self, body: str):
-            assert body == "SELECT * FROM my_table"
-            return "my_result"
-
-    mocked_client_resource = mock.Mock()
-    mocked_client_resource.get_client.return_value = FakeClient()
-
-    assert my_asset(mocked_client_resource) == "my_result"
 ```
 
 ### Testing with resource context

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -189,9 +189,7 @@ def new_resource_runtime() -> "Definitions":
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-    update_data_job = define_asset_job(
-        name="update_data_job", selection=[data_from_database]
-    )
+    update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
 
     @sensor(job=update_data_job)
     def table_update_sensor():
@@ -249,9 +247,7 @@ def new_resources_nesting() -> "Definitions":
         assets=[my_asset],
         resources={
             "bucket": FileStoreBucket(
-                credentials=CredentialsResource(
-                    username="my_user", password="my_password"
-                ),
+                credentials=CredentialsResource(username="my_user", password="my_password"),
                 region="us-east-1",
             ),
         },
@@ -416,9 +412,7 @@ def resource_adapter() -> None:
     def my_asset(writer: Writer):
         writer.output("hello, world!")
 
-    defs = Definitions(
-        assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")}
-    )
+    defs = Definitions(assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")})
 
     # end_resource_adapter
 
@@ -443,9 +437,7 @@ def io_adapter() -> None:
             self.base_path = base_path
 
         def handle_output(self, context: OutputContext, obj):
-            with open(
-                os.path.join(self.base_path, context.step_key, context.name), "w"
-            ) as fd:
+            with open(os.path.join(self.base_path, context.step_key, context.name), "w") as fd:
                 fd.write(obj)
 
         def load_input(self, context: InputContext):
@@ -575,9 +567,7 @@ def raw_github_resource_factory() -> None:
 
     defs = Definitions(
         assets=[public_github_repos],
-        resources={
-            "github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))
-        },
+        resources={"github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))},
     )
 
     # end_raw_github_resource_factory
@@ -621,14 +611,18 @@ def with_state_example() -> None:
     from dagster import ConfigurableResource, asset
     import requests
 
-    class MyClient:
-        """Client class with mutable state."""
+    from pydantic import PrivateAttr
 
-        def __init__(self, username: str, password: str):
-            self.username = username
-            self.password = password
+    class MyClientResource(ConfigurableResource):
+        username: str
+        password: str
+
+        _api_token: str = PrivateAttr()
+
+        def __post_init__(self):
+            # Fetch and set up an API token based on the username and password
             self._api_token = requests.get(
-                "https://my-api.com/token", auth=(username, password)
+                "https://my-api.com/token", auth=(self.username, self.password)
             ).text
 
         def query(self, body: str):
@@ -638,18 +632,39 @@ def with_state_example() -> None:
                 data=body,
             )
 
+    @asset
+    def my_asset(client: MyClientResource):
+        return client.query("foobar")
+
+    # end_with_state_example
+
+
+def with_complex_state_example() -> None:
+    # start_with_complex_state_example
+
+    from dagster import ConfigurableResource, asset
+    from contextlib import contextmanager
+
+    @contextmanager
+    def get_database_connection(username: str, password: str):
+        ...
+
     class MyClientResource(ConfigurableResource):
         username: str
         password: str
 
-        def get_client(self):
-            return MyClient(self.username, self.password)
+        # Setup and teardown occurs in the asset or op body
+        @contextmanager
+        def get_connection(self):
+            with get_database_connection(self.username, self.password) as conn:
+                yield conn
 
     @asset
     def my_asset(client: MyClientResource):
-        return client.get_client().query("SELECT * FROM my_table")
+        with client.get_connection() as conn:
+            conn.query("SELECT * FROM my_table")
 
-    # end_with_state_example
+    # end_with_complex_state_example
 
 
 def new_resource_testing_with_state() -> None:
@@ -837,15 +852,10 @@ def new_resource_on_schedule() -> None:
     from dagster import build_schedule_context, validate_run_config
 
     def test_process_data_schedule():
-        context = build_schedule_context(
-            scheduled_execution_time=datetime.datetime(2020, 1, 1)
-        )
+        context = build_schedule_context(scheduled_execution_time=datetime.datetime(2020, 1, 1))
         run_request = process_data_schedule(
             context, date_formatter=DateFormatter(format="%Y-%m-%d")
         )
-        assert (
-            run_request.run_config["ops"]["fetch_data"]["config"]["date"]
-            == "2020-01-01"
-        )
+        assert run_request.run_config["ops"]["fetch_data"]["config"]["date"] == "2020-01-01"
 
     # end_test_resource_on_schedule

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -189,7 +189,9 @@ def new_resource_runtime() -> "Definitions":
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-    update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
+    update_data_job = define_asset_job(
+        name="update_data_job", selection=[data_from_database]
+    )
 
     @sensor(job=update_data_job)
     def table_update_sensor():
@@ -247,7 +249,9 @@ def new_resources_nesting() -> "Definitions":
         assets=[my_asset],
         resources={
             "bucket": FileStoreBucket(
-                credentials=CredentialsResource(username="my_user", password="my_password"),
+                credentials=CredentialsResource(
+                    username="my_user", password="my_password"
+                ),
                 region="us-east-1",
             ),
         },
@@ -412,7 +416,9 @@ def resource_adapter() -> None:
     def my_asset(writer: Writer):
         writer.output("hello, world!")
 
-    defs = Definitions(assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")})
+    defs = Definitions(
+        assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")}
+    )
 
     # end_resource_adapter
 
@@ -437,7 +443,9 @@ def io_adapter() -> None:
             self.base_path = base_path
 
         def handle_output(self, context: OutputContext, obj):
-            with open(os.path.join(self.base_path, context.step_key, context.name), "w") as fd:
+            with open(
+                os.path.join(self.base_path, context.step_key, context.name), "w"
+            ) as fd:
                 fd.write(obj)
 
         def load_input(self, context: InputContext):
@@ -567,7 +575,9 @@ def raw_github_resource_factory() -> None:
 
     defs = Definitions(
         assets=[public_github_repos],
-        resources={"github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))},
+        resources={
+            "github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))
+        },
     )
 
     # end_raw_github_resource_factory
@@ -619,22 +629,21 @@ def with_state_example() -> None:
 
         _api_token: str = PrivateAttr()
 
-        def __post_init__(self):
+        def setup_for_execution(self, context) -> None:
             # Fetch and set up an API token based on the username and password
             self._api_token = requests.get(
                 "https://my-api.com/token", auth=(self.username, self.password)
             ).text
 
-        def query(self, body: str):
+        def get_all_users(self):
             return requests.get(
-                "https://my-api.com/query",
+                "https://my-api.com/users",
                 headers={"Authorization": self._api_token},
-                data=body,
             )
 
     @asset
     def my_asset(client: MyClientResource):
-        return client.query("foobar")
+        return client.get_all_users()
 
     # end_with_state_example
 
@@ -644,6 +653,13 @@ def with_complex_state_example() -> None:
 
     from dagster import ConfigurableResource, asset
     from contextlib import contextmanager
+    from pydantic import PrivateAttr
+
+    class DBConnection:
+        ...
+
+        def query(self, body: str):
+            ...
 
     @contextmanager
     def get_database_connection(username: str, password: str):
@@ -653,11 +669,20 @@ def with_complex_state_example() -> None:
         username: str
         password: str
 
-        # Setup and teardown occurs in the asset or op body
+        _db_connection: DBConnection = PrivateAttr()
+
         @contextmanager
-        def get_connection(self):
+        def yield_for_execution(self, context):
+            # keep connection open for the duration of the execution
             with get_database_connection(self.username, self.password) as conn:
-                yield conn
+                # set up the connection attribute so it can be used in the execution
+                self._db_connection = conn
+
+                # yield, allowing execution to occur
+                yield self
+
+        def query(self, body: str):
+            return self._db_connection.query(body)
 
     @asset
     def my_asset(client: MyClientResource):
@@ -852,10 +877,15 @@ def new_resource_on_schedule() -> None:
     from dagster import build_schedule_context, validate_run_config
 
     def test_process_data_schedule():
-        context = build_schedule_context(scheduled_execution_time=datetime.datetime(2020, 1, 1))
+        context = build_schedule_context(
+            scheduled_execution_time=datetime.datetime(2020, 1, 1)
+        )
         run_request = process_data_schedule(
             context, date_formatter=DateFormatter(format="%Y-%m-%d")
         )
-        assert run_request.run_config["ops"]["fetch_data"]["config"]["date"] == "2020-01-01"
+        assert (
+            run_request.run_config["ops"]["fetch_data"]["config"]["date"]
+            == "2020-01-01"
+        )
 
     # end_test_resource_on_schedule

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -189,9 +189,7 @@ def new_resource_runtime() -> "Definitions":
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-    update_data_job = define_asset_job(
-        name="update_data_job", selection=[data_from_database]
-    )
+    update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
 
     @sensor(job=update_data_job)
     def table_update_sensor():
@@ -249,9 +247,7 @@ def new_resources_nesting() -> "Definitions":
         assets=[my_asset],
         resources={
             "bucket": FileStoreBucket(
-                credentials=CredentialsResource(
-                    username="my_user", password="my_password"
-                ),
+                credentials=CredentialsResource(username="my_user", password="my_password"),
                 region="us-east-1",
             ),
         },
@@ -416,9 +412,7 @@ def resource_adapter() -> None:
     def my_asset(writer: Writer):
         writer.output("hello, world!")
 
-    defs = Definitions(
-        assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")}
-    )
+    defs = Definitions(assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")})
 
     # end_resource_adapter
 
@@ -443,9 +437,7 @@ def io_adapter() -> None:
             self.base_path = base_path
 
         def handle_output(self, context: OutputContext, obj):
-            with open(
-                os.path.join(self.base_path, context.step_key, context.name), "w"
-            ) as fd:
+            with open(os.path.join(self.base_path, context.step_key, context.name), "w") as fd:
                 fd.write(obj)
 
         def load_input(self, context: InputContext):
@@ -575,9 +567,7 @@ def raw_github_resource_factory() -> None:
 
     defs = Definitions(
         assets=[public_github_repos],
-        resources={
-            "github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))
-        },
+        resources={"github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))},
     )
 
     # end_raw_github_resource_factory
@@ -690,43 +680,6 @@ def with_complex_state_example() -> None:
             conn.query("SELECT * FROM my_table")
 
     # end_with_complex_state_example
-
-
-def new_resource_testing_with_state() -> None:
-    # start_new_resource_testing_with_state
-
-    from dagster import ConfigurableResource, asset
-    import mock
-
-    class MyClient:
-        ...
-
-        def query(self, body: str):
-            ...
-
-    class MyClientResource(ConfigurableResource):
-        username: str
-        password: str
-
-        def get_client(self):
-            return MyClient(self.username, self.password)
-
-    @asset
-    def my_asset(client: MyClientResource):
-        return client.get_client().query("SELECT * FROM my_table")
-
-    def test_my_asset():
-        class FakeClient:
-            def query(self, body: str):
-                assert body == "SELECT * FROM my_table"
-                return "my_result"
-
-        mocked_client_resource = mock.Mock()
-        mocked_client_resource.get_client.return_value = FakeClient()
-
-        assert my_asset(mocked_client_resource) == "my_result"
-
-    # end_new_resource_testing_with_state
 
 
 def new_resource_testing_with_state_ops() -> None:
@@ -877,15 +830,10 @@ def new_resource_on_schedule() -> None:
     from dagster import build_schedule_context, validate_run_config
 
     def test_process_data_schedule():
-        context = build_schedule_context(
-            scheduled_execution_time=datetime.datetime(2020, 1, 1)
-        )
+        context = build_schedule_context(scheduled_execution_time=datetime.datetime(2020, 1, 1))
         run_request = process_data_schedule(
             context, date_formatter=DateFormatter(format="%Y-%m-%d")
         )
-        assert (
-            run_request.run_config["ops"]["fetch_data"]["config"]["date"]
-            == "2020-01-01"
-        )
+        assert run_request.run_config["ops"]["fetch_data"]["config"]["date"] == "2020-01-01"
 
     # end_test_resource_on_schedule

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -189,7 +189,9 @@ def new_resource_runtime() -> "Definitions":
     # start_new_resource_runtime_launch
     from dagster import sensor, define_asset_job, RunRequest, RunConfig
 
-    update_data_job = define_asset_job(name="update_data_job", selection=[data_from_database])
+    update_data_job = define_asset_job(
+        name="update_data_job", selection=[data_from_database]
+    )
 
     @sensor(job=update_data_job)
     def table_update_sensor():
@@ -247,7 +249,9 @@ def new_resources_nesting() -> "Definitions":
         assets=[my_asset],
         resources={
             "bucket": FileStoreBucket(
-                credentials=CredentialsResource(username="my_user", password="my_password"),
+                credentials=CredentialsResource(
+                    username="my_user", password="my_password"
+                ),
                 region="us-east-1",
             ),
         },
@@ -412,7 +416,9 @@ def resource_adapter() -> None:
     def my_asset(writer: Writer):
         writer.output("hello, world!")
 
-    defs = Definitions(assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")})
+    defs = Definitions(
+        assets=[my_asset], resources={"writer": WriterResource(prefix="greeting: ")}
+    )
 
     # end_resource_adapter
 
@@ -437,7 +443,9 @@ def io_adapter() -> None:
             self.base_path = base_path
 
         def handle_output(self, context: OutputContext, obj):
-            with open(os.path.join(self.base_path, context.step_key, context.name), "w") as fd:
+            with open(
+                os.path.join(self.base_path, context.step_key, context.name), "w"
+            ) as fd:
                 fd.write(obj)
 
         def load_input(self, context: InputContext):
@@ -567,7 +575,9 @@ def raw_github_resource_factory() -> None:
 
     defs = Definitions(
         assets=[public_github_repos],
-        resources={"github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))},
+        resources={
+            "github": GitHubResource(access_token=EnvVar("GITHUB_ACCESS_TOKEN"))
+        },
     )
 
     # end_raw_github_resource_factory
@@ -676,8 +686,7 @@ def with_complex_state_example() -> None:
 
     @asset
     def my_asset(client: MyClientResource):
-        with client.get_connection() as conn:
-            conn.query("SELECT * FROM my_table")
+        client.query("SELECT * FROM my_table")
 
     # end_with_complex_state_example
 
@@ -830,10 +839,15 @@ def new_resource_on_schedule() -> None:
     from dagster import build_schedule_context, validate_run_config
 
     def test_process_data_schedule():
-        context = build_schedule_context(scheduled_execution_time=datetime.datetime(2020, 1, 1))
+        context = build_schedule_context(
+            scheduled_execution_time=datetime.datetime(2020, 1, 1)
+        )
         run_request = process_data_schedule(
             context, date_formatter=DateFormatter(format="%Y-%m-%d")
         )
-        assert run_request.run_config["ops"]["fetch_data"]["config"]["date"] == "2020-01-01"
+        assert (
+            run_request.run_config["ops"]["fetch_data"]["config"]["date"]
+            == "2020-01-01"
+        )
 
     # end_test_resource_on_schedule


### PR DESCRIPTION
## Summary

Updates the resources docs to utilize the hooks in #13938, explaining a basic case using `PrivateAttr` & `setup_for_execution` alongside a more complex yield case.

Corresponds to the approach taken in #13894
