### PR TITLE
Fix asset metadata value typing

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -812,7 +812,7 @@ class DagsterAssetMetadataValue(
     @public
     @property
     def value(self) -> "AssetKey":
-        return self.value
+        return self.asset_key
 
 
 # This should be deprecated or fixed so that `value` does not return itself.


### PR DESCRIPTION
This was causing a max recursion depth exceeded error. Fixes to use the format of other MetadataValue types.

Relevant slack thread: https://dagster.slack.com/archives/C01U954MEER/p1682539420842229