### PR TITLE
Refactor job subset specification

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -506,7 +506,7 @@ def test_runs_over_time():
         foo_run_id = repo_1.get_job("foo_job").execute_in_process(instance=instance).run_id
         evolve_a_run_id = (
             repo_1.get_job("evolving_job")
-            .get_subset(["op_A"])
+            .get_subset(op_selection={"op_A"})
             .execute_in_process(
                 instance=instance,
             )
@@ -514,7 +514,7 @@ def test_runs_over_time():
         )
         evolve_b_run_id = (
             repo_1.get_job("evolving_job")
-            .get_subset(["op_B"])
+            .get_subset(op_selection={"op_B"})
             .execute_in_process(
                 instance=instance,
             )
@@ -596,7 +596,7 @@ def test_run_groups_over_time():
         foo_run_id = repo_1.get_job("foo_job").execute_in_process(instance=instance).run_id
         evolve_a_run_id = (
             repo_1.get_job("evolving_job")
-            .get_subset(["op_A"])
+            .get_subset(op_selection={"op_A"})
             .execute_in_process(
                 instance=instance,
             )
@@ -604,7 +604,7 @@ def test_run_groups_over_time():
         )
         evolve_b_run_id = (
             repo_1.get_job("evolving_job")
-            .get_subset(["op_B"])
+            .get_subset(op_selection={"op_B"})
             .execute_in_process(
                 instance=instance,
             )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -506,7 +506,7 @@ def test_runs_over_time():
         foo_run_id = repo_1.get_job("foo_job").execute_in_process(instance=instance).run_id
         evolve_a_run_id = (
             repo_1.get_job("evolving_job")
-            .get_job_def_for_subset_selection(["op_A"])
+            .get_subset(["op_A"])
             .execute_in_process(
                 instance=instance,
             )
@@ -514,7 +514,7 @@ def test_runs_over_time():
         )
         evolve_b_run_id = (
             repo_1.get_job("evolving_job")
-            .get_job_def_for_subset_selection(["op_B"])
+            .get_subset(["op_B"])
             .execute_in_process(
                 instance=instance,
             )
@@ -596,7 +596,7 @@ def test_run_groups_over_time():
         foo_run_id = repo_1.get_job("foo_job").execute_in_process(instance=instance).run_id
         evolve_a_run_id = (
             repo_1.get_job("evolving_job")
-            .get_job_def_for_subset_selection(["op_A"])
+            .get_subset(["op_A"])
             .execute_in_process(
                 instance=instance,
             )
@@ -604,7 +604,7 @@ def test_run_groups_over_time():
         )
         evolve_b_run_id = (
             repo_1.get_job("evolving_job")
-            .get_job_def_for_subset_selection(["op_B"])
+            .get_subset(["op_B"])
             .execute_in_process(
                 instance=instance,
             )

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -144,8 +144,7 @@ class ReOriginatedReconstructableJobForTest(ReconstructableJob):
             cls,
             reconstructable_job.repository,
             reconstructable_job.job_name,
-            reconstructable_job.solid_selection_str,
-            reconstructable_job.solids_to_execute,
+            reconstructable_job.op_selection,
         )
 
     def get_python_origin(self):

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -419,7 +419,10 @@ def _execute_step_command_body(
         recon_job = (
             recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
             .with_repository_load_data(repository_load_data)
-            .get_subset(dagster_run.solids_to_execute, dagster_run.asset_selection)
+            .get_subset(
+                op_selection=dagster_run.solids_to_execute,
+                asset_selection=dagster_run.asset_selection,
+            )
         )
 
         execution_plan = create_execution_plan(

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -419,9 +419,7 @@ def _execute_step_command_body(
         recon_job = (
             recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
             .with_repository_load_data(repository_load_data)
-            .subset_for_execution_from_existing_job(
-                dagster_run.solids_to_execute, dagster_run.asset_selection
-            )
+            .get_subset(dagster_run.solids_to_execute, dagster_run.asset_selection)
         )
 
         execution_plan = create_execution_plan(

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -586,6 +586,10 @@ class NodeOutput(NamedTuple("_NodeOutput", [("node", Node), ("output_def", Outpu
     def is_dynamic(self) -> bool:
         return self.output_def.is_dynamic
 
+    @property
+    def output_name(self) -> str:
+        return self.output_def.name
+
 
 class DependencyType(Enum):
     DIRECT = "DIRECT"

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -646,7 +646,7 @@ class GraphDefinition(NodeDefinition):
             input_values=input_values,
             _subset_selection_data=_asset_selection_data,
             _was_explicitly_provided_resources=None,  # None means this is determined by whether resource_defs contains any explicitly provided resources
-        ).get_subset(op_selection)
+        ).get_subset(op_selection=op_selection)
 
     def coerce_to_job(self) -> "JobDefinition":
         # attempt to coerce a Graph in to a Job, raising a useful error if it doesn't work
@@ -714,7 +714,7 @@ class GraphDefinition(NodeDefinition):
             executor_def=execute_in_process_executor,
             resource_defs=resource_defs,
             input_values=input_values,
-        ).get_subset(op_selection)
+        ).get_subset(op_selection=op_selection)
 
         run_config = run_config if run_config is not None else {}
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -646,7 +646,7 @@ class GraphDefinition(NodeDefinition):
             input_values=input_values,
             _subset_selection_data=_asset_selection_data,
             _was_explicitly_provided_resources=None,  # None means this is determined by whether resource_defs contains any explicitly provided resources
-        ).get_job_def_for_subset_selection(op_selection)
+        ).get_subset(op_selection)
 
     def coerce_to_job(self) -> "JobDefinition":
         # attempt to coerce a Graph in to a Job, raising a useful error if it doesn't work
@@ -714,7 +714,7 @@ class GraphDefinition(NodeDefinition):
             executor_def=execute_in_process_executor,
             resource_defs=resource_defs,
             input_values=input_values,
-        ).get_job_def_for_subset_selection(op_selection)
+        ).get_subset(op_selection)
 
         run_config = run_config if run_config is not None else {}
         op_selection = check.opt_sequence_param(op_selection, "op_selection", str)

--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence
+from typing import TYPE_CHECKING, AbstractSet, Iterable, Optional, Sequence
 
 from typing_extensions import Self
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
-from dagster._core.errors import DagsterInvalidSubsetError
-from dagster._core.selector import parse_solid_selection
 
 if TYPE_CHECKING:
     from .job_definition import JobDefinition
@@ -24,16 +22,16 @@ class IJob(ABC):
         pass
 
     @abstractmethod
-    def subset_for_execution(
+    def get_subset(
         self,
-        solid_selection: Optional[Sequence[str]] = None,
+        solid_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ) -> "IJob":
         pass
 
     @property
     @abstractmethod
-    def solids_to_execute(self) -> Optional[AbstractSet[str]]:
+    def solid_selection(self) -> Optional[Sequence[str]]:
         pass
 
     @property
@@ -41,109 +39,49 @@ class IJob(ABC):
     def asset_selection(self) -> Optional[AbstractSet[AssetKey]]:
         pass
 
-    @abstractmethod
-    def subset_for_execution_from_existing_job(
-        self,
-        solids_to_execute: Optional[AbstractSet[str]] = None,
-        asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ) -> "IJob":
-        pass
+    @property
+    def solids_to_execute(self) -> Optional[AbstractSet[str]]:
+        return set(self.solid_selection) if self.solid_selection else None
 
 
-class InMemoryJob(IJob, object):
+class InMemoryJob(IJob):
     def __init__(
         self,
         job_def: "JobDefinition",
-        solid_selection: Optional[Sequence[str]] = None,
-        solids_to_execute: Optional[AbstractSet[str]] = None,
+        solid_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ):
         self._job_def = job_def
-        self._solid_selection = solid_selection
-        self._solids_to_execute = solids_to_execute
+        self._solid_selection = list(solid_selection) if solid_selection else None
         self._asset_selection = asset_selection
 
     def get_definition(self) -> "JobDefinition":
         return self._job_def
 
-    def _resolve_op_selection(self, op_selection: Sequence[str]) -> AbstractSet[str]:
-        # resolve a list of op selection queries to a frozenset of qualified op names
-        # e.g. ['foo_op+'] to {'foo_op', 'bar_op'}
-        check.list_param(op_selection, "op_selection", of_type=str)
-        solids_to_execute = parse_solid_selection(self.get_definition(), op_selection)
-        if len(solids_to_execute) == 0:
-            raise DagsterInvalidSubsetError(
-                f"No qualified ops to execute found for op_selection={op_selection}"
-            )
-        return solids_to_execute
-
-    def _subset_for_execution(
+    def get_subset(
         self,
-        solids_to_execute: Optional[AbstractSet[str]],
-        solid_selection: Optional[Sequence[str]] = None,
+        solid_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ) -> Self:
-        if asset_selection:
+        if solid_selection and asset_selection:
+            check.failed(
+                "solid_selection and asset_selection cannot both be provided as arguments",
+            )
+        elif solid_selection:
+            solid_selection = list(solid_selection)
+            return InMemoryJob(self._job_def.get_subset(solid_selection))
+        elif asset_selection:
             return InMemoryJob(
                 self._job_def.get_subset(asset_selection=asset_selection),
                 asset_selection=asset_selection,
             )
-        if self._job_def.is_subset_job:
-            return InMemoryJob(
-                self._job_def.parent_job_def.get_pipeline_subset_def(solids_to_execute),  # type: ignore  # (possible none)
-                solid_selection=solid_selection,
-                solids_to_execute=solids_to_execute,
-            )
-
-        return InMemoryJob(
-            self._job_def.get_pipeline_subset_def(solids_to_execute),  # type: ignore  # (possible none)
-            solid_selection=solid_selection,
-            solids_to_execute=solids_to_execute,
-        )
-
-    def subset_for_execution(
-        self,
-        solid_selection: Optional[Sequence[str]] = None,
-        asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ) -> Self:
-        # take a list of solid queries and resolve the queries to names of solids to execute
-        solid_selection = check.opt_sequence_param(solid_selection, "solid_selection", of_type=str)
-        check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
-
-        check.invariant(
-            not (solid_selection and asset_selection),
-            "solid_selection and asset_selection cannot both be provided as arguments",
-        )
-
-        solids_to_execute = self._resolve_op_selection(solid_selection) if solid_selection else None
-        return self._subset_for_execution(solids_to_execute, solid_selection, asset_selection)
-
-    def subset_for_execution_from_existing_job(
-        self,
-        solids_to_execute: Optional[AbstractSet[str]] = None,
-        asset_selection: Optional[AbstractSet[AssetKey]] = None,
-    ) -> Self:
-        # take a frozenset of resolved solid names from an existing run
-        # so there's no need to parse the selection
-        check.opt_set_param(solids_to_execute, "solids_to_execute", of_type=str)
-        check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
-
-        check.invariant(
-            not (solids_to_execute and asset_selection),
-            "solids_to_execute and asset_selection cannot both be provided as arguments",
-        )
-
-        return self._subset_for_execution(solids_to_execute, asset_selection=asset_selection)
+        else:
+            check.failed("Must provide solid_selection or asset_selection")
 
     @property
     def solid_selection(self) -> Sequence[str]:
         # a list of solid queries provided by the user
         return self._solid_selection  # type: ignore  # (possible none)
-
-    @property
-    def solids_to_execute(self) -> Optional[AbstractSet[str]]:
-        # a frozenset which contains the names of the solids to execute
-        return self._solids_to_execute
 
     @property
     def asset_selection(self) -> Optional[AbstractSet[AssetKey]]:

--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -85,7 +85,7 @@ class InMemoryJob(IJob, object):
     ) -> Self:
         if asset_selection:
             return InMemoryJob(
-                self._job_def.get_job_def_for_subset_selection(asset_selection=asset_selection),
+                self._job_def.get_subset(asset_selection=asset_selection),
                 asset_selection=asset_selection,
             )
         if self._job_def.is_subset_job:

--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -24,14 +24,14 @@ class IJob(ABC):
     @abstractmethod
     def get_subset(
         self,
-        solid_selection: Optional[Iterable[str]] = None,
+        op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ) -> "IJob":
         pass
 
     @property
     @abstractmethod
-    def solid_selection(self) -> Optional[Sequence[str]]:
+    def op_selection(self) -> Optional[Sequence[str]]:
         pass
 
     @property
@@ -41,7 +41,7 @@ class IJob(ABC):
 
     @property
     def solids_to_execute(self) -> Optional[AbstractSet[str]]:
-        return set(self.solid_selection) if self.solid_selection else None
+        return set(self.op_selection) if self.op_selection else None
 
 
 class InMemoryJob(IJob):
@@ -60,16 +60,16 @@ class InMemoryJob(IJob):
 
     def get_subset(
         self,
-        solid_selection: Optional[Iterable[str]] = None,
+        op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ) -> Self:
-        if solid_selection and asset_selection:
+        if op_selection and asset_selection:
             check.failed(
                 "solid_selection and asset_selection cannot both be provided as arguments",
             )
-        elif solid_selection:
-            solid_selection = list(solid_selection)
-            return InMemoryJob(self._job_def.get_subset(solid_selection))
+        elif op_selection:
+            op_selection = list(op_selection)
+            return InMemoryJob(self._job_def.get_subset(op_selection))
         elif asset_selection:
             return InMemoryJob(
                 self._job_def.get_subset(asset_selection=asset_selection),
@@ -79,7 +79,7 @@ class InMemoryJob(IJob):
             check.failed("Must provide solid_selection or asset_selection")
 
     @property
-    def solid_selection(self) -> Sequence[str]:
+    def op_selection(self) -> Sequence[str]:
         # a list of solid queries provided by the user
         return self._solid_selection  # type: ignore  # (possible none)
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -657,7 +657,7 @@ class JobDefinition(IHasInternalInit):
             _was_explicitly_provided_resources=True,
         )
 
-        ephemeral_job = ephemeral_job.get_job_def_for_subset_selection(
+        ephemeral_job = ephemeral_job.get_subset(
             op_selection, frozenset(asset_selection) if asset_selection else None
         )
 
@@ -711,7 +711,7 @@ class JobDefinition(IHasInternalInit):
     def is_subset_job(self) -> bool:
         return bool(self._subset_selection_data)
 
-    def get_job_def_for_subset_selection(
+    def get_subset(
         self,
         op_selection: Optional[Sequence[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -698,7 +698,7 @@ class JobDefinition(IHasInternalInit):
         )
 
     @property
-    def is_subset_job(self) -> bool:
+    def is_subset(self) -> bool:
         return bool(self._subset_selection_data)
 
     def get_subset(
@@ -1207,7 +1207,7 @@ def _create_run_config_schema(
     # from the original job as ignored to allow execution with
     # run config that is valid for the original
     ignored_nodes: Sequence[Node] = []
-    if job_def.is_subset_job:
+    if job_def.is_subset:
         if isinstance(job_def.graph, SubselectedGraphDefinition):  # op selection provided
             ignored_nodes = job_def.graph.get_top_level_omitted_nodes()
         elif job_def.asset_selection_data:

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -15,7 +15,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -27,20 +26,16 @@ from dagster._annotations import public
 from dagster._config import Field, Shape, StringSource
 from dagster._config.config_type import ConfigType
 from dagster._config.validate import validate_config
-from dagster._core.definitions.composition import MappedInputPlaceholder
 from dagster._core.definitions.dependency import (
-    DynamicCollectDependencyDefinition,
-    IDependencyDefinition,
-    MultiDependencyDefinition,
     Node,
     NodeHandle,
     NodeInputHandle,
     NodeInvocation,
-    NodeOutput,
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.op_selection import OpSelection, get_graph_subset
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_requirement import (
@@ -58,9 +53,6 @@ from dagster._core.errors import (
 from dagster._core.selector.subset_selector import (
     AssetSelectionData,
     OpSelectionData,
-    SelectionTreeBranch,
-    SelectionTreeLeaf,
-    parse_op_selection,
 )
 from dagster._core.storage.io_manager import IOManagerDefinition, io_manager
 from dagster._core.storage.tags import MEMOIZED_RUN_TAG
@@ -73,10 +65,8 @@ from dagster._utils.merger import merge_dicts
 from .asset_layer import AssetLayer, build_asset_selection_job
 from .config import ConfigMapping
 from .dependency import (
-    DependencyDefinition,
     DependencyMapping,
     DependencyStructure,
-    GraphNode,
     OpNode,
 )
 from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
@@ -777,10 +767,8 @@ class JobDefinition(IHasInternalInit):
         return new_job
 
     def _get_job_def_for_op_selection(self, op_selection: Sequence[str]) -> Self:
-        resolved_op_selection_dict = parse_op_selection(self, op_selection)
-
         try:
-            sub_graph = get_subselected_graph_definition(self.graph, resolved_op_selection_dict)
+            sub_graph = get_graph_subset(self.graph, op_selection)
 
             # if explicit config was passed the config_mapping that resolves the defaults implicitly is
             # very unlikely to work. The job will still present the default config in dagit.
@@ -795,9 +783,7 @@ class JobDefinition(IHasInternalInit):
                 graph_def=sub_graph,
                 _subset_selection_data=OpSelectionData(
                     op_selection=op_selection,
-                    resolved_op_selection=set(
-                        resolved_op_selection_dict.keys()
-                    ),  # equivalent to solids_to_execute. currently only gets top level nodes.
+                    resolved_op_selection=OpSelection(op_selection).resolve(self.graph),
                     parent_job_def=self,  # used by job snapshot lineage
                 ),
                 # TODO: subset this structure.
@@ -808,8 +794,9 @@ class JobDefinition(IHasInternalInit):
             # This handles the case when you construct a subset such that an unsatisfied
             # input cannot be loaded from config. Instead of throwing a DagsterInvalidDefinitionError,
             # we re-raise a DagsterInvalidSubsetError.
+            node_paths = OpSelection(op_selection).resolve(self.graph)
             raise DagsterInvalidSubsetError(
-                f"The attempted subset {str_format_set(resolved_op_selection_dict)} for graph "
+                f"The attempted subset {str_format_set(node_paths)} for graph "
                 f"{self.graph.name} results in an invalid graph."
             ) from exc
 
@@ -984,112 +971,6 @@ def _swap_default_io_man(resources: Mapping[str, ResourceDefinition], job: JobDe
         return updated_resources
 
     return resources
-
-
-def _dep_key_of(node: Node) -> NodeInvocation:
-    return NodeInvocation(
-        name=node.definition.name,
-        alias=node.name,
-        tags=node.tags,
-        hook_defs=node.hook_defs,
-        retry_policy=node.retry_policy,
-    )
-
-
-def get_subselected_graph_definition(
-    graph: GraphDefinition,
-    resolved_op_selection_dict: SelectionTreeBranch,
-    parent_handle: Optional[NodeHandle] = None,
-) -> SubselectedGraphDefinition:
-    deps: Dict[
-        NodeInvocation,
-        Dict[str, IDependencyDefinition],
-    ] = {}
-
-    selected_nodes: List[Tuple[str, NodeDefinition]] = []
-
-    for node in graph.nodes_in_topological_order:
-        node_handle = NodeHandle(node.name, parent=parent_handle)
-        # skip if the node isn't selected
-        if node.name not in resolved_op_selection_dict:
-            continue
-
-        # rebuild graph if any nodes inside the graph are selected
-        definition: Union[SubselectedGraphDefinition, NodeDefinition]
-        selection_node = resolved_op_selection_dict[node.name]
-        if isinstance(node, GraphNode) and not isinstance(selection_node, SelectionTreeLeaf):
-            definition = get_subselected_graph_definition(
-                node.definition,
-                selection_node,
-                parent_handle=node_handle,
-            )
-        # use definition if the node as a whole is selected. this includes selecting the entire graph
-        else:
-            definition = node.definition
-        selected_nodes.append((node.name, definition))
-
-        # build dependencies for the node. we do it for both cases because nested graphs can have
-        # inputs and outputs too
-        deps[_dep_key_of(node)] = {}
-        for node_input in node.inputs():
-            if graph.dependency_structure.has_direct_dep(node_input):
-                node_output = graph.dependency_structure.get_direct_dep(node_input)
-                if node_output.node.name in resolved_op_selection_dict:
-                    deps[_dep_key_of(node)][node_input.input_def.name] = DependencyDefinition(
-                        node=node_output.node.name, output=node_output.output_def.name
-                    )
-            elif graph.dependency_structure.has_dynamic_fan_in_dep(node_input):
-                node_output = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
-                if node_output.node.name in resolved_op_selection_dict:
-                    deps[_dep_key_of(node)][
-                        node_input.input_def.name
-                    ] = DynamicCollectDependencyDefinition(
-                        node_name=node_output.node.name,
-                        output_name=node_output.output_def.name,
-                    )
-            elif graph.dependency_structure.has_fan_in_deps(node_input):
-                outputs = graph.dependency_structure.get_fan_in_deps(node_input)
-                multi_dependencies = [
-                    DependencyDefinition(
-                        node=output_handle.node.name, output=output_handle.output_def.name
-                    )
-                    for output_handle in outputs
-                    if (
-                        isinstance(output_handle, NodeOutput)
-                        and output_handle.node.name in resolved_op_selection_dict
-                    )
-                ]
-                deps[_dep_key_of(node)][node_input.input_def.name] = MultiDependencyDefinition(
-                    cast(
-                        List[Union[DependencyDefinition, Type[MappedInputPlaceholder]]],
-                        multi_dependencies,
-                    )
-                )
-            # else input is unconnected
-
-    # filter out unselected input/output mapping
-    new_input_mappings = list(
-        filter(
-            lambda input_mapping: input_mapping.maps_to.node_name
-            in [name for name, _ in selected_nodes],
-            graph._input_mappings,  # noqa: SLF001
-        )
-    )
-    new_output_mappings = list(
-        filter(
-            lambda output_mapping: output_mapping.maps_from.node_name
-            in [name for name, _ in selected_nodes],
-            graph._output_mappings,  # noqa: SLF001
-        )
-    )
-
-    return SubselectedGraphDefinition(
-        parent_graph_def=graph,
-        dependencies=deps,
-        node_defs=[definition for _, definition in selected_nodes],
-        input_mappings=new_input_mappings,
-        output_mappings=new_output_mappings,
-    )
 
 
 @io_manager(

--- a/python_modules/dagster/dagster/_core/definitions/op_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_selection.py
@@ -31,7 +31,7 @@ from dagster._core.selector.subset_selector import parse_op_queries
 
 
 class OpSelection:
-    def __init__(self, query: Sequence[str]):
+    def __init__(self, query: Iterable[str]):
         self.query = query
 
     def resolve(self, graph_def: GraphDefinition) -> AbstractSet[str]:
@@ -40,7 +40,7 @@ class OpSelection:
             _validate_node_paths(resolved_node_paths, graph_def)
         else:
             # validation happens inside parse_op_queries
-            resolved_node_paths = set(parse_op_queries(graph_def, self.query))
+            resolved_node_paths = set(parse_op_queries(graph_def, list(self.query)))
         return resolved_node_paths
 
 
@@ -96,7 +96,7 @@ def _validate_selection_tree(selection_tree: OpSelectionNode, graph_def: GraphDe
 
 def get_graph_subset(
     graph: GraphDefinition,
-    op_selection: Sequence[str],
+    op_selection: Iterable[str],
 ) -> SubselectedGraphDefinition:
     node_paths = OpSelection(op_selection).resolve(graph)
     selection_tree = _node_paths_to_tree(node_paths)

--- a/python_modules/dagster/dagster/_core/definitions/op_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_selection.py
@@ -1,0 +1,195 @@
+import itertools
+from typing import (
+    AbstractSet,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from dagster._core.definitions.composition import MappedInputPlaceholder
+from dagster._core.definitions.dependency import (
+    DependencyDefinition,
+    DynamicCollectDependencyDefinition,
+    GraphNode,
+    IDependencyDefinition,
+    MultiDependencyDefinition,
+    NodeHandle,
+    NodeInvocation,
+    NodeOutput,
+)
+from dagster._core.definitions.graph_definition import GraphDefinition, SubselectedGraphDefinition
+from dagster._core.definitions.node_definition import NodeDefinition
+from dagster._core.errors import DagsterInvalidSubsetError
+from dagster._core.selector.subset_selector import parse_op_queries
+
+
+class OpSelection:
+    def __init__(self, query: Sequence[str]):
+        self.query = query
+
+    def resolve(self, graph_def: GraphDefinition) -> AbstractSet[str]:
+        if any(["." in item for item in self.query]):
+            resolved_node_paths = set(self.query)
+            _validate_node_paths(resolved_node_paths, graph_def)
+        else:
+            # validation happens inside parse_op_queries
+            resolved_node_paths = set(parse_op_queries(graph_def, self.query))
+        return resolved_node_paths
+
+
+class OpSelectionNode(NamedTuple):
+    name: str
+    children: List["OpSelectionNode"]
+
+    @property
+    def is_leaf(self) -> bool:
+        return not self.children
+
+    def has_child(self, name: str) -> bool:
+        return any(child.name == name for child in self.children)
+
+    def get_child(self, name: str) -> "OpSelectionNode":
+        return next(child for child in self.children if child.name == name)
+
+
+def _validate_node_paths(node_paths: Iterable[str], graph_def: GraphDefinition) -> None:
+    selection_tree = _node_paths_to_tree(node_paths)
+    _validate_selection_tree(selection_tree, graph_def)
+
+
+def _node_paths_to_tree(node_paths: Iterable[str]) -> OpSelectionNode:
+    node_path_lists = sorted([tuple(path.split(".")) for path in node_paths])
+    return _node_path_lists_to_tree(node_path_lists)
+
+
+def _node_path_lists_to_tree(paths: Sequence[Tuple[str, ...]]) -> OpSelectionNode:
+    root = OpSelectionNode("ROOT", [])
+    for k, group in itertools.groupby(paths, lambda x: x[0]):
+        child = _node_path_lists_to_tree([x[1:] for x in group if len(x) > 1])._replace(name=k)
+        root.children.append(child)
+    return root
+
+
+def _validate_selection_tree(selection_tree: OpSelectionNode, graph_def: GraphDefinition) -> None:
+    for selection_child in selection_tree.children:
+        node_name = selection_child.name
+        if not graph_def.has_node_named(node_name):
+            raise DagsterInvalidSubsetError(
+                f"Node {node_name} was selected, but no node named {node_name} was found."
+            )
+        if not selection_child.is_leaf:
+            graph_child = graph_def.node_named(node_name)
+            if isinstance(graph_child, GraphNode):
+                _validate_selection_tree(selection_child, graph_child.definition)
+            else:
+                raise DagsterInvalidSubsetError(
+                    f"Children of node {node_name} were selected, but {node_name} is not a graph."
+                )
+
+
+def get_graph_subset(
+    graph: GraphDefinition,
+    op_selection: Sequence[str],
+) -> SubselectedGraphDefinition:
+    node_paths = OpSelection(op_selection).resolve(graph)
+    selection_tree = _node_paths_to_tree(node_paths)
+    return _get_graph_subset(graph, selection_tree, parent_handle=None)
+
+
+def _get_graph_subset(
+    graph: GraphDefinition, selection_tree: OpSelectionNode, parent_handle: Optional[NodeHandle]
+) -> SubselectedGraphDefinition:
+    subgraph_deps: Dict[
+        NodeInvocation,
+        Dict[str, IDependencyDefinition],
+    ] = {}
+
+    subgraph_nodes: Dict[str, NodeDefinition] = {}
+
+    for node in graph.nodes_in_topological_order:
+        # skip if the node isn't selected
+        if not selection_tree.has_child(node.name):
+            continue
+
+        node_handle = NodeHandle(node.name, parent=parent_handle)
+        node_def: Union[SubselectedGraphDefinition, NodeDefinition] = node.definition
+        node_selection_tree = selection_tree.get_child(node.name)
+
+        # subselect graph if any nodes inside the graph are selected
+        if isinstance(node, GraphNode) and not node_selection_tree.is_leaf:
+            node_def = _get_graph_subset(
+                node.definition,
+                node_selection_tree,
+                parent_handle=node_handle,
+            )
+
+        subgraph_nodes[node.name] = node_def
+
+        # build dependencies for the node. we do it for both cases because nested graphs can have
+        # inputs and outputs too
+        node_deps: Dict[str, IDependencyDefinition] = {}
+        for node_input in node.inputs():
+            if graph.dependency_structure.has_direct_dep(node_input):
+                node_output = graph.dependency_structure.get_direct_dep(node_input)
+                if selection_tree.has_child(node_output.node_name):
+                    node_deps[node_input.input_name] = DependencyDefinition(
+                        node=node_output.node.name, output=node_output.output_name
+                    )
+            elif graph.dependency_structure.has_dynamic_fan_in_dep(node_input):
+                node_output = graph.dependency_structure.get_dynamic_fan_in_dep(node_input)
+                if selection_tree.has_child(node_output.node_name):
+                    node_deps[node_input.input_name] = DynamicCollectDependencyDefinition(
+                        node_name=node_output.node_name,
+                        output_name=node_output.output_name,
+                    )
+            elif graph.dependency_structure.has_fan_in_deps(node_input):
+                outputs = graph.dependency_structure.get_fan_in_deps(node_input)
+                multi_dependencies = [
+                    DependencyDefinition(
+                        node=output_handle.node.name, output=output_handle.output_def.name
+                    )
+                    for output_handle in outputs
+                    if (
+                        isinstance(output_handle, NodeOutput)
+                        and selection_tree.has_child(output_handle.node_name)
+                    )
+                ]
+                node_deps[node_input.input_name] = MultiDependencyDefinition(
+                    cast(
+                        List[Union[DependencyDefinition, Type[MappedInputPlaceholder]]],
+                        multi_dependencies,
+                    )
+                )
+            # else input is unconnected
+
+        dep_key = NodeInvocation(
+            name=node.definition.name,
+            alias=node.name,
+            tags=node.tags,
+            hook_defs=node.hook_defs,
+            retry_policy=node.retry_policy,
+        )
+        subgraph_deps[dep_key] = node_deps
+
+    # filter out unselected input/output mapping
+    subgraph_input_mappings = [
+        imap for imap in graph.input_mappings if imap.maps_to.node_name in subgraph_nodes.keys()
+    ]
+    subgraph_output_mappings = [
+        omap for omap in graph.output_mappings if omap.maps_from.node_name in subgraph_nodes.keys()
+    ]
+
+    return SubselectedGraphDefinition(
+        parent_graph_def=graph,
+        dependencies=subgraph_deps,
+        node_defs=list(subgraph_nodes.values()),
+        input_mappings=subgraph_input_mappings,
+        output_mappings=subgraph_output_mappings,
+    )

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -233,7 +233,7 @@ class ReconstructableJob(
         return self._replace(repository=self.repository.with_repository_load_data(metadata))
 
     @property
-    def solid_selection(self) -> Optional[Sequence[str]]:
+    def op_selection(self) -> Optional[Sequence[str]]:
         return seven.json.loads(self.solid_selection_str) if self.solid_selection_str else None
 
     # Keep the most recent 1 definition (globally since this is a NamedTuple method)
@@ -242,7 +242,7 @@ class ReconstructableJob(
     def get_definition(self) -> Union[JobDefinition, "JobDefinition"]:
         return self.repository.get_definition().get_maybe_subset_job_def(
             self.job_name,
-            self.solid_selection,
+            self.op_selection,
             self.asset_selection,
             self.solids_to_execute,
         )
@@ -252,14 +252,14 @@ class ReconstructableJob(
 
     def get_subset(
         self,
-        solid_selection: Optional[Iterable[str]] = None,
+        op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
     ) -> "ReconstructableJob":
-        if solid_selection and asset_selection:
+        if op_selection and asset_selection:
             check.failed(
                 "solid_selection and asset_selection cannot both be provided as arguments",
             )
-        elif solid_selection is None and asset_selection is None:
+        elif op_selection is None and asset_selection is None:
             return ReconstructableJob(
                 repository=self.repository,
                 job_name=self.job_name,
@@ -268,7 +268,7 @@ class ReconstructableJob(
             return ReconstructableJob(
                 repository=self.repository,
                 job_name=self.job_name,
-                solid_selection_str=seven.json.dumps(solid_selection) if solid_selection else None,
+                solid_selection_str=seven.json.dumps(op_selection) if op_selection else None,
                 solids_to_execute=None,
                 asset_selection=asset_selection,
             )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -270,12 +270,12 @@ class RepositoryDefinition:
     def get_maybe_subset_job_def(
         self,
         job_name: str,
-        op_selection: Optional[Sequence[str]] = None,
+        op_selection: Optional[Iterable[str]] = None,
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
         solids_to_execute: Optional[AbstractSet[str]] = None,
     ):
         defn = self.get_job(job_name)
-        return defn.get_subset(op_selection, asset_selection)
+        return defn.get_subset(op_selection=op_selection, asset_selection=asset_selection)
 
     @public
     def load_asset_value(

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -275,7 +275,7 @@ class RepositoryDefinition:
         solids_to_execute: Optional[AbstractSet[str]] = None,
     ):
         defn = self.get_job(job_name)
-        return defn.get_job_def_for_subset_selection(op_selection, asset_selection)
+        return defn.get_subset(op_selection, asset_selection)
 
     @public
     def load_asset_value(

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -141,7 +141,9 @@ def execute_run_iterator(
         # note that when we receive the solids to execute via DagsterRun, it won't support
         # solid selection query syntax
         job = job.get_subset(
-            frozenset(dagster_run.solids_to_execute) if dagster_run.solids_to_execute else None,
+            op_selection=list(dagster_run.solids_to_execute)
+            if dagster_run.solids_to_execute
+            else None,
             asset_selection=dagster_run.asset_selection,
         )
 
@@ -221,8 +223,10 @@ def execute_run(
         # note that when we receive the solids to execute via DagsterRun, it won't support
         # solid selection query syntax
         job = job.get_subset(
-            frozenset(dagster_run.solids_to_execute) if dagster_run.solids_to_execute else None,
-            dagster_run.asset_selection,
+            op_selection=list(dagster_run.solids_to_execute)
+            if dagster_run.solids_to_execute
+            else None,
+            asset_selection=dagster_run.asset_selection,
         )
 
     execution_plan = _get_execution_plan_from_run(job, dagster_run, instance)
@@ -913,7 +917,7 @@ def _check_execute_job_args(
 
     # generate job subset from the given solid_selection
     if op_selection:
-        job_arg = job_arg.get_subset(op_selection)
+        job_arg = job_arg.get_subset(op_selection=op_selection)
 
     return (
         job_arg,
@@ -932,7 +936,7 @@ def _resolve_reexecute_step_selection(
     step_selection: Sequence[str],
 ) -> ExecutionPlan:
     if parent_dagster_run.solid_selection:
-        job = job.get_subset(parent_dagster_run.solid_selection, None)
+        job = job.get_subset(op_selection=parent_dagster_run.solid_selection)
 
     state = KnownExecutionState.build_for_reexecution(instance, parent_dagster_run)
 

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -140,7 +140,7 @@ def execute_run_iterator(
         # when `execute_run_iterator` is directly called, the sub pipeline hasn't been created
         # note that when we receive the solids to execute via DagsterRun, it won't support
         # solid selection query syntax
-        job = job.subset_for_execution_from_existing_job(
+        job = job.get_subset(
             frozenset(dagster_run.solids_to_execute) if dagster_run.solids_to_execute else None,
             asset_selection=dagster_run.asset_selection,
         )
@@ -220,7 +220,7 @@ def execute_run(
         # when `execute_run` is directly called, the sub job hasn't been created
         # note that when we receive the solids to execute via DagsterRun, it won't support
         # solid selection query syntax
-        job = job.subset_for_execution_from_existing_job(
+        job = job.get_subset(
             frozenset(dagster_run.solids_to_execute) if dagster_run.solids_to_execute else None,
             dagster_run.asset_selection,
         )
@@ -554,7 +554,7 @@ def _reexecute_job(
             )
 
         if parent_dagster_run.asset_selection:
-            job_arg = job_arg.subset_for_execution(
+            job_arg = job_arg.get_subset(
                 solid_selection=None, asset_selection=parent_dagster_run.asset_selection
             )
 
@@ -913,7 +913,7 @@ def _check_execute_job_args(
 
     # generate job subset from the given solid_selection
     if op_selection:
-        job_arg = job_arg.subset_for_execution(op_selection)
+        job_arg = job_arg.get_subset(op_selection)
 
     return (
         job_arg,
@@ -932,7 +932,7 @@ def _resolve_reexecute_step_selection(
     step_selection: Sequence[str],
 ) -> ExecutionPlan:
     if parent_dagster_run.solid_selection:
-        job = job.subset_for_execution(parent_dagster_run.solid_selection, None)
+        job = job.get_subset(parent_dagster_run.solid_selection, None)
 
     state = KnownExecutionState.build_for_reexecution(instance, parent_dagster_run)
 

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -555,7 +555,7 @@ def _reexecute_job(
 
         if parent_dagster_run.asset_selection:
             job_arg = job_arg.get_subset(
-                solid_selection=None, asset_selection=parent_dagster_run.asset_selection
+                op_selection=None, asset_selection=parent_dagster_run.asset_selection
             )
 
         dagster_run = execute_instance.create_run_for_job(

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -190,7 +190,7 @@ def execute_run_host_mode(
     )
 
     recon_job = recon_job.get_subset(
-        frozenset(dagster_run.solids_to_execute) if dagster_run.solids_to_execute else None,
+        op_selection=dagster_run.solids_to_execute,
         asset_selection=dagster_run.asset_selection,
     )
 

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -189,10 +189,8 @@ def execute_run_host_mode(
         ),
     )
 
-    recon_job = recon_job.subset_for_execution_from_existing_job(
-        solids_to_execute=frozenset(dagster_run.solids_to_execute)
-        if dagster_run.solids_to_execute
-        else None,
+    recon_job = recon_job.get_subset(
+        frozenset(dagster_run.solids_to_execute) if dagster_run.solids_to_execute else None,
         asset_selection=dagster_run.asset_selection,
     )
 

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -144,7 +144,7 @@ def step_context_to_step_run_ref(
                     repository_load_data=step_context.plan_data.execution_plan.repository_load_data,
                 ),
                 job_name=recon_job.job_name,
-                solids_to_execute=recon_job.solids_to_execute,
+                op_selection=recon_job.op_selection,
             )
 
     return StepRunRef(
@@ -189,7 +189,7 @@ def step_run_ref_to_step_context(
     solids_to_execute = step_run_ref.dagster_run.solids_to_execute
     if solids_to_execute or step_run_ref.dagster_run.asset_selection:
         job = step_run_ref.recon_job.get_subset(
-            frozenset(solids_to_execute) if solids_to_execute else None,
+            op_selection=solids_to_execute,
             asset_selection=step_run_ref.dagster_run.asset_selection,
         )
 

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -188,7 +188,7 @@ def step_run_ref_to_step_context(
 
     solids_to_execute = step_run_ref.dagster_run.solids_to_execute
     if solids_to_execute or step_run_ref.dagster_run.asset_selection:
-        job = step_run_ref.recon_job.subset_for_execution_from_existing_job(
+        job = step_run_ref.recon_job.get_subset(
             frozenset(solids_to_execute) if solids_to_execute else None,
             asset_selection=step_run_ref.dagster_run.asset_selection,
         )

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -390,7 +390,7 @@ class InProcessCodeLocation(CodeLocation):
         execution_plan = create_execution_plan(
             job=self.get_reconstructable_job(
                 external_job.repository_handle.repository_name, external_job.name
-            ).subset_for_execution_from_existing_job(
+            ).get_subset(
                 external_job.solids_to_execute,
                 external_job.asset_selection,
             ),

--- a/python_modules/dagster/dagster/_core/host_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/host_representation/code_location.py
@@ -391,8 +391,8 @@ class InProcessCodeLocation(CodeLocation):
             job=self.get_reconstructable_job(
                 external_job.repository_handle.repository_name, external_job.name
             ).get_subset(
-                external_job.solids_to_execute,
-                external_job.asset_selection,
+                op_selection=external_job.solids_to_execute,
+                asset_selection=external_job.asset_selection,
             ),
             run_config=run_config,
             step_keys_to_execute=step_keys_to_execute,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -986,7 +986,7 @@ class DagsterInstance(DynamicPartitionsStore):
         # solids_to_execute never provided
         if asset_selection or solid_selection:
             # for cases when `create_run_for_pipeline` is directly called
-            job_def = job_def.get_job_def_for_subset_selection(
+            job_def = job_def.get_subset(
                 asset_selection=asset_selection,
                 op_selection=solid_selection,
             )

--- a/python_modules/dagster/dagster/_core/selector/__init__.py
+++ b/python_modules/dagster/dagster/_core/selector/__init__.py
@@ -3,6 +3,6 @@ from .subset_selector import (
     generate_dep_graph as generate_dep_graph,
     parse_clause as parse_clause,
     parse_items_from_selection as parse_items_from_selection,
-    parse_solid_selection as parse_solid_selection,
+    parse_op_queries as parse_op_queries,
     parse_step_selection as parse_step_selection,
 )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_job.py
@@ -1390,7 +1390,7 @@ def test_asset_selection_reconstructable():
                 "reconstruct_asset_job",
                 reconstructable_args=tuple(),
                 reconstructable_kwargs={},
-            ).subset_for_execution(asset_selection=frozenset([AssetKey("f")]))
+            ).get_subset(asset_selection=frozenset([AssetKey("f")]))
 
             events = list(execute_run_iterator(reconstructable_foo_job, run, instance=instance))
             assert len([event for event in events if event.is_job_success]) == 1

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -541,7 +541,7 @@ def test_job_config_with_asset_partitions():
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
     assert (
-        the_job.get_job_def_for_subset_selection(asset_selection={AssetKey("asset1")})
+        the_job.get_subset(asset_selection={AssetKey("asset1")})
         .execute_in_process(partition_key="2020-01-01")
         .success
     )

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -663,7 +663,7 @@ def test_job_subset():
 
     the_job = basic.to_job()
 
-    assert isinstance(the_job.get_subset(["my_op"]), JobDefinition)
+    assert isinstance(the_job.get_subset(op_selection=["my_op"]), JobDefinition)
 
 
 def test_tags():

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -663,7 +663,7 @@ def test_job_subset():
 
     the_job = basic.to_job()
 
-    assert isinstance(the_job.get_job_def_for_subset_selection(["my_op"]), JobDefinition)
+    assert isinstance(the_job.get_subset(["my_op"]), JobDefinition)
 
 
 def test_tags():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -552,7 +552,7 @@ def test_root_input_manager():
         end(start())
 
     with pytest.raises(DagsterInvalidSubsetError):
-        _invalid = _valid.get_job_def_for_subset_selection(["wraps_b_error"])
+        _invalid = _valid.get_subset(["wraps_b_error"])
 
 
 def test_root_input_manager_missing_fails():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -552,7 +552,7 @@ def test_root_input_manager():
         end(start())
 
     with pytest.raises(DagsterInvalidSubsetError):
-        _invalid = _valid.get_subset(["wraps_b_error"])
+        _invalid = _valid.get_subset(op_selection=["wraps_b_error"])
 
 
 def test_root_input_manager_missing_fails():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -1108,21 +1108,21 @@ def test_resource_op_subset():
         "io_manager",
     }
 
-    assert nested.get_job_def_for_subset_selection(
-        ["foo_op"]
-    ).get_required_resource_defs().keys() == {
+    assert nested.get_subset(["foo_op"]).get_required_resource_defs().keys() == {
         "foo",
         "bar",
         "io_manager",
     }
 
-    assert nested.get_job_def_for_subset_selection(
-        ["bar_op"]
-    ).get_required_resource_defs().keys() == {"bar", "io_manager"}
+    assert nested.get_subset(["bar_op"]).get_required_resource_defs().keys() == {
+        "bar",
+        "io_manager",
+    }
 
-    assert nested.get_job_def_for_subset_selection(
-        ["baz_op"]
-    ).get_required_resource_defs().keys() == {"baz", "io_manager"}
+    assert nested.get_subset(["baz_op"]).get_required_resource_defs().keys() == {
+        "baz",
+        "io_manager",
+    }
 
 
 def test_config_with_no_schema():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_resource_definition.py
@@ -1108,18 +1108,18 @@ def test_resource_op_subset():
         "io_manager",
     }
 
-    assert nested.get_subset(["foo_op"]).get_required_resource_defs().keys() == {
+    assert nested.get_subset(op_selection=["foo_op"]).get_required_resource_defs().keys() == {
         "foo",
         "bar",
         "io_manager",
     }
 
-    assert nested.get_subset(["bar_op"]).get_required_resource_defs().keys() == {
+    assert nested.get_subset(op_selection=["bar_op"]).get_required_resource_defs().keys() == {
         "bar",
         "io_manager",
     }
 
-    assert nested.get_subset(["baz_op"]).get_required_resource_defs().keys() == {
+    assert nested.get_subset(op_selection=["baz_op"]).get_required_resource_defs().keys() == {
         "baz",
         "io_manager",
     }

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_builtin_schemas.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/config_schema_tests/test_builtin_schemas.py
@@ -19,9 +19,7 @@ from dagster._utils.test import get_temp_file_name
 
 
 def _execute_job_with_subset(job_def, run_config, op_selection):
-    return job_def.get_job_def_for_subset_selection(op_selection).execute_in_process(
-        run_config=run_config
-    )
+    return job_def.get_subset(op_selection=op_selection).execute_in_process(run_config=run_config)
 
 
 def define_test_all_scalars_job():

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -11,10 +11,9 @@ from .test_subset_selector import foo_job, get_asset_selection_job
 
 def test_subset_for_execution():
     recon_job = reconstructable(foo_job)
-    sub_job = recon_job.get_subset(["*add_nums"])
+    sub_job = recon_job.get_subset(op_selection=["*add_nums"])
 
-    assert sub_job.op_selection == ["*add_nums"]
-    assert sub_job.solids_to_execute is None
+    assert sub_job.op_selection == {"*add_nums"}
 
     with instance_for_test() as instance:
         result = execute_job(sub_job, instance)

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -11,7 +11,7 @@ from .test_subset_selector import foo_job, get_asset_selection_job
 
 def test_subset_for_execution():
     recon_job = reconstructable(foo_job)
-    sub_job = recon_job.subset_for_execution(["*add_nums"])
+    sub_job = recon_job.get_subset(["*add_nums"])
 
     assert sub_job.solid_selection == ["*add_nums"]
     assert sub_job.solids_to_execute is None
@@ -28,7 +28,7 @@ def test_subset_for_execution():
 
 def test_asset_subset_for_execution():
     recon_job = reconstructable(get_asset_selection_job)
-    sub_job = recon_job.subset_for_execution(
+    sub_job = recon_job.get_subset(
         solid_selection=None, asset_selection=frozenset({AssetKey("my_asset")})
     )
     assert sub_job.asset_selection == {AssetKey("my_asset")}

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_execute.py
@@ -13,7 +13,7 @@ def test_subset_for_execution():
     recon_job = reconstructable(foo_job)
     sub_job = recon_job.get_subset(["*add_nums"])
 
-    assert sub_job.solid_selection == ["*add_nums"]
+    assert sub_job.op_selection == ["*add_nums"]
     assert sub_job.solids_to_execute is None
 
     with instance_for_test() as instance:
@@ -29,7 +29,7 @@ def test_subset_for_execution():
 def test_asset_subset_for_execution():
     recon_job = reconstructable(get_asset_selection_job)
     sub_job = recon_job.get_subset(
-        solid_selection=None, asset_selection=frozenset({AssetKey("my_asset")})
+        op_selection=None, asset_selection=frozenset({AssetKey("my_asset")})
     )
     assert sub_job.asset_selection == {AssetKey("my_asset")}
 

--- a/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
+++ b/python_modules/dagster/dagster_tests/core_tests/selector_tests/test_subset_selector.py
@@ -7,7 +7,7 @@ from dagster._core.selector.subset_selector import (
     clause_to_subset,
     generate_dep_graph,
     parse_clause,
-    parse_solid_selection,
+    parse_op_queries,
     parse_step_selection,
 )
 
@@ -100,15 +100,15 @@ def test_parse_clause_invalid():
 
 
 def test_parse_op_selection_single():
-    solid_selection_single = parse_solid_selection(foo_job, ["add_nums"])
+    solid_selection_single = parse_op_queries(foo_job, ["add_nums"])
     assert len(solid_selection_single) == 1
     assert solid_selection_single == {"add_nums"}
 
-    solid_selection_star = parse_solid_selection(foo_job, ["add_nums*"])
+    solid_selection_star = parse_op_queries(foo_job, ["add_nums*"])
     assert len(solid_selection_star) == 3
     assert set(solid_selection_star) == {"add_nums", "multiply_two", "add_one"}
 
-    solid_selection_both = parse_solid_selection(foo_job, ["*add_nums+"])
+    solid_selection_both = parse_op_queries(foo_job, ["*add_nums+"])
     assert len(solid_selection_both) == 4
     assert set(solid_selection_both) == {
         "return_one",
@@ -119,7 +119,7 @@ def test_parse_op_selection_single():
 
 
 def test_parse_op_selection_multi():
-    solid_selection_multi_disjoint = parse_solid_selection(foo_job, ["return_one", "add_nums+"])
+    solid_selection_multi_disjoint = parse_op_queries(foo_job, ["return_one", "add_nums+"])
     assert len(solid_selection_multi_disjoint) == 3
     assert set(solid_selection_multi_disjoint) == {
         "return_one",
@@ -127,7 +127,7 @@ def test_parse_op_selection_multi():
         "multiply_two",
     }
 
-    solid_selection_multi_overlap = parse_solid_selection(foo_job, ["*add_nums", "return_one+"])
+    solid_selection_multi_overlap = parse_op_queries(foo_job, ["*add_nums", "return_one+"])
     assert len(solid_selection_multi_overlap) == 3
     assert set(solid_selection_multi_overlap) == {
         "return_one",
@@ -139,7 +139,7 @@ def test_parse_op_selection_multi():
         DagsterInvalidSubsetError,
         match="No qualified ops to execute found for op_selection",
     ):
-        parse_solid_selection(foo_job, ["*add_nums", "a"])
+        parse_op_queries(foo_job, ["*add_nums", "a"])
 
 
 def test_parse_op_selection_invalid():
@@ -147,7 +147,7 @@ def test_parse_op_selection_invalid():
         DagsterInvalidSubsetError,
         match="No qualified ops to execute found for op_selection",
     ):
-        parse_solid_selection(foo_job, ["some,solid"])
+        parse_op_queries(foo_job, ["some,solid"])
 
 
 step_deps = {

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -424,7 +424,7 @@ def test_job_subset_of_subset():
     assert result.output_for_node("return_one_b") == 1
     assert result.output_for_node("add_one_b") == 2
 
-    subset_job = job_def.get_subset(["add_one_a", "return_one_a"])
+    subset_job = job_def.get_subset(op_selection=["add_one_a", "return_one_a"])
     subset_result = subset_job.execute_in_process()
     assert subset_result.success
     with pytest.raises(DagsterInvariantViolationError):
@@ -465,14 +465,16 @@ def test_job_subset_with_multi_dependency():
     assert result.success
     assert result.output_for_node("noop") == 3
 
-    subset_result = job_def.get_subset(["noop"]).execute_in_process()
+    subset_result = job_def.get_subset(op_selection=["noop"]).execute_in_process()
 
     assert subset_result.success
     with pytest.raises(DagsterInvariantViolationError):
         subset_result.output_for_node("return_one")
     assert subset_result.output_for_node("noop") == 3
 
-    subset_result = job_def.get_subset(["return_one", "return_two", "noop"]).execute_in_process()
+    subset_result = job_def.get_subset(
+        op_selection=["return_one", "return_two", "noop"]
+    ).execute_in_process()
 
     assert subset_result.success
     assert subset_result.output_for_node("return_one") == 1
@@ -544,11 +546,11 @@ def define_three_part_job():
 
 
 def define_created_disjoint_three_part_job():
-    return define_three_part_job().get_subset(["add_one", "add_three"])
+    return define_three_part_job().get_subset(op_selection=["add_one", "add_three"])
 
 
 def test_job_disjoint_subset():
-    disjoint_job = define_three_part_job().get_subset(["add_one", "add_three"])
+    disjoint_job = define_three_part_job().get_subset(op_selection=["add_one", "add_three"])
     assert len(disjoint_job.nodes) == 2
 
 
@@ -937,7 +939,9 @@ def test_selector_with_subset_for_execution():
         def_one()
         def_two()
 
-    assert pipe.get_subset(["def_two"]).op_selection_data.resolved_op_selection == {"def_two"}
+    assert pipe.get_subset(op_selection=["def_two"]).op_selection_data.resolved_op_selection == {
+        "def_two"
+    }
 
 
 def test_default_run_id():

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -424,7 +424,7 @@ def test_job_subset_of_subset():
     assert result.output_for_node("return_one_b") == 1
     assert result.output_for_node("add_one_b") == 2
 
-    subset_job = job_def.get_job_def_for_subset_selection(["add_one_a", "return_one_a"])
+    subset_job = job_def.get_subset(["add_one_a", "return_one_a"])
     subset_result = subset_job.execute_in_process()
     assert subset_result.success
     with pytest.raises(DagsterInvariantViolationError):
@@ -465,16 +465,14 @@ def test_job_subset_with_multi_dependency():
     assert result.success
     assert result.output_for_node("noop") == 3
 
-    subset_result = job_def.get_job_def_for_subset_selection(["noop"]).execute_in_process()
+    subset_result = job_def.get_subset(["noop"]).execute_in_process()
 
     assert subset_result.success
     with pytest.raises(DagsterInvariantViolationError):
         subset_result.output_for_node("return_one")
     assert subset_result.output_for_node("noop") == 3
 
-    subset_result = job_def.get_job_def_for_subset_selection(
-        ["return_one", "return_two", "noop"]
-    ).execute_in_process()
+    subset_result = job_def.get_subset(["return_one", "return_two", "noop"]).execute_in_process()
 
     assert subset_result.success
     assert subset_result.output_for_node("return_one") == 1
@@ -546,13 +544,11 @@ def define_three_part_job():
 
 
 def define_created_disjoint_three_part_job():
-    return define_three_part_job().get_job_def_for_subset_selection(["add_one", "add_three"])
+    return define_three_part_job().get_subset(["add_one", "add_three"])
 
 
 def test_job_disjoint_subset():
-    disjoint_job = define_three_part_job().get_job_def_for_subset_selection(
-        ["add_one", "add_three"]
-    )
+    disjoint_job = define_three_part_job().get_subset(["add_one", "add_three"])
     assert len(disjoint_job.nodes) == 2
 
 
@@ -941,9 +937,7 @@ def test_selector_with_subset_for_execution():
         def_one()
         def_two()
 
-    assert pipe.get_job_def_for_subset_selection(
-        ["def_two"]
-    ).op_selection_data.resolved_op_selection == {"def_two"}
+    assert pipe.get_subset(["def_two"]).op_selection_data.resolved_op_selection == {"def_two"}
 
 
 def test_default_run_id():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
@@ -842,7 +842,7 @@ def test_tag_subset():
         empty()
         emit.tag({"invoke": "2"})()
 
-    plan = create_execution_plan(tag.get_job_def_for_subset_selection(["emit"]))
+    plan = create_execution_plan(tag.get_subset(["emit"]))
     step = list(plan.step_dict.values())[0]
     assert step.tags == {"def": "1", "invoke": "2"}
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_composition.py
@@ -842,7 +842,7 @@ def test_tag_subset():
         empty()
         emit.tag({"invoke": "2"})()
 
-    plan = create_execution_plan(tag.get_subset(["emit"]))
+    plan = create_execution_plan(tag.get_subset(op_selection=["emit"]))
     step = list(plan.step_dict.values())[0]
     assert step.tags == {"def": "1", "invoke": "2"}
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -151,10 +151,10 @@ def test_inner_decorator():
 def test_op_selection():
     recon_pipe = reconstructable(get_the_pipeline)
     sub_pipe_full = recon_pipe.get_subset(["the_op"], asset_selection=None)
-    assert sub_pipe_full.solid_selection == ["the_op"]
+    assert sub_pipe_full.op_selection == ["the_op"]
 
     sub_pipe_unresolved = recon_pipe.get_subset(["the_op+"], asset_selection=None)
-    assert sub_pipe_unresolved.solid_selection == ["the_op+"]
+    assert sub_pipe_unresolved.op_selection == ["the_op+"]
 
 
 def test_reconstructable_module():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -150,10 +150,10 @@ def test_inner_decorator():
 
 def test_op_selection():
     recon_pipe = reconstructable(get_the_pipeline)
-    sub_pipe_full = recon_pipe.subset_for_execution(["the_op"], asset_selection=None)
+    sub_pipe_full = recon_pipe.get_subset(["the_op"], asset_selection=None)
     assert sub_pipe_full.solid_selection == ["the_op"]
 
-    sub_pipe_unresolved = recon_pipe.subset_for_execution(["the_op+"], asset_selection=None)
+    sub_pipe_unresolved = recon_pipe.get_subset(["the_op+"], asset_selection=None)
     assert sub_pipe_unresolved.solid_selection == ["the_op+"]
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -150,11 +150,11 @@ def test_inner_decorator():
 
 def test_op_selection():
     recon_pipe = reconstructable(get_the_pipeline)
-    sub_pipe_full = recon_pipe.get_subset(["the_op"], asset_selection=None)
-    assert sub_pipe_full.op_selection == ["the_op"]
+    sub_pipe_full = recon_pipe.get_subset(op_selection={"the_op"})
+    assert sub_pipe_full.op_selection == {"the_op"}
 
-    sub_pipe_unresolved = recon_pipe.get_subset(["the_op+"], asset_selection=None)
-    assert sub_pipe_unresolved.op_selection == ["the_op+"]
+    sub_pipe_unresolved = recon_pipe.get_subset(op_selection={"the_op+"})
+    assert sub_pipe_unresolved.op_selection == {"the_op+"}
 
 
 def test_reconstructable_module():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_tags.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_tags.py
@@ -38,12 +38,10 @@ def test_op_subset_tags():
     def tags_job():
         noop_op()
 
-    assert tags_job.get_job_def_for_subset_selection(op_selection=["noop_op"]).tags == {
-        "foo": "bar"
-    }
+    assert tags_job.get_subset(op_selection=["noop_op"]).tags == {"foo": "bar"}
 
     @job
     def no_tags_job():
         noop_op()
 
-    assert no_tags_job.get_job_def_for_subset_selection(op_selection=["noop_op"]).tags == {}
+    assert no_tags_job.get_subset(op_selection=["noop_op"]).tags == {}

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_host_run_worker.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_host_run_worker.py
@@ -50,16 +50,14 @@ class ExplodingTestPipeline(ReconstructableJob):
         cls,
         repository,
         pipeline_name,
-        solid_selection_str=None,
-        solids_to_execute=None,
+        op_selection=None,
         asset_selection=None,
     ):
         return super(ExplodingTestPipeline, cls).__new__(
             cls,
             repository,
             pipeline_name,
-            solid_selection_str,
-            solids_to_execute,
+            op_selection,
             asset_selection,
         )
 

--- a/python_modules/dagster/dagster_tests/execution_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/test_job.py
@@ -205,7 +205,7 @@ def test_subset_job_with_config():
     result = no_config.execute_in_process(run_config={"ops": {"emit": {"inputs": {"x": 1}}}})
     assert result.success
 
-    subset_no_config = no_config.get_job_def_for_subset_selection(op_selection=["echo"])
+    subset_no_config = no_config.get_subset(op_selection=["echo"])
 
     result = subset_no_config.execute_in_process(run_config={"ops": {"echo": {"inputs": {"x": 1}}}})
     assert result.success
@@ -217,7 +217,7 @@ def test_subset_job_with_config():
     result = with_config.execute_in_process()
     assert result.success
 
-    subset_with_config = with_config.get_job_def_for_subset_selection(op_selection=["echo"])
+    subset_with_config = with_config.get_subset(op_selection=["echo"])
 
     result = subset_with_config.execute_in_process(
         run_config={"ops": {"echo": {"inputs": {"x": 1}}}}

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
@@ -48,7 +48,7 @@ def execute_job_on_celery(
     subset: Optional[Sequence[str]] = None,
 ) -> Iterator[ExecutionResult]:
     with tempdir_wrapper(tempdir) as tempdir:
-        job_def = ReconstructableJob.for_file(REPO_FILE, job_name).get_subset(subset)
+        job_def = ReconstructableJob.for_file(REPO_FILE, job_name).get_subset(op_selection=subset)
         with _instance_wrapper(instance) as wrapped_instance:
             run_config = run_config or {
                 "resources": {"io_manager": {"config": {"base_dir": tempdir}}},

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/utils.py
@@ -48,7 +48,7 @@ def execute_job_on_celery(
     subset: Optional[Sequence[str]] = None,
 ) -> Iterator[ExecutionResult]:
     with tempdir_wrapper(tempdir) as tempdir:
-        job_def = ReconstructableJob.for_file(REPO_FILE, job_name).subset_for_execution(subset)
+        job_def = ReconstructableJob.for_file(REPO_FILE, job_name).get_subset(subset)
         with _instance_wrapper(instance) as wrapped_instance:
             run_config = run_config or {
                 "resources": {"io_manager": {"config": {"base_dir": tempdir}}},

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -131,7 +131,7 @@ def query_on_dask_worker(
     scheduling, even though we do not use this argument within the function.
     """
     with DagsterInstance.from_ref(instance_ref) as instance:
-        subset_job = recon_job.get_subset(dagster_run.solids_to_execute)
+        subset_job = recon_job.get_subset(op_selection=dagster_run.solids_to_execute)
 
         execution_plan = create_execution_plan(
             subset_job,

--- a/python_modules/libraries/dagster-dask/dagster_dask/executor.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/executor.py
@@ -131,7 +131,7 @@ def query_on_dask_worker(
     scheduling, even though we do not use this argument within the function.
     """
     with DagsterInstance.from_ref(instance_ref) as instance:
-        subset_job = recon_job.subset_for_execution_from_existing_job(dagster_run.solids_to_execute)
+        subset_job = recon_job.get_subset(dagster_run.solids_to_execute)
 
         execution_plan = create_execution_plan(
             subset_job,


### PR DESCRIPTION
## Summary & Motivation

The current handling of job subsetting is a bit of a mess due to inherited technical debt from `PipelineDefinition`. Now that `PipelineDefinition` is gone, there is a lot of room for improvement. This PR is the first in a series that will aim to refactor the subsetting and execution APIs for simplicity, clarity, and consistency. In this PR:

- Consolidate two subsetting methods `subset_for_execution` and `subset_for_execution_from_existing_job` on `IJob` class into new `get_subset` method.
- Replace `IJob.solids_to_execute` with `op_selection`
- Change fields on `ReconstructableJob` to accommodate new interface
- Move op selection resolution to new `op_selection` module. Introduce `OpSelection` class (currently an implementation detail). This parallels the existing `AssetSelection` and  is part of unifying our approach to `asset_selection` and `op_selection`.
- `JobDefinition.is_subset_job` -> `is_subset`

## How I Tested These Changes

Existing test suite, with some tests modified to account for changed APIs.