### PR TITLE
[rfc][pythonic resources] Introduce Pythonic resource lifecycle hooks

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
     Generic,
     Iterable,
     Mapping,
@@ -903,17 +904,44 @@ class ConfigurableResourceFactory(
         )
         return copy
 
-    def _initialize_and_run(self, context: InitResourceContext) -> TResValue:
+    def _initialize_and_run(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
         updated_resource = (
             self._resolve_and_update_nested_resources(context)  # noqa: SLF001
             .with_resource_context(context)
             ._resolve_and_update_env_vars()
         )
 
-        return updated_resource._create_object_fn(context)  # noqa: SLF001
+        yield from updated_resource.yield_for_execution(context)
 
-    def _create_object_fn(self, context: InitResourceContext) -> TResValue:
-        return self.create_resource(context)
+    def pre_execute(self, context: InitResourceContext) -> None:
+        """Optionally override this method to perform any pre-execution steps
+        needed before the resource is used in execution.
+        """
+        pass
+
+    def post_execute(self, context: InitResourceContext) -> None:
+        """Optionally override this method to perform any post-execution steps
+        needed after the resource is used in execution.
+
+        post_execute will be called even if the resource fails to initialize in the
+        pre_execute step, and if any part of the run fails.
+        """
+        pass
+
+    def yield_for_execution(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
+        """Optionally override this method to perform any lifecycle steps
+        before or after the resource is used in execution. By default, calls
+        pre_execute before yielding, and post_execute after yielding.
+
+        Note that if you override this method and want pre_execute or
+        post_execute to be called, you must invoke them yourself.
+        """
+        try:
+            self.pre_execute(context)
+            yield self.create_resource(context)
+        finally:
+            # what to do if post_execute throws
+            self.post_execute(context)
 
     def get_resource_context(self) -> InitResourceContext:
         """Returns the context that this resource was initialized with."""
@@ -940,7 +968,7 @@ class ConfigurableResourceFactory(
                 return MyResource.from_resource_context(context)
 
         """
-        return cls(**context.resource_config or {})._create_object_fn(context)  # noqa: SLF001
+        return cls(**context.resource_config or {}).create_resource(context)
 
 
 class ConfigurableResource(ConfigurableResourceFactory[TResValue]):
@@ -1184,13 +1212,8 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
         """Implement as one would implement a @io_manager decorator function."""
         raise NotImplementedError()
 
-    def _create_object_fn(self, context: InitResourceContext) -> TIOManagerValue:
-        return self.create_io_manager(context)
-
     def create_resource(self, context: InitResourceContext) -> TIOManagerValue:
-        # I/O manager factories execute a different code path that does not
-        # call create_resource
-        raise NotImplementedError()
+        return self.create_io_manager(context)
 
     @classmethod
     def configure_at_launch(cls: "Type[Self]", **kwargs) -> "PartialIOManager[Self]":

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -27,10 +27,18 @@ from dagster import (
     Enum as DagsterEnum,
     Field as DagsterField,
 )
-from dagster._config.config_type import Array, ConfigFloatInstance, ConfigType, EnumValue, Noneable
+from dagster._config.config_type import (
+    Array,
+    ConfigFloatInstance,
+    ConfigType,
+    EnumValue,
+    Noneable,
+)
 from dagster._config.field_utils import config_dictionary_from_values
 from dagster._config.post_process import resolve_defaults
-from dagster._config.pythonic_config.typing_utils import TypecheckAllowPartialResourceInitParams
+from dagster._config.pythonic_config.typing_utils import (
+    TypecheckAllowPartialResourceInitParams,
+)
 from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.validate import process_config, validate_config
 from dagster._core.decorator_utils import get_function_params
@@ -64,7 +72,13 @@ except ImportError:
 from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Extra
-from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_MAPPING, SHAPE_SINGLETON, ModelField
+from pydantic.fields import (
+    SHAPE_DICT,
+    SHAPE_LIST,
+    SHAPE_MAPPING,
+    SHAPE_SINGLETON,
+    ModelField,
+)
 
 import dagster._check as check
 from dagster import Field, Selector, Shape
@@ -214,7 +228,8 @@ class Config(MakeConfigCacheable):
 
                 nested_items = list(check.is_dict(nested_dict).items())
                 check.invariant(
-                    len(nested_items) == 1, "Discriminated union must have exactly one key"
+                    len(nested_items) == 1,
+                    "Discriminated union must have exactly one key",
                 )
                 discriminated_value, nested_values = nested_items[0]
 
@@ -385,7 +400,8 @@ def _apply_defaults_to_schema_field(field: Field, additional_default_values: Any
         # applies the new value as the default value of the field in question.
         defaults_processed_evr = resolve_defaults(field.config_type, additional_default_values)
         check.invariant(
-            defaults_processed_evr.success, "Since validation passed, this should always work."
+            defaults_processed_evr.success,
+            "Since validation passed, this should always work.",
         )
         default_to_pass = defaults_processed_evr.value
         return copy_with_default(field, default_to_pass)
@@ -528,7 +544,9 @@ class ResourceWithKeyMapping(ResourceDefinition):
     """
 
     def __init__(
-        self, resource: ResourceDefinition, resource_id_to_key_mapping: Dict[ResourceId, str]
+        self,
+        resource: ResourceDefinition,
+        resource_id_to_key_mapping: Dict[ResourceId, str],
     ):
         self._resource = resource
         self._resource_id_to_key_mapping = resource_id_to_key_mapping
@@ -573,7 +591,9 @@ class IOManagerWithKeyMapping(ResourceWithKeyMapping, IOManagerDefinition):
     """Version of ResourceWithKeyMapping wrapper that also implements IOManagerDefinition."""
 
     def __init__(
-        self, resource: ResourceDefinition, resource_id_to_key_mapping: Dict[ResourceId, str]
+        self,
+        resource: ResourceDefinition,
+        resource_id_to_key_mapping: Dict[ResourceId, str],
     ):
         ResourceWithKeyMapping.__init__(self, resource, resource_id_to_key_mapping)
         IOManagerDefinition.__init__(
@@ -621,7 +641,9 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
         nested_resources: Mapping[str, CoercibleToResource],
     ):
         super().__init__(
-            resource_fn=resource_fn, config_schema=config_schema, description=description
+            resource_fn=resource_fn,
+            config_schema=config_schema,
+            description=description,
         )
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
@@ -954,8 +976,7 @@ class ConfigurableResourceFactory(
         """Optionally override this method to perform any post-execution steps
         needed after the resource is used in execution.
 
-        teardown_after_execution will be called even if the resource fails to initialize in the
-        setup_for_execution step, and if any part of the run fails.
+        teardown_after_execution will be called even if any part of the run fails.
         """
         pass
 
@@ -968,8 +989,8 @@ class ConfigurableResourceFactory(
         Note that if you override this method and want setup_for_execution or
         teardown_after_execution to be called, you must invoke them yourself.
         """
+        self.setup_for_execution(context)
         try:
-            self.setup_for_execution(context)
             yield self.create_resource(context)
         finally:
             # what to do if teardown_after_execution throws
@@ -1108,7 +1129,9 @@ class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCa
     resource_cls: Type[ConfigurableResourceFactory[TResValue]]
 
     def __init__(
-        self, resource_cls: Type[ConfigurableResourceFactory[TResValue]], data: Dict[str, Any]
+        self,
+        resource_cls: Type[ConfigurableResourceFactory[TResValue]],
+        data: Dict[str, Any],
     ):
         resource_pointers, _data_without_resources = separate_resource_params(data)
 
@@ -1303,17 +1326,23 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
         )
 
     @classmethod
-    def input_config_schema(cls) -> Optional[Union[CoercableToConfigSchema, Type[Config]]]:
+    def input_config_schema(
+        cls,
+    ) -> Optional[Union[CoercableToConfigSchema, Type[Config]]]:
         return None
 
     @classmethod
-    def output_config_schema(cls) -> Optional[Union[CoercableToConfigSchema, Type[Config]]]:
+    def output_config_schema(
+        cls,
+    ) -> Optional[Union[CoercableToConfigSchema, Type[Config]]]:
         return None
 
 
 class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
     def __init__(
-        self, resource_cls: Type[ConfigurableResourceFactory[TResValue]], data: Dict[str, Any]
+        self,
+        resource_cls: Type[ConfigurableResourceFactory[TResValue]],
+        data: Dict[str, Any],
     ):
         PartialResource.__init__(self, resource_cls, data)
 
@@ -1387,7 +1416,9 @@ MAPPING_KEY_TYPE_TO_SCALAR = {
 
 
 def _wrap_config_type(
-    shape_type: PydanticShapeType, key_type: Optional[ConfigType], config_type: ConfigType
+    shape_type: PydanticShapeType,
+    key_type: Optional[ConfigType],
+    config_type: ConfigType,
 ) -> ConfigType:
     """Based on a Pydantic shape type, wraps a config type in the appropriate Dagster config wrapper.
     For example, if the shape type is a Pydantic list, the config type will be wrapped in an Array.

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -977,6 +977,7 @@ class ConfigurableResourceFactory(
         needed after the resource is used in execution.
 
         teardown_after_execution will be called even if any part of the run fails.
+        It will not be called if setup_for_execution fails.
         """
         pass
 
@@ -993,7 +994,6 @@ class ConfigurableResourceFactory(
         try:
             yield self.create_resource(context)
         finally:
-            # what to do if teardown_after_execution throws
             self.teardown_after_execution(context)
 
     def get_resource_context(self) -> InitResourceContext:

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 import re
 from enum import Enum
@@ -744,6 +745,7 @@ class ConfigurableResourceFactory(
 
     def __init__(self, **data: Any):
         resource_pointers, data_without_resources = separate_resource_params(data)
+      
 
         schema = infer_schema_from_config_class(
             self.__class__, fields_to_omit=set(resource_pointers.keys())
@@ -853,9 +855,10 @@ class ConfigurableResourceFactory(
         )
         return self._with_updated_values(post_processed_data)
 
+    @contextlib.contextmanager
     def _resolve_and_update_nested_resources(
         self, context: InitResourceContext
-    ) -> "ConfigurableResourceFactory[TResValue]":
+    ) -> Generator["ConfigurableResourceFactory[TResValue]", None, None]:
         """Updates any nested resources with the resource values from the context.
         In this case, populating partially configured resources or
         resources that return plain Python types.
@@ -882,15 +885,16 @@ class ConfigurableResourceFactory(
             }
 
         # Also evaluate any resources that are not partial
-        resources_to_update, _ = separate_resource_params(self.__dict__)
-        resources_to_update = {
-            attr_name: _call_resource_fn_with_default(coerce_to_resource(resource), context)
-            for attr_name, resource in resources_to_update.items()
-            if attr_name not in partial_resources_to_update
-        }
+        with contextlib.ExitStack() as stack:
+            resources_to_update, _ = separate_resource_params(self.__dict__)
+            resources_to_update = {
+                attr_name: stack.enter_context(_call_resource_fn_with_default(coerce_to_resource(resource), context))
+                for attr_name, resource in resources_to_update.items()
+                if attr_name not in partial_resources_to_update
+            }
 
-        to_update = {**resources_to_update, **partial_resources_to_update}
-        return self._with_updated_values(to_update)
+            to_update = {**resources_to_update, **partial_resources_to_update}
+            yield self._with_updated_values(to_update)
 
     def with_resource_context(
         self, resource_context: InitResourceContext
@@ -904,14 +908,16 @@ class ConfigurableResourceFactory(
         )
         return copy
 
+    @contextlib.contextmanager
     def _initialize_and_run(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
-        updated_resource = (
-            self._resolve_and_update_nested_resources(context)  # noqa: SLF001
-            .with_resource_context(context)
-            ._resolve_and_update_env_vars()
-        )
+        with self._resolve_and_update_nested_resources(context) as has_nested_resource:
+            updated_resource = (
+                has_nested_resource.with_resource_context(context)
+                ._resolve_and_update_env_vars()
+            )
 
-        yield from updated_resource.yield_for_execution(context)
+            with updated_resource.yield_for_execution(context) as value:
+                yield value
 
     def pre_execute(self, context: InitResourceContext) -> None:
         """Optionally override this method to perform any pre-execution steps
@@ -928,6 +934,7 @@ class ConfigurableResourceFactory(
         """
         pass
 
+    @ contextlib.contextmanager
     def yield_for_execution(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
         """Optionally override this method to perform any lifecycle steps
         before or after the resource is used in execution. By default, calls

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -799,8 +799,8 @@ class ConfigurableResourceFactory(
     def _get_initialize_and_run_fn(self) -> Callable:
         is_cm_resource = (
             self.__class__.yield_for_execution != ConfigurableResourceFactory.yield_for_execution
-            or self.__class__.teardown_for_execution
-            != ConfigurableResourceFactory.teardown_for_execution
+            or self.__class__.teardown_after_execution
+            != ConfigurableResourceFactory.teardown_after_execution
         )
         return self._initialize_and_run_cm if is_cm_resource else self._initialize_and_run
 
@@ -944,11 +944,11 @@ class ConfigurableResourceFactory(
         """
         pass
 
-    def teardown_for_execution(self, context: InitResourceContext) -> None:
+    def teardown_after_execution(self, context: InitResourceContext) -> None:
         """Optionally override this method to perform any post-execution steps
         needed after the resource is used in execution.
 
-        teardown_for_execution will be called even if the resource fails to initialize in the
+        teardown_after_execution will be called even if the resource fails to initialize in the
         setup_for_execution step, and if any part of the run fails.
         """
         pass
@@ -957,17 +957,17 @@ class ConfigurableResourceFactory(
     def yield_for_execution(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
         """Optionally override this method to perform any lifecycle steps
         before or after the resource is used in execution. By default, calls
-        setup_for_execution before yielding, and teardown_for_execution after yielding.
+        setup_for_execution before yielding, and teardown_after_execution after yielding.
 
         Note that if you override this method and want setup_for_execution or
-        teardown_for_execution to be called, you must invoke them yourself.
+        teardown_after_execution to be called, you must invoke them yourself.
         """
         try:
             self.setup_for_execution(context)
             yield self.create_resource(context)
         finally:
-            # what to do if teardown_for_execution throws
-            self.teardown_for_execution(context)
+            # what to do if teardown_after_execution throws
+            self.teardown_after_execution(context)
 
     def get_resource_context(self) -> InitResourceContext:
         """Returns the context that this resource was initialized with."""

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -745,7 +745,6 @@ class ConfigurableResourceFactory(
 
     def __init__(self, **data: Any):
         resource_pointers, data_without_resources = separate_resource_params(data)
-      
 
         schema = infer_schema_from_config_class(
             self.__class__, fields_to_omit=set(resource_pointers.keys())
@@ -888,7 +887,9 @@ class ConfigurableResourceFactory(
         with contextlib.ExitStack() as stack:
             resources_to_update, _ = separate_resource_params(self.__dict__)
             resources_to_update = {
-                attr_name: stack.enter_context(_call_resource_fn_with_default(coerce_to_resource(resource), context))
+                attr_name: stack.enter_context(
+                    _call_resource_fn_with_default(coerce_to_resource(resource), context)
+                )
                 for attr_name, resource in resources_to_update.items()
                 if attr_name not in partial_resources_to_update
             }
@@ -911,10 +912,9 @@ class ConfigurableResourceFactory(
     @contextlib.contextmanager
     def _initialize_and_run(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
         with self._resolve_and_update_nested_resources(context) as has_nested_resource:
-            updated_resource = (
-                has_nested_resource.with_resource_context(context)
-                ._resolve_and_update_env_vars()
-            )
+            updated_resource = has_nested_resource.with_resource_context(  # noqa: SLF001
+                context
+            )._resolve_and_update_env_vars()
 
             with updated_resource.yield_for_execution(context) as value:
                 yield value
@@ -934,7 +934,7 @@ class ConfigurableResourceFactory(
         """
         pass
 
-    @ contextlib.contextmanager
+    @contextlib.contextmanager
     def yield_for_execution(self, context: InitResourceContext) -> Generator[TResValue, None, None]:
         """Optionally override this method to perform any lifecycle steps
         before or after the resource is used in execution. By default, calls

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
@@ -1,0 +1,238 @@
+from typing import Any, Dict, Generator
+
+import pytest
+from dagster import (
+    ConfigurableResource,
+    job,
+    op,
+)
+from dagster._core.errors import DagsterResourceFunctionError
+from dagster._core.execution.context.init import InitResourceContext
+from pydantic import PrivateAttr
+
+
+def test_basic_pre_post_execute() -> None:
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append("pre_execute")
+
+        def post_execute(self, context: InitResourceContext) -> None:
+            log.append("post_execute")
+
+    @op
+    def hello_world_op(res: MyResource):
+        log.append("hello_world_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def hello_world_job() -> None:
+        hello_world_op()
+
+    result = hello_world_job.execute_in_process()
+    assert result.success
+    assert log == [
+        "pre_execute",
+        "hello_world_op",
+        "post_execute",
+    ]
+
+
+def test_basic_yield() -> None:
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def yield_for_execution(
+            self, context: InitResourceContext
+        ) -> Generator["MyResource", None, None]:
+            log.append("pre_execute")
+            yield self
+            log.append("post_execute")
+
+    @op
+    def hello_world_op(res: MyResource):
+        log.append("hello_world_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def hello_world_job() -> None:
+        hello_world_op()
+
+    result = hello_world_job.execute_in_process()
+    assert result.success
+    assert log == [
+        "pre_execute",
+        "hello_world_op",
+        "post_execute",
+    ]
+
+
+def test_basic_pre_post_execute_multi_op() -> None:
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append("pre_execute")
+
+        def post_execute(self, context: InitResourceContext) -> None:
+            log.append("post_execute")
+
+    @op
+    def hello_world_op(res: MyResource):
+        log.append("hello_world_op")
+
+    @op
+    def another_hello_world_op(res: MyResource, _: Any):
+        log.append("another_hello_world_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def hello_world_job() -> None:
+        another_hello_world_op(hello_world_op())
+
+    result = hello_world_job.execute_in_process()
+    assert result.success
+    assert log == [
+        "pre_execute",
+        "hello_world_op",
+        "another_hello_world_op",
+        "post_execute",
+    ]
+
+
+def test_basic_yield_multi_op() -> None:
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def yield_for_execution(
+            self, context: InitResourceContext
+        ) -> Generator["MyResource", None, None]:
+            log.append("pre_execute")
+            yield self
+            log.append("post_execute")
+
+    @op
+    def hello_world_op(res: MyResource):
+        log.append("hello_world_op")
+
+    @op
+    def another_hello_world_op(res: MyResource, _: Any):
+        log.append("another_hello_world_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def hello_world_job() -> None:
+        another_hello_world_op(hello_world_op())
+
+    result = hello_world_job.execute_in_process()
+    assert result.success
+    assert log == [
+        "pre_execute",
+        "hello_world_op",
+        "another_hello_world_op",
+        "post_execute",
+    ]
+
+
+def test_pre_post_execute_with_op_execution_error() -> None:
+    # If an op raises an error, we should still call post_execute on the resource
+
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append("pre_execute")
+
+        def post_execute(self, context: InitResourceContext) -> None:
+            log.append("post_execute")
+
+    @op
+    def my_erroring_op(res: MyResource):
+        log.append("my_erroring_op")
+        raise Exception("foo")
+
+    @op
+    def my_never_run_op(res: MyResource, _: Any):
+        log.append("my_never_run_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def erroring_job() -> None:
+        my_never_run_op(my_erroring_op())
+
+    with pytest.raises(Exception, match="foo"):
+        erroring_job.execute_in_process()
+
+    assert log == [
+        "pre_execute",
+        "my_erroring_op",
+        "post_execute",
+    ]
+
+
+def test_pre_execute_with_error() -> None:
+    # If an error occurs in pre_execute, this error will manifest as a DagsterResourceFunctionError and
+    # the resource teardown will be called
+
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append("pre_execute")
+            raise Exception("foo")
+
+        def post_execute(self, context: InitResourceContext) -> None:
+            log.append("post_execute")
+
+    @op
+    def my_never_run_op(res: MyResource):
+        log.append("my_never_run_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def hello_world_job() -> None:
+        my_never_run_op()
+
+    with pytest.raises(DagsterResourceFunctionError):
+        hello_world_job.execute_in_process()
+
+    assert log == [
+        "pre_execute",
+        "post_execute",
+    ]
+
+
+def test_basic_init_with_privateattr() -> None:
+    log = []
+
+    class Connection:
+        def __init__(self, username: str, password: str):
+            self.username = username
+            self.password = password
+
+    class MyDBResource(ConfigurableResource):
+        username: str
+        password: str
+
+        _connection: Connection = PrivateAttr()
+
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append(f"pre_execute with {self.username} and {self.password}")
+            self._connection = Connection(self.username, self.password)
+
+        def query(self, query: str) -> Dict[str, Any]:
+            log.append(
+                f"query {query} with {self._connection.username} and {self._connection.password}"
+            )
+            return {"foo": "bar"}
+
+    @op
+    def hello_world_op(db: MyDBResource):
+        res = db.query("select * from table")
+        assert res == {"foo": "bar"}
+
+    @job(resource_defs={"db": MyDBResource(username="foo", password="bar")})
+    def hello_world_job() -> None:
+        hello_world_op()
+
+    result = hello_world_job.execute_in_process()
+    assert result.success
+    assert log == [
+        "pre_execute with foo and bar",
+        "query select * from table with foo and bar",
+    ]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import Any, Dict, Generator
 
 import pytest
@@ -42,6 +43,7 @@ def test_basic_yield() -> None:
     log = []
 
     class MyResource(ConfigurableResource):
+        @contextlib.contextmanager
         def yield_for_execution(
             self, context: InitResourceContext
         ) -> Generator["MyResource", None, None]:
@@ -102,6 +104,7 @@ def test_basic_yield_multi_op() -> None:
     log = []
 
     class MyResource(ConfigurableResource):
+        @contextlib.contextmanager
         def yield_for_execution(
             self, context: InitResourceContext
         ) -> Generator["MyResource", None, None]:
@@ -197,6 +200,36 @@ def test_pre_execute_with_error() -> None:
     ]
 
 
+def test_post_execute_with_error() -> None:
+    # If an error occurs in post_execute, this error will manifest as a DagsterResourceFunctionError
+
+    log = []
+
+    class MyResource(ConfigurableResource):
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append("pre_execute")
+
+        def post_execute(self, context: InitResourceContext) -> None:
+            log.append("post_execute")
+            raise Exception("foo")
+
+    @op
+    def my_hello_world_op(res: MyResource):
+        log.append("my_hello_world_op")
+
+    @job(resource_defs={"res": MyResource()})
+    def hello_world_job() -> None:
+        my_hello_world_op()
+
+    hello_world_job.execute_in_process()
+
+    assert log == [
+        "pre_execute",
+        "my_hello_world_op",
+        "post_execute",
+    ]
+
+
 def test_basic_init_with_privateattr() -> None:
     log = []
 
@@ -235,4 +268,68 @@ def test_basic_init_with_privateattr() -> None:
     assert log == [
         "pre_execute with foo and bar",
         "query select * from table with foo and bar",
+    ]
+
+
+def test_nested_resources_init_with_privateattr() -> None:
+    log = []
+
+    def fetch_jwt(access_key: str, secret_key: str) -> str:
+        log.append(f"fetch_jwt with {access_key} and {secret_key}")
+        return "my_jwt"
+
+    class S3Client:
+        def __init__(self, jwt: str):
+            self.jwt = jwt
+
+    class AWSCredentialsResource(ConfigurableResource):
+        access_key: str
+        secret_key: str
+
+        _jwt: str = PrivateAttr()
+
+        def pre_execute(self, context: InitResourceContext) -> None:
+            self._jwt = fetch_jwt(self.access_key, self.secret_key)
+
+        @property
+        def jwt(self) -> str:
+            return self._jwt
+
+    class S3Resource(ConfigurableResource):
+        credentials: AWSCredentialsResource
+
+        _s3_client: Any = PrivateAttr()
+
+        def pre_execute(self, context: InitResourceContext) -> None:
+            log.append(f"pre_execute with jwt {self.credentials.jwt}")
+            self._s3_client = S3Client(self.credentials.jwt)
+
+        def get_object(self, bucket: str, key: str) -> Dict[str, Any]:
+            log.append(f"get_object {bucket} {key} with jwt {self.credentials.jwt}")
+            return {"foo": "bar"}
+
+    @op
+    def load_from_s3_op(s3: S3Resource) -> Dict[str, Any]:
+        log.append("load_from_s3_op")
+        res = s3.get_object("my-bucket", "my-key")
+        assert res == {"foo": "bar"}
+        return res
+
+    @job(
+        resource_defs={
+            "s3": S3Resource(
+                credentials=AWSCredentialsResource(access_key="my_key", secret_key="my_secret")
+            )
+        }
+    )
+    def load_from_s3_job() -> None:
+        load_from_s3_op()
+
+    result = load_from_s3_job.execute_in_process()
+    assert result.success
+    assert log == [
+        "fetch_jwt with my_key and my_secret",
+        "pre_execute with jwt my_jwt",
+        "load_from_s3_op",
+        "get_object my-bucket my-key with jwt my_jwt",
     ]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
@@ -14,15 +14,15 @@ from dagster._core.execution.context.init import InitResourceContext
 from pydantic import PrivateAttr
 
 
-def test_basic_pre_teardown_for_execution() -> None:
+def test_basic_pre_teardown_after_execution() -> None:
     log = []
 
     class MyResource(ConfigurableResource):
         def setup_for_execution(self, context: InitResourceContext) -> None:
             log.append("setup_for_execution")
 
-        def teardown_for_execution(self, context: InitResourceContext) -> None:
-            log.append("teardown_for_execution")
+        def teardown_after_execution(self, context: InitResourceContext) -> None:
+            log.append("teardown_after_execution")
 
     @op
     def hello_world_op(res: MyResource):
@@ -37,7 +37,7 @@ def test_basic_pre_teardown_for_execution() -> None:
     assert log == [
         "setup_for_execution",
         "hello_world_op",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 
@@ -51,7 +51,7 @@ def test_basic_yield() -> None:
         ) -> Generator["MyResource", None, None]:
             log.append("setup_for_execution")
             yield self
-            log.append("teardown_for_execution")
+            log.append("teardown_after_execution")
 
     @op
     def hello_world_op(res: MyResource):
@@ -66,19 +66,19 @@ def test_basic_yield() -> None:
     assert log == [
         "setup_for_execution",
         "hello_world_op",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 
-def test_basic_pre_teardown_for_execution_multi_op() -> None:
+def test_basic_pre_teardown_after_execution_multi_op() -> None:
     log = []
 
     class MyResource(ConfigurableResource):
         def setup_for_execution(self, context: InitResourceContext) -> None:
             log.append("setup_for_execution")
 
-        def teardown_for_execution(self, context: InitResourceContext) -> None:
-            log.append("teardown_for_execution")
+        def teardown_after_execution(self, context: InitResourceContext) -> None:
+            log.append("teardown_after_execution")
 
     @op
     def hello_world_op(res: MyResource):
@@ -98,7 +98,7 @@ def test_basic_pre_teardown_for_execution_multi_op() -> None:
         "setup_for_execution",
         "hello_world_op",
         "another_hello_world_op",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 
@@ -112,7 +112,7 @@ def test_basic_yield_multi_op() -> None:
         ) -> Generator["MyResource", None, None]:
             log.append("setup_for_execution")
             yield self
-            log.append("teardown_for_execution")
+            log.append("teardown_after_execution")
 
     @op
     def hello_world_op(res: MyResource):
@@ -132,12 +132,12 @@ def test_basic_yield_multi_op() -> None:
         "setup_for_execution",
         "hello_world_op",
         "another_hello_world_op",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 
-def test_pre_teardown_for_execution_with_op_execution_error() -> None:
-    # If an op raises an error, we should still call teardown_for_execution on the resource
+def test_pre_teardown_after_execution_with_op_execution_error() -> None:
+    # If an op raises an error, we should still call teardown_after_execution on the resource
 
     log = []
 
@@ -145,8 +145,8 @@ def test_pre_teardown_for_execution_with_op_execution_error() -> None:
         def setup_for_execution(self, context: InitResourceContext) -> None:
             log.append("setup_for_execution")
 
-        def teardown_for_execution(self, context: InitResourceContext) -> None:
-            log.append("teardown_for_execution")
+        def teardown_after_execution(self, context: InitResourceContext) -> None:
+            log.append("teardown_after_execution")
 
     @op
     def my_erroring_op(res: MyResource):
@@ -167,7 +167,7 @@ def test_pre_teardown_for_execution_with_op_execution_error() -> None:
     assert log == [
         "setup_for_execution",
         "my_erroring_op",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 
@@ -182,8 +182,8 @@ def test_setup_for_execution_with_error() -> None:
             log.append("setup_for_execution")
             raise Exception("foo")
 
-        def teardown_for_execution(self, context: InitResourceContext) -> None:
-            log.append("teardown_for_execution")
+        def teardown_after_execution(self, context: InitResourceContext) -> None:
+            log.append("teardown_after_execution")
 
     @op
     def my_never_run_op(res: MyResource):
@@ -198,12 +198,12 @@ def test_setup_for_execution_with_error() -> None:
 
     assert log == [
         "setup_for_execution",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 
-def test_teardown_for_execution_with_error() -> None:
-    # If an error occurs in teardown_for_execution, this error will manifest as a DagsterResourceFunctionError
+def test_teardown_after_execution_with_error() -> None:
+    # If an error occurs in teardown_after_execution, this error will manifest as a DagsterResourceFunctionError
 
     log = []
 
@@ -211,8 +211,8 @@ def test_teardown_for_execution_with_error() -> None:
         def setup_for_execution(self, context: InitResourceContext) -> None:
             log.append("setup_for_execution")
 
-        def teardown_for_execution(self, context: InitResourceContext) -> None:
-            log.append("teardown_for_execution")
+        def teardown_after_execution(self, context: InitResourceContext) -> None:
+            log.append("teardown_after_execution")
             raise Exception("foo")
 
     @op
@@ -228,7 +228,7 @@ def test_teardown_for_execution_with_error() -> None:
     assert log == [
         "setup_for_execution",
         "my_hello_world_op",
-        "teardown_for_execution",
+        "teardown_after_execution",
     ]
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
@@ -174,8 +174,8 @@ def test_pre_teardown_after_execution_with_op_execution_error() -> None:
 
 
 def test_setup_for_execution_with_error() -> None:
-    # If an error occurs in setup_for_execution, this error will manifest as a DagsterResourceFunctionError and
-    # the resource teardown will be called
+    # If an error occurs in setup_for_execution, this error will manifest as a DagsterResourceFunctionError
+    # The resource teardown will not be called
 
     log = []
 
@@ -200,7 +200,6 @@ def test_setup_for_execution_with_error() -> None:
 
     assert log == [
         "setup_for_execution",
-        "teardown_after_execution",
     ]
 
 


### PR DESCRIPTION
## Motivation

As part of the initial 1.3 release of Pythonic resources, the decision was made to make `ConfigurableResources` immutable and to encourage users to defer state management to a separate class.

This created a clean separation of concerns, leaving the resource class as a lightweight class holding only config schema. However, this decision was a heavy-handed prescription for how users needed to model their code:

```python

class MyDatabaseClient:
    def __init__(self, conn_str: str):
        self._connection = connection.open(conn_str)

    def query(self, query: str):
        return self._connection.query(query)

class MyDatabaseResource(ConfigurableResource):
    username: str
    password: str
    uri: str
    
    def get_client(self) -> MyDatabaseClient:
        return MyDatabaseClient(conn_str=...)

@asset
def my_asset(db: MyDatabaseResource):
    db.get_client().query(...)
```

Initial feedback from users suggests that we should give more freedom to creating stateful resource classes which both model config and hold some state. Many resources, from database connections to external API clients require initial setup that is verbose to build with the current restrictions.

## Summary

This PR introduces (1) a blessed pattern for specifying private state within a `ConfigurableResource` and (2) a set of Dagster-specific lifecycle hooks which users can use to specify setup, teardown, and context behavior for their resources.


### Specifying private state

The Pythonic resource system is built on top of Pydantic, which already supports a notion of [private model attributes](https://docs.pydantic.dev/usage/models/#private-model-attributes). These attributes can be specified by assigning attributes intended to be private an instance of `PrivateAttr`. As part of this PR, `PrivateAttr` will become an endorsed method of managing state on a resource class:

```python
class MyDatabaseResource(ConfigurableResource):
    username: str
    password: str
    uri: str

    _connection: Connection = PrivateAttr()
```

These private attributes can be initialized before runtime as part of lifecycle hooks (see below) and reassigned at any time during execution:

```python
class MyAPIClientResource(ConfigurableResource):
    api_key: str

    _cache: Dict[str, Any] = PrivateAttr(default_factory=dict)

    def request(self, input: str):
        if input in self._cache:
            return self._cache["input"]
        result = ...
        self._cache[input] = result
        return result
```

### Lifecycle hooks

To make setting up and tearing down connections and state easier, this PR introduces a set of resource lifecycle hooks that can optionally be implemented. 

#### `setup_for_execution` and `teardown_after_execution` hooks

The simplest set of hooks is `setup_for_execution` and `teardown_after_execution`. `setup_for_execution` is invoked at run execution time, after all resource config is populated, env vars resolved, and nested resources set up. `teardown_after_execution` is invoked after a run execution completes to allow for cleanup.


```python
class MyAPIClientResource(ConfigurableResource):
    api_key: str
    _internal_client: MyAPIClient = PrivateAttr()

    def setup_for_execution(self, context):
        self._internal_client = MyAPIClient(self.api_key)

    def get_all_items(self):
        return self._internal_client.items.get()

@asset
def all_items(api_client: MyAPIClientResource):
    return api_client.get_all_items()
```

#### `yield_for_execution`

More advanced use cases may instead want to open contexts instead of separate setup and teardown steps. These resources can override `yield_for_execution`, which by default invokes `setup_for_execution`, yields the resource, and invokes `teardown_after_execution` afterwards.

```python
class MyDatabaseResource(ConfigurableResource):
    username: str
    password: str
    uri: str

    _connection: Connection = PrivateAttr()
   
    @contextlib.contextmanager
    def yield_for_execution(self, context):
        with open_connection(self.uri, self.username, self.password) as conn:
            self._connection = conn
            yield self
```

#### Dagster lifecycle methods v.s. dataclass lifecycle methods

Here we choose explicitly to introduce Dagster-specific lifecycle methods rather than using established methods such as `dataclass`' `__post_init__` or Pydantic [root validators](https://docs.pydantic.dev/usage/validators/#root-validators). This is to delay resource setup and teardown to Dagster execution time, as traditional init lifecycle methods would be called every time a resource class is initialized on code location refresh or run load.

These Dagster lifecycle methods can coexist with lightweight post-init methods such as root validators.

### Example patterns

This change allows users to follow more palatable patterns for common resource use cases. For example, `ConfigurableIOManagers` which wrap a plain `IOManager`:

```python
class InternalIOManager(IOManager):
    ...

class AConfigurableIOManager(ConfigurableIOManager):
    api_key: str

    _internal_io_manager: InternalIOManager = PrivateAttr()

    def setup_for_execution(self, context):
        self._internal_io_manager = InternalIOManager(self.api_key)

    def load_input(self, context):
        return self._internal_io_manager.load_input(context)

    def handle_output(self, context):
        return self._internal_io_manager.handle_output(context)
``` 

## Test Plan

New suite of unit tests.