### PR TITLE
Remove DagsterGraphQLClient.submit_pipeline_execution

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
+++ b/integration_tests/test_suites/backcompat-test-suite/tests/test_backcompat.py
@@ -240,11 +240,10 @@ def test_backcompat_ping_dagit(graphql_client: DagsterGraphQLClient):
 def assert_runs_and_exists(
     client: DagsterGraphQLClient, name: str, subset_selection: Optional[Sequence[str]] = None
 ):
-    run_id = client.submit_pipeline_execution(
-        pipeline_name=name,
-        mode="default",
+    run_id = client.submit_job_execution(
+        job_name=name,
         run_config={},
-        solid_selection=subset_selection,
+        op_selection=subset_selection,
     )
     assert_run_success(client, run_id)
 

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -121,7 +121,7 @@ class DagsterGraphQLClient:
         mode: str = "default",
         preset: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
-        solid_selection: Optional[Sequence[str]] = None,
+        op_selection: Optional[Sequence[str]] = None,
         is_using_job_op_graph_apis: Optional[bool] = False,
     ):
         check.opt_str_param(repository_location_name, "repository_location_name")
@@ -170,7 +170,7 @@ class DagsterGraphQLClient:
                     "repositoryLocationName": repository_location_name,
                     "repositoryName": repository_name,
                     "pipelineName": pipeline_name,
-                    "solidSelection": solid_selection,
+                    "solidSelection": op_selection,
                 }
             }
         }
@@ -212,67 +212,6 @@ class DagsterGraphQLClient:
             # a PipelineNotFoundError, a RunConflict, or a PythonError
             raise DagsterGraphQLClientError(query_result_type, query_result["message"])
 
-    def submit_pipeline_execution(
-        self,
-        pipeline_name: str,
-        repository_location_name: Optional[str] = None,
-        repository_name: Optional[str] = None,
-        run_config: Optional[Any] = None,
-        mode: str = "default",
-        preset: Optional[str] = None,
-        tags: Optional[Dict[str, Any]] = None,
-        solid_selection: Optional[Sequence[str]] = None,
-    ) -> str:
-        """Submits a Pipeline with attached configuration for execution.
-
-        Args:
-            pipeline_name (str): The pipeline's name
-            repository_location_name (Optional[str], optional): The name of the repository location where
-                the pipeline is located. If omitted, the client will try to infer the repository location
-                from the available options on the Dagster deployment. Defaults to None.
-            repository_name (Optional[str], optional): The name of the repository where the pipeline is located.
-                If omitted, the client will try to infer the repository from the available options
-                on the Dagster deployment. Defaults to None.
-            run_config (Optional[Any], optional): This is the run config to execute the pipeline with.
-                Note that runConfigData is any-typed in the GraphQL type system. This type is used when passing in
-                an arbitrary object for run config. However, it must conform to the constraints of the config
-                schema for this pipeline. If it does not, the client will throw a DagsterGraphQLClientError with a message of
-                RunConfigValidationInvalid. Defaults to None.
-            mode (Optional[str], optional): The mode to run the pipeline with. If you have not
-                defined any custom modes for your pipeline, the default mode is "default". Defaults to None.
-            preset (Optional[str], optional): The name of a pre-defined preset to use instead of a
-                run config. Defaults to None.
-            tags (Optional[Dict[str, Any]], optional): A set of tags to add to the pipeline execution.
-
-        Raises:
-            DagsterGraphQLClientError("InvalidStepError", invalid_step_key): the pipeline has an invalid step
-            DagsterGraphQLClientError("InvalidOutputError", body=error_object): some solid has an invalid output within the pipeline.
-                The error_object is of type dagster_graphql.InvalidOutputErrorInfo.
-            DagsterGraphQLClientError("ConflictingExecutionParamsError", invalid_step_key): a preset and a run_config & mode are present
-                that conflict with one another
-            DagsterGraphQLClientError("PresetNotFoundError", message): if the provided preset name is not found
-            DagsterGraphQLClientError("RunConflict", message): a `DagsterRunConflict` occured during execution.
-                This indicates that a conflicting pipeline run already exists in run storage.
-            DagsterGraphQLClientError("PipelineConfigurationInvalid", invalid_step_key): the run_config is not in the expected format
-                for the pipeline
-            DagsterGraphQLClientError("PipelineNotFoundError", message): the requested pipeline does not exist
-            DagsterGraphQLClientError("PythonError", message): an internal framework error occurred
-
-        Returns:
-            str: run id of the submitted pipeline run
-        """
-        return self._core_submit_execution(
-            pipeline_name,
-            repository_location_name,
-            repository_name,
-            run_config,
-            mode,
-            preset,
-            tags,
-            solid_selection,
-            is_using_job_op_graph_apis=False,
-        )
-
     @public
     def submit_job_execution(
         self,
@@ -281,7 +220,7 @@ class DagsterGraphQLClient:
         repository_name: Optional[str] = None,
         run_config: Optional[Dict[str, Any]] = None,
         tags: Optional[Dict[str, Any]] = None,
-        op_selection: Optional[List[str]] = None,
+        op_selection: Optional[Sequence[str]] = None,
     ) -> str:
         """Submits a job with attached configuration for execution.
 
@@ -322,7 +261,7 @@ class DagsterGraphQLClient:
             mode="default",
             preset=None,
             tags=tags,
-            solid_selection=op_selection,
+            op_selection=op_selection,
             is_using_job_op_graph_apis=True,
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_submit_pipeline_execution.py
@@ -15,37 +15,12 @@ launch_job_success_response = {
 
 
 @python_client_test_suite
-def test_success(mock_client: MockClient):
-    mock_client.mock_gql_client.execute.return_value = launch_job_success_response
-    actual_run_id = mock_client.python_client.submit_pipeline_execution(
-        "bar",
-        repository_location_name="baz",
-        repository_name="quux",
-        run_config={},
-    )
-    assert actual_run_id == EXPECTED_RUN_ID
-
-
-@python_client_test_suite
 def test_job_success(mock_client: MockClient):
     mock_client.mock_gql_client.execute.return_value = launch_job_success_response
     actual_run_id = mock_client.python_client.submit_job_execution(
         "bar",
         repository_location_name="baz",
         repository_name="quux",
-    )
-    assert actual_run_id == EXPECTED_RUN_ID
-
-
-@python_client_test_suite
-def test_tags_success(mock_client: MockClient):
-    mock_client.mock_gql_client.execute.return_value = launch_job_success_response
-    actual_run_id = mock_client.python_client.submit_pipeline_execution(
-        "bar",
-        repository_location_name="baz",
-        repository_name="quuz",
-        run_config={},
-        tags={"my_tag": "a", "my_other_tag": "b"},
     )
     assert actual_run_id == EXPECTED_RUN_ID
 
@@ -58,19 +33,6 @@ def test_job_tags_success(mock_client: MockClient):
         repository_location_name="baz",
         repository_name="quuz",
         tags={"my_tag": "a", "my_other_tag": "b"},
-    )
-    assert actual_run_id == EXPECTED_RUN_ID
-
-
-@python_client_test_suite
-def test_pipeline_subset_success(mock_client: MockClient):
-    mock_client.mock_gql_client.execute.return_value = launch_job_success_response
-    actual_run_id = mock_client.python_client.submit_pipeline_execution(
-        "bar",
-        repository_location_name="baz",
-        repository_name="quuz",
-        solid_selection=[""],
-        run_config={},
     )
     assert actual_run_id == EXPECTED_RUN_ID
 
@@ -96,15 +58,6 @@ def test_complex_tags_success(mock_client: MockClient):
         }
     }
     mock_client.mock_gql_client.execute.return_value = response
-    actual_run_id = mock_client.python_client.submit_pipeline_execution(
-        "bar",
-        repository_location_name="baz",
-        repository_name="quuz",
-        run_config={},
-        tags={"my_tag": {"I'm": {"a JSON-encodable": "thing"}}},
-    )
-    assert actual_run_id == EXPECTED_RUN_ID
-
     actual_run_id = mock_client.python_client.submit_job_execution(
         "bar",
         repository_location_name="baz",
@@ -119,15 +72,6 @@ def test_complex_tags_success(mock_client: MockClient):
 def test_invalid_tags_failure(mock_client: MockClient):
     class SomeWeirdObject:
         pass
-
-    with pytest.raises(DagsterInvalidDefinitionError):
-        mock_client.python_client.submit_pipeline_execution(
-            "bar",
-            repository_location_name="baz",
-            repository_name="quuz",
-            run_config={},
-            tags={"my_invalid_tag": SomeWeirdObject()},
-        )
 
     with pytest.raises(DagsterInvalidDefinitionError):
         mock_client.python_client.submit_job_execution(
@@ -166,17 +110,6 @@ def test_no_location_or_repo_provided_success(mock_client: MockClient):
             "run": {"runId": EXPECTED_RUN_ID},
         }
     }
-    mock_client.mock_gql_client.execute.side_effect = [
-        get_locations_and_names_response,
-        submit_execution_response,
-    ]
-
-    actual_run_id = mock_client.python_client.submit_pipeline_execution(
-        job_name,
-        run_config={},
-    )
-    assert actual_run_id == EXPECTED_RUN_ID
-
     mock_client.mock_gql_client.execute.side_effect = [
         get_locations_and_names_response,
         submit_execution_response,
@@ -221,19 +154,6 @@ def no_location_or_repo_provided_duplicate_pipeline_mock_config(mock_client: Moc
 
 
 @python_client_test_suite
-def test_no_location_or_repo_provided_duplicate_pipeline_failure(mock_client: MockClient):
-    job_name = no_location_or_repo_provided_duplicate_pipeline_mock_config(mock_client)
-
-    with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
-            job_name,
-            run_config={},
-        )
-
-    assert exc_info.value.args[0].find(f"multiple pipelines with the name {job_name}") != -1
-
-
-@python_client_test_suite
 def test_no_location_or_repo_provided_duplicate_job_failure(mock_client: MockClient):
     job_name = no_location_or_repo_provided_duplicate_pipeline_mock_config(mock_client)
 
@@ -270,16 +190,6 @@ def no_location_or_repo_provided_mock_config(mock_client):
 
 
 @python_client_test_suite
-def test_no_location_or_repo_provided_no_pipeline_failure(mock_client: MockClient):
-    no_location_or_repo_provided_mock_config(mock_client)
-
-    with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution("123", run_config={})
-
-    assert exc_info.value.args[0] == "PipelineNotFoundError"
-
-
-@python_client_test_suite
 def test_no_location_or_repo_provided_no_job_failure(mock_client: MockClient):
     no_location_or_repo_provided_mock_config(mock_client)
 
@@ -301,7 +211,7 @@ def test_failure_with_invalid_step_error(mock_client: MockClient):
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
+        mock_client.python_client.submit_job_execution(
             "bar",
             repository_location_name="baz",
             repository_name="quux",
@@ -326,7 +236,7 @@ def test_failure_with_invalid_output_error(mock_client: MockClient):
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
+        mock_client.python_client.submit_job_execution(
             "bar",
             repository_location_name="baz",
             repository_name="quux",
@@ -340,7 +250,7 @@ def test_failure_with_invalid_output_error(mock_client: MockClient):
 
 
 @python_client_test_suite
-def test_failure_with_pipeline_config_invalid(mock_client: MockClient):
+def test_failure_with_job_config_invalid(mock_client: MockClient):
     error_type = "RunConfigValidationInvalid"
     errors = [
         {
@@ -354,7 +264,7 @@ def test_failure_with_pipeline_config_invalid(mock_client: MockClient):
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
+        mock_client.python_client.submit_job_execution(
             "bar",
             repository_location_name="baz",
             repository_name="quux",
@@ -378,18 +288,6 @@ def test_failure_with_python_error(mock_client: MockClient):
     mock_client.mock_gql_client.execute.return_value = response
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
-            "bar",
-            repository_location_name="baz",
-            repository_name="quux",
-            run_config={},
-        )
-    exc_args = exc_info.value.args
-
-    assert exc_args[0] == error_type
-    assert exc_args[1] == message
-
-    with pytest.raises(DagsterGraphQLClientError) as exc_info:
         mock_client.python_client.submit_job_execution(
             "bar",
             repository_location_name="baz",
@@ -402,7 +300,7 @@ def test_failure_with_python_error(mock_client: MockClient):
     assert exc_args[1] == message
 
 
-def failure_with_pipeline_run_conflict_mock_config(mock_client: MockClient):
+def failure_with_job_run_conflict_mock_config(mock_client: MockClient):
     error_type, message = "RunConflict", "some conflict"
     response = {
         "launchPipelineExecution": {
@@ -414,25 +312,8 @@ def failure_with_pipeline_run_conflict_mock_config(mock_client: MockClient):
 
 
 @python_client_test_suite
-def test_failure_with_pipeline_run_conflict(mock_client: MockClient):
-    failure_with_pipeline_run_conflict_mock_config(mock_client)
-
-    with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
-            "bar",
-            repository_location_name="baz",
-            repository_name="quux",
-            run_config={},
-        )
-    exc_args = exc_info.value.args
-
-    assert exc_args[0] == "RunConflict"
-    assert exc_args[1] == "some conflict"
-
-
-@python_client_test_suite
 def test_failure_with_job_run_conflict(mock_client: MockClient):
-    failure_with_pipeline_run_conflict_mock_config(mock_client)
+    failure_with_job_run_conflict_mock_config(mock_client)
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
         mock_client.python_client.submit_job_execution(
@@ -452,7 +333,7 @@ def test_failure_with_query_error(mock_client: MockClient):
     mock_client.mock_gql_client.side_effect = Exception("foo")
 
     with pytest.raises(DagsterGraphQLClientError) as exc_info:
-        mock_client.python_client.submit_pipeline_execution(
+        mock_client.python_client.submit_job_execution(
             "bar",
             repository_location_name="baz",
             repository_name="quux",


### PR DESCRIPTION
## Summary & Motivation

Remove `DagsterGraphQLClient.submit_pipeline_execution`. There were a bunch of parallel tests that did the same thing for `submit_pipeline_execution` and `submit_job_execution`-- in these cases, I deleted the pipeline variant. If there was no corresponding test that use `submit_job_execution`, I converted the test.

## How I Tested These Changes

Existing test suite.