### PR TITLE
Update resources.mdx

### DIFF
--- a/docs/content/concepts/resources.mdx
+++ b/docs/content/concepts/resources.mdx
@@ -76,7 +76,7 @@ class MyConnectionResource(ConfigurableResource):
 
 @asset
 def data_from_service(my_conn: MyConnectionResource) -> Dict[str, Any]:
-    return my_conn.request("/fetch_data").json()
+    return my_conn.request("fetch_data").json()
 
 defs = Definitions(
     assets=[data_from_service],


### PR DESCRIPTION
In provided docs there is bug with wrong result url, currently we have https://my-api.com//fetch_data as result url, changed to https://my-api.com/fetch_data

## Summary & Motivation

## How I Tested These Changes
