### PR TITLE
Make ExecutionPlan build from JobDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -113,9 +113,7 @@ def create_context_creation_data(
         dagster_run=dagster_run,
         executor_def=executor_def,
         instance=instance,
-        resource_keys_to_init=get_required_resource_keys_to_init(
-            execution_plan, job_def, resolved_run_config
-        ),
+        resource_keys_to_init=get_required_resource_keys_to_init(execution_plan, job_def),
         execution_plan=execution_plan,
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -37,7 +37,6 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
 )
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.api import create_execution_plan, execute_plan
-from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.instance import DagsterInstance
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.test_utils import instance_for_test
@@ -90,7 +89,7 @@ def test_using_file_system_for_subplan():
     instance = DagsterInstance.ephemeral()
 
     resolved_run_config = ResolvedRunConfig.build(foo_job)
-    execution_plan = ExecutionPlan.build(InMemoryJob(foo_job), resolved_run_config)
+    execution_plan = create_execution_plan(foo_job)
     run = instance.create_run_for_job(job_def=foo_job, execution_plan=execution_plan)
     assert execution_plan.get_step_by_key("return_one")
 
@@ -135,9 +134,8 @@ def test_using_file_system_for_subplan_multiprocessing():
             foo_job.get_definition(),
         )
 
-        execution_plan = ExecutionPlan.build(
+        execution_plan = create_execution_plan(
             foo_job,
-            resolved_run_config,
         )
         run = instance.create_run_for_job(
             job_def=foo_job.get_definition(), execution_plan=execution_plan
@@ -193,13 +191,8 @@ def test_execute_step_wrong_step_key():
     foo_job = define_inty_job()
     instance = DagsterInstance.ephemeral()
 
-    resolved_run_config = ResolvedRunConfig.build(
-        foo_job,
-    )
-    execution_plan = ExecutionPlan.build(
-        InMemoryJob(foo_job),
-        resolved_run_config,
-    )
+    resolved_run_config = ResolvedRunConfig.build(foo_job)
+    execution_plan = create_execution_plan(foo_job)
     run = instance.create_run_for_job(job_def=foo_job, execution_plan=execution_plan)
 
     with pytest.raises(DagsterExecutionStepNotFoundError) as exc_info:
@@ -233,13 +226,8 @@ def test_using_file_system_for_subplan_missing_input():
     foo_job = define_inty_job(using_file_system=True)
 
     instance = DagsterInstance.ephemeral()
-    resolved_run_config = ResolvedRunConfig.build(
-        foo_job,
-    )
-    execution_plan = ExecutionPlan.build(
-        InMemoryJob(foo_job),
-        resolved_run_config,
-    )
+    resolved_run_config = ResolvedRunConfig.build(foo_job)
+    execution_plan = create_execution_plan(foo_job)
     run = instance.create_run_for_job(job_def=foo_job, execution_plan=execution_plan)
 
     events = execute_plan(
@@ -259,13 +247,8 @@ def test_using_file_system_for_subplan_invalid_step():
 
     instance = DagsterInstance.ephemeral()
 
-    resolved_run_config = ResolvedRunConfig.build(
-        foo_job,
-    )
-    execution_plan = ExecutionPlan.build(
-        InMemoryJob(foo_job),
-        resolved_run_config,
-    )
+    resolved_run_config = ResolvedRunConfig.build(foo_job)
+    execution_plan = create_execution_plan(foo_job)
 
     run = instance.create_run_for_job(job_def=foo_job, execution_plan=execution_plan)
 

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_execution_plan_reexecution.py
@@ -15,8 +15,12 @@ from dagster._core.errors import (
     DagsterRunNotFoundError,
 )
 from dagster._core.events import get_step_output_event
-from dagster._core.execution.api import ReexecutionOptions, execute_job, execute_plan
-from dagster._core.execution.plan.plan import ExecutionPlan
+from dagster._core.execution.api import (
+    ReexecutionOptions,
+    create_execution_plan,
+    execute_job,
+    execute_plan,
+)
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.mem_io_manager import mem_io_manager
@@ -94,9 +98,9 @@ def test_execution_plan_reexecution():
         )
         _check_known_state(known_state)
 
-        execution_plan = ExecutionPlan.build(
+        execution_plan = create_execution_plan(
             reconstructable(job_fn),
-            resolved_run_config,
+            run_config,
             known_state=known_state,
         )
 
@@ -166,9 +170,9 @@ def test_execution_plan_reexecution_with_in_memory():
         )
         _check_known_state(known_state)
 
-        execution_plan = ExecutionPlan.build(
+        execution_plan = create_execution_plan(
             reconstructable(define_addy_job_mem_io),
-            resolved_run_config,
+            run_config,
             known_state=known_state,
         )
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -29,8 +29,7 @@ from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.events import DagsterEventType
-from dagster._core.execution.api import execute_plan
-from dagster._core.execution.plan.plan import ExecutionPlan
+from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._core.utils import make_new_run_id
@@ -110,7 +109,7 @@ def test_adls2_pickle_io_manager_deletes_recursively(storage_account, file_syste
     run_id = make_new_run_id()
 
     resolved_run_config = ResolvedRunConfig.build(job, run_config=run_config)
-    execution_plan = ExecutionPlan.build(InMemoryJob(job), resolved_run_config)
+    execution_plan = create_execution_plan(job, run_config)
 
     assert execution_plan.get_step_by_key("return_one")
 
@@ -180,7 +179,7 @@ def test_adls2_pickle_io_manager_execution(storage_account, file_system, credent
     run_id = make_new_run_id()
 
     resolved_run_config = ResolvedRunConfig.build(job, run_config=run_config)
-    execution_plan = ExecutionPlan.build(InMemoryJob(job), resolved_run_config)
+    execution_plan = create_execution_plan(job, run_config)
 
     assert execution_plan.get_step_by_key("return_one")
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -27,9 +27,8 @@ from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.events import DagsterEventType
-from dagster._core.execution.api import execute_plan
+from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.plan.outputs import StepOutputHandle
-from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.storage.dagster_run import (
     DagsterRun as DagsterRun,
 )
@@ -98,7 +97,7 @@ def test_gcs_pickle_io_manager_execution(gcs_bucket):
     run_id = make_new_run_id()
 
     resolved_run_config = ResolvedRunConfig.build(inty_job, run_config=run_config)
-    execution_plan = ExecutionPlan.build(InMemoryJob(inty_job), resolved_run_config)
+    execution_plan = create_execution_plan(inty_job, run_config)
 
     assert execution_plan.get_step_by_key("return_one")
 

--- a/python_modules/libraries/dagstermill/dagstermill/manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill/manager.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
 from dagster._core.events import DagsterEvent
-from dagster._core.execution.api import scoped_job_context
+from dagster._core.execution.api import create_execution_plan, scoped_job_context
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.plan import ExecutionPlan
 from dagster._core.execution.plan.step import ExecutionStep
@@ -157,11 +157,11 @@ class Manager:
         self.op_def = op_def
         self.job = job
 
-        resolved_run_config = ResolvedRunConfig.build(job_def, run_config)
+        ResolvedRunConfig.build(job_def, run_config)
 
-        execution_plan = ExecutionPlan.build(
+        execution_plan = create_execution_plan(
             self.job,
-            resolved_run_config,
+            run_config,
             step_keys_to_execute=dagster_run.step_keys_to_execute,
         )
 
@@ -182,7 +182,6 @@ class Manager:
                 resource_keys_to_init=get_required_resource_keys_to_init(
                     execution_plan,
                     job_def,
-                    resolved_run_config,
                 ),
                 op_name=op.name,
                 node_handle=node_handle,
@@ -262,10 +261,8 @@ class Manager:
         self.op_def = op_def
         self.job = job_def
 
-        resolved_run_config = ResolvedRunConfig.build(job_def, run_config)
-
         job = InMemoryJob(job_def)
-        execution_plan = ExecutionPlan.build(job, resolved_run_config)
+        execution_plan = create_execution_plan(job, run_config)
 
         with scoped_job_context(
             execution_plan,
@@ -282,7 +279,6 @@ class Manager:
                 resource_keys_to_init=get_required_resource_keys_to_init(
                     execution_plan,
                     job_def,
-                    resolved_run_config,
                 ),
                 op_name=op_def.name,
                 node_handle=NodeHandle(op_def.name, parent=None),


### PR DESCRIPTION
## Summary & Motivation

`ExecutionPlan` construction does not require access to reconstruction context, nor does it pass on its job argument to other functions or structures that need this context. Therefore it makes sense for construction to operate directly on `JobDefinition`.

This also reroutes all calls to `ExecutionPlan.build` through `create_execution_plan` (the vast majority of existing calls were already routed this way but there were a few stragglers). This allows `ExecutionPlan.build` to be written directly against `JobDefinition`, as its only callsite is in `create_execution_plan` which should be considered the "public" function for creating an execution plan.

Prior to this PR, `ExecutionPlan` internal construction operated on an `IJob`, but the only thing it did was perform a check on `ReconstructableJob` to make sure its repository load data was the same as any `repository_load_data` passed in. That's no longer necessary if we operate on `JobDefinition` directly, and this check is satisfied in any case by going through `create_execution_plan`.

## How I Tested These Changes

Existing test suite.