### PR TITLE
patch pk schema migration

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/038_701913684cb4_add_postgres_pks.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/038_701913684cb4_add_postgres_pks.py
@@ -1,0 +1,43 @@
+"""add postgres pks
+
+Revision ID: 701913684cb4
+Revises: d9092588866f
+Create Date: 2023-05-04 09:12:34.974039
+
+"""
+from alembic import op
+from dagster._core.storage.migration.utils import get_primary_key, has_column, has_table
+
+# revision identifiers, used by Alembic.
+revision = "701913684cb4"
+down_revision = "d9092588866f"
+branch_labels = None
+depends_on = None
+
+
+def has_primary_key(tablename):
+    primary_key = get_primary_key(tablename)
+    return primary_key and len(primary_key.get("constrained_columns", [])) > 0
+
+
+def upgrade():
+    if has_table("kvs") and has_column("kvs", "id") and not has_primary_key("kvs"):
+        op.create_primary_key("kvs_pkey", "kvs", ["id"])
+
+    if (
+        has_table("instance_info")
+        and not has_column("instance_info", "id")
+        and not has_primary_key("instance_info")
+    ):
+        op.create_primary_key("instance_info_pkey", "instance_info", ["id"])
+
+    if (
+        has_table("daemon_heartbeats")
+        and has_column("daemon_heartbeats", "id")
+        and not has_primary_key("daemon_heartbeats")
+    ):
+        op.create_primary_key("daemon_heartbeats_pkey", "daemon_heartbeats", ["id"])
+
+
+def downgrade():
+    pass

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/038_701913684cb4_add_postgres_pks.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/038_701913684cb4_add_postgres_pks.py
@@ -26,7 +26,7 @@ def upgrade():
 
     if (
         has_table("instance_info")
-        and not has_column("instance_info", "id")
+        and has_column("instance_info", "id")
         and not has_primary_key("instance_info")
     ):
         op.create_primary_key("instance_info_pkey", "instance_info", ["id"])

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -37,6 +37,13 @@ def get_indexes(instance, table_name: str):
     return set(c["name"] for c in inspect(instance.run_storage._engine).get_indexes(table_name))
 
 
+def get_primary_key(instance, table_name: str):
+    constraint = inspect(instance.run_storage._engine).get_pk_constraint(table_name)
+    if not constraint:
+        return None
+    return constraint.get("name")
+
+
 def get_tables(instance):
     return instance.run_storage._engine.table_names()
 
@@ -865,6 +872,7 @@ def test_add_primary_keys(hostname, conn_string):
                     instance.run_storage, KeyValueStoreTable, with_non_null_id=True
                 )
             assert kvs_id_count == kvs_row_count
+            assert get_primary_key(instance, "kvs")
 
             assert "id" in get_columns(instance, "instance_info")
             with instance.run_storage.connect():
@@ -872,6 +880,7 @@ def test_add_primary_keys(hostname, conn_string):
                     instance.run_storage, InstanceInfo, with_non_null_id=True
                 )
             assert instance_info_id_count == instance_info_row_count
+            assert get_primary_key(instance, "instance_info")
 
             assert "id" in get_columns(instance, "daemon_heartbeats")
             with instance.run_storage.connect():
@@ -879,3 +888,4 @@ def test_add_primary_keys(hostname, conn_string):
                     instance.run_storage, DaemonHeartbeatsTable, with_non_null_id=True
                 )
             assert daemon_heartbeats_id_count == daemon_heartbeats_row_count
+            assert get_primary_key(instance, "daemon_heartbeats")


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/12711 added id columns to all the tables, but for postgres storage only, primary key constraints were not created.

This PR makes sure that PK constraints are added if they do not exist.

## How I Tested These Changes
Changed backcompat test to explicit check for primary keys
