### PR TITLE
Demonstrate for benh

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -70,7 +70,7 @@ def sensor(
     def inner(fn: RawSensorEvaluationFunction) -> SensorDefinition:
         check.callable_param(fn, "fn")
 
-        sensor_def = SensorDefinition(
+        sensor_def = SensorDefinition.internal_init(
             name=name,
             job_name=job_name,
             evaluation_fn=fn,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -471,15 +471,17 @@ class SensorDefinition:
             job (ExecutableDefinition): The job that should execute when this
                 schedule runs.
         """
-        return SensorDefinition(
+        return SensorDefinition.internal_init(
             name=self.name,
             evaluation_fn=self._evaluation_fn,
             minimum_interval_seconds=self.minimum_interval_seconds,
             description=self.description,
+            job_name=None,  # if original init was passed job name, was resolved to a job
             jobs=new_jobs if len(new_jobs) > 1 else None,
             job=new_jobs[0] if len(new_jobs) == 1 else None,
             default_status=self.default_status,
             asset_selection=self.asset_selection,
+            required_resource_keys=self.required_resource_keys,
         )
 
     def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":
@@ -490,6 +492,33 @@ class SensorDefinition:
                 schedule runs.
         """
         return self.with_updated_jobs([new_job])
+
+    @staticmethod
+    def internal_init(
+        *,
+        name: Optional[str],
+        evaluation_fn: Optional[RawSensorEvaluationFunction],
+        job_name: Optional[str],
+        minimum_interval_seconds: Optional[int],
+        description: Optional[str],
+        job: Optional[ExecutableDefinition],
+        jobs: Optional[Sequence[ExecutableDefinition]],
+        default_status: DefaultSensorStatus,
+        asset_selection: Optional[AssetSelection],
+        required_resource_keys: Optional[Set[str]],
+    ):
+        return SensorDefinition(
+            name=name,
+            evaluation_fn=evaluation_fn,
+            job_name=job_name,
+            minimum_interval_seconds=minimum_interval_seconds,
+            description=description,
+            job=job,
+            jobs=jobs,
+            default_status=default_status,
+            asset_selection=asset_selection,
+            required_resource_keys=required_resource_keys,
+        )
 
     def __init__(
         self,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
@@ -1,14 +1,16 @@
+import inspect
+from typing import Type
 import pytest
 from dagster import SensorDefinition, graph
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 
-def test_jobs_attr():
-    def eval_fn():
+def test_jobs_attr() -> None:
+    def eval_fn() -> None:
         pass
 
     @graph
-    def my_graph():
+    def my_graph() -> None:
         pass
 
     sensor = SensorDefinition(evaluation_fn=eval_fn, job=my_graph)
@@ -21,7 +23,7 @@ def test_jobs_attr():
         sensor.job
 
     @graph
-    def my_second_graph():
+    def my_second_graph() -> None:
         pass
 
     sensor = SensorDefinition(evaluation_fn=eval_fn, jobs=[my_graph, my_second_graph])
@@ -32,9 +34,27 @@ def test_jobs_attr():
         sensor.job
 
 
-def test_direct_sensor_definition_instantiation():
+def test_direct_sensor_definition_instantiation() -> None:
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="Must provide evaluation_fn to SensorDefinition.",
     ):
         SensorDefinition()
+
+
+def assert_internal_init_class_follow_rules(cls: Type):
+    internal_init_argspec = inspect.getfullargspec(cls.internal_init)
+    init_args_spec = inspect.getfullargspec(cls.__init__)
+
+    # internal_init cannot have default
+    assert internal_init_argspec.defaults is None
+    # internal_init can only have kwonlyargs
+    assert internal_init_argspec.args == []
+
+    assert internal_init_argspec.kwonlyargs == (
+        init_args_spec.args[1:] + init_args_spec.kwonlyargs  # exclude self
+    )
+
+
+def test_internal_init_matches() -> None:
+    assert_internal_init_class_follow_rules(SensorDefinition)


### PR DESCRIPTION
## Summary & Motivation

Scratched this together to demonstrate a style that avoid errors like in https://github.com/dagster-io/dagster/pull/13956 across all of our definition types.

I think we should have a convention, enforced by tests, that creates a parallel init method for internal codepaths that disallows default arguments. This forces anyone who adds any parameters to a public init method on a definition class to update all internal callsites that likely require shuffling parameters through. For example codepaths for `copy_for_configured` or in the decorators.

We should consider a marker interface for this.

## How I Tested These Changes
