### PR TITLE
Fix docs build code-snippets

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/dagster-cloud-yaml.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/dagster-cloud-yaml.mdx
@@ -151,11 +151,9 @@ The `dagster_cloud.yaml` file contains a single top-level key, `locations`. This
 - [Python executable](#python-executable)
 - [Container context](#container-context)
 
-
 ### Location name
 
 **This key is required.** The `location_name` key specifies the name of the code location. The location name will always be paired with a [code source](#code-source).
-
 
 ```yaml
 # dagster_cloud.yaml


### PR DESCRIPTION
## Summary & Motivation

Docs build is broken on BK because code snippets aren't synced, this fixes that.

## How I Tested These Changes

BK
