### PR TITLE
Pin urllib3<2 in dagster-graphql

### DIFF
--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -39,6 +39,7 @@ setup(
         "gql[requests]>=3.0.0",
         "requests",
         "starlette",  # used for run_in_threadpool utility fn
+        "urllib3<2.0.0",  # https://github.com/psf/requests/issues/6432
     ],
     entry_points={"console_scripts": ["dagster-graphql = dagster_graphql.cli:main"]},
 )


### PR DESCRIPTION
It looks like requests yanked their latest version, urllib3 fixed the regression, requests re-added their latest version, and a new regression appeared.

Let's pin to urllib3<2.0.0 until the dust settles on their upgrade.
