### PR TITLE
[ui] Fix infinite recursion on asset job partitions page when using TimeWindowPartitionMapping

### DIFF
--- a/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
+++ b/js_modules/dagit/packages/core/src/gantt/GanttChartLayout.ts
@@ -56,7 +56,11 @@ export const buildLayout = (params: BuildLayoutParams) => {
       return;
     }
     box.x = x;
-    box.children.forEach((child) => deepen(child, box.x + box.width + BOX_SPACING_X));
+    box.children.forEach((child) => {
+      if (child.key !== box.key) {
+        deepen(child, box.x + box.width + BOX_SPACING_X);
+      }
+    });
   };
   roots.forEach((box) => deepen(box, LEFT_INSET));
 

--- a/js_modules/dagit/packages/core/src/gantt/__tests__/GanttChartLayout.test.ts
+++ b/js_modules/dagit/packages/core/src/gantt/__tests__/GanttChartLayout.test.ts
@@ -24,7 +24,7 @@ describe('toGraphQueryItems', () => {
 
     expect(result.markers).toEqual([]);
     expect(result.boxes.length).toEqual(2);
-    expect(result.boxes[0]).toContain({
+    expect(result.boxes[0]).toMatchObject({
       key: 'depends_on_nothing',
       root: true,
       state: undefined,
@@ -33,7 +33,7 @@ describe('toGraphQueryItems', () => {
       y: 0,
     });
     expect(result.boxes[0].children.length).toEqual(1);
-    expect(result.boxes[1]).toContain({
+    expect(result.boxes[1]).toMatchObject({
       key: 'depends_on_yesterday',
       root: false,
       state: undefined,

--- a/js_modules/dagit/packages/core/src/gantt/__tests__/GanttChartLayout.test.ts
+++ b/js_modules/dagit/packages/core/src/gantt/__tests__/GanttChartLayout.test.ts
@@ -1,0 +1,45 @@
+import {GanttChartMode} from '../GanttChart';
+import {buildLayout} from '../GanttChartLayout';
+
+describe('toGraphQueryItems', () => {
+  it('ignores self-dependencies caused by TimeWindowPartitionMapping', () => {
+    const result = buildLayout({
+      mode: GanttChartMode.FLAT,
+      nodes: [
+        {
+          name: 'depends_on_nothing',
+          inputs: [],
+          outputs: [{dependedBy: [{solid: {name: 'depends_on_yesterday'}}]}],
+        },
+        {
+          name: 'depends_on_yesterday',
+          inputs: [
+            {dependsOn: [{solid: {name: 'depends_on_nothing'}}]},
+            {dependsOn: [{solid: {name: 'depends_on_yesterday'}}]},
+          ],
+          outputs: [{dependedBy: [{solid: {name: 'depends_on_yesterday'}}]}],
+        },
+      ],
+    });
+
+    expect(result.markers).toEqual([]);
+    expect(result.boxes.length).toEqual(2);
+    expect(result.boxes[0]).toContain({
+      key: 'depends_on_nothing',
+      root: true,
+      state: undefined,
+      width: 100,
+      x: 16,
+      y: 0,
+    });
+    expect(result.boxes[0].children.length).toEqual(1);
+    expect(result.boxes[1]).toContain({
+      key: 'depends_on_yesterday',
+      root: false,
+      state: undefined,
+      width: 100,
+      x: 152,
+      y: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

Discussion: https://elementl-workspace.slack.com/archives/C03CCE471E0/p1682953217787039

## How I Tested These Changes

I created a repro case (code below), added a failing test case, and then fixed the layout logic.

```

@asset()
def depends_on_nothing():
    return 2


@asset(
    partitions_def=DailyPartitionsDefinition(start_date="2020-01-01"),
    ins={
        "depends_on_yesterday": AssetIn(
            partition_mapping=TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
        )
    },
)
def depends_on_yesterday(depends_on_nothing, depends_on_yesterday):
    return 2


job = define_asset_job("depends_on_yesterday_job", selection=AssetSelection.keys("depends_on_nothing", "depends_on_yesterday")),
```` 