### PR TITLE
[proof of concept] Fix output metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -132,6 +132,9 @@ def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue[Any]
         "MetadataValue type."
     )
 
+def metadata_to_raw(metadata: "MetadataMapping") -> Dict[str, PackableValue]:
+    return {k: v.value for k, v in metadata.items()}
+
 
 # ########################
 # ##### METADATA VALUE

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -29,6 +29,7 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
 from dagster._core.execution.plan.utils import build_resources_for_manager
+from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
     from dagster._core.definitions import JobDefinition, PartitionsDefinition
@@ -718,6 +719,7 @@ def get_output_context(
     step_context: Optional["StepExecutionContext"],
     resources: Optional["Resources"],
     version: Optional[str],
+    output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     warn_on_step_context_use: bool = False,
 ) -> "OutputContext":
     """Args:
@@ -761,7 +763,7 @@ def get_output_context(
         name=step_output_handle.output_name,
         job_name=job_def.name,
         run_id=run_id,
-        metadata=output_def.metadata,
+        metadata=merge_dicts(output_def.metadata, output_metadata or {}),
         mapping_key=step_output_handle.mapping_key,
         config=output_config,
         op_def=job_def.get_node(step.node_handle).definition,  # type: ignore  # (should be OpDefinition not NodeDefinition)

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -262,7 +262,7 @@ def validate_and_coerce_op_result_to_iterator(
                     yield Output(
                         output_name=output_def.name,
                         value=element.value,
-                        metadata=element.metadata,
+                        metadata=element.raw_metadata, # type: ignore
                         data_version=element.data_version,
                     )
             else:

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -915,6 +915,7 @@ class ExecutionPlan(
                     log_manager=log_manager,
                     step_context=None,
                     resources=resources,
+                    output_metadata=None,
                     version=step_output_versions[step_output_handle],
                 )
                 if not io_manager.has_output(context):


### PR DESCRIPTION
Related issues: 
https://github.com/dagster-io/dagster/issues/8521
https://github.com/dagster-io/dagster/discussions/6913
https://github.com/dagster-io/dagster/issues/9076

Shows what code changes could look like that enable retrieval of output metadata from `Output(...)` objects. A few things to consider from a design perspective:
- putting this on the metadata object requires overriding the metadata provided on the `Out()` object, which could be undesirable.
- requires a read every time an input is loaded, probably prohibitive from a perf standpoint.
- doesn't handle memoization case / how do we retrieve custom metadata for memoization? I guess we need to read event log in that case as well.

The first two points could be solved by some sort of gated, lazy access of the event log a la `OutputContext.get_runtime_output_metadata`, but the memoization case is challenging. At least for assets, maybe we could just retrieve the last materialization event and use the metadata provided there?