### PR TITLE
Add a timeout for runs stuck in canceling

### DIFF
--- a/docs/content/dagster-cloud/managing-deployments/deployment-settings-reference.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/deployment-settings-reference.mdx
@@ -27,6 +27,7 @@ run_queue:
 
 run_monitoring:
   start_timeout_seconds: 1200
+  cancel_timeout_seconds: 1200
 
 run_retries:
   max_retries: 0
@@ -119,11 +120,12 @@ run_queue:
 
 ### Run monitoring (run_monitoring)
 
-The `run_monitoring` settings allow you to define how long Dagster Cloud should wait for runs to start before failing them in the deployment.
+The `run_monitoring` settings allow you to define how long Dagster Cloud should wait for runs to start before making them as failed, or to terminate before marking them as canceled.
 
 ```yaml
 run_monitoring:
   start_timeout_seconds: 1200
+  cancel_timeout_seconds: 1200
 ```
 
 <ReferenceTable>

--- a/docs/content/dagster-cloud/managing-deployments/managing-deployments.mdx
+++ b/docs/content/dagster-cloud/managing-deployments/managing-deployments.mdx
@@ -145,6 +145,7 @@ run_queue:
 
 run_monitoring:
   start_timeout_seconds: 1200
+  cancel_timeout_seconds: 1200
 
 run_retries:
   max_retries: 0

--- a/docs/content/deployment/run-monitoring.mdx
+++ b/docs/content/deployment/run-monitoring.mdx
@@ -11,11 +11,12 @@ Dagster can detect hanging runs and restart crashed [run workers](/deployment/ov
 - Enabling run monitoring in the Dagster Instance:
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_run_monitoring endbefore=end_run_monitoring
-# Opt in to the experimental Monitoring Daemon
+# Opt in to run monitoring
 run_monitoring:
   enabled: true
   # values below are the defaults, and don't need to be specified execpt to override them
   start_timeout_seconds: 180
+  cancel_timeout_seconds: 180
   max_resume_run_attempts: 3 # experimental if above 0
   poll_interval_seconds: 120
 ```
@@ -23,6 +24,10 @@ run_monitoring:
 ## Run start timeouts
 
 When Dagster launches a run, the run stays in STARTING status until the run worker spins up and marks the run as STARTED. In the event that some failure causes the run worker to not spin up, the run might be stuck in STARTING status. The `start_timeout_seconds` offers a time limit for how long runs can hang in this state before being marked as failed.
+
+## Run cancelation timeouts
+
+When Dagster terminates a run, the run moves into CANCELING status and sends a termination signal to the run worker. When the run worker cleans up its resources, it moves into CANCELED status. In the event that some failure causes the run worker to not spin down cleanly, the run might be stuck in CANCELING status. The `cancel_timeout_seconds` offers a time limit for how long runs can hang in this state before being marked as canceled.
 
 ## General run timeouts
 

--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -328,11 +328,12 @@ local_artifact_storage:
 
 # start_run_monitoring
 
-# Opt in to the experimental Monitoring Daemon
+# Opt in to run monitoring
 run_monitoring:
   enabled: true
   # values below are the defaults, and don't need to be specified execpt to override them
   start_timeout_seconds: 180
+  cancel_timeout_seconds: 180
   max_resume_run_attempts: 3 # experimental if above 0
   poll_interval_seconds: 120
 

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -90,6 +90,9 @@ data:
     run_monitoring:
       enabled: {{ $runMonitoring.enabled }}
       start_timeout_seconds:  {{ $runMonitoring.startTimeoutSeconds }}
+      {{- if not (kindIs "invalid" $runMonitoring.cancelTimeoutSeconds) }}
+      cancel_timeout_seconds:  {{ $runMonitoring.cancelTimeoutSeconds }}
+      {{- end }}
       {{- if not (kindIs "invalid" $runMonitoring.maxResumeRunAttempts) }}
       max_resume_run_attempts: {{ $runMonitoring.maxResumeRunAttempts }}
       {{- end }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1093,6 +1093,8 @@ dagsterDaemon:
     enabled: true
     # Timeout for runs to start (avoids runs hanging in STARTED)
     startTimeoutSeconds: 300
+    # Timeout for runs to cancel (avoids runs hanging in CANCELING)
+    # cancelTimeoutSeconds: 300
     # How often to check on in progress runs
     pollIntervalSeconds: 120
     # [Experimental] Max number of times to attempt to resume a run with a new run worker instead

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -799,6 +799,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self.run_monitoring_settings.get("start_timeout_seconds", 180)
 
     @property
+    def run_monitoring_cancel_timeout_seconds(self) -> int:
+        return self.run_monitoring_settings.get("cancel_timeout_seconds", 180)
+
+    @property
     def code_server_settings(self) -> Any:
         return self.get_settings("code_servers")
 

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -303,6 +303,7 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
             {
                 "enabled": Field(Bool, is_required=False),
                 "start_timeout_seconds": Field(int, is_required=False),
+                "cancel_timeout_seconds": Field(int, is_required=False),
                 "max_resume_run_attempts": Field(int, is_required=False),
                 "poll_interval_seconds": Field(int, is_required=False),
                 "cancellation_thread_poll_interval_seconds": Field(int, is_required=False),


### PR DESCRIPTION
Summary:
Just like for STARTING. only question I have is whether or not the point query on the event log to determine the CANCELING time is likely to run into perf issues, or if the fact that it's filtering on a specific event type will help.

Test Plan: BK, simulate a real hanging cancel in `dagster dev` by commenting out the line that cancels the run and waiting 3 minutes

## Summary & Motivation

## How I Tested These Changes
