### PR TITLE
[dagster-snowflake] Fix issues with newlines in private key authentication

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -1,3 +1,4 @@
+import base64
 import sys
 import warnings
 from contextlib import closing, contextmanager
@@ -120,7 +121,9 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         description=(
             "Raw private key password to use. See"
             " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details. Required for"
-            " both private_key and private_key_path."
+            " both private_key and private_key_path. To avoid issues with newlines in the keys, you"
+            " must base64 encode the key. You can retrieve the base64 encoded key with this shell"
+            " command: cat rsa_key.pub | base64"
         ),
     )
 
@@ -352,12 +355,14 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         return sqlalchemy_engine_args
 
     def _snowflake_private_key(self, config) -> bytes:
-        private_key = config.get("private_key", None)
         # If the user has defined a path to a private key, we will use that.
         if config.get("private_key_path", None) is not None:
             # read the file from the path.
             with open(config.get("private_key_path"), "rb") as key:
                 private_key = key.read()
+        else:
+            private_key_encoded = config.get("private_key", None)
+            private_key = base64.b64decode(private_key_encoded)
 
         kwargs = {}
         if config.get("private_key_password", None) is not None:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -177,7 +177,9 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
         default=None,
         description=(
             "Raw private key to use. See"
-            " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details."
+            " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details. To avoid"
+            " issues with newlines in the keys, you must base64 encode the key. You can retrieve"
+            " the base64 encoded key with this shell command: cat rsa_key.pub | base64"
         ),
     )
     private_key_path: Optional[str] = Field(

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -178,8 +178,8 @@ class SnowflakeIOManager(ConfigurableIOManagerFactory):
         description=(
             "Raw private key to use. See"
             " https://docs.snowflake.com/en/user-guide/key-pair-auth.html for details. To avoid"
-            " issues with newlines in the keys, you must base64 encode the key. You can retrieve"
-            " the base64 encoded key with this shell command: cat rsa_key.pub | base64"
+            " issues with newlines in the keys, you can base64 encode the key. You can retrieve"
+            " the base64 encoded key with this shell command: cat rsa_key.p8 | base64"
         ),
     )
     private_key_path: Optional[str] = Field(

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -1,3 +1,4 @@
+import base64
 from unittest import mock
 
 import pytest
@@ -256,7 +257,7 @@ def test_snowflake_resource_missing_private_key_password(snowflake_connect):
             "database": "TESTDB",
             "schema": "TESTSCHEMA",
             "warehouse": "TINY_WAREHOUSE",
-            "private_key": "TESTKEY",
+            "private_key": base64.b64encode(str.encode("TEST_KEY")).decode(),
         }
     )
 
@@ -280,7 +281,7 @@ def test_pydantic_snowflake_resource_missing_private_key_password():
         database="TESTDB",
         schema="TESTSCHEMA",
         warehouse="TINY_WAREHOUSE",
-        private_key="TESTKEY",
+        private_key=base64.b64encode(str.encode("TEST_KEY")).decode(),
     )
 
     @job(resource_defs={"snowflake": resource})


### PR DESCRIPTION
## Summary & Motivation
User reported that if you use private key authentication for snowflake and pass the private key as an environment variable, the environment variable can't handle the newlines within the key correctly, causing the authentication to fail. 

This is similar to what happens with GCP, so we can solve the problem the same way, by base64 encoding the key before passing it as configuration, and decoding it within the resource/io manager 

One thing i'm a little concerned about is that this "private_key" config option has been available for a while. The fact that no one has complained about passing a key via env var not working either means that there is another workaround, or that no one is using pk authentication with an env var. If it's the later, then this change is fine, but if it's the former then this change is breaking. Maybe instead we add a new config value called `b64_private_key` or something along those lines?

To Do:
- [x] fix unit tests that mock out a private key

## How I Tested These Changes
tested locally