### PR TITLE
[dagster-airflow] switch uri to string source

### DIFF
--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_persistent_db.py
@@ -10,6 +10,7 @@ from dagster import (
     Field,
     InitResourceContext,
     ResourceDefinition,
+    StringSource,
     _check as check,
 )
 
@@ -96,7 +97,7 @@ def make_persistent_airflow_db_resource(
         resource_fn=AirflowPersistentDatabase.from_resource_context,
         config_schema={
             "uri": Field(
-                str,
+                StringSource,
                 default_value=uri,
                 is_required=False,
             ),


### PR DESCRIPTION
## Summary & Motivation
to allow passing the uri as an environment variable and obfuscate the value from the UI. @benpankow is there a way to mark config values as secrets in the new config system?

## How I Tested These Changes
