### PR TITLE
rename test_*pipeline/solid* -> test_*job/op*

### DIFF
--- a/integration_tests/test_suites/celery-k8s-test-suite/tests/test_integration.py
+++ b/integration_tests/test_suites/celery-k8s-test-suite/tests/test_integration.py
@@ -199,7 +199,7 @@ def test_execute_subset_on_celery_k8s(dagster_docker_image, helm_namespace, dagi
     assert "PIPELINE_SUCCESS" in result, f"no match, result: {result}"
 
 
-def test_execute_on_celery_k8s_retry_pipeline(
+def test_execute_on_celery_k8s_retry_job(
     dagster_docker_image, dagster_instance, helm_namespace, dagit_url
 ):
     run_config = merge_dicts(

--- a/python_modules/dagster-test/dagster_test_tests/test_test_project.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_test_project.py
@@ -5,7 +5,7 @@ from dagster_test.test_project import (
 )
 
 
-def test_reoriginated_external_pipeline():
+def test_reoriginated_external_job():
     with instance_for_test() as instance:
         with get_test_project_workspace_and_external_job(instance, "demo_job_celery_k8s") as (
             _workspace,

--- a/python_modules/dagster-test/dagster_test_tests/test_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_toys.py
@@ -115,7 +115,7 @@ def test_branch_job_failed(executor_def):
         )
 
 
-def test_spew_pipeline(executor_def):
+def test_spew_job(executor_def):
     assert log_spew.to_job(executor_def=executor_def).execute_in_process().success
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -24,7 +24,7 @@ def _check_event_log_contains(event_log, expected_type_and_message):
         )
 
 
-def test_launch_run_with_unloadable_pipeline_grpc():
+def test_launch_run_with_unloadable_job_grpc():
     with instance_for_test() as instance:
         with get_bar_repo_code_location(instance) as code_location:
             job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -18,7 +18,7 @@ def _test_job_subset_grpc(job_handle, api_client, solid_selection=None):
     )
 
 
-def test_pipeline_snapshot_api_grpc(instance):
+def test_job_snapshot_api_grpc(instance):
     with get_bar_repo_code_location(instance) as code_location:
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
@@ -29,7 +29,7 @@ def test_pipeline_snapshot_api_grpc(instance):
         assert external_job_subset_result.external_job_data.name == "foo"
 
 
-def test_pipeline_snapshot_deserialize_error(instance):
+def test_job_snapshot_deserialize_error(instance):
     with get_bar_repo_code_location(instance) as code_location:
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
@@ -48,7 +48,7 @@ def test_pipeline_snapshot_deserialize_error(instance):
         assert external_pipeline_subset_result.error
 
 
-def test_pipeline_with_valid_subset_snapshot_api_grpc(instance):
+def test_job_with_valid_subset_snapshot_api_grpc(instance):
     with get_bar_repo_code_location(instance) as code_location:
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
@@ -59,7 +59,7 @@ def test_pipeline_with_valid_subset_snapshot_api_grpc(instance):
         assert external_job_subset_result.external_job_data.name == "foo"
 
 
-def test_pipeline_with_invalid_subset_snapshot_api_grpc(instance):
+def test_job_with_invalid_subset_snapshot_api_grpc(instance):
     with get_bar_repo_code_location(instance) as code_location:
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
@@ -71,7 +71,7 @@ def test_pipeline_with_invalid_subset_snapshot_api_grpc(instance):
             _test_job_subset_grpc(job_handle, api_client, ["invalid_op"])
 
 
-def test_pipeline_with_invalid_definition_snapshot_api_grpc(instance):
+def test_job_with_invalid_definition_snapshot_api_grpc(instance):
     with get_bar_repo_code_location(instance) as code_location:
         job_handle = JobHandle("bar", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -79,7 +79,7 @@ def _asset_keys_for_node(result, node_name):
     return ret
 
 
-def test_single_asset_pipeline():
+def test_single_asset_job():
     @asset
     def asset1(context):
         assert context.asset_key_for_output() == AssetKey(["asset1"])
@@ -90,7 +90,7 @@ def test_single_asset_pipeline():
     assert job.execute_in_process().success
 
 
-def test_two_asset_pipeline():
+def test_two_asset_job():
     @asset
     def asset1():
         return 1
@@ -108,7 +108,7 @@ def test_two_asset_pipeline():
     assert job.execute_in_process().success
 
 
-def test_single_asset_pipeline_with_config():
+def test_single_asset_job_with_config():
     @asset(config_schema={"foo": Field(StringSource)})
     def asset1(context):
         return context.op_config["foo"]

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_backfill_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_backfill_command.py
@@ -109,7 +109,7 @@ def test_backfill_partition_enum(backfill_args_context: BackfillCommandTestConte
 
 
 @pytest.mark.parametrize("backfill_args_context", backfill_command_contexts())
-def test_backfill_tags_pipeline(backfill_args_context: BackfillCommandTestContext):
+def test_backfill_tags_job(backfill_args_context: BackfillCommandTestContext):
     with backfill_args_context as (cli_args, instance):
         args = merge_dicts(
             cli_args,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_launch_command.py
@@ -42,7 +42,7 @@ def run_job_launch_cli(execution_args, instance, expected_count=None):
 
 
 @pytest.mark.parametrize("gen_job_args", launch_command_contexts())
-def test_launch_pipeline(gen_job_args):
+def test_launch_job(gen_job_args):
     with gen_job_args as (cli_args, instance):
         run_launch(cli_args, instance, expected_count=1)
 

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -163,7 +163,7 @@ def test_execute_run_with_secrets_loader():
         ), f"no match, result: {result.stdout}"
 
 
-def test_execute_run_fail_pipeline():
+def test_execute_run_fail_job():
     with instance_for_test(
         overrides={
             "compute_logs": {

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_job_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_job_load.py
@@ -55,7 +55,7 @@ def get_all_loading_combos():
 
 
 @pytest.mark.parametrize("cli_args", get_all_loading_combos())
-def test_valid_loading_combos_single_pipeline_code_location(cli_args):
+def test_valid_loading_combos_single_job_code_location(cli_args):
     external_job = successfully_load_pipeline_via_cli(cli_args)
     assert isinstance(external_job, ExternalJob)
     assert external_job.name == "hello_world_job"
@@ -76,7 +76,7 @@ def test_repository_target_argument_one_repo_and_specified_wrong():
 MULTI_JOB_WORKSPACE = file_relative_path(__file__, "multi_job/multi_job.yaml")
 
 
-def test_successfully_find_pipeline():
+def test_successfully_find_job():
     assert (
         successfully_load_pipeline_via_cli(["-w", MULTI_JOB_WORKSPACE, "-j", "job_one"]).name
         == "job_one"
@@ -88,7 +88,7 @@ def test_successfully_find_pipeline():
     )
 
 
-def test_must_provide_name_to_multi_pipeline():
+def test_must_provide_name_to_multi_job():
     result, _ = load_pipeline_via_cli_runner(["-w", MULTI_JOB_WORKSPACE])
 
     assert result.exit_code == 2

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_default_required.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_default_required.py
@@ -34,7 +34,7 @@ def test_noneable_shaped_field_defaults():
     assert Field(Noneable(schema)).default_value is None
 
 
-def test_noneable_string_in_solid():
+def test_noneable_string_in_op():
     executed = {}
 
     @op(config_schema=Noneable(int))

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_schema.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_schema.py
@@ -4,7 +4,7 @@ from dagster._check import CheckError
 from dagster._config import ConfigAnyInstance
 
 
-def test_solid_field_backcompat():
+def test_op_field_backcompat():
     @op
     def op_without_schema(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_spec.py
@@ -89,7 +89,7 @@ def test_builtin_dict():
     assert executed["yup"]
 
 
-def test_bad_solid_config_argument():
+def test_bad_op_config_argument():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema="dkjfkd")
@@ -101,7 +101,7 @@ def test_bad_solid_config_argument():
     )
 
 
-def test_bad_solid_config_argument_nested():
+def test_bad_op_config_argument_nested():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema={"field": "kdjkfjd"})
@@ -114,7 +114,7 @@ def test_bad_solid_config_argument_nested():
     )
 
 
-def test_bad_solid_config_argument_list_wrong_length():
+def test_bad_op_config_argument_list_wrong_length():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema={"bad_list": []})
@@ -128,7 +128,7 @@ def test_bad_solid_config_argument_list_wrong_length():
     )
 
 
-def test_bad_solid_config_argument_map_bad_value():
+def test_bad_op_config_argument_map_bad_value():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema={"bad_map": {str: "asdf"}})
@@ -138,7 +138,7 @@ def test_bad_solid_config_argument_map_bad_value():
     assert "Map must have a single value and contain a valid type" in str(exc_info.value)
 
 
-def test_bad_solid_config_argument_list_bad_item():
+def test_bad_op_config_argument_list_bad_item():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema={"bad_list": ["kdjfkd"]})
@@ -153,7 +153,7 @@ def test_bad_solid_config_argument_list_bad_item():
     )
 
 
-def test_bad_solid_config_argument_list_bad_nested_item():
+def test_bad_op_config_argument_list_bad_nested_item():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema={"bad_nested_list": [{"bad_field": "kjdkfd"}]})

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_type_system.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_type_system.py
@@ -674,7 +674,7 @@ def test_build_optionality():
     assert optional_test_type.fields["optional"].is_required is False
 
 
-def test_wrong_solid_name():
+def test_wrong_op_name():
     @op(name="some_op", ins={}, out={}, config_schema=Int)
     def some_op(_):
         return None
@@ -719,7 +719,7 @@ def test_wrong_resources():
         job_def.execute_in_process({"resources": {"nope": {}}})
 
 
-def test_solid_list_config():
+def test_op_list_config():
     value = [1, 2]
     called = {}
 
@@ -1038,7 +1038,7 @@ def test_multilevel_good_error_handling_ops():
     assert str(expected_suggested_config) in missing_field_pe_info.value.errors[0].message
 
 
-def test_multilevel_good_error_handling_solid_name_ops():
+def test_multilevel_good_error_handling_op_name_ops():
     @op(config_schema=Int)
     def good_error_handling(_context):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_type_printer.py
@@ -232,7 +232,7 @@ def test_scalar_union():
     assert_inner_types(scalar_union_type, String, Int, non_scalar_type)
 
 
-def test_test_type_pipeline_construction():
+def test_test_type_job_construction():
     assert define_test_type_pipeline()
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -20,26 +20,3 @@ def test_op_execution_context():
         ctx_op()
 
     assert foo.execute_in_process().success
-
-
-def test_solid_execution_context():
-    @op
-    def ctx_op(context: OpExecutionContext):
-        check.inst(context.run, DagsterRun)
-        assert context.job_name == "foo"
-
-        check.inst(context.job_def, JobDefinition)
-
-        assert context.op_config is None
-
-        check.inst(context.op_def, OpDefinition)
-
-        check.inst(context.run, DagsterRun)
-        assert context.job_name == "foo"
-        assert context.op_config is None
-
-    @job
-    def foo():
-        ctx_op()
-
-    assert foo.execute_in_process().success

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
@@ -215,7 +215,7 @@ def test_success_hook_cm_resource(hook_decorator, is_event_list_hook):
             hook(build_hook_context(resources={"cm": cm_resource}))
 
 
-def test_hook_invocation_with_solid():
+def test_hook_invocation_with_op():
     @success_hook
     def basic_hook(context):
         assert context.op.name == "foo"

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -340,7 +340,7 @@ def test_cross_job_asset_dependency():
     ]
 
 
-def test_same_asset_in_multiple_pipelines():
+def test_same_asset_in_multiple_jobs():
     @asset
     def asset1():
         return 1

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -729,7 +729,7 @@ def test_resource_init_failure_with_teardown():
     assert cleaned == ["B", "A"]
 
 
-def test_solid_failure_resource_teardown():
+def test_op_failure_resource_teardown():
     called = []
     cleaned = []
 
@@ -774,7 +774,7 @@ def test_solid_failure_resource_teardown():
     assert cleaned == ["B", "A"]
 
 
-def test_solid_failure_resource_teardown_raise():
+def test_op_failure_resource_teardown_raise():
     """Test that teardown is invoked in resources for tests that raise_on_error."""
     called = []
     cleaned = []

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_python_dict.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_typed_python_dict.py
@@ -16,7 +16,7 @@ def test_typed_python_dict_failure():
     assert not res.success
 
 
-def test_basic_solid_dict_int_int_output():
+def test_basic_op_dict_int_int_output():
     @op(out=Out(Dict[int, int]))
     def emit_dict_int_int():
         return {1: 1}
@@ -24,7 +24,7 @@ def test_basic_solid_dict_int_int_output():
     assert wrap_op_in_graph_and_execute(emit_dict_int_int).output_value() == {1: 1}
 
 
-def test_basic_solid_dict_int_int_output_faile():
+def test_basic_op_dict_int_int_output_faile():
     @op(out=Out(Dict[int, int]))
     def emit_dict_int_int():
         return {1: "1"}
@@ -33,7 +33,7 @@ def test_basic_solid_dict_int_int_output_faile():
         wrap_op_in_graph_and_execute(emit_dict_int_int)
 
 
-def test_basic_solid_dict_int_int_input_pass():
+def test_basic_op_dict_int_int_input_pass():
     @op(ins={"ddict": In(Dict[int, int])})
     def emit_dict_int_int(ddict):
         return ddict
@@ -43,7 +43,7 @@ def test_basic_solid_dict_int_int_input_pass():
     ).output_value() == {1: 2}
 
 
-def test_basic_solid_dict_int_int_input_fails():
+def test_basic_op_dict_int_int_input_fails():
     @op(ins={"ddict": In(Dict[int, int])})
     def emit_dict_int_int(ddict):
         return ddict

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -99,7 +99,7 @@ def test_parse_clause_invalid():
     assert parse_clause("1+some_solid") is None
 
 
-def test_parse_solid_selection_single():
+def test_parse_op_selection_single():
     solid_selection_single = parse_solid_selection(foo_job, ["add_nums"])
     assert len(solid_selection_single) == 1
     assert solid_selection_single == {"add_nums"}
@@ -118,7 +118,7 @@ def test_parse_solid_selection_single():
     }
 
 
-def test_parse_solid_selection_multi():
+def test_parse_op_selection_multi():
     solid_selection_multi_disjoint = parse_solid_selection(foo_job, ["return_one", "add_nums+"])
     assert len(solid_selection_multi_disjoint) == 3
     assert set(solid_selection_multi_disjoint) == {
@@ -142,7 +142,7 @@ def test_parse_solid_selection_multi():
         parse_solid_selection(foo_job, ["*add_nums", "a"])
 
 
-def test_parse_solid_selection_invalid():
+def test_parse_op_selection_invalid():
     with pytest.raises(
         DagsterInvalidSubsetError,
         match="No qualified ops to execute found for op_selection",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -75,7 +75,7 @@ def test_external_repository_data(snapshot):
     snapshot.assert_match(serialize_pp(external_repo_data))
 
 
-def test_external_pipeline_data(snapshot):
+def test_external_job_data(snapshot):
     snapshot.assert_match(serialize_pp(external_job_data_from_def(foo_job)))
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -222,7 +222,7 @@ def test_kitchen_sink():
     assert kitchen_sink_snap == rehydrated_snap
 
 
-def test_simple_pipeline_smoke_test():
+def test_simple_job_smoke_test():
     @op
     def op_without_config(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -39,11 +39,11 @@ def get_noop_pipeline():
     return noop_job
 
 
-def test_empty_pipeline_snap_snapshot(snapshot):
+def test_empty_job_snap_snapshot(snapshot):
     snapshot.assert_match(serialize_pp(JobSnapshot.from_job_def(get_noop_pipeline())))
 
 
-def test_empty_pipeline_snap_props(snapshot):
+def test_empty_job_snap_props(snapshot):
     job_snapshot = JobSnapshot.from_job_def(get_noop_pipeline())
 
     assert job_snapshot.name == "noop_job"
@@ -56,7 +56,7 @@ def test_empty_pipeline_snap_props(snapshot):
     snapshot.assert_match(create_job_snapshot_id(job_snapshot))
 
 
-def test_pipeline_snap_all_props(snapshot):
+def test_job_snap_all_props(snapshot):
     @op
     def noop_op(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -338,7 +338,7 @@ def test_deserialize_node_def_snaps_selector():
     )
 
 
-def test_deserialize_solid_def_snaps_permissive():
+def test_deserialize_op_def_snaps_permissive():
     @op(config_schema=Field(Permissive({"foo": Field(str)})))
     def noop_op(_):
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_node_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_node_def_snap.py
@@ -82,7 +82,7 @@ def test_op_definition_kitchen_sink():
     )
 
 
-def test_noop_comp_solid_definition():
+def test_noop_graph_definition():
     @op
     def noop_op(_):
         pass
@@ -97,7 +97,7 @@ def test_noop_comp_solid_definition():
     assert deserialize_value(serialize_value(comp_solid_meta), GraphDefSnap) == comp_solid_meta
 
 
-def test_basic_comp_solid_definition():
+def test_basic_graph_definition():
     @op
     def return_one(_):
         return 1
@@ -122,7 +122,7 @@ def test_basic_comp_solid_definition():
     assert index.get_upstream_output("take_one", "one").output_name == "result"
 
 
-def test_complex_comp_solid_definition():
+def test_complex_graph_definition():
     @op
     def return_one(_):
         return 1

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -127,13 +127,13 @@ def test_default_environment():
     assert ResolvedRunConfig.build(job_def, {})
 
 
-def test_solid_config():
+def test_op_config():
     solid_config_type = Shape({"config": Field(Int)})
     solid_inst = process_config(solid_config_type, {"config": 1})
     assert solid_inst.value["config"] == 1
 
 
-def test_solid_dictionary_type():
+def test_op_dictionary_type():
     job_def = define_test_solids_config_pipeline()
 
     env_obj = ResolvedRunConfig.build(
@@ -186,7 +186,7 @@ def assert_has_fields(dtype, *fields):
     return set(dtype.fields.keys()) == set(fields)
 
 
-def test_solid_configs_defaults():
+def test_op_configs_defaults():
     env_type = create_run_config_schema_type(define_test_solids_config_pipeline())
 
     solids_field = env_type.fields["ops"]
@@ -208,7 +208,7 @@ def test_solid_configs_defaults():
     assert not int_solid_config_field.default_provided
 
 
-def test_solid_dictionary_some_no_config():
+def test_op_dictionary_some_no_config():
     @op(name="int_config_op", config_schema=Int, ins={}, out={})
     def int_config_op(_):
         return None
@@ -275,7 +275,7 @@ def test_whole_environment():
     }
 
 
-def test_solid_config_error():
+def test_op_config_error():
     job_def = define_test_solids_config_pipeline()
     solid_dict_type = define_node_shape(
         nodes=job_def.nodes,
@@ -297,7 +297,7 @@ def test_solid_config_error():
     assert not res.success
 
 
-def test_optional_solid_with_no_config():
+def test_optional_op_with_no_config():
     def _assert_config_none(context, value):
         assert context.op_config is value
 
@@ -323,7 +323,7 @@ def test_optional_solid_with_no_config():
     assert job_def.execute_in_process({"ops": {"int_config_op": {"config": 234}}}).success
 
 
-def test_optional_solid_with_optional_scalar_config():
+def test_optional_op_with_optional_scalar_config():
     def _assert_config_none(context, value):
         assert context.op_config is value
 
@@ -353,7 +353,7 @@ def test_optional_solid_with_optional_scalar_config():
     assert env_obj.ops["int_config_op"].config is None
 
 
-def test_optional_solid_with_required_scalar_config():
+def test_optional_op_with_required_scalar_config():
     def _assert_config_none(context, value):
         assert context.op_config is value
 
@@ -389,7 +389,7 @@ def test_optional_solid_with_required_scalar_config():
     job_def.execute_in_process({"ops": {"int_config_op": {"config": 234}}})
 
 
-def test_required_solid_with_required_subfield():
+def test_required_op_with_required_subfield():
     job_def = GraphDefinition(
         name="some_pipeline",
         node_defs=[
@@ -429,7 +429,7 @@ def test_required_solid_with_required_subfield():
     assert not res.success
 
 
-def test_optional_solid_with_optional_subfield():
+def test_optional_op_with_optional_subfield():
     job_def = GraphDefinition(
         name="some_pipeline",
         node_defs=[

--- a/python_modules/dagster/dagster_tests/core_tests/test_configured.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_configured.py
@@ -1,7 +1,7 @@
 from dagster import job, op, resource
 
 
-def test_configured_solids_and_resources():
+def test_configured_ops_and_resources():
     # idiomatic usage
     @op(config_schema={"greeting": str}, required_resource_keys={"animal", "plant"})
     def emit_greet_creature(context):

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -1,7 +1,7 @@
 from dagster import GraphDefinition, NodeInvocation, op
 
 
-def test_solid_instance_tags():
+def test_op_instance_tags():
     called = {}
 
     @op(tags={"foo": "bar", "baz": "quux"})

--- a/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_naming_collisions.py
@@ -25,7 +25,7 @@ def define_pass_value_op(name, description=None):
     return pass_value_op
 
 
-def test_execute_solid_with_input_same_name():
+def test_execute_op_with_input_same_name():
     @op
     def a_thing(_, a_thing):
         return a_thing + a_thing
@@ -42,7 +42,7 @@ def test_execute_solid_with_input_same_name():
     assert result.output_for_node("a_thing") == "foofoo"
 
 
-def test_execute_two_solids_with_same_input_name():
+def test_execute_two_ops_with_same_input_name():
     @op
     def op_one(_, a_thing):
         return a_thing + a_thing
@@ -70,7 +70,7 @@ def test_execute_two_solids_with_same_input_name():
     assert result.output_for_node("op_two") == "barbar"
 
 
-def test_execute_dep_solid_different_input_name():
+def test_execute_dep_op_different_input_name():
     pass_to_first = define_pass_value_op("pass_to_first")
 
     @op

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_arguments.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_arguments.py
@@ -4,7 +4,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
-def test_solid_input_arguments():
+def test_op_input_arguments():
     # Solid with no parameters
     @op
     def _no_param():

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -802,7 +802,7 @@ def test_graph_invocation_out_of_composition():
         the_graph()
 
 
-def test_pipeline_invocation():
+def test_job_invocation():
     @job
     def basic_job():
         pass

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_with_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_with_config.py
@@ -12,7 +12,7 @@ from dagster import (
 )
 
 
-def test_basic_solid_with_config():
+def test_basic_op_with_config():
     did_get = {}
 
     @op(
@@ -59,7 +59,7 @@ def test_config_arg_mismatch():
         )
 
 
-def test_solid_not_found():
+def test_op_not_found():
     @op(name="find_me_op", ins={}, out={})
     def find_me_op(_):
         raise Exception("should not reach")

--- a/python_modules/dagster/dagster_tests/core_tests/test_user_code_boundary.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_user_code_boundary.py
@@ -14,7 +14,7 @@ class UserError(Exception):
         super(UserError, self).__init__("The user has errored")
 
 
-def test_user_error_boundary_solid_compute():
+def test_user_error_boundary_op_compute():
     @op
     def throws_user_error(_):
         raise UserError()

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -16,7 +16,6 @@ from dagster import (
     ExpectationResult,
     In,
     Nothing,
-    OpDefinition,
     Out,
     Output,
     build_op_context,
@@ -44,7 +43,7 @@ def execute_in_graph(an_op, raise_on_error=True, run_config=None):
     return result
 
 
-def test_no_parens_solid():
+def test_no_parens_op():
     called = {}
 
     @op
@@ -56,7 +55,7 @@ def test_no_parens_solid():
     assert called["yup"]
 
 
-def test_empty_solid():
+def test_empty_op():
     called = {}
 
     @op()
@@ -68,7 +67,7 @@ def test_empty_solid():
     assert called["yup"]
 
 
-def test_solid():
+def test_op():
     @op(out=Out())
     def hello_world(_context):
         return {"foo": "bar"}
@@ -79,7 +78,7 @@ def test_solid():
     assert result.output_for_node("hello_world")["foo"] == "bar"
 
 
-def test_solid_one_output():
+def test_op_one_output():
     @op
     def hello_world():
         return {"foo": "bar"}
@@ -90,7 +89,7 @@ def test_solid_one_output():
     assert result.output_for_node("hello_world")["foo"] == "bar"
 
 
-def test_solid_yield():
+def test_op_yield():
     @op(out=Out())
     def hello_world(_context):
         yield Output(value={"foo": "bar"})
@@ -101,7 +100,7 @@ def test_solid_yield():
     assert result.output_for_node("hello_world")["foo"] == "bar"
 
 
-def test_solid_result_return():
+def test_op_result_return():
     @op(out=Out())
     def hello_world(_context):
         return Output(value={"foo": "bar"})
@@ -112,7 +111,7 @@ def test_solid_result_return():
     assert result.output_for_node("hello_world")["foo"] == "bar"
 
 
-def test_solid_with_explicit_empty_outputs():
+def test_op_with_explicit_empty_outputs():
     @op(out={})
     def hello_world(_context):
         return "foo"
@@ -121,7 +120,7 @@ def test_solid_with_explicit_empty_outputs():
         execute_in_graph(hello_world)
 
 
-def test_solid_with_implicit_single_output():
+def test_op_with_implicit_single_output():
     @op()
     def hello_world(_context):
         return "foo"
@@ -132,7 +131,7 @@ def test_solid_with_implicit_single_output():
     assert result.output_for_node("hello_world") == "foo"
 
 
-def test_solid_return_list_instead_of_multiple_results():
+def test_op_return_list_instead_of_multiple_results():
     @op(out={"foo": Out(), "bar": Out()})
     def hello_world(_context):
         return ["foo", "bar"]
@@ -144,7 +143,7 @@ def test_solid_return_list_instead_of_multiple_results():
         execute_in_graph(hello_world)
 
 
-def test_solid_with_name():
+def test_op_with_name():
     @op(name="foobar", out=Out())
     def hello_world(_context):
         return {"foo": "bar"}
@@ -155,7 +154,7 @@ def test_solid_with_name():
     assert result.output_for_node("foobar")["foo"] == "bar"
 
 
-def test_solid_with_input():
+def test_op_with_input():
     @op(ins={"foo_to_foo": In()})
     def hello_world(foo_to_foo):
         return foo_to_foo
@@ -174,7 +173,7 @@ def test_solid_with_input():
     assert result.output_for_node("hello_world") == {"foo": "bar"}
 
 
-def test_solid_definition_errors():
+def test_op_definition_errors():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=re.escape("positional vararg parameter '*args'"),
@@ -257,19 +256,19 @@ def test_any_config_field():
     assert called["yup"]
 
 
-def test_solid_required_resources_no_arg():
+def test_op_required_resources_no_arg():
     @op(required_resource_keys={"foo"})
     def _noop():
         return
 
 
-def test_solid_config_no_arg():
+def test_op_config_no_arg():
     @op(config_schema={"foo": str})
     def _noop2():
         return
 
 
-def test_solid_docstring():
+def test_op_docstring():
     @op
     def foo_op(_):
         """FOO_DOCSTRING."""
@@ -335,7 +334,7 @@ def test_solid_docstring():
     assert the_graph.__name__ == "the_graph"
 
 
-def test_solid_yields_single_bare_value():
+def test_op_yields_single_bare_value():
     @op
     def return_iterator(_):
         yield 1
@@ -347,7 +346,7 @@ def test_solid_yields_single_bare_value():
         execute_in_graph(return_iterator)
 
 
-def test_solid_yields_multiple_bare_values():
+def test_op_yields_multiple_bare_values():
     @op
     def return_iterator(_):
         yield 1
@@ -360,7 +359,7 @@ def test_solid_yields_multiple_bare_values():
         execute_in_graph(return_iterator)
 
 
-def test_solid_returns_iterator():
+def test_op_returns_iterator():
     def iterator():
         for i in range(3):
             yield i
@@ -407,15 +406,6 @@ def test_no_outs():
         pass
 
     assert len(the_op.outs) == 0
-
-
-def test_op():
-    @op
-    def my_op():
-        pass
-
-    assert isinstance(my_op, OpDefinition)
-    execute_op_in_graph(my_op)
 
 
 def test_ins():

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -218,7 +218,7 @@ def test_solid_definition_errors():
         pass
 
 
-def test_wrong_argument_to_pipeline():
+def test_wrong_argument_to_job():
     def non_solid_func():
         pass
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_autoalias.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_autoalias.py
@@ -11,7 +11,7 @@ def echo(_context, x):
     return x
 
 
-def test_pipeline_autoalias():
+def test_job_autoalias():
     @job
     def autopipe():
         echo(echo(echo(hello())))

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
@@ -169,7 +169,7 @@ def test_aliased_with_name_name_fails():
             add_one.alias("add_one")(num=two)  # explicit alias disables autoalias
 
 
-def test_composite_with_duplicate_solids():
+def test_composite_with_duplicate_ops():
     solid_1, solid_2 = get_duplicate_ops()
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -182,7 +182,7 @@ def test_composite_with_duplicate_solids():
             solid_2()
 
 
-def test_job_with_duplicate_solids():
+def test_job_with_duplicate_ops():
     solid_1, solid_2 = get_duplicate_ops()
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -454,7 +454,7 @@ def test_recursion_with_exceptions():
     assert called["throws"] is True
 
 
-def test_job_has_solid_def():
+def test_job_has_op_def():
     @graph
     def inner():
         return add_one(return_one())
@@ -773,7 +773,7 @@ def test_composition_metadata():
     assert res.output_for_node("metadata_graph.metadata_op") == "quux"
 
 
-def test_uninvoked_solid_fails():
+def test_uninvoked_op_fails():
     with pytest.raises(DagsterInvalidDefinitionError, match=r".*Did you forget parentheses?"):
 
         @job
@@ -783,7 +783,7 @@ def test_uninvoked_solid_fails():
         uninvoked_solid_job.execute_in_process()
 
 
-def test_uninvoked_aliased_solid_fails():
+def test_uninvoked_aliased_op_fails():
     with pytest.raises(DagsterInvalidDefinitionError, match=r".*Did you forget parentheses?"):
 
         @job
@@ -793,7 +793,7 @@ def test_uninvoked_aliased_solid_fails():
         uninvoked_aliased_solid_job.execute_in_process()
 
 
-def test_alias_on_invoked_solid_fails():
+def test_alias_on_invoked_op_fails():
     with pytest.raises(
         DagsterInvariantViolationError,
         match=r".*Consider checking the location of parentheses.",
@@ -894,7 +894,7 @@ def test_fan_in_scalars_fails():
             fan_in_op([1, 2, 3])
 
 
-def test_with_hooks_on_invoked_solid_fails():
+def test_with_hooks_on_invoked_op_fails():
     @op
     def yield_1_op(_):
         return 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
@@ -34,7 +34,7 @@ def solid_a_b_list():
     ]
 
 
-def test_create_pipeline_with_bad_solids_list():
+def test_create_job_with_bad_solids_list():
     with pytest.raises(
         ParameterCheckError,
         match=r'Param "node_defs" is not one of \[\'Sequence\'\]',

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
@@ -34,7 +34,7 @@ def solid_a_b_list():
     ]
 
 
-def test_create_job_with_bad_solids_list():
+def test_create_job_with_bad_ops_list():
     with pytest.raises(
         ParameterCheckError,
         match=r'Param "node_defs" is not one of \[\'Sequence\'\]',
@@ -51,7 +51,7 @@ def test_circular_dep():
         )
 
 
-def test_from_solid_not_there():
+def test_from_op_not_there():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match='node "NOTTHERE" in dependency dictionary not found',
@@ -79,7 +79,7 @@ def test_from_non_existant_input():
         )
 
 
-def test_to_solid_not_there():
+def test_to_op_not_there():
     with pytest.raises(
         DagsterInvalidDefinitionError, match='node "NOTTHERE" not found in node list'
     ):
@@ -90,7 +90,7 @@ def test_to_solid_not_there():
         )
 
 
-def test_to_solid_output_not_there():
+def test_to_op_output_not_there():
     with pytest.raises(
         DagsterInvalidDefinitionError, match='node "A" does not have output "NOTTHERE"'
     ):
@@ -101,7 +101,7 @@ def test_to_solid_output_not_there():
         )
 
 
-def test_invalid_item_in_solid_list():
+def test_invalid_item_in_op_list():
     with pytest.raises(
         DagsterInvalidDefinitionError, match="Invalid item in node list: 'not_a_op'"
     ):
@@ -143,7 +143,7 @@ def test_list_dependencies():
         GraphDefinition(node_defs=solid_a_b_list(), name="test", dependencies=[])
 
 
-def test_pass_unrelated_type_to_field_error_solid_definition():
+def test_pass_unrelated_type_to_field_error_op_definition():
     with pytest.raises(DagsterInvalidConfigDefinitionError) as exc_info:
 
         @op(config_schema="nope")
@@ -221,7 +221,7 @@ def test_bad_out():
         _output = Out(Exotic())
 
 
-def test_solid_tags():
+def test_op_tags():
     @op(tags={"good": {"ok": "fine"}})
     def _fine_tags(_):
         pass

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
@@ -116,7 +116,7 @@ def test_solid_def_receives_version():
     assert op_with_version.version == "42"
 
 
-def test_pipeline_types():
+def test_job_types():
     @op
     def produce_string():
         return "foo"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
@@ -28,7 +28,7 @@ def test_deps_equal():
     assert DependencyDefinition("foo", "bar") != DependencyDefinition("foo", "quuz")
 
 
-def test_solid_def():
+def test_op_def():
     @op
     def produce_string():
         return "foo"
@@ -94,7 +94,7 @@ def test_solid_def():
     assert len(job_def.dependency_structure.inputs()) == 1
 
 
-def test_solid_def_bad_input_name():
+def test_op_def_bad_input_name():
     with pytest.raises(DagsterInvalidDefinitionError, match='"context" is not a valid name'):
 
         @op(ins={"context": In(String)})
@@ -102,7 +102,7 @@ def test_solid_def_bad_input_name():
             pass
 
 
-def test_solid_def_receives_version():
+def test_op_def_receives_version():
     @op
     def op_no_version(_):
         pass
@@ -184,7 +184,7 @@ def test_materialization_assign_label_from_asset_key():
     assert mat.label == "foo bar"
 
 
-def test_rehydrate_solid_handle():
+def test_rehydrate_op_handle():
     h = NodeHandle.from_dict({"name": "foo", "parent": None})
     assert h.name == "foo"
     assert h.parent is None

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_job.py
@@ -168,7 +168,7 @@ def test_deep_graph():
     assert result.output_for_node("load_num") == 126
 
 
-def test_unconfigurable_inputs_pipeline():
+def test_unconfigurable_inputs_job():
     @usable_as_dagster_type
     class NewType:
         pass

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -148,7 +148,7 @@ def test_inner_decorator():
         reconstructable(pipe)
 
 
-def test_solid_selection():
+def test_op_selection():
     recon_pipe = reconstructable(get_the_pipeline)
     sub_pipe_full = recon_pipe.subset_for_execution(["the_op"], asset_selection=None)
     assert sub_pipe_full.solid_selection == ["the_op"]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_tags.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_tags.py
@@ -1,7 +1,7 @@
 from dagster import job, op
 
 
-def test_solid_tags():
+def test_op_tags():
     @op(tags={"foo": "bar"})
     def tags_op(_):
         pass
@@ -29,7 +29,7 @@ def test_job_tags():
     assert no_tags_job.tags == {}
 
 
-def test_solid_subset_tags():
+def test_op_subset_tags():
     @op
     def noop_op(_):
         pass

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -190,7 +190,7 @@ def test_execution_plan_reexecution_with_in_memory():
             )
 
 
-def test_pipeline_step_key_subset_execution():
+def test_job_step_key_subset_execution():
     job_fn = define_addy_job_fs_io
     run_config = {"ops": {"add_one": {"inputs": {"num": {"value": 3}}}}}
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_custom_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_custom_reconstructable.py
@@ -36,7 +36,7 @@ def reconstruct_job(factory_prefix: str, has_nested_scope_op: bool, name: str) -
     return factory.make_job(has_nested_scope_op, name=name)
 
 
-def test_build_reconstructable_pipeline():
+def test_build_reconstructable_job():
     sys_path = sys.path
     try:
         factory = JobFactory("foo_")
@@ -64,7 +64,7 @@ def test_build_reconstructable_pipeline():
         sys.path = sys_path
 
 
-def test_build_reconstructable_pipeline_serdes():
+def test_build_reconstructable_job_serdes():
     sys_path = sys.path
     try:
         factory = JobFactory("foo_")

--- a/python_modules/dagster/dagster_tests/execution_tests/test_op_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_op_iterators.py
@@ -3,7 +3,7 @@ from dagster._annotations import experimental
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
-def test_generator_return_solid():
+def test_generator_return_op():
     def _gen():
         yield Output("done")
 
@@ -15,7 +15,7 @@ def test_generator_return_solid():
     assert result.output_value() == "done"
 
 
-def test_generator_yield_solid():
+def test_generator_yield_op():
     def _gen():
         yield Output("done")
 
@@ -28,7 +28,7 @@ def test_generator_yield_solid():
     assert result.output_value() == "done"
 
 
-def test_generator_yield_from_solid():
+def test_generator_yield_from_op():
     def _gen():
         yield Output("done")
 
@@ -40,7 +40,7 @@ def test_generator_yield_from_solid():
     assert result.output_value() == "done"
 
 
-def test_nested_generator_solid():
+def test_nested_generator_op():
     def _gen1():
         yield AssetMaterialization("test")
 
@@ -59,7 +59,7 @@ def test_nested_generator_solid():
     assert result.output_value() == "done"
 
 
-def test_experimental_generator_solid():
+def test_experimental_generator_op():
     @op
     @experimental
     def gen_op():

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -151,7 +151,7 @@ def get_sqlite3_indexes(db_path, table_name):
     return [r[1] for r in cursor.fetchall()]
 
 
-def test_snapshot_0_7_6_pre_add_pipeline_snapshot():
+def test_snapshot_0_7_6_pre_add_job_snapshot():
     run_id = "fb0b3905-068b-4444-8f00-76fcbaef7e8b"
     src_dir = file_relative_path(__file__, "snapshot_0_7_6_pre_add_pipeline_snapshot/sqlite")
     with copy_directory(src_dir) as test_dir:
@@ -543,7 +543,7 @@ def test_op_handle_node_handle():
     assert result.name == test_handle.name
 
 
-def test_pipeline_run_dagster_run():
+def test_job_run_dagster_run():
     # serialize in current code
     test_run = DagsterRun(job_name="test")
     test_str = serialize_value(test_run)
@@ -575,7 +575,7 @@ def test_pipeline_run_dagster_run():
     assert result.pipeline_name == test_run.job_name
 
 
-def test_pipeline_run_status_dagster_run_status():
+def test_job_run_status_dagster_run_status():
     # serialize in current code
     test_status = DagsterRunStatus("QUEUED")
     test_str = serialize_value(test_status)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_dead_events.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_dead_events.py
@@ -17,7 +17,7 @@ def test_dead_events():
     assert len(objs) == 6
 
 
-def test_dead_pipeline_init_failure_event():
+def test_dead_job_init_failure_event():
     old_pipeline_init_failure_event = """{"__class__":"EventRecord","dagster_event":{"__class__":"DagsterEvent","event_specific_data":{"__class__":"PipelineFailureData","error":{"__class__":"SerializableErrorInfo","cause":null,"cls_name":"DagsterError","message":"","stack":[]}},"event_type_value":"PIPELINE_FAILURE","logging_tags":{},"message":"Pipeline failure during initialization for pipeline.","pid":16977,"pipeline_name":"error_monster","solid_handle":null,"step_handle":null,"step_key":null,"step_kind_value":null},"error_info":null,"level":40,"message":"error_monster - a52c3489-60ca-4801-bf8d-43d3ebcbf81f - 16977 - PIPELINE_INIT_FAILURE - Pipeline failure during initialization for pipeline.","pipeline_name":"error_monster","run_id":"a52c3489-60ca-4801-bf8d-43d3ebcbf81f","step_key":null,"timestamp":1622868716.203709,"user_message":"Pipeline failure during initialization for pipeline. This may be due to a failure in initializing the executor or one of the loggers."}"""
     event_record = deserialize_value(old_pipeline_init_failure_event, EventLogEntry)
     old_event = event_record.dagster_event

--- a/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
+++ b/python_modules/dagster/dagster_tests/general_tests/py3_tests/test_inference.py
@@ -19,7 +19,7 @@ from dagster._core.types.dagster_type import DagsterTypeKind
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
 
-def test_infer_solid_description_from_docstring():
+def test_infer_op_description_from_docstring():
     @op
     def my_op(_):
         """Here is some docstring."""
@@ -27,7 +27,7 @@ def test_infer_solid_description_from_docstring():
     assert my_op.description == "Here is some docstring."
 
 
-def test_infer_solid_description_no_docstring():
+def test_infer_op_description_no_docstring():
     @op
     def my_op(_):
         pass
@@ -498,7 +498,7 @@ def test_use_auto_type_twice():
     my_job.execute_in_process()
 
 
-def test_register_after_solid_definition():
+def test_register_after_op_definition():
     class MyClass:
         pass
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
@@ -25,7 +25,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import deserialize_value, serialize_value
 
 
-def test_queued_pipeline_origin_check():
+def test_queued_job_origin_check():
     code_pointer = ModuleCodePointer("fake", "fake", working_directory=None)
     fake_job_origin = ExternalJobOrigin(
         ExternalRepositoryOrigin(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_defensive_row_unpack.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_defensive_row_unpack.py
@@ -9,7 +9,7 @@ from dagster._core.storage.runs.sql_run_storage import (
 from dagster._serdes import serialize_value
 
 
-def test_defensive_pipeline_not_a_string():
+def test_defensive_job_not_a_string():
     mock_logger = mock.MagicMock()
 
     assert defensively_unpack_execution_plan_snapshot_query(mock_logger, [234]) is None
@@ -20,7 +20,7 @@ def test_defensive_pipeline_not_a_string():
     )
 
 
-def test_defensive_pipeline_not_bytes():
+def test_defensive_job_not_bytes():
     mock_logger = mock.MagicMock()
 
     assert defensively_unpack_execution_plan_snapshot_query(mock_logger, ["notbytes"]) is None
@@ -38,7 +38,7 @@ def test_defensive_pipeline_not_bytes():
         )
 
 
-def test_defensive_pipelines_cannot_decompress():
+def test_defensive_jobs_cannot_decompress():
     mock_logger = mock.MagicMock()
 
     assert defensively_unpack_execution_plan_snapshot_query(mock_logger, [b"notbytes"]) is None
@@ -48,7 +48,7 @@ def test_defensive_pipelines_cannot_decompress():
     )
 
 
-def test_defensive_pipelines_cannot_decode_post_decompress():
+def test_defensive_jobs_cannot_decode_post_decompress():
     mock_logger = mock.MagicMock()
 
     # guarantee that we cannot decode by double compressing bytes.
@@ -65,7 +65,7 @@ def test_defensive_pipelines_cannot_decode_post_decompress():
     )
 
 
-def test_defensive_pipelines_cannot_parse_json():
+def test_defensive_jobs_cannot_parse_json():
     mock_logger = mock.MagicMock()
 
     assert (

--- a/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
@@ -25,7 +25,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import deserialize_value, serialize_value
 
 
-def test_queued_pipeline_origin_check():
+def test_queued_job_origin_check():
     code_pointer = ModuleCodePointer("fake", "fake", working_directory=None)
     fake_job_origin = ExternalJobOrigin(
         ExternalRepositoryOrigin(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -167,7 +167,7 @@ class TestRunStorage:
         storage_id_again = storage.get_run_storage_id()
         assert storage_id == storage_id_again
 
-    def test_fetch_by_pipeline(self, storage):
+    def test_fetch_by_job(self, storage):
         assert storage
         one = make_new_run_id()
         two = make_new_run_id()
@@ -1290,7 +1290,7 @@ class TestRunStorage:
         for name in REQUIRED_DATA_MIGRATIONS.keys():
             assert storage.has_built_index(name)
 
-    def test_handle_run_event_pipeline_success_test(self, storage):
+    def test_handle_run_event_job_success_test(self, storage):
         run_id = make_new_run_id()
         run_to_add = TestRunStorage.build_run(job_name="pipeline_name", run_id=run_id)
         storage.add_run(run_to_add)

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_tags.py
@@ -81,7 +81,7 @@ def get_dag():
 
 
 @requires_no_db
-def test_pipeline_tags():
+def test_job_tags():
     dag = get_dag()
 
     with instance_for_test() as instance:
@@ -102,7 +102,7 @@ def test_pipeline_tags():
 
 
 @requires_no_db
-def test_pipeline_auto_tag():
+def test_job_auto_tag():
     dag = get_dag()
 
     with instance_for_test() as instance:

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -157,7 +157,7 @@ def test_adls_file_manager_resource(MockADLS2FileManager, MockADLS2Resource):
     }
 
     @op(required_resource_keys={"file_manager"})
-    def test_solid(context):
+    def test_op(context):
         # test that we got back a ADLS2FileManager
         assert context.resources.file_manager == MockADLS2FileManager.return_value
 
@@ -176,7 +176,7 @@ def test_adls_file_manager_resource(MockADLS2FileManager, MockADLS2Resource):
     context = build_op_context(
         resources={"file_manager": configured(adls2_file_manager)(resource_config)},
     )
-    test_solid(context)
+    test_op(context)
     assert did_it_run["it_ran"]
 
 
@@ -198,7 +198,7 @@ def test_adls_file_manager_resource_defaultazurecredential(
     }
 
     @op(required_resource_keys={"file_manager"})
-    def test_solid(context):
+    def test_op(context):
         # test that we got back a ADLS2FileManager
         assert context.resources.file_manager == MockADLS2FileManager.return_value
 
@@ -219,5 +219,5 @@ def test_adls_file_manager_resource_defaultazurecredential(
     context = build_op_context(
         resources={"file_manager": configured(adls2_file_manager)(resource_config)},
     )
-    test_solid(context)
+    test_op(context)
     assert did_it_run["it_ran"]

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_execute_docker.py
@@ -75,7 +75,7 @@ def test_execute_celery_docker_image_on_executor_config(aws_creds):
             assert result.output_for_node("get_environment") == "here!"
 
 
-def test_execute_celery_docker_image_on_pipeline_config(aws_creds):
+def test_execute_celery_docker_image_on_job_config(aws_creds):
     docker_image = get_test_project_docker_image()
     docker_config = {
         "network": "container:test-postgres-db-celery-docker",

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_execute.py
@@ -41,7 +41,7 @@ def test_execute_serial_on_celery(dagster_celery_worker):
         assert len(events_of_type(result, "STEP_SUCCESS")) == 2
 
 
-def test_execute_diamond_pipeline_on_celery(dagster_celery_worker):
+def test_execute_diamond_job_on_celery(dagster_celery_worker):
     with execute_job_on_celery("test_diamond_job") as result:
         assert result.output_for_node("emit_values", "value_one") == 1
         assert result.output_for_node("emit_values", "value_two") == 2
@@ -50,24 +50,24 @@ def test_execute_diamond_pipeline_on_celery(dagster_celery_worker):
         assert result.output_for_node("subtract") == -1
 
 
-def test_execute_parallel_pipeline_on_celery(dagster_celery_worker):
+def test_execute_parallel_job_on_celery(dagster_celery_worker):
     with execute_job_on_celery("test_parallel_job") as result:
         assert len(result.get_step_success_events()) == 11
 
 
-def test_execute_composite_pipeline_on_celery(dagster_celery_worker):
+def test_execute_composite_job_on_celery(dagster_celery_worker):
     with execute_job_on_celery("composite_job") as result:
         assert result.success
         assert len(result.get_step_success_events()) == 16
 
 
-def test_execute_optional_outputs_pipeline_on_celery(dagster_celery_worker):
+def test_execute_optional_outputs_job_on_celery(dagster_celery_worker):
     with execute_job_on_celery("test_optional_outputs") as result:
         assert len(result.get_step_success_events()) == 2
         assert len(result.get_step_skipped_events()) == 2
 
 
-def test_execute_fails_pipeline_on_celery(dagster_celery_worker):
+def test_execute_fails_job_on_celery(dagster_celery_worker):
     with execute_job_on_celery("test_fails") as result:
         assert len(result.get_step_failure_events()) == 1
         assert result.is_node_failed("fails")
@@ -75,9 +75,7 @@ def test_execute_fails_pipeline_on_celery(dagster_celery_worker):
         assert result.is_node_untouched("should_never_execute")
 
 
-def test_terminate_pipeline_on_celery(
-    dagster_celery_worker, instance: DagsterInstance, tempdir: str
-):
+def test_terminate_job_on_celery(dagster_celery_worker, instance: DagsterInstance, tempdir: str):
     recon_job = ReconstructableJob.for_file(REPO_FILE, "interrupt_job")
 
     run_config = {
@@ -172,7 +170,7 @@ def test_execute_eagerly_serial_on_celery():
         assert len(events_of_type(result, "STEP_SUCCESS")) == 2
 
 
-def test_execute_eagerly_diamond_pipeline_on_celery():
+def test_execute_eagerly_diamond_job_on_celery():
     with execute_eagerly_on_celery("test_diamond_job") as result:
         assert result.output_for_node("emit_values", "value_one") == 1
         assert result.output_for_node("emit_values", "value_two") == 2
@@ -181,37 +179,37 @@ def test_execute_eagerly_diamond_pipeline_on_celery():
         assert result.output_for_node("subtract") == -1
 
 
-def test_execute_eagerly_diamond_pipeline_subset_on_celery():
+def test_execute_eagerly_diamond_job_subset_on_celery():
     with execute_eagerly_on_celery("test_diamond_job", subset=["emit_values"]) as result:
         assert result.output_for_node("emit_values", "value_one") == 1
         assert result.output_for_node("emit_values", "value_two") == 2
         assert len(result.get_step_success_events()) == 1
 
 
-def test_execute_eagerly_parallel_pipeline_on_celery():
+def test_execute_eagerly_parallel_job_on_celery():
     with execute_eagerly_on_celery("test_parallel_job") as result:
         assert len(result.get_step_success_events()) == 11
 
 
-def test_execute_eagerly_composite_pipeline_on_celery():
+def test_execute_eagerly_composite_job_on_celery():
     with execute_eagerly_on_celery("composite_job") as result:
         assert result.success
         assert len(result.get_step_success_events()) == 16
 
 
-def test_execute_eagerly_optional_outputs_pipeline_on_celery():
+def test_execute_eagerly_optional_outputs_job_on_celery():
     with execute_eagerly_on_celery("test_optional_outputs") as result:
         assert len(result.get_step_success_events()) == 2
         assert len(result.get_step_skipped_events()) == 2
 
 
-def test_execute_eagerly_resources_limit_pipeline_on_celery():
+def test_execute_eagerly_resources_limit_job_on_celery():
     with execute_eagerly_on_celery("test_resources_limit") as result:
         assert result.is_node_success("resource_req_op")
         assert result.success
 
 
-def test_execute_eagerly_fails_pipeline_on_celery():
+def test_execute_eagerly_fails_job_on_celery():
     with execute_eagerly_on_celery("test_fails") as result:
         assert len(result.get_step_failure_events()) == 1
         assert result.is_node_failed("fails")
@@ -219,7 +217,7 @@ def test_execute_eagerly_fails_pipeline_on_celery():
         assert result.is_node_untouched("should_never_execute")
 
 
-def test_execute_eagerly_retries_pipeline_on_celery():
+def test_execute_eagerly_retries_job_on_celery():
     with execute_eagerly_on_celery("test_retries") as result:
         assert len(events_of_type(result, "STEP_START")) == 1
         assert len(events_of_type(result, "STEP_UP_FOR_RETRY")) == 1

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_priority.py
@@ -12,7 +12,7 @@ from dagster_celery.tags import DAGSTER_CELERY_RUN_PRIORITY_TAG
 from .utils import execute_eagerly_on_celery, execute_on_thread, start_celery_worker
 
 
-def test_eager_priority_pipeline():
+def test_eager_priority_job():
     with execute_eagerly_on_celery("simple_priority_job") as result:
         assert result.success
         step_events_in_order = [event for event in result.all_events if event.is_step_event]
@@ -31,7 +31,7 @@ def test_eager_priority_pipeline():
         ]
 
 
-def test_run_priority_pipeline(rabbitmq):
+def test_run_priority_job(rabbitmq):
     with tempfile.TemporaryDirectory() as tempdir:
         with instance_for_test(temp_dir=tempdir) as instance:
             low_done = threading.Event()

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -100,7 +100,7 @@ def test_launch_docker_no_network(aws_env):
                     container.remove(force=True)
 
 
-def test_launch_docker_image_on_pipeline_config(aws_env):
+def test_launch_docker_image_on_job_config(aws_env):
     # Docker image name to use for launch specified as part of the job origin
     # rather than in the run launcher instance config
 

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launcher_and_executor.py
@@ -28,7 +28,7 @@ from . import IS_BUILDKITE, docker_postgres_instance
         (True, {AssetKey("foo"), AssetKey("bar")}),
     ],
 )
-def test_image_on_pipeline(monkeypatch, aws_env, from_pending_repository, asset_selection):
+def test_image_on_job(monkeypatch, aws_env, from_pending_repository, asset_selection):
     monkeypatch.setenv("IN_EXTERNAL_PROCESS", "yes")
     docker_image = get_test_project_docker_image()
 
@@ -108,7 +108,7 @@ def test_image_on_pipeline(monkeypatch, aws_env, from_pending_repository, asset_
             assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.SUCCESS
 
 
-def test_container_context_on_pipeline(aws_env):
+def test_container_context_on_job(aws_env):
     docker_image = get_test_project_docker_image()
 
     launcher_config = {}

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
@@ -24,7 +24,7 @@ def fail_op(_):
 
 
 @patch("dagster_msteams.client.TeamsClient.post_message")
-def test_failure_hook_on_solid_instance(mock_teams_post_message):
+def test_failure_hook_on_op_instance(mock_teams_post_message):
     @job(resource_defs={"msteams": msteams_resource})
     def job_def():
         pass_op.with_hooks(hook_defs={teams_on_failure()})()
@@ -43,7 +43,7 @@ def test_failure_hook_on_solid_instance(mock_teams_post_message):
 
 
 @patch("dagster_msteams.client.TeamsClient.post_message")
-def test_success_hook_on_solid_instance(mock_teams_post_message):
+def test_success_hook_on_op_instance(mock_teams_post_message):
     @job(resource_defs={"msteams": msteams_resource})
     def job_def():
         pass_op.with_hooks(hook_defs={teams_on_success()})()

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_ops.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_dagstermill_pandas_ops.py
@@ -7,7 +7,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 
 
-def test_papermill_pandas_hello_world_pipeline():
+def test_papermill_pandas_hello_world_job():
     recon_job = ReconstructableJob.for_module(
         "dagster_pandas.examples", "papermill_pandas_hello_world_test"
     )

--- a/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas_tests/test_data_frame.py
@@ -36,7 +36,7 @@ def test_create_pandas_dataframe_dagster_type():
     assert isinstance(TestDataFrame, DagsterType)
 
 
-def test_basic_pipeline_with_pandas_dataframe_dagster_type():
+def test_basic_job_with_pandas_dataframe_dagster_type():
     def compute_metadata(dataframe):
         return {"max_pid": str(max(dataframe["pid"]))}
 
@@ -247,7 +247,7 @@ def test_custom_dagster_dataframe_parametrizable_input():
     assert output_df["foo"].tolist() == ["goat"]
 
 
-def test_basic_pipeline_with_pandas_dataframe_dagster_type_metadata():
+def test_basic_job_with_pandas_dataframe_dagster_type_metadata():
     def compute_metadata(dataframe):
         return {
             "max_pid": MetadataValue.text(str(max(dataframe["pid"]))),

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_ops.py
@@ -73,7 +73,7 @@ def test_shell_command_retcode(factory):
 
 
 @pytest.mark.parametrize("shell_defn", [shell_op])
-def test_shell_solid_retcode(shell_defn):
+def test_shell_op_retcode(shell_defn):
     with pytest.raises(Failure, match="Shell command execution failed"):
         wrap_op_in_graph_and_execute(shell_defn, input_values={"shell_command": "exit 1"})
 
@@ -99,7 +99,7 @@ def test_shell_command_stream_logs(factory):
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
-def test_shell_script_solid(factory):
+def test_shell_script_op(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
     result = wrap_op_in_graph_and_execute(
@@ -110,7 +110,7 @@ def test_shell_script_solid(factory):
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
-def test_shell_script_solid_no_config(factory):
+def test_shell_script_op_no_config(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
     result = wrap_op_in_graph_and_execute(op_def)
@@ -118,7 +118,7 @@ def test_shell_script_solid_no_config(factory):
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
-def test_shell_script_solid_no_config_composite(factory):
+def test_shell_script_op_no_config_composite(factory):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
 
@@ -137,7 +137,7 @@ def test_shell_script_solid_no_config_composite(factory):
 
 
 @pytest.mark.parametrize("factory", [create_shell_command_op])
-def test_shell_command_solid_overrides(factory):
+def test_shell_command_op_overrides(factory):
     op_def = factory(
         'echo "this is a test message: $MY_ENV_VAR"',
         name="foobar",
@@ -152,7 +152,7 @@ def test_shell_command_solid_overrides(factory):
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
-def test_shell_script_solid_run_time_config(factory, monkeypatch):
+def test_shell_script_op_run_time_config(factory, monkeypatch):
     monkeypatch.setattr(os, "environ", {"MY_ENV_VAR": "foobar"})
     script_dir = os.path.dirname(os.path.abspath(__file__))
     op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")
@@ -161,7 +161,7 @@ def test_shell_script_solid_run_time_config(factory, monkeypatch):
 
 
 @pytest.mark.parametrize("factory", [create_shell_script_op])
-def test_shell_script_solid_run_time_config_composite(factory, monkeypatch):
+def test_shell_script_op_run_time_config_composite(factory, monkeypatch):
     monkeypatch.setattr(os, "environ", {"MY_ENV_VAR": "foobar"})
     script_dir = os.path.dirname(os.path.abspath(__file__))
     op_def = factory(os.path.join(script_dir, "test.sh"), name="foobar")

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -10,7 +10,7 @@ class SomeUserException(Exception):
 
 
 @patch("slack_sdk.WebClient.api_call")
-def test_failure_hook_on_solid_instance(mock_api_call):
+def test_failure_hook_on_op_instance(mock_api_call):
     @op
     def pass_op(_):
         pass
@@ -66,7 +66,7 @@ def test_failure_hook_decorator(mock_api_call):
 
 
 @patch("slack_sdk.WebClient.api_call")
-def test_success_hook_on_solid_instance(mock_api_call):
+def test_success_hook_on_op_instance(mock_api_call):
     def my_message_fn(_):
         return "Some custom text"
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_ops.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_ops.py
@@ -8,7 +8,7 @@ from .utils import create_mock_connector
 
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
-def test_snowflake_solid(snowflake_connect):
+def test_snowflake_op(snowflake_connect):
     snowflake_solid = snowflake_solid_for_query("SELECT 1")
 
     result = wrap_op_in_graph_and_execute(

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_context.py
@@ -30,7 +30,7 @@ def test_environment_config():
     assert isinstance(BARE_OUT_OF_JOB_CONTEXT.resolved_run_config, ResolvedRunConfig)
 
 
-def test_pipeline_def():
+def test_job_def():
     assert BARE_OUT_OF_JOB_CONTEXT.job_def.name == "ephemeral_dagstermill_pipeline"
     assert len(BARE_OUT_OF_JOB_CONTEXT.job_def.nodes) == 1
     assert BARE_OUT_OF_JOB_CONTEXT.job_def.nodes[0].name == "this_op"


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/5554

Rename test functions containing "pipeline" or "solid" to "job"/"op" equivalent.

## How I Tested These Changes

Existing test suite.