### PR TITLE
auto-observe source assets: API addition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -71,6 +71,7 @@ class AssetGraph:
         required_multi_asset_sets_by_key: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]],
         code_versions_by_key: Mapping[AssetKey, Optional[str]],
         is_observable_by_key: Mapping[AssetKey, bool],
+        auto_observe_interval_minutes_by_key: Mapping[AssetKey, Optional[float]],
     ):
         self._asset_dep_graph = asset_dep_graph
         self._source_asset_keys = source_asset_keys
@@ -82,6 +83,7 @@ class AssetGraph:
         self._required_multi_asset_sets_by_key = required_multi_asset_sets_by_key
         self._code_versions_by_key = code_versions_by_key
         self._is_observable_by_key = is_observable_by_key
+        self._auto_observe_interval_minutes_by_key = auto_observe_interval_minutes_by_key
 
     @property
     def asset_dep_graph(self) -> DependencyGraph[AssetKey]:
@@ -112,6 +114,9 @@ class AssetGraph:
     ) -> Mapping[AssetKey, Optional[AutoMaterializePolicy]]:
         return self._auto_materialize_policies_by_key
 
+    def get_auto_observe_interval_minutes(self, asset_key: AssetKey) -> Optional[float]:
+        return self._auto_observe_interval_minutes_by_key.get(asset_key)
+
     @staticmethod
     def from_assets(
         all_assets: Iterable[Union[AssetsDefinition, SourceAsset]]
@@ -128,6 +133,7 @@ class AssetGraph:
         required_multi_asset_sets_by_key: Dict[AssetKey, AbstractSet[AssetKey]] = {}
         code_versions_by_key: Dict[AssetKey, Optional[str]] = {}
         is_observable_by_key: Dict[AssetKey, bool] = {}
+        auto_observe_interval_minutes_by_key: Dict[AssetKey, Optional[float]] = {}
 
         for asset in all_assets:
             if isinstance(asset, SourceAsset):
@@ -135,6 +141,9 @@ class AssetGraph:
                 partitions_defs_by_key[asset.key] = asset.partitions_def
                 group_names_by_key[asset.key] = asset.group_name
                 is_observable_by_key[asset.key] = asset.is_observable
+                auto_observe_interval_minutes_by_key[
+                    asset.key
+                ] = asset.auto_observe_interval_minutes
             else:  # AssetsDefinition
                 assets_defs.append(asset)
                 partition_mappings_by_key.update(
@@ -162,6 +171,7 @@ class AssetGraph:
             source_assets=source_assets,
             code_versions_by_key=code_versions_by_key,
             is_observable_by_key=is_observable_by_key,
+            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
         )
 
     @property
@@ -618,6 +628,7 @@ class InternalAssetGraph(AssetGraph):
         source_assets: Sequence[SourceAsset],
         code_versions_by_key: Mapping[AssetKey, Optional[str]],
         is_observable_by_key: Mapping[AssetKey, bool],
+        auto_observe_interval_minutes_by_key: Mapping[AssetKey, Optional[float]],
     ):
         super().__init__(
             asset_dep_graph=asset_dep_graph,
@@ -630,6 +641,7 @@ class InternalAssetGraph(AssetGraph):
             required_multi_asset_sets_by_key=required_multi_asset_sets_by_key,
             code_versions_by_key=code_versions_by_key,
             is_observable_by_key=is_observable_by_key,
+            auto_observe_interval_minutes_by_key=auto_observe_interval_minutes_by_key,
         )
         self._assets = assets
         self._source_assets = source_assets

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -30,6 +30,7 @@ def observable_source_asset(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
+    auto_observe_interval_minutes: Optional[float] = None,
 ) -> "_ObservableSourceAsset":
     ...
 
@@ -48,6 +49,7 @@ def observable_source_asset(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
+    auto_observe_interval_minutes: Optional[float] = None,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
     """Create a `SourceAsset` with an associated observation function.
 
@@ -78,6 +80,8 @@ def observable_source_asset(
             the `io_manager_def` argument.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the asset.
+        auto_observe_interval_minutes (Optional[float]): While the asset daemon is turned on, a run
+            of the observation function for this asset will be launched at this interval.
         observe_fn (Optional[SourceAssetObserveFunction]) Observation function for the source asset.
     """
     if observe_fn is not None:
@@ -94,6 +98,7 @@ def observable_source_asset(
         required_resource_keys,
         resource_defs,
         partitions_def,
+        auto_observe_interval_minutes,
     )
 
 
@@ -110,6 +115,7 @@ class _ObservableSourceAsset:
         required_resource_keys: Optional[AbstractSet[str]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
+        auto_observe_interval_minutes: Optional[float] = None,
     ):
         self.name = name
         if isinstance(key_prefix, str):
@@ -125,6 +131,7 @@ class _ObservableSourceAsset:
         self.required_resource_keys = required_resource_keys
         self.resource_defs = resource_defs
         self.partitions_def = partitions_def
+        self.auto_observe_interval_minutes = auto_observe_interval_minutes
 
     def __call__(self, observe_fn: SourceAssetObserveFunction) -> SourceAsset:
         source_asset_name = self.name or observe_fn.__name__
@@ -152,4 +159,5 @@ class _ObservableSourceAsset:
             resource_defs=self.resource_defs,
             observe_fn=observe_fn,
             partitions_def=self.partitions_def,
+            auto_observe_interval_minutes=self.auto_observe_interval_minutes,
         )

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -92,6 +92,7 @@ class SourceAsset(ResourceAddable):
     resource_defs: PublicAttr[Dict[str, ResourceDefinition]]
     observe_fn: PublicAttr[Optional[SourceAssetObserveFunction]]
     _node_def: Optional[OpDefinition]  # computed lazily
+    auto_observe_interval_minutes: Optional[float]
 
     def __init__(
         self,
@@ -104,6 +105,8 @@ class SourceAsset(ResourceAddable):
         group_name: Optional[str] = None,
         resource_defs: Optional[Mapping[str, object]] = None,
         observe_fn: Optional[SourceAssetObserveFunction] = None,
+        *,
+        auto_observe_interval_minutes: Optional[float] = None,
         # This is currently private because it is necessary for source asset observation functions,
         # but we have not yet decided on a final API for associated one or more ops with a source
         # asset. If we were to make this public, then we would have a canonical public
@@ -156,6 +159,9 @@ class SourceAsset(ResourceAddable):
             _required_resource_keys, "_required_resource_keys", of_type=str
         )
         self._node_def = None
+        self.auto_observe_interval_minutes = check.opt_numeric_param(
+            auto_observe_interval_minutes, "auto_observe_interval_minutes"
+        )
 
     def get_io_manager_key(self) -> str:
         return self.io_manager_key or DEFAULT_IO_MANAGER_KEY
@@ -310,6 +316,7 @@ class SourceAsset(ResourceAddable):
                 resource_defs=relevant_resource_defs,
                 group_name=self.group_name,
                 observe_fn=self.observe_fn,
+                auto_observe_interval_minutes=self.auto_observe_interval_minutes,
                 _required_resource_keys=self._required_resource_keys,
             )
 
@@ -335,6 +342,7 @@ class SourceAsset(ResourceAddable):
                 group_name=group_name,
                 resource_defs=self.resource_defs,
                 observe_fn=self.observe_fn,
+                auto_observe_interval_minutes=self.auto_observe_interval_minutes,
                 _required_resource_keys=self._required_resource_keys,
             )
 

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -1074,6 +1074,7 @@ class ExternalAssetNode(
             ("atomic_execution_unit_id", Optional[str]),
             ("required_top_level_resources", Optional[Sequence[str]]),
             ("auto_materialize_policy", Optional[AutoMaterializePolicy]),
+            ("auto_observe_interval_minutes", Optional[float]),
         ],
     )
 ):
@@ -1106,6 +1107,7 @@ class ExternalAssetNode(
         atomic_execution_unit_id: Optional[str] = None,
         required_top_level_resources: Optional[Sequence[str]] = None,
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+        auto_observe_interval_minutes: Optional[float] = None,
     ):
         # backcompat logic to handle ExternalAssetNodes serialized without op_names/graph_name
         if not op_names:
@@ -1160,6 +1162,9 @@ class ExternalAssetNode(
                 auto_materialize_policy,
                 "auto_materialize_policy",
                 AutoMaterializePolicy,
+            ),
+            auto_observe_interval_minutes=check.opt_numeric_param(
+                auto_observe_interval_minutes, "auto_observe_interval_minutes"
             ),
         )
 
@@ -1422,6 +1427,7 @@ def external_asset_graph_from_defs(
                     group_name=source_asset.group_name,
                     is_source=True,
                     is_observable=source_asset.is_observable,
+                    auto_observe_interval_minutes=source_asset.auto_observe_interval_minutes,
                     partitions_def_data=external_partitions_definition_from_def(
                         source_asset.partitions_def
                     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
@@ -25,6 +25,7 @@ def test_all_fields():
         io_manager_key="lambda",
         io_manager_def=foo_manager,
         group_name="rho",
+        auto_observe_interval_minutes=5,
     )
     def foo_source_asset(context):
         raise Exception("not executed")
@@ -36,6 +37,7 @@ def test_all_fields():
     assert foo_source_asset.resource_defs == {"lambda": foo_manager}
     assert foo_source_asset.io_manager_def == foo_manager
     assert foo_source_asset.metadata == {"epsilon": MetadataValue.text("gamma")}
+    assert foo_source_asset.auto_observe_interval_minutes == 5
 
 
 def test_no_context_observable_asset():


### PR DESCRIPTION
## Background

(Much of the following language stolen from an earlier discussion by Owen):

Observing source assets is critical to the functionality of auto-materialization, as we need to know when sources are updated in order to know when to update our downstream assets.

We never know what the "best time" is to run an observation function, as it's always valuable to know the specific time that a source changes, and this can be very unpredictable. However, the downside to running observation functions more often is that this computation may be expensive / noisy. Different source assets may have different properties. For something that you don't expect to change very often, running it once every few hours might be fine. For something you expect to change very frequently, you'll want to run the observation function much more often.

Currently, users can create a scheduled job to observe their source assets, as documented at the bottom of [this docs section](https://docs.dagster.io/concepts/assets/asset-observations#observable-source-assets). However, this requires them to use and understand concepts like schedules and jobs that they otherwise wouldn't need to when using declarative scheduling.

### Proposal

Proposal: Observable source assets get an `auto_observe_frequency_minutes` argument. The same daemon that launches auto-materialization runs launches auto-observation runs, at the specified frequency.

I.e., if the asset daemon is switched on, a run will be launched to observe this asset every 30 minutes:

```python
@observable_source_asset(auto_observe_frequency_minutes=30)
def raw_events():
    ...
```

Some implications:
- Because observations happens as part of a run that's launched by the daemon, separate ticks are required to observe an asset and then auto-materialize downstream assets based on that observation.
The UI will need to be updated to reflect the fact that the asset daemon can launch observations as well as materializations. I.e. this is no longer comprehensive:
  - <img width="652" alt="image" src="https://user-images.githubusercontent.com/654855/236733746-3631ea25-23cf-4140-955c-602b8a837d58.png">

Along with downstream PRs, resolves https://github.com/dagster-io/dagster/issues/14103. Next PR in the stack: https://github.com/dagster-io/dagster/pull/14149.

## How I Tested These Changes
