### PR TITLE
Unpin acryl-datahub

### DIFF
--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -71,7 +71,7 @@ def datahub_rest_emitter(init_context: InitResourceContext) -> DatahubRestEmitte
                 ),
             }
         ),
-        "topic": Field(str, default_value=DEFAULT_MCE_KAFKA_TOPIC, is_required=False),
+        "topic": Field(str, is_required=False),
         "topic_routes": Field(
             Map(str, str),
             default_value={

--- a/python_modules/libraries/dagster-datahub/dagster_datahub_tests/test_resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub_tests/test_resources.py
@@ -104,7 +104,6 @@ def test_datahub_kafka_emitter_resource_failure():
                             "bootstrap": "foobar:9092",
                             "schema_registry_url": "http://foobar:8081",
                         },
-                        "topic": "NewTopic",
                         "topic_routes": {MCE_KEY: "NewTopic"},
                     }
                 )

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(exclude=["dagster_datahub_tests*"]),
     include_package_data=True,
     install_requires=[
-        "acryl-datahub[datahub-rest, datahub-kafka]<0.8.41.2",
+        "acryl-datahub[datahub-rest, datahub-kafka]",
         f"dagster{pin}",
         "packaging",
         "requests",


### PR DESCRIPTION
Summary:
Current pinned version has a CVE - the main thing keeping us from unpinning seems to have been setting both topics and topic_routes. The former is deprecated, so remove the default value on the former.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
