### PR TITLE
Add urllib3<2 pin, remove ipython pin

### DIFF
--- a/.buildkite/dagster-buildkite/setup.py
+++ b/.buildkite/dagster-buildkite/setup.py
@@ -23,6 +23,9 @@ setup(
         "requests",
         "typing_extensions>=4.2",
         "pathspec",
+        # Need this until we have OpenSSL 1.1.1+ available in BK base image
+        # Context: https://github.com/psf/requests/issues/6432
+        "urllib3<2",
     ],
     entry_points={
         "console_scripts": [

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -33,6 +33,8 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_docker_tests*"]),
-    install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
+    # urllib3<2 pin needed until docker-py is updated
+    # see: https://github.com/docker/docker-py/issues/3113
+    install_requires=[f"dagster{pin}", "docker", "docker-image-py", "urllib3<2"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -36,9 +36,6 @@ setup(
         f"dagster-pandas{pin}",
         "pandas",
         "great_expectations >=0.11.9, !=0.12.8, !=0.13.17, !=0.13.27",
-        # 8.13+ explicitly does not support python 3.8
-        # Can remove when this resolves https://github.com/ipython/ipython/issues/14053
-        "ipython<=8.12; python_version<='3.8'",
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -50,9 +50,6 @@ setup(
         "scrapbook>=0.5.0",
         "nbconvert",
         "jupyter-client<8",  # jupyter-client 8 causing test hangs
-        # 8.13+ explicitly does not support python 3.8
-        # Can remove when this resolves https://github.com/ipython/ipython/issues/14053
-        "ipython<=8.12; python_version<='3.8'",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Summary & Motivation

- Add `urllib3<2` pin. Needed until OpenSSL 1.1.1+ available in all our infrastructure. Without it, we get e.g.:

```
[2023-05-03T16:29:22Z]     "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
--
  | [2023-05-03T16:29:22Z] ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips  26 Jan 2017. See: https://github.com/urllib3/urllib3/issues/2168
```
- Remove ipython pins to work around issues with a previous version that has now been yanked.

## How I Tested These Changes

BK