### PR TITLE
[dagit] “Propagate changes” should materialize only stale and not missing assets

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -27,7 +27,7 @@ import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
 import {MULTIPLE_DEFINITIONS_WARNING} from './AssetDefinedInMultipleReposNotice';
 import {LaunchAssetChoosePartitionsDialog} from './LaunchAssetChoosePartitionsDialog';
 import {partitionDefinitionsEqual} from './MultipartitioningSupport';
-import {isAssetMissing, isAssetStale} from './Stale';
+import {isAssetStale} from './Stale';
 import {AssetKey} from './types';
 import {
   LaunchAssetExecutionAssetNodeFragment,
@@ -134,10 +134,8 @@ function optionsForButton(scope: AssetsInScope, liveDataForStale?: LiveData): La
   });
 
   if (liveDataForStale) {
-    const missingOrStale = assets.filter(
-      (a) =>
-        isAssetMissing(liveDataForStale[toGraphId(a.assetKey)]) ||
-        isAssetStale(liveDataForStale[toGraphId(a.assetKey)]),
+    const missingOrStale = assets.filter((a) =>
+      isAssetStale(liveDataForStale[toGraphId(a.assetKey)]),
     );
 
     options.push({


### PR DESCRIPTION
## Summary & Motivation

This is a tiny, short term fix to the issue described in https://github.com/dagster-io/dagster/issues/13735

## How I Tested These Changes

I tested this manually - we do have tests for the LaunchAssetExecutionButton, but it looks like feeding them the "live" asset data required to correctly validate this `.filter` might be worthy of a separate PR when we have a bit more time.