### PR TITLE
Update io-managers.mdx, improper class called

### DIFF
--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -517,7 +517,7 @@ class BetterPandasIOManager(ConfigurableIOManager):
 
 
 # write a subclass that uses _get_path for your custom loading logic
-class MyBetterNumpyLoader(PandasIOManager):
+class MyBetterNumpyLoader(BetterPandasIOManager):
     def load_input(self, context):
         file_path = self._get_path(context.upstream_output)
         array = np.genfromtxt(file_path, delimiter=",", dtype=None)
@@ -532,7 +532,7 @@ def better_analyze_as_numpy(np_array_input: np.ndarray):
 @job(
     resource_defs={
         "numpy_manager": MyBetterNumpyLoader(),
-        "io_manager": PandasIOManager(),
+        "io_manager": BetterPandasIOManager(),
     }
 )
 def my_better_job():

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/input_managers.py
@@ -113,7 +113,7 @@ class BetterPandasIOManager(ConfigurableIOManager):
 
 
 # write a subclass that uses _get_path for your custom loading logic
-class MyBetterNumpyLoader(PandasIOManager):
+class MyBetterNumpyLoader(BetterPandasIOManager):
     def load_input(self, context):
         file_path = self._get_path(context.upstream_output)
         array = np.genfromtxt(file_path, delimiter=",", dtype=None)
@@ -128,7 +128,7 @@ def better_analyze_as_numpy(np_array_input: np.ndarray):
 @job(
     resource_defs={
         "numpy_manager": MyBetterNumpyLoader(),
-        "io_manager": PandasIOManager(),
+        "io_manager": BetterPandasIOManager(),
     }
 )
 def my_better_job():


### PR DESCRIPTION
When looking at the class MyBetterNumpyLoader. It appears that the `_get_path` method being called should be from the BetterPandasIOManager. Further, I would then expect the BetterPandasIOManager class to be part of the resource definition.

I'm new to dagster - so apologies if I'm not understanding the example properly. But this seems like it may be a straightforward fix that can make it easier for the next individual reading through the docs. 😄

## Summary & Motivation

## How I Tested These Changes
