### PR TITLE
[docs][pythonic_resources] Update remaining refs to fs_io_manager

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -88,7 +88,7 @@ I/O managers are provided through the [resources](/concepts/resources) system wh
 
 ### Applying I/O managers to assets
 
-By default, materializing an asset named `my_asset` will pickle it to a local file named `my_asset`. The directory that file lives underneath is determined by the configuration and methods in <PyObject object="FilesystemIOManager" />.
+By default, materializing an asset named `my_asset` will pickle it to a local file named `my_asset`. The directory that file lives underneath is determined by the rules in <PyObject object="FilesytemIOManager" />.
 
 [I/O managers](/concepts/io-management/io-managers) enable fully overriding this behavior and storing asset contents in any way you wish - e.g. writing them as tables in a database or as objects in a cloud object store such as s3. You can use one of Dagster's [built-in I/O managers](#built-in-io-managers), or you can write your own.
 
@@ -251,7 +251,7 @@ defs = Definitions(
 
 By default, all the inputs and outputs in a job use the same I/O manager. This I/O manager is determined by the <PyObject module="dagster" object="ResourceDefinition" /> provided for the `"io_manager"` resource key. `"io_manager"` is a resource key that Dagster reserves specifically for this purpose.
 
-Here’s how to specify that all op outputs are stored using the <PyObject module="dagster" object="FileSystemIOManager" />, which pickles outputs and stores them on the local filesystem. It stores files in a directory with the run ID in the path, so that outputs from prior runs will never be overwritten.
+Here’s how to specify that all op outputs are stored using the <PyObject module="dagster" object="FilesystemIOManager" />, which pickles outputs and stores them on the local filesystem. It stores files in a directory with the run ID in the path, so that outputs from prior runs will never be overwritten.
 
 ```python file=/concepts/io_management/default_io_manager.py
 from dagster import FilesystemIOManager, job, op

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -276,7 +276,7 @@ def my_job():
 
 Not all the outputs in a job should necessarily be stored the same way. Maybe some of the outputs should live on the filesystem so they can be inspected, and others can be transiently stored in memory.
 
-To select the I/O manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting I/O managers in your job. In this example, the output of `op_1` will go to `fs_io_manager` and the output of `op_2` will go to `s3_pickle_io_manager`.
+To select the I/O manager for a particular output, you can set an `io_manager_key` on <PyObject module="dagster" object="Out" />, and then refer to that `io_manager_key` when setting I/O managers in your job. In this example, the output of `op_1` will go to `FilesystemIOManager` and the output of `op_2` will go to `ConfigurablePickledObjectS3IOManager`.
 
 ```python file=/concepts/io_management/io_manager_per_output.py startafter=start_marker endbefore=end_marker
 from dagster_aws.s3 import ConfigurablePickledObjectS3IOManager, S3Resource

--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -167,7 +167,7 @@ To do this, provide a `$DAGSTER_HOME/dagster.yaml` file, which Dagit and all Dag
       <td>
         Configures storage for artifacts that require a local disk or when using
         the filesystem I/O manager (
-        <PyObject module="dagster" object="fs_io_manager" />
+        <PyObject module="dagster" object="FilesytemIOManager" />
         ).
       </td>
     </tr>
@@ -690,7 +690,7 @@ compute_logs:
 The `local_artifact_storage` key allows you to configure local artifact storage. Local artifact storage is used to:
 
 - Configure storage for artifacts that require a local disk, or
-- Store inputs and outputs when using the filesystem I/O manager (<PyObject module="dagster" object="fs_io_manager" />). Refer to the <Link href="/concepts/io-management/io-managers">I/O managers documentation</Link> for more information on how other I/O managers store artifacts.
+- Store inputs and outputs when using the filesystem I/O manager (<PyObject module="dagster" object="FilesytemIOManager" />). Refer to the <Link href="/concepts/io-management/io-managers">I/O managers documentation</Link> for more information on how other I/O managers store artifacts.
 
 **Note**: <PyObject module="dagster._core.storage.root" object="LocalArtifactStorage" /> is currently the only option for local artifact storage. This option configures the directory used by the default filesystem I/O Manager, as well as any artifacts that require a local disk.
 

--- a/docs/content/deployment/run-retries.mdx
+++ b/docs/content/deployment/run-retries.mdx
@@ -39,4 +39,4 @@ The `dagster/retry_strategy` tag controls which Ops the retry will run.
 
 By default, retries will re-execute from failure (tag value `FROM_FAILURE`). This means that any successful Ops will be skipped, but their output will be used for downstream Ops. If the `dagster/retry_strategy` tag is set to `ALL_STEPS`, all the Ops will run again.
 
-NOTE: `FROM_FAILURE` requires an IOManager that can access outputs from other runs. For example, on Kubernetes the [s3\_pickle_io_manager](/\_apidocs/libraries/dagster-aws#dagster_aws.s3.s3\_pickle_io_manager) would work but the [fs_io_manager](https://docs.dagster.io/\_apidocs/io-managers#dagster.fs_io_manager) would not, since the new run is in a new Kubernetes Job with a separate filesystem.
+NOTE: `FROM_FAILURE` requires an IOManager that can access outputs from other runs. For example, on Kubernetes the [s3\_pickle_io_manager](/\_apidocs/libraries/dagster-aws#dagster_aws.s3.s3\_pickle_io_manager) would work but the [`FilesytemIOManager`](https://docs.dagster.io/\_apidocs/io-managers#dagster.FilesytemIOManager) would not, since the new run is in a new Kubernetes Job with a separate filesystem.

--- a/docs/content/integrations/spark.mdx
+++ b/docs/content/integrations/spark.mdx
@@ -38,7 +38,7 @@ The downside is that this approach only works with PySpark, and setting up a ste
 Passing PySpark DataFrames between ops requires a little bit of extra care, compared to other data types, for a couple reasons:
 
 - Spark has a lazy execution model, which means that PySpark won't process any data until an action like `write` or `collect` is called on a DataFrame.
-- PySpark DataFrames cannot be pickled, which means that [IO Managers](/concepts/io-management/io-managers) like the `fs_io_manager` won't work for them.
+- PySpark DataFrames cannot be pickled, which means that [IO Managers](/concepts/io-management/io-managers) like the `FilesystemIOManager` won't work for them.
 
 In this example, we've defined an <PyObject module='dagster' object='IOManager' /> that knows how to store and retrieve PySpark DataFrames that are produced and consumed by ops.
 

--- a/docs/content/tutorial/saving-your-data.mdx
+++ b/docs/content/tutorial/saving-your-data.mdx
@@ -128,7 +128,7 @@ There are three changes in this snippet:
 
 ### Choosing an I/O manager for each asset
 
-You now have two I/O managers configured within a code location. By default, all assets will use the I/O manager under the `io_manager` key. Because you updated the `io_manager` key, the `fs_io_manager` could plug and play without any additional changes. Overriding and priority are given to the I/O manager key that is most specific to the asset.
+You now have two I/O managers configured within a code location. By default, all assets will use the I/O manager under the `io_manager` key. Because you updated the `io_manager` key, the `FilesytemIOManager` could plug and play without any additional changes. Overriding and priority are given to the I/O manager key that is most specific to the asset.
 
 To have the `topstories` asset store its data in DuckDB, modify its asset function in `assets.py` by specifying the asset’s `io_manager_key` to be `"database_io_manager"`, as shown below:
 

--- a/docs/content/tutorial/saving-your-data.mdx
+++ b/docs/content/tutorial/saving-your-data.mdx
@@ -29,7 +29,7 @@ I/O managers control **output** by writing the asset's to the location configure
 
 ## Step 1: Writing files to storage
 
-Now, you’ll write your files to a more permanent location. For this tutorial, you’ll be writing to another directory in your file system by using the `fs_io_manager`, which is bundled with the core `dagster` package.
+Now, you’ll write your files to a more permanent location. For this tutorial, you’ll be writing to another directory in your file system by using the `FilesystemIOManager`, which is bundled with the core `dagster` package.
 
 In `__init__.py`, add the following snippet anywhere above the `def = Definitions(...)` line:
 


### PR DESCRIPTION
## Summary

Fixes some stray docs references to the non-pythonic `fs_io_manager`
