### PR TITLE
[ui] Show a tag with pause state when auto-materialization policy is present

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -45,15 +45,16 @@ import {AssetLineageScope} from './AssetNodeLineageGraph';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetPartitions} from './AssetPartitions';
 import {AssetPlots} from './AssetPlots';
+import {AutomaterializeDaemonStatusTag} from './AutomaterializeDaemonStatusTag';
 import {CurrentMinutesLateTag} from './CurrentMinutesLateTag';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from './LaunchAssetObservationButton';
 import {UNDERLYING_OPS_ASSET_NODE_FRAGMENT} from './UnderlyingOpsOrGraph';
 import {AssetKey} from './types';
 import {
-  AssetViewDefinitionNodeFragment,
   AssetViewDefinitionQuery,
   AssetViewDefinitionQueryVariables,
+  AssetViewDefinitionNodeFragment,
 } from './types/AssetView.types';
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 
@@ -486,6 +487,7 @@ const AssetViewPageHeaderTags: React.FC<{
           </Link>
         </Tag>
       )}
+      {definition && definition.autoMaterializePolicy && <AutomaterializeDaemonStatusTag />}
       {definition && definition.freshnessPolicy && (
         <CurrentMinutesLateTag
           liveData={liveData}

--- a/js_modules/dagit/packages/core/src/assets/AutomaterializeDaemonStatusTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutomaterializeDaemonStatusTag.tsx
@@ -1,0 +1,76 @@
+import {gql, useMutation, useQuery} from '@apollo/client';
+import {Tag, Tooltip} from '@dagster-io/ui';
+import React, {useCallback} from 'react';
+import {Link} from 'react-router-dom';
+
+import {
+  GetAutoMaterializePausedQuery,
+  GetAutoMaterializePausedQueryVariables,
+  SetAutoMaterializePausedMutation,
+  SetAutoMaterializePausedMutationVariables,
+} from './types/AutomaterializeDaemonStatusTag.types';
+
+export const AutomaterializeDaemonStatusTag: React.FC = () => {
+  const {paused} = useAutomaterializeDaemonStatus();
+
+  return (
+    <Link to="/health">
+      {paused ? (
+        <Tooltip content="Auto-materializing is paused. New materializations will not be triggered by auto-materialization policies.">
+          <Tag icon="toggle_off" intent="warning">
+            Auto-materialize
+          </Tag>
+        </Tooltip>
+      ) : (
+        <Tag icon="toggle_on" intent="success">
+          Auto-materialize
+        </Tag>
+      )}
+    </Link>
+  );
+};
+
+export function useAutomaterializeDaemonStatus() {
+  const {data, loading, refetch} = useQuery<
+    GetAutoMaterializePausedQuery,
+    GetAutoMaterializePausedQueryVariables
+  >(AUTOMATERIALIZE_PAUSED_QUERY);
+
+  const [setAutoMaterializePaused] = useMutation<
+    SetAutoMaterializePausedMutation,
+    SetAutoMaterializePausedMutationVariables
+  >(SET_AUTOMATERIALIZE_PAUSED_MUTATION, {
+    onCompleted: () => {
+      refetch();
+    },
+  });
+
+  const setPaused = useCallback(
+    (paused: boolean) => {
+      setAutoMaterializePaused({variables: {paused}});
+    },
+    [setAutoMaterializePaused],
+  );
+
+  return {
+    loading,
+    setPaused,
+    paused: data?.instance?.autoMaterializePaused,
+    refetch,
+  };
+}
+
+export const AUTOMATERIALIZE_PAUSED_QUERY = gql`
+  query GetAutoMaterializePausedQuery {
+    instance {
+      id
+      autoMaterializePaused
+    }
+  }
+`;
+
+export const SET_AUTOMATERIALIZE_PAUSED_MUTATION = gql`
+  mutation SetAutoMaterializePausedMutation($paused: Boolean!) {
+    setAutoMaterializePaused(paused: $paused)
+  }
+`;

--- a/js_modules/dagit/packages/core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutomaterializePolicyTag.tsx
@@ -2,6 +2,7 @@ import {Tag} from '@dagster-io/ui';
 import React from 'react';
 
 import {AutoMaterializePolicyType} from '../graphql/types';
+
 export const AutomaterializePolicyTag: React.FC<{
   policy: {
     policyType: AutoMaterializePolicyType;

--- a/js_modules/dagit/packages/core/src/assets/types/AssetGroupRoot.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AssetGroupRoot.types.ts
@@ -1,0 +1,19 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type AssetGroupMetadataQueryVariables = Types.Exact<{
+  selector: Types.AssetGroupSelector;
+}>;
+
+export type AssetGroupMetadataQuery = {
+  __typename: 'DagitQuery';
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    id: string;
+    autoMaterializePolicy: {
+      __typename: 'AutoMaterializePolicy';
+      policyType: Types.AutoMaterializePolicyType;
+    } | null;
+  }>;
+};

--- a/js_modules/dagit/packages/core/src/assets/types/AutomaterializeDaemonStatusTag.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/AutomaterializeDaemonStatusTag.types.ts
@@ -1,0 +1,19 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type GetAutoMaterializePausedQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type GetAutoMaterializePausedQuery = {
+  __typename: 'DagitQuery';
+  instance: {__typename: 'Instance'; id: string; autoMaterializePaused: boolean};
+};
+
+export type SetAutoMaterializePausedMutationVariables = Types.Exact<{
+  paused: Types.Scalars['Boolean'];
+}>;
+
+export type SetAutoMaterializePausedMutation = {
+  __typename: 'DagitMutation';
+  setAutoMaterializePaused: boolean;
+};

--- a/js_modules/dagit/packages/core/src/instance/__tests__/DaemonList.test.tsx
+++ b/js_modules/dagit/packages/core/src/instance/__tests__/DaemonList.test.tsx
@@ -2,13 +2,13 @@ import {MockedResponse, MockedProvider} from '@apollo/client/testing';
 import {fireEvent, render, waitFor} from '@testing-library/react';
 import React from 'react';
 
-import {buildDaemonStatus, buildInstance} from '../../graphql/types';
 import {
-  DaemonList,
   AUTOMATERIALIZE_PAUSED_QUERY,
   SET_AUTOMATERIALIZE_PAUSED_MUTATION,
-} from '../DaemonList';
-import {GetAutoMaterializePausedQuery} from '../types/DaemonList.types';
+} from '../../assets/AutomaterializeDaemonStatusTag';
+import {GetAutoMaterializePausedQuery} from '../../assets/types/AutomaterializeDaemonStatusTag.types';
+import {buildDaemonStatus, buildInstance} from '../../graphql/types';
+import {DaemonList} from '../DaemonList';
 
 let mockResolveConfirmation = (_any: any) => {};
 beforeEach(() => {

--- a/js_modules/dagit/packages/core/src/instance/types/DaemonList.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/DaemonList.types.ts
@@ -43,19 +43,3 @@ export type DaemonStatusForListFragment = {
     }>;
   }>;
 };
-
-export type GetAutoMaterializePausedQueryVariables = Types.Exact<{[key: string]: never}>;
-
-export type GetAutoMaterializePausedQuery = {
-  __typename: 'DagitQuery';
-  instance: {__typename: 'Instance'; id: string; autoMaterializePaused: boolean};
-};
-
-export type SetAutoMaterializePausedMutationVariables = Types.Exact<{
-  paused: Types.Scalars['Boolean'];
-}>;
-
-export type SetAutoMaterializePausedMutation = {
-  __typename: 'DagitMutation';
-  setAutoMaterializePaused: boolean;
-};

--- a/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/nav/JobMetadata.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 
 import {tokenForAssetKey} from '../asset-graph/Utils';
+import {AutomaterializeDaemonStatusTag} from '../assets/AutomaterializeDaemonStatusTag';
 import {DagsterTag} from '../runs/RunTag';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitch';
@@ -78,6 +79,9 @@ export const JobMetadata: React.FC<Props> = (props) => {
         <JobScheduleOrSensorTag job={metadata.job} repoAddress={repoAddress} />
       ) : null}
       <LatestRunTag pipelineName={pipelineName} repoAddress={repoAddress} />
+      {metadata.assetNodes && metadata.assetNodes.some((a) => !!a.autoMaterializePolicy) && (
+        <AutomaterializeDaemonStatusTag />
+      )}
       {metadata.runsForAssetScan ? (
         <RelatedAssetsTag relatedAssets={getRelatedAssets(metadata)} />
       ) : null}
@@ -203,6 +207,9 @@ const JOB_METADATA_QUERY = gql`
 
   fragment JobMetadataAssetNode on AssetNode {
     id
+    autoMaterializePolicy {
+      policyType
+    }
     assetKey {
       path
     }

--- a/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagit/packages/core/src/nav/types/JobMetadata.types.ts
@@ -49,6 +49,10 @@ export type JobMetadataQuery = {
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;
+    autoMaterializePolicy: {
+      __typename: 'AutoMaterializePolicy';
+      policyType: Types.AutoMaterializePolicyType;
+    } | null;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
   }>;
   pipelineRunsOrError:
@@ -75,6 +79,10 @@ export type JobMetadataQuery = {
 export type JobMetadataAssetNodeFragment = {
   __typename: 'AssetNode';
   id: string;
+  autoMaterializePolicy: {
+    __typename: 'AutoMaterializePolicy';
+    policyType: Types.AutoMaterializePolicyType;
+  } | null;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
 };
 


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/13717

Loom video: https://www.loom.com/share/68907579d31342a090780abc7307d48b

This PR adds a small tag in the page header: green if an auto-materializing asset is present and the daemon is un-paused, and yellow if it is paused. If no auto-materializing assets are present, it is hidden. You can click the tag to visit the health page where you can toggle the status of the daemon.

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1037212/234459904-cd65cbca-44e5-4c4b-a952-5df0ece4da56.png">


## How I Tested These Changes

I tested this by viewing asset jobs, asset groups, and asset details pages with and without a materialization policy present. I updated the existing daemon page tests to reflect the changes.