### PR TITLE
Snapshot default run config & expose via GraphQL

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
@@ -12,6 +12,7 @@ export const CONFIG_EDITOR_RUN_CONFIG_SCHEMA_FRAGMENT = gql`
     allConfigTypes {
       ...AllConfigTypesForEditor
     }
+    rootDefaultYaml
   }
 
   fragment AllConfigTypesForEditor on ConfigType {

--- a/js_modules/dagit/packages/core/src/configeditor/types/ConfigEditorUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/configeditor/types/ConfigEditorUtils.types.ts
@@ -4,6 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type ConfigEditorRunConfigSchemaFragment = {
   __typename: 'RunConfigSchema';
+  rootDefaultYaml: string;
   rootConfigType:
     | {__typename: 'ArrayConfigType'; key: string}
     | {__typename: 'CompositeConfigType'; key: string}

--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2517,6 +2517,7 @@ type RunConfigSchema {
   rootConfigType: ConfigType!
   allConfigTypes: [ConfigType!]!
   isRunConfigValid(runConfigData: RunConfigData): PipelineConfigValidationResult!
+  rootDefaultYaml: String!
 }
 
 union RunConfigSchemaOrError =

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3111,6 +3111,7 @@ export type RunConfigSchema = {
   allConfigTypes: Array<ConfigType>;
   isRunConfigValid: PipelineConfigValidationResult;
   rootConfigType: ConfigType;
+  rootDefaultYaml: Scalars['String'];
 };
 
 export type RunConfigSchemaIsRunConfigValidArgs = {
@@ -9802,6 +9803,8 @@ export const buildRunConfigSchema = (
         : relationshipsToOmit.has('ConfigType')
         ? ({} as ConfigType)
         : buildConfigType({}, relationshipsToOmit),
+    rootDefaultYaml:
+      overrides && overrides.hasOwnProperty('rootDefaultYaml') ? overrides.rootDefaultYaml! : 'cum',
   };
 };
 

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -271,6 +271,18 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     }
   };
 
+  const onExpandDefaults = () => {
+    if (runConfigSchema?.rootDefaultYaml) {
+      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
+
+      const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
+      const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
+      const mergedYaml = yaml.stringify(updatedRunConfigData);
+
+      onSaveSession({runConfigYaml: mergedYaml});
+    }
+  };
+
   const buildExecutionVariables = () => {
     if (!currentSession) {
       return;
@@ -716,6 +728,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
               onHighlightPath={(path) => editor.current?.moveCursorToPath(path)}
               onRemoveExtraPaths={(paths) => onRemoveExtraPaths(paths)}
               onScaffoldMissingConfig={onScaffoldMissingConfig}
+              onExpandDefaults={onExpandDefaults}
             />
           </>
         }

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -201,6 +201,43 @@ const ScaffoldConfigButton = ({
   );
 };
 
+const ExpandDefaultButton = ({
+  onExpandDefaults,
+  disabled,
+}: {
+  onExpandDefaults: () => void;
+  disabled: boolean;
+}) => {
+  const confirm = useConfirmation();
+
+  const onClick = async () => {
+    await confirm({
+      title: 'Scaffold all default config',
+      description: (
+        <div>
+          Clicking confirm will automatically scaffold any unspecified configuration fields into
+          your run config with default values. You will need to change the values appropriately.
+        </div>
+      ),
+    });
+    onExpandDefaults();
+  };
+
+  return (
+    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+      <Button disabled={disabled} onClick={onClick}>
+        Scaffold all default config
+      </Button>
+      {disabled ? (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="check_circle" color={Colors.Green500} />
+          No missing config
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
 interface RunPreviewProps {
   validation: RunPreviewValidationFragment | null;
   document: any | null;
@@ -210,6 +247,7 @@ interface RunPreviewProps {
   onHighlightPath: (path: string[]) => void;
   onRemoveExtraPaths: (paths: string[]) => void;
   onScaffoldMissingConfig: () => void;
+  onExpandDefaults: () => void;
   solidSelection: string[] | null;
 }
 
@@ -221,6 +259,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
     launchpadType,
     onRemoveExtraPaths,
     onScaffoldMissingConfig,
+    onExpandDefaults,
     solidSelection,
     runConfigSchema,
   } = props;
@@ -396,6 +435,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
                 missingNodes={missingNodes}
                 disabled={!missingNodes.length}
               />
+              <ExpandDefaultButton onExpandDefaults={onExpandDefaults} disabled={false} />
               <RemoveExtraConfigButton
                 onRemoveExtraPaths={onRemoveExtraPaths}
                 extraNodes={extraNodes}

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSession.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSession.types.ts
@@ -133,6 +133,7 @@ export type PipelineExecutionConfigSchemaQuery = {
     | {__typename: 'PythonError'}
     | {
         __typename: 'RunConfigSchema';
+        rootDefaultYaml: string;
         rootConfigType:
           | {__typename: 'ArrayConfigType'; key: string}
           | {__typename: 'CompositeConfigType'; key: string}
@@ -230,6 +231,7 @@ export type LaunchpadSessionRunConfigSchemaFragment_PythonError_ = {__typename: 
 
 export type LaunchpadSessionRunConfigSchemaFragment_RunConfigSchema_ = {
   __typename: 'RunConfigSchema';
+  rootDefaultYaml: string;
   rootConfigType:
     | {__typename: 'ArrayConfigType'; key: string}
     | {__typename: 'CompositeConfigType'; key: string}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -105,7 +105,7 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
 
         root_type = config_schema_snapshot.get_config_snap(root_key)
 
-        return default_values_yaml_from_type_snap(root_type)
+        return default_values_yaml_from_type_snap(config_schema_snapshot, root_type)
 
 
 class GrapheneRunConfigSchemaOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -96,12 +96,12 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
             parse_run_config_input(runConfigData or {}, raise_on_error=False),  # type: ignore
         )
 
-    def resolve_rootDefaultYaml(self, _graphene_info):
-        config_schema_snapshot: ConfigSchemaSnapshot = (
-            self._represented_pipeline.config_schema_snapshot
-        )
+    def resolve_rootDefaultYaml(self, _graphene_info) -> str:
+        config_schema_snapshot: ConfigSchemaSnapshot = self._represented_job.config_schema_snapshot
 
-        root_key = self._represented_pipeline.get_mode_def_snap(self._mode).root_config_key
+        root_key = check.not_none(
+            self._represented_job.get_mode_def_snap(self._mode).root_config_key
+        )
 
         root_type = config_schema_snapshot.get_config_snap(root_key)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_environment_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_environment_schema.py
@@ -7,6 +7,171 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_postgres_instance_lazy_repository] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'RunConfigValidationInvalid',
+            'errors': [
+                {
+                    '__typename': 'FieldNotDefinedConfigError',
+                    'fieldName': 'nope',
+                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
+                    'reason': 'FIELD_NOT_DEFINED',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                },
+                {
+                    '__typename': 'MissingFieldConfigError',
+                    'field': {
+                        'name': 'ops'
+                    },
+                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+                    'reason': 'MISSING_REQUIRED_FIELD',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                }
+            ],
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'RunConfigValidationInvalid',
+            'errors': [
+                {
+                    '__typename': 'FieldNotDefinedConfigError',
+                    'fieldName': 'nope',
+                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
+                    'reason': 'FIELD_NOT_DEFINED',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                },
+                {
+                    '__typename': 'MissingFieldConfigError',
+                    'field': {
+                        'name': 'ops'
+                    },
+                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+                    'reason': 'MISSING_REQUIRED_FIELD',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                }
+            ],
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_postgres_instance_multi_location] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'RunConfigValidationInvalid',
+            'errors': [
+                {
+                    '__typename': 'FieldNotDefinedConfigError',
+                    'fieldName': 'nope',
+                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
+                    'reason': 'FIELD_NOT_DEFINED',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                },
+                {
+                    '__typename': 'MissingFieldConfigError',
+                    'field': {
+                        'name': 'ops'
+                    },
+                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+                    'reason': 'MISSING_REQUIRED_FIELD',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                }
+            ],
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'RunConfigValidationInvalid',
+            'errors': [
+                {
+                    '__typename': 'FieldNotDefinedConfigError',
+                    'fieldName': 'nope',
+                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
+                    'reason': 'FIELD_NOT_DEFINED',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                },
+                {
+                    '__typename': 'MissingFieldConfigError',
+                    'field': {
+                        'name': 'ops'
+                    },
+                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+                    'reason': 'MISSING_REQUIRED_FIELD',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                }
+            ],
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_sqlite_instance_lazy_repository] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'RunConfigValidationInvalid',
+            'errors': [
+                {
+                    '__typename': 'FieldNotDefinedConfigError',
+                    'fieldName': 'nope',
+                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
+                    'reason': 'FIELD_NOT_DEFINED',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                },
+                {
+                    '__typename': 'MissingFieldConfigError',
+                    'field': {
+                        'name': 'ops'
+                    },
+                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+                    'reason': 'MISSING_REQUIRED_FIELD',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                }
+            ],
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
 snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_sqlite_instance_managed_grpc_env] 1'] = {
     'runConfigSchemaOrError': {
         'isRunConfigValid': {
@@ -40,11 +205,203 @@ snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[
     }
 }
 
+snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_sqlite_instance_multi_location] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'RunConfigValidationInvalid',
+            'errors': [
+                {
+                    '__typename': 'FieldNotDefinedConfigError',
+                    'fieldName': 'nope',
+                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
+                    'reason': 'FIELD_NOT_DEFINED',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                },
+                {
+                    '__typename': 'MissingFieldConfigError',
+                    'field': {
+                        'name': 'ops'
+                    },
+                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+                    'reason': 'MISSING_REQUIRED_FIELD',
+                    'stack': {
+                        'entries': [
+                        ]
+                    }
+                }
+            ],
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_postgres_instance_lazy_repository] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'PipelineConfigValidationValid',
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'PipelineConfigValidationValid',
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_postgres_instance_multi_location] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'PipelineConfigValidationValid',
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'PipelineConfigValidationValid',
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_sqlite_instance_lazy_repository] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'PipelineConfigValidationValid',
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
 snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_sqlite_instance_managed_grpc_env] 1'] = {
     'runConfigSchemaOrError': {
         'isRunConfigValid': {
             '__typename': 'PipelineConfigValidationValid',
             'pipelineName': 'csv_hello_world'
         }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_sqlite_instance_multi_location] 1'] = {
+    'runConfigSchemaOrError': {
+        'isRunConfigValid': {
+            '__typename': 'PipelineConfigValidationValid',
+            'pipelineName': 'csv_hello_world'
+        }
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_postgres_instance_lazy_repository] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_postgres_instance_multi_location] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_lazy_repository] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_managed_grpc_env] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
+    }
+}
+
+snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_multi_location] 1'] = {
+    'runConfigSchemaOrError': {
+        '__typename': 'RunConfigSchema',
+        'rootDefaultYaml': '''execution:
+  config:
+    retries:
+      enabled: {}
+loggers: {}
+ops: null
+resources:
+  io_manager: {}
+'''
     }
 }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_environment_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/snapshots/snap_test_environment_schema.py
@@ -7,105 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_postgres_instance_lazy_repository] 1'] = {
-    'runConfigSchemaOrError': {
-        'isRunConfigValid': {
-            '__typename': 'RunConfigValidationInvalid',
-            'errors': [
-                {
-                    '__typename': 'FieldNotDefinedConfigError',
-                    'fieldName': 'nope',
-                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
-                    'reason': 'FIELD_NOT_DEFINED',
-                    'stack': {
-                        'entries': [
-                        ]
-                    }
-                },
-                {
-                    '__typename': 'MissingFieldConfigError',
-                    'field': {
-                        'name': 'ops'
-                    },
-                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
-                    'reason': 'MISSING_REQUIRED_FIELD',
-                    'stack': {
-                        'entries': [
-                        ]
-                    }
-                }
-            ],
-            'pipelineName': 'csv_hello_world'
-        }
-    }
-}
-
-snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
-    'runConfigSchemaOrError': {
-        'isRunConfigValid': {
-            '__typename': 'RunConfigValidationInvalid',
-            'errors': [
-                {
-                    '__typename': 'FieldNotDefinedConfigError',
-                    'fieldName': 'nope',
-                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
-                    'reason': 'FIELD_NOT_DEFINED',
-                    'stack': {
-                        'entries': [
-                        ]
-                    }
-                },
-                {
-                    '__typename': 'MissingFieldConfigError',
-                    'field': {
-                        'name': 'ops'
-                    },
-                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
-                    'reason': 'MISSING_REQUIRED_FIELD',
-                    'stack': {
-                        'entries': [
-                        ]
-                    }
-                }
-            ],
-            'pipelineName': 'csv_hello_world'
-        }
-    }
-}
-
-snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_postgres_instance_multi_location] 1'] = {
-    'runConfigSchemaOrError': {
-        'isRunConfigValid': {
-            '__typename': 'RunConfigValidationInvalid',
-            'errors': [
-                {
-                    '__typename': 'FieldNotDefinedConfigError',
-                    'fieldName': 'nope',
-                    'message': 'Received unexpected config entry "nope" at the root. Expected: "{ execution?: { config?: { marker_to_close?: String retries?: { disabled?: { } enabled?: { } } } } loggers?: { console?: { config?: { log_level?: String name?: String } } } ops: { sum_op: { config?: Any inputs: { num: String } } sum_sq_op?: { config?: Any } } resources?: { io_manager?: { config?: Any } } }".',
-                    'reason': 'FIELD_NOT_DEFINED',
-                    'stack': {
-                        'entries': [
-                        ]
-                    }
-                },
-                {
-                    '__typename': 'MissingFieldConfigError',
-                    'field': {
-                        'name': 'ops'
-                    },
-                    'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
-                    'reason': 'MISSING_REQUIRED_FIELD',
-                    'stack': {
-                        'entries': [
-                        ]
-                    }
-                }
-            ],
-            'pipelineName': 'csv_hello_world'
-        }
-    }
-}
-
 snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
     'runConfigSchemaOrError': {
         'isRunConfigValid': {
@@ -238,33 +139,6 @@ snapshots['TestEnvironmentSchema.test_basic_invalid_config_on_run_config_schema[
     }
 }
 
-snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_postgres_instance_lazy_repository] 1'] = {
-    'runConfigSchemaOrError': {
-        'isRunConfigValid': {
-            '__typename': 'PipelineConfigValidationValid',
-            'pipelineName': 'csv_hello_world'
-        }
-    }
-}
-
-snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
-    'runConfigSchemaOrError': {
-        'isRunConfigValid': {
-            '__typename': 'PipelineConfigValidationValid',
-            'pipelineName': 'csv_hello_world'
-        }
-    }
-}
-
-snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_postgres_instance_multi_location] 1'] = {
-    'runConfigSchemaOrError': {
-        'isRunConfigValid': {
-            '__typename': 'PipelineConfigValidationValid',
-            'pipelineName': 'csv_hello_world'
-        }
-    }
-}
-
 snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
     'runConfigSchemaOrError': {
         'isRunConfigValid': {
@@ -301,51 +175,6 @@ snapshots['TestEnvironmentSchema.test_basic_valid_config_on_run_config_schema[no
     }
 }
 
-snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_postgres_instance_lazy_repository] 1'] = {
-    'runConfigSchemaOrError': {
-        '__typename': 'RunConfigSchema',
-        'rootDefaultYaml': '''execution:
-  config:
-    retries:
-      enabled: {}
-loggers: {}
-ops: null
-resources:
-  io_manager: {}
-'''
-    }
-}
-
-snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_postgres_instance_managed_grpc_env] 1'] = {
-    'runConfigSchemaOrError': {
-        '__typename': 'RunConfigSchema',
-        'rootDefaultYaml': '''execution:
-  config:
-    retries:
-      enabled: {}
-loggers: {}
-ops: null
-resources:
-  io_manager: {}
-'''
-    }
-}
-
-snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_postgres_instance_multi_location] 1'] = {
-    'runConfigSchemaOrError': {
-        '__typename': 'RunConfigSchema',
-        'rootDefaultYaml': '''execution:
-  config:
-    retries:
-      enabled: {}
-loggers: {}
-ops: null
-resources:
-  io_manager: {}
-'''
-    }
-}
-
 snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_deployed_grpc_env] 1'] = {
     'runConfigSchemaOrError': {
         '__typename': 'RunConfigSchema',
@@ -354,7 +183,10 @@ snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_d
     retries:
       enabled: {}
 loggers: {}
-ops: null
+ops:
+  sum_op:
+    inputs: {}
+  sum_sq_op: {}
 resources:
   io_manager: {}
 '''
@@ -369,7 +201,10 @@ snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_l
     retries:
       enabled: {}
 loggers: {}
-ops: null
+ops:
+  sum_op:
+    inputs: {}
+  sum_sq_op: {}
 resources:
   io_manager: {}
 '''
@@ -384,7 +219,10 @@ snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_m
     retries:
       enabled: {}
 loggers: {}
-ops: null
+ops:
+  sum_op:
+    inputs: {}
+  sum_sq_op: {}
 resources:
   io_manager: {}
 '''
@@ -399,7 +237,10 @@ snapshots['TestEnvironmentSchema.test_full_yaml[non_launchable_sqlite_instance_m
     retries:
       enabled: {}
 loggers: {}
-ops: null
+ops:
+  sum_op:
+    inputs: {}
+  sum_sq_op: {}
 resources:
   io_manager: {}
 '''

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -1736,7 +1736,7 @@ def infer_schema_from_config_class(
         "Config type annotation must inherit from dagster.Config",
     )
 
-    fields = {}
+    fields: Dict[str, Field] = {}
     for pydantic_field in model_cls.__fields__.values():
         if pydantic_field.name not in fields_to_omit:
             if isinstance(pydantic_field.default, Field):
@@ -1762,6 +1762,7 @@ def infer_schema_from_config_class(
     shape_cls = Permissive if model_cls.__config__.extra == Extra.allow else Shape
 
     docstring = model_cls.__doc__.strip() if model_cls.__doc__ else None
+
     return Field(config=shape_cls(fields), description=description or docstring)
 
 

--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -1,0 +1,23 @@
+import json
+from typing import Optional
+
+from dagster._config.snap import ConfigTypeSnap
+from dagster._utils.yaml_utils import dump_run_config_yaml
+
+
+def _safe_json_loads(json_str: Optional[str]) -> object:
+    try:
+        return json.loads(json_str) if json_str else None
+    except json.JSONDecodeError:
+        return None
+
+
+def default_values_yaml_from_type_snap(type_snap: ConfigTypeSnap) -> str:
+    defaults_by_field = {}
+
+    for field_name in type_snap.field_names:
+        default_value_as_json = type_snap.get_field(field_name).default_value_as_json_str
+        default_value = _safe_json_loads(default_value_as_json)
+        defaults_by_field[field_name] = default_value
+
+    return dump_run_config_yaml(defaults_by_field)

--- a/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
+++ b/python_modules/dagster/dagster/_core/snap/snap_to_yaml.py
@@ -16,29 +16,34 @@ def default_values_yaml_from_type_snap(
     snapshot: ConfigSchemaSnapshot,
     type_snap: ConfigTypeSnap,
 ) -> str:
+    """Returns a YAML representation of the default values for the given type snap."""
     return dump_run_config_yaml(default_values_from_type_snap(type_snap, snapshot))
 
 
 def default_values_from_type_snap(type_snap: ConfigTypeSnap, snapshot: ConfigSchemaSnapshot) -> Any:
+    """Given a type snap and a snapshot, returns a dictionary of default values for the type
+    snap, recursively assembling a default if the type snap does not have a default value
+    explicitly set.
+    """
     defaults_by_field = {}
 
     for field_name in type_snap.field_names:
         field = type_snap.get_field(field_name)
 
-        # no default placeholder
-        default_value = ...
-
         default_value_as_json = field.default_value_as_json_str
+        field_snap = (
+            snapshot.get_config_snap(field.type_key)
+            if snapshot.has_config_snap(field.type_key)
+            else None
+        )
+
+        # First, we try to get the default value from the field itself
+        # this is usually only set for primitive field types with user-supplied defaults
         if default_value_as_json:
-            default_value = _safe_json_loads(default_value_as_json)
-        if not default_value_as_json and snapshot:
-            key = field.type_key
-            snap = snapshot.get_config_snap(key)
-
-            if snap.fields:
-                default_value = default_values_from_type_snap(snap, snapshot)
-
-        if default_value is not ...:
-            defaults_by_field[field_name] = default_value
+            defaults_by_field[field_name] = _safe_json_loads(default_value_as_json)
+        # If there is no default value on the field, if the field has child fields, we recurse
+        # to assemble the default values for the child fields
+        elif field_snap and field_snap.fields:
+            defaults_by_field[field_name] = default_values_from_type_snap(field_snap, snapshot)
 
     return defaults_by_field

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -1,0 +1,76 @@
+import os
+import sys
+
+from dagster import Field, job, op
+from dagster._config.field import resolve_to_config_type
+from dagster._config.snap import snap_from_config_type
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.host_representation import InProcessRepositoryLocationOrigin
+from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+
+
+def test_basic_default():
+    snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "foo")}))
+    yaml_str = default_values_yaml_from_type_snap(snap)
+    assert yaml_str == "a: foo\n"
+
+
+def test_with_spaces():
+    snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "with spaces")}))
+    yaml_str = default_values_yaml_from_type_snap(snap)
+    assert yaml_str == "a: with spaces\n"
+
+
+def external_repository_for_function(fn):
+    return external_repository_for_module(fn.__module__, fn.__name__)
+
+
+def external_repository_for_module(module_name, attribute=None, repository_name="__repository__"):
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=sys.executable,
+        module_name=module_name,
+        working_directory=os.getcwd(),
+        attribute=attribute,
+    )
+
+    location = InProcessRepositoryLocationOrigin(
+        loadable_target_origin=loadable_target_origin, location_name=module_name
+    ).create_location()
+
+    return location.get_repository(repository_name)
+
+
+def trivial_job_defs():
+    @op
+    def an_op():
+        pass
+
+    @job
+    def a_job():
+        an_op()
+
+    return Definitions(jobs=[a_job])
+
+
+def test_print_root():
+    external_repository = external_repository_for_function(trivial_job_defs)
+    external_a_job = external_repository.get_full_external_job("a_job")
+    root_config_key = external_a_job.root_config_key_for_mode(None)
+    assert root_config_key
+    root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
+    assert (
+        default_values_yaml_from_type_snap(root_type)
+        == """execution:
+  config:
+    multiprocess:
+      max_concurrent: 0
+      retries:
+        enabled: {}
+loggers: {}
+ops:
+  an_op: {}
+resources:
+  io_manager: {}
+"""
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -1,9 +1,10 @@
 import os
 import sys
+from typing import Dict, List, Optional
 
-from dagster import Field, job, op
+from dagster import Config, Field, job, op
 from dagster._config.field import resolve_to_config_type
-from dagster._config.snap import snap_from_config_type
+from dagster._config.snap import ConfigSchemaSnapshot, snap_from_config_type
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.host_representation import InProcessCodeLocationOrigin
 from dagster._core.host_representation.external import ExternalJob
@@ -12,13 +13,17 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
 
 def test_basic_default():
-    snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "foo")}))
+    snap = snap_from_config_type(
+        ConfigSchemaSnapshot({}), resolve_to_config_type({"a": Field(str, "foo")})
+    )
     yaml_str = default_values_yaml_from_type_snap(snap)
     assert yaml_str == "a: foo\n"
 
 
 def test_with_spaces():
-    snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "with spaces")}))
+    snap = snap_from_config_type(
+        ConfigSchemaSnapshot({}), resolve_to_config_type({"a": Field(str, "with spaces")})
+    )
     yaml_str = default_values_yaml_from_type_snap(snap)
     assert yaml_str == "a: with spaces\n"
 
@@ -61,7 +66,7 @@ def test_print_root() -> None:
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (
-        default_values_yaml_from_type_snap(root_type)
+        default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
         == """execution:
   config:
     multiprocess:
@@ -71,6 +76,96 @@ def test_print_root() -> None:
 loggers: {}
 ops:
   an_op: {}
+resources:
+  io_manager: {}
+"""
+    )
+
+
+def job_def_with_config():
+    class MyOpConfig(Config):
+        a_str_with_default: str = "foo"
+        optional_int: Optional[int] = None
+        a_str_no_default: str
+
+    @op
+    def an_op(config: MyOpConfig):
+        pass
+
+    @job
+    def a_job():
+        an_op()
+
+    return Definitions(jobs=[a_job])
+
+
+def test_print_root_op_config() -> None:
+    external_repository = external_repository_for_function(job_def_with_config)
+    external_a_job: ExternalJob = external_repository.get_full_external_job("a_job")
+    root_config_key = external_a_job.root_config_key
+    assert root_config_key
+    root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
+    assert (
+        default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
+        == """execution:
+  config:
+    multiprocess:
+      max_concurrent: 0
+      retries:
+        enabled: {}
+loggers: {}
+ops:
+  an_op:
+    config:
+      a_str_with_default: foo
+resources:
+  io_manager: {}
+"""
+    )
+
+
+def job_def_with_complex_config():
+    class MyNestedConfig(Config):
+        a_default_int: int = 1
+
+    class MyOpConfig(Config):
+        nested: MyNestedConfig
+        my_list: List[Dict[str, int]] = [{"foo": 1, "bar": 2}]
+
+    @op
+    def an_op(config: MyOpConfig):
+        pass
+
+    @job
+    def a_job():
+        an_op()
+
+    return Definitions(jobs=[a_job])
+
+
+def test_print_root_complex_op_config() -> None:
+    external_repository = external_repository_for_function(job_def_with_complex_config)
+    external_a_job: ExternalJob = external_repository.get_full_external_job("a_job")
+    root_config_key = external_a_job.root_config_key
+    assert root_config_key
+    root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
+    assert (
+        default_values_yaml_from_type_snap(external_a_job.config_schema_snapshot, root_type)
+        == """execution:
+  config:
+    multiprocess:
+      max_concurrent: 0
+      retries:
+        enabled: {}
+loggers: {}
+ops:
+  an_op:
+    config:
+      my_list:
+      - bar: 2
+        foo: 1
+      nested:
+        a_default_int: 1
 resources:
   io_manager: {}
 """

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -6,6 +6,7 @@ from dagster._config.field import resolve_to_config_type
 from dagster._config.snap import snap_from_config_type
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.host_representation import InProcessCodeLocationOrigin
+from dagster._core.host_representation.external import ExternalJob
 from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
@@ -53,10 +54,10 @@ def trivial_job_defs():
     return Definitions(jobs=[a_job])
 
 
-def test_print_root():
+def test_print_root() -> None:
     external_repository = external_repository_for_function(trivial_job_defs)
-    external_a_job = external_repository.get_full_external_job("a_job")
-    root_config_key = external_a_job.root_config_key_for_mode(None)
+    external_a_job: ExternalJob = external_repository.get_full_external_job("a_job")
+    root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
     assert (

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -5,7 +5,7 @@ from dagster import Field, job, op
 from dagster._config.field import resolve_to_config_type
 from dagster._config.snap import snap_from_config_type
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.host_representation import InProcessRepositoryLocationOrigin
+from dagster._core.host_representation import InProcessCodeLocationOrigin
 from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
@@ -34,7 +34,7 @@ def external_repository_for_module(module_name, attribute=None, repository_name=
         attribute=attribute,
     )
 
-    location = InProcessRepositoryLocationOrigin(
+    location = InProcessCodeLocationOrigin(
         loadable_target_origin=loadable_target_origin, location_name=module_name
     ).create_location()
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -13,18 +13,14 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
 
 def test_basic_default():
-    snap = snap_from_config_type(
-        ConfigSchemaSnapshot({}), resolve_to_config_type({"a": Field(str, "foo")})
-    )
-    yaml_str = default_values_yaml_from_type_snap(snap)
+    snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "foo")}))
+    yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)
     assert yaml_str == "a: foo\n"
 
 
 def test_with_spaces():
-    snap = snap_from_config_type(
-        ConfigSchemaSnapshot({}), resolve_to_config_type({"a": Field(str, "with spaces")})
-    )
-    yaml_str = default_values_yaml_from_type_snap(snap)
+    snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "with spaces")}))
+    yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)
     assert yaml_str == "a: with spaces\n"
 
 


### PR DESCRIPTION
## Summary

Update of #12282. Serializes the default run config for jobs, making it available via GraphQL to the frontend. Used in stacked PR to enable "expand all defaults" button in launchpad.

## Test Plan

Snapshot test; tested manually.
