### PR TITLE
solid renames

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -243,26 +243,26 @@ class AssetsDefinition(ResourceAddable):
 
         if isinstance(self.node_def, GraphDefinition):
             return self._node_def(*args, **kwargs)
-        solid_def = self.op
+        op_def = self.op
         provided_context: Optional[OpExecutionContext] = None
         if len(args) > 0 and isinstance(args[0], OpExecutionContext):
             provided_context = _build_invocation_context_with_included_resources(self, args[0])
             new_args = [provided_context, *args[1:]]
-            return solid_def(*new_args, **kwargs)
+            return op_def(*new_args, **kwargs)
         elif (
-            isinstance(solid_def.compute_fn, DecoratedOpFunction)
-            and solid_def.compute_fn.has_context_arg()
+            isinstance(op_def.compute_fn, DecoratedOpFunction)
+            and op_def.compute_fn.has_context_arg()
         ):
-            context_param_name = get_function_params(solid_def.compute_fn.decorated_fn)[0].name
+            context_param_name = get_function_params(op_def.compute_fn.decorated_fn)[0].name
             if context_param_name in kwargs:
                 provided_context = _build_invocation_context_with_included_resources(
                     self, cast(OpExecutionContext, kwargs[context_param_name])
                 )
                 new_kwargs = dict(kwargs)
                 new_kwargs[context_param_name] = provided_context
-                return solid_def(*args, **new_kwargs)
+                return op_def(*args, **new_kwargs)
 
-        return solid_def(*args, **kwargs)
+        return op_def(*args, **kwargs)
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -725,7 +725,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
     ) -> "JobDefinition":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(
-                "Attemped to call `execute_in_process` on a composite solid.  Only graphs "
+                "Attemped to call `to_job` on a non-graph.  Only graphs "
                 "constructed using the `@graph` decorator support this method."
             )
 
@@ -763,7 +763,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
     ) -> "ExecuteInProcessResult":
         if not isinstance(self.node_def, GraphDefinition):
             raise DagsterInvalidInvocationError(
-                "Attemped to call `execute_in_process` on a composite solid.  Only graphs "
+                "Attemped to call `execute_in_process` on a non-graph.  Only graphs "
                 "constructed using the `@graph` decorator support this method."
             )
 
@@ -1031,7 +1031,7 @@ def do_composition(
     """
     from .decorators.op_decorator import (
         NoContextDecoratedOpFunction,
-        resolve_checked_solid_fn_inputs,
+        resolve_checked_op_fn_inputs,
     )
 
     actual_output_defs: Sequence[OutputDefinition]
@@ -1047,7 +1047,7 @@ def do_composition(
 
     compute_fn = NoContextDecoratedOpFunction(fn)
 
-    actual_input_defs = resolve_checked_solid_fn_inputs(
+    actual_input_defs = resolve_checked_op_fn_inputs(
         decorator_name=decorator_name,
         fn_name=graph_name,
         compute_fn=compute_fn,

--- a/python_modules/dagster/dagster/_core/definitions/config.py
+++ b/python_modules/dagster/dagster/_core/definitions/config.py
@@ -40,7 +40,7 @@ class ConfigMapping(
 
     Config mappings require the configuration schema to be specified as ``config_schema``, which will
     be exposed as the configuration schema for the graph, as well as a configuration mapping
-    function, ``config_fn``, which maps the config provided to the composite solid to the config
+    function, ``config_fn``, which maps the config provided to the graph to the config
     that will be provided to the child nodes.
 
     Args:

--- a/python_modules/dagster/dagster/_core/definitions/configurable.py
+++ b/python_modules/dagster/dagster/_core/definitions/configurable.py
@@ -45,7 +45,7 @@ class ConfigurableDefinition(ABC):
 
         Expects incoming config to be validated and have fully-resolved values (StringSource values
         resolved, Enum types hydrated, etc.) via process_config() during ResolvedRunConfig
-        construction and CompositeSolid config mapping.
+        construction and Graph config mapping.
 
         Args:
             config (Any): A validated and resolved configuration dictionary matching this object's
@@ -167,8 +167,8 @@ def _check_configurable_param(configurable: ConfigurableDefinition) -> None:
         "configurable",
         (
             "You have invoked `configured` on a PendingNodeInvocation (an intermediate type), which"
-            " is produced by aliasing or tagging a solid definition. To configure a solid, you must"
-            " call `configured` on either a SolidDefinition and CompositeSolidDefinition. To fix"
+            " is produced by aliasing or tagging a node definition. To configure a node, you must"
+            " call `configured` on either an OpDefinition and GraphDefinition. To fix"
             " this error, make sure to call `configured` on the definition object *before* using"
             " the `tag` or `alias` methods. For usage examples, see"
             " https://docs.dagster.io/concepts/configuration/configured"
@@ -180,7 +180,7 @@ def _check_configurable_param(configurable: ConfigurableDefinition) -> None:
         ConfigurableDefinition,
         (
             "Only the following types can be used with the `configured` method: ResourceDefinition,"
-            " ExecutorDefinition, CompositeSolidDefinition, SolidDefinition, and LoggerDefinition."
+            " ExecutorDefinition, GraphDefinition, NodeDefinition, and LoggerDefinition."
             " For usage examples of `configured`, see"
             " https://docs.dagster.io/concepts/configuration/configured"
         ),

--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -72,7 +72,7 @@ class _Graph:
             input_mappings,
             output_mappings,
             dependencies,
-            solid_defs,
+            node_defs,
             config_mapping,
             positional_inputs,
             node_input_source_assets,
@@ -89,7 +89,7 @@ class _Graph:
         graph_def = GraphDefinition(
             name=self.name,
             dependencies=dependencies,
-            node_defs=solid_defs,
+            node_defs=node_defs,
             description=self.description or format_docstring_for_description(fn),
             input_mappings=input_mappings,
             output_mappings=output_mappings,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/hook_decorator.py
@@ -102,8 +102,8 @@ def event_list_hook(
     The user-defined hook function requires two parameters:
     - A `context` object is passed as the first parameter. The context is an instance of
         :py:class:`context <HookContext>`, and provides access to system
-        information, such as loggers (context.log), resources (context.resources), the solid
-        (context.solid) and its execution step (context.step) which triggers this hook.
+        information, such as loggers (context.log), resources (context.resources), the op
+        (context.op) and its execution step (context.step) which triggers this hook.
     - An `event_list` object is passed as the second paramter. It provides the full event list of the
         associated execution step.
 
@@ -119,10 +119,7 @@ def event_list_hook(
             def slack_on_materializations(context, event_list):
                 for event in event_list:
                     if event.event_type == DagsterEventType.ASSET_MATERIALIZATION:
-                        message = '{solid} has materialized an asset {key}.'.format(
-                            solid=context.solid.name,
-                            key=event.asset_key
-                        )
+                        message = f'{context.op_name} has materialized an asset {event.asset_key}.'
                         # send a slack message every time a materialization event occurs
                         context.resources.slack.send_message(message)
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -67,7 +67,7 @@ class _Job:
             input_mappings,
             output_mappings,
             dependencies,
-            solid_defs,
+            node_defs,
             config_mapping,
             positional_inputs,
             node_input_source_assets,
@@ -84,7 +84,7 @@ class _Job:
         graph_def = GraphDefinition(
             name=self.name,
             dependencies=dependencies,
-            node_defs=solid_defs,
+            node_defs=node_defs,
             description=self.description or format_docstring_for_description(fn),
             input_mappings=input_mappings,
             output_mappings=output_mappings,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -62,13 +62,13 @@ class _Op:
 
         self.description = check.opt_str_param(description, "description")
 
-        # these will be checked within SolidDefinition
+        # these will be checked within OpDefinition
         self.required_resource_keys = required_resource_keys
         self.tags = tags
         self.code_version = code_version
         self.retry_policy = retry_policy
 
-        # config will be checked within SolidDefinition
+        # config will be checked within OpDefinition
         self.config_schema = config_schema
 
         self.ins = check.opt_nullable_mapping_param(ins, "ins", key_type=str, value_type=In)
@@ -268,7 +268,7 @@ def op(
 
 
 class DecoratedOpFunction(NamedTuple):
-    """Wrapper around the decorated solid function to provide commonly used util methods."""
+    """Wrapper around the decorated op function to provide commonly used util methods."""
 
     decorated_fn: Callable[..., Any]
 
@@ -320,8 +320,8 @@ class DecoratedOpFunction(NamedTuple):
 
 
 class NoContextDecoratedOpFunction(DecoratedOpFunction):
-    """Wrapper around a decorated solid function, when the decorator does not permit a context
-    parameter (such as lambda_solid).
+    """Wrapper around a decorated op function, when the decorator does not permit a context
+    parameter.
     """
 
     @lru_cache(maxsize=1)
@@ -335,7 +335,7 @@ def is_context_provided(params: Sequence[Parameter]) -> bool:
     return params[0].name in get_valid_name_permutations("context")
 
 
-def resolve_checked_solid_fn_inputs(
+def resolve_checked_op_fn_inputs(
     decorator_name: str,
     fn_name: str,
     compute_fn: DecoratedOpFunction,
@@ -346,10 +346,10 @@ def resolve_checked_solid_fn_inputs(
     Returns the resolved set of InputDefinitions.
 
     Args:
-        decorator_name (str): Name of the decorator that is wrapping the op/solid function.
+        decorator_name (str): Name of the decorator that is wrapping the op function.
         fn_name (str): Name of the decorated function.
-        compute_fn (DecoratedSolidFunction): The decorated function, wrapped in the
-            DecoratedSolidFunction wrapper.
+        compute_fn (DecoratedOpFunction): The decorated function, wrapped in the
+            DecoratedOpFunction wrapper.
         explicit_input_defs (List[InputDefinition]): The input definitions that were explicitly
             provided in the decorator.
         exclude_nothing (bool): True if Nothing type inputs should be excluded from compute_fn

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -632,7 +632,7 @@ class TypeCheck(
     :py:func:`as_dagster_type`, :py:func:`@usable_as_dagster_type <dagster_type>`, or the underlying
     :py:func:`PythonObjectDagsterType` API.)
 
-    Solid compute functions should generally avoid yielding events of this type to avoid confusion.
+    Op compute functions should generally avoid yielding events of this type to avoid confusion.
 
     Args:
         success (bool): ``True`` if the type check succeeded, ``False`` otherwise.

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -298,7 +298,7 @@ def in_process_executor(init_context):
         execution:
           in_process:
 
-    Execution priority can be configured using the ``dagster/priority`` tag via solid/op metadata,
+    Execution priority can be configured using the ``dagster/priority`` tag via op metadata,
     where the higher the number the higher the priority. 0 is the default and both positive
     and negative numbers can be used.
     """
@@ -418,7 +418,7 @@ def multiprocess_executor(init_context):
     concurrently. By default, or if you set ``max_concurrent`` to be 0, this is the return value of
     :py:func:`python:multiprocessing.cpu_count`.
 
-    Execution priority can be configured using the ``dagster/priority`` tag via solid/op metadata,
+    Execution priority can be configured using the ``dagster/priority`` tag via op metadata,
     where the higher the number the higher the priority. 0 is the default and both positive
     and negative numbers can be used.
     """
@@ -514,7 +514,7 @@ def multi_or_in_process_executor(init_context: "InitExecutorContext") -> "Execut
 
     When using the in_process mode, then only retries can be configured.
 
-    Execution priority can be configured using the ``dagster/priority`` tag via solid metadata,
+    Execution priority can be configured using the ``dagster/priority`` tag via op metadata,
     where the higher the number the higher the priority. 0 is the default and both positive
     and negative numbers can be used.
     """

--- a/python_modules/dagster/dagster/_core/definitions/hook_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/hook_definition.py
@@ -76,7 +76,7 @@ class HookDefinition(
         from .job_definition import JobDefinition
 
         if len(args) > 0 and isinstance(args[0], (JobDefinition, GraphDefinition)):
-            # when it decorates a job, we apply this hook to all the solid invocations within
+            # when it decorates a job, we apply this hook to all the op invocations within
             # the job.
             return args[0].with_hooks({self})
         else:

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -69,9 +69,9 @@ def _check_default_value(input_name: str, dagster_type: DagsterType, default_val
 
 
 class InputDefinition:
-    """Defines an argument to a solid's compute function.
+    """Defines an argument to an op's compute function.
 
-    Inputs may flow from previous solids' outputs, or be stubbed using config. They may optionally
+    Inputs may flow from previous op outputs, or be stubbed using config. They may optionally
     be typed using the Dagster type system.
 
     Args:
@@ -229,7 +229,7 @@ class InputDefinition:
             return self.hardcoded_asset_key
 
     def get_asset_partitions(self, context: "InputContext") -> Optional[Set[str]]:
-        """Get the set of partitions that this solid will read from this InputDefinition for the given
+        """Get the set of partitions that this op will read from this InputDefinition for the given
         :py:class:`InputContext` (if any).
 
         Args:
@@ -242,32 +242,32 @@ class InputDefinition:
         return self._asset_partitions_fn(context)
 
     def mapping_to(
-        self, solid_name: str, input_name: str, fan_in_index: Optional[int] = None
+        self, node_name: str, input_name: str, fan_in_index: Optional[int] = None
     ) -> "InputMapping":
-        """Create an input mapping to an input of a child solid.
+        """Create an input mapping to an input of a child node.
 
-        In a CompositeSolidDefinition, you can use this helper function to construct
-        an :py:class:`InputMapping` to the input of a child solid.
+        In a GraphDefinition, you can use this helper function to construct
+        an :py:class:`InputMapping` to the input of a child node.
 
         Args:
-            solid_name (str): The name of the child solid to which to map this input.
-            input_name (str): The name of the child solid' input to which to map this input.
+            node_name (str): The name of the child node to which to map this input.
+            input_name (str): The name of the child node' input to which to map this input.
             fan_in_index (Optional[int]): The index in to a fanned in input, else None
 
         Examples:
             .. code-block:: python
 
                 input_mapping = InputDefinition('composite_input', Int).mapping_to(
-                    'child_solid', 'int_input'
+                    'child_node', 'int_input'
                 )
         """
-        check.str_param(solid_name, "solid_name")
+        check.str_param(node_name, "node_name")
         check.str_param(input_name, "input_name")
         check.opt_int_param(fan_in_index, "fan_in_index")
 
         return InputMapping(
             graph_input_name=self.name,
-            mapped_node_name=solid_name,
+            mapped_node_name=node_name,
             mapped_node_input_name=input_name,
             fan_in_index=fan_in_index,
             graph_input_description=self.description,

--- a/python_modules/dagster/dagster/_core/definitions/node_container.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_container.py
@@ -131,12 +131,12 @@ def create_execution_structure(
     This will create:
 
     node_dict = {
-        'giver': <dagster._core.definitions.dependency.Solid object>,
-        'sleeper_1': <dagster._core.definitions.dependency.Solid object>,
-        'sleeper_2': <dagster._core.definitions.dependency.Solid object>,
-        'sleeper_3': <dagster._core.definitions.dependency.Solid object>,
-        'sleeper_4': <dagster._core.definitions.dependency.Solid object>,
-        'total': <dagster._core.definitions.dependency.Solid object>
+        'giver': <dagster._core.definitions.dependency.Node object>,
+        'sleeper_1': <dagster._core.definitions.dependency.Node object>,
+        'sleeper_2': <dagster._core.definitions.dependency.Node object>,
+        'sleeper_3': <dagster._core.definitions.dependency.Node object>,
+        'sleeper_4': <dagster._core.definitions.dependency.Node object>,
+        'total': <dagster._core.definitions.dependency.Node object>
     }
 
     as well as a dagster._core.definitions.dependency.DependencyStructure object.

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from .output import OutputDefinition
 
 
-# base class for SolidDefinition and GraphDefinition
+# base class for OpDefinition and GraphDefinition
 # represents that this is embedable within a graph
 class NodeDefinition(NamedConfigurableDefinition):
     _name: str

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -126,7 +126,7 @@ class OutputDefinition:
     ) -> "OutputMapping":
         """Create an output mapping from an output of a child node.
 
-        In a CompositeSolidDefinition, you can use this helper function to construct
+        In a GraphDefinition, you can use this helper function to construct
         an :py:class:`OutputMapping` from the output of a child node.
 
         Args:

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -200,9 +200,9 @@ class ReconstructableJob(
             the job belongs to.
         job_name (str): The name of the job.
         solid_selection_str (Optional[str]): The string value of a comma separated list of user-input
-            solid/op selection. None if no selection is specified, i.e. the entire job will
+            op selection. None if no selection is specified, i.e. the entire job will
             be run.
-        solids_to_execute (Optional[FrozenSet[str]]): A set of solid/op names to execute. None if no selection
+        solids_to_execute (Optional[FrozenSet[str]]): A set of op names to execute. None if no selection
             is specified, i.e. the entire job will be run.
         asset_selection (Optional[FrozenSet[AssetKey]]) A set of assets to execute. None if no selection
             is specified, i.e. the entire job will be run.

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -274,7 +274,7 @@ def define_asset_job(
             Describes how the Job is parameterized at runtime.
 
             If no value is provided, then the schema for the job's run config is a standard
-            format based on its solids and resources.
+            format based on its ops and resources.
 
             If a dictionary is provided, then it must conform to the standard config schema, and
             it will be used as the job's run config for the job whenever the job is executed.

--- a/python_modules/dagster/dagster/_core/definitions/version_strategy.py
+++ b/python_modules/dagster/dagster/_core/definitions/version_strategy.py
@@ -21,14 +21,6 @@ class OpVersionContext(NamedTuple):
     op_def: "OpDefinition"
     op_config: Any
 
-    @property
-    def solid_def(self) -> "OpDefinition":
-        return self.op_def
-
-    @property
-    def solid_config(self) -> Any:
-        return self.op_config
-
 
 class ResourceVersionContext(NamedTuple):
     """Provides execution-time information for computing the version for a resource.

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -375,7 +375,7 @@ class DagsterEvent(
         ],
     )
 ):
-    """Events yielded by solid and pipeline execution.
+    """Events yielded by op and job execution.
 
     Users should not instantiate this class.
 
@@ -501,7 +501,7 @@ class DagsterEvent(
         )
 
     @property
-    def solid_name(self) -> str:
+    def node_name(self) -> str:
         check.invariant(self.node_handle is not None)
         node_handle = cast(NodeHandle, self.node_handle)
         return node_handle.name
@@ -760,7 +760,7 @@ class DagsterEvent(
     def step_output_event(
         step_context: StepExecutionContext, step_output_data: StepOutputData
     ) -> "DagsterEvent":
-        output_def = step_context.solid.output_def_named(
+        output_def = step_context.op.output_def_named(
             step_output_data.step_output_handle.output_name
         )
 
@@ -1273,8 +1273,9 @@ class DagsterEvent(
             step_kind_value=step_context.step.kind.value,
             logging_tags=step_context.event_tags,
             message=(
-                'Finished the execution of hook "{hook_name}" triggered for "{solid_name}".'
-            ).format(hook_name=hook_def.name, solid_name=step_context.solid.name),
+                f'Finished the execution of hook "{hook_def.name}" triggered for'
+                f' "{step_context.op.name}".'
+            ),
         )
 
         step_context.log.log_dagster_event(
@@ -1324,7 +1325,7 @@ class DagsterEvent(
             message=(
                 'Skipped the execution of hook "{hook_name}". It did not meet its triggering '
                 'condition during the execution of "{solid_name}".'
-            ).format(hook_name=hook_def.name, solid_name=step_context.solid.name),
+            ).format(hook_name=hook_def.name, solid_name=step_context.op.name),
         )
 
         step_context.log.log_dagster_event(

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -39,7 +39,7 @@ from .system import StepExecutionContext
 
 
 class AbstractComputeExecutionContext(ABC):
-    """Base class for solid context implemented by SolidExecutionContext and DagstermillExecutionContext.
+    """Base class for op context implemented by OpExecutionContext and DagstermillExecutionContext.
     """
 
     @abstractmethod
@@ -208,7 +208,7 @@ class OpExecutionContext(AbstractComputeExecutionContext):
 
     @property
     def node_handle(self) -> NodeHandle:
-        """NodeHandle: The current solid's handle.
+        """NodeHandle: The current op's handle.
 
         :meta private:
         """
@@ -223,22 +223,13 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         return self.node_handle
 
     @property
-    def solid(self) -> Node:
-        """Solid: The current solid object.
-
-        :meta private:
-
-        """
-        return self._step_execution_context.job_def.get_node(self.node_handle)
-
-    @property
     def op(self) -> Node:
         """Solid: The current op object.
 
         :meta private:
 
         """
-        return self.solid
+        return self._step_execution_context.job_def.get_node(self.node_handle)
 
     @public
     @property

--- a/python_modules/dagster/dagster/_core/execution/context/hook.py
+++ b/python_modules/dagster/dagster/_core/execution/context/hook.py
@@ -86,7 +86,7 @@ class HookContext:
     @property
     def op(self) -> Node:
         """The op instance associated with the hook."""
-        return self._step_execution_context.solid
+        return self._step_execution_context.op
 
     @property
     def step(self) -> ExecutionStep:

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -548,18 +548,18 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     @property
     def op_def(self) -> OpDefinition:
-        return self.solid.definition
+        return self.op.definition
 
     @property
     def job_def(self) -> "JobDefinition":
         return self._execution_data.job_def
 
     @property
-    def solid(self) -> OpNode:
+    def op(self) -> OpNode:
         return self.job_def.get_op(self._step.node_handle)
 
     @property
-    def solid_retry_policy(self) -> Optional[RetryPolicy]:
+    def op_retry_policy(self) -> Optional[RetryPolicy]:
         return self.job_def.get_retry_policy_for_handle(self.node_handle)
 
     def describe_op(self) -> str:
@@ -725,13 +725,13 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
                 else f"output '{output_def.name}' with mapping_key '{mapping_key}'"
             )
             raise DagsterInvariantViolationError(
-                f"In {self.op_def.node_type_str} '{self.solid.name}', attempted to log output"
+                f"In {self.op_def.node_type_str} '{self.op.name}', attempted to log output"
                 f" metadata for {output_desc} which has already been yielded. Metadata must be"
                 " logged before the output is yielded."
             )
         if output_def.is_dynamic and not mapping_key:
             raise DagsterInvariantViolationError(
-                f"In {self.op_def.node_type_str} '{self.solid.name}', attempted to log metadata"
+                f"In {self.op_def.node_type_str} '{self.op.name}', attempted to log metadata"
                 f" for dynamic output '{output_def.name}' without providing a mapping key. When"
                 " logging metadata for a dynamic output, it is necessary to provide a mapping key."
             )
@@ -739,7 +739,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         if output_name in self._output_metadata:
             if not mapping_key or mapping_key in self._output_metadata[output_name]:
                 raise DagsterInvariantViolationError(
-                    f"In {self.op_def.node_type_str} '{self.solid.name}', attempted to log"
+                    f"In {self.op_def.node_type_str} '{self.op.name}', attempted to log"
                     f" metadata for output '{output_name}' more than once."
                 )
         if mapping_key:

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -70,9 +70,7 @@ def inner_plan_execution_iterator(
                     (
                         "Expected step context for solid {solid_name} to have all required"
                         " resources, but missing {missing_resources}."
-                    ).format(
-                        solid_name=step_context.solid.name, missing_resources=missing_resources
-                    ),
+                    ).format(solid_name=step_context.op.name, missing_resources=missing_resources),
                 )
 
                 with ExitStack() as step_stack:

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -346,9 +346,9 @@ def core_dagster_event_sequence_for_step(
             yield evt
 
     # The core execution loop expects a compute generator in a specific format: a generator that
-    # takes a context and dictionary of inputs as input, yields output events. If a solid definition
-    # was generated from the @solid or @lambda_solid decorator, then compute_fn needs to be coerced
-    # into this format. If the solid definition was created directly, then it is expected that the
+    # takes a context and dictionary of inputs as input, yields output events. If an op definition
+    # was generated from the @op decorator, then compute_fn needs to be coerced
+    # into this format. If the op definition was created directly, then it is expected that the
     # compute_fn is already in this format.
     if isinstance(step_context.op_def.compute_fn, DecoratedOpFunction):
         core_gen = create_op_compute_wrapper(step_context.op_def)
@@ -406,7 +406,7 @@ def _type_check_and_store_output(
         step_key=step_context.step.key, output_name=output.output_name, mapping_key=mapping_key
     )
 
-    # If we are executing using the execute_in_process API, then we allow for the outputs of solids
+    # If we are executing using the execute_in_process API, then we allow for the outputs of ops
     # to be directly captured to a dictionary after they are computed.
     if step_context.output_capture is not None:
         step_context.output_capture[step_output_handle] = output.value

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -291,8 +291,8 @@ class FromRootInputManager(
 
         input_def = step_context.op_def.input_def_named(input_def.name)
 
-        solid_config = step_context.resolved_run_config.ops.get(str(self.node_handle))
-        config_data = solid_config.inputs.get(self.input_name) if solid_config else None
+        op_config = step_context.resolved_run_config.ops.get(str(self.node_handle))
+        config_data = op_config.inputs.get(self.input_name) if op_config else None
 
         input_manager_key = check.not_none(
             input_def.root_manager_key
@@ -330,16 +330,16 @@ class FromRootInputManager(
     ) -> Optional[str]:
         from ..resolve_versions import check_valid_version, resolve_config_version
 
-        solid = job_def.get_node(self.node_handle)
+        node = job_def.get_node(self.node_handle)
         input_manager_key: str = check.not_none(
-            solid.input_def_named(self.input_name).root_manager_key
-            if solid.input_def_named(self.input_name).root_manager_key
-            else solid.input_def_named(self.input_name).input_manager_key
+            node.input_def_named(self.input_name).root_manager_key
+            if node.input_def_named(self.input_name).root_manager_key
+            else node.input_def_named(self.input_name).input_manager_key
         )
         input_manager_def = job_def.resource_defs[input_manager_key]
 
-        solid_config = resolved_run_config.ops[solid.name]
-        input_config = solid_config.inputs.get(self.input_name)
+        op_config = resolved_run_config.ops[node.name]
+        input_config = op_config.inputs.get(self.input_name)
         resource_config = check.not_none(
             resolved_run_config.resources.get(input_manager_key)
         ).config

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -372,8 +372,9 @@ class _PlanBuilder:
             else:
                 check.invariant(
                     False,
-                    "Unexpected solid type {type} encountered during execution planning".format(
-                        type=type(node.definition)
+                    (
+                        f"Unexpected node type {type(node.definition)} encountered during execution"
+                        " planning"
                     ),
                 )
 
@@ -554,7 +555,7 @@ def get_step_input_source(
         return FromDefaultValue(node_handle=handle, input_name=input_name)
 
     # At this point we have an input that is not hooked up to
-    # the output of another solid or provided via run config.
+    # the output of another op or provided via run config.
 
     # We will allow this for "Nothing" type inputs and continue.
     if input_def.dagster_type.is_nothing:

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -159,7 +159,7 @@ class ExecutionStep(
                 {
                     "step_key": handle.to_key(),
                     "job_name": job_name,
-                    "solid_name": handle.node_handle.name,
+                    "op_name": handle.node_handle.name,
                 },
                 check.opt_mapping_param(logging_tags, "logging_tags"),
             ),
@@ -172,7 +172,7 @@ class ExecutionStep(
         return self.handle.node_handle
 
     @property
-    def solid_name(self) -> str:
+    def op_name(self) -> str:
         return self.node_handle.name
 
     @property

--- a/python_modules/dagster/dagster/_core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/utils.py
@@ -48,7 +48,7 @@ def op_execution_error_boundary(
 
     with raise_execution_interrupts():
         step_context.log.begin_python_log_capture()
-        retry_policy = step_context.solid_retry_policy
+        retry_policy = step_context.op_retry_policy
 
         try:
             yield

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -398,21 +398,21 @@ def get_transitive_required_resource_keys(
 
 
 def get_required_resource_keys_for_step(
-    pipeline_def: JobDefinition, execution_step: IExecutionStep, execution_plan: ExecutionPlan
+    job_def: JobDefinition, execution_step: IExecutionStep, execution_plan: ExecutionPlan
 ) -> AbstractSet[str]:
     resource_keys: Set[str] = set()
 
-    # add all the solid compute resource keys
-    solid_def = pipeline_def.get_node(execution_step.node_handle).definition
-    resource_keys = resource_keys.union(solid_def.required_resource_keys)  # type: ignore  # (should be OpDefinition)
+    # add all the op compute resource keys
+    node_def = job_def.get_node(execution_step.node_handle).definition
+    resource_keys = resource_keys.union(node_def.required_resource_keys)  # type: ignore  # (should be OpDefinition)
 
     # add input type, input loader, and input io manager resource keys
     for step_input in execution_step.step_inputs:
-        input_def = solid_def.input_def_named(step_input.name)
+        input_def = node_def.input_def_named(step_input.name)
 
         resource_keys = resource_keys.union(input_def.dagster_type.required_resource_keys)
 
-        resource_keys = resource_keys.union(step_input.source.required_resource_keys(pipeline_def))
+        resource_keys = resource_keys.union(step_input.source.required_resource_keys(job_def))
 
         if input_def.input_manager_key:
             resource_keys = resource_keys.union([input_def.input_manager_key])
@@ -427,14 +427,14 @@ def get_required_resource_keys_for_step(
             check.failed(f"Unexpected step input type {step_input}")
 
         for source_handle in source_handles:
-            source_manager_key = execution_plan.get_manager_key(source_handle, pipeline_def)
+            source_manager_key = execution_plan.get_manager_key(source_handle, job_def)
             if source_manager_key:
                 resource_keys = resource_keys.union([source_manager_key])
 
     # add output type and output io manager resource keys
     for step_output in execution_step.step_outputs:
         # Load the output type
-        output_def = solid_def.output_def_named(step_output.name)
+        output_def = node_def.output_def_named(step_output.name)
 
         resource_keys = resource_keys.union(output_def.dagster_type.required_resource_keys)
         if output_def.io_manager_key:

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
 class CodeLocation(AbstractContextManager):
     """A CodeLocation represents a target containing user code which has a set of Dagster
     definition objects. A given location will contain some number of uniquely named
-    RepositoryDefinitions, which therein contains Pipeline, Solid, and other definitions.
+    RepositoryDefinitions, which therein contains job, op, and other definitions.
 
     Dagster tools are typically "host" processes, meaning they load a CodeLocation and
     communicate with it over an IPC/RPC layer. Currently this IPC layer is implemented by
@@ -126,7 +126,7 @@ class CodeLocation(AbstractContextManager):
     def get_external_job(self, selector: JobSubsetSelector) -> ExternalJob:
         """Return the ExternalPipeline for a specific pipeline. Subclasses only
         need to implement get_subset_external_pipeline_result to handle the case where
-        a solid selection is specified, which requires access to the underlying JobDefinition
+        an op selection is specified, which requires access to the underlying JobDefinition
         to generate the subsetted pipeline snapshot.
         """
         if not selector.solid_selection and not selector.asset_selection:
@@ -150,7 +150,7 @@ class CodeLocation(AbstractContextManager):
     def get_subset_external_job_result(
         self, selector: JobSubsetSelector
     ) -> ExternalJobSubsetResult:
-        """Returns a snapshot about an ExternalPipeline with a solid selection, which requires
+        """Returns a snapshot about an ExternalPipeline with an op selection, which requires
         access to the underlying JobDefinition. Callsites should likely use
         `get_external_pipeline` instead.
         """

--- a/python_modules/dagster/dagster/_core/host_representation/external.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external.py
@@ -346,7 +346,7 @@ class ExternalJob(RepresentedJob):
         return self._job_index.job_snapshot.description
 
     @property
-    def solid_names_in_topological_order(self):
+    def node_names_in_topological_order(self):
         return self._job_index.job_snapshot.node_names_in_topological_order
 
     @property
@@ -392,12 +392,12 @@ class ExternalJob(RepresentedJob):
         return list(self._active_preset_dict.values())
 
     @property
-    def solid_names(self) -> Sequence[str]:
+    def node_names(self) -> Sequence[str]:
         return self._job_index.job_snapshot.node_names
 
-    def has_solid_invocation(self, solid_name: str):
-        check.str_param(solid_name, "solid_name")
-        return self._job_index.has_solid_invocation(solid_name)
+    def has_node_invocation(self, node_name: str):
+        check.str_param(node_name, "node_name")
+        return self._job_index.has_node_invocation(node_name)
 
     def has_preset(self, preset_name: str) -> bool:
         check.str_param(preset_name, "preset_name")

--- a/python_modules/dagster/dagster/_core/host_representation/job_index.py
+++ b/python_modules/dagster/dagster/_core/host_representation/job_index.py
@@ -93,15 +93,15 @@ class JobIndex:
         check.str_param(node_def_name, "node_def_name")
         return self._node_defs_snaps_index[node_def_name]
 
-    def get_dep_structure_index(self, comp_solid_def_name: str) -> DependencyStructureIndex:
-        return self._comp_dep_structures[comp_solid_def_name]
+    def get_dep_structure_index(self, graph_def_name: str) -> DependencyStructureIndex:
+        return self._comp_dep_structures[graph_def_name]
 
     def get_dagster_type_snaps(self) -> Sequence[DagsterTypeSnap]:
         dt_namespace = self.job_snapshot.dagster_type_namespace_snapshot
         return list(dt_namespace.all_dagster_type_snaps_by_key.values())
 
-    def has_solid_invocation(self, solid_name: str) -> bool:
-        return self.dep_structure_index.has_invocation(solid_name)
+    def has_node_invocation(self, node_name: str) -> bool:
+        return self.dep_structure_index.has_invocation(node_name)
 
     def get_default_mode_name(self) -> str:
         return self.job_snapshot.mode_def_snaps[0].name

--- a/python_modules/dagster/dagster/_core/host_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/host_representation/represented.py
@@ -102,14 +102,14 @@ class RepresentedJob(ABC):
     def dep_structure_index(self) -> DependencyStructureIndex:
         return self._job_index.dep_structure_index
 
-    # Solids
-    def get_node_def_snap(self, solid_def_name: str) -> Union[OpDefSnap, GraphDefSnap]:
-        check.str_param(solid_def_name, "solid_def_name")
-        return self._job_index.get_node_def_snap(solid_def_name)
+    # Nodes
+    def get_node_def_snap(self, node_def_name: str) -> Union[OpDefSnap, GraphDefSnap]:
+        check.str_param(node_def_name, "node_def_name")
+        return self._job_index.get_node_def_snap(node_def_name)
 
-    def get_dep_structure_index(self, solid_def_name: str) -> DependencyStructureIndex:
-        check.str_param(solid_def_name, "solid_def_name")
-        return self._job_index.get_dep_structure_index(solid_def_name)
+    def get_dep_structure_index(self, node_def_name: str) -> DependencyStructureIndex:
+        check.str_param(node_def_name, "node_def_name")
+        return self._job_index.get_dep_structure_index(node_def_name)
 
     # Graph
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -310,7 +310,7 @@ class DagsterInstance(DynamicPartitionsStore):
             :py:class:`dagster._core.storage.event_log.SqliteEventLogStorage`. Configurable in
             ``dagster.yaml`` using the :py:class:`~dagster.serdes.ConfigurableClass` machinery.
         compute_log_manager (ComputeLogManager): The compute log manager handles stdout and stderr
-            logging for solid compute functions. By default, this will be a
+            logging for op compute functions. By default, this will be a
             :py:class:`dagster._core.storage.local_compute_log_manager.LocalComputeLogManager`.
             Configurable in ``dagster.yaml`` using the
             :py:class:`~dagster.serdes.ConfigurableClass` machinery.

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -111,7 +111,7 @@ class DagsterLoggingMetadata(
             ("job_name", Optional[str]),
             ("job_tags", Mapping[str, str]),
             ("step_key", Optional[str]),
-            ("solid_name", Optional[str]),
+            ("op_name", Optional[str]),
             ("resource_name", Optional[str]),
             ("resource_fn_name", Optional[str]),
         ],
@@ -127,7 +127,7 @@ class DagsterLoggingMetadata(
         job_name: Optional[str] = None,
         job_tags: Optional[Mapping[str, str]] = None,
         step_key: Optional[str] = None,
-        solid_name: Optional[str] = None,
+        op_name: Optional[str] = None,
         resource_name: Optional[str] = None,
         resource_fn_name: Optional[str] = None,
     ):
@@ -137,7 +137,7 @@ class DagsterLoggingMetadata(
             job_name=job_name,
             job_tags=job_tags or {},
             step_key=step_key,
-            solid_name=solid_name,
+            op_name=op_name,
             resource_name=resource_name,
             resource_fn_name=resource_fn_name,
         )

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -1,6 +1,6 @@
 """This module contains serializable classes that contain all the meta information
 in our definitions and type systems. The purpose is to be able to represent
-user-defined code artifacts (e.g. Pipelines Solids) in a serializable format
+user-defined code artifacts (e.g. jobs, ops) in a serializable format
 so that they can be persisted and manipulated in remote processes.
 
 This will have a number of uses, but the most immediately germane are:

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -77,7 +77,7 @@ def composite_descent(
     """This function is responsible for constructing the dictionary of OpConfig (indexed by handle)
     that will be passed into the ResolvedRunConfig. Critically this is the codepath that manages
     config mapping, where the runtime calls into user-defined config mapping functions to produce
-    config for child solids of composites.
+    config for child nodes of graphs.
 
     Args:
         job_def (JobDefinition): JobDefinition
@@ -90,7 +90,7 @@ def composite_descent(
             composite tree - i.e. not just leaf ops, but composite ops as well
     """
     check.inst_param(job_def, "job_def", JobDefinition)
-    check.dict_param(ops_config, "solids_config")
+    check.dict_param(ops_config, "ops_config")
     check.dict_param(resource_defs, "resource_defs", key_type=str, value_type=ResourceDefinition)
 
     # If top-level graph has config mapping, apply that config mapping before descending.
@@ -162,8 +162,8 @@ def _composite_descent(
                 ),
             )
 
-            # If there is a config mapping, invoke it and get the descendent solids
-            # config that way. Else just grabs the solids entry of the current config
+            # If there is a config mapping, invoke it and get the descendent nodes
+            # config that way. Else just grabs the ops entry of the current config
             mapped_nodes_config = (
                 _apply_config_mapping(
                     node,
@@ -242,12 +242,12 @@ def _apply_config_mapping(
     asset_layer: AssetLayer,
 ) -> Mapping[str, RawNodeConfig]:
     # the spec of the config mapping function is that it takes the dictionary at:
-    # solid_name:
+    # op_name:
     #    config: {dict_passed_to_user}
 
-    # and it returns the dictionary rooted at solids
-    # solid_name:
-    #    solids: {return_value_of_config_fn}
+    # and it returns the dictionary rooted at ops
+    # op_name:
+    #    ops: {return_value_of_config_fn}
 
     # We must call the config mapping function and then validate it against
     # the child schema.
@@ -267,7 +267,7 @@ def _apply_config_mapping(
         DagsterConfigMappingFunctionError, _get_error_lambda(current_stack)
     ):
         config_mapping = check.not_none(graph_def.config_mapping)
-        mapped_solids_config = config_mapping.resolve_from_validated_config(
+        mapped_ops_config = config_mapping.resolve_from_validated_config(
             config_mapped_node_config.value.get("config", {})  # type: ignore  # (unknown EVR type)
         )
 
@@ -276,7 +276,7 @@ def _apply_config_mapping(
 
     # diff original graph and the subselected graph to find nodes to ignore so the system knows to
     # skip the validation then when config mapping generates values where the nodes are not selected
-    ignored_solids = (
+    ignored_nodes = (
         graph_def.get_top_level_omitted_nodes()
         if isinstance(graph_def, SubselectedGraphDefinition)
         else None
@@ -284,7 +284,7 @@ def _apply_config_mapping(
 
     type_to_evaluate_against = define_node_shape(
         nodes=graph_def.nodes,
-        ignored_nodes=ignored_solids,
+        ignored_nodes=ignored_nodes,
         dependency_structure=graph_def.dependency_structure,
         parent_handle=current_stack.handle,
         resource_defs=resource_defs,
@@ -294,10 +294,10 @@ def _apply_config_mapping(
 
     # process against that new type
 
-    evr = process_config(type_to_evaluate_against, mapped_solids_config)
+    evr = process_config(type_to_evaluate_against, mapped_ops_config)
 
     if not evr.success:
-        raise_composite_descent_config_error(current_stack, mapped_solids_config, evr)
+        raise_composite_descent_config_error(current_stack, mapped_ops_config, evr)
 
     return evr.value  # type: ignore  # (unknown evr type)
 
@@ -337,18 +337,18 @@ def raise_composite_descent_config_error(
     check.inst_param(descent_stack, "descent_stack", DescentStack)
     check.inst_param(evr, "evr", EvaluateValueResult)
 
-    solid = descent_stack.current_node
+    node = descent_stack.current_node
     message = "In job {job_name} at stack {stack}: \n".format(
         job_name=descent_stack.job_def.name,
         stack=":".join(descent_stack.handle.path),
     )
     message += (
-        f'Op "{solid.name}" with definition "{solid.definition.name}" has a '
+        f'Op "{node.name}" with definition "{node.definition.name}" has a '
         "configuration error. "
         "It has produced config a via its config_fn that fails to "
-        "pass validation in the solids that it contains. "
+        "pass validation in the ops that it contains. "
         "This indicates an error in the config mapping function itself. It must "
-        "produce correct config for its constiuent solids in all cases. The correct "
+        "produce correct config for its constituent ops in all cases. The correct "
         "resolution is to fix the mapping function. Details on the error (and the paths "
         'on this error are relative to config mapping function "root", not the entire document): '
     )

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -184,12 +184,10 @@ def dagster_type_loader(
         missing_positional = validate_expected_params(params, EXPECTED_POSITIONALS)
         if missing_positional:
             raise DagsterInvalidDefinitionError(
-                "@dagster_type_loader '{solid_name}' decorated function does not have required"
-                " positional parameter '{missing_param}'. @dagster_type_loader decorated functions"
-                " should only have keyword arguments that match input names and a first positional"
-                " parameter named 'context'.".format(
-                    solid_name=func.__name__, missing_param=missing_positional
-                )
+                f"@dagster_type_loader '{func.__name__}' decorated function does not have required"
+                f" positional parameter '{missing_positional}'. @dagster_type_loader decorated"
+                " functions should only have keyword arguments that match input names and a first"
+                " positional parameter named 'context'."
             )
 
         return _create_type_loader_for_decorator(

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_def.py
@@ -339,9 +339,9 @@ def test_success_hook_event():
     assert len(hook_events) == 2
     for event in hook_events:
         if event.event_type == DagsterEventType.HOOK_COMPLETED:
-            assert event.solid_name == "a_op"
+            assert event.node_name == "a_op"
         if event.event_type == DagsterEventType.HOOK_SKIPPED:
-            assert event.solid_name == "failed_op"
+            assert event.node_name == "failed_op"
 
 
 def test_failure_hook_event():
@@ -374,9 +374,9 @@ def test_failure_hook_event():
     assert len(hook_events) == 2
     for event in hook_events:
         if event.event_type == DagsterEventType.HOOK_COMPLETED:
-            assert event.solid_name == "failed_op"
+            assert event.node_name == "failed_op"
         if event.event_type == DagsterEventType.HOOK_SKIPPED:
-            assert event.solid_name == "a_op"
+            assert event.node_name == "a_op"
 
 
 @op

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -103,7 +103,7 @@ def test_repository_data_can_reload_without_restarting(
     assert not repo.has_external_job("foo_1")
 
     external_job = repo.get_full_external_job("foo_2")
-    assert external_job.has_solid_invocation("do_something_2")
+    assert external_job.has_node_invocation("do_something_2")
 
     # Reloading the location changes the pipeline without needing
     # to restart the server process
@@ -115,4 +115,4 @@ def test_repository_data_can_reload_without_restarting(
     assert not repo.has_external_job("foo_3")
 
     external_job = repo.get_full_external_job("foo_4")
-    assert external_job.has_solid_invocation("do_something_4")
+    assert external_job.has_node_invocation("do_something_4")

--- a/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_event_logging.py
@@ -92,7 +92,7 @@ def test_single_op_job_success():
 
     start_event = single_dagster_event(events, DagsterEventType.STEP_START)
     assert start_event.job_name == "single_op_job"
-    assert start_event.dagster_event.solid_name == "op_one"
+    assert start_event.dagster_event.node_name == "op_one"
 
     # persisted logging tags contain pipeline_name but not pipeline_tags
     assert start_event.dagster_event.logging_tags["job_name"] == "single_op_job"
@@ -104,7 +104,7 @@ def test_single_op_job_success():
 
     success_event = single_dagster_event(events, DagsterEventType.STEP_SUCCESS)
     assert success_event.job_name == "single_op_job"
-    assert success_event.dagster_event.solid_name == "op_one"
+    assert success_event.dagster_event.node_name == "op_one"
 
     assert isinstance(success_event.dagster_event.step_success_data.duration_ms, float)
     assert success_event.dagster_event.step_success_data.duration_ms > 0.0
@@ -135,13 +135,13 @@ def test_single_op_job_failure():
     start_event = single_dagster_event(events, DagsterEventType.STEP_START)
     assert start_event.job_name == "single_op_job"
 
-    assert start_event.dagster_event.solid_name == "op_one"
+    assert start_event.dagster_event.node_name == "op_one"
     assert start_event.level == logging.DEBUG
 
     failure_event = single_dagster_event(events, DagsterEventType.STEP_FAILURE)
     assert failure_event.job_name == "single_op_job"
 
-    assert failure_event.dagster_event.solid_name == "op_one"
+    assert failure_event.dagster_event.node_name == "op_one"
     assert failure_event.level == logging.ERROR
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -193,7 +193,7 @@ def test_external_diamond_toposort():
         ).create_single_location(instance) as repo_location:
             external_repo = next(iter(repo_location.get_repositories().values()))
             external_job = next(iter(external_repo.get_all_external_jobs()))
-            assert external_job.solid_names_in_topological_order == [
+            assert external_job.node_names_in_topological_order == [
                 "A_source",
                 "A",
                 "B",

--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/pyspark_step_launcher.py
@@ -324,7 +324,7 @@ class EmrPySparkStepLauncher(StepLauncher):
         step_key = step_run_ref.step_key
         self._post_artifacts(log, step_run_ref, run_id, step_key)
 
-        emr_step_def = self._get_emr_step_def(run_id, step_key, step_context.solid.name)
+        emr_step_def = self._get_emr_step_def(run_id, step_key, step_context.op.name)
         emr_step_id = self.emr_job_runner.add_job_flow_steps(log, self.cluster_id, [emr_step_def])[
             0
         ]


### PR DESCRIPTION
## Summary & Motivation

- Rename a bunch of local variables containing "solid" to op equivalents
- Change "solid"/"composite solid" in docstrings/comments to "op"/"node"/"graph"

Non-local changes

- `resolve_checked_solid_fn_inputs` -> `resolved_checked_op_fn_inputs`
- delete `OpExecutionContext.solid` (.`op` already exists)
- `StepExecutionContext.solid` -> `op`
- `StepExecutionContext.solid_retry_policy` -> `op_retry_policy`
- `ExternalJob.solid_names_in_topological_order` -> `node_names_in_topological_order`
- `ExternalJob.solid_names` -> `node_names`
- `ExternalJob.has_solid_invocation` -> `has_node_invocation`
- `JobIndex.has_solid_invocation` -> `has_node_invocation`
- `DagsterLoggingMetadata.solid_name` -> `op_name`

## How I Tested These Changes

Existing test suite
