### PR TITLE
Add 'scaffold all default config' button to launchpad

### DIFF
--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
@@ -12,6 +12,7 @@ export const CONFIG_EDITOR_RUN_CONFIG_SCHEMA_FRAGMENT = gql`
     allConfigTypes {
       ...AllConfigTypesForEditor
     }
+    rootDefaultYaml
   }
 
   fragment AllConfigTypesForEditor on ConfigType {

--- a/js_modules/dagit/packages/core/src/configeditor/types/ConfigEditorUtils.types.ts
+++ b/js_modules/dagit/packages/core/src/configeditor/types/ConfigEditorUtils.types.ts
@@ -4,6 +4,7 @@ import * as Types from '../../graphql/types';
 
 export type ConfigEditorRunConfigSchemaFragment = {
   __typename: 'RunConfigSchema';
+  rootDefaultYaml: string;
   rootConfigType:
     | {__typename: 'ArrayConfigType'; key: string}
     | {__typename: 'CompositeConfigType'; key: string}

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -271,6 +271,18 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
     }
   };
 
+  const onExpandDefaults = () => {
+    if (runConfigSchema?.rootDefaultYaml) {
+      const defaultsYaml = yaml.parse(sanitizeConfigYamlString(runConfigSchema?.rootDefaultYaml));
+
+      const currentUserConfig = yaml.parse(sanitizeConfigYamlString(currentSession.runConfigYaml));
+      const updatedRunConfigData = merge(defaultsYaml, currentUserConfig);
+      const mergedYaml = yaml.stringify(updatedRunConfigData);
+
+      onSaveSession({runConfigYaml: mergedYaml});
+    }
+  };
+
   const buildExecutionVariables = () => {
     if (!currentSession) {
       return;
@@ -716,6 +728,7 @@ const LaunchpadSession: React.FC<LaunchpadSessionProps> = (props) => {
               onHighlightPath={(path) => editor.current?.moveCursorToPath(path)}
               onRemoveExtraPaths={(paths) => onRemoveExtraPaths(paths)}
               onScaffoldMissingConfig={onScaffoldMissingConfig}
+              onExpandDefaults={onExpandDefaults}
             />
           </>
         }

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -13,6 +13,7 @@ import {
   Code,
   Tooltip,
   FontFamily,
+  MetadataTable,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';
@@ -201,6 +202,45 @@ const ScaffoldConfigButton = ({
   );
 };
 
+const ExpandDefaultButton = ({
+  onExpandDefaults,
+  disabled,
+}: {
+  onExpandDefaults: () => void;
+  disabled: boolean;
+}) => {
+  const confirm = useConfirmation();
+
+  const onClick = async () => {
+    await confirm({
+      title: 'Scaffold all default config',
+      description: (
+        <div>
+          <p>
+            Clicking confirm will automatically scaffold any unspecified configuration fields into
+            your run config with default values. You will need to change the values appropriately.
+          </p>
+        </div>
+      ),
+    });
+    onExpandDefaults();
+  };
+
+  return (
+    <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+      <Button disabled={disabled} onClick={onClick}>
+        Scaffold all default config
+      </Button>
+      {disabled ? (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Icon name="check_circle" color={Colors.Green500} />
+          No missing config
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
 interface RunPreviewProps {
   validation: RunPreviewValidationFragment | null;
   document: any | null;
@@ -210,6 +250,7 @@ interface RunPreviewProps {
   onHighlightPath: (path: string[]) => void;
   onRemoveExtraPaths: (paths: string[]) => void;
   onScaffoldMissingConfig: () => void;
+  onExpandDefaults: () => void;
   solidSelection: string[] | null;
 }
 
@@ -221,6 +262,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
     launchpadType,
     onRemoveExtraPaths,
     onScaffoldMissingConfig,
+    onExpandDefaults,
     solidSelection,
     runConfigSchema,
   } = props;
@@ -396,6 +438,7 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
                 missingNodes={missingNodes}
                 disabled={!missingNodes.length}
               />
+              <ExpandDefaultButton onExpandDefaults={onExpandDefaults} disabled={false} />
               <RemoveExtraConfigButton
                 onRemoveExtraPaths={onRemoveExtraPaths}
                 extraNodes={extraNodes}

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -216,10 +216,8 @@ const ExpandDefaultButton = ({
       title: 'Scaffold all default config',
       description: (
         <div>
-          <p>
-            Clicking confirm will automatically scaffold any unspecified configuration fields into
-            your run config with default values. You will need to change the values appropriately.
-          </p>
+          Clicking confirm will automatically scaffold any unspecified configuration fields into
+          your run config with default values. You will need to change the values appropriately.
         </div>
       ),
     });

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -13,7 +13,6 @@ import {
   Code,
   Tooltip,
   FontFamily,
-  MetadataTable,
 } from '@dagster-io/ui';
 import * as React from 'react';
 import styled from 'styled-components/macro';

--- a/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSession.types.ts
+++ b/js_modules/dagit/packages/core/src/launchpad/types/LaunchpadSession.types.ts
@@ -133,6 +133,7 @@ export type PipelineExecutionConfigSchemaQuery = {
     | {__typename: 'PythonError'}
     | {
         __typename: 'RunConfigSchema';
+        rootDefaultYaml: string;
         rootConfigType:
           | {__typename: 'ArrayConfigType'; key: string}
           | {__typename: 'CompositeConfigType'; key: string}
@@ -230,6 +231,7 @@ export type LaunchpadSessionRunConfigSchemaFragment_PythonError_ = {__typename: 
 
 export type LaunchpadSessionRunConfigSchemaFragment_RunConfigSchema_ = {
   __typename: 'RunConfigSchema';
+  rootDefaultYaml: string;
   rootConfigType:
     | {__typename: 'ArrayConfigType'; key: string}
     | {__typename: 'CompositeConfigType'; key: string}


### PR DESCRIPTION
## Summary

Introduces a new button to the launchpad which allows users to expand all default config values.

Resolves #11828 

![Screen Shot 2023-05-01 at 4 31 41 PM](https://user-images.githubusercontent.com/10215173/235550064-1ecc1a05-b481-4e8f-be22-c56ab0008cc4.png)

![Screen Shot 2023-05-01 at 4 31 47 PM](https://user-images.githubusercontent.com/10215173/235550060-9d88c11e-ab39-466e-8ab7-930508295fb9.png)

One possible improvement to stack on this would be checkboxes in the dialog to toggle on/off which defaults to expand (ops, resources, execution, logging).

## Test Plan

Tested locally.
