### PR TITLE
allow filtering by custom result

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
@@ -179,10 +179,13 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
         variables: {tagKeys: tagKey ? [tagKey] : []},
       });
       if (data?.runTagsOrError?.__typename === 'RunTags') {
-        return data?.runTagsOrError.tags[0].values.map((tagValue) =>
-          tagSuggestionValueObject(tagKey, tagValue),
+        return (
+          data?.runTagsOrError.tags?.[0]?.values.map((tagValue) =>
+            tagSuggestionValueObject(tagKey, tagValue),
+          ) || []
         );
       }
+
       return [];
     },
     [client],
@@ -485,6 +488,13 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
         name: 'Tag',
         icon: 'tag',
         initialSuggestions: tagSuggestions,
+
+        freeformSearchResult: React.useCallback((query, path) => {
+          return {
+            ...tagSuggestionValueObject(path.length ? path[0].value : null, query),
+            final: !!path.length,
+          };
+        }, []),
 
         state: React.useMemo(() => {
           return tokens

--- a/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useSuggestionFilter.test.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/__tests__/useSuggestionFilter.test.tsx
@@ -132,4 +132,62 @@ describe('useSuggestionFilter', () => {
       expectedResult,
     );
   });
+
+  it('should handle empty initialSuggestions', () => {
+    const {result} = renderHook(() =>
+      useSuggestionFilter({...hookArgs, initialSuggestions: [], state: [], setState: () => {}}),
+    );
+
+    expect(result.current.getResults('')).toEqual([]);
+  });
+
+  it('should handle empty query', () => {
+    let state: string[] = [];
+    const setState = (newState: string[]) => {
+      state = newState;
+    };
+
+    const {result} = renderHook(() => useSuggestionFilter({...hookArgs, state, setState}));
+
+    expect(result.current.getResults('').map((suggestion) => suggestion.value)).toEqual(
+      initialSuggestions,
+    );
+  });
+
+  it('should handle freeformSearchResult', async () => {
+    let state: string[] = [];
+    const setState = (newState: string[]) => {
+      state = newState;
+    };
+
+    const freeformSearchResult = (query: string) => ({final: true, value: `Custom: ${query}`});
+    const {result} = renderHook(() =>
+      useSuggestionFilter({...hookArgs, freeformSearchResult, state, setState}),
+    );
+
+    const expectedResult = [
+      {final: true, value: 'Custom: test'},
+      ...initialSuggestions.filter(({value}) => isMatch(value, 'test')),
+    ];
+
+    expect(result.current.getResults('test').map((suggestion) => suggestion.value)).toEqual(
+      expectedResult,
+    );
+  });
+
+  it('should handle renderActiveStateLabel', () => {
+    let state: string[] = ['apple'];
+    const setState = (newState: string[]) => {
+      state = newState;
+    };
+
+    const renderActiveStateLabel = ({value, isActive}: {value: string; isActive: boolean}) => (
+      <div>{isActive ? `(${value})` : value}</div>
+    );
+    const {result} = renderHook(() =>
+      useSuggestionFilter({...hookArgs, renderActiveStateLabel, state, setState}),
+    );
+
+    expect(result.current.activeJSX).toBeTruthy();
+  });
 });

--- a/js_modules/dagit/packages/core/src/ui/Filters/useFilter.tsx
+++ b/js_modules/dagit/packages/core/src/ui/Filters/useFilter.tsx
@@ -4,14 +4,14 @@ import styled from 'styled-components/macro';
 
 import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
 
-export type FilterObject = {
+export type FilterObject<T = any> = {
   isActive: boolean;
   activeJSX: JSX.Element;
   icon: IconName;
   name: string;
   getResults: (query: string) => {label: JSX.Element; key: string; value: any}[];
   onSelect: (selectArg: {
-    value: any;
+    value: T;
     close: () => void;
     createPortal: (element: JSX.Element) => () => void;
     clearSearch: () => void;


### PR DESCRIPTION
## Summary & Motivation

Problem:
For some customers the query to fetch all tag keys or all tag values for a particular key might time out. When this happens we don't show any results for the tag key / values effectively making it impossible to filter by tag.

Solution:
As users type into the filter search bar, we automatically create a search result entry for the value they typed so that they can select it.

## How I Tested These Changes

jest

https://www.loom.com/share/db36cd7406ad4ad28ea06f6b96e97a4f
