### PR TITLE
fix(databricks): handle skipped Databricks runs

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -161,6 +161,9 @@ class DatabricksClient:
             if run_state.is_successful():
                 logger.info(f"Run `{databricks_run_id}` completed successfully.")
                 return True
+            if run_state.is_skipped():
+                logger.info(f"Run `{databricks_run_id}` was skipped.")
+                return True
             else:
                 error_message = (
                     f"Run `{databricks_run_id}` failed with result state:"

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
@@ -29,7 +29,11 @@ class DatabricksRunLifeCycleState(str, Enum):
             DatabricksRunLifeCycleState.TERMINATING,
             DatabricksRunLifeCycleState.TERMINATED,
             DatabricksRunLifeCycleState.INTERNAL_ERROR,
+            DatabricksRunLifeCycleState.SKIPPED,
         ]
+
+    def is_skipped(self) -> bool:
+        return self == DatabricksRunLifeCycleState.SKIPPED
 
 
 class DatabricksRunState(NamedTuple):
@@ -42,6 +46,9 @@ class DatabricksRunState(NamedTuple):
     def has_terminated(self) -> bool:
         """Has the job terminated?"""
         return self.life_cycle_state.has_terminated()
+
+    def is_skipped(self) -> bool:
+        return self.life_cycle_state.is_skipped()
 
     def is_successful(self) -> bool:
         """Was the job successful?"""

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -132,6 +132,23 @@ def test_databricks_wait_for_run(mocker: MockerFixture):
     calls["num_calls"] = 0
     calls["final_state"] = {
         "state": {
+            "result_state": None,
+            "life_cycle_state": DatabricksRunLifeCycleState.SKIPPED,
+            "state_message": "Skipped",
+        }
+    }
+
+    databricks_client.wait_for_run_to_complete(
+        logger=context.log,
+        databricks_run_id=1,
+        poll_interval_sec=0.01,
+        max_wait_time_sec=10,
+        verbose_logs=True,
+    )
+
+    calls["num_calls"] = 0
+    calls["final_state"] = {
+        "state": {
             "result_state": DatabricksRunResultState.FAILED,
             "life_cycle_state": DatabricksRunLifeCycleState.TERMINATED,
             "state_message": "Failed",


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/13668.

Mark Databricks job runs that are skipped as terminated. This way, we end the process that is monitoring the run.

## How I Tested These Changes
pytest
