### PR TITLE
make intro to jobs page less op-focused

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/jobs.mdx
@@ -9,7 +9,7 @@ Jobs are the main unit of execution and monitoring in Dagster.
 
 A job does one of two things:
 
-- Materializes a selection of [software-defined assets](/concepts/assets/software-defined-assets)
+- Materializes a selection of [Software-defined Assets](/concepts/assets/software-defined-assets)
 - Executes a [graph](/concepts/ops-jobs-graphs/graphs) of [ops](/concepts/ops-jobs-graphs/ops), which are not tied to software-defined assets
 
 Jobs can be launched in a few different ways:

--- a/docs/content/concepts/ops-jobs-graphs/jobs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/jobs.mdx
@@ -1,32 +1,33 @@
 ---
 title: Jobs | Dagster
-description: A job is an executable graph of ops, with optional resources and configuration.
+description: Jobs are the main unit of execution and monitoring in Dagster.
 ---
 
 # Jobs
 
-Jobs are the main unit of execution and monitoring in Dagster. The core of a job is a [graph](/concepts/ops-jobs-graphs/graphs) of [ops](/concepts/ops-jobs-graphs/ops) connected via data dependencies.
+Jobs are the main unit of execution and monitoring in Dagster.
 
-Ops are linked together by defining the dependencies between their inputs and outputs. An important difference between Dagster and other workflow systems is that, in Dagster, op dependencies are expressed as data dependencies, not just execution dependencies.
+A job does one of two things:
 
-This difference enables Dagster to support richer modeling of dependencies. Instead of merely ensuring that the order of execution is correct, dependencies in Dagster provide a variety of compile and run-time checks.
+- Materializes a selection of [software-defined assets](/concepts/assets/software-defined-assets)
+- Executes a [graph](/concepts/ops-jobs-graphs/graphs) of [ops](/concepts/ops-jobs-graphs/ops), which are not tied to software-defined assets
 
-Using jobs, you can:
+Jobs can be launched in a few different ways:
 
-- Materialize a selection of [assets](/concepts/assets/software-defined-assets)
-- Determine op behavior using [resources](/concepts/resources) and [configuration](/concepts/configuration/config-schema)
-- Define [schedules](/concepts/partitions-schedules-sensors/schedules) to execute jobs at fixed intervals
-- Define [sensors](/concepts/partitions-schedules-sensors/sensors) to trigger jobs when external changes occur
+- Manually from the UI
+- At fixed intervals, by [schedules](/concepts/partitions-schedules-sensors/schedules)
+- When external changes occur, using [sensors](/concepts/partitions-schedules-sensors/sensors)
 
 ---
 
 ## Relevant APIs
 
-| Name                                | Description                                                                                                                                                     |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <PyObject object="job" decorator /> | The decorator used to create a job.                                                                                                                             |
-| <PyObject object="JobDefinition" /> | A job definition. Jobs are the main unit of execution and monitoring in Dagster. Typically constructed using the <PyObject object="job" decorator /> decorator. |
-|                                     |                                                                                                                                                                 |
+| Name                                   | Description                                                                                                                                                     |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <PyObject object="define_asset_job" /> | A function for defining a job from a selection of assets.                                                                                                       |
+| <PyObject object="job" decorator />    | The decorator used to define a job.                                                                                                                             |
+| <PyObject object="JobDefinition" />    | A job definition. Jobs are the main unit of execution and monitoring in Dagster. Typically constructed using the <PyObject object="job" decorator /> decorator. |
+|                                        |                                                                                                                                                                 |
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

The first sentence of the job page currently states:

> Jobs are the main unit of execution and monitoring in Dagster. The core of a job is a [graph](/concepts/ops-jobs-graphs/graphs) of [ops](/concepts/ops-jobs-graphs/ops) connected via data dependencies.

The Dagster expert will acknowledge this as an accurate statement, via their enlightened understanding of the duality of ops and assets. However, it's easy to imagine a new user being confused by this after reading other parts of the docs that focus on the centrality of assets.

This is arguably what happened here: https://www.flypenguin.de/2023/04/30/getting-started-with-dagster/.

## How I Tested These Changes
