### PR TITLE
[pythonic resources] Attach resource function name to function-style resources in snapshots

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -3,6 +3,7 @@ host processes and user processes. They should contain no
 business logic or clever indexing. Use the classes in external.py
 for that.
 """
+import inspect
 import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -1615,8 +1616,6 @@ def external_resource_data_from_def(
     # use the resource function name as the resource type if it's a function resource
     # (ie direct instantiation of ResourceDefinition or IOManagerDefinition)
     if type(resource_type_def) in (ResourceDefinition, IOManagerDefinition):
-        import inspect
-
         module_name = check.not_none(inspect.getmodule(resource_type_def.resource_fn)).__name__
         resource_type = f"{module_name}.{resource_type_def.resource_fn.__name__}"
     # if it's a Pythonic resource, get the underlying Pythonic class name

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -89,6 +89,7 @@ from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.snap import JobSnapshot
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
+from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
@@ -1611,9 +1612,15 @@ def external_resource_data_from_def(
     if isinstance(resource_type_def, ResourceWithKeyMapping):
         resource_type_def = resource_type_def.wrapped_resource
 
-    resource_type = _get_class_name(type(resource_type_def))
+    # use the resource function name as the resource type if it's a function resource
+    # (ie direct instantiation of ResourceDefinition or IOManagerDefinition)
+    if type(resource_type_def) in (ResourceDefinition, IOManagerDefinition):
+        import inspect
 
-    if isinstance(
+        module_name = check.not_none(inspect.getmodule(resource_type_def.resource_fn)).__name__
+        resource_type = f"{module_name}.{resource_type_def.resource_fn.__name__}"
+    # if it's a Pythonic resource, get the underlying Pythonic class name
+    elif isinstance(
         resource_type_def,
         (
             ConfigurableResourceFactoryResourceDefinition,
@@ -1621,6 +1628,8 @@ def external_resource_data_from_def(
         ),
     ):
         resource_type = _get_class_name(resource_type_def.configurable_resource_cls)
+    else:
+        resource_type = _get_class_name(type(resource_type_def))
 
     return ExternalResourceData(
         name=name,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -183,10 +183,18 @@ def test_repository_snap_definitions_function_style_resources_nested() -> None:
     assert len(foo[0].nested_resources) == 1
     assert "inner" in foo[0].nested_resources
     assert foo[0].nested_resources["inner"] == NestedResource(NestedResourceType.TOP_LEVEL, "inner")
+    assert (
+        foo[0].resource_type
+        == "dagster_tests.core_tests.snap_tests.test_repository_snap.my_outer_resource"
+    )
 
     assert len(inner[0].parent_resources) == 1
     assert "foo" in inner[0].parent_resources
     assert inner[0].parent_resources["foo"] == "inner"
+    assert (
+        inner[0].resource_type
+        == "dagster_tests.core_tests.snap_tests.test_repository_snap.my_inner_resource"
+    )
 
 
 def test_repository_snap_definitions_resources_nested_many() -> None:


### PR DESCRIPTION
## Summary

Extracts the wrapped resource function name when getting a resource name for snapshot purposes. Previously, the type would just display as `ResourceDefinition` or `IOManagerDefinition`.

![Screen Shot 2023-05-05 at 11 26 10 AM](https://user-images.githubusercontent.com/10215173/236538751-c196e226-1aa1-46f0-9b77-0f1e2011c1c4.png)



## Test Plan

New unit tests, tested locally.