### PR TITLE
Introduce dagster_internal_init pattern w/ interface

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -239,7 +239,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         )
 
     @staticmethod
-    def internal_init(
+    def dagster_internal_init(
         *,
         keys_by_input_name: Mapping[str, AssetKey],
         keys_by_output_name: Mapping[str, AssetKey],
@@ -562,7 +562,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         else:
             group_names_by_key = None
 
-        return AssetsDefinition.internal_init(
+        return AssetsDefinition.dagster_internal_init(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name_with_prefix,
             node_def=node_def,
@@ -1080,7 +1080,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 for out_asset_key in subsetted_keys_by_output_name.values()
             }
 
-            return AssetsDefinition.internal_init(
+            return AssetsDefinition.dagster_internal_init(
                 keys_by_input_name=subsetted_keys_by_input_name,
                 keys_by_output_name=subsetted_keys_by_output_name,
                 node_def=subsetted_node,
@@ -1228,7 +1228,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             if key in relevant_keys
         }
 
-        return AssetsDefinition.internal_init(
+        return AssetsDefinition.dagster_internal_init(
             keys_by_input_name=self._keys_by_input_name,
             keys_by_output_name=self._keys_by_output_name,
             node_def=self.node_def,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -609,7 +609,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             if descriptions_by_output_name
             else None,
             can_subset=can_subset,
-            selected_asset_keys=None,
+            selected_asset_keys=None,  # node has no subselection info
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -881,7 +881,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             for key, description in self._descriptions_by_key.items()
         }
 
-        return __class__.internal_init(
+        return __class__.dagster_internal_init(
             keys_by_input_name={
                 input_name: input_asset_key_replacements.get(key, key)
                 for input_name, key in self._keys_by_input_name.items()
@@ -966,7 +966,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 name=f"{self.op.name}_subset_{suffix}", ins=ins
             )
 
-        return AssetsDefinition.internal_init(
+        return AssetsDefinition.dagster_internal_init(
             keys_by_input_name={**{v: k for k, v in input_names_by_key.items()}},
             # keep track of the original mapping
             keys_by_output_name=self.node_keys_by_output_name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -369,11 +369,11 @@ class _Asset:
             auto_materialize_policies_by_key={out_asset_key: self.auto_materialize_policy}
             if self.auto_materialize_policy
             else None,
-            asset_deps=None,
-            selected_asset_keys=None,
+            asset_deps=None,  # no asset deps in single-asset decorator
+            selected_asset_keys=None,  # no subselection in decorator
             can_subset=False,
-            metadata_by_key=None,
-            descriptions_by_key=None,
+            metadata_by_key=None,  # not supported for now
+            descriptions_by_key=None,  # not supported for now
         )
 
 
@@ -583,9 +583,9 @@ def multi_asset(
             group_names_by_key=group_names_by_key,
             freshness_policies_by_key=freshness_policies_by_key,
             auto_materialize_policies_by_key=auto_materialize_policies_by_key,
-            selected_asset_keys=None,
-            descriptions_by_key=None,
-            metadata_by_key=None,
+            selected_asset_keys=None,  # no subselection in decorator
+            descriptions_by_key=None,  # not supported for now
+            metadata_by_key=None,  # not supported for now
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -355,7 +355,7 @@ class _Asset:
             if asset_in.partition_mapping is not None
         }
 
-        return AssetsDefinition.internal_init(
+        return AssetsDefinition.dagster_internal_init(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name={"result": out_asset_key},
             node_def=op,
@@ -571,7 +571,7 @@ def multi_asset(
             if asset_in.partition_mapping is not None
         }
 
-        return AssetsDefinition.internal_init(
+        return AssetsDefinition.dagster_internal_init(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
             node_def=op,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -355,7 +355,7 @@ class _Asset:
             if asset_in.partition_mapping is not None
         }
 
-        return AssetsDefinition(
+        return AssetsDefinition.internal_init(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name={"result": out_asset_key},
             node_def=op,
@@ -369,6 +369,11 @@ class _Asset:
             auto_materialize_policies_by_key={out_asset_key: self.auto_materialize_policy}
             if self.auto_materialize_policy
             else None,
+            asset_deps=None,
+            selected_asset_keys=None,
+            can_subset=False,
+            metadata_by_key=None,
+            descriptions_by_key=None,
         )
 
 
@@ -566,7 +571,7 @@ def multi_asset(
             if asset_in.partition_mapping is not None
         }
 
-        return AssetsDefinition(
+        return AssetsDefinition.internal_init(
             keys_by_input_name=keys_by_input_name,
             keys_by_output_name=keys_by_output_name,
             node_def=op,
@@ -578,6 +583,9 @@ def multi_asset(
             group_names_by_key=group_names_by_key,
             freshness_policies_by_key=freshness_policies_by_key,
             auto_materialize_policies_by_key=auto_materialize_policies_by_key,
+            selected_asset_keys=None,
+            descriptions_by_key=None,
+            metadata_by_key=None,
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -123,7 +123,7 @@ class _Op:
         )
         resolved_resource_keys = decorator_resource_keys.union(arg_resource_keys)
 
-        op_def = OpDefinition(
+        op_def = OpDefinition.internal_init(
             name=self.name,
             ins=self.ins,
             outs=outs,
@@ -134,6 +134,7 @@ class _Op:
             tags=self.tags,
             code_version=self.code_version,
             retry_policy=self.retry_policy,
+            version = None # code_version has replaced version
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -123,7 +123,7 @@ class _Op:
         )
         resolved_resource_keys = decorator_resource_keys.union(arg_resource_keys)
 
-        op_def = OpDefinition.internal_init(
+        op_def = OpDefinition.dagster_internal_init(
             name=self.name,
             ins=self.ins,
             outs=outs,
@@ -134,7 +134,7 @@ class _Op:
             tags=self.tags,
             code_version=self.code_version,
             retry_policy=self.retry_policy,
-            version = None # code_version has replaced version
+            version=None,  # code_version has replaced version
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -182,11 +182,11 @@ def schedule(
             job=job,
             default_status=default_status,
             required_resource_keys=required_resource_keys,
-            run_config=None,
+            run_config=None,  # cannot supply run_config or run_config_fn to decorator
             run_config_fn=None,
-            tags=None,
+            tags=None,  # cannot supply tags or tags_fn to decorator
             tags_fn=None,
-            should_execute=None,
+            should_execute=None,  # already encompassed in evaluation_fn
         )
 
         update_wrapper(schedule_def, wrapped=fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -171,7 +171,7 @@ def schedule(
             has_context_arg=has_context_arg,
         )
 
-        schedule_def = ScheduleDefinition(
+        schedule_def = ScheduleDefinition.internal_init(
             name=schedule_name,
             cron_schedule=cron_schedule,
             job_name=job_name,
@@ -182,6 +182,11 @@ def schedule(
             job=job,
             default_status=default_status,
             required_resource_keys=required_resource_keys,
+            run_config=None,
+            run_config_fn=None,
+            tags=None,
+            tags_fn=None,
+            should_execute=None,
         )
 
         update_wrapper(schedule_def, wrapped=fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -171,7 +171,7 @@ def schedule(
             has_context_arg=has_context_arg,
         )
 
-        schedule_def = ScheduleDefinition.internal_init(
+        schedule_def = ScheduleDefinition.dagster_internal_init(
             name=schedule_name,
             cron_schedule=cron_schedule,
             job_name=job_name,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -70,7 +70,7 @@ def sensor(
     def inner(fn: RawSensorEvaluationFunction) -> SensorDefinition:
         check.callable_param(fn, "fn")
 
-        sensor_def = SensorDefinition.internal_init(
+        sensor_def = SensorDefinition.dagster_internal_init(
             name=name,
             job_name=job_name,
             evaluation_fn=fn,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -70,7 +70,7 @@ def sensor(
     def inner(fn: RawSensorEvaluationFunction) -> SensorDefinition:
         check.callable_param(fn, "fn")
 
-        sensor_def = SensorDefinition(
+        sensor_def = SensorDefinition.internal_init(
             name=name,
             job_name=job_name,
             evaluation_fn=fn,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -628,7 +628,7 @@ class GraphDefinition(NodeDefinition):
 
         wrapped_resource_defs = wrap_resources_for_execution(resource_defs)
 
-        return JobDefinition(
+        return JobDefinition.internal_init(
             name=name,
             description=description or self.description,
             graph_def=self,
@@ -645,6 +645,7 @@ class GraphDefinition(NodeDefinition):
             asset_layer=asset_layer,
             input_values=input_values,
             _subset_selection_data=_asset_selection_data,
+            _was_explicitly_provided_resources=None,
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self) -> "JobDefinition":

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -628,7 +628,7 @@ class GraphDefinition(NodeDefinition):
 
         wrapped_resource_defs = wrap_resources_for_execution(resource_defs)
 
-        return JobDefinition.internal_init(
+        return JobDefinition.dagster_internal_init(
             name=name,
             description=description or self.description,
             graph_def=self,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -645,7 +645,7 @@ class GraphDefinition(NodeDefinition):
             asset_layer=asset_layer,
             input_values=input_values,
             _subset_selection_data=_asset_selection_data,
-            _was_explicitly_provided_resources=None,
+            _was_explicitly_provided_resources=None,  # None means this is determined by whether resource_defs contains any explicitly provided resources
         ).get_job_def_for_subset_selection(op_selection)
 
     def coerce_to_job(self) -> "JobDefinition":

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -653,7 +653,7 @@ class JobDefinition(IHasInternalInit):
             description=self.description,
             partitions_def=self.partitions_def,
             metadata=self.metadata,
-            _subset_selection_data=self._subset_selection_data,
+            _subset_selection_data=None,  # this is added below
             _was_explicitly_provided_resources=True,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -651,10 +651,10 @@ class JobDefinition(IHasInternalInit):
             asset_layer=self.asset_layer,
             input_values=input_values,
             description=self.description,
-            partitions_def=None,
-            metadata=None,
-            _subset_selection_data=None,
-            _was_explicitly_provided_resources=None,
+            partitions_def=self.partitions_def,
+            metadata=self.metadata,
+            _subset_selection_data=self._subset_selection_data,
+            _was_explicitly_provided_resources=True,
         )
 
         ephemeral_job = ephemeral_job.get_job_def_for_subset_selection(
@@ -944,7 +944,7 @@ class JobDefinition(IHasInternalInit):
             _was_explicitly_provided_resources=None,
         )
         resolved_kwargs = {**base_kwargs, **kwargs}  # base kwargs overwritten for conflicts
-        job_def = JobDefinition(**resolved_kwargs)
+        job_def = JobDefinition.dagster_internal_init(**resolved_kwargs)
         update_wrapper(job_def, self, updated=())
         return job_def
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -260,7 +260,7 @@ class JobDefinition(IHasInternalInit):
                     f" key '{input_name}', but job has no top-level input with that name."
                 )
 
-    def internal_init(
+    def dagster_internal_init(
         *,
         graph_def: GraphDefinition,
         resource_defs: Optional[Mapping[str, ResourceDefinition]],
@@ -637,7 +637,7 @@ class JobDefinition(IHasInternalInit):
         input_values = merge_dicts(self.input_values, input_values)
 
         bound_resource_defs = dict(self.resource_defs)
-        ephemeral_job = JobDefinition.internal_init(
+        ephemeral_job = JobDefinition.dagster_internal_init(
             name=self._name,
             graph_def=self._graph_def,
             resource_defs={**_swap_default_io_man(bound_resource_defs, self), **resource_defs},

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -176,7 +176,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             positional_inputs=positional_inputs,
         )
 
-    def internal_init(
+    def dagster_internal_init(
         *,
         compute_fn: Union[Callable[..., Any], "DecoratedOpFunction"],
         name: str,
@@ -344,7 +344,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         config_schema: Optional[IDefinitionConfigSchema] = None,
         description: Optional[str] = None,
     ) -> "OpDefinition":
-        return OpDefinition.internal_init(
+        return OpDefinition.dagster_internal_init(
             name=name,
             ins=ins
             or {input_def.name: In.from_definition(input_def) for input_def in self.input_defs},

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -33,6 +33,7 @@ from dagster._core.definitions.resource_requirement import (
 )
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
+from dagster._utils import IHasInternalInit
 from dagster._utils.backcompat import canonicalize_backcompat_args, deprecation_warning
 
 from .definition_config_schema import (
@@ -53,7 +54,7 @@ if TYPE_CHECKING:
 OpComputeFunction: TypeAlias = Callable[..., Any]
 
 
-class OpDefinition(NodeDefinition):
+class OpDefinition(NodeDefinition, IHasInternalInit):
     """Defines an op, the functional unit of user-defined computation.
 
     For more details on what a op is, refer to the
@@ -173,6 +174,34 @@ class OpDefinition(NodeDefinition):
             description=description,
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
             positional_inputs=positional_inputs,
+        )
+
+    def internal_init(
+        *,
+        compute_fn: Union[Callable[..., Any], "DecoratedOpFunction"],
+        name: str,
+        ins: Optional[Mapping[str, In]],
+        outs: Optional[Mapping[str, Out]],
+        description: Optional[str],
+        config_schema: Optional[Union[UserConfigSchema, IDefinitionConfigSchema]],
+        required_resource_keys: Optional[AbstractSet[str]],
+        tags: Optional[Mapping[str, Any]],
+        version: Optional[str],
+        retry_policy: Optional[RetryPolicy],
+        code_version: Optional[str],
+    ) -> "OpDefinition":
+        return OpDefinition(
+            compute_fn=compute_fn,
+            name=name,
+            ins=ins,
+            outs=outs,
+            description=description,
+            config_schema=config_schema,
+            required_resource_keys=required_resource_keys,
+            tags=tags,
+            version=version,
+            retry_policy=retry_policy,
+            code_version=code_version,
         )
 
     @property
@@ -315,7 +344,7 @@ class OpDefinition(NodeDefinition):
         config_schema: Optional[IDefinitionConfigSchema] = None,
         description: Optional[str] = None,
     ) -> "OpDefinition":
-        return OpDefinition(
+        return OpDefinition.internal_init(
             name=name,
             ins=ins
             or {input_def.name: In.from_definition(input_def) for input_def in self.input_defs},
@@ -330,6 +359,7 @@ class OpDefinition(NodeDefinition):
             required_resource_keys=self.required_resource_keys,
             code_version=self._version,
             retry_policy=self.retry_policy,
+            version=None,  # code_version replaces version
         )
 
     def copy_for_configured(

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -108,7 +108,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
             experimental_arg_warning("version", "ResourceDefinition.__init__")
 
     @staticmethod
-    def internal_init(
+    def dagster_internal_init(
         *,
         resource_fn: ResourceFunction,
         config_schema: CoercableToConfigSchema,
@@ -206,7 +206,7 @@ class ResourceDefinition(AnonymousConfigurableDefinition, RequiresResources, IHa
         description: Optional[str],
         config_schema: CoercableToConfigSchema,
     ) -> "ResourceDefinition":
-        return ResourceDefinition.internal_init(
+        return ResourceDefinition.dagster_internal_init(
             config_schema=config_schema,
             description=description or self.description,
             resource_fn=self.resource_fn,
@@ -304,7 +304,7 @@ class _ResourceDecoratorCallable:
                 f" {', '.join(positional_arg_name_list(required_extras))}"
             )
 
-        resource_def = ResourceDefinition.internal_init(
+        resource_def = ResourceDefinition.dagster_internal_init(
             resource_fn=resource_fn,
             config_schema=self.config_schema,
             description=self.description or format_docstring_for_description(resource_fn),

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -509,13 +509,13 @@ class ScheduleDefinition(IHasInternalInit):
             description=self.description,
             job=new_job,
             default_status=self.default_status,
-            run_config=None,  # run_config encapsulated in the _run_config_fn
-            run_config_fn=self._run_config_fn,
-            tags=self._tags,
-            tags_fn=self._tags_fn,
             environment_vars=self._environment_vars,
             required_resource_keys=self.required_resource_keys,
-            should_execute=self._should_execute,
+            run_config=None,  # run_config, tags, should_execute encapsulated in execution_fn
+            run_config_fn=None,
+            tags=None,
+            tags_fn=None,
+            should_execute=None,
         )
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -509,13 +509,13 @@ class ScheduleDefinition(IHasInternalInit):
             description=self.description,
             job=new_job,
             default_status=self.default_status,
-            run_config=None,
+            run_config=None,  # run_config encapsulated in the _run_config_fn
             run_config_fn=self._run_config_fn,
             tags=self._tags,
             tags_fn=self._tags_fn,
             environment_vars=self._environment_vars,
             required_resource_keys=self.required_resource_keys,
-            should_execute=None,
+            should_execute=self._should_execute,
         )
 
     def __init__(
@@ -622,7 +622,7 @@ class ScheduleDefinition(IHasInternalInit):
             self._tags_fn = tags_fn
             self._tags = tags
 
-            _should_execute: ScheduleShouldExecuteFunction = check.opt_callable_param(
+            self._should_execute: ScheduleShouldExecuteFunction = check.opt_callable_param(
                 should_execute, "should_execute", default=lambda _context: True
             )
 
@@ -633,7 +633,7 @@ class ScheduleDefinition(IHasInternalInit):
                     ScheduleExecutionError,
                     lambda: f"Error occurred during the execution of should_execute for schedule {name}",
                 ):
-                    if not _should_execute(context):
+                    if not self._should_execute(context):
                         yield SkipReason(
                             "should_execute function for {schedule_name} returned false.".format(
                                 schedule_name=name

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -500,7 +500,7 @@ class ScheduleDefinition(IHasInternalInit):
             job (ExecutableDefinition): The job that should execute when this
                 schedule runs.
         """
-        return ScheduleDefinition.internal_init(
+        return ScheduleDefinition.dagster_internal_init(
             name=self.name,
             cron_schedule=self._cron_schedule,
             job_name=self.job_name,
@@ -699,7 +699,7 @@ class ScheduleDefinition(IHasInternalInit):
         )
 
     @staticmethod
-    def internal_init(
+    def dagster_internal_init(
         *,
         name: Optional[str],
         cron_schedule: Optional[Union[str, Sequence[str]]],

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -471,7 +471,7 @@ class SensorDefinition(IHasInternalInit):
             job (ExecutableDefinition): The job that should execute when this
                 schedule runs.
         """
-        return SensorDefinition.internal_init(
+        return SensorDefinition.dagster_internal_init(
             name=self.name,
             evaluation_fn=self._evaluation_fn,
             minimum_interval_seconds=self.minimum_interval_seconds,
@@ -589,7 +589,7 @@ class SensorDefinition(IHasInternalInit):
         )
 
     @staticmethod
-    def internal_init(
+    def dagster_internal_init(
         *,
         name: Optional[str],
         evaluation_fn: Optional[RawSensorEvaluationFunction],

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -47,7 +47,7 @@ from dagster._core.errors import (
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._serdes import whitelist_for_serdes
-from dagster._utils import normalize_to_repository
+from dagster._utils import IHasInternalInit, normalize_to_repository
 
 from ..decorator_utils import (
     get_function_params,
@@ -442,7 +442,7 @@ def _check_dynamic_partitions_requests(
             check.failed(f"Unexpected dynamic partition request type: {req}")
 
 
-class SensorDefinition:
+class SensorDefinition(IHasInternalInit):
     """Define a sensor that initiates a set of runs based on some external state.
 
     Args:
@@ -471,11 +471,12 @@ class SensorDefinition:
             job (ExecutableDefinition): The job that should execute when this
                 schedule runs.
         """
-        return SensorDefinition(
+        return SensorDefinition.internal_init(
             name=self.name,
             evaluation_fn=self._evaluation_fn,
             minimum_interval_seconds=self.minimum_interval_seconds,
             description=self.description,
+            job_name=None,  # if original init was passed job name, was resolved to a job
             jobs=new_jobs if len(new_jobs) > 1 else None,
             job=new_jobs[0] if len(new_jobs) == 1 else None,
             default_status=self.default_status,
@@ -585,6 +586,33 @@ class SensorDefinition:
         self._required_resource_keys = (
             check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
             or resource_arg_names
+        )
+
+    @staticmethod
+    def internal_init(
+        *,
+        name: Optional[str],
+        evaluation_fn: Optional[RawSensorEvaluationFunction],
+        job_name: Optional[str],
+        minimum_interval_seconds: Optional[int],
+        description: Optional[str],
+        job: Optional[ExecutableDefinition],
+        jobs: Optional[Sequence[ExecutableDefinition]],
+        default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
+        asset_selection: Optional[AssetSelection],
+        required_resource_keys: Optional[Set[str]],
+    ) -> "SensorDefinition":
+        return SensorDefinition(
+            name=name,
+            evaluation_fn=evaluation_fn,
+            job_name=job_name,
+            minimum_interval_seconds=minimum_interval_seconds,
+            description=description,
+            job=job,
+            jobs=jobs,
+            default_status=default_status,
+            asset_selection=asset_selection,
+            required_resource_keys=required_resource_keys,
         )
 
     def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -49,6 +49,8 @@ from typing_extensions import Literal, TypeAlias, TypeGuard
 import dagster._check as check
 import dagster._seven as seven
 
+from .internal_init import IHasInternalInit as IHasInternalInit
+
 if sys.version_info > (3,):
     from pathlib import Path
 else:

--- a/python_modules/dagster/dagster/_utils/internal_init.py
+++ b/python_modules/dagster/dagster/_utils/internal_init.py
@@ -1,0 +1,5 @@
+class IHasInternalInit:
+    """Marker interface which indicates that this class has an internal_init method. All classes with this interface
+    are unit tested to ensure that the signature of their internal_init method matches the signature of their
+    __init__ method, and that internal_init has no defaults.
+    """

--- a/python_modules/dagster/dagster/_utils/internal_init.py
+++ b/python_modules/dagster/dagster/_utils/internal_init.py
@@ -1,5 +1,5 @@
 class IHasInternalInit:
-    """Marker interface which indicates that this class has an internal_init method. All classes with this interface
-    are unit tested to ensure that the signature of their internal_init method matches the signature of their
-    __init__ method, and that internal_init has no defaults.
+    """Marker interface which indicates that this class has an dagster_internal_init method. All classes with this interface
+    are unit tested to ensure that the signature of their dagster_internal_init method matches the signature of their
+    __init__ method, and that dagster_internal_init has no defaults.
     """

--- a/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
@@ -5,8 +5,17 @@ import dagster as dagster
 import pytest
 from dagster._utils import IHasInternalInit
 
+INTERNAL_INIT_SUBCLASSES = [
+    symbol
+    for symbol in dagster.__dict__.values()
+    if isinstance(symbol, type)
+    and issubclass(symbol, IHasInternalInit)
+    and IHasInternalInit
+    in symbol.__bases__  # ensure that the class is a direct subclass of IHasInternalInit (not a subclass of a subclass)
+]
 
-@pytest.mark.parametrize("cls", IHasInternalInit.__subclasses__())
+
+@pytest.mark.parametrize("cls", INTERNAL_INIT_SUBCLASSES)
 def test_dagster_internal_init_class_follow_rules(cls: Type):
     assert hasattr(
         cls, "dagster_internal_init"

--- a/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
@@ -1,33 +1,36 @@
 import inspect
 from typing import Type
 
+import dagster as dagster
 import pytest
 from dagster._utils import IHasInternalInit
 
 
 @pytest.mark.parametrize("cls", IHasInternalInit.__subclasses__())
-def test_internal_init_class_follow_rules(cls: Type):
-    assert hasattr(cls, "internal_init"), f"{cls.__name__} does not have internal_init method"
+def test_dagster_internal_init_class_follow_rules(cls: Type):
+    assert hasattr(
+        cls, "dagster_internal_init"
+    ), f"{cls.__name__} does not have dagster_internal_init method"
 
-    internal_init_argspec = inspect.getfullargspec(cls.internal_init)
+    dagster_internal_init_argspec = inspect.getfullargspec(cls.dagster_internal_init)
     init_args_spec = inspect.getfullargspec(cls.__init__)
 
-    internal_init_return = inspect.signature(cls.internal_init).return_annotation
+    dagster_internal_init_return = inspect.signature(cls.dagster_internal_init).return_annotation
 
     assert (
-        internal_init_return == cls or internal_init_return == cls.__name__
-    ), f"{cls.__name__}.internal_init has a different return type than the class itself"
+        dagster_internal_init_return == cls or dagster_internal_init_return == cls.__name__
+    ), f"{cls.__name__}.dagster_internal_init has a different return type than the class itself"
 
-    assert internal_init_argspec.defaults is None, (
-        f"{cls.__name__}.internal_init has one or more default values, internal_init methods cannot"
-        " have default values"
+    assert dagster_internal_init_argspec.defaults is None, (
+        f"{cls.__name__}.dagster_internal_init has one or more default values,"
+        " dagster_internal_init methods cannot have default values"
     )
 
-    assert internal_init_argspec.args == [], (
-        f"{cls.__name__}.internal_init has one or more positional arguments, internal_init methods"
-        " can only have keyword-only arguments"
+    assert dagster_internal_init_argspec.args == [], (
+        f"{cls.__name__}.dagster_internal_init has one or more positional arguments,"
+        " dagster_internal_init methods can only have keyword-only arguments"
     )
 
-    assert internal_init_argspec.kwonlyargs == (
+    assert dagster_internal_init_argspec.kwonlyargs == (
         init_args_spec.args[1:] + init_args_spec.kwonlyargs  # exclude self
-    ), f"{cls.__name__}.internal_init has different arguments than __init__"
+    ), f"{cls.__name__}.dagster_internal_init has different arguments than __init__"

--- a/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
@@ -1,0 +1,33 @@
+import inspect
+from typing import Type
+
+import pytest
+from dagster._utils import IHasInternalInit
+
+
+@pytest.mark.parametrize("cls", IHasInternalInit.__subclasses__())
+def test_internal_init_class_follow_rules(cls: Type):
+    assert hasattr(cls, "internal_init"), f"{cls.__name__} does not have internal_init method"
+
+    internal_init_argspec = inspect.getfullargspec(cls.internal_init)
+    init_args_spec = inspect.getfullargspec(cls.__init__)
+
+    internal_init_return = inspect.signature(cls.internal_init).return_annotation
+
+    assert (
+        internal_init_return == cls or internal_init_return == cls.__name__
+    ), f"{cls.__name__}.internal_init has a different return type than the class itself"
+
+    assert internal_init_argspec.defaults is None, (
+        f"{cls.__name__}.internal_init has one or more default values, internal_init methods cannot"
+        " have default values"
+    )
+
+    assert internal_init_argspec.args == [], (
+        f"{cls.__name__}.internal_init has one or more positional arguments, internal_init methods"
+        " can only have keyword-only arguments"
+    )
+
+    assert internal_init_argspec.kwonlyargs == (
+        init_args_spec.args[1:] + init_args_spec.kwonlyargs  # exclude self
+    ), f"{cls.__name__}.internal_init has different arguments than __init__"


### PR DESCRIPTION
## Summary

Implements a pattern of a separate, internal-facing `dagster_internal_init` method for public classes. This acts as a variant of `__init__` but which which requires all inputs (e.g. no defaults). The goal of this change is to prevent bugs like #13956 which are introduced by new, optional inputs being added to the constructor. Patterned after #13960.

This change requires us to explicitly specify all inputs/defaults in internal construction cases, while still allowing users to use the more flexible constructor w/ defaults.


## Test Plan

Added a unit test which finds all subclasses of the marker interface `IHasInternalInit` and validates that the `dagster_internal_init` method has the right properties (correct return value, all arguments same as constructor, no defaults etc)
