### PR TITLE
Improve performance of `cron_string_iterator` in cases where you're starting on a cron tick boundary.

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -76,8 +76,9 @@ def cron_string_iterator(
     if is_numeric[1]:
         expected_hour = int(cron_parts[1][0])
 
-    date_iter = None
     if delta_fn is not None and start_offset == 0 and croniter.match(cron_string, start_timestamp):
+        # In simple cases, where you're already on a cron boundary, the below logic is unnecessary
+        # and slow
         next_date = start_datetime
     else:
         date_iter = croniter(cron_string, start_datetime)
@@ -136,7 +137,7 @@ def cron_string_iterator(
             yield next_date
     else:
         # Otherwise fall back to croniter
-        date_iter = date_iter or croniter(cron_string, next_date)
+        date_iter = croniter(cron_string, next_date)
         while True:
             next_date = to_timezone(
                 pendulum.instance(date_iter.get_next(datetime.datetime)), timezone_str

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -91,6 +91,8 @@ def cron_string_iterator(
         # In simple cases, where you're already on a cron boundary, the below logic is unnecessary
         # and slow
         next_date = start_datetime
+        # This is already on a cron boundary, so yield it
+        yield to_timezone(pendulum.instance(next_date), timezone_str)
     else:
         # Go back one iteration so that the next iteration is the first time that is >= start_datetime
         # and matches the cron schedule
@@ -110,8 +112,6 @@ def cron_string_iterator(
     if delta_fn is not None:
         # Use pendulums for intervals when possible
         next_date = to_timezone(pendulum.instance(next_date), timezone_str)
-        if next_date >= start_datetime:
-            yield next_date
         while True:
             curr_hour = next_date.hour
 

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -104,6 +104,8 @@ def cron_string_iterator(
     if delta_fn is not None:
         # Use pendulums for intervals when possible
         next_date = to_timezone(pendulum.instance(next_date), timezone_str)
+        if next_date >= start_datetime:
+            yield next_date
         while True:
             curr_hour = next_date.hour
 

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -19,7 +19,7 @@ class CroniterShim(_croniter):
         return super().expand(*args, **kwargs)
 
 
-def exact_match(cron_expression: str, dt: datetime.datetime) -> bool:
+def _exact_match(cron_expression: str, dt: datetime.datetime) -> bool:
     """The default croniter match function only checks that the given datetime is within 60 seconds
     of a cron schedule tick. This function checks that the given datetime is exactly on a cron tick.
     """
@@ -87,7 +87,7 @@ def cron_string_iterator(
         expected_hour = int(cron_parts[1][0])
 
     date_iter = CroniterShim(cron_string, start_datetime)
-    if delta_fn is not None and start_offset == 0 and exact_match(cron_string, start_datetime):
+    if delta_fn is not None and start_offset == 0 and _exact_match(cron_string, start_datetime):
         # In simple cases, where you're already on a cron boundary, the below logic is unnecessary
         # and slow
         next_date = start_datetime

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -142,7 +142,7 @@ def test_first_monday():
     assert next(iterator) == create_pendulum_time(year=2023, month=3, day=6, tz="US/Pacific")
 
 
-def test_on_tick_boundary():
+def test_on_tick_boundary_simple():
     # Saturday
     start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
 
@@ -159,5 +159,26 @@ def test_on_tick_boundary():
     expected_next_timestamps = [
         create_pendulum_time(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
         for i in range(8)
+    ]
+    assert next_timestamps == expected_next_timestamps
+
+
+def test_on_tick_boundary_complex():
+    # Saturday
+    start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
+
+    time_iter = schedule_execution_time_iterator(
+        start_time.timestamp(),
+        [
+            "0 3 * * MON-FRI",  # 03:00 every day MON-FRI
+        ],
+        "UTC",
+    )
+    # Test an entire week's cycle
+    next_timestamps = [next(time_iter).timestamp() for _ in range(10)]
+
+    expected_next_timestamps = [
+        create_pendulum_time(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
+        for i in (*range(2, 7), *range(9, 14))  # skip SAT and SUN
     ]
     assert next_timestamps == expected_next_timestamps

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -140,3 +140,24 @@ def test_first_monday():
     assert next(iterator) == create_pendulum_time(year=2023, month=2, day=6, tz="US/Pacific")
     # monday 3/6
     assert next(iterator) == create_pendulum_time(year=2023, month=3, day=6, tz="US/Pacific")
+
+
+def test_on_tick_boundary():
+    # Saturday
+    start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
+
+    time_iter = schedule_execution_time_iterator(
+        start_time.timestamp(),
+        [
+            "0 3 * * *",  # 03:00 every day
+        ],
+        "UTC",
+    )
+    # Test an entire week's cycle
+    next_timestamps = [next(time_iter).timestamp() for _ in range(8)]
+
+    expected_next_timestamps = [
+        create_pendulum_time(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
+        for i in range(8)
+    ]
+    assert next_timestamps == expected_next_timestamps


### PR DESCRIPTION
## Summary & Motivation

We've gotten bitten by the fact that creating new `cron_string_iterator`s is surprisingly expensive, such that doing it `O(1000)` times can time out a sensor tick.

This has two main optimizations:

1. In the case that we're on a cron tick boundary (calculated using the relatively cheap `croniter.match()`), we skip this `get_prev` / `get_next` stuff, which is significantly slower. This means that in the case of calculating partition windows, we'll never even hit croniter unless the user has a custom (and devious) TimeWindowPartitionsDefinition.
2. A lightweight shim over the static croniter class, which allows us to cache the result of the `expand` call. This gets called on every iteration of croniter, as well as in the matching codepath. It calls regex stuff, which makes it fairly slow. This is admittedly a more hacky solution than I'd like.

On a local repo, constructed a case where the auto materialization logic would require the calculation of ~8000 time windows (in turn requiring this method to be called ~8000 times).

- pre-changes: ~18s
- without hacky shim: ~10s
- with hacky shim: ~4.5s

Note that these times are including a lot of other stuff that the auto materialization logic is doing, but the vast majority of these runtimes (~90%) are associated specifically with this cron string iteration.

## How I Tested These Changes
