### PR TITLE
OpExecutionContext.asset_partitions_time_window_for_input

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -443,6 +443,17 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         )
 
     @public
+    def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
+        """The time window for the partitions of the input asset.
+
+        Raises an error if either of the following are true:
+        - The input asset has no partitioning.
+        - The input asset is not partitioned with a TimeWindowPartitionsDefinition or a
+        MultiPartitionsDefinition with one time-partitioned dimension.
+        """
+        return self._step_execution_context.asset_partitions_time_window_for_input(input_name)
+
+    @public
     def has_tag(self, key: str) -> bool:
         """Check if a logging tag is set.
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -329,7 +329,10 @@ def test_input_context_asset_partitions_time_window():
         pass
 
     @asset(partitions_def=partitions_def)
-    def downstream_asset(upstream_asset):
+    def downstream_asset(context, upstream_asset):
+        assert context.asset_partitions_time_window_for_input("upstream_asset") == TimeWindow(
+            pendulum.parse("2021-06-06"), pendulum.parse("2021-06-07")
+        )
         assert upstream_asset is None
 
     assert materialize(


### PR DESCRIPTION
## Summary & Motivation

`OpExecutionContext` has `asset_partitions_time_window_for_output` and `asset_partition_key_range_for_input`, but did not have `asset_partitions_time_window_for_input`.

## How I Tested These Changes

Modified an existing unit test to exercise this.