### PR TITLE
[docs] - Correct numbering for tutorial in sidenav

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -45,15 +45,15 @@
         "path": "/tutorial/writing-your-first-asset"
       },
       {
-        "title": "Part 3: Building an asset graph",
+        "title": "Part 4: Building an asset graph",
         "path": "/tutorial/building-an-asset-graph"
       },
       {
-        "title": "Part 4: Scheduling your pipeline",
+        "title": "Part 5: Scheduling your pipeline",
         "path": "/tutorial/scheduling-your-pipeline"
       },
       {
-        "title": "Part 5: Saving your data",
+        "title": "Part 6: Saving your data",
         "path": "/tutorial/saving-your-data"
       },
       {


### PR DESCRIPTION
## Summary & Motivation

This PR corrects the numbering of tutorial sections in the sidenav. Looks like we skipped 2; whoops

## How I Tested These Changes
