### PR TITLE
chore(dbt): constrain dbt-core to support versions 1.2 through 1.5

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        "dbt-core>=1.1",
+        "dbt-core>=1.2,<1.6",
         "networkx",
         "requests",
         "typer[all]",


### PR DESCRIPTION
## Summary & Motivation
Whenever `dbt-core` updates, it inevitably breaks us. Rather than scrambling to address errors if users did not preemptively pin, or are unable to conclude from the error messages that they need to pin, we should just pin on their behalf.

When a user requests support for the next version of dbt Core, that when we know to loosen this constraint and fix any machinery that needs to be fixed.

Also, 1.1 is EOL, so bump up the floor to 1.2.

https://docs.getdbt.com/docs/dbt-versions/core

## How I Tested These Changes
bk
