### PR TITLE
enable prefixing source assets when loading

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -316,7 +316,9 @@ def _find_modules_in_package(package_module: ModuleType) -> Iterable[ModuleType]
 
 
 def prefix_assets(
-    assets_defs: Sequence[AssetsDefinition], key_prefix: CoercibleToAssetKeyPrefix
+    assets_defs: Sequence[AssetsDefinition],
+    key_prefix: CoercibleToAssetKeyPrefix,
+    source_assets: Optional[Sequence[SourceAsset]],
 ) -> Sequence[AssetsDefinition]:
     """Given a list of assets, prefix the input and output asset keys with key_prefix.
     The prefix is not added to source assets.
@@ -354,6 +356,8 @@ def prefix_assets(
 
     """
     asset_keys = {asset_key for assets_def in assets_defs for asset_key in assets_def.keys}
+    if source_assets:
+        asset_keys |= {source_asset.key for source_asset in source_assets}
 
     if isinstance(key_prefix, str):
         key_prefix = [key_prefix]
@@ -377,6 +381,10 @@ def prefix_assets(
                 input_asset_key_replacements=input_asset_key_replacements,
             )
         )
+
+    if source_assets:
+        ...
+
     return result_assets
 
 

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -102,7 +102,7 @@ def load_assets_from_modules(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
-    prefix_sources: bool = False,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets from the given modules.
 
@@ -118,8 +118,8 @@ def load_assets_from_modules(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
-        prefix_sources (bool): If a key_prefix is provided, whether that key_prefix should also be
-            prepended to the keys of source assets. Defaults to false
+        source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
+            assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
         Sequence[Union[AssetsDefinition, SourceAsset]]:
@@ -146,7 +146,7 @@ def load_assets_from_modules(
         group_name=group_name,
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
-        prefix_sources=prefix_sources,
+        source_key_prefix=source_key_prefix,
     )
 
 
@@ -156,7 +156,7 @@ def load_assets_from_current_module(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
-    prefix_sources: bool = False,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets from the module where
     this function is called.
@@ -172,8 +172,8 @@ def load_assets_from_current_module(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
-        prefix_sources (bool): If a key_prefix is provided, whether that key_prefix should also be
-            prepended to the keys of source assets. Defaults to false
+        source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
+            assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
         Sequence[Union[AssetsDefinition, SourceAsset, CachableAssetsDefinition]]:
@@ -222,7 +222,7 @@ def load_assets_from_package_module(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
-    prefix_sources: bool = False,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets and source assets that includes all asset
     definitions, source assets, and cacheable assets in all sub-modules of the given package module.
@@ -241,8 +241,8 @@ def load_assets_from_package_module(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
-        prefix_sources (bool): If a key_prefix is provided, whether that key_prefix should also be
-            prepended to the keys of source assets. Defaults to false
+        source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
+            assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
         Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
@@ -268,7 +268,7 @@ def load_assets_from_package_module(
         group_name=group_name,
         freshness_policy=freshness_policy,
         auto_materialize_policy=auto_materialize_policy,
-        prefix_sources=prefix_sources,
+        source_key_prefix=source_key_prefix,
     )
 
 
@@ -279,7 +279,7 @@ def load_assets_from_package_name(
     *,
     freshness_policy: Optional[FreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
-    prefix_sources: bool = False,
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     """Constructs a list of assets, source assets, and cacheable assets that includes all asset
     definitions and source assets in all sub-modules of the given package.
@@ -296,8 +296,8 @@ def load_assets_from_package_name(
             assets.
         auto_materialize_policy (Optional[AutoMaterializePolicy]): AutoMaterializePolicy to apply
             to all the loaded assets.
-        prefix_sources (bool): If a key_prefix is provided, whether that key_prefix should also be
-            prepended to the keys of source assets. Defaults to false
+        source_key_prefix (bool): Prefix to prepend to the keys of loaded SourceAssets. The returned
+            assets will be copies of the loaded objects, with the prefix prepended.
 
     Returns:
         Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
@@ -333,6 +333,7 @@ def prefix_assets(
     assets_defs: Sequence[AssetsDefinition],
     key_prefix: CoercibleToAssetKeyPrefix,
     source_assets: Sequence[SourceAsset],
+    source_key_prefix: Optional[CoercibleToAssetKeyPrefix],
 ) -> Tuple[Sequence[AssetsDefinition], Sequence[SourceAsset]]:
     """Given a list of assets, prefix the input and output asset keys with key_prefix.
     The prefix is not added to source assets.
@@ -369,9 +370,8 @@ def prefix_assets(
             assert result.assets[1].dependency_keys == {AssetKey(["my_prefix", "asset1"])}
 
     """
-    asset_keys = {asset_key for assets_def in assets_defs for asset_key in assets_def.keys} | {
-        source_asset.key for source_asset in source_assets
-    }
+    asset_keys = {asset_key for assets_def in assets_defs for asset_key in assets_def.keys}
+    source_asset_keys = {source_asset.key for source_asset in source_assets}
 
     if isinstance(key_prefix, str):
         key_prefix = [key_prefix]
@@ -388,6 +388,10 @@ def prefix_assets(
                 input_asset_key_replacements[dep_asset_key] = AssetKey(
                     [*key_prefix, *dep_asset_key.path]
                 )
+            elif source_key_prefix and dep_asset_key in source_asset_keys:
+                input_asset_key_replacements[dep_asset_key] = AssetKey(
+                    [*source_key_prefix, *dep_asset_key.path]
+                )
 
         result_assets.append(
             assets_def.with_attributes(
@@ -396,10 +400,13 @@ def prefix_assets(
             )
         )
 
-    result_source_assets = [
-        source_asset.with_attributes(key=AssetKey([*key_prefix, *source_asset.key.path]))
-        for source_asset in source_assets
-    ]
+    if source_key_prefix:
+        result_source_assets = [
+            source_asset.with_attributes(key=AssetKey([*source_key_prefix, *source_asset.key.path]))
+            for source_asset in source_assets
+        ]
+    else:
+        result_source_assets = source_assets
 
     return result_assets, result_source_assets
 
@@ -412,17 +419,16 @@ def assets_with_attributes(
     group_name: Optional[str],
     freshness_policy: Optional[FreshnessPolicy],
     auto_materialize_policy: Optional[AutoMaterializePolicy],
-    prefix_sources: bool,
+    source_key_prefix: Optional[Sequence[str]],
 ) -> Sequence[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
     # There is a tricky edge case here where if a non-cacheable asset depends on a cacheable asset,
     # and the assets are prefixed, the non-cacheable asset's dependency will not be prefixed since
     # at prefix-time it is not known that its dependency is one of the cacheable assets.
     # https://github.com/dagster-io/dagster/pull/10389#pullrequestreview-1170913271
     if key_prefix:
-        if prefix_sources:
-            assets_defs, source_assets = prefix_assets(assets_defs, key_prefix, source_assets)
-        else:
-            assets_defs, _ = prefix_assets(assets_defs, key_prefix, [])
+        assets_defs, source_assets = prefix_assets(
+            assets_defs, key_prefix, source_assets, source_key_prefix
+        )
         cacheable_assets = [
             cached_asset.with_prefix_for_all(key_prefix) for cached_asset in cacheable_assets
         ]

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -285,8 +285,10 @@ class SourceAsset(ResourceAddable):
                 _required_resource_keys=self._required_resource_keys,
             )
 
-    def with_group_name(self, group_name: str) -> "SourceAsset":
-        if self.group_name != DEFAULT_GROUP_NAME:
+    def with_attributes(
+        self, group_name: Optional[str] = None, key: Optional[AssetKey] = None
+    ) -> "SourceAsset":
+        if group_name is not None and self.group_name != DEFAULT_GROUP_NAME:
             raise DagsterInvalidDefinitionError(
                 "A group name has already been provided to source asset"
                 f" {self.key.to_user_string()}"
@@ -296,7 +298,7 @@ class SourceAsset(ResourceAddable):
             warnings.simplefilter("ignore", category=ExperimentalWarning)
 
             return SourceAsset(
-                key=self.key,
+                key=key or self.key,
                 metadata=self.raw_metadata,
                 io_manager_key=self.io_manager_key,
                 io_manager_def=self.io_manager_def,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/module_with_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/module_with_assets.py
@@ -9,5 +9,5 @@ elvis_presley = SourceAsset(key=AssetKey("elvis_presley"))
 
 
 @asset
-def chuck_berry():
+def chuck_berry(elvis_presley, miles_davis):
     pass

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -1,5 +1,5 @@
 import re
-from typing import cast
+from typing import Sequence, Union, cast
 
 import pytest
 from dagster import (
@@ -50,7 +50,9 @@ def check_auto_materialize_policy(assets, auto_materialize_policy):
                 ), asset_key
 
 
-def check_asset_prefix(prefix, assets):
+def assert_assets_have_prefix(
+    prefix: Union[str, Sequence[str]], assets: Sequence[AssetsDefinition]
+) -> None:
     for a in assets:
         if isinstance(a, AssetsDefinition):
             asset_keys = a.keys
@@ -59,6 +61,27 @@ def check_asset_prefix(prefix, assets):
                 if len(observed_prefix) == 1:
                     observed_prefix = observed_prefix[0]
                 assert observed_prefix == prefix
+
+
+def get_assets_def_with_key(
+    assets: Sequence[Union[AssetsDefinition, SourceAsset]], key: AssetKey
+) -> AssetsDefinition:
+    assets_by_key = {
+        key: assets_def
+        for assets_def in assets
+        if isinstance(assets_def, AssetsDefinition)
+        for key in assets_def.keys
+    }
+    return assets_by_key[key]
+
+
+def get_source_asset_with_key(
+    assets: Sequence[Union[AssetsDefinition, SourceAsset]], key: AssetKey
+) -> SourceAsset:
+    source_assets_by_key = {
+        key: source_asset for source_asset in assets if isinstance(source_asset, SourceAsset)
+    }
+    return source_assets_by_key[key]
 
 
 def test_load_assets_from_package_name():
@@ -204,10 +227,39 @@ def test_prefix(prefix):
     from .asset_package import module_with_assets
 
     assets = load_assets_from_modules([asset_package, module_with_assets], key_prefix=prefix)
-    check_asset_prefix(prefix, assets)
+    assert_assets_have_prefix(prefix, assets)
 
     assets = load_assets_from_package_module(asset_package, key_prefix=prefix)
-    check_asset_prefix(prefix, assets)
+    assert_assets_have_prefix(prefix, assets)
+
+
+def test_prefix_sources():
+    from .asset_package import module_with_assets
+
+    prefix = ["foo", "my_cool_prefix"]
+    assets_without_prefix_sources = load_assets_from_modules(
+        [module_with_assets], key_prefix=prefix
+    )
+    assert get_source_asset_with_key(assets_without_prefix_sources, AssetKey(["elvis_presley"]))
+    assert get_assets_def_with_key(
+        assets_without_prefix_sources, AssetKey(["foo", "my_cool_prefix", "chuck_berry"])
+    ).dependency_keys == {
+        AssetKey(["elvis_presley"]),
+        AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
+    }
+
+    assets_with_prefix_sources = load_assets_from_modules(
+        [module_with_assets], key_prefix=prefix, prefix_sources=True
+    )
+    assert get_source_asset_with_key(
+        assets_with_prefix_sources, AssetKey(["foo", "my_cool_prefix", "elvis_presley"])
+    )
+    assert get_assets_def_with_key(
+        assets_with_prefix_sources, AssetKey(["foo", "my_cool_prefix", "chuck_berry"])
+    ).dependency_keys == {
+        AssetKey(["foo", "my_cool_prefix", "elvis_presley"]),
+        AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
+    }
 
 
 @pytest.mark.parametrize(
@@ -252,4 +304,4 @@ def test_load_assets_cacheable(load_fn, prefix):
             cacheable_def.compute_cacheable_data()
         )
 
-        check_asset_prefix(prefix, resolved_asset_defs)
+        assert_assets_have_prefix(prefix, resolved_asset_defs)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -233,7 +233,7 @@ def test_prefix(prefix):
     assert_assets_have_prefix(prefix, assets)
 
 
-def test_prefix_sources():
+def test_source_key_prefix():
     from .asset_package import module_with_assets
 
     prefix = ["foo", "my_cool_prefix"]
@@ -249,15 +249,15 @@ def test_prefix_sources():
     }
 
     assets_with_prefix_sources = load_assets_from_modules(
-        [module_with_assets], key_prefix=prefix, prefix_sources=True
+        [module_with_assets], key_prefix=prefix, source_key_prefix=["bar", "cooler_prefix"]
     )
     assert get_source_asset_with_key(
-        assets_with_prefix_sources, AssetKey(["foo", "my_cool_prefix", "elvis_presley"])
+        assets_with_prefix_sources, AssetKey(["bar", "cooler_prefix", "elvis_presley"])
     )
     assert get_assets_def_with_key(
         assets_with_prefix_sources, AssetKey(["foo", "my_cool_prefix", "chuck_berry"])
     ).dependency_keys == {
-        AssetKey(["foo", "my_cool_prefix", "elvis_presley"]),
+        AssetKey(["bar", "cooler_prefix", "elvis_presley"]),
         AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
     }
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -2456,7 +2456,7 @@ def test_asset_group_build_subset_job(job_selection, expected_assets, use_multi,
     all_assets = _get_assets_defs(use_multi=use_multi, allow_subset=use_multi)
     # apply prefixes
     for prefix in reversed(prefixes or []):
-        all_assets = prefix_assets(all_assets, prefix)
+        all_assets, _ = prefix_assets(all_assets, prefix, [])
 
     defs = Definitions(
         # for these, if we have multi assets, we'll always allow them to be subset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -2456,7 +2456,7 @@ def test_asset_group_build_subset_job(job_selection, expected_assets, use_multi,
     all_assets = _get_assets_defs(use_multi=use_multi, allow_subset=use_multi)
     # apply prefixes
     for prefix in reversed(prefixes or []):
-        all_assets, _ = prefix_assets(all_assets, prefix, [])
+        all_assets, _ = prefix_assets(all_assets, prefix, [], None)
 
     defs = Definitions(
         # for these, if we have multi assets, we'll always allow them to be subset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -348,7 +348,7 @@ def test_define_selection_job(job_selection, expected_assets, use_multi, prefixe
     prefixed_assets = _get_assets_defs(use_multi=use_multi, allow_subset=use_multi)
     # apply prefixes
     for prefix in reversed(prefixes or []):
-        prefixed_assets = prefix_assets(prefixed_assets, prefix)
+        prefixed_assets, _ = prefix_assets(prefixed_assets, prefix, [], None)
 
     final_assets = with_resources(
         prefixed_assets,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -701,5 +701,5 @@ def load_assets_from_dbt_manifest(
         dbt_assets = [dbt_assets_def]
 
     if key_prefix:
-        dbt_assets, _ = prefix_assets(dbt_assets, key_prefix, [])
+        dbt_assets, _ = prefix_assets(dbt_assets, key_prefix, [], source_key_prefix)
     return dbt_assets

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -701,5 +701,5 @@ def load_assets_from_dbt_manifest(
         dbt_assets = [dbt_assets_def]
 
     if key_prefix:
-        dbt_assets = prefix_assets(dbt_assets, key_prefix)
+        dbt_assets, _ = prefix_assets(dbt_assets, key_prefix, [])
     return dbt_assets


### PR DESCRIPTION
## Motivation

From a user:

> Is there a reason why source assets aren't able to be prefixed when loading from a module?
>
> Context here, is we are trying to load into assets with a client prefix from the same module per client. We can prepend the client prefix to normal assets, but it explicitly isn't working for source assets. Found a comment in the code that seems to indicate this is intentional?

## Summary

This adds a `source_key_prefix` boolean to the core `load_assets_from_*` functions. This makes it consistent with `load_assets_from_dbt_project`.

## How I Tested These Changes
