### PR TITLE
pin onnx

### DIFF
--- a/examples/with_wandb/setup.py
+++ b/examples/with_wandb/setup.py
@@ -8,7 +8,9 @@ setup(
         "dagster-wandb",
         "onnxruntime",
         "skl2onnx",
-        "onnx>=1.13.0",  # Ensure a version is installed that is protobuf 4 compatible
+        # Pin onnx with min version to ensure protobuf 4 compatability
+        # Pin onnx with max version until https://github.com/onnx/onnx/issues/5202 is resolved
+        "onnx>=1.13.0,<1.14.0",
         "joblib",
         "torch",
         "torchvision",


### PR DESCRIPTION
## Summary & Motivation
Breaking the build: root cause is incompatability between onnx and skl2onnx see https://github.com/onnx/onnx/issues/5202

Can either pin onnx or wait til skl2onnx patches.

## How I Tested These Changes
BK