### PR TITLE
[fix] Fix sensor resource binding error when late-binding to sensor, job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -512,6 +512,7 @@ class ScheduleDefinition:
             description=self.description,
             job=new_job,
             default_status=self.default_status,
+            required_resource_keys=self.required_resource_keys
         )
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -512,7 +512,7 @@ class ScheduleDefinition:
             description=self.description,
             job=new_job,
             default_status=self.default_status,
-            required_resource_keys=self.required_resource_keys
+            required_resource_keys=self.required_resource_keys,
         )
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -480,6 +480,7 @@ class SensorDefinition:
             job=new_jobs[0] if len(new_jobs) == 1 else None,
             default_status=self.default_status,
             asset_selection=self.asset_selection,
+            required_resource_keys=self.required_resource_keys,
         )
 
     def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -80,6 +80,21 @@ def sensor_from_fn_arg(context: SensorEvaluationContext, my_resource: MyResource
     return RunRequest(my_resource.a_str, run_config={}, tags={})
 
 
+@op(out={})
+def the_op_but_with_a_resource_dep(my_resource: MyResource):
+    assert my_resource.a_str == "foo"
+
+
+@job
+def the_job_but_with_a_resource_dep() -> None:
+    the_op_but_with_a_resource_dep()
+
+
+@sensor(job_name="the_job_but_with_a_resource_dep")
+def sensor_with_job_with_resource_dep(context: SensorEvaluationContext, my_resource: MyResource):
+    return RunRequest(my_resource.a_str, run_config={}, tags={})
+
+
 is_in_cm = False
 
 
@@ -244,10 +259,11 @@ def sensor_run_status_with_cm(
 
 
 the_repo = Definitions(
-    jobs=[the_job],
+    jobs=[the_job, the_job_but_with_a_resource_dep],
     sensors=[
         sensor_from_context,
         sensor_from_fn_arg,
+        sensor_with_job_with_resource_dep,
         sensor_with_cm,
         sensor_from_context_weird_name,
         sensor_from_fn_arg_no_context,
@@ -328,6 +344,7 @@ def test_cant_use_required_resource_keys_and_params_both() -> None:
     [
         "sensor_from_context",
         "sensor_from_fn_arg",
+        "sensor_with_job_with_resource_dep",
         "sensor_with_cm",
         "sensor_from_context_weird_name",
         "sensor_from_fn_arg_no_context",


### PR DESCRIPTION
## Summary

Fixes a bug where sensors attached to jobs that rely on late-bound resources do not have the required resource definition:

https://dagster.slack.com/archives/C01U954MEER/p1682588150393499

This was a casualty of the two features (late-binding resources to jobs and resources in sensors) being developed in parallel - the codepath to reconstruct a sensor with an updated job fails to take into account the resource requirements.

## Test Plan

Test case of job w/ late-bound resource & sensor w/ late-bound resource.
