### PR TITLE
Add type check to dagster-shell env

### DIFF
--- a/python_modules/libraries/dagster-shell/dagster_shell/utils.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/utils.py
@@ -60,7 +60,7 @@ def execute_script_file(shell_script_path, output_logging, log, cwd=None, env=No
     check.str_param(shell_script_path, "shell_script_path")
     check.str_param(output_logging, "output_logging")
     check.opt_str_param(cwd, "cwd", default=os.path.dirname(shell_script_path))
-    env = check.opt_nullable_dict_param(env, "env")
+    env = check.opt_nullable_dict_param(env, "env", key_type=str, value_type=str)
 
     if output_logging not in OUTPUT_LOGGING_OPTIONS:
         raise Exception("Unrecognized output_logging %s" % output_logging)


### PR DESCRIPTION
A user hit a confusing error by having a None here:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/utils.py", line 54, in op_execution_error_boundary
    yield
  File "/Users/johann/dagster/python_modules/dagster/dagster/_utils/__init__.py", line 445, in iterate_with_context
    next_output = next(iterator)
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py", line 124, in _coerce_op_compute_fn_to_iterator
    result = invoke_compute_fn(
  File "/Users/johann/dagster/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py", line 118, in invoke_compute_fn
    return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
  File "shell.py", line 7, in shell_op
    execute_shell_command(
  File "/Users/johann/dagster/python_modules/libraries/dagster-shell/dagster_shell/utils.py", line 161, in execute
    return execute_script_file(
  File "/Users/johann/dagster/python_modules/libraries/dagster-shell/dagster_shell/utils.py", line 87, in execute_script_file
    sub_process = Popen(
  File "/Users/johann/.pyenv/versions/3.9.10/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/johann/.pyenv/versions/3.9.10/lib/python3.9/subprocess.py", line 1741, in _execute_child
    env_list.append(k + b'=' + os.fsencode(v))
  File "/Users/johann/.pyenv/versions/3.9.10/lib/python3.9/os.py", line 810, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
```