### PR TITLE
Calculate AutoMaterializeReasons in `reconcile()` logic

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -57,7 +57,7 @@ dagster-pandas==0.11.14
 -e python_modules/libraries/dagster-snowflake-pyspark
 -e python_modules/libraries/dagster-spark
 dbt-core==1.5.0
-dbt-duckdb==1.5.1
+dbt-duckdb==1.5.0
 dbt-extractor==0.4.1
 dbt-snowflake==1.5.0
 debugpy==1.6.7
@@ -65,7 +65,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 dill==0.3.6
 distlib==0.3.6
-docker==6.1.0
+docker==6.0.1
 docstring-parser==0.15
 duckdb==0.7.1
 execnet==1.9.0
@@ -83,7 +83,7 @@ google-api-core==2.11.0
 google-auth==2.17.3
 google-auth-oauthlib==1.0.0
 google-cloud-core==2.3.2
-google-cloud-storage==2.9.0
+google-cloud-storage==2.8.0
 google-crc32c==1.5.0
 google-resumable-media==2.5.0
 googleapis-common-protos==1.59.0
@@ -102,10 +102,9 @@ httptools==0.5.0
 humanfriendly==10.0
 idna==3.4
 importlib-metadata==6.6.0
-importlib-resources==5.12.0
 iniconfig==2.0.0
 ipykernel==6.22.0
-ipython==8.13.2
+ipython==8.13.1
 ipython-genutils==0.2.0
 isodate==0.6.1
 isoduration==20.11.0
@@ -151,7 +150,7 @@ multidict==6.0.4
 multimethod==1.9.1
 mypy==1.2.0
 mypy-extensions==1.0.0
-nbclassic==1.0.0
+nbclassic==0.5.6
 nbclient==0.7.4
 nbconvert==7.3.1
 nbformat==5.8.0
@@ -166,7 +165,7 @@ objgraph==3.5.0
 oscrypto==1.3.0
 packaging==23.1
 pandas==1.3.5
-pandas-stubs==2.0.1.230501
+pandas-stubs==2.0.0.230412
 pandera==0.14.5
 pandocfilters==1.5.0
 parsedatetime==2.4
@@ -219,7 +218,7 @@ pytz==2023.3
 pytzdata==2020.1
 PyYAML==6.0
 pyzmq==25.0.2
-requests==2.30.0
+requests==2.29.0
 requests-oauthlib==1.3.1
 requests-toolbelt==0.10.1
 responses==0.23.1
@@ -228,7 +227,7 @@ rfc3986-validator==0.1.1
 rich==13.3.5
 rsa==4.9
 s3fs==2023.4.0
-s3transfer==0.6.1
+s3transfer==0.6.0
 scikit-learn==1.2.2
 scipy==1.10.1
 seaborn==0.12.2
@@ -259,20 +258,20 @@ tornado==6.3.1
 tox==3.25.0
 tqdm==4.65.0
 traitlets==5.9.0
-typer==0.9.0
+typer==0.8.0
 types-backports==0.1.3
 types-certifi==2021.10.8.3
 types-chardet==5.0.4.5
 types-croniter==1.3.2.9
 types-cryptography==3.3.23.2
 types-mock==5.0.0.6
-types-paramiko==3.0.0.9
+types-paramiko==3.0.0.8
 types-pkg-resources==0.1.3
 types-pyOpenSSL==23.1.0.2
 types-python-dateutil==2.8.19.12
 types-pytz==2023.3.0.0
 types-PyYAML==6.0.12.9
-types-requests==2.30.0.0
+types-requests==2.29.0.0
 types-simplejson==3.19.0.0
 types-six==1.16.21.8
 types-SQLAlchemy==1.4.53.34

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -57,7 +57,7 @@ dagster-pandas==0.11.14
 -e python_modules/libraries/dagster-snowflake-pyspark
 -e python_modules/libraries/dagster-spark
 dbt-core==1.5.0
-dbt-duckdb==1.5.0
+dbt-duckdb==1.5.1
 dbt-extractor==0.4.1
 dbt-snowflake==1.5.0
 debugpy==1.6.7
@@ -65,7 +65,7 @@ decorator==5.1.1
 defusedxml==0.7.1
 dill==0.3.6
 distlib==0.3.6
-docker==6.0.1
+docker==6.1.0
 docstring-parser==0.15
 duckdb==0.7.1
 execnet==1.9.0
@@ -83,7 +83,7 @@ google-api-core==2.11.0
 google-auth==2.17.3
 google-auth-oauthlib==1.0.0
 google-cloud-core==2.3.2
-google-cloud-storage==2.8.0
+google-cloud-storage==2.9.0
 google-crc32c==1.5.0
 google-resumable-media==2.5.0
 googleapis-common-protos==1.59.0
@@ -102,9 +102,10 @@ httptools==0.5.0
 humanfriendly==10.0
 idna==3.4
 importlib-metadata==6.6.0
+importlib-resources==5.12.0
 iniconfig==2.0.0
 ipykernel==6.22.0
-ipython==8.13.1
+ipython==8.13.2
 ipython-genutils==0.2.0
 isodate==0.6.1
 isoduration==20.11.0
@@ -150,7 +151,7 @@ multidict==6.0.4
 multimethod==1.9.1
 mypy==1.2.0
 mypy-extensions==1.0.0
-nbclassic==0.5.6
+nbclassic==1.0.0
 nbclient==0.7.4
 nbconvert==7.3.1
 nbformat==5.8.0
@@ -165,7 +166,7 @@ objgraph==3.5.0
 oscrypto==1.3.0
 packaging==23.1
 pandas==1.3.5
-pandas-stubs==2.0.0.230412
+pandas-stubs==2.0.1.230501
 pandera==0.14.5
 pandocfilters==1.5.0
 parsedatetime==2.4
@@ -218,7 +219,7 @@ pytz==2023.3
 pytzdata==2020.1
 PyYAML==6.0
 pyzmq==25.0.2
-requests==2.29.0
+requests==2.30.0
 requests-oauthlib==1.3.1
 requests-toolbelt==0.10.1
 responses==0.23.1
@@ -227,7 +228,7 @@ rfc3986-validator==0.1.1
 rich==13.3.5
 rsa==4.9
 s3fs==2023.4.0
-s3transfer==0.6.0
+s3transfer==0.6.1
 scikit-learn==1.2.2
 scipy==1.10.1
 seaborn==0.12.2
@@ -258,20 +259,20 @@ tornado==6.3.1
 tox==3.25.0
 tqdm==4.65.0
 traitlets==5.9.0
-typer==0.8.0
+typer==0.9.0
 types-backports==0.1.3
 types-certifi==2021.10.8.3
 types-chardet==5.0.4.5
 types-croniter==1.3.2.9
 types-cryptography==3.3.23.2
 types-mock==5.0.0.6
-types-paramiko==3.0.0.8
+types-paramiko==3.0.0.9
 types-pkg-resources==0.1.3
 types-pyOpenSSL==23.1.0.2
 types-python-dateutil==2.8.19.12
 types-pytz==2023.3.0.0
 types-PyYAML==6.0.12.9
-types-requests==2.29.0.0
+types-requests==2.30.0.0
 types-simplejson==3.19.0.0
 types-six==1.16.21.8
 types-SQLAlchemy==1.4.53.34

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -2,6 +2,7 @@ import datetime
 import itertools
 import json
 from collections import defaultdict
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -33,6 +34,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     has_one_dimension_time_window_partitioning,
 )
+from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.backcompat import deprecation_warning
 from dagster._utils.schedules import cron_string_iterator
 
@@ -46,6 +48,96 @@ from .utils import check_valid_name
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
     from dagster._utils.caching_instance_queryer import CachingInstanceQueryer  # expensive import
+
+
+class _AutoMaterializeCondition(Enum):
+    FRESHNESS = "FRESHNESS"
+    DOWNSTREAM_FRESHNESS = "DOWNSTREAM_FRESHNESS"
+    PARENT_UPDATED = "PARENT_UPDATED"
+    MISSING = "MISSING"
+
+
+@whitelist_for_serdes
+class AutoMaterializeReason(NamedTuple):
+    condition: _AutoMaterializeCondition
+
+    @staticmethod
+    def freshness() -> "AutoMaterializeReason":
+        return AutoMaterializeReason(condition=_AutoMaterializeCondition.FRESHNESS)
+
+    @staticmethod
+    def downstream_freshness() -> "AutoMaterializeReason":
+        return AutoMaterializeReason(condition=_AutoMaterializeCondition.DOWNSTREAM_FRESHNESS)
+
+    @staticmethod
+    def parent_updated() -> "AutoMaterializeReason":
+        return AutoMaterializeReason(condition=_AutoMaterializeCondition.PARENT_UPDATED)
+
+    @staticmethod
+    def missing() -> "AutoMaterializeReason":
+        return AutoMaterializeReason(condition=_AutoMaterializeCondition.MISSING)
+
+
+class _AutoMaterializeSkipCondition(Enum):
+    PARENT_UNRECONCILED = "PARENT_UNRECONCILED"
+
+
+@whitelist_for_serdes
+class AutoMaterializeSkipReason(NamedTuple):
+    condition: _AutoMaterializeSkipCondition
+
+    @staticmethod
+    def parent_unreconciled() -> "AutoMaterializeSkipReason":
+        return AutoMaterializeSkipReason(
+            condition=_AutoMaterializeSkipCondition.PARENT_UNRECONCILED
+        )
+
+
+@whitelist_for_serdes
+class AutoMaterializeDecision(NamedTuple):
+    materialize_reasons: Union[
+        AbstractSet[AutoMaterializeReason],
+        AbstractSet[Tuple[AutoMaterializeReason, PartitionsSubset]],
+    ]
+    skip_reasons: Union[
+        AbstractSet[AutoMaterializeSkipReason],
+        AbstractSet[Tuple[AutoMaterializeSkipReason, PartitionsSubset]],
+    ]
+
+    @staticmethod
+    def from_reasons(
+        asset_graph: AssetGraph,
+        asset_key: AssetKey,
+        materialize_reasons: Mapping[AssetKeyPartitionKey, AutoMaterializeReason],
+        skip_reasons: Mapping[AssetKeyPartitionKey, AutoMaterializeSkipReason],
+    ):
+        partitions_def = asset_graph.get_partitions_def(asset_key)
+        if partitions_def is None:
+            return AutoMaterializeDecision(
+                materialize_reasons=set(materialize_reasons.values()),
+                skip_reasons=set(skip_reasons.values()),
+            )
+        else:
+            subset_by_materialize_reason: Dict[AutoMaterializeReason, Set[str]] = defaultdict(set)
+            subset_by_skip_reason: Dict[AutoMaterializeSkipReason, Set[str]] = defaultdict(set)
+
+            for asset_partition, reason in materialize_reasons.items():
+                subset_by_materialize_reason[reason].add(
+                    check.not_none(asset_partition.partition_key)
+                )
+            for asset_partition, reason in skip_reasons.items():
+                subset_by_skip_reason[reason].add(check.not_none(asset_partition.partition_key))
+
+            return AutoMaterializeDecision(
+                materialize_reasons=set(
+                    (reason, partitions_def.empty_subset().with_partition_keys(partition_keys))
+                    for reason, partition_keys in subset_by_materialize_reason.items()
+                ),
+                skip_reasons=set(
+                    (reason, partitions_def.empty_subset().with_partition_keys(partition_keys))
+                    for reason, partition_keys in subset_by_skip_reason.items()
+                ),
+            )
 
 
 def get_implicit_auto_materialize_policy(
@@ -510,14 +602,17 @@ def find_never_materialized_or_requested_root_asset_partitions(
     )
 
 
-def determine_asset_partitions_to_reconcile(
+def determine_asset_partitions_to_auto_materialize(
     instance_queryer: "CachingInstanceQueryer",
     cursor: AssetReconciliationCursor,
     target_asset_keys: AbstractSet[AssetKey],
     target_asset_keys_and_parents: AbstractSet[AssetKey],
     asset_graph: AssetGraph,
+    current_time: datetime.datetime,
+    materialize_reasons_for_freshness: Mapping[AssetKeyPartitionKey, Set[AutoMaterializeReason]],
 ) -> Tuple[
-    AbstractSet[AssetKeyPartitionKey],
+    Mapping[AssetKeyPartitionKey, AbstractSet[AutoMaterializeReason]],
+    Mapping[AssetKeyPartitionKey, AbstractSet[AutoMaterializeSkipReason]],
     AbstractSet[AssetKey],
     Mapping[AssetKey, AbstractSet[str]],
     Optional[int],
@@ -534,6 +629,12 @@ def determine_asset_partitions_to_reconcile(
         target_asset_keys=target_asset_keys,
         asset_graph=asset_graph,
     )
+
+    # initialize materialize_reasons with the materialize_reasons_for_freshness
+    materialize_reasons: Dict[AssetKeyPartitionKey, Set[AutoMaterializeReason]] = defaultdict(
+        set, materialize_reasons_for_freshness
+    )
+    skip_reasons: Mapping[AssetKeyPartitionKey, Set[AutoMaterializeSkipReason]] = defaultdict(set)
 
     # a filter for eliminating candidates
     def can_reconcile_candidate(candidate: AssetKeyPartitionKey) -> bool:
@@ -595,7 +696,7 @@ def determine_asset_partitions_to_reconcile(
                 continue
 
             if not (
-                parent in to_reconcile
+                (parent in to_reconcile or parent in materialize_reasons)
                 # if they don't have the same partitioning, then we can't launch a run that
                 # targets both, so we need to wait until the parent is reconciled before
                 # launching a run for the child
@@ -614,22 +715,23 @@ def determine_asset_partitions_to_reconcile(
 
         return True
 
-    def should_reconcile_candidate(candidate: AssetKeyPartitionKey) -> bool:
+    def materialize_reason_for_candidate(
+        candidate: AssetKeyPartitionKey,
+    ) -> Optional[AutoMaterializeReason]:
         auto_materialize_policy = get_implicit_auto_materialize_policy(
             asset_graph=asset_graph, asset_key=candidate.asset_key
         )
         if auto_materialize_policy is None:
-            return False
-
-        return (
-            auto_materialize_policy.on_missing
-            and not instance_queryer.materialization_exists(asset_partition=candidate)
-        ) or (
-            auto_materialize_policy.on_new_parent_data
-            and not instance_queryer.is_reconciled(
-                asset_partition=candidate, asset_graph=asset_graph
-            )
-        )
+            return None
+        elif auto_materialize_policy.on_missing and not instance_queryer.materialization_exists(
+            asset_partition=candidate
+        ):
+            return AutoMaterializeReason.missing()
+        elif auto_materialize_policy.on_new_parent_data and not instance_queryer.is_reconciled(
+            asset_partition=candidate, asset_graph=asset_graph
+        ):
+            return AutoMaterializeReason.parent_updated()
+        return None
 
     def should_reconcile(
         asset_graph: AssetGraph,
@@ -647,12 +749,28 @@ def determine_asset_partitions_to_reconcile(
         ):
             return False
 
-        return all(
+        if all(
             parents_will_be_reconciled(asset_graph, candidate, to_reconcile)
             for candidate in candidates_unit
-        ) and any(should_reconcile_candidate(candidate) for candidate in candidates_unit)
+        ):
+            auto_materialize_reason = next(
+                filter(
+                    None,
+                    (materialize_reason_for_candidate(candidate) for candidate in candidates_unit),
+                ),
+                None,
+            )
+            if auto_materialize_reason:
+                for candidate in candidates_unit:
+                    materialize_reasons[candidate].add(auto_materialize_reason)
+                return True
+        else:
+            for candidate in candidates_unit:
+                skip_reasons[candidate].add(AutoMaterializeSkipReason.parent_unreconciled())
+        return False
 
-    to_reconcile = asset_graph.bfs_filter_asset_partitions(
+    # will update materialize_reasons and skip_reasons
+    asset_graph.bfs_filter_asset_partitions(
         instance_queryer,
         lambda candidates_unit, to_reconcile: should_reconcile(
             asset_graph, candidates_unit, to_reconcile
@@ -662,7 +780,8 @@ def determine_asset_partitions_to_reconcile(
     )
 
     return (
-        to_reconcile,
+        materialize_reasons,
+        skip_reasons,
         newly_materialized_root_asset_keys,
         newly_materialized_root_partitions_by_asset_key,
         latest_storage_id,
@@ -700,22 +819,24 @@ def get_execution_period_for_policy(
         )
 
 
-def get_execution_period_for_policies(
+def get_execution_period_and_reasons_for_policies(
+    local_policy: Optional[FreshnessPolicy],
     policies: AbstractSet[FreshnessPolicy],
     effective_data_time: Optional[datetime.datetime],
     current_time: datetime.datetime,
-) -> Optional[pendulum.Period]:
+) -> Tuple[Optional[pendulum.Period], AbstractSet[AutoMaterializeReason]]:
     """Determines a range of times for which you can kick off an execution of this asset to solve
     the most pressing constraint, alongside a maximum number of additional constraints.
     """
     merged_period = None
-    for period in sorted(
+    reasons = set()
+    for period, policy in sorted(
         (
-            get_execution_period_for_policy(policy, effective_data_time, current_time)
+            (get_execution_period_for_policy(policy, effective_data_time, current_time), policy)
             for policy in policies
         ),
         # sort execution periods by most pressing
-        key=lambda period: period.end,
+        key=lambda pp: pp[0].end,
     ):
         if merged_period is None:
             merged_period = period
@@ -727,16 +848,21 @@ def get_execution_period_for_policies(
         else:
             break
 
-    return merged_period
+        if policy == local_policy:
+            reasons.add(AutoMaterializeReason.freshness())
+        else:
+            reasons.add(AutoMaterializeReason.downstream_freshness())
+
+    return merged_period, reasons
 
 
-def determine_asset_partitions_to_reconcile_for_freshness(
+def determine_asset_partitions_to_auto_materialize_for_freshness(
     data_time_resolver: "CachingDataTimeResolver",
     asset_graph: AssetGraph,
     target_asset_keys: AbstractSet[AssetKey],
     target_asset_keys_and_parents: AbstractSet[AssetKey],
     current_time: datetime.datetime,
-) -> AbstractSet[AssetKeyPartitionKey]:
+) -> Mapping[AssetKeyPartitionKey, Set[AutoMaterializeReason]]:
     """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies, as well as a set of AssetKeyPartitionKeys which will be materialized at
     some point within the plan window.
@@ -746,7 +872,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
     from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 
     # now we have a full set of constraints, we can find solutions for them as we move down
-    to_materialize: Set[AssetKeyPartitionKey] = set()
+    reasons: Mapping[AssetKeyPartitionKey, Set[AutoMaterializeReason]] = defaultdict(set)
     waiting_to_materialize: Set[AssetKey] = set()
     expected_data_time_by_key: Dict[AssetKey, Optional[datetime.datetime]] = {}
 
@@ -771,7 +897,7 @@ def determine_asset_partitions_to_reconcile_for_freshness(
             if isinstance(asset_graph, ExternalAssetGraph):
                 repo = asset_graph.get_repository_handle(key)
                 if any(
-                    AssetKeyPartitionKey(p, None) in to_materialize
+                    AssetKeyPartitionKey(p, None) in reasons
                     and asset_graph.get_repository_handle(p) is not repo
                     for p in parents
                 ):
@@ -810,18 +936,19 @@ def determine_asset_partitions_to_reconcile_for_freshness(
 
                 # figure out a time period that you can execute this asset within to solve a maximum
                 # number of constraints
-                execution_period = get_execution_period_for_policies(
+                execution_period, execution_reasons = get_execution_period_and_reasons_for_policies(
+                    local_policy=asset_graph.freshness_policies_by_key.get(key),
                     policies=asset_graph.get_downstream_freshness_policies(asset_key=key),
                     effective_data_time=effective_data_time,
                     current_time=current_time,
                 )
             else:
-                execution_period = None
+                execution_period, execution_reasons = None, set()
 
             # a key may already be in to_materialize by the time we get here if a required
             # neighbor was selected to be updated
             asset_key_partition_key = AssetKeyPartitionKey(key, None)
-            if asset_key_partition_key in to_materialize:
+            if asset_key_partition_key in reasons:
                 expected_data_time_by_key[key] = expected_data_time
             elif (
                 execution_period is not None
@@ -829,17 +956,17 @@ def determine_asset_partitions_to_reconcile_for_freshness(
                 and expected_data_time is not None
                 and expected_data_time >= execution_period.start
             ):
-                to_materialize.add(asset_key_partition_key)
+                reasons[asset_key_partition_key].update(execution_reasons)
                 expected_data_time_by_key[key] = expected_data_time
                 # all required neighbors will be updated on the same tick
                 for required_key in asset_graph.get_required_multi_asset_keys(key):
-                    to_materialize.add(AssetKeyPartitionKey(required_key, None))
+                    reasons[(AssetKeyPartitionKey(required_key, None))].update(execution_reasons)
             else:
                 # if downstream assets consume this, they should expect data time equal to the
                 # current time for this asset, as it's not going to be updated
                 expected_data_time_by_key[key] = current_data_time
 
-    return to_materialize
+    return reasons
 
 
 def reconcile(
@@ -848,7 +975,12 @@ def reconcile(
     instance: "DagsterInstance",
     cursor: AssetReconciliationCursor,
     run_tags: Optional[Mapping[str, str]],
-):
+) -> Tuple[
+    Sequence[RunRequest],
+    AssetReconciliationCursor,
+    Mapping[AssetKeyPartitionKey, AbstractSet[AutoMaterializeReason]],
+    Mapping[AssetKeyPartitionKey, AbstractSet[AutoMaterializeSkipReason]],
+]:
     from dagster._utils.caching_instance_queryer import CachingInstanceQueryer  # expensive import
 
     current_time = pendulum.now("UTC")
@@ -869,8 +1001,8 @@ def reconcile(
         target_asset_keys_and_parents_list, after_cursor=cursor.latest_storage_id
     )
 
-    asset_partitions_to_reconcile_for_freshness = (
-        determine_asset_partitions_to_reconcile_for_freshness(
+    materialize_reasons_for_freshness = (
+        determine_asset_partitions_to_auto_materialize_for_freshness(
             data_time_resolver=CachingDataTimeResolver(
                 instance_queryer=instance_queryer, asset_graph=asset_graph
             ),
@@ -882,30 +1014,42 @@ def reconcile(
     )
 
     (
-        asset_partitions_to_reconcile,
+        materialize_reasons,
+        skip_reasons,
         newly_materialized_root_asset_keys,
         newly_materialized_root_partitions_by_asset_key,
         latest_storage_id,
-    ) = determine_asset_partitions_to_reconcile(
+    ) = determine_asset_partitions_to_auto_materialize(
         instance_queryer=instance_queryer,
         asset_graph=asset_graph,
         cursor=cursor,
         target_asset_keys=target_asset_keys,
         target_asset_keys_and_parents=target_asset_keys_and_parents,
+        current_time=current_time,
+        materialize_reasons_for_freshness=materialize_reasons_for_freshness,
     )
 
     run_requests = build_run_requests(
-        asset_partitions_to_reconcile | asset_partitions_to_reconcile_for_freshness,
-        asset_graph,
-        run_tags,
+        asset_partitions={
+            asset_partition
+            for asset_partition in materialize_reasons
+            if asset_partition not in skip_reasons
+        },
+        asset_graph=asset_graph,
+        run_tags=run_tags,
     )
 
-    return run_requests, cursor.with_updates(
-        latest_storage_id=latest_storage_id,
-        run_requests=run_requests,
-        asset_graph=asset_graph,
-        newly_materialized_root_asset_keys=newly_materialized_root_asset_keys,
-        newly_materialized_root_partitions_by_asset_key=newly_materialized_root_partitions_by_asset_key,
+    return (
+        run_requests,
+        cursor.with_updates(
+            latest_storage_id=latest_storage_id,
+            run_requests=run_requests,
+            asset_graph=asset_graph,
+            newly_materialized_root_asset_keys=newly_materialized_root_asset_keys,
+            newly_materialized_root_partitions_by_asset_key=newly_materialized_root_partitions_by_asset_key,
+        ),
+        materialize_reasons,
+        skip_reasons,
     )
 
 
@@ -1095,7 +1239,7 @@ def build_asset_reconciliation_sensor(
                 ),
             )
 
-        run_requests, updated_cursor = reconcile(
+        run_requests, updated_cursor, _, _ = reconcile(
             asset_graph=asset_graph,
             target_asset_keys=target_asset_keys,
             instance=context.instance,
@@ -1107,3 +1251,35 @@ def build_asset_reconciliation_sensor(
         return run_requests
 
     return _sensor
+
+
+def build_auto_materialize_decisions(
+    asset_graph: AssetGraph,
+    materialize_reasons: Mapping[AssetKeyPartitionKey, AutoMaterializeReason],
+    skip_reasons: Mapping[AssetKeyPartitionKey, AutoMaterializeSkipReason],
+) -> Sequence[AutoMaterializeDecision]:
+    """Bundles up the materialize and skip reasons into AutoMaterializeDecisions."""
+    materialize_reasons_by_asset_key: Dict[
+        AssetKey, Set[Tuple[AssetKeyPartitionKey, AutoMaterializeReason]]
+    ] = defaultdict(set)
+    skip_reasons_by_asset_key: Dict[
+        AssetKey, Set[Tuple[AssetKeyPartitionKey, AutoMaterializeSkipReason]]
+    ] = defaultdict(set)
+
+    for asset_partition, reason in materialize_reasons.items():
+        materialize_reasons_by_asset_key[asset_partition.asset_key].add((asset_partition, reason))
+    for asset_partition, reason in skip_reasons.items():
+        skip_reasons_by_asset_key[asset_partition.asset_key].add((asset_partition, reason))
+
+    return [
+        AutoMaterializeDecision.from_reasons(
+            asset_graph,
+            asset_key,
+            dict(materialize_reasons_by_asset_key[asset_key]),
+            dict(skip_reasons_by_asset_key[asset_key]),
+        )
+        for asset_key in {
+            *materialize_reasons_by_asset_key.keys(),
+            *skip_reasons_by_asset_key.keys(),
+        }
+    ]

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -70,7 +70,7 @@ class AssetDaemon(IntervalDaemon):
             else AssetReconciliationCursor.empty()
         )
 
-        run_requests, new_cursor, _, _ = reconcile(
+        run_requests, new_cursor, _ = reconcile(
             asset_graph=asset_graph,
             target_asset_keys=target_asset_keys,
             instance=instance,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -70,7 +70,7 @@ class AssetDaemon(IntervalDaemon):
             else AssetReconciliationCursor.empty()
         )
 
-        run_requests, new_cursor = reconcile(
+        run_requests, new_cursor, _, _ = reconcile(
             asset_graph=asset_graph,
             target_asset_keys=target_asset_keys,
             instance=instance,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -43,8 +43,8 @@ from dagster import (
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_reconciliation_sensor import (
     AssetReconciliationCursor,
-   AutoMaterializeReason,
-   AutoMaterializeSkipReason,
+    AutoMaterializeReason,
+    AutoMaterializeSkipReason,
     reconcile,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -4,7 +4,18 @@ import itertools
 import os
 import random
 import sys
-from typing import Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, Union
+from typing import (
+    AbstractSet,
+    Iterable,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import mock
 import pendulum
@@ -32,9 +43,12 @@ from dagster import (
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_reconciliation_sensor import (
     AssetReconciliationCursor,
+   AutoMaterializeReason,
+   AutoMaterializeSkipReason,
     reconcile,
 )
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.external_asset_graph import ExternalAssetGraph
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observe import observe
@@ -74,6 +88,18 @@ class AssetReconciliationScenario(NamedTuple):
     event_log_entries: Optional[Sequence[EventLogEntry]] = None
     expected_run_requests: Optional[Sequence[RunRequest]] = None
     code_locations: Optional[Mapping[str, Sequence[Union[SourceAsset, AssetsDefinition]]]] = None
+    expected_materialize_reasons: Optional[
+        Mapping[
+            Union[CoercibleToAssetKey, Tuple[CoercibleToAssetKey, str]],
+            AbstractSet[AutoMaterializeReason],
+        ]
+    ] = None
+    expected_skip_reasons: Optional[
+        Mapping[
+            Union[CoercibleToAssetKey, Tuple[CoercibleToAssetKey, str]],
+            AbstractSet[AutoMaterializeSkipReason],
+        ]
+    ] = None
 
     def _get_code_location_origin(
         self, scenario_name, location_name=None
@@ -148,7 +174,12 @@ class AssetReconciliationScenario(NamedTuple):
                 def prior_repo():
                     return self.cursor_from.assets
 
-                run_requests, cursor = self.cursor_from.do_sensor_scenario(
+                (
+                    run_requests,
+                    cursor,
+                    materialize_reasons,
+                    skip_reasons,
+                ) = self.cursor_from.do_sensor_scenario(
                     instance,
                     scenario_name=scenario_name,
                     with_external_asset_graph=with_external_asset_graph,
@@ -222,7 +253,7 @@ class AssetReconciliationScenario(NamedTuple):
                 else asset_graph.non_source_asset_keys
             )
 
-            run_requests, cursor = reconcile(
+            run_requests, cursor, materialize_reasons, skip_reasons = reconcile(
                 asset_graph=asset_graph,
                 target_asset_keys=target_asset_keys,
                 instance=instance,
@@ -234,7 +265,7 @@ class AssetReconciliationScenario(NamedTuple):
             base_job = repo.get_implicit_job_def_for_assets(run_request.asset_selection)
             assert base_job is not None
 
-        return run_requests, cursor
+        return run_requests, cursor, materialize_reasons, skip_reasons
 
     def do_daemon_scenario(self, instance, scenario_name):
         assert bool(self.assets) != bool(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/asset_reconciliation_scenario.py
@@ -177,8 +177,7 @@ class AssetReconciliationScenario(NamedTuple):
                 (
                     run_requests,
                     cursor,
-                    materialize_reasons,
-                    skip_reasons,
+                    evaluations,
                 ) = self.cursor_from.do_sensor_scenario(
                     instance,
                     scenario_name=scenario_name,
@@ -253,7 +252,7 @@ class AssetReconciliationScenario(NamedTuple):
                 else asset_graph.non_source_asset_keys
             )
 
-            run_requests, cursor, materialize_reasons, skip_reasons = reconcile(
+            run_requests, cursor, evaluations = reconcile(
                 asset_graph=asset_graph,
                 target_asset_keys=target_asset_keys,
                 instance=instance,
@@ -265,7 +264,7 @@ class AssetReconciliationScenario(NamedTuple):
             base_job = repo.get_implicit_job_def_for_assets(run_request.asset_selection)
             assert base_job is not None
 
-        return run_requests, cursor, materialize_reasons, skip_reasons
+        return run_requests, cursor, evaluations
 
     def do_daemon_scenario(self, instance, scenario_name):
         assert bool(self.assets) != bool(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/basic_scenarios.py
@@ -1,3 +1,5 @@
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeReason
+
 from .asset_reconciliation_scenario import (
     AssetReconciliationScenario,
     asset_def,
@@ -67,11 +69,16 @@ basic_scenarios = {
         assets=one_asset,
         unevaluated_runs=[],
         expected_run_requests=[run_request(asset_keys=["asset1"])],
+        expected_materialize_reasons={"asset1": {AutoMaterializeReason.missing()}},
     ),
     "two_assets_in_sequence_never_materialized": AssetReconciliationScenario(
         assets=two_assets_in_sequence,
         unevaluated_runs=[],
         expected_run_requests=[run_request(asset_keys=["asset1", "asset2"])],
+        expected_materialize_reasons={
+            "asset1": {AutoMaterializeReason.missing()},
+            "asset2": {AutoMaterializeReason.missing()},
+        },
     ),
     "one_asset_already_launched": AssetReconciliationScenario(
         assets=one_asset,
@@ -86,11 +93,18 @@ basic_scenarios = {
         assets=two_assets_in_sequence,
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
+        expected_materialize_reasons={
+            "asset2": {AutoMaterializeReason.missing()},
+        },
     ),
     "parent_materialized_launch_two_children": AssetReconciliationScenario(
         assets=two_assets_depend_on_one,
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2", "asset3"])],
+        expected_materialize_reasons={
+            "asset2": {AutoMaterializeReason.missing()},
+            "asset3": {AutoMaterializeReason.missing()},
+        },
     ),
     "parent_materialized_with_source_asset_launch_child": AssetReconciliationScenario(
         assets=two_assets_one_source,
@@ -104,6 +118,7 @@ basic_scenarios = {
         ),
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
+        expected_materialize_reasons={"asset2": {AutoMaterializeReason.parent_updated()}},
     ),
     "parent_rematerialized": AssetReconciliationScenario(
         assets=two_assets_in_sequence,
@@ -117,6 +132,10 @@ basic_scenarios = {
         assets=one_asset_depends_on_two,
         unevaluated_runs=[single_asset_run(asset_key="parent1")],
         expected_run_requests=[run_request(asset_keys=["parent2", "child"])],
+        expected_materialize_reasons={
+            "parent2": {AutoMaterializeReason.missing()},
+            "child": {AutoMaterializeReason.missing()},
+        },
     ),
     "one_parent_materialized_others_materialized_before": AssetReconciliationScenario(
         assets=one_asset_depends_on_two,
@@ -126,6 +145,7 @@ basic_scenarios = {
             unevaluated_runs=[run(["parent1", "parent2", "child"])],
         ),
         expected_run_requests=[run_request(asset_keys=["child"])],
+        expected_materialize_reasons={"child": {AutoMaterializeReason.parent_updated()}},
     ),
     "diamond_never_materialized": AssetReconciliationScenario(
         assets=diamond,
@@ -145,6 +165,11 @@ basic_scenarios = {
             unevaluated_runs=[run(["asset1", "asset2", "asset3", "asset4"])],
         ),
         expected_run_requests=[run_request(asset_keys=["asset2", "asset3", "asset4"])],
+        expected_materialize_reasons={
+            "asset2": {AutoMaterializeReason.parent_updated()},
+            "asset3": {AutoMaterializeReason.parent_updated()},
+            "asset4": {AutoMaterializeReason.parent_updated()},
+        },
     ),
     "diamond_root_and_one_in_middle_rematerialized": AssetReconciliationScenario(
         assets=diamond,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/basic_scenarios.py
@@ -118,7 +118,7 @@ basic_scenarios = {
         ),
         unevaluated_runs=[single_asset_run(asset_key="asset1")],
         expected_run_requests=[run_request(asset_keys=["asset2"])],
-        expected_materialize_reasons={"asset2": {AutoMaterializeReason.parent_updated()}},
+        expected_materialize_reasons={"asset2": {AutoMaterializeReason.parent_materialized()}},
     ),
     "parent_rematerialized": AssetReconciliationScenario(
         assets=two_assets_in_sequence,
@@ -145,7 +145,7 @@ basic_scenarios = {
             unevaluated_runs=[run(["parent1", "parent2", "child"])],
         ),
         expected_run_requests=[run_request(asset_keys=["child"])],
-        expected_materialize_reasons={"child": {AutoMaterializeReason.parent_updated()}},
+        expected_materialize_reasons={"child": {AutoMaterializeReason.parent_materialized()}},
     ),
     "diamond_never_materialized": AssetReconciliationScenario(
         assets=diamond,
@@ -166,9 +166,9 @@ basic_scenarios = {
         ),
         expected_run_requests=[run_request(asset_keys=["asset2", "asset3", "asset4"])],
         expected_materialize_reasons={
-            "asset2": {AutoMaterializeReason.parent_updated()},
-            "asset3": {AutoMaterializeReason.parent_updated()},
-            "asset4": {AutoMaterializeReason.parent_updated()},
+            "asset2": {AutoMaterializeReason.parent_materialized()},
+            "asset3": {AutoMaterializeReason.parent_materialized()},
+            "asset4": {AutoMaterializeReason.parent_materialized()},
         },
     ),
     "diamond_root_and_one_in_middle_rematerialized": AssetReconciliationScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/freshness_policy_scenarios.py
@@ -4,6 +4,7 @@ from dagster import (
     AssetSelection,
     SourceAsset,
 )
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeReason
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._seven.compat.pendulum import create_pendulum_time
 
@@ -199,6 +200,12 @@ freshness_policy_scenarios = {
         evaluation_delta=datetime.timedelta(minutes=35),
         # now that it's been awhile since that run failed, give it another attempt
         expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
+        expected_materialize_reasons={
+            "asset1": {AutoMaterializeReason.downstream_freshness()},
+            "asset2": {AutoMaterializeReason.downstream_freshness()},
+            "asset3": {AutoMaterializeReason.downstream_freshness()},
+            "asset4": {AutoMaterializeReason.freshness()},
+        },
     ),
     "freshness_root_failure": AssetReconciliationScenario(
         assets=diamond_freshness,
@@ -315,6 +322,10 @@ freshness_policy_scenarios = {
         unevaluated_runs=[run([f"asset{i}" for i in range(1, 6)])],
         evaluation_delta=datetime.timedelta(minutes=35),
         expected_run_requests=[run_request(asset_keys=["asset2", "asset5"])],
+        expected_materialize_reasons={
+            "asset2": {AutoMaterializeReason.downstream_freshness()},
+            "asset5": {AutoMaterializeReason.freshness()},
+        },
     ),
     "freshness_complex_subsettable": AssetReconciliationScenario(
         assets=subsettable_multi_asset_complex,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
@@ -17,7 +17,7 @@ from .scenarios import ASSET_RECONCILIATION_SCENARIOS
 def test_reconcile_with_external_asset_graph(scenario_item):
     scenario_name, scenario = scenario_item
     instance = DagsterInstance.ephemeral()
-    run_requests, _, _, _ = scenario.do_sensor_scenario(
+    run_requests, _, _ = scenario.do_sensor_scenario(
         instance, scenario_name=scenario_name, with_external_asset_graph=True
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_daemon.py
@@ -17,7 +17,7 @@ from .scenarios import ASSET_RECONCILIATION_SCENARIOS
 def test_reconcile_with_external_asset_graph(scenario_item):
     scenario_name, scenario = scenario_item
     instance = DagsterInstance.ephemeral()
-    run_requests, _ = scenario.do_sensor_scenario(
+    run_requests, _, _, _ = scenario.do_sensor_scenario(
         instance, scenario_name=scenario_name, with_external_asset_graph=True
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -13,7 +13,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_reconciliation_sensor import (
-    build_auto_materialize_evaluation_results,
+    build_auto_materialize_asset_evaluations,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
@@ -51,7 +51,7 @@ def test_reconciliation(scenario):
             for key, reason in (scenario.expected_skip_reasons or {}).items()
         }
         assert (
-            build_auto_materialize_evaluation_results(
+            build_auto_materialize_asset_evaluations(
                 AssetGraph.from_assets(scenario.assets), materialize_reasons, skip_reasons
             )
             == evaluations

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -12,7 +12,9 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_reconciliation_sensor import build_auto_materialize_evaluations
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    build_auto_materialize_evaluation_results,
+)
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
@@ -49,7 +51,7 @@ def test_reconciliation(scenario):
             for key, reason in (scenario.expected_skip_reasons or {}).items()
         }
         assert (
-            build_auto_materialize_evaluations(
+            build_auto_materialize_evaluation_results(
                 AssetGraph.from_assets(scenario.assets), materialize_reasons, skip_reasons
             )
             == evaluations

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -48,11 +48,12 @@ def test_reconciliation(scenario):
             ): reason
             for key, reason in (scenario.expected_skip_reasons or {}).items()
         }
-        assert build_auto_materialize_evaluations(
-            AssetGraph.from_assets(scenario.assets),
-            materialize_reasons,
-            skip_reasons
-        ) == evaluations
+        assert (
+            build_auto_materialize_evaluations(
+                AssetGraph.from_assets(scenario.assets), materialize_reasons, skip_reasons
+            )
+            == evaluations
+        )
 
     assert len(run_requests) == len(scenario.expected_run_requests)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -51,10 +51,10 @@ def test_reconciliation(scenario):
             for key, reason in (scenario.expected_skip_reasons or {}).items()
         }
         assert (
-            build_auto_materialize_asset_evaluations(
+            sorted(build_auto_materialize_asset_evaluations(
                 AssetGraph.from_assets(scenario.assets), materialize_reasons, skip_reasons
-            )
-            == evaluations
+            ), key=lambda x: x.asset_key)
+            == sorted(evaluations, key=lambda x: x.asset_key)
         )
 
     assert len(run_requests) == len(scenario.expected_run_requests)

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -11,6 +11,7 @@ from dagster import (
     repository,
 )
 from dagster._check import CheckError
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
 )
@@ -26,7 +27,26 @@ from .scenarios import ASSET_RECONCILIATION_SCENARIOS
 )
 def test_reconciliation(scenario):
     instance = DagsterInstance.ephemeral()
-    run_requests, _ = scenario.do_sensor_scenario(instance)
+    run_requests, _, materialize_reasons, skip_reasons = scenario.do_sensor_scenario(instance)
+
+    if scenario.expected_materialize_reasons:
+        assert materialize_reasons == {
+            (
+                AssetKeyPartitionKey(AssetKey.from_coercible(key[0]), key[1])
+                if isinstance(key, tuple)
+                else AssetKeyPartitionKey(AssetKey.from_coercible(key))
+            ): reason
+            for key, reason in scenario.expected_materialize_reasons.items()
+        }
+    if scenario.expected_skip_reasons:
+        assert skip_reasons == {
+            (
+                AssetKeyPartitionKey(AssetKey.from_coercible(key[0]), key[1])
+                if isinstance(key, tuple)
+                else AssetKeyPartitionKey(AssetKey.from_coercible(key))
+            )
+            for key, reason in scenario.expected_skip_reasons.items()
+        }
 
     assert len(run_requests) == len(scenario.expected_run_requests)
 
@@ -53,7 +73,7 @@ def test_reconciliation_no_tags(scenario):
     # simulates an environment where asset_event_tags cannot be added
     instance = DagsterInstance.ephemeral()
 
-    run_requests, _ = scenario.do_sensor_scenario(instance)
+    run_requests, _, _, _ = scenario.do_sensor_scenario(instance)
 
     assert len(run_requests) == len(scenario.expected_run_requests)
 
@@ -121,7 +141,7 @@ def test_bad_partition_key():
     scenario = AssetReconciliationScenario(
         assets=assets, unevaluated_runs=[], asset_selection=AssetSelection.keys("hourly2")
     )
-    run_requests, _ = scenario.do_sensor_scenario(instance)
+    run_requests, _, _, _ = scenario.do_sensor_scenario(instance)
     assert len(run_requests) == 0
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_asset_reconciliation_sensor.py
@@ -50,12 +50,12 @@ def test_reconciliation(scenario):
             ): reason
             for key, reason in (scenario.expected_skip_reasons or {}).items()
         }
-        assert (
-            sorted(build_auto_materialize_asset_evaluations(
+        assert sorted(
+            build_auto_materialize_asset_evaluations(
                 AssetGraph.from_assets(scenario.assets), materialize_reasons, skip_reasons
-            ), key=lambda x: x.asset_key)
-            == sorted(evaluations, key=lambda x: x.asset_key)
-        )
+            ),
+            key=lambda x: x.asset_key,
+        ) == sorted(evaluations, key=lambda x: x.asset_key)
 
     assert len(run_requests) == len(scenario.expected_run_requests)
 


### PR DESCRIPTION
## Summary & Motivation

Adds a few things:

`_AutoMaterializeCondition`: An Enum containing the set of conditions that can cause something to be auto-materialized
`AutoMaterializeReason`: A NamedTuple containing (currently) just a single field, which is an `_AutoMaterializeCondition`. In the future, we can add a `data` field to this NamedTuple, to allow us to provide additional context for certain conditions.

Same as above, but for SkipConditions/Reasons

`AutoMaterializeDecision`: A bundle of information about all of the stuff we decided for an asset on a given tick. This contains all of the materialize/skip reasons

Not implemented (yet):
- more specific information inside the reasons

## How I Tested These Changes
