### PR TITLE
Split pytest logs into their own Buildkite section

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+import os
+
+
+def pytest_configure():
+    # Create a section break in the logs any time Buildkite invokes pytest
+    # https://buildkite.com/docs/pipelines/managing-log-output
+    # https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=pytest_configure#pytest.hookspec.pytest_configure
+    if os.getenv("BUILDKITE"):
+        print("+++ Running :pytest: PyTest")


### PR DESCRIPTION
Similar to where I've done this for some of our internal repos. I assume we're comfortable with the top level conftest?