### PR TITLE
[ui] Small styling improvements to asset definition tab

### DIFF
--- a/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagit/packages/core/src/asset-graph/SidebarAssetInfo.tsx
@@ -84,7 +84,7 @@ export const SidebarAssetInfo: React.FC<{
       {(asset.description || OpMetadataPlugin?.SidebarComponent || !hasAssetMetadata) && (
         <SidebarSection title="Description">
           <Box padding={{vertical: 16, horizontal: 24}}>
-            <Description description={asset.description || 'No description provided.'} />
+            <Description description={asset.description || 'No description provided'} />
           </Box>
           {asset.op && OpMetadataPlugin?.SidebarComponent && (
             <Box padding={{bottom: 16, horizontal: 24}}>

--- a/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetNodeDefinition.tsx
@@ -42,7 +42,9 @@ export const AssetNodeDefinition: React.FC<{
   const {assetMetadata, assetType} = metadataForAssetNode(assetNode);
   const liveDataForNode = liveDataByNode[toGraphId(assetNode.assetKey)];
 
-  const assetConfigSchema = assetNode.configField?.configType;
+  const configType = assetNode.configField?.configType;
+  const assetConfigSchema = configType && configType.key !== 'Any' ? configType : null;
+
   const repoAddress = buildRepoAddress(
     assetNode.repository.name,
     assetNode.repository.location.name,
@@ -71,12 +73,13 @@ export const AssetNodeDefinition: React.FC<{
           </Box>
           <Box
             padding={{vertical: 16, horizontal: 24}}
-            style={{flex: 1, flexBasis: 'content', flexGrow: 0, minHeight: 120}}
+            style={{flex: 1, flexBasis: 'content', flexGrow: 0, minHeight: 123}}
           >
-            <Description
-              description={assetNode.description || 'No description provided.'}
-              maxHeight={260}
-            />
+            {assetNode.description ? (
+              <Description description={assetNode.description} maxHeight={260} />
+            ) : (
+              <Body>No description provided</Body>
+            )}
           </Box>
           {assetNode.opVersion && (
             <>
@@ -168,94 +171,131 @@ export const AssetNodeDefinition: React.FC<{
           {/** Ensures the line between the left and right columns goes to the bottom of the page */}
           <div style={{flex: 1}} />
         </Box>
-        {assetConfigSchema || assetNode.requiredResources.length > 0 ? (
-          <Box
-            border={{side: 'vertical', width: 1, color: Colors.KeylineGray}}
-            style={{flex: 0.5, minWidth: 0}}
-            flex={{direction: 'column'}}
-          >
-            {assetNode.requiredResources.length > 0 && (
-              <>
-                <Box
-                  padding={{vertical: 16, horizontal: 24}}
-                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-                >
-                  <Subheading>Required Resources</Subheading>
-                </Box>
-                <Box
-                  padding={{vertical: 16, horizontal: 24}}
-                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-                >
-                  {assetNode.requiredResources.map((resource) => (
-                    <ResourceContainer key={resource.resourceKey}>
-                      <Icon name="resource" color={Colors.Gray700} />
-                      {repoAddress ? (
-                        <Link
-                          to={workspacePathFromAddress(
-                            repoAddress,
-                            `/resources/${resource.resourceKey}`,
-                          )}
-                        >
-                          <ResourceHeader>{resource.resourceKey}</ResourceHeader>
-                        </Link>
-                      ) : (
-                        <ResourceHeader>{resource.resourceKey}</ResourceHeader>
-                      )}
-                    </ResourceContainer>
-                  ))}
-                </Box>
-              </>
-            )}
-            {assetConfigSchema && (
-              <>
-                <Box
-                  padding={{vertical: 16, horizontal: 24}}
-                  border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-                >
-                  <Subheading>Config</Subheading>
-                </Box>
-                <Box padding={{vertical: 16, horizontal: 24}}>
-                  <ConfigTypeSchema
-                    type={assetConfigSchema}
-                    typesInScope={assetConfigSchema.recursiveConfigTypes}
-                  />
-                </Box>
-              </>
-            )}
-          </Box>
-        ) : null}
 
-        <Box style={{flex: 0.5, minWidth: 0}} flex={{direction: 'column'}}>
-          <Box
-            padding={{vertical: 16, horizontal: 24}}
-            border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
-          >
-            <Subheading>Type</Subheading>
-          </Box>
-          {assetType ? (
-            <DagsterTypeSummary type={assetType} />
-          ) : (
-            <Box padding={{vertical: 16, horizontal: 24}}>
-              <Description description="No type data provided." />
+        <Box
+          border={{side: 'vertical', width: 1, color: Colors.KeylineGray}}
+          style={{flex: 0.5, minWidth: 0}}
+          flex={{direction: 'column'}}
+        >
+          <>
+            <Box
+              padding={{vertical: 16, horizontal: 24}}
+              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            >
+              <Subheading>Required Resources</Subheading>
             </Box>
-          )}
-          {assetMetadata.length > 0 && (
-            <>
-              <Box
-                padding={{vertical: 16, horizontal: 24}}
-                border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
-                flex={{justifyContent: 'space-between', gap: 8}}
-              >
-                <Subheading>Metadata</Subheading>
+            <Box
+              padding={{vertical: 16, horizontal: 24}}
+              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            >
+              {assetNode.requiredResources.map((resource) => (
+                <ResourceContainer key={resource.resourceKey}>
+                  <Icon name="resource" color={Colors.Gray700} />
+                  {repoAddress ? (
+                    <Link
+                      to={workspacePathFromAddress(
+                        repoAddress,
+                        `/resources/${resource.resourceKey}`,
+                      )}
+                    >
+                      <ResourceHeader>{resource.resourceKey}</ResourceHeader>
+                    </Link>
+                  ) : (
+                    <ResourceHeader>{resource.resourceKey}</ResourceHeader>
+                  )}
+                </ResourceContainer>
+              ))}
+              {assetNode.requiredResources.length === 0 && (
+                <Body>
+                  No required resources to display
+                  <Box padding={{top: 4}}>
+                    <a href="https://docs.dagster.io/concepts/resources#using-software-defined-assets">
+                      View documentation
+                    </a>
+                  </Box>
+                </Body>
+              )}
+            </Box>
+          </>
+
+          <>
+            <Box
+              padding={{vertical: 16, horizontal: 24}}
+              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            >
+              <Subheading>Config</Subheading>
+            </Box>
+            <Box
+              padding={{vertical: 16, horizontal: 24}}
+              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            >
+              {assetConfigSchema ? (
+                <ConfigTypeSchema
+                  type={assetConfigSchema}
+                  typesInScope={assetConfigSchema.recursiveConfigTypes}
+                />
+              ) : (
+                <Body>
+                  No config schema defined
+                  <Box padding={{top: 4}}>
+                    <a href="https://docs.dagster.io/concepts/assets/software-defined-assets#asset-configuration">
+                      View documentation
+                    </a>
+                  </Box>
+                </Body>
+              )}
+            </Box>
+          </>
+
+          <>
+            <Box
+              padding={{vertical: 16, horizontal: 24}}
+              border={{side: 'bottom', width: 1, color: Colors.KeylineGray}}
+            >
+              <Subheading>Type</Subheading>
+            </Box>
+            {assetType && assetType.displayName !== 'Any' ? (
+              <DagsterTypeSummary type={assetType} />
+            ) : (
+              <Box padding={{vertical: 16, horizontal: 24}}>
+                <Body>
+                  No input and output type data defined
+                  <Box padding={{top: 4}}>
+                    <a href="https://docs.dagster.io/concepts/types#overview">View documentation</a>
+                  </Box>
+                </Body>
               </Box>
-              <Box style={{flex: 1}}>
+            )}
+          </>
+
+          <>
+            <Box
+              padding={{vertical: 16, horizontal: 24}}
+              border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
+              flex={{justifyContent: 'space-between', gap: 8}}
+            >
+              <Subheading>Metadata</Subheading>
+            </Box>
+            <Box style={{flex: 1}}>
+              {assetMetadata.length > 0 ? (
                 <AssetMetadataTable
                   assetMetadata={assetMetadata}
                   repoLocation={repoAddress?.location}
                 />
-              </Box>
-            </>
-          )}
+              ) : (
+                <Box padding={{vertical: 16, horizontal: 24}}>
+                  <Body>
+                    No asset definition metadata defined
+                    <Box padding={{top: 4}}>
+                      <a href="https://docs.dagster.io/concepts/assets/software-defined-assets#attaching-definition-metadata">
+                        View documentation
+                      </a>
+                    </Box>
+                  </Body>
+                </Box>
+              )}
+            </Box>
+          </>
         </Box>
       </Box>
     </>

--- a/js_modules/dagit/packages/core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
@@ -1,6 +1,7 @@
+import {MockedProvider} from '@apollo/client/testing';
 import {Meta} from '@storybook/react';
 import * as React from 'react';
-import {AssetNodeDefinition} from '../AssetNodeDefinition';
+
 import {
   buildAssetNode,
   buildAutoMaterializePolicy,
@@ -11,10 +12,10 @@ import {
   buildFreshnessPolicy,
   buildIntMetadataEntry,
   buildPathMetadataEntry,
+  buildResourceRequirement,
+  buildAssetKey,
 } from '../../graphql/types';
-import {MockedProvider} from '@apollo/client/testing';
-import {buildResourceRequirement} from '../../graphql/types';
-import {buildAssetKey} from '../../graphql/types';
+import {AssetNodeDefinition} from '../AssetNodeDefinition';
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/js_modules/dagit/packages/core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__stories__/AssetNodeDefinition.stories.tsx
@@ -1,0 +1,102 @@
+import {Meta} from '@storybook/react';
+import * as React from 'react';
+import {AssetNodeDefinition} from '../AssetNodeDefinition';
+import {
+  buildAssetNode,
+  buildAutoMaterializePolicy,
+  buildCompositeConfigType,
+  buildConfigType,
+  buildConfigTypeField,
+  buildDagsterType,
+  buildFreshnessPolicy,
+  buildIntMetadataEntry,
+  buildPathMetadataEntry,
+} from '../../graphql/types';
+import {MockedProvider} from '@apollo/client/testing';
+import {buildResourceRequirement} from '../../graphql/types';
+import {buildAssetKey} from '../../graphql/types';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'AssetNodeDefinition',
+  component: AssetNodeDefinition,
+} as Meta;
+
+export const MinimalAsset = () => {
+  return (
+    <MockedProvider>
+      <AssetNodeDefinition
+        dependsOnSelf={false}
+        downstream={[]}
+        upstream={[]}
+        liveDataByNode={{}}
+        assetNode={
+          buildAssetNode({
+            description: null,
+            freshnessPolicy: null,
+            autoMaterializePolicy: null,
+            configField: buildConfigTypeField({configType: buildConfigType({key: 'Any'})}),
+            type: buildDagsterType({displayName: 'Any'}),
+            metadataEntries: [],
+          }) as any
+        }
+      />
+    </MockedProvider>
+  );
+};
+
+export const FullUseAsset = () => {
+  return (
+    <MockedProvider>
+      <AssetNodeDefinition
+        dependsOnSelf={true}
+        upstream={[buildAssetNode({assetKey: buildAssetKey({path: ['upstream']})})]}
+        downstream={[
+          buildAssetNode({assetKey: buildAssetKey({path: ['downstream_1']})}),
+          buildAssetNode({assetKey: buildAssetKey({path: ['downstream_2']})}),
+        ]}
+        liveDataByNode={{}}
+        assetNode={
+          buildAssetNode({
+            description: `
+            # Welcome 
+            
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+            
+            ## Markdown
+            
+            The sql query I used was:
+
+            \`\`\`sql
+            SELECT 
+                COUNT(*)
+            FROM ability_viewed_then_completed_grouped 
+            WHERE 
+                ability_viewed_then_completed_grouped."lastViewElapsedTime" < interval '12 hours' 
+                AND "completedAt" >= '2023-04-01' AND "completedAt" < '2023-05-01'
+            GROUP BY address;
+            \`\`\`
+            `,
+            freshnessPolicy: buildFreshnessPolicy(),
+            autoMaterializePolicy: buildAutoMaterializePolicy(),
+            requiredResources: [
+              buildResourceRequirement({
+                resourceKey: 's3',
+              }),
+              buildResourceRequirement({
+                resourceKey: 'redshift_prod',
+              }),
+            ],
+            configField: buildConfigTypeField({
+              configType: buildCompositeConfigType({
+                fields: [],
+              }),
+            }),
+            type: buildDagsterType(),
+            metadataEntries: [buildIntMetadataEntry({}), buildPathMetadataEntry()],
+          }) as any
+        }
+      />
+    </MockedProvider>
+  );
+};

--- a/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorer.tsx
+++ b/js_modules/dagit/packages/core/src/typeexplorer/TypeExplorer.tsx
@@ -35,7 +35,7 @@ export const TypeExplorer: React.FC<ITypeExplorerProps> = (props) => {
       </Box>
       <SidebarSection title="Description">
         <Box padding={{vertical: 16, horizontal: 24}}>
-          <Description description={description || 'No Description Provided'} />
+          <Description description={description || 'No description provided'} />
         </Box>
       </SidebarSection>
       {tableSchema && (


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/9303

This PR moves "Type" and "Config" (often empty) into the same column. It also fixes the empty states, which were not being used because the values are "Any" and not `null`.  The empty states now display links to the docs (which have great pages for each of these concepts!)

Rather than hiding / showing these sections when they're empty, we're showing them with empty states to encourage users to explore these features. 

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/236558770-d91aef34-0646-4d65-939d-d425103310da.png">


## How I Tested These Changes

I added two new storybooks, one for a minimal / mostly empty asset definition tab, and one for an asset that utilizes ALL the available features:

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/236558740-52468c97-4cc5-4796-a589-155b8d4ad4fe.png">


<img width="1840" alt="image" src="https://user-images.githubusercontent.com/1037212/236558714-60cfc8dd-5811-45a4-9c21-3ecda3d90392.png">

