### PR TITLE
Expose `QueuedRunCoordinator`, `SubmitRunContext`, `script_relative_path` as public and clean up docs_snippets imports

### DIFF
--- a/docs/content/guides/dagster/run-attribution.mdx
+++ b/docs/content/guides/dagster/run-attribution.mdx
@@ -20,8 +20,7 @@ To accomplish this, we'll use a custom Run Coordinator to read Flask HTTP header
 In this use case, we'd like to add a hook to customize submitted runs while still using a queue to submit runs to the [Dagster Daemon](/deployment/dagster-daemon). To accomplish this, we can use the [Queued Run Coordinator](/deployment/run-coordinator) in the example below. The `context` object available in `submit_run` has a `get_request_header` method we can use to read HTTP headers:
 
 ```python file=/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py startafter=start_custom_run_coordinator_marker endbefore=end_custom_run_coordinator_marker
-from dagster._core.run_coordinator import QueuedRunCoordinator, SubmitRunContext
-from dagster._core.storage.dagster_run import DagsterRun
+from dagster import DagsterRun, QueuedRunCoordinator, SubmitRunContext
 
 
 class CustomRunCoordinator(QueuedRunCoordinator):

--- a/docs/content/integrations/pandas.mdx
+++ b/docs/content/integrations/pandas.mdx
@@ -61,7 +61,7 @@ Once our custom data type is defined, we can use it as the type declaration for 
 @op(out=Out(TripDataFrame))
 def load_trip_dataframe() -> DataFrame:
     return read_csv(
-        script_relative_path("./ebike_trips.csv"),
+        file_relative_path(__file__, "./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
         dtype={"color": "category"},

--- a/examples/docs_snippets/docs_snippets/concepts/logging/logging_jobs.py
+++ b/examples/docs_snippets/docs_snippets/concepts/logging/logging_jobs.py
@@ -1,7 +1,6 @@
 from dagster_aws.cloudwatch.loggers import cloudwatch_logger
 
-from dagster import graph, op, repository
-from dagster._loggers import colored_console_logger
+from dagster import colored_console_logger, graph, op, repository
 
 
 # start_logging_mode_marker_0

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -2,17 +2,16 @@
 
 from dagster import (
     AssetMaterialization,
+    Config,
     DagsterEventType,
     ExpectationResult,
     ExecuteInProcessResult,
-    In,
+    OpExecutionContext,
     Output,
     Out,
     op,
-    Config,
     graph,
 )
-from dagster._core.execution.context.compute import OpExecutionContext
 
 
 class AddOneConfig(Config):

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensor_alert.py
@@ -174,7 +174,7 @@ my_email_sensor(run_status_sensor_context)
 
 # end_run_status_sensor_testing_marker
 
-from dagster._core.definitions.sensor_definition import SensorDefinition
+from dagster import SensorDefinition
 from typing import List
 
 my_jobs: List[SensorDefinition] = []

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py
@@ -1,9 +1,4 @@
-from attr import define
-
 from dagster import asset
-from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
-from dagster._core.execution.context.compute import OpExecutionContext
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_resources.py
@@ -1,7 +1,6 @@
 from typing import Iterator
 
-from dagster import Definitions
-from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster import Definitions, define_asset_job
 
 
 def initial_code_base() -> Definitions:

--- a/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator.py
@@ -3,8 +3,7 @@ from base64 import b64decode
 from json import JSONDecodeError, loads
 from typing import Optional
 
-from dagster._core.run_coordinator import QueuedRunCoordinator, SubmitRunContext
-from dagster._core.storage.dagster_run import DagsterRun
+from dagster import DagsterRun, QueuedRunCoordinator, SubmitRunContext
 
 
 class CustomRunCoordinator(QueuedRunCoordinator):

--- a/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/run_attribution/custom_run_coordinator_skeleton.py
@@ -3,8 +3,7 @@
 CUSTOM_HEADER_NAME = "X-SOME-HEADER"
 # start_custom_run_coordinator_marker
 
-from dagster._core.run_coordinator import QueuedRunCoordinator, SubmitRunContext
-from dagster._core.storage.dagster_run import DagsterRun
+from dagster import DagsterRun, QueuedRunCoordinator, SubmitRunContext
 
 
 class CustomRunCoordinator(QueuedRunCoordinator):

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/core_trip.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from dagster_pandas import PandasColumn, create_dagster_pandas_dataframe_type
 from pandas import DataFrame, read_csv
 
-from dagster import Out, job, op
-from dagster._utils import script_relative_path
+from dagster import Out, file_relative_path, job, op
 
 # start_core_trip_marker_0
 TripDataFrame = create_dagster_pandas_dataframe_type(
@@ -30,7 +29,7 @@ TripDataFrame = create_dagster_pandas_dataframe_type(
 @op(out=Out(TripDataFrame))
 def load_trip_dataframe() -> DataFrame:
     return read_csv(
-        script_relative_path("./ebike_trips.csv"),
+        file_relative_path(__file__, "./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
         dtype={"color": "category"},

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/custom_column_constraint.py
@@ -8,8 +8,7 @@ from dagster_pandas.constraints import (
 )
 from pandas import DataFrame, read_csv
 
-from dagster import Out, job, op
-from dagster._utils import script_relative_path
+from dagster import Out, file_relative_path, job, op
 
 
 # start_custom_col
@@ -51,7 +50,7 @@ CustomTripDataFrame = create_dagster_pandas_dataframe_type(
 @op(out=Out(CustomTripDataFrame))
 def load_custom_trip_dataframe() -> DataFrame:
     return read_csv(
-        script_relative_path("./ebike_trips.csv"),
+        file_relative_path(__file__, "./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
         dtype={"color": "category"},

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/shape_constrained_trip.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from dagster_pandas import RowCountConstraint, create_dagster_pandas_dataframe_type
 from pandas import DataFrame, read_csv
 
-from dagster import Out, job, op
-from dagster._utils import script_relative_path
+from dagster import Out, file_relative_path, job, op
 
 # start_create_type
 ShapeConstrainedTripDataFrame = create_dagster_pandas_dataframe_type(
@@ -16,7 +15,7 @@ ShapeConstrainedTripDataFrame = create_dagster_pandas_dataframe_type(
 @op(out=Out(ShapeConstrainedTripDataFrame))
 def load_shape_constrained_trip_dataframe() -> DataFrame:
     return read_csv(
-        script_relative_path("./ebike_trips.csv"),
+        file_relative_path(__file__, "./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
         dtype={"color": "category"},

--- a/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
+++ b/examples/docs_snippets/docs_snippets/legacy/dagster_pandas_guide/summary_stats.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from dagster_pandas import create_dagster_pandas_dataframe_type
 from pandas import DataFrame, read_csv
 
-from dagster import Out, job, op
-from dagster._utils import script_relative_path
+from dagster import Out, file_relative_path, job, op
 
 
 # start_summary
@@ -28,7 +27,7 @@ SummaryStatsTripDataFrame = create_dagster_pandas_dataframe_type(
 @op(out=Out(SummaryStatsTripDataFrame))
 def load_summary_stats_trip_dataframe() -> DataFrame:
     return read_csv(
-        script_relative_path("./ebike_trips.csv"),
+        file_relative_path(__file__, "./ebike_trips.csv"),
         parse_dates=["start_time", "end_time"],
         date_parser=lambda x: datetime.strptime(x, "%Y-%m-%d %H:%M:%S.%f"),
         dtype={"color": "category"},

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -454,6 +454,10 @@ from dagster._core.instance import DagsterInstance as DagsterInstance
 from dagster._core.instance_for_test import instance_for_test as instance_for_test
 from dagster._core.launcher.default_run_launcher import DefaultRunLauncher as DefaultRunLauncher
 from dagster._core.log_manager import DagsterLogManager as DagsterLogManager
+from dagster._core.run_coordinator.queued_run_coordinator import (
+    QueuedRunCoordinator as QueuedRunCoordinator,
+    SubmitRunContext as SubmitRunContext,
+)
 from dagster._core.storage.asset_value_loader import AssetValueLoader as AssetValueLoader
 from dagster._core.storage.dagster_run import (
     DagsterRun as DagsterRun,
@@ -520,7 +524,9 @@ from dagster._serdes.serdes import (
     deserialize_value as deserialize_value,
     serialize_value as serialize_value,
 )
-from dagster._utils import file_relative_path as file_relative_path
+from dagster._utils import (
+    file_relative_path as file_relative_path,
+)
 from dagster._utils.alert import (
     make_email_on_run_failure_sensor as make_email_on_run_failure_sensor,
 )

--- a/python_modules/dagster/dagster/_core/run_coordinator/base.py
+++ b/python_modules/dagster/dagster/_core/run_coordinator/base.py
@@ -1,18 +1,22 @@
 from abc import ABC, abstractmethod
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
-from dagster._core.workspace.context import IWorkspace, WorkspaceRequestContext
+
+if TYPE_CHECKING:
+    from dagster._core.workspace.context import IWorkspace
 
 
 class SubmitRunContext(NamedTuple):
     """Context available within a run coordinator's submit_run method."""
 
     dagster_run: DagsterRun
-    workspace: IWorkspace
+    workspace: "IWorkspace"
 
     def get_request_header(self, key: str) -> Optional[str]:
+        from dagster._core.workspace.context import WorkspaceRequestContext
+
         # if there is a source
         if isinstance(self.workspace, WorkspaceRequestContext) and self.workspace.source:
             headers = getattr(self.workspace.source, "headers", None)


### PR DESCRIPTION
## Summary & Motivation

Primary goal of this PR was to make sure any dagster imports exposed in our docs snippets are top-level. Ideally we would have a lint-rule enforcing this but I don't think that's possible until ruff supports custom rules.

- Clean up `docs_snippets` imports. Ruff clean up of unused imports is disabled for `docs_snippets`, and import sorting is disabled in many individual files, so there was room for some manual improvement here.
- Make sure any imports appearing in an actual snippet are from top-level `dagster`. This required making some previous private symbols public.
- Make `script_relative_path`, `QueuedRunCoordinator`, and `SubmitRunContext` public (exported from top-level dagster). These were used in our docs snippets.
- Massage some imports in dagster core to make sure that the import changes above didn't lead to importing grpc.

## How I Tested These Changes

Existing test suite.
