### PR TITLE
Add retries to k8s create_namespaced_job

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -11,7 +11,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from kubernetes.client.models import V1JobStatus
+from kubernetes.client.models import V1Job, V1JobStatus
 
 try:
     from kubernetes.client.models import EventsV1Event  # noqa
@@ -748,4 +748,16 @@ class DagsterKubernetesClient:
             + (f"\n\n{specific_warning}" if specific_warning else "")
             + (f"\n\n{log_str}" if log_str else "")
             + f"\n\n{warning_str}"
+        )
+
+    def create_namespaced_job_with_retries(
+        self,
+        body: V1Job,
+        namespace: str,
+        wait_time_between_attempts: float = DEFAULT_WAIT_BETWEEN_ATTEMPTS,
+    ):
+        k8s_api_retry(
+            lambda: self.batch_api.create_namespaced_job(body=body, namespace=namespace),
+            max_retries=3,
+            timeout=wait_time_between_attempts,
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -262,9 +262,8 @@ class K8sStepHandler(StepHandler):
             },
         )
 
-        self._api_client.batch_api.create_namespaced_job(
-            body=job, namespace=container_context.namespace
-        )
+        namespace = check.not_none(container_context.namespace)
+        self._api_client.create_namespaced_job_with_retries(body=job, namespace=namespace)
 
     def check_step_health(self, step_handler_context: StepHandlerContext) -> CheckStepHealthResult:
         step_key = self._get_step_key(step_handler_context)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -238,22 +238,22 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             ],
         )
 
+        namespace = check.not_none(container_context.namespace)
+
         self._instance.report_engine_event(
             "Creating Kubernetes run worker job",
             run,
             EngineEventData(
                 {
                     "Kubernetes Job name": job_name,
-                    "Kubernetes Namespace": container_context.namespace,
+                    "Kubernetes Namespace": namespace,
                     "Run ID": run.run_id,
                 }
             ),
             cls=self.__class__,
         )
 
-        self._api_client.batch_api.create_namespaced_job(
-            body=job, namespace=container_context.namespace
-        )
+        self._api_client.create_namespaced_job_with_retries(body=job, namespace=namespace)
         self._instance.report_engine_event(
             "Kubernetes run worker job created",
             run,


### PR DESCRIPTION
Per https://github.com/dagster-io/dagster/issues/13059, this api call can result in transient 500s that AWS claims will be avoided if you retry at most 30 seconds.

The retry function is limited to transient error codes (including 500), and will try, wait 15 seconds, try, wait another 15 seconds, try a final time.

In the worst case where we use all these tries, the method will be blocking for 30 seconds. This feels bad but may actually be ok: the two places it's called is from the run queue daemon and run workers. Blocking will stop them from launching other runs/steps, but if the api requests are failing then that's fine. It'd only be problematic if there was something about the specific job causing the failure, and usually that wouldn't be a transient error code.