### PR TITLE
[pythonic resources] Correctly attach resource type to pythonic resources in snapshots

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -653,7 +653,7 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
     @property
     def configurable_resource_cls(self) -> Type:
         return self._configurable_resource_cls
-    
+
     @property
     def nested_resources(
         self,

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -634,6 +634,7 @@ def coerce_to_resource(
 class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDelayedDependencies):
     def __init__(
         self,
+        configurable_resource_cls: Type,
         resource_fn: ResourceFunction,
         config_schema: Any,
         description: Optional[str],
@@ -645,9 +646,14 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
             config_schema=config_schema,
             description=description,
         )
+        self._configurable_resource_cls = configurable_resource_cls
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
 
+    @property
+    def configurable_resource_cls(self) -> Type:
+        return self._configurable_resource_cls
+    
     @property
     def nested_resources(
         self,
@@ -663,6 +669,7 @@ class ConfigurableResourceFactoryResourceDefinition(ResourceDefinition, AllowDel
 class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowDelayedDependencies):
     def __init__(
         self,
+        configurable_resource_cls: Type,
         resource_fn: ResourceFunction,
         config_schema: Any,
         description: Optional[str],
@@ -690,6 +697,11 @@ class ConfigurableIOManagerFactoryResourceDefinition(IOManagerDefinition, AllowD
         )
         self._resolve_resource_keys = resolve_resource_keys
         self._nested_resources = nested_resources
+        self._configurable_resource_cls = configurable_resource_cls
+
+    @property
+    def configurable_resource_cls(self) -> Type:
+        return self._configurable_resource_cls
 
     @property
     def nested_resources(
@@ -835,6 +847,7 @@ class ConfigurableResourceFactory(
     @cached_method
     def get_resource_definition(self) -> ConfigurableResourceFactoryResourceDefinition:
         return ConfigurableResourceFactoryResourceDefinition(
+            self.__class__,
             resource_fn=self._get_initialize_and_run_fn(),
             config_schema=self._config_schema,
             description=self.__doc__,
@@ -1171,6 +1184,7 @@ class PartialResource(Generic[TResValue], AllowDelayedDependencies, MakeConfigCa
     @cached_method
     def get_resource_definition(self) -> ConfigurableResourceFactoryResourceDefinition:
         return ConfigurableResourceFactoryResourceDefinition(
+            self.__class__,
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
@@ -1239,6 +1253,7 @@ class ConfigurableLegacyResourceAdapter(ConfigurableResource, ABC):
     @cached_method
     def get_resource_definition(self) -> ConfigurableResourceFactoryResourceDefinition:
         return ConfigurableResourceFactoryResourceDefinition(
+            self.__class__,
             resource_fn=self.wrapped_resource.resource_fn,
             config_schema=self._config_schema,
             description=self.__doc__,
@@ -1316,6 +1331,7 @@ class ConfigurableIOManagerFactory(ConfigurableResourceFactory[TIOManagerValue])
     @cached_method
     def get_resource_definition(self) -> ConfigurableIOManagerFactoryResourceDefinition:
         return ConfigurableIOManagerFactoryResourceDefinition(
+            self.__class__,
             resource_fn=self._get_initialize_and_run_fn(),
             config_schema=self._config_schema,
             description=self.__doc__,
@@ -1358,6 +1374,7 @@ class PartialIOManager(Generic[TResValue], PartialResource[TResValue]):
             output_config_schema = factory_cls.output_config_schema()
 
         return ConfigurableIOManagerFactoryResourceDefinition(
+            self.__class__,
             resource_fn=self._state__internal__.resource_fn,
             config_schema=self._state__internal__.config_schema,
             description=self._state__internal__.description,
@@ -1620,6 +1637,7 @@ class ConfigurableLegacyIOManagerAdapter(ConfigurableIOManagerFactory):
     @cached_method
     def get_resource_definition(self) -> ConfigurableIOManagerFactoryResourceDefinition:
         return ConfigurableIOManagerFactoryResourceDefinition(
+            self.__class__,
             resource_fn=self.wrapped_io_manager.resource_fn,
             config_schema=self._config_schema,
             description=self.__doc__,

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -18,6 +18,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -1564,6 +1565,11 @@ def _get_nested_resources(
         }
 
 
+def _get_class_name(cls: Type) -> str:
+    """Returns the fully qualified class name of the given class."""
+    return str(cls)[8:-2]
+
+
 def external_resource_data_from_def(
     name: str,
     resource_def: ResourceDefinition,
@@ -1605,7 +1611,7 @@ def external_resource_data_from_def(
     if isinstance(resource_type_def, ResourceWithKeyMapping):
         resource_type_def = resource_type_def.wrapped_resource
 
-    resource_type = str(type(resource_type_def))[8:-2]
+    resource_type = _get_class_name(type(resource_type_def))
 
     if isinstance(
         resource_type_def,
@@ -1614,7 +1620,7 @@ def external_resource_data_from_def(
             ConfigurableIOManagerFactoryResourceDefinition,
         ),
     ):
-        resource_type = str(resource_type_def.configurable_resource_cls)[8:-2]
+        resource_type = _get_class_name(resource_type_def.configurable_resource_cls)
 
     return ExternalResourceData(
         name=name,

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1604,7 +1604,17 @@ def external_resource_data_from_def(
     resource_type_def = resource_def
     if isinstance(resource_type_def, ResourceWithKeyMapping):
         resource_type_def = resource_type_def.wrapped_resource
+
     resource_type = str(type(resource_type_def))[8:-2]
+
+    if isinstance(
+        resource_type_def,
+        (
+            ConfigurableResourceFactoryResourceDefinition,
+            ConfigurableIOManagerFactoryResourceDefinition,
+        ),
+    ):
+        resource_type = str(resource_type_def.configurable_resource_cls)[8:-2]
 
     return ExternalResourceData(
         name=name,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -99,6 +99,11 @@ def test_repository_snap_definitions_resources_nested() -> None:
     foo = [data for data in external_repo_data.external_resource_data if data.name == "foo"]
 
     assert len(foo) == 1
+    assert (
+        foo[0].resource_type
+        == "dagster_tests.core_tests.snap_tests.test_repository_snap."
+        "test_repository_snap_definitions_resources_nested.<locals>.MyOuterResource"
+    )
 
     assert len(foo[0].nested_resources) == 1
     assert "inner" in foo[0].nested_resources
@@ -134,10 +139,20 @@ def test_repository_snap_definitions_resources_nested_top_level() -> None:
     assert len(foo[0].nested_resources) == 1
     assert "inner" in foo[0].nested_resources
     assert foo[0].nested_resources["inner"] == NestedResource(NestedResourceType.TOP_LEVEL, "inner")
+    assert (
+        foo[0].resource_type
+        == "dagster_tests.core_tests.snap_tests.test_repository_snap."
+        "test_repository_snap_definitions_resources_nested_top_level.<locals>.MyOuterResource"
+    )
 
     assert len(inner[0].parent_resources) == 1
     assert "foo" in inner[0].parent_resources
     assert inner[0].parent_resources["foo"] == "inner"
+    assert (
+        inner[0].resource_type
+        == "dagster_tests.core_tests.snap_tests.test_repository_snap."
+        "test_repository_snap_definitions_resources_nested_top_level.<locals>.MyInnerResource"
+    )
 
 
 def test_repository_snap_definitions_function_style_resources_nested() -> None:


### PR DESCRIPTION
## Summary

Resolves the correct resource type for `ConfigurableResource` instances in the UI/repo snapshot. Each of these resources was listed as `ConfigurableResourceFactoryResourceDefinition` as a result of #13567.


## Test Plan

Tested locally, update tests.