### PR TITLE
[ui] Add feature flag for panning vs. zooming DAG on scroll

### DIFF
--- a/js_modules/dagit/packages/core/src/app/Flags.tsx
+++ b/js_modules/dagit/packages/core/src/app/Flags.tsx
@@ -7,6 +7,7 @@ export const DAGIT_FLAGS_KEY = 'DAGIT_FLAGS';
 
 // Use const because we need to extend this in cloud. https://blog.logrocket.com/extend-enums-typescript/
 export const FeatureFlag = {
+  flagDAGPanWithScrollWheel: 'flagDAGPanWithScrollWheel' as const,
   flagDebugConsoleLogging: 'flagDebugConsoleLogging' as const,
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
   flagSensorScheduleLogging: 'flagSensorScheduleLogging' as const,

--- a/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagit/packages/core/src/app/getVisibleFeatureFlagRows.tsx
@@ -17,6 +17,10 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagSidebarResources,
   },
   {
+    key: 'Pan graph visualizations when scrolling',
+    flagType: FeatureFlag.flagDAGPanWithScrollWheel,
+  },
+  {
     key: 'Experimental schedule/sensor logging view',
     flagType: FeatureFlag.flagSensorScheduleLogging,
   },


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/13474

This PR adds a new feature flag: `Pan graph visualizations when scrolling`

When enabled, the scroll wheel and the trackpad pan the asset and op graphs rather than zooming them. To zoom, you hold the Meta key while scrolling.

This mirrors Figma with one small exception -- in Figma with a mouse scroll wheel, holding shift scrolls -X instead of +X. I can't figure out how they do this on scroll wheel scrolling and not on trackpad scrolling, and it may not be worth the squeeze unless we really like this interaction.

I think this feels much more natural and treats the viz more like a "canvas" in other apps!

## How I Tested These Changes

I toggled the feature flag on and off and verified that the interactions change as expected.