### PR TITLE
[easy] remove wheel from automation package

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -26,7 +26,6 @@ setup(
         "requests",
         "twine==1.15.0",
         "virtualenv==20.13.2",
-        "wheel==0.33.6",
         "urllib3",
     ],
     extras_require={


### PR DESCRIPTION
Summary:
current pinned version has a CVE and automation no longer used the dep

Test Plan: Bk

## Summary & Motivation

## How I Tested These Changes
