### PR TITLE
Refactor AssetNode status logic

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -187,14 +187,12 @@ export type StatusCaseObject =
       liveData: LiveDataForNode;
     } & Pick<GenericStatusProps, 'liveData' | 'currentMinutesLate' | 'late'> &
       Partial<Pick<GenericStatusProps, 'runWhichFailedToMaterialize'>>)
-  | {
+  | ({
       case: StatusCase.NEVER_MATERIALIZED;
-      liveData: LiveDataForNode;
-    }
-  | {
+    } & Pick<GenericStatusProps, 'liveData'>)
+  | ({
       case: StatusCase.MATERIALIZED;
-      liveData: LiveDataForNode;
-    }
+    } & Pick<GenericStatusProps, 'liveData'>)
   | ({
       case: StatusCase.PARTITIONS_FAILED;
     } & Pick<
@@ -570,19 +568,6 @@ export function buildAssetNodeStatusContent({
         ),
       };
   }
-
-  return {
-    background: Colors.Green50,
-    border: Colors.Green500,
-    content: (
-      <>
-        {expanded && <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />}
-        <span style={{color: Colors.Green700}}>Materialized</span>
-        {expanded && <SpacerDot />}
-        {lastMaterializationLink}
-      </>
-    ),
-  };
 }
 
 export const AssetNodeMinimal: React.FC<{

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -564,6 +564,18 @@ export function buildAssetNodeStatusContent({
         ),
       };
   }
+  return {
+    background: Colors.Green50,
+    border: Colors.Green500,
+    content: (
+      <>
+        {expanded && <AssetPartitionStatusDot status={[AssetPartitionStatus.MATERIALIZED]} />}
+        <span style={{color: Colors.Green700}}>Materialized</span>
+        {expanded && <SpacerDot />}
+        {lastMaterializationLink}
+      </>
+    ),
+  };
 }
 
 export const AssetNodeMinimal: React.FC<{

--- a/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/AssetNode.tsx
@@ -230,10 +230,6 @@ export type StatusCaseObject =
       | 'numMaterialized'
     >);
 
-/**
- *
- * This logic is based off `buildAssetNodeStatusContent`
- */
 export function getAssetNodeStatusCase({
   definition,
   liveData,


### PR DESCRIPTION
## Summary & Motivation

The AssetNode coloring logic is currently entrenched with a bunch of rendering logic specific to the asset graph.
This PR refactors the core logic out into a hook `getAssetNodeStatusCase` which maps each case of the logic to a specific "StatusCase". That function returns an object with a StatusCase and any relevant variables to the status case. The reason for also returning the relevant variables is to "reuse" the type checking done by `getAssetNodeStatusCase`.


The idea is that now I can re-use that core logic that maps an asset to a "status" and I can group these cases into buckets for the new Asset Factory Floor page.


## How I Tested These Changes


before:
![screencapture-localhost-6006-iframe-html-2023-05-05-13_28_21](https://user-images.githubusercontent.com/2286579/236526414-74d73aa0-d048-4337-9fbc-fd5c15652d3e.png)


After:
![screencapture-localhost-6006-iframe-html-2023-05-05-13_30_02](https://user-images.githubusercontent.com/2286579/236526445-9ac07981-fd81-4b2e-9b9c-8246ddc99c98.png)

