### PR TITLE
[ui] Clean up __typename

### DIFF
--- a/js_modules/dagit/packages/core/src/app/AppCache.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppCache.tsx
@@ -4,7 +4,6 @@ import possibleTypes from '../graphql/possibleTypes.generated.json';
 
 export const createAppCache = () =>
   new InMemoryCache({
-    addTypename: true,
     possibleTypes,
     typePolicies: {
       PartitionStatus: {

--- a/js_modules/dagit/packages/core/src/app/PythonErrorFragment.tsx
+++ b/js_modules/dagit/packages/core/src/app/PythonErrorFragment.tsx
@@ -2,7 +2,6 @@ import {gql} from '@apollo/client';
 
 export const PYTHON_ERROR_FRAGMENT = gql`
   fragment PythonErrorFragment on PythonError {
-    __typename
     message
     stack
     errorChain {

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetRunLogObserver.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetRunLogObserver.tsx
@@ -126,10 +126,8 @@ const SingleRunLogObserver: React.FC<{
 export const ASSET_LIVE_RUN_LOGS_SUBSCRIPTION = gql`
   subscription AssetLiveRunLogsSubscription($runId: ID!) {
     pipelineRunLogs(runId: $runId, cursor: "HEAD") {
-      __typename
       ... on PipelineRunLogsSubscriptionSuccess {
         messages {
-          __typename
           ... on AssetMaterializationPlannedEvent {
             assetKey {
               path

--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -270,7 +270,6 @@ const SIDEBAR_ASSET_FRAGMENT = gql`
 export const SIDEBAR_ASSET_QUERY = gql`
   query SidebarAssetQuery($assetKey: AssetKeyInput!) {
     assetNodeOrError(assetKey: $assetKey) {
-      __typename
       ... on AssetNode {
         id
         ...SidebarAssetFragment

--- a/js_modules/dagit/packages/core/src/asset-graph/useFindAssetLocation.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/useFindAssetLocation.tsx
@@ -50,7 +50,6 @@ export function useFindAssetLocation() {
 const ASSET_FOR_NAVIGATION_QUERY = gql`
   query AssetForNavigationQuery($key: AssetKeyInput!) {
     assetOrError(assetKey: $key) {
-      __typename
       ... on Asset {
         id
         definition {

--- a/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMaterializationUpstreamData.tsx
@@ -117,7 +117,6 @@ export const AssetMaterializationUpstreamData: React.FC<{
 export const ASSET_MATERIALIZATION_UPSTREAM_QUERY = gql`
   query AssetMaterializationUpstreamQuery($assetKey: AssetKeyInput!, $timestamp: String!) {
     assetNodeOrError(assetKey: $assetKey) {
-      __typename
       ... on AssetNode {
         id
         assetMaterializationUsedData(timestampMillis: $timestamp) {
@@ -128,7 +127,6 @@ export const ASSET_MATERIALIZATION_UPSTREAM_QUERY = gql`
   }
 
   fragment MaterializationUpstreamDataVersionFragment on MaterializationUpstreamDataVersion {
-    __typename
     timestamp
     assetKey {
       path

--- a/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetMetadata.tsx
@@ -41,7 +41,6 @@ export const ASSET_NODE_OP_METADATA_FRAGMENT = gql`
       ...MetadataEntryFragment
     }
     type {
-      __typename
       ...DagsterTypeFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeInstigatorTag.tsx
@@ -34,12 +34,12 @@ export const ASSET_NODE_INSTIGATORS_FRAGMENT = gql`
       name
       schedules {
         id
-        __typename
+
         ...ScheduleSwitchFragment
       }
       sensors {
         id
-        __typename
+
         ...SensorSwitchFragment
       }
     }

--- a/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPartitionDetail.tsx
@@ -98,7 +98,6 @@ export const AssetPartitionDetailLoader: React.FC<{assetKey: AssetKey; partition
 export const ASSET_PARTITION_DETAIL_QUERY = gql`
   query AssetPartitionDetailQuery($assetKey: AssetKeyInput!, $partitionKey: String!) {
     assetNodeOrError(assetKey: $assetKey) {
-      __typename
       ... on AssetNode {
         id
         latestRunForPartition(partition: $partitionKey) {
@@ -121,7 +120,6 @@ export const ASSET_PARTITION_DETAIL_QUERY = gql`
     }
   }
   fragment AssetPartitionLatestRunFragment on Run {
-    __typename
     id
     status
     endTime

--- a/js_modules/dagit/packages/core/src/assets/AssetTableFragment.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetTableFragment.tsx
@@ -26,7 +26,6 @@ export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
 
 export const ASSET_TABLE_FRAGMENT = gql`
   fragment AssetTableFragment on Asset {
-    __typename
     id
     key {
       path

--- a/js_modules/dagit/packages/core/src/assets/AssetView.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetView.tsx
@@ -426,7 +426,6 @@ export const ASSET_VIEW_DEFINITION_QUERY = gql`
     id
     groupName
     partitionDefinition {
-      __typename
       description
     }
     partitionKeysByDimension {

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogRoot.tsx
@@ -89,7 +89,6 @@ export default AssetsCatalogRoot;
 const ASSETS_CATALOG_ROOT_QUERY = gql`
   query AssetsCatalogRootQuery($assetKey: AssetKeyInput!) {
     assetOrError(assetKey: $assetKey) {
-      __typename
       ... on Asset {
         id
         key {

--- a/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetsCatalogTable.tsx
@@ -249,7 +249,6 @@ const AssetGroupSuggest: React.FC<{
 export const ASSET_CATALOG_TABLE_QUERY = gql`
   query AssetCatalogTableQuery {
     assetsOrError {
-      __typename
       ... on AssetConnection {
         nodes {
           id

--- a/js_modules/dagit/packages/core/src/assets/RunningBackfillsNotice.tsx
+++ b/js_modules/dagit/packages/core/src/assets/RunningBackfillsNotice.tsx
@@ -44,7 +44,6 @@ export const RunningBackfillsNotice: React.FC<{partitionSetName: string}> = ({
 export const RUNNING_BACKFILLS_NOTICE_QUERY = gql`
   query RunningBackfillsNoticeQuery {
     partitionBackfillsOrError(status: REQUESTED) {
-      __typename
       ... on PartitionBackfills {
         results {
           id

--- a/js_modules/dagit/packages/core/src/assets/usePartitionNameForPipeline.tsx
+++ b/js_modules/dagit/packages/core/src/assets/usePartitionNameForPipeline.tsx
@@ -51,13 +51,10 @@ export const ASSET_JOB_PARTITION_SETS_QUERY = gql`
         repositoryLocationName: $repositoryLocationName
       }
     ) {
-      __typename
       ... on PipelineNotFoundError {
-        __typename
         message
       }
       ... on PartitionSets {
-        __typename
         results {
           id
           name

--- a/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
+++ b/js_modules/dagit/packages/core/src/configeditor/ConfigEditorUtils.tsx
@@ -55,15 +55,12 @@ export const CONFIG_EDITOR_RUN_CONFIG_SCHEMA_FRAGMENT = gql`
 
 export const CONFIG_EDITOR_VALIDATION_FRAGMENT = gql`
   fragment ConfigEditorValidationFragment on PipelineConfigValidationResult {
-    __typename
     ... on RunConfigValidationInvalid {
       errors {
-        __typename
         reason
         message
         stack {
           entries {
-            __typename
             ... on EvaluationStackPathEntry {
               fieldName
             }

--- a/js_modules/dagit/packages/core/src/dagstertype/DagsterType.tsx
+++ b/js_modules/dagit/packages/core/src/dagstertype/DagsterType.tsx
@@ -78,10 +78,8 @@ export const DagsterTypeSummary: React.FC<{
 // NOTE: Because you can't have a recursive fragment, inner types are limited.
 export const DAGSTER_TYPE_FRAGMENT = gql`
   fragment DagsterTypeFragment on DagsterType {
-    __typename
     ...InnerDagsterTypeFragment
     innerTypes {
-      __typename
       ...InnerDagsterTypeFragment
     }
   }

--- a/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
+++ b/js_modules/dagit/packages/core/src/gantt/RunGroupPanel.tsx
@@ -140,7 +140,6 @@ export const RunGroupPanel: React.FC<{runId: string; runStatusLastChangedAt: num
 const RUN_GROUP_PANEL_QUERY = gql`
   query RunGroupPanelQuery($runId: ID!) {
     runGroupOrError(runId: $runId) {
-      __typename
       ... on RunGroup {
         rootRunId
         runs {

--- a/js_modules/dagit/packages/core/src/graph/OpNode.tsx
+++ b/js_modules/dagit/packages/core/src/graph/OpNode.tsx
@@ -243,7 +243,6 @@ export const OP_NODE_INVOCATION_FRAGMENT = gql`
 
 export const OP_NODE_DEFINITION_FRAGMENT = gql`
   fragment OpNodeDefinitionFragment on ISolidDefinition {
-    __typename
     name
     description
     metadata {

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -107,7 +107,6 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
 const CANCEL_BACKFILL_MUTATION = gql`
   mutation CancelBackfill($backfillId: String!) {
     cancelPartitionBackfill(backfillId: $backfillId) {
-      __typename
       ... on CancelBackfillSuccess {
         backfillId
       }

--- a/js_modules/dagit/packages/core/src/instance/BackfillUtils.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillUtils.tsx
@@ -5,7 +5,6 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 export const RESUME_BACKFILL_MUTATION = gql`
   mutation resumeBackfill($backfillId: String!) {
     resumePartitionBackfill(backfillId: $backfillId) {
-      __typename
       ... on ResumeBackfillSuccess {
         backfillId
       }
@@ -22,7 +21,6 @@ export const RESUME_BACKFILL_MUTATION = gql`
 export const LAUNCH_PARTITION_BACKFILL_MUTATION = gql`
   mutation LaunchPartitionBackfill($backfillParams: LaunchBackfillParams!) {
     launchPartitionBackfill(backfillParams: $backfillParams) {
-      __typename
       ... on LaunchBackfillSuccess {
         backfillId
       }
@@ -54,7 +52,6 @@ export const LAUNCH_PARTITION_BACKFILL_MUTATION = gql`
       ... on RunConfigValidationInvalid {
         pipelineName
         errors {
-          __typename
           message
           path
           reason

--- a/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
+++ b/js_modules/dagit/packages/core/src/instance/useDaemonStatus.tsx
@@ -100,7 +100,6 @@ const INSTANCE_WARNING_QUERY = gql`
       ...InstanceHealthFragment
     }
     partitionBackfillsOrError(status: REQUESTED) {
-      __typename
       ... on PartitionBackfills {
         results {
           id

--- a/js_modules/dagit/packages/core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickDetailsDialog.tsx
@@ -74,7 +74,6 @@ export const TickDetailsDialog: React.FC<{
 const JOB_SELECTED_TICK_QUERY = gql`
   query SelectedTickQuery($instigationSelector: InstigationSelector!, $timestamp: Float!) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
-      __typename
       ... on InstigationState {
         id
         tick(timestamp: $timestamp) {

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -369,7 +369,6 @@ const JOB_TICK_HISTORY_QUERY = gql`
     $statuses: [InstigationTickStatus!]
   ) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
-      __typename
       ... on InstigationState {
         id
         instigationType

--- a/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -451,7 +451,6 @@ const CONFIG_PARTITIONS_QUERY = gql`
       repositorySelector: $repositorySelector
       partitionSetName: $partitionSetName
     ) {
-      __typename
       ... on PartitionSet {
         id
         partitionsOrError {
@@ -490,7 +489,6 @@ export const CONFIG_PARTITION_SELECTION_QUERY = gql`
       repositorySelector: $repositorySelector
       partitionSetName: $partitionSetName
     ) {
-      __typename
       ... on PartitionSet {
         id
         partition(partitionName: $partitionName) {

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadRoot.tsx
@@ -223,7 +223,6 @@ const PIPELINE_EXECUTION_ROOT_QUERY = gql`
         repositoryLocationName: $repositoryLocationName
       }
     ) {
-      __typename
       ... on PipelineNotFoundError {
         message
       }

--- a/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/LaunchpadSession.tsx
@@ -792,7 +792,6 @@ const PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY = gql`
   }
 
   fragment LaunchpadSessionRunConfigSchemaFragment on RunConfigSchemaOrError {
-    __typename
     ... on RunConfigSchema {
       ...ConfigEditorRunConfigSchemaFragment
     }

--- a/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/OpSelector.tsx
@@ -29,7 +29,6 @@ interface IOpSelectorProps {
 const SOLID_SELECTOR_QUERY = gql`
   query OpSelectorQuery($selector: PipelineSelector!, $requestScopeHandleID: String) {
     pipelineOrError(params: $selector) {
-      __typename
       ... on Pipeline {
         id
         name

--- a/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagit/packages/core/src/launchpad/RunPreview.tsx
@@ -461,7 +461,6 @@ export const RunPreview: React.FC<RunPreviewProps> = (props) => {
 
 export const RUN_PREVIEW_VALIDATION_FRAGMENT = gql`
   fragment RunPreviewValidationFragment on PipelineConfigValidationResult {
-    __typename
     ... on RunConfigValidationInvalid {
       errors {
         ...RunPreviewValidationErrors
@@ -481,7 +480,6 @@ export const RUN_PREVIEW_VALIDATION_FRAGMENT = gql`
     message
     stack {
       entries {
-        __typename
         ... on EvaluationStackPathEntry {
           fieldName
         }

--- a/js_modules/dagit/packages/core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagit/packages/core/src/metadata/TableSchema.tsx
@@ -113,7 +113,6 @@ const ArbitraryConstraintTag: React.FC<{constraint: string}> = ({constraint}) =>
 
 export const TABLE_SCHEMA_FRAGMENT = gql`
   fragment TableSchemaFragment on TableSchema {
-    __typename
     columns {
       name
       description

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -279,7 +279,6 @@ const ViewButton = styled(ButtonLink)`
 const CODE_LOCATION_STATUS_QUERY = gql`
   query CodeLocationStatusQuery {
     locationStatusesOrError {
-      __typename
       ... on WorkspaceLocationStatusEntries {
         entries {
           id

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -223,11 +223,9 @@ export const useRepositoryLocationReload = ({
 const REPOSITORY_LOCATION_STATUS_QUERY = gql`
   query RepositoryLocationStatusQuery {
     workspaceOrError {
-      __typename
       ... on Workspace {
         id
         locationEntries {
-          __typename
           id
           loadStatus
           locationOrLoadError {

--- a/js_modules/dagit/packages/core/src/ops/OpCard.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpCard.tsx
@@ -57,7 +57,6 @@ export const OpCard: React.FC<OpCardProps> = (props) => {
 
 export const OP_CARD_SOLID_DEFINITION_FRAGMENT = gql`
   fragment OpCardSolidDefinitionFragment on ISolidDefinition {
-    __typename
     name
     description
     metadata {

--- a/js_modules/dagit/packages/core/src/ops/OpDetailsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/ops/OpDetailsRoot.tsx
@@ -68,13 +68,11 @@ const USED_SOLID_DETAILS_QUERY = gql`
       ... on Repository {
         id
         usedSolid(name: $name) {
-          __typename
           definition {
             ...OpCardSolidDefinitionFragment
             ...SidebarOpDefinitionFragment
           }
           invocations {
-            __typename
             pipeline {
               id
               name

--- a/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/CreatePartitionDialog.tsx
@@ -242,7 +242,6 @@ export const CREATE_PARTITION_MUTATION = gql`
       partitionKey: $partitionKey
       repositorySelector: $repositorySelector
     ) {
-      __typename
       ... on AddDynamicPartitionSuccess {
         partitionsDefName
         partitionKey

--- a/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/OpJobPartitionsView.tsx
@@ -363,7 +363,6 @@ const PARTITIONS_STATUS_QUERY = gql`
       }
     }
     partitionStatusesOrError {
-      __typename
       ... on PartitionStatuses {
         results {
           id

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOp.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOp.tsx
@@ -164,7 +164,6 @@ const SIDEBAR_OP_FRAGMENT = gql`
         ...SidebarOpInvocationFragment
 
         definition {
-          __typename
           ...SidebarOpDefinitionFragment
         }
       }
@@ -178,7 +177,6 @@ const SIDEBAR_OP_FRAGMENT = gql`
 const SIDEBAR_PIPELINE_OP_QUERY = gql`
   query SidebarPipelineOpQuery($selector: PipelineSelector!, $handleID: String!) {
     pipelineOrError(params: $selector) {
-      __typename
       ... on Pipeline {
         id
         ...SidebarOpFragment
@@ -192,7 +190,6 @@ const SIDEBAR_PIPELINE_OP_QUERY = gql`
 const SIDEBAR_GRAPH_OP_QUERY = gql`
   query SidebarGraphOpQuery($selector: GraphSelector!, $handleID: String!) {
     graphOrError(selector: $selector) {
-      __typename
       ... on Graph {
         id
         ...SidebarOpFragment

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpDefinition.tsx
@@ -186,7 +186,6 @@ export const SidebarOpDefinition: React.FC<SidebarOpDefinitionProps> = (props) =
 
 export const SIDEBAR_OP_DEFINITION_FRAGMENT = gql`
   fragment SidebarOpDefinitionFragment on ISolidDefinition {
-    __typename
     name
     description
     metadata {

--- a/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagit/packages/core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -137,14 +137,11 @@ export const SidebarOpExecutionGraphs: React.FC<{
 const SIDEBAR_OP_GRAPHS_QUERY = gql`
   query SidebarOpGraphsQuery($selector: PipelineSelector!, $handleID: String!) {
     pipelineOrError(params: $selector) {
-      __typename
       ... on Pipeline {
         id
         name
         solidHandle(handleID: $handleID) {
           stepStats(limit: 20) {
-            __typename
-
             ... on SolidStepStatsConnection {
               nodes {
                 runId
@@ -152,9 +149,6 @@ const SIDEBAR_OP_GRAPHS_QUERY = gql`
                 endTime
                 status
               }
-            }
-            ... on SolidStepStatusUnavailableError {
-              __typename
             }
           }
         }

--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -359,7 +359,6 @@ export const LogsProvider: React.FC<LogsProviderProps> = (props) => {
 const PIPELINE_RUN_LOGS_SUBSCRIPTION = gql`
   subscription PipelineRunLogsSubscription($runId: ID!, $cursor: String) {
     pipelineRunLogs(runId: $runId, cursor: $cursor) {
-      __typename
       ... on PipelineRunLogsSubscriptionFailure {
         missingRunId
         message
@@ -402,7 +401,6 @@ const RUN_LOGS_QUERY = gql`
     logsForRun(runId: $runId, afterCursor: $cursor, limit: $limit) {
       ... on EventConnection {
         events {
-          __typename
           ... on MessageEvent {
             runId
           }

--- a/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsRow.tsx
@@ -89,7 +89,6 @@ export class Structured extends React.Component<StructuredProps, StructuredState
 
 export const LOGS_ROW_STRUCTURED_FRAGMENT = gql`
   fragment LogsRowStructuredFragment on DagsterRunEvent {
-    __typename
     ... on MessageEvent {
       message
       eventType
@@ -255,7 +254,6 @@ export class Unstructured extends React.Component<UnstructuredProps> {
 
 export const LOGS_ROW_UNSTRUCTURED_FRAGMENT = gql`
   fragment LogsRowUnstructuredFragment on DagsterRunEvent {
-    __typename
     ... on MessageEvent {
       message
       timestamp

--- a/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsScrollingTable.tsx
@@ -130,7 +130,6 @@ export const LogsScrollingTable: React.FC<ILogsScrollingTableProps> = (props) =>
 
 export const LOGS_SCROLLING_TABLE_MESSAGE_FRAGMENT = gql`
   fragment LogsScrollingTableMessageFragment on DagsterRunEvent {
-    __typename
     ...LogsRowStructuredFragment
     ...LogsRowUnstructuredFragment
   }

--- a/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunMetadataProvider.tsx
@@ -358,7 +358,6 @@ export const RunMetadataProvider: React.FC<IRunMetadataProviderProps> = ({logs, 
 
 export const RUN_METADATA_PROVIDER_MESSAGE_FRAGMENT = gql`
   fragment RunMetadataProviderMessageFragment on DagsterRunEvent {
-    __typename
     ... on MessageEvent {
       message
       timestamp

--- a/js_modules/dagit/packages/core/src/runs/RunStats.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunStats.tsx
@@ -55,7 +55,6 @@ export const RunStats = ({runId}: {runId: string}) => {
 const RUN_STATS_QUERY = gql`
   query RunStatsQuery($runId: ID!) {
     pipelineRunOrError(runId: $runId) {
-      __typename
       ... on RunNotFoundError {
         message
       }

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -200,7 +200,6 @@ export function getReexecutionVariables(input: {
 export const LAUNCH_PIPELINE_EXECUTION_MUTATION = gql`
   mutation LaunchPipelineExecution($executionParams: ExecutionParams!) {
     launchPipelineExecution(executionParams: $executionParams) {
-      __typename
       ... on LaunchRunSuccess {
         run {
           id
@@ -228,7 +227,6 @@ export const LAUNCH_PIPELINE_EXECUTION_MUTATION = gql`
 export const DELETE_MUTATION = gql`
   mutation Delete($runId: String!) {
     deletePipelineRun(runId: $runId) {
-      __typename
       ... on UnauthorizedError {
         message
       }
@@ -245,7 +243,6 @@ export const DELETE_MUTATION = gql`
 export const TERMINATE_MUTATION = gql`
   mutation Terminate($runId: String!, $terminatePolicy: TerminateRunPolicy) {
     terminatePipelineExecution(runId: $runId, terminatePolicy: $terminatePolicy) {
-      __typename
       ... on TerminateRunFailure {
         message
       }
@@ -277,7 +274,6 @@ export const LAUNCH_PIPELINE_REEXECUTION_MUTATION = gql`
       executionParams: $executionParams
       reexecutionParams: $reexecutionParams
     ) {
-      __typename
       ... on LaunchRunSuccess {
         run {
           id

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -313,7 +313,6 @@ export const RUN_TAG_KEYS_QUERY = gql`
 export const RUN_TAG_VALUES_QUERY = gql`
   query RunTagValuesQuery($tagKeys: [String!]!) {
     runTagsOrError(tagKeys: $tagKeys) {
-      __typename
       ... on RunTags {
         tags {
           key

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInputNew.tsx
@@ -575,7 +575,6 @@ export const RUN_TAG_KEYS_QUERY = gql`
 export const RUN_TAG_VALUES_QUERY = gql`
   query RunTagValuesNewQuery($tagKeys: [String!]!) {
     runTagsOrError(tagKeys: $tagKeys) {
-      __typename
       ... on RunTags {
         tags {
           key

--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunListRoot.tsx
@@ -101,7 +101,6 @@ const SCHEDULED_RUNS_LIST_QUERY = gql`
     repositoriesOrError {
       ... on RepositoryConnection {
         nodes {
-          __typename
           id
           ... on Repository {
             id

--- a/js_modules/dagit/packages/core/src/runs/ScheduledRunsListRoot.new.tsx
+++ b/js_modules/dagit/packages/core/src/runs/ScheduledRunsListRoot.new.tsx
@@ -109,7 +109,6 @@ const SCHEDULED_RUNS_LIST_QUERY = gql`
     repositoriesOrError {
       ... on RepositoryConnection {
         nodes {
-          __typename
           id
           ... on Repository {
             id

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleMutations.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleMutations.tsx
@@ -10,10 +10,8 @@ import {StartThisScheduleMutation, StopScheduleMutation} from './types/ScheduleM
 export const START_SCHEDULE_MUTATION = gql`
   mutation StartThisSchedule($scheduleSelector: ScheduleSelector!) {
     startSchedule(scheduleSelector: $scheduleSelector) {
-      __typename
       ... on ScheduleStateResult {
         scheduleState {
-          __typename
           id
           status
           runningCount
@@ -35,10 +33,8 @@ export const STOP_SCHEDULE_MUTATION = gql`
       scheduleOriginId: $scheduleOriginId
       scheduleSelectorId: $scheduleSelectorId
     ) {
-      __typename
       ... on ScheduleStateResult {
         scheduleState {
-          __typename
           id
           status
           runningCount

--- a/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/ScheduleRoot.tsx
@@ -180,7 +180,6 @@ const SCHEDULE_ROOT_QUERY = gql`
 const PREVIOUS_RUNS_FOR_SCHEDULE_QUERY = gql`
   query PreviousRunsForScheduleQuery($filter: RunsFilter, $limit: Int) {
     pipelineRunsOrError(filter: $filter, limit: $limit) {
-      __typename
       ... on Runs {
         results {
           id

--- a/js_modules/dagit/packages/core/src/sensors/SensorMutations.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorMutations.tsx
@@ -10,7 +10,6 @@ import {StartSensorMutation, StopRunningSensorMutation} from './types/SensorMuta
 export const START_SENSOR_MUTATION = gql`
   mutation StartSensor($sensorSelector: SensorSelector!) {
     startSensor(sensorSelector: $sensorSelector) {
-      __typename
       ... on Sensor {
         id
         sensorState {
@@ -34,7 +33,6 @@ export const START_SENSOR_MUTATION = gql`
 export const STOP_SENSOR_MUTATION = gql`
   mutation StopRunningSensor($jobOriginId: String!, $jobSelectorId: String!) {
     stopSensor(jobOriginId: $jobOriginId, jobSelectorId: $jobSelectorId) {
-      __typename
       ... on StopSensorMutationResult {
         instigationState {
           id

--- a/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorPreviousRuns.tsx
@@ -50,7 +50,6 @@ export const SensorPreviousRuns: React.FC<{
 const PREVIOUS_RUNS_FOR_SENSOR_QUERY = gql`
   query PreviousRunsForSensorQuery($filter: RunsFilter, $limit: Int) {
     pipelineRunsOrError(filter: $filter, limit: $limit) {
-      __typename
       ... on Runs {
         results {
           id

--- a/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/SensorRoot.tsx
@@ -95,7 +95,6 @@ export const SensorRoot: React.FC<{repoAddress: RepoAddress}> = ({repoAddress}) 
 const SENSOR_ROOT_QUERY = gql`
   query SensorRootQuery($sensorSelector: SensorSelector!) {
     sensorOrError(sensorSelector: $sensorSelector) {
-      __typename
       ... on Sensor {
         id
         ...SensorFragment

--- a/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/EvaluateScheduleDialog.tsx
@@ -205,7 +205,6 @@ export const GET_SCHEDULE_QUERY = gql`
     $ticksBefore: Int
   ) {
     scheduleOrError(scheduleSelector: $scheduleSelector) {
-      __typename
       ... on PythonError {
         message
         stack
@@ -358,7 +357,6 @@ const EvaluateScheduleContent: React.FC<{
 export const SCHEDULE_DRY_RUN_MUTATION = gql`
   mutation ScheduleDryRunMutation($selectorData: ScheduleSelector!, $timestamp: Float) {
     scheduleDryRun(selectorData: $selectorData, timestamp: $timestamp) {
-      __typename
       ...PythonErrorFragment
       ... on DryRunInstigationTick {
         timestamp

--- a/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
@@ -362,7 +362,6 @@ const SensorDryRun: React.FC<Props> = ({repoAddress, name, currentCursor, onClos
 export const EVALUATE_SENSOR_MUTATION = gql`
   mutation SensorDryRunMutation($selectorData: SensorSelector!, $cursor: String) {
     sensorDryRun(selectorData: $selectorData, cursor: $cursor) {
-      __typename
       ... on DryRunInstigationTick {
         timestamp
         evaluationResult {

--- a/js_modules/dagit/packages/core/src/ticks/TickLogDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/TickLogDialog.tsx
@@ -117,7 +117,6 @@ const TickLogRow: React.FC<{event: TickLogEventFragment}> = ({event}) => {
 const TICK_LOG_EVENTS_QUERY = gql`
   query TickLogEventsQuery($instigationSelector: InstigationSelector!, $timestamp: Float!) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
-      __typename
       ... on InstigationState {
         id
         tick(timestamp: $timestamp) {

--- a/js_modules/dagit/packages/core/src/typeexplorer/ConfigTypeSchema.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/ConfigTypeSchema.tsx
@@ -2,7 +2,6 @@ import {gql} from '@apollo/client';
 
 export const CONFIG_TYPE_SCHEMA_FRAGMENT = gql`
   fragment ConfigTypeSchemaFragment on ConfigType {
-    __typename
     ... on EnumConfigType {
       givenName
       values {

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorerContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorerContainer.tsx
@@ -62,12 +62,10 @@ const TYPE_EXPLORER_CONTAINER_QUERY = gql`
     $dagsterTypeName: String!
   ) {
     pipelineOrError(params: $pipelineSelector) {
-      __typename
       ... on Pipeline {
         id
         isJob
         dagsterTypeOrError(dagsterTypeName: $dagsterTypeName) {
-          __typename
           ... on RegularDagsterType {
             ...TypeExplorerFragment
           }

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeListContainer.tsx
@@ -77,7 +77,6 @@ export const TypeListContainer: React.FC<ITypeListContainerProps> = ({
 const TYPE_LIST_CONTAINER_QUERY = gql`
   query TypeListContainerQuery($pipelineSelector: PipelineSelector!) {
     pipelineOrError(params: $pipelineSelector) {
-      __typename
       ... on Pipeline {
         id
         isJob

--- a/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/WorkspaceGraphsRoot.tsx
@@ -159,7 +159,6 @@ const WORSKPACE_GRAPHS_QUERY = gql`
         id
         usedSolids {
           definition {
-            __typename
             ... on CompositeSolidDefinition {
               id
               name


### PR DESCRIPTION
## Summary & Motivation

Our GraphQL operations don't need to include `__typename`, since it is added by default by Apollo. Also update `AppCache`, since `addTypename: true` is already the default.

## How I Tested These Changes

Lint, TS, Jest. Load app, sanity check that queries are behaving properly.
