### PR TITLE
Fix table name in example enriching-with-software-defined-assets.mdx

### DIFF
--- a/docs/content/guides/dagster/enriching-with-software-defined-assets.mdx
+++ b/docs/content/guides/dagster/enriching-with-software-defined-assets.mdx
@@ -359,7 +359,7 @@ def get_categories(products: DataFrame) -> DataFrame:
 
 @op
 def write_products_table(products: DataFrame) -> None:
-    products.to_sql(name="categories", con=create_db_connection())
+    products.to_sql(name="products", con=create_db_connection())
 
 
 @op


### PR DESCRIPTION
`write_products_table` example function should write to `products` table instead of `categories` table.

## Summary & Motivation
Fix what seems to be a copy/paste mistake in example.

## How I Tested These Changes
