### PR TITLE
Guard against empty partition lists

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3246,6 +3246,9 @@ class TestEventLogStorage:
 
         assert set(storage.get_dynamic_partitions("baz")) == set()
 
+        # Adding no partitions is a no-op
+        storage.add_dynamic_partitions(partitions_def_name="foo", partition_keys=[])
+
     def test_delete_dynamic_partitions(self, storage):
         assert storage
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -1,4 +1,4 @@
-from typing import Any, ContextManager, Mapping, Optional
+from typing import Any, ContextManager, Mapping, Optional, Sequence
 
 import dagster._check as check
 import sqlalchemy as db
@@ -12,6 +12,7 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.config import pg_config
 from dagster._core.storage.event_log import (
     AssetKeyTable,
+    DynamicPartitionsTable,
     SqlEventLogStorage,
     SqlEventLogStorageMetadata,
     SqlEventLogStorageTable,
@@ -252,6 +253,23 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             else:
                 query = query.on_conflict_do_nothing()
             conn.execute(query)
+
+    def add_dynamic_partitions(
+        self, partitions_def_name: str, partition_keys: Sequence[str]
+    ) -> None:
+        # Overload base implementation to push upsert logic down into the db layer
+        self._check_partitions_table()
+        with self.index_connection() as conn:
+            conn.execute(
+                db_dialects.postgresql.insert(DynamicPartitionsTable)
+                .values(
+                    [
+                        dict(partitions_def_name=partitions_def_name, partition=partition_key)
+                        for partition_key in partition_keys
+                    ]
+                )
+                .on_conflict_do_nothing(),
+            )
 
     def _connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -257,6 +257,9 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def add_dynamic_partitions(
         self, partitions_def_name: str, partition_keys: Sequence[str]
     ) -> None:
+        if not partition_keys:
+            return
+
         # Overload base implementation to push upsert logic down into the db layer
         self._check_partitions_table()
         with self.index_connection() as conn:


### PR DESCRIPTION
This brings https://github.com/dagster-io/dagster/pull/13844 back but
adds an additional test case for when there are no partitions.

The default implementation already handled this because it first checked
to see if had anything to insert. The new implementation didn't because
without partition keys, it tries to insert an empty list which
SqlAlchemy resolves to trying to insert the default values (a bunch of
nulls).