### PR TITLE
enabled is arg of retries and not of multiprocess

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -511,7 +511,7 @@ def multi_or_in_process_executor(init_context: "InitExecutorContext") -> "Execut
             multiprocess:
               max_concurrent: 4
               retries:
-              enabled:
+                enabled:
 
     The ``max_concurrent`` arg is optional and tells the execution engine how many processes may run
     concurrently. By default, or if you set ``max_concurrent`` to be 0, this is the return value of


### PR DESCRIPTION
## Summary & Motivation
In the Multiprocess Executor config, `enabled` is arg of `retries` and not of `multiprocess`.