### PR TITLE
storage (with priority) for single-dimension global op concurrency 

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/038_add_in_progress_step_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/038_add_in_progress_step_table.py
@@ -1,0 +1,40 @@
+"""add in progress step table
+
+Revision ID: 5771160a95ad
+Revises: d9092588866f
+Create Date: 2023-04-10 19:26:23.232433
+
+"""
+import sqlalchemy as db
+from alembic import op
+from dagster._core.storage.migration.utils import has_table
+from dagster._core.storage.sql import get_current_timestamp
+from sqlalchemy.dialects import sqlite
+
+# revision identifiers, used by Alembic.
+revision = "5771160a95ad"
+down_revision = "d9092588866f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not has_table("concurrency_slots"):
+        op.create_table(
+            "concurrency_slots",
+            db.Column(
+                "id",
+                db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+                primary_key=True,
+                autoincrement=True,
+            ),
+            db.Column("concurrency_key", db.Text, nullable=False),
+            db.Column("run_id", db.Text),
+            db.Column("step_key", db.Text),
+            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+        )
+
+
+def downgrade():
+    if has_table("concurrency_slots"):
+        op.drop_table("concurrency_slots")

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/038_add_in_progress_step_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/038_add_in_progress_step_table.py
@@ -31,6 +31,7 @@ def upgrade():
             db.Column("concurrency_key", db.Text, nullable=False),
             db.Column("run_id", db.Text),
             db.Column("step_key", db.Text),
+            db.Column("deleted", db.Boolean, nullable=False, default=False),
             db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
         )
 

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/038_add_in_progress_step_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/038_add_in_progress_step_table.py
@@ -1,19 +1,19 @@
 """add in progress step table
 
 Revision ID: 5771160a95ad
-Revises: d9092588866f
+Revises: 701913684cb4
 Create Date: 2023-04-10 19:26:23.232433
 
 """
 import sqlalchemy as db
 from alembic import op
-from dagster._core.storage.migration.utils import has_table
+from dagster._core.storage.migration.utils import has_index, has_table
 from dagster._core.storage.sql import get_current_timestamp
 from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
 revision = "5771160a95ad"
-down_revision = "d9092588866f"
+down_revision = "701913684cb4"
 branch_labels = None
 depends_on = None
 
@@ -35,7 +35,36 @@ def upgrade():
             db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
         )
 
+    if not has_table("pending_steps"):
+        op.create_table(
+            "pending_steps",
+            db.Column(
+                "id",
+                db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+                primary_key=True,
+                autoincrement=True,
+            ),
+            db.Column("concurrency_key", db.Text, nullable=False),
+            db.Column("run_id", db.Text),
+            db.Column("step_key", db.Text),
+            db.Column("priority", db.Integer),
+            db.Column("assigned_timestamp", db.Integer),
+            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+        )
+        op.create_index(
+            "idx_pending_steps",
+            "pending_steps",
+            ["concurrency_key", "run_id", "step_key"],
+            mysql_length={"concurrency_key": 255, "run_id": 255, "step_key": 32},
+            unique=True,
+        )
+
 
 def downgrade():
     if has_table("concurrency_slots"):
         op.drop_table("concurrency_slots")
+
+    if has_table("pending_steps"):
+        if has_index("pending_steps", "idx_pending_steps"):
+            op.drop_index("idx_pending_steps", "pending_steps")
+        op.drop_table("pending_steps")

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -408,6 +408,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Indicates that the EventLogStoarge is sharded."""
         return False
 
+    @property
+    def supports_global_concurrency_limits(self) -> bool:
+        """Indicates that the EventLogStorage supports global concurrency limits."""
+        return False
+
     @abstractmethod
     def allocate_concurrency_slots(self, concurrency_key: str, num_int: int) -> None:
         """Allocate concurrency slots for the given concurrency key."""

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -407,3 +407,28 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def is_run_sharded(self) -> bool:
         """Indicates that the EventLogStoarge is sharded."""
         return False
+
+    @abstractmethod
+    def allocate_concurrency_slots(self, concurrency_key: str, num_int: int) -> None:
+        """Allocate concurrency slots for the given concurrency key."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_concurrency_limited_keys(self) -> Set[str]:
+        """Get the set of concurrency limited keys."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_concurrency_info(self, concurrency_key: str):
+        """Get concurrency info for key."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def claim_concurrency_slots(self, concurrency_keys: Set[str], run_id: str, step_key: str):
+        """Claim concurrency slots for step."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def free_concurrency_slots(self, run_id: str, step_key: Optional[str] = None):
+        """Frees concurrency slots for a given run/step."""
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -424,7 +424,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_concurrency_info(self, concurrency_key: str):
+    def get_concurrency_info(self, concurrency_key: str, include_deleted: bool = False):
         """Get concurrency info for key."""
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -429,7 +429,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def claim_concurrency_slots(self, concurrency_keys: Set[str], run_id: str, step_key: str):
+    def claim_concurrency_slot(
+        self, concurrency_key: str, run_id: str, step_key: str, priority: Optional[int] = None
+    ):
         """Claim concurrency slots for step."""
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -80,6 +80,20 @@ DynamicPartitionsTable = db.Table(
     db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
 )
 
+ConcurrencySlotsTable = db.Table(
+    "concurrency_slots",
+    SqlEventLogStorageMetadata,
+    db.Column(
+        "id",
+        db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    db.Column("concurrency_key", db.Text, nullable=False),
+    db.Column("run_id", db.Text),
+    db.Column("step_key", db.Text),
+    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+)
 
 db.Index(
     "idx_step_key",

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -92,6 +92,7 @@ ConcurrencySlotsTable = db.Table(
     db.Column("concurrency_key", db.Text, nullable=False),
     db.Column("run_id", db.Text),
     db.Column("step_key", db.Text),
+    db.Column("deleted", db.Boolean, nullable=False, default=False),
     db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
 )
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -96,6 +96,23 @@ ConcurrencySlotsTable = db.Table(
     db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
 )
 
+PendingStepsTable = db.Table(
+    "pending_steps",
+    SqlEventLogStorageMetadata,
+    db.Column(
+        "id",
+        db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    db.Column("concurrency_key", db.Text, nullable=False),
+    db.Column("run_id", db.Text),
+    db.Column("step_key", db.Text),
+    db.Column("priority", db.Text),
+    db.Column("assigned_timestamp", db.DateTime),
+    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+)
+
 db.Index(
     "idx_step_key",
     SqlEventLogStorageTable.c.step_key,
@@ -151,5 +168,13 @@ db.Index(
     DynamicPartitionsTable.c.partitions_def_name,
     DynamicPartitionsTable.c.partition,
     mysql_length={"partitions_def_name": 64, "partition": 64},
+    unique=True,
+)
+db.Index(
+    "idx_pending_steps",
+    PendingStepsTable.c.concurrency_key,
+    PendingStepsTable.c.run_id,
+    PendingStepsTable.c.step_key,
+    mysql_length={"concurrency_key": 255, "run_id": 255, "step_key": 32},
     unique=True,
 )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1854,6 +1854,10 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             )
 
+    @property
+    def supports_global_concurrency_limits(self) -> bool:
+        return self.has_table(ConcurrencySlotsTable.name)
+
     def allocate_concurrency_slots(self, concurrency_key: str, num_int: int) -> None:
         """Allocate a set of concurrency slots.
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -535,6 +535,23 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> EventLogConnection:
         return self._storage.event_log_storage.get_records_for_run(run_id, cursor, of_type, limit)
 
+    def allocate_concurrency_slots(self, concurrency_key: str, num_int: int) -> None:
+        return self._storage.event_log_storage.allocate_concurrency_slots(concurrency_key, num_int)
+
+    def get_concurrency_limited_keys(self) -> Set[str]:
+        return self._storage.event_log_storage.get_concurrency_limited_keys()
+
+    def get_concurrency_info(self, concurrency_key: str):
+        return self._storage.event_log_storage.get_concurrency_info(concurrency_key)
+
+    def claim_concurrency_slots(self, concurrency_keys: Set[str], run_id: str, step_key: str):
+        return self._storage.event_log_storage.claim_concurrency_slots(
+            concurrency_keys, run_id, step_key
+        )
+
+    def free_concurrency_slots(self, run_id: str, step_key: Optional[str] = None):
+        return self._storage.event_log_storage.free_concurrency_slots(run_id, step_key)
+
 
 class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
     def __init__(self, storage: DagsterStorage, inst_data: Optional[ConfigurableClassData] = None):

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -541,8 +541,10 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     def get_concurrency_limited_keys(self) -> Set[str]:
         return self._storage.event_log_storage.get_concurrency_limited_keys()
 
-    def get_concurrency_info(self, concurrency_key: str):
-        return self._storage.event_log_storage.get_concurrency_info(concurrency_key)
+    def get_concurrency_info(self, concurrency_key: str, include_deleted: bool = False):
+        return self._storage.event_log_storage.get_concurrency_info(
+            concurrency_key, include_deleted
+        )
 
     def claim_concurrency_slots(self, concurrency_keys: Set[str], run_id: str, step_key: str):
         return self._storage.event_log_storage.claim_concurrency_slots(

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -546,9 +546,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             concurrency_key, include_deleted
         )
 
-    def claim_concurrency_slots(self, concurrency_keys: Set[str], run_id: str, step_key: str):
-        return self._storage.event_log_storage.claim_concurrency_slots(
-            concurrency_keys, run_id, step_key
+    def claim_concurrency_slot(
+        self, concurrency_key: str, run_id: str, step_key: str, priority: Optional[int] = None
+    ):
+        return self._storage.event_log_storage.claim_concurrency_slot(
+            concurrency_key, run_id, step_key, priority
         )
 
     def free_concurrency_slots(self, run_id: str, step_key: Optional[str] = None):

--- a/python_modules/dagster/dagster/_utils/concurrency.py
+++ b/python_modules/dagster/dagster/_utils/concurrency.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ConcurrencyState(Enum):
+    BLOCKED = "BLOCKED"
+    CLAIMED = "CLAIMED"

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3289,39 +3289,121 @@ class TestEventLogStorage:
 
         run_id_one = make_new_run_id()
         run_id_two = make_new_run_id()
-        blocked_run_id = make_new_run_id()
+        run_id_three = make_new_run_id()
 
-        def claim(keys, run_id, step_key):
-            return storage.claim_concurrency_slots(keys, run_id, step_key)
+        def claim(key, run_id, step_key, priority=0):
+            return storage.claim_concurrency_slot(key, run_id, step_key, priority)
 
         # initially there are no concurrency limited keys
         assert storage.get_concurrency_limited_keys() == set()
 
         # fill concurrency slots
-        storage.allocate_concurrency_slots("foo", 4)
+        storage.allocate_concurrency_slots("foo", 3)
         storage.allocate_concurrency_slots("bar", 1)
 
         # now there are two concurrency limited keys
         assert storage.get_concurrency_limited_keys() == {"foo", "bar"}
 
-        assert claim({"foo"}, run_id_one, "step_1") == ConcurrencyState.CLAIMED
-        assert claim({"foo"}, run_id_two, "step_2") == ConcurrencyState.CLAIMED
-        assert claim({"foo"}, run_id_one, "step_3") == ConcurrencyState.CLAIMED
-        assert claim({"foo", "bar"}, run_id_two, "step_4") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id_one, "step_1") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id_two, "step_2") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id_one, "step_3") == ConcurrencyState.CLAIMED
+        assert claim("bar", run_id_two, "step_4") == ConcurrencyState.CLAIMED
 
         # next claim should be blocked
-        assert claim({"foo"}, blocked_run_id, "blocked") == ConcurrencyState.BLOCKED
-        assert claim({"bar"}, blocked_run_id, "blocked") == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id_three, "step_5") == ConcurrencyState.BLOCKED
+        assert claim("bar", run_id_three, "step_6") == ConcurrencyState.BLOCKED
 
         # free single slot, one in each concurrency key: foo, bar
-        storage.free_concurrency_slots(run_id_two, "step_4")
-        assert claim({"foo", "bar"}, run_id_two, "step_4") == ConcurrencyState.CLAIMED
-        assert claim({"foo"}, blocked_run_id, "blocked") == ConcurrencyState.BLOCKED
-        assert claim({"bar"}, blocked_run_id, "blocked") == ConcurrencyState.BLOCKED
-
-        # free all slots for run_id_one, 2 slots for foo, 1 for bar
         storage.free_concurrency_slots(run_id_two)
-        assert claim({"foo"}, run_id_two, "step_2") == ConcurrencyState.CLAIMED
-        assert claim({"foo", "bar"}, run_id_two, "step_4") == ConcurrencyState.CLAIMED
-        assert claim({"foo"}, blocked_run_id, "blocked") == ConcurrencyState.BLOCKED
-        assert claim({"bar"}, blocked_run_id, "blocked") == ConcurrencyState.BLOCKED
+        # try to claim again
+        assert claim("foo", run_id_three, "step_5") == ConcurrencyState.CLAIMED
+        assert claim("bar", run_id_three, "step_6") == ConcurrencyState.CLAIMED
+        # new claims should be blocked
+        assert claim("foo", run_id_three, "step_7") == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id_three, "step_8") == ConcurrencyState.BLOCKED
+
+    def test_concurrency_priority(self, storage):
+        run_id = make_new_run_id()
+
+        def claim(key, run_id, step_key, priority=0):
+            return storage.claim_concurrency_slot(key, run_id, step_key, priority)
+
+        storage.allocate_concurrency_slots("foo", 5)
+        storage.allocate_concurrency_slots("bar", 1)
+
+        # fill all the slots
+        assert claim("foo", run_id, "step_1") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id, "step_2") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id, "step_3") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id, "step_4") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id, "step_5") == ConcurrencyState.CLAIMED
+
+        # next claims should be blocked
+        assert claim("foo", run_id, "a", 0) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "b", 2) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "c", 0) == ConcurrencyState.BLOCKED
+
+        # free up a slot
+        storage.free_concurrency_slots(run_id, "step_1")
+
+        # a new step trying to claim foo should also be blocked
+        assert claim("foo", run_id, "d", 0) == ConcurrencyState.BLOCKED
+
+        # the claim calls for all the previously blocked steps should all remain blocked, except for
+        # the highest priority one
+        assert claim("foo", run_id, "a", 0) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "c", 0) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "d", 0) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "b", 2) == ConcurrencyState.CLAIMED
+
+        # free up another slot
+        storage.free_concurrency_slots(run_id, "step_2")
+
+        # the claim calls for all the previously blocked steps should all remain blocked, except for
+        # the oldest of the zero priority pending steps
+        assert claim("foo", run_id, "c", 0) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "d", 0) == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "a", 0) == ConcurrencyState.CLAIMED
+
+        # b, c remain of the previous set of pending steps
+        # freeing up 3 slots means that trying to claim a new slot should go through, even though
+        # b and c have not claimed a slot yet (whilst being assigned)
+        storage.free_concurrency_slots(run_id, "step_3")
+        storage.free_concurrency_slots(run_id, "step_4")
+        storage.free_concurrency_slots(run_id, "step_5")
+
+        assert claim("foo", run_id, "e") == ConcurrencyState.CLAIMED
+
+    def test_concurrency_allocate_from_pending(self, storage):
+        run_id = make_new_run_id()
+
+        def claim(key, run_id, step_key, priority=0):
+            return storage.claim_concurrency_slot(key, run_id, step_key, priority)
+
+        storage.allocate_concurrency_slots("foo", 1)
+
+        # fill
+        assert claim("foo", run_id, "a") == ConcurrencyState.CLAIMED
+        assert claim("foo", run_id, "b") == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "c") == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "d") == ConcurrencyState.BLOCKED
+        assert claim("foo", run_id, "e") == ConcurrencyState.BLOCKED
+
+        # there is only one claimed slot, the rest are pending
+        assert storage.get_concurrency_info("foo") == [(run_id, 1)]
+
+        # all the pending slots should not be assigned
+        assert not storage.can_claim_from_pending("foo", run_id, "b")
+        assert not storage.can_claim_from_pending("foo", run_id, "c")
+        assert not storage.can_claim_from_pending("foo", run_id, "d")
+        assert not storage.can_claim_from_pending("foo", run_id, "e")
+
+        # now, allocate enough slots for all the pending rows
+        storage.allocate_concurrency_slots("foo", 5)
+
+        # there is still only one claimed slot, the rest are pending (but now assigned)
+        assert storage.get_concurrency_info("foo") == [(None, 4), (run_id, 1)]
+        assert storage.can_claim_from_pending("foo", run_id, "b")
+        assert storage.can_claim_from_pending("foo", run_id, "c")
+        assert storage.can_claim_from_pending("foo", run_id, "d")
+        assert storage.can_claim_from_pending("foo", run_id, "e")


### PR DESCRIPTION
## Summary & Motivation
Alternative to https://github.com/dagster-io/dagster/pull/13769, which implements priority for queued ops and enforces single-dimension concurrency limits.

## How I Tested These Changes
BK