### PR TITLE
Grab-bag of report_run_canceling fixes

### DIFF
--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -163,6 +163,8 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
         if not run:
             return False
 
+        self._instance.report_run_canceling(run)
+
         client = self._get_grpc_client_for_termination(run_id)
 
         if not client:
@@ -173,7 +175,6 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
             )
             return False
 
-        self._instance.report_run_canceling(run)
         res = deserialize_value(
             client.cancel_execution(CancelExecutionRequest(run_id=run_id)), CancelExecutionResult
         )

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -477,6 +477,12 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     def terminate(self, run_id):
         tags = self._get_run_tags(run_id)
 
+        run = self._instance.get_run_by_id(run_id)
+        if not run:
+            return False
+
+        self._instance.report_run_canceling(run)
+
         if not (tags.arn and tags.cluster):
             return False
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -1,7 +1,13 @@
+from dagster import DagsterRunStatus
+
+
 def test_termination(instance, workspace, run):
     instance.launch_run(run.run_id, workspace)
 
     assert instance.run_launcher.terminate(run.run_id)
+
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.CANCELING
+
     assert not instance.run_launcher.terminate(run.run_id)
 
 
@@ -26,6 +32,9 @@ def test_missing_tag(instance, workspace, run):
 
     instance.add_run_tags(run.run_id, {"ecs/task_arn": ""})
     assert not instance.run_launcher.terminate(run.run_id)
+
+    # Still moves to CANCELING
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.CANCELING
 
     instance.add_run_tags(run.run_id, original)
     instance.add_run_tags(run.run_id, {"ecs/cluster": ""})

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -195,6 +195,12 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
 
     def terminate(self, run_id):
         run = self._instance.get_run_by_id(run_id)
+
+        if not run:
+            return False
+
+        self._instance.report_run_canceling(run)
+
         container = self._get_container(run)
 
         if not container:
@@ -204,8 +210,6 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
                 cls=self.__class__,
             )
             return False
-
-        self._instance.report_run_canceling(run)
 
         container.stop()
 


### PR DESCRIPTION
Summary:
- Always call report_run_canceling up top in the terminate() method - so that the cancel time will kick off as expected, even if there's some issue in the cluster preventing us from sending the signal to the task/process..
- Remove some old crufty places in k8s and celery-k8s run launchers where we were still checking run status (the callsite now does this)
- Fix a place where the report_run_canceling call was missing entirely in EcsRunLauncher.

Test Plan:
Existing termination tests largely cover this

## Summary & Motivation

## How I Tested These Changes
