### PR TITLE
[dagster-fivetran][fix] Ignore Fivetran connectors that are broken or incomplete when loading from instance

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -357,6 +357,11 @@ class FivetranInstanceCacheableAssetsDefinition(CacheableAssetsDefinition):
                 connector_id = connector["id"]
 
                 connector_name = connector["schema"]
+
+                setup_state = connector.get("status", {}).get("setup_state")
+                if setup_state and setup_state in ("incomplete", "broken"):
+                    continue
+
                 connector_url = get_fivetran_connector_url(connector)
 
                 schemas = self._fivetran_instance.make_request(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
@@ -220,6 +220,17 @@ def get_sample_connectors_response_multiple():
                 "id": DEFAULT_CONNECTOR_ID_2,
                 "service": "some_other_service",
                 "schema": "some_other_service.some_name",
+                "status": {
+                    "setup_state": "connected",
+                },
+            },
+            {
+                "id": "FAKE",
+                "service": "some_other_service",
+                "schema": "some_other_service.some_name",
+                "status": {
+                    "setup_state": "broken",
+                },
             },
         ]
     }


### PR DESCRIPTION
## Summary

Based on user report, filters out fivetran connections which have a setup state [marked as `incomplete` or `broken`](https://fivetran.com/docs/rest-api/connectors#fields) when loading the list of all connector types.

## Test Plan

Added a broken connector to mock test cases.

TODO: test against dev instance