### PR TITLE
[docs] run black and ruff before mdx-format

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,5 +22,7 @@ next-dev-install:
 next-watch-build:
 	yarn --cwd=next dev
 
-mdx-format: docs_black docs_ruff;
+mdx-format: 
 	yarn --cwd=next mdx-format
+
+mdx-full-format: docs_black docs_ruff mdx-format

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,11 @@
+docs_black:
+	black --fast \
+    ../examples/docs_snippets
+
+docs_ruff:
+	ruff --fix ../examples/docs_snippets
+
+
 apidoc-build:
 	tox -e sphinx && python scripts/pack_json.py
 
@@ -14,5 +22,5 @@ next-dev-install:
 next-watch-build:
 	yarn --cwd=next dev
 
-mdx-format:
+mdx-format: docs_black docs_ruff;
 	yarn --cwd=next mdx-format


### PR DESCRIPTION
## Summary & Motivation
I often find myself having to run `mdx-format` a bunch of times because i update a code snippet, run `mdx-format` then make a commit which reformats the code snippet with black and ruff. then i need to rerun `mdx-format`. This adds a `black` and `ruff` run to a new command `mdx-full-format` so that the formatting is done the first time. 

~Open to pushback on this. it would make each individual run of `mdx-format` longer. I could instead make a new command that does the full format suite, and keep `mdx-format` as is~ Updating to have a full format command so that CI can continue to just do the plain mdx-format

## How I Tested These Changes
