### PR TITLE
Enable to set an `end_dt` in TimeWindowPartitionsDefinition to stop generating new partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -123,7 +123,7 @@ class TimeWindowPartitionsDefinition(
             start_dt = pendulum.instance(datetime.strptime(start, fmt), tz=timezone)
 
         if not end:
-            end_dt = pendulum.instance(datetime.strptime("9999-12-31", "%Y-%m-%d"), tz=timezone)
+            end_dt = None
         elif isinstance(end, datetime):
             end_dt = pendulum.instance(end, tz=timezone)
         else:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -479,6 +479,9 @@ class TimeWindowPartitionsDefinition(
             else pendulum.now(self.timezone)
         )
 
+        if self.end and self.end < current_time:
+            current_time = self.end
+
         if self.end_offset == 0:
             return next(iter(self._reverse_iterate_time_windows(current_time)))
         else:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -66,7 +66,7 @@ class TimeWindowPartitionsDefinition(
         [
             ("start", PublicAttr[datetime]),
             ("timezone", PublicAttr[str]),
-            ("end", PublicAttr[datetime]),
+            ("end", PublicAttr[Optional[datetime]]),
             ("fmt", PublicAttr[str]),
             ("end_offset", PublicAttr[int]),
             ("cron_schedule", PublicAttr[str]),

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -66,6 +66,7 @@ class TimeWindowPartitionsDefinition(
         [
             ("start", PublicAttr[datetime]),
             ("timezone", PublicAttr[str]),
+            ("end", PublicAttr[datetime]),
             ("fmt", PublicAttr[str]),
             ("end_offset", PublicAttr[int]),
             ("cron_schedule", PublicAttr[str]),
@@ -92,6 +93,7 @@ class TimeWindowPartitionsDefinition(
         timezone (Optional[str]): The timezone in which each time should exist.
             Supported strings for timezones are the ones provided by the
             `IANA time zone database <https://www.iana.org/time-zones>` - e.g. "America/Los_Angeles".
+        end (datetime): The last partition (excluding) in the set.
         fmt (str): The date format to use for partition_keys.
         end_offset (int): Extends the partition set by a number of partitions equal to the value
             passed. If end_offset is 0 (the default), the last partition ends before the current
@@ -103,6 +105,7 @@ class TimeWindowPartitionsDefinition(
         cls,
         start: Union[datetime, str],
         fmt: str,
+        end: Union[datetime, str, None] = None,
         schedule_type: Optional[ScheduleType] = None,
         timezone: Optional[str] = None,
         end_offset: int = 0,
@@ -118,6 +121,13 @@ class TimeWindowPartitionsDefinition(
             start_dt = pendulum.instance(start, tz=timezone)
         else:
             start_dt = pendulum.instance(datetime.strptime(start, fmt), tz=timezone)
+
+        if not end:
+            end_dt = pendulum.instance(datetime.strptime("9999-12-31", "%Y-%m-%d"), tz=timezone)
+        elif isinstance(end, datetime):
+            end_dt = pendulum.instance(end, tz=timezone)
+        else:
+            end_dt = pendulum.instance(datetime.strptime(end, fmt), tz=timezone)
 
         if cron_schedule is not None:
             check.invariant(
@@ -145,7 +155,7 @@ class TimeWindowPartitionsDefinition(
             )
 
         return super(TimeWindowPartitionsDefinition, cls).__new__(
-            cls, start_dt, timezone, fmt, end_offset, cron_schedule
+            cls, start_dt, timezone, end_dt, fmt, end_offset, cron_schedule
         )
 
     def get_current_timestamp(self, current_time: Optional[datetime] = None) -> float:
@@ -169,6 +179,8 @@ class TimeWindowPartitionsDefinition(
 
         num_partitions = 0
         for time_window in self._iterate_time_windows(self.start):
+            if self.end and time_window.end.timestamp() > self.end.timestamp():
+                break
             if (
                 time_window.end.timestamp() <= current_timestamp
                 or partitions_past_current_time < self.end_offset
@@ -201,6 +213,8 @@ class TimeWindowPartitionsDefinition(
         for idx, time_window in enumerate(self._iterate_time_windows(self.start)):
             if time_window.end.timestamp() >= current_timestamp:
                 reached_end = True
+            if self.end and time_window.end.timestamp() > self.end.timestamp():
+                reached_end = True
             if (
                 time_window.end.timestamp() <= current_timestamp
                 or partitions_past_current_time < self.end_offset
@@ -229,6 +243,8 @@ class TimeWindowPartitionsDefinition(
         partitions_past_current_time = 0
         partition_keys: List[str] = []
         for time_window in self._iterate_time_windows(self.start):
+            if self.end and time_window.end.timestamp() > self.end.timestamp():
+                break
             if (
                 time_window.end.timestamp() <= current_timestamp
                 or partitions_past_current_time < self.end_offset
@@ -775,6 +791,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
     def __new__(
         cls,
         start_date: Union[datetime, str],
+        end_date: Union[datetime, str, None] = None,
         minute_offset: int = 0,
         hour_offset: int = 0,
         timezone: Optional[str] = None,
@@ -787,6 +804,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
             cls,
             schedule_type=ScheduleType.DAILY,
             start=start_date,
+            end=end_date,
             minute_offset=minute_offset,
             hour_offset=hour_offset,
             timezone=timezone,
@@ -933,6 +951,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
     def __new__(
         cls,
         start_date: Union[datetime, str],
+        end_date: Union[datetime, str, None] = None,
         minute_offset: int = 0,
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
@@ -944,6 +963,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
             cls,
             schedule_type=ScheduleType.HOURLY,
             start=start_date,
+            end=end_date,
             minute_offset=minute_offset,
             timezone=timezone,
             fmt=_fmt,
@@ -1063,6 +1083,7 @@ class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
     def __new__(
         cls,
         start_date: Union[datetime, str],
+        end_date: Union[datetime, str, None] = None,
         minute_offset: int = 0,
         hour_offset: int = 0,
         day_offset: int = 1,
@@ -1076,6 +1097,7 @@ class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
             cls,
             schedule_type=ScheduleType.MONTHLY,
             start=start_date,
+            end=end_date,
             minute_offset=minute_offset,
             hour_offset=hour_offset,
             day_offset=day_offset,
@@ -1207,6 +1229,7 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
     def __new__(
         cls,
         start_date: Union[datetime, str],
+        end_date: Union[datetime, str, None] = None,
         minute_offset: int = 0,
         hour_offset: int = 0,
         day_offset: int = 0,
@@ -1220,6 +1243,7 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
             cls,
             schedule_type=ScheduleType.WEEKLY,
             start=start_date,
+            end=end_date,
             minute_offset=minute_offset,
             hour_offset=hour_offset,
             day_offset=day_offset,

--- a/python_modules/dagster/dagster/_core/host_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/host_representation/external_data.py
@@ -616,6 +616,7 @@ class ExternalTimeWindowPartitionsDefinitionData(
         [
             ("start", float),
             ("timezone", Optional[str]),
+            ("end", float),
             ("fmt", str),
             ("end_offset", int),
             ("cron_schedule", Optional[str]),
@@ -634,6 +635,7 @@ class ExternalTimeWindowPartitionsDefinitionData(
         cls,
         start: float,
         timezone: Optional[str],
+        end: float,
         fmt: str,
         end_offset: int,
         cron_schedule: Optional[str] = None,
@@ -647,6 +649,7 @@ class ExternalTimeWindowPartitionsDefinitionData(
             schedule_type=check.opt_inst_param(schedule_type, "schedule_type", ScheduleType),
             start=check.float_param(start, "start"),
             timezone=check.opt_str_param(timezone, "timezone"),
+            end=check.float_param(end, "end"),
             fmt=check.str_param(fmt, "fmt"),
             end_offset=check.int_param(end_offset, "end_offset"),
             minute_offset=check.opt_int_param(minute_offset, "minute_offset"),
@@ -660,6 +663,7 @@ class ExternalTimeWindowPartitionsDefinitionData(
             return TimeWindowPartitionsDefinition(
                 cron_schedule=self.cron_schedule,
                 start=pendulum.from_timestamp(self.start, tz=self.timezone),
+                end=pendulum.from_timestamp(self.end, tz=self.timezone),
                 timezone=self.timezone,
                 fmt=self.fmt,
                 end_offset=self.end_offset,
@@ -669,6 +673,7 @@ class ExternalTimeWindowPartitionsDefinitionData(
             return TimeWindowPartitionsDefinition(
                 schedule_type=self.schedule_type,
                 start=pendulum.from_timestamp(self.start, tz=self.timezone),
+                end=pendulum.from_timestamp(self.end, tz=self.timezone),
                 timezone=self.timezone,
                 fmt=self.fmt,
                 end_offset=self.end_offset,
@@ -1678,6 +1683,7 @@ def external_time_window_partitions_definition_from_def(
     return ExternalTimeWindowPartitionsDefinitionData(
         cron_schedule=partitions_def.cron_schedule,
         start=pendulum.instance(partitions_def.start, tz=partitions_def.timezone).timestamp(),
+        end=pendulum.instance(partitions_def.end, tz=partitions_def.timezone).timestamp(),
         timezone=partitions_def.timezone,
         fmt=partitions_def.fmt,
         end_offset=partitions_def.end_offset,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional, Sequence
 
+import pendulum
 import pytest
 from dagster import (
     DailyPartitionsDefinition,
@@ -9,6 +10,7 @@ from dagster import (
     TimeWindowPartitionMapping,
     TimeWindowPartitionsDefinition,
     WeeklyPartitionsDefinition,
+    TimeWindow,
 )
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.errors import DagsterInvalidInvocationError
@@ -424,3 +426,73 @@ def test_get_upstream_with_current_time(
             ).get_partition_keys()
             == expected_upstream_keys
         )
+
+
+@pytest.mark.parametrize(
+    "partitions_def,first_partition_window,last_partition_window,number_of_partitions,fmt",
+    [
+        (
+            HourlyPartitionsDefinition(start_date="2022-01-01-00:00", end_date="2022-02-01-00:00"),
+            ["2022-01-01-00:00", "2022-01-01-01:00"],
+            ["2022-01-31-23:00", "2022-02-01-00:00"],
+            744,
+            "%Y-%m-%d-%H:%M",
+        ),
+        (
+            DailyPartitionsDefinition(start_date="2022-01-01", end_date="2022-02-01"),
+            ["2022-01-01", "2022-01-02"],
+            ["2022-01-31", "2022-02-01"],
+            31,
+            "%Y-%m-%d",
+        ),
+        (
+            WeeklyPartitionsDefinition(start_date="2022-01-01", end_date="2022-02-01"),
+            ["2022-01-02", "2022-01-09"],  # 2022-01-02 is Sunday, weekly cron starts from Sunday
+            ["2022-01-23", "2022-01-30"],
+            4,
+            "%Y-%m-%d",
+        ),
+        (
+            MonthlyPartitionsDefinition(start_date="2022-01-01", end_date="2023-01-01"),
+            ["2022-01-01", "2022-02-01"],
+            ["2022-12-01", "2023-01-01"],
+            12,
+            "%Y-%m-%d",
+        ),
+])
+def test_partition_with_end_date(
+    partitions_def: TimeWindowPartitionsDefinition,
+    first_partition_window: Sequence[str],
+    last_partition_window: Sequence[str],
+    number_of_partitions: int,
+    fmt: str
+):
+    first_partition_window_ = TimeWindow(
+        start=pendulum.instance(datetime.strptime(first_partition_window[0], fmt), tz="UTC"),
+        end=pendulum.instance(datetime.strptime(first_partition_window[1], fmt), tz="UTC")
+    )
+
+    last_partition_window_ = TimeWindow(
+        start=pendulum.instance(datetime.strptime(last_partition_window[0], fmt), tz="UTC"),
+        end=pendulum.instance(datetime.strptime(last_partition_window[1], fmt), tz="UTC")
+    )
+
+    # get_last_partition_window
+    assert partitions_def.get_last_partition_window() == last_partition_window_
+    # get_next_partition_window
+    assert partitions_def.get_next_partition_window(partitions_def.start) == first_partition_window_
+    assert partitions_def.get_next_partition_window(last_partition_window_.start) == last_partition_window_
+    assert not partitions_def.get_next_partition_window(last_partition_window_.end)
+    # get_partition_keys
+    assert len(partitions_def.get_partition_keys()) == number_of_partitions
+    assert partitions_def.get_partition_keys()[0] == first_partition_window[0]
+    assert partitions_def.get_partition_keys()[-1] == last_partition_window[0]
+    # get_next_partition_key
+    assert partitions_def.get_next_partition_key(first_partition_window[0]) == first_partition_window[1]
+    assert not partitions_def.get_next_partition_key(last_partition_window[0])
+    # get_last_partition_key
+    assert partitions_def.get_last_partition_key() == last_partition_window[0]
+    # has_partition_key
+    assert partitions_def.has_partition_key(first_partition_window[0])
+    assert partitions_def.has_partition_key(last_partition_window[0])
+    assert not partitions_def.has_partition_key(last_partition_window[1])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -7,10 +7,10 @@ from dagster import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition,
+    TimeWindow,
     TimeWindowPartitionMapping,
     TimeWindowPartitionsDefinition,
     WeeklyPartitionsDefinition,
-    TimeWindow,
 )
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.errors import DagsterInvalidInvocationError
@@ -459,36 +459,43 @@ def test_get_upstream_with_current_time(
             12,
             "%Y-%m-%d",
         ),
-])
+    ],
+)
 def test_partition_with_end_date(
     partitions_def: TimeWindowPartitionsDefinition,
     first_partition_window: Sequence[str],
     last_partition_window: Sequence[str],
     number_of_partitions: int,
-    fmt: str
+    fmt: str,
 ):
     first_partition_window_ = TimeWindow(
         start=pendulum.instance(datetime.strptime(first_partition_window[0], fmt), tz="UTC"),
-        end=pendulum.instance(datetime.strptime(first_partition_window[1], fmt), tz="UTC")
+        end=pendulum.instance(datetime.strptime(first_partition_window[1], fmt), tz="UTC"),
     )
 
     last_partition_window_ = TimeWindow(
         start=pendulum.instance(datetime.strptime(last_partition_window[0], fmt), tz="UTC"),
-        end=pendulum.instance(datetime.strptime(last_partition_window[1], fmt), tz="UTC")
+        end=pendulum.instance(datetime.strptime(last_partition_window[1], fmt), tz="UTC"),
     )
 
     # get_last_partition_window
     assert partitions_def.get_last_partition_window() == last_partition_window_
     # get_next_partition_window
     assert partitions_def.get_next_partition_window(partitions_def.start) == first_partition_window_
-    assert partitions_def.get_next_partition_window(last_partition_window_.start) == last_partition_window_
+    assert (
+        partitions_def.get_next_partition_window(last_partition_window_.start)
+        == last_partition_window_
+    )
     assert not partitions_def.get_next_partition_window(last_partition_window_.end)
     # get_partition_keys
     assert len(partitions_def.get_partition_keys()) == number_of_partitions
     assert partitions_def.get_partition_keys()[0] == first_partition_window[0]
     assert partitions_def.get_partition_keys()[-1] == last_partition_window[0]
     # get_next_partition_key
-    assert partitions_def.get_next_partition_key(first_partition_window[0]) == first_partition_window[1]
+    assert (
+        partitions_def.get_next_partition_key(first_partition_window[0])
+        == first_partition_window[1]
+    )
     assert not partitions_def.get_next_partition_key(last_partition_window[0])
     # get_last_partition_key
     assert partitions_def.get_last_partition_key() == last_partition_window[0]

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
@@ -1123,7 +1123,7 @@ snapshots['test_external_repository_data 1'] = '''{
         "__class__": "ExternalTimeWindowPartitionsDefinitionData",
         "cron_schedule": "15 0 * * *",
         "day_offset": null,
-        "end": 253402214400.0,
+        "end": null,
         "end_offset": 0,
         "fmt": "%Y-%m-%d",
         "hour_offset": null,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/snapshots/snap_test_active_data.py
@@ -1123,6 +1123,7 @@ snapshots['test_external_repository_data 1'] = '''{
         "__class__": "ExternalTimeWindowPartitionsDefinitionData",
         "cron_schedule": "15 0 * * *",
         "day_offset": null,
+        "end": 253402214400.0,
         "end_offset": 0,
         "fmt": "%Y-%m-%d",
         "hour_offset": null,


### PR DESCRIPTION
## Summary
Add an optional argument `end` date for `TimeWindowPartitionsDefinition`,  so that it stops generating new partitions from `end` date. Eg.
```
HourlyPartitionsDefinition(start_date="2022-01-01-00:00", end_date="2022-02-01-00:00")
DailyPartitionsDefinition(start_date="2022-01-01", end_date="2022-02-01")
```
## Motivation
We have a use case, which we need to keep the asset with TimeWindowPartitionsDefinition, but we must stop running new partitions from an end date.

A simple work around is to remove the scheduler for that job, but it will keep generating new partitions from UI. It doesn't run these partitions though, since the scheduler is removed. But it's confusing for users. Therefore I make this PR

## How I Tested These Changes
* Unittests are included in the PR
* Test in our environment:
<img width="1346" alt="image" src="https://github.com/dagster-io/dagster/assets/42205607/e0c40131-e244-4519-8d03-256399e01e21">
<img width="1456" alt="image" src="https://github.com/dagster-io/dagster/assets/42205607/2de72cc3-8332-4cae-88a1-93b28da0e1ca">

