### PR TITLE
WIP: Add a grpc proxy server that allows you to reload code within dagit without restarting the whole process

### DIFF
--- a/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/host_representation/grpc_server_registry.py
@@ -119,16 +119,15 @@ class GrpcServerRegistry(AbstractContextManager):
 
         self._log_level = check.str_param(log_level, "log_level")
 
-        if self._reload_interval > 0:
-            self._cleanup_thread_shutdown_event = threading.Event()
+        self._cleanup_thread_shutdown_event = threading.Event()
 
-            self._cleanup_thread = threading.Thread(
-                target=self._clear_old_processes,
-                name="grpc-server-registry-cleanup",
-                args=(self._cleanup_thread_shutdown_event, self._reload_interval),
-            )
-            self._cleanup_thread.daemon = True
-            self._cleanup_thread.start()
+        self._cleanup_thread = threading.Thread(
+            target=self._clear_old_processes,
+            name="grpc-server-registry-cleanup",
+            args=(self._cleanup_thread_shutdown_event, self._reload_interval),
+        )
+        self._cleanup_thread.daemon = True
+        self._cleanup_thread.start()
 
     def supports_origin(
         self, code_location_origin: CodeLocationOrigin
@@ -245,7 +244,8 @@ class GrpcServerRegistry(AbstractContextManager):
 
                 for origin_id, entry in self._active_entries.items():
                     if (
-                        current_time - entry.creation_timestamp > reload_interval
+                        reload_interval > 0
+                        and current_time - entry.creation_timestamp > reload_interval
                     ):  # Use a different threshold for errors so they aren't cached as long?
                         origin_ids_to_clear.append(origin_id)
 

--- a/python_modules/dagster/dagster/_core/host_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/host_representation/origin.py
@@ -317,6 +317,15 @@ class GrpcServerCodeLocationOrigin(
         }
         return {key: value for key, value in metadata.items() if value is not None}
 
+    def reload_location(self) -> "GrpcServerCodeLocation":
+        from dagster._core.host_representation.code_location import (
+            GrpcServerCodeLocation,
+        )
+
+        self.create_client().reload_code()
+
+        return GrpcServerCodeLocation(self)
+
     def create_location(self) -> "GrpcServerCodeLocation":
         from dagster._core.host_representation.code_location import (
             GrpcServerCodeLocation,

--- a/python_modules/dagster/dagster/_grpc/__generated__/api_pb2.py
+++ b/python_modules/dagster/dagster/_grpc/__generated__/api_pb2.py
@@ -65,9 +65,10 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
     b" \x01(\t\x12\x10\n\x08job_name\x18\x02"
     b' \x01(\t"I\n\x10\x45xternalJobReply\x12\x1b\n\x13serialized_job_data\x18\x01'
     b" \x01(\t\x12\x18\n\x10serialized_error\x18\x02"
-    b' \x01(\t2\xd3\x0e\n\nDagsterApi\x12*\n\x04Ping\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12/\n\tHeartbeat\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12G\n\rStreamingPing\x12\x19.api.StreamingPingRequest\x1a\x17.api.StreamingPingEvent"\x00\x30\x01\x12\x32\n\x0bGetServerId\x12\n.api.Empty\x1a\x15.api.GetServerIdReply"\x00\x12]\n\x15\x45xecutionPlanSnapshot\x12!.api.ExecutionPlanSnapshotRequest\x1a\x1f.api.ExecutionPlanSnapshotReply"\x00\x12N\n\x10ListRepositories\x12\x1c.api.ListRepositoriesRequest\x1a\x1a.api.ListRepositoriesReply"\x00\x12`\n\x16\x45xternalPartitionNames\x12".api.ExternalPartitionNamesRequest\x1a'
+    b' \x01(\t"\x13\n\x11ReloadCodeRequest"+\n\x0fReloadCodeReply\x12\x18\n\x10serialized_error\x18\x02'
+    b' \x01(\t2\x91\x0f\n\nDagsterApi\x12*\n\x04Ping\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12/\n\tHeartbeat\x12\x10.api.PingRequest\x1a\x0e.api.PingReply"\x00\x12G\n\rStreamingPing\x12\x19.api.StreamingPingRequest\x1a\x17.api.StreamingPingEvent"\x00\x30\x01\x12\x32\n\x0bGetServerId\x12\n.api.Empty\x1a\x15.api.GetServerIdReply"\x00\x12]\n\x15\x45xecutionPlanSnapshot\x12!.api.ExecutionPlanSnapshotRequest\x1a\x1f.api.ExecutionPlanSnapshotReply"\x00\x12N\n\x10ListRepositories\x12\x1c.api.ListRepositoriesRequest\x1a\x1a.api.ListRepositoriesReply"\x00\x12`\n\x16\x45xternalPartitionNames\x12".api.ExternalPartitionNamesRequest\x1a'
     b' .api.ExternalPartitionNamesReply"\x00\x12Z\n\x14\x45xternalNotebookData\x12'
-    b' .api.ExternalNotebookDataRequest\x1a\x1e.api.ExternalNotebookDataReply"\x00\x12\x63\n\x17\x45xternalPartitionConfig\x12#.api.ExternalPartitionConfigRequest\x1a!.api.ExternalPartitionConfigReply"\x00\x12]\n\x15\x45xternalPartitionTags\x12!.api.ExternalPartitionTagsRequest\x1a\x1f.api.ExternalPartitionTagsReply"\x00\x12t\n#ExternalPartitionSetExecutionParams\x12/.api.ExternalPartitionSetExecutionParamsRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12x\n\x1e\x45xternalPipelineSubsetSnapshot\x12*.api.ExternalPipelineSubsetSnapshotRequest\x1a(.api.ExternalPipelineSubsetSnapshotReply"\x00\x12T\n\x12\x45xternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a\x1c.api.ExternalRepositoryReply"\x00\x12?\n\x0b\x45xternalJob\x12\x17.api.ExternalJobRequest\x1a\x15.api.ExternalJobReply"\x00\x12h\n\x1bStreamingExternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a%.api.StreamingExternalRepositoryEvent"\x00\x30\x01\x12`\n\x19\x45xternalScheduleExecution\x12%.api.ExternalScheduleExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\\\n\x17\x45xternalSensorExecution\x12#.api.ExternalSensorExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\x38\n\x0eShutdownServer\x12\n.api.Empty\x1a\x18.api.ShutdownServerReply"\x00\x12K\n\x0f\x43\x61ncelExecution\x12\x1b.api.CancelExecutionRequest\x1a\x19.api.CancelExecutionReply"\x00\x12T\n\x12\x43\x61nCancelExecution\x12\x1e.api.CanCancelExecutionRequest\x1a\x1c.api.CanCancelExecutionReply"\x00\x12\x36\n\x08StartRun\x12\x14.api.StartRunRequest\x1a\x12.api.StartRunReply"\x00\x12:\n\x0fGetCurrentImage\x12\n.api.Empty\x1a\x19.api.GetCurrentImageReply"\x00\x12\x38\n\x0eGetCurrentRuns\x12\n.api.Empty\x1a\x18.api.GetCurrentRunsReply"\x00\x62\x06proto3'
+    b' .api.ExternalNotebookDataRequest\x1a\x1e.api.ExternalNotebookDataReply"\x00\x12\x63\n\x17\x45xternalPartitionConfig\x12#.api.ExternalPartitionConfigRequest\x1a!.api.ExternalPartitionConfigReply"\x00\x12]\n\x15\x45xternalPartitionTags\x12!.api.ExternalPartitionTagsRequest\x1a\x1f.api.ExternalPartitionTagsReply"\x00\x12t\n#ExternalPartitionSetExecutionParams\x12/.api.ExternalPartitionSetExecutionParamsRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12x\n\x1e\x45xternalPipelineSubsetSnapshot\x12*.api.ExternalPipelineSubsetSnapshotRequest\x1a(.api.ExternalPipelineSubsetSnapshotReply"\x00\x12T\n\x12\x45xternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a\x1c.api.ExternalRepositoryReply"\x00\x12?\n\x0b\x45xternalJob\x12\x17.api.ExternalJobRequest\x1a\x15.api.ExternalJobReply"\x00\x12h\n\x1bStreamingExternalRepository\x12\x1e.api.ExternalRepositoryRequest\x1a%.api.StreamingExternalRepositoryEvent"\x00\x30\x01\x12`\n\x19\x45xternalScheduleExecution\x12%.api.ExternalScheduleExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\\\n\x17\x45xternalSensorExecution\x12#.api.ExternalSensorExecutionRequest\x1a\x18.api.StreamingChunkEvent"\x00\x30\x01\x12\x38\n\x0eShutdownServer\x12\n.api.Empty\x1a\x18.api.ShutdownServerReply"\x00\x12K\n\x0f\x43\x61ncelExecution\x12\x1b.api.CancelExecutionRequest\x1a\x19.api.CancelExecutionReply"\x00\x12T\n\x12\x43\x61nCancelExecution\x12\x1e.api.CanCancelExecutionRequest\x1a\x1c.api.CanCancelExecutionReply"\x00\x12\x36\n\x08StartRun\x12\x14.api.StartRunRequest\x1a\x12.api.StartRunReply"\x00\x12:\n\x0fGetCurrentImage\x12\n.api.Empty\x1a\x19.api.GetCurrentImageReply"\x00\x12\x38\n\x0eGetCurrentRuns\x12\n.api.Empty\x1a\x18.api.GetCurrentRunsReply"\x00\x12<\n\nReloadCode\x12\x16.api.ReloadCodeRequest\x1a\x14.api.ReloadCodeReply"\x00\x62\x06proto3'
 )
 
 
@@ -119,6 +120,8 @@ _GETCURRENTIMAGEREPLY = DESCRIPTOR.message_types_by_name["GetCurrentImageReply"]
 _GETCURRENTRUNSREPLY = DESCRIPTOR.message_types_by_name["GetCurrentRunsReply"]
 _EXTERNALJOBREQUEST = DESCRIPTOR.message_types_by_name["ExternalJobRequest"]
 _EXTERNALJOBREPLY = DESCRIPTOR.message_types_by_name["ExternalJobReply"]
+_RELOADCODEREQUEST = DESCRIPTOR.message_types_by_name["ReloadCodeRequest"]
+_RELOADCODEREPLY = DESCRIPTOR.message_types_by_name["ReloadCodeReply"]
 Empty = _reflection.GeneratedProtocolMessageType(
     "Empty",
     (_message.Message,),
@@ -537,6 +540,28 @@ ExternalJobReply = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(ExternalJobReply)
 
+ReloadCodeRequest = _reflection.GeneratedProtocolMessageType(
+    "ReloadCodeRequest",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _RELOADCODEREQUEST,
+        "__module__": "api_pb2"
+        # @@protoc_insertion_point(class_scope:api.ReloadCodeRequest)
+    },
+)
+_sym_db.RegisterMessage(ReloadCodeRequest)
+
+ReloadCodeReply = _reflection.GeneratedProtocolMessageType(
+    "ReloadCodeReply",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _RELOADCODEREPLY,
+        "__module__": "api_pb2"
+        # @@protoc_insertion_point(class_scope:api.ReloadCodeReply)
+    },
+)
+_sym_db.RegisterMessage(ReloadCodeReply)
+
 _DAGSTERAPI = DESCRIPTOR.services_by_name["DagsterApi"]
 if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
@@ -616,6 +641,10 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _EXTERNALJOBREQUEST._serialized_end = 2628
     _EXTERNALJOBREPLY._serialized_start = 2630
     _EXTERNALJOBREPLY._serialized_end = 2703
-    _DAGSTERAPI._serialized_start = 2706
-    _DAGSTERAPI._serialized_end = 4581
+    _RELOADCODEREQUEST._serialized_start = 2705
+    _RELOADCODEREQUEST._serialized_end = 2724
+    _RELOADCODEREPLY._serialized_start = 2726
+    _RELOADCODEREPLY._serialized_end = 2769
+    _DAGSTERAPI._serialized_start = 2772
+    _DAGSTERAPI._serialized_end = 4709
 # @@protoc_insertion_point(module_scope)

--- a/python_modules/dagster/dagster/_grpc/__generated__/api_pb2_grpc.py
+++ b/python_modules/dagster/dagster/_grpc/__generated__/api_pb2_grpc.py
@@ -135,6 +135,11 @@ class DagsterApiStub(object):
             request_serializer=api__pb2.Empty.SerializeToString,
             response_deserializer=api__pb2.GetCurrentRunsReply.FromString,
         )
+        self.ReloadCode = channel.unary_unary(
+            "/api.DagsterApi/ReloadCode",
+            request_serializer=api__pb2.ReloadCodeRequest.SerializeToString,
+            response_deserializer=api__pb2.ReloadCodeReply.FromString,
+        )
 
 
 class DagsterApiServicer(object):
@@ -278,6 +283,12 @@ class DagsterApiServicer(object):
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
+    def ReloadCode(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
 
 def add_DagsterApiServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -395,6 +406,11 @@ def add_DagsterApiServicer_to_server(servicer, server):
             servicer.GetCurrentRuns,
             request_deserializer=api__pb2.Empty.FromString,
             response_serializer=api__pb2.GetCurrentRunsReply.SerializeToString,
+        ),
+        "ReloadCode": grpc.unary_unary_rpc_method_handler(
+            servicer.ReloadCode,
+            request_deserializer=api__pb2.ReloadCodeRequest.FromString,
+            response_serializer=api__pb2.ReloadCodeReply.SerializeToString,
         ),
     }
     generic_handler = grpc.method_handlers_generic_handler("api.DagsterApi", rpc_method_handlers)
@@ -1062,6 +1078,35 @@ class DagsterApi(object):
             "/api.DagsterApi/GetCurrentRuns",
             api__pb2.Empty.SerializeToString,
             api__pb2.GetCurrentRunsReply.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
+
+    @staticmethod
+    def ReloadCode(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/api.DagsterApi/ReloadCode",
+            api__pb2.ReloadCodeRequest.SerializeToString,
+            api__pb2.ReloadCodeReply.FromString,
             options,
             channel_credentials,
             insecure,

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -296,6 +296,12 @@ class DagsterGrpcClient:
 
         return res.serialized_external_pipeline_subset_result
 
+    def reload_code(self):
+        return self._query(
+            "ReloadCode",
+            api_pb2.ReloadCodeRequest,
+        )
+
     def external_repository(
         self,
         external_repository_origin: ExternalRepositoryOrigin,

--- a/python_modules/dagster/dagster/_grpc/protos/api.proto
+++ b/python_modules/dagster/dagster/_grpc/protos/api.proto
@@ -28,6 +28,7 @@ service DagsterApi {
   rpc StartRun (StartRunRequest) returns (StartRunReply) {}
   rpc GetCurrentImage (Empty) returns (GetCurrentImageReply) {}
   rpc GetCurrentRuns (Empty) returns (GetCurrentRunsReply) {}
+  rpc ReloadCode (ReloadCodeRequest) returns (ReloadCodeReply) {}
 }
 
 message Empty {}
@@ -183,5 +184,12 @@ message ExternalJobRequest {
 
 message ExternalJobReply {
   string serialized_job_data = 1;
+  string serialized_error = 2;
+}
+
+message ReloadCodeRequest {
+}
+
+message ReloadCodeReply {
   string serialized_error = 2;
 }


### PR DESCRIPTION
Alternate solution to https://github.com/dagster-io/dagster/pull/14097/files . grpc servers can now be spun up as system code processes that don't actually load user code.

The simplest way to implement this was to have them both implement the same grpc api, but have the proxy forward it on to a 'real' grpc server running as a subprocess.

that part was actually relatively straightforward and seems to work (although lots of cleanup still required, and unclear if we'll end up using GrpcServerRegistry here vs. interacting with the subprocess directly)

The thing i'm now stuck on is making it thread-safe in dagit :/ I put a comment inline with the specific question i'm struggling with in case you all have any ideas.

## How I Tested These Changes
