### PR TITLE
Make dynamic partitions store methods abstract

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -351,6 +351,10 @@ class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
     def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
         return self._instance.get_dynamic_partitions(partitions_def_name)
 
+    @cached_method
+    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+        return self._instance.has_dynamic_partition(partitions_def_name, partition_key)
+
 
 class DynamicPartitionsDefinition(
     PartitionsDefinition,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 import weakref
+from abc import abstractmethod
 from collections import defaultdict
 from enum import Enum
 from tempfile import TemporaryDirectory
@@ -266,13 +267,13 @@ class MayHaveInstanceWeakref(Generic[T_DagsterInstance]):
 
 @runtime_checkable
 class DynamicPartitionsStore(Protocol):
+    @abstractmethod
     def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
-        return self.get_dynamic_partitions(partitions_def_name=partitions_def_name)
+        ...
 
+    @abstractmethod
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
-        return self.has_dynamic_partition(
-            partitions_def_name=partitions_def_name, partition_key=partition_key
-        )
+        ...
 
 
 class DagsterInstance(DynamicPartitionsStore):


### PR DESCRIPTION
When fixing https://github.com/dagster-io/dagster/pull/14133 in version 1.3.3, I encountered an infinite recursion error (stack trace at bottom of PR description).

The cause of the error is that the `CachingDynamicPartitionsStore` class did not override the `has_dynamic_partition` method, so the `DynamicPartitionsStore` continued calling `self.has_dynamic_partition` recursively. The `has_dynamic_partition` method is called from `has_partition_key`, which prior to 1.3.3 was not called using the `CachingDynamicPartitionsStore` object. The recent removal of `Partition` has replaced `get_partition` with `has_partition_key`, which is why the error is now surfaced.

Luckily, this recursion error can only be encountered via the bug linked in the PR above, as the other classes that subclass `DynamicPartitionsStore` have the `has_partition_key` method implemented. Nonetheless, this PR makes the dynamic partitions store methods abstract so that an error is raised when the method is not implemented in subclasses to prevent future errors.

Tested via BK, played around locally in Dagit to confirm things still worked.

Stack trace:
```
RecursionError: maximum recursion depth exceeded
Stack Trace:
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/errors.py", line 272, in user_code_error_boundary
    yield
  File "/Users/claire/dagster/python_modules/dagster/dagster/_grpc/impl.py", line 369, in get_external_sensor_execution
    return sensor_def.evaluate_tick(sensor_context)
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/definitions/sensor_definition.py", line 764, in evaluate_tick
    resolved_run_requests = self.resolve_run_requests(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/definitions/sensor_definition.py", line 857, in resolve_run_requests
    run_request.with_resolved_tags_and_config(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/definitions/run_request.py", line 242, in with_resolved_tags_and_config
    partitions_def.validate_partition_key(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/definitions/partition.py", line 268, in validate_partition_key
    if not self.has_partition_key(partition_key, current_time, dynamic_partitions_store):
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py", line 266, in has_partition_key
    if not dimension.partitions_def.has_partition_key(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/definitions/partition.py", line 500, in has_partition_key
    return dynamic_partitions_store.has_dynamic_partition(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 273, in has_dynamic_partition
    return self.has_dynamic_partition(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 273, in has_dynamic_partition
    return self.has_dynamic_partition(
  File "/Users/claire/dagster/python_modules/dagster/dagster/_core/instance/__init__.py", line 273, in has_dynamic_partition
    return self.has_dynamic_partition(
  [Previous line repeated 980 more times]
```