### PR TITLE
unpin apache-airflow-spark-provider

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -48,7 +48,7 @@ setup(
             "boto3>=1.26.7",
             "kubernetes>=10.0.1",
             "apache-airflow-providers-docker>=3.2.0,<4",
-            "apache-airflow-providers-apache-spark>=3.0.0,<4",
+            "apache-airflow-providers-apache-spark",
             # Logging messages are set to debug starting 4.1.1
             "apache-airflow-providers-http<4.1.1",
         ],


### PR DESCRIPTION
Summary:
Only used in tests, but the current version has a CVE: https://github.com/dagster-io/dagster/security/dependabot/253

## Summary & Motivation

## How I Tested These Changes
