### PR TITLE
[dynamic partitions requests in tick 3/3] Add dynamic partitions request results to GQL

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2236,6 +2236,7 @@ type InstigationTick {
   originRunIds: [String!]!
   logKey: [String!]
   logEvents: InstigationEventConnection!
+  dynamicPartitionsRequestResults: [DynamicPartitionsRequestResult!]!
 }
 
 type InstigationEventConnection {
@@ -2248,6 +2249,13 @@ type InstigationEvent {
   message: String!
   timestamp: String!
   level: LogLevel!
+}
+
+type DynamicPartitionsRequestResult {
+  partitionsDefName: String!
+  type: DynamicPartitionsRequestType!
+  partitionKeys: [String!]!
+  skippedPartitionKeys: [String!]!
 }
 
 type ScheduleData {

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2252,9 +2252,9 @@ type InstigationEvent {
 }
 
 type DynamicPartitionsRequestResult {
+  partitionKeys: [String!]
   partitionsDefName: String!
   type: DynamicPartitionsRequestType!
-  partitionKeys: [String!]!
   skippedPartitionKeys: [String!]!
 }
 

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1070,7 +1070,7 @@ export type DynamicPartitionRequest = {
 
 export type DynamicPartitionsRequestResult = {
   __typename: 'DynamicPartitionsRequestResult';
-  partitionKeys: Array<Scalars['String']>;
+  partitionKeys: Maybe<Array<Scalars['String']>>;
   partitionsDefName: Scalars['String'];
   skippedPartitionKeys: Array<Scalars['String']>;
   type: DynamicPartitionsRequestType;
@@ -5645,7 +5645,7 @@ export const buildDynamicPartitionsRequestResult = (
   return {
     __typename: 'DynamicPartitionsRequestResult',
     partitionKeys:
-      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : ['non'],
+      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
     partitionsDefName:
       overrides && overrides.hasOwnProperty('partitionsDefName')
         ? overrides.partitionsDefName!
@@ -5653,7 +5653,7 @@ export const buildDynamicPartitionsRequestResult = (
     skippedPartitionKeys:
       overrides && overrides.hasOwnProperty('skippedPartitionKeys')
         ? overrides.skippedPartitionKeys!
-        : ['aliquam'],
+        : [],
     type:
       overrides && overrides.hasOwnProperty('type')
         ? overrides.type!
@@ -6902,11 +6902,7 @@ export const buildInstigationTick = (
     dynamicPartitionsRequestResults:
       overrides && overrides.hasOwnProperty('dynamicPartitionsRequestResults')
         ? overrides.dynamicPartitionsRequestResults!
-        : [
-            relationshipsToOmit.has('DynamicPartitionsRequestResult')
-              ? ({} as DynamicPartitionsRequestResult)
-              : buildDynamicPartitionsRequestResult({}, relationshipsToOmit),
-          ],
+        : [],
     error:
       overrides && overrides.hasOwnProperty('error')
         ? overrides.error!

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1068,6 +1068,14 @@ export type DynamicPartitionRequest = {
   type: DynamicPartitionsRequestType;
 };
 
+export type DynamicPartitionsRequestResult = {
+  __typename: 'DynamicPartitionsRequestResult';
+  partitionKeys: Array<Scalars['String']>;
+  partitionsDefName: Scalars['String'];
+  skippedPartitionKeys: Array<Scalars['String']>;
+  type: DynamicPartitionsRequestType;
+};
+
 export enum DynamicPartitionsRequestType {
   ADD_PARTITIONS = 'ADD_PARTITIONS',
   DELETE_PARTITIONS = 'DELETE_PARTITIONS',
@@ -1684,6 +1692,7 @@ export enum InstigationStatus {
 export type InstigationTick = {
   __typename: 'InstigationTick';
   cursor: Maybe<Scalars['String']>;
+  dynamicPartitionsRequestResults: Array<DynamicPartitionsRequestResult>;
   error: Maybe<PythonError>;
   id: Scalars['ID'];
   logEvents: InstigationEventConnection;
@@ -5627,6 +5636,31 @@ export const buildDynamicPartitionRequest = (
   };
 };
 
+export const buildDynamicPartitionsRequestResult = (
+  overrides?: Partial<DynamicPartitionsRequestResult>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'DynamicPartitionsRequestResult'} & DynamicPartitionsRequestResult => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('DynamicPartitionsRequestResult');
+  return {
+    __typename: 'DynamicPartitionsRequestResult',
+    partitionKeys:
+      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : ['non'],
+    partitionsDefName:
+      overrides && overrides.hasOwnProperty('partitionsDefName')
+        ? overrides.partitionsDefName!
+        : 'necessitatibus',
+    skippedPartitionKeys:
+      overrides && overrides.hasOwnProperty('skippedPartitionKeys')
+        ? overrides.skippedPartitionKeys!
+        : ['aliquam'],
+    type:
+      overrides && overrides.hasOwnProperty('type')
+        ? overrides.type!
+        : DynamicPartitionsRequestType.ADD_PARTITIONS,
+  };
+};
+
 export const buildEngineEvent = (
   overrides?: Partial<EngineEvent>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -6865,6 +6899,14 @@ export const buildInstigationTick = (
   return {
     __typename: 'InstigationTick',
     cursor: overrides && overrides.hasOwnProperty('cursor') ? overrides.cursor! : 'voluptatem',
+    dynamicPartitionsRequestResults:
+      overrides && overrides.hasOwnProperty('dynamicPartitionsRequestResults')
+        ? overrides.dynamicPartitionsRequestResults!
+        : [
+            relationshipsToOmit.has('DynamicPartitionsRequestResult')
+              ? ({} as DynamicPartitionsRequestResult)
+              : buildDynamicPartitionsRequestResult({}, relationshipsToOmit),
+          ],
     error:
       overrides && overrides.hasOwnProperty('error')
         ? overrides.error!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -14,8 +14,7 @@ from dagster._core.definitions.schedule_definition import ScheduleExecutionData
 from dagster._core.definitions.selector import ScheduleSelector, SensorSelector
 from dagster._core.definitions.sensor_definition import SensorExecutionData
 from dagster._core.scheduler.instigation import (
-    AddDynamicPartitionsRequestResult,
-    DeleteDynamicPartitionsRequestResult,
+    DynamicPartitionsRequestResult,
     InstigatorState,
     InstigatorTick,
     InstigatorType,
@@ -141,13 +140,40 @@ class GrapheneDynamicPartitionsRequestType(graphene.Enum):
         name = "DynamicPartitionsRequestType"
 
 
-class GrapheneDynamicPartitionsRequest(graphene.ObjectType):
-    # TODO maybe unify this object?
-    # Or at least use some sort of mixin?
+class DynamicPartitionsRequestMixin:
+    # Mixin this class to implement DynamicPartitionsRequest
+    #
+    # Graphene has some strange properties that make it so that you cannot
+    # implement ABCs nor use properties in an overridable way. So the way
+    # the mixin works is that the target classes have to have a method
+    # get_dynamic_partitions_request()
     partitionKeys = graphene.List(graphene.NonNull(graphene.String))
     partitionsDefName = graphene.NonNull(graphene.String)
     type = graphene.NonNull(GrapheneDynamicPartitionsRequestType)
 
+    class Meta:
+        name = "DynamicPartitionRequestMixin"
+
+    def get_dynamic_partitions_request(
+        self,
+    ) -> Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest,]:
+        raise NotImplementedError()
+
+    def resolve_partitionKeys(self, _graphene_info: ResolveInfo):
+        return self.get_dynamic_partitions_request().partition_keys
+
+    def resolve_partitionsDefName(self, _graphene_info: ResolveInfo):
+        return self.get_dynamic_partitions_request().partitions_def_name
+
+    def resolve_type(self, _graphene_info: ResolveInfo):
+        return (
+            GrapheneDynamicPartitionsRequestType.ADD_PARTITIONS
+            if isinstance(self.get_dynamic_partitions_request(), AddDynamicPartitionsRequest)
+            else GrapheneDynamicPartitionsRequestType.DELETE_PARTITIONS
+        )
+
+
+class GrapheneDynamicPartitionsRequest(DynamicPartitionsRequestMixin, graphene.ObjectType):
     class Meta:
         name = "DynamicPartitionRequest"
 
@@ -157,51 +183,46 @@ class GrapheneDynamicPartitionsRequest(graphene.ObjectType):
             AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest
         ],
     ):
-        super().__init__(
-            type=GrapheneDynamicPartitionsRequestType.ADD_PARTITIONS
-            if isinstance(dynamic_partition_request, AddDynamicPartitionsRequest)
-            else GrapheneDynamicPartitionsRequestType.DELETE_PARTITIONS,
-            partitionKeys=dynamic_partition_request.partition_keys,
-            partitionsDefName=dynamic_partition_request.partitions_def_name,
-        )
+        super().__init__()
+        self._dynamic_partitions_request = dynamic_partition_request
+
+    def get_dynamic_partitions_request(
+        self,
+    ) -> Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest,]:
+        return self._dynamic_partitions_request
 
 
-class GrapheneDynamicPartitionsRequestResult(graphene.ObjectType):
+class GrapheneDynamicPartitionsRequestResult(DynamicPartitionsRequestMixin, graphene.ObjectType):
     class Meta:
         name = "DynamicPartitionsRequestResult"
 
-    partitionsDefName = graphene.NonNull(graphene.String)
-    type = graphene.NonNull(GrapheneDynamicPartitionsRequestType)
-    partitionKeys = non_null_list(graphene.String)
     skippedPartitionKeys = non_null_list(graphene.String)
 
-    def __init__(
+    def __init__(self, dynamic_partitions_request_result: DynamicPartitionsRequestResult):
+        super().__init__()
+        self._dynamic_partitions_request_result = dynamic_partitions_request_result
+
+    def get_dynamic_partitions_request(
         self,
-        dynamic_partitions_request_result: Union[
-            AddDynamicPartitionsRequestResult, DeleteDynamicPartitionsRequestResult
-        ],
-    ):
-        if isinstance(dynamic_partitions_request_result, AddDynamicPartitionsRequestResult):
-            request_type = GrapheneDynamicPartitionsRequestType.ADD_PARTITIONS
-            partition_keys = dynamic_partitions_request_result.added_partitions
+    ) -> Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]:
+        if self._dynamic_partitions_request_result.added_partitions is not None:
+            return AddDynamicPartitionsRequest(
+                partition_keys=self._dynamic_partitions_request_result.added_partitions,
+                partitions_def_name=self._dynamic_partitions_request_result.partitions_def_name,
+            )
+        elif self._dynamic_partitions_request_result.deleted_partitions is not None:
+            return DeleteDynamicPartitionsRequest(
+                partition_keys=self._dynamic_partitions_request_result.deleted_partitions,
+                partitions_def_name=self._dynamic_partitions_request_result.partitions_def_name,
+            )
         else:
-            if not isinstance(
-                dynamic_partitions_request_result, DeleteDynamicPartitionsRequestResult
-            ):
-                check.failed(
-                    "Unexpected dynamic_partitions_request_result type"
-                    f" {dynamic_partitions_request_result}"
-                )
+            check.failed(
+                "Unexpected dynamic_partitions_request_result"
+                f" {self._dynamic_partitions_request_result}"
+            )
 
-            request_type = GrapheneDynamicPartitionsRequestType.DELETE_PARTITIONS
-            partition_keys = dynamic_partitions_request_result.deleted_partitions
-
-        super().__init__(
-            type=request_type,
-            partitionKeys=partition_keys,
-            partitionsDefName=dynamic_partitions_request_result.partitions_def_name,
-            skippedPartitionKeys=dynamic_partitions_request_result.skipped_partitions,
-        )
+    def resolve_skippedPartitionKeys(self, _graphene_info: ResolveInfo):
+        return self._dynamic_partitions_request_result.skipped_partitions
 
 
 class GrapheneInstigationTick(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1129,8 +1129,12 @@ def define_sensors():
         yield SensorResult(
             run_requests=[RunRequest(partition_key="new_key")],
             dynamic_partitions_requests=[
-                DynamicPartitionsDefinition(name="foo").build_add_request(["new_key", "new_key2"]),
-                DynamicPartitionsDefinition(name="foo").build_delete_request(["old_key"]),
+                DynamicPartitionsDefinition(name="foo").build_add_request(
+                    ["new_key", "new_key2", "existent_key"]
+                ),
+                DynamicPartitionsDefinition(name="foo").build_delete_request(
+                    ["old_key", "nonexistent_key"]
+                ),
             ],
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -493,13 +493,17 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
         assert evaluation_result["dynamicPartitionsRequests"][0]["partitionKeys"] == [
             "new_key",
             "new_key2",
+            "existent_key",
         ]
         assert evaluation_result["dynamicPartitionsRequests"][0]["partitionsDefName"] == "foo"
         assert (
             evaluation_result["dynamicPartitionsRequests"][0]["type"]
             == GrapheneDynamicPartitionsRequestType.ADD_PARTITIONS
         )
-        assert evaluation_result["dynamicPartitionsRequests"][1]["partitionKeys"] == ["old_key"]
+        assert evaluation_result["dynamicPartitionsRequests"][1]["partitionKeys"] == [
+            "old_key",
+            "nonexistent_key",
+        ]
         assert evaluation_result["dynamicPartitionsRequests"][1]["partitionsDefName"] == "foo"
         assert (
             evaluation_result["dynamicPartitionsRequests"][1]["type"]

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -359,6 +359,12 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     def is_success(self) -> bool:
         return self.tick_data.status == TickStatus.SUCCESS
 
+    @property
+    def dynamic_partitions_request_results(
+        self,
+    ) -> Sequence[Union[AddDynamicPartitionsRequestResult, DeleteDynamicPartitionsRequestResult]]:
+        return self.tick_data.dynamic_partitions_request_results
+
 
 @whitelist_for_serdes(
     old_storage_names={"JobTickData"},

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -362,7 +362,7 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     @property
     def dynamic_partitions_request_results(
         self,
-    ) -> Sequence[Union[AddDynamicPartitionsRequestResult, DeleteDynamicPartitionsRequestResult]]:
+    ) -> Sequence[DynamicPartitionsRequestResult]:
         return self.tick_data.dynamic_partitions_request_results
 
 


### PR DESCRIPTION
Part 1: https://github.com/dagster-io/dagster/pull/13996
Part 2: https://github.com/dagster-io/dagster/pull/13997

This PR adds a resolver to `InstigationTick` that returns the evaluated dynamic partitions requests in the sensor. This enables displaying the evaluated dynamic partitions requests in Dagit.

Addresses the backend portion of https://github.com/dagster-io/dagster/issues/13762