### PR TITLE
split external url for compute logs into stdout/stderr, put under test

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -44,6 +44,8 @@ class S3ComputeLogManager(BaseModel):
     skipEmptyFiles: Optional[bool]
     uploadInterval: Optional[int]
     uploadExtraArgs: Optional[dict]
+    showUrlOnly: Optional[bool]
+    region: Optional[StringSource]
 
 
 class ComputeLogManagerConfig(BaseModel):

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -749,6 +749,8 @@ def test_s3_compute_log_manager(template: HelmTemplate):
     skip_empty_files = True
     upload_interval = 30
     upload_extra_args = {"ACL": "public-read"}
+    show_url_only = True
+    region = "us-west-1"
 
     helm_values = DagsterHelmValues.construct(
         computeLogManager=ComputeLogManager.construct(
@@ -765,6 +767,8 @@ def test_s3_compute_log_manager(template: HelmTemplate):
                     skipEmptyFiles=skip_empty_files,
                     uploadInterval=upload_interval,
                     uploadExtraArgs=upload_extra_args,
+                    showUrlOnly=show_url_only,
+                    region=region,
                 )
             ),
         )
@@ -787,6 +791,8 @@ def test_s3_compute_log_manager(template: HelmTemplate):
         "skip_empty_files": skip_empty_files,
         "upload_interval": upload_interval,
         "upload_extra_args": upload_extra_args,
+        "show_url_only": show_url_only,
+        "region": region,
     }
 
     # Test all config fields in configurable class

--- a/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
+++ b/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
@@ -105,6 +105,14 @@ config:
   {{- if $s3ComputeLogManagerConfig.uploadExtraArgs }}
   upload_extra_args: {{ $s3ComputeLogManagerConfig.uploadExtraArgs | toYaml | nindent 4 }}
   {{- end }}
+
+  {{- if $s3ComputeLogManagerConfig.showUrlOnly }}
+  show_url_only: {{ $s3ComputeLogManagerConfig.showUrlOnly }}
+  {{- end }}
+
+  {{- if $s3ComputeLogManagerConfig.region }}
+  region: {{ $s3ComputeLogManagerConfig.region }}
+  {{- end }}
 {{- end }}
 
 {{- define "dagsterYaml.computeLogManager.custom" }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1486,6 +1486,31 @@
                             "type": "null"
                         }
                     ]
+                },
+                "showUrlOnly": {
+                    "title": "Showurlonly",
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "region": {
+                    "title": "Region",
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -1071,10 +1071,12 @@ type LogsCapturedEvent implements MessageEvent {
   solidHandleID: String
   eventType: DagsterEventType
   fileKey: String!
-  logKey: String!
   stepKeys: [String!]
   externalUrl: String
+  externalStdoutUrl: String
+  externalStderrUrl: String
   pid: Int
+  logKey: String!
 }
 
 type AlertStartEvent implements MessageEvent & RunEvent {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -1978,6 +1978,8 @@ export type Logger = {
 export type LogsCapturedEvent = MessageEvent & {
   __typename: 'LogsCapturedEvent';
   eventType: Maybe<DagsterEventType>;
+  externalStderrUrl: Maybe<Scalars['String']>;
+  externalStdoutUrl: Maybe<Scalars['String']>;
   externalUrl: Maybe<Scalars['String']>;
   fileKey: Scalars['String'];
   level: LogLevel;
@@ -7973,6 +7975,14 @@ export const buildLogsCapturedEvent = (
       overrides && overrides.hasOwnProperty('eventType')
         ? overrides.eventType!
         : DagsterEventType.ALERT_FAILURE,
+    externalStderrUrl:
+      overrides && overrides.hasOwnProperty('externalStderrUrl')
+        ? overrides.externalStderrUrl!
+        : 'velit',
+    externalStdoutUrl:
+      overrides && overrides.hasOwnProperty('externalStdoutUrl')
+        ? overrides.externalStdoutUrl!
+        : 'consequatur',
     externalUrl:
       overrides && overrides.hasOwnProperty('externalUrl') ? overrides.externalUrl! : 'qui',
     fileKey: overrides && overrides.hasOwnProperty('fileKey') ? overrides.fileKey! : 'et',

--- a/js_modules/dagit/packages/core/src/runs/CapturedLogPanel.tsx
+++ b/js_modules/dagit/packages/core/src/runs/CapturedLogPanel.tsx
@@ -6,6 +6,7 @@ import {AppContext} from '../app/AppContext';
 import {WebSocketContext} from '../app/WebSocketProvider';
 
 import {RawLogContent} from './RawLogContent';
+import {ILogCaptureInfo} from './RunMetadataProvider';
 import {
   CapturedLogFragment,
   CapturedLogsMetadataQuery,
@@ -23,11 +24,16 @@ interface CapturedLogProps {
 }
 
 interface CapturedOrExternalLogPanelProps extends CapturedLogProps {
-  externalUrl?: string;
+  logCaptureInfo?: ILogCaptureInfo;
 }
 
 export const CapturedOrExternalLogPanel: React.FC<CapturedOrExternalLogPanelProps> = React.memo(
-  ({externalUrl, ...props}) => {
+  ({logCaptureInfo, ...props}) => {
+    const externalUrl =
+      logCaptureInfo &&
+      (props.visibleIOType === 'stdout'
+        ? logCaptureInfo.externalStdoutUrl
+        : logCaptureInfo.externalStderrUrl);
     if (externalUrl) {
       return (
         <Box

--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -185,6 +185,8 @@ export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
       fileKey
       stepKeys
       externalUrl
+      externalStdoutUrl
+      externalStderrUrl
     }
   }
 

--- a/js_modules/dagit/packages/core/src/runs/Run.tsx
+++ b/js_modules/dagit/packages/core/src/runs/Run.tsx
@@ -354,7 +354,7 @@ const RunWithData: React.FC<RunWithDataProps> = ({
                 supportsCapturedLogs ? (
                   <CapturedOrExternalLogPanel
                     logKey={computeLogFileKey ? [runId, 'compute_logs', computeLogFileKey] : []}
-                    externalUrl={logCaptureInfo?.externalUrl}
+                    logCaptureInfo={logCaptureInfo}
                     visibleIOType={LogType[logType]}
                     onSetDownloadUrl={setComputeLogUrl}
                   />

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -64,7 +64,8 @@ export interface ILogCaptureInfo {
   fileKey: string;
   stepKeys: string[];
   pid?: string;
-  externalUrl?: string;
+  externalStdoutUrl?: string;
+  externalStderrUrl?: string;
 }
 
 export interface IRunMetadataDict {
@@ -253,7 +254,8 @@ export function extractMetadataFromLogs(
         fileKey: log.fileKey,
         stepKeys: log.stepKeys || [],
         pid: String(log.pid),
-        externalUrl: log.externalUrl || undefined,
+        externalStdoutUrl: log.externalStdoutUrl || undefined,
+        externalStderrUrl: log.externalStderrUrl || undefined,
       };
     }
 
@@ -378,7 +380,8 @@ export const RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT = gql`
       fileKey
       stepKeys
       pid
-      externalUrl
+      externalStdoutUrl
+      externalStderrUrl
     }
   }
 

--- a/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsProvider.types.ts
@@ -1145,8 +1145,10 @@ export type PipelineRunLogsSubscription = {
               fileKey: string;
               stepKeys: Array<string> | null;
               pid: number | null;
-              externalUrl: string | null;
+              externalStdoutUrl: string | null;
+              externalStderrUrl: string | null;
               eventType: Types.DagsterEventType | null;
+              externalUrl: string | null;
             }
           | {
               __typename: 'MaterializationEvent';
@@ -3575,8 +3577,10 @@ export type RunLogsSubscriptionSuccessFragment = {
         fileKey: string;
         stepKeys: Array<string> | null;
         pid: number | null;
-        externalUrl: string | null;
+        externalStdoutUrl: string | null;
+        externalStderrUrl: string | null;
         eventType: Types.DagsterEventType | null;
+        externalUrl: string | null;
       }
     | {
         __typename: 'MaterializationEvent';
@@ -6011,8 +6015,10 @@ export type RunLogsQuery = {
               fileKey: string;
               stepKeys: Array<string> | null;
               pid: number | null;
-              externalUrl: string | null;
+              externalStdoutUrl: string | null;
+              externalStderrUrl: string | null;
               eventType: Types.DagsterEventType | null;
+              externalUrl: string | null;
             }
           | {
               __typename: 'MaterializationEvent';

--- a/js_modules/dagit/packages/core/src/runs/types/LogsRow.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsRow.types.ts
@@ -993,6 +993,8 @@ export type LogsRowStructuredFragment_LogsCapturedEvent_ = {
   fileKey: string;
   stepKeys: Array<string> | null;
   externalUrl: string | null;
+  externalStdoutUrl: string | null;
+  externalStderrUrl: string | null;
 };
 
 export type LogsRowStructuredFragment_MaterializationEvent_ = {

--- a/js_modules/dagit/packages/core/src/runs/types/LogsScrollingTable.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/LogsScrollingTable.types.ts
@@ -993,6 +993,8 @@ export type LogsScrollingTableMessageFragment_LogsCapturedEvent_ = {
   fileKey: string;
   stepKeys: Array<string> | null;
   externalUrl: string | null;
+  externalStdoutUrl: string | null;
+  externalStderrUrl: string | null;
 };
 
 export type LogsScrollingTableMessageFragment_MaterializationEvent_ = {

--- a/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunFragments.types.ts
@@ -1048,8 +1048,10 @@ export type RunDagsterRunEventFragment_LogsCapturedEvent_ = {
   fileKey: string;
   stepKeys: Array<string> | null;
   pid: number | null;
-  externalUrl: string | null;
+  externalStdoutUrl: string | null;
+  externalStderrUrl: string | null;
   eventType: Types.DagsterEventType | null;
+  externalUrl: string | null;
 };
 
 export type RunDagsterRunEventFragment_MaterializationEvent_ = {

--- a/js_modules/dagit/packages/core/src/runs/types/RunMetadataProvider.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunMetadataProvider.types.ts
@@ -145,7 +145,8 @@ export type RunMetadataProviderMessageFragment_LogsCapturedEvent_ = {
   fileKey: string;
   stepKeys: Array<string> | null;
   pid: number | null;
-  externalUrl: string | null;
+  externalStdoutUrl: string | null;
+  externalStderrUrl: string | null;
 };
 
 export type RunMetadataProviderMessageFragment_MaterializationEvent_ = {

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -369,6 +369,8 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
             logKey=data.file_key,
             stepKeys=data.step_keys,
             externalUrl=data.external_url,
+            externalStdoutUrl=data.external_stdout_url or data.external_url,
+            externalStderrUrl=data.external_stderr_url or data.external_url,
             pid=dagster_event.pid,
             **basic_params,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -297,12 +297,14 @@ class GrapheneLogsCapturedEvent(graphene.ObjectType):
         name = "LogsCapturedEvent"
 
     fileKey = graphene.NonNull(graphene.String)
+    stepKeys = graphene.List(graphene.NonNull(graphene.String))
+    externalUrl = graphene.String()
+    externalStdoutUrl = graphene.String()
+    externalStderrUrl = graphene.String()
+    pid = graphene.Int()
     # legacy name for compute log file key... required for back-compat reasons, but has been
     # renamed to fileKey for newer versions of dagit
     logKey = graphene.NonNull(graphene.String)
-    stepKeys = graphene.List(graphene.NonNull(graphene.String))
-    externalUrl = graphene.String()
-    pid = graphene.Int()
 
 
 def _construct_asset_event_metadata_params(event, metadata):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
@@ -28,6 +28,28 @@ CAPTURED_LOGS_SUBSCRIPTION = """
   }
 """
 
+CAPTURED_LOGS_EVENT_QUERY = """
+  query CapturedLogsEventQuery($runId: ID!) {
+    runOrError(runId: $runId) {
+      __typename
+      ... on Run {
+        eventConnection {
+          events {
+            ... on LogsCapturedEvent {
+              message
+              timestamp
+              fileKey
+              stepKeys
+              externalStdoutUrl
+              externalStderrUrl
+            }
+          }
+        }
+      }
+    }
+  }
+"""
+
 
 class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
     def test_get_captured_logs_over_graphql(self, graphql_context):
@@ -72,3 +94,19 @@ class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
         assert len(results) == 1
         stdout = results[0].data["capturedLogs"]["stdout"]
         assert stdout == "HELLO WORLD\n"
+
+    def test_captured_logs_event_graphql(self, graphql_context):
+        selector = infer_pipeline_selector(graphql_context, "spew_job")
+        payload = sync_execute_get_run_log_data(
+            context=graphql_context,
+            variables={"executionParams": {"selector": selector, "mode": "default"}},
+        )
+        run_id = payload["run"]["runId"]
+        result = execute_dagster_graphql(
+            graphql_context,
+            CAPTURED_LOGS_EVENT_QUERY,
+            variables={"runId": run_id},
+        )
+        assert result.data["runOrError"]["__typename"] == "Run"
+        events = result.data["runOrError"]["eventConnection"]["events"]
+        assert len(events) > 0

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1359,7 +1359,11 @@ class DagsterEvent(
             job_context,
             message=f"Started capturing logs in process (pid: {os.getpid()}).",
             event_specific_data=ComputeLogsCaptureData(
-                step_keys=step_keys, file_key=file_key, external_url=log_context.external_url
+                step_keys=step_keys,
+                file_key=file_key,
+                external_stdout_url=log_context.external_stdout_url,
+                external_stderr_url=log_context.external_stderr_url,
+                external_url=log_context.external_url,
             ),
         )
 
@@ -1687,15 +1691,26 @@ class ComputeLogsCaptureData(
             ("file_key", str),  # renamed log_key => file_key to avoid confusion
             ("step_keys", Sequence[str]),
             ("external_url", Optional[str]),
+            ("external_stdout_url", Optional[str]),
+            ("external_stderr_url", Optional[str]),
         ],
     )
 ):
-    def __new__(cls, file_key: str, step_keys: Sequence[str], external_url: Optional[str] = None):
+    def __new__(
+        cls,
+        file_key: str,
+        step_keys: Sequence[str],
+        external_url: Optional[str] = None,
+        external_stdout_url: Optional[str] = None,
+        external_stderr_url: Optional[str] = None,
+    ):
         return super(ComputeLogsCaptureData, cls).__new__(
             cls,
             file_key=check.str_param(file_key, "file_key"),
             step_keys=check.opt_list_param(step_keys, "step_keys", of_type=str),
             external_url=check.opt_str_param(external_url, "external_url"),
+            external_stdout_url=check.opt_str_param(external_stdout_url, "external_stdout_url"),
+            external_stderr_url=check.opt_str_param(external_stderr_url, "external_stderr_url"),
         )
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -1,8 +1,17 @@
+import sys
 import tempfile
+from contextlib import contextmanager
+from typing import Any, Generator, Mapping, Sequence
 
 import pytest
+from dagster import job, op
+from dagster._core.events import DagsterEventType
+from dagster._core.storage.captured_log_manager import CapturedLogContext
 from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
+from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster._core.test_utils import instance_for_test
+from dagster._serdes import ConfigurableClassData
+from typing_extensions import Self
 
 from .utils.captured_log_manager import TestCapturedLogManager
 
@@ -20,3 +29,61 @@ class TestLocalCapturedLogManager(TestCapturedLogManager):
     def captured_log_manager(self):
         with tempfile.TemporaryDirectory() as tmpdir_path:
             return LocalComputeLogManager(tmpdir_path)
+
+
+class ExternalTestComputeLogManager(NoOpComputeLogManager):
+    """Test compute log manager that does not actually capture logs, but generates an external url
+    to be shown within Dagit
+    .
+    """
+
+    @classmethod
+    def from_config_value(
+        cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
+    ) -> Self:
+        return ExternalTestComputeLogManager(inst_data=inst_data, **config_value)
+
+    def enabled(self, _dagster_run, _step_key):
+        return True
+
+    @contextmanager
+    def capture_logs(self, log_key: Sequence[str]) -> Generator[CapturedLogContext, None, None]:
+        yield CapturedLogContext(
+            log_key=log_key,
+            external_stdout_url="https://fake.com/stdout",
+            external_stderr_url="https://fake.com/stderr",
+        )
+
+
+def test_external_captured_log_manager():
+    @op
+    def my_op():
+        print("hello out")  # noqa: T201
+        print("hello error", file=sys.stderr)  # noqa: T201
+
+    @job
+    def my_job():
+        my_op()
+
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster_tests.storage_tests.test_captured_log_manager",
+                "class": "ExternalTestComputeLogManager",
+            },
+        },
+    ) as instance:
+        result = my_job.execute_in_process(instance=instance)
+        assert result.success
+        assert result.run_id
+        captured_log_entries = instance.all_logs(
+            result.run_id, of_type=DagsterEventType.LOGS_CAPTURED
+        )
+        assert len(captured_log_entries) == 1
+        entry = captured_log_entries[0]
+        assert (
+            entry.dagster_event.logs_captured_data.external_stdout_url == "https://fake.com/stdout"
+        )
+        assert (
+            entry.dagster_event.logs_captured_data.external_stderr_url == "https://fake.com/stderr"
+        )

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -210,9 +210,11 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
 
         s3_key = self._s3_key(log_key, io_type, partial=partial)
         with open(path, "rb") as data:
-            self._s3_session.upload_fileobj(
-                data, self._s3_bucket, s3_key, ExtraArgs=self._upload_extra_args
-            )
+            extra_args = {
+                "ContentType": "text/plain",
+                **(self._upload_extra_args if self._upload_extra_args else {}),
+            }
+            self._s3_session.upload_fileobj(data, self._s3_bucket, s3_key, ExtraArgs=extra_args)
 
     def download_from_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial=False

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -248,9 +248,10 @@ def test_external_compute_log_manager(mock_s3_bucket):
         overrides={
             "compute_logs": {
                 "module": "dagster_aws.s3.compute_log_manager",
-                "class": "ExternalS3ComputeLogManager",
+                "class": "S3ComputeLogManager",
                 "config": {
                     "bucket": mock_s3_bucket.name,
+                    "show_url_only": True,
                 },
             },
         },

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -13,7 +13,7 @@ from dagster._core.storage.event_log import SqliteEventLogStorage
 from dagster._core.storage.local_compute_log_manager import IO_TYPE_EXTENSION
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
-from dagster._core.test_utils import environ
+from dagster._core.test_utils import environ, instance_for_test
 from dagster_aws.s3 import S3ComputeLogManager
 from dagster_tests.storage_tests.test_captured_log_manager import TestCapturedLogManager
 
@@ -232,3 +232,36 @@ class TestS3ComputeLogManager(TestCapturedLogManager):
             yield S3ComputeLogManager(
                 bucket=mock_s3_bucket.name, prefix="my_prefix", local_dir=temp_dir
             )
+
+
+def test_external_compute_log_manager(mock_s3_bucket):
+    @op
+    def my_op():
+        print("hello out")  # noqa: T201
+        print("hello error", file=sys.stderr)  # noqa: T201
+
+    @job
+    def my_job():
+        my_op()
+
+    with instance_for_test(
+        overrides={
+            "compute_logs": {
+                "module": "dagster_aws.s3.compute_log_manager",
+                "class": "ExternalS3ComputeLogManager",
+                "config": {
+                    "bucket": mock_s3_bucket.name,
+                },
+            },
+        },
+    ) as instance:
+        result = my_job.execute_in_process(instance=instance)
+        assert result.success
+        assert result.run_id
+        captured_log_entries = instance.all_logs(
+            result.run_id, of_type=DagsterEventType.LOGS_CAPTURED
+        )
+        assert len(captured_log_entries) == 1
+        entry = captured_log_entries[0]
+        assert entry.dagster_event.logs_captured_data.external_stdout_url
+        assert entry.dagster_event.logs_captured_data.external_stderr_url


### PR DESCRIPTION
## Summary & Motivation
Allows the compute log manager to specify different external urls for stdout/stderr to be displayed in the compute log panel in Dagit.  Also adds a reference S3 implementation for the `dagster_aws` library.


## How I Tested These Changes
BK, manually saw stdout/stderr urls displayed in compute log panel