### PR TITLE
[SqlPollingEventWatcher] dont error on unwatch after dispose

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/polling_event_watcher.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/polling_event_watcher.py
@@ -82,7 +82,7 @@ class SqlPollingEventWatcher:
                         watcher_thread.should_thread_exit.set()
                 for run_id in self._run_id_to_watcher_dict:
                     self._run_id_to_watcher_dict[run_id].join()
-                del self._run_id_to_watcher_dict
+                self._run_id_to_watcher_dict = {}
 
 
 class SqlPollingRunIdEventWatcherThread(threading.Thread):

--- a/python_modules/dagster/dagster_tests/storage_tests/test_polling_event_watcher.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_polling_event_watcher.py
@@ -74,7 +74,9 @@ def create_event(count: int, run_id: str = RUN_ID):
 @contextmanager
 def create_sqlite_run_event_logstorage():
     with tempfile.TemporaryDirectory() as tmpdir_path:
-        yield SqlitePollingEventLogStorage(tmpdir_path)
+        storage = SqlitePollingEventLogStorage(tmpdir_path)
+        yield storage
+        storage.dispose()
 
 
 def test_using_logstorage():
@@ -133,3 +135,6 @@ def test_using_logstorage():
 
         assert [int(evt.message) for evt in watched_1] == [2, 3, 4]
         assert [int(evt.message) for evt in watched_2] == [4, 5]
+
+    # calling end_watch after dispose does not error
+    storage.end_watch(RUN_ID, watch_two)


### PR DESCRIPTION
if `end_watch` is called after the context manager exit we currently get
`'SqlPollingEventWatcher' object has no attribute '_run_id_to_watcher_dict'"`

since we delete the property. Just reset it to an empty dict on dispose instead.

## How I Tested These Changes

added test that was previously failing

