### PR TITLE
[ui] Remove ReactDOM.render

### DIFF
--- a/js_modules/dagit/packages/app/src/index.tsx
+++ b/js_modules/dagit/packages/app/src/index.tsx
@@ -11,7 +11,7 @@ import {UserSettingsButton} from '@dagster-io/dagit-core/app/UserSettingsButton'
 import {logLink, timeStartLink} from '@dagster-io/dagit-core/app/apolloLinks';
 import {DeploymentStatusType} from '@dagster-io/dagit-core/instance/DeploymentStatusProvider';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 
 import {CommunityNux} from './NUX/CommunityNux';
 import {extractInitializationData} from './extractInitializationData';
@@ -38,8 +38,10 @@ const config = {
 };
 
 const appCache = createAppCache();
+const container = document.getElementById('root');
+const root = createRoot(container!);
 
-ReactDOM.render(
+root.render(
   <AppProvider appCache={appCache} config={config}>
     <AppTopNav searchPlaceholder="Search…">
       <UserSettingsButton />
@@ -49,5 +51,4 @@ ReactDOM.render(
       <CommunityNux />
     </App>
   </AppProvider>,
-  document.getElementById('root'),
 );

--- a/js_modules/dagit/packages/core/src/app/AppError.tsx
+++ b/js_modules/dagit/packages/core/src/app/AppError.tsx
@@ -3,6 +3,7 @@ import {ServerError} from '@apollo/client/link/utils';
 import {Observable} from '@apollo/client/utilities';
 import {FontFamily, Toaster} from '@dagster-io/ui';
 import {GraphQLError} from 'graphql';
+import memoize from 'lodash/memoize';
 import * as React from 'react';
 
 import {showCustomAlert} from './CustomAlertProvider';
@@ -23,16 +24,19 @@ type DagsterGraphQLError = GraphQLError & {
     | undefined;
 };
 
-const ErrorToaster = Toaster.create({position: 'top-right'});
+const getErrorToaster = memoize(async () => {
+  return await Toaster.asyncCreate({position: 'top-right'}, document.body);
+});
 
-const showGraphQLError = (error: DagsterGraphQLError, operationName?: string) => {
+const showGraphQLError = async (error: DagsterGraphQLError, operationName?: string) => {
   const message = (
     <div>
       Unexpected GraphQL error
       <AppStackTraceLink error={error} operationName={operationName} />
     </div>
   );
-  ErrorToaster.show({message, intent: 'danger'});
+  const toaster = await getErrorToaster();
+  toaster.show({message, intent: 'danger'});
   console.error('[GraphQL error]', error);
 };
 
@@ -170,8 +174,9 @@ export const setupErrorToasts = () => {
         // If the console.error happens during render, then our ErrorToaster.show call
         // will trigger the "Can't re-render component during render" console error
         // which would send us in an infinite loop. So we use setTimeout to avoid this.
-        setTimeout(() => {
-          ErrorToaster.show({
+        setTimeout(async () => {
+          const toaster = await getErrorToaster();
+          toaster.show({
             intent: 'danger',
             message: (
               <div
@@ -184,8 +189,8 @@ export const setupErrorToasts = () => {
     },
   });
 
-  window.addEventListener('unhandledrejection', (event) => {
-    ErrorToaster.show({
+  window.addEventListener('unhandledrejection', async (event) => {
+    (await getErrorToaster()).show({
       intent: 'danger',
       message: (
         <div

--- a/js_modules/dagit/packages/core/src/app/DomUtils.tsx
+++ b/js_modules/dagit/packages/core/src/app/DomUtils.tsx
@@ -1,6 +1,17 @@
-import {Toaster} from '@dagster-io/ui';
+import {DToasterShowProps, Toaster} from '@dagster-io/ui';
+import memoize from 'lodash/memoize';
 
+// todo dish: Delete this after Cloud is updated.
 export const SharedToaster = Toaster.create({position: 'top'}, document.body);
+
+export const getSharedToaster = memoize(async () => {
+  return await Toaster.asyncCreate({position: 'top'}, document.body);
+});
+
+export const showSharedToaster = async (config: DToasterShowProps) => {
+  const toaster = await getSharedToaster();
+  toaster.show(config);
+};
 
 export async function copyValue(event: React.MouseEvent<any>, value: string) {
   event.preventDefault();
@@ -12,7 +23,7 @@ export async function copyValue(event: React.MouseEvent<any>, value: string) {
   document.execCommand('copy');
   el.remove();
 
-  SharedToaster.show({
+  await showSharedToaster({
     message: 'Copied to clipboard!',
     icon: 'copy_to_clipboard_done',
     intent: 'none',

--- a/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AssetPageHeader.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
 
 type Props = {assetKey: {path: string[]}} & Partial<React.ComponentProps<typeof PageHeader>>;
@@ -16,14 +16,14 @@ export const AssetPageHeader: React.FC<Props> = ({assetKey, ...extra}) => {
   const [didCopy, setDidCopy] = React.useState(false);
   const iconTimeout = React.useRef<NodeJS.Timeout>();
 
-  const performCopy = React.useCallback(() => {
+  const performCopy = React.useCallback(async () => {
     if (iconTimeout.current) {
       clearTimeout(iconTimeout.current);
     }
 
     copy(copyableString);
     setDidCopy(true);
-    SharedToaster.show({
+    await showSharedToaster({
       icon: 'done',
       intent: 'primary',
       message: 'Copied asset key!',

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -3,7 +3,7 @@ import {Group, Table} from '@dagster-io/ui';
 import * as React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 
@@ -52,7 +52,7 @@ export const BackfillTable = ({
     if (data && data.resumePartitionBackfill.__typename === 'ResumeBackfillSuccess') {
       refetch();
     } else if (data && data.resumePartitionBackfill.__typename === 'UnauthorizedError') {
-      SharedToaster.show({
+      await showSharedToaster({
         message: (
           <Group direction="column" spacing={4}>
             <div>
@@ -65,7 +65,7 @@ export const BackfillTable = ({
       });
     } else if (data && data.resumePartitionBackfill.__typename === 'PythonError') {
       const error = data.resumePartitionBackfill;
-      SharedToaster.show({
+      await showSharedToaster({
         message: <div>An unexpected error occurred. This backfill was not retried.</div>,
         icon: 'error',
         intent: 'danger',

--- a/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagit/packages/core/src/instigation/TickHistory.tsx
@@ -19,7 +19,7 @@ import zoomPlugin from 'chartjs-plugin-zoom';
 import * as React from 'react';
 import styled from 'styled-components/macro';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
@@ -221,9 +221,9 @@ export const TicksTable = ({
                           {truncate(tick.cursor || '')}
                         </div>
                         <CopyButton
-                          onClick={() => {
+                          onClick={async () => {
                             copyToClipboard(tick.cursor || '');
-                            SharedToaster.show({
+                            await showSharedToaster({
                               message: <div>Copied value</div>,
                               intent: 'success',
                             });

--- a/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useCodeLocationsStatus.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {RepositoryLocationLoadStatus} from '../graphql/types';
 import {StatusAndMessage} from '../instance/DeploymentStatusType';
@@ -59,7 +59,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     const showViewButton = !alreadyViewingCodeLocations();
 
     if (anyErrors) {
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'warning',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
@@ -70,7 +70,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         icon: 'check_circle',
       });
     } else {
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'success',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
@@ -83,7 +83,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     }
   }, [onClickViewButton, refetch]);
 
-  const onLocationUpdate = (data: CodeLocationStatusQuery) => {
+  const onLocationUpdate = async (data: CodeLocationStatusQuery) => {
     const isFreshPageload = previousEntriesById === null;
 
     // Given the previous and current code locations, determine whether to show a) a loading spinner
@@ -169,7 +169,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
         return <span>{addedEntries.length} code locations added</span>;
       };
 
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'primary',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
@@ -193,7 +193,7 @@ export const useCodeLocationsStatus = (skip = false): StatusAndMessage | null =>
     if (!anyPreviouslyLoading && anyCurrentlyLoading) {
       setShowSpinner(true);
 
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'primary',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>

--- a/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
+++ b/js_modules/dagit/packages/core/src/nav/useRepositoryLocationReload.tsx
@@ -3,7 +3,7 @@ import {ApolloClient, gql, useApolloClient, useQuery} from '@apollo/client';
 import {Intent} from '@blueprintjs/core';
 import * as React from 'react';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useInvalidateConfigsForRepo} from '../app/ExecutionSessionStorage';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {UNAUTHORIZED_ERROR_FRAGMENT} from '../app/PythonErrorInfo';
@@ -108,7 +108,7 @@ export const useRepositoryLocationReload = ({
     notifyOnNetworkStatusChange: true,
     onCompleted: (data: RepositoryLocationStatusQuery) => {
       // SetTimeout to avoid infinite loop in test
-      setTimeout(() => {
+      setTimeout(async () => {
         const workspace = data.workspaceOrError;
 
         if (workspace.__typename === 'PythonError') {
@@ -172,7 +172,7 @@ export const useRepositoryLocationReload = ({
         stopPolling();
 
         // On success, show the successful toast, hide the dialog (if open), and reset Apollo.
-        SharedToaster.show({
+        await showSharedToaster({
           message: `${scope === 'location' ? 'Code location' : 'Definitions'} reloaded!`,
           timeout: 3000,
           icon: 'check_circle',

--- a/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
@@ -4,7 +4,7 @@ import {History} from 'history';
 import * as React from 'react';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {LaunchPartitionBackfillMutation} from '../instance/types/BackfillUtils.types';
 import {runsPathWithFilters} from '../runs/RunsFilterInput';
@@ -56,20 +56,22 @@ function messageForLaunchBackfillError(data: LaunchPartitionBackfillMutation | n
   );
 }
 
-export function showBackfillErrorToast(data: LaunchPartitionBackfillMutation | null | undefined) {
-  SharedToaster.show({
+export async function showBackfillErrorToast(
+  data: LaunchPartitionBackfillMutation | null | undefined,
+) {
+  await showSharedToaster({
     message: messageForLaunchBackfillError(data),
     icon: 'error',
     intent: 'danger',
   });
 }
 
-export function showBackfillSuccessToast(
+export async function showBackfillSuccessToast(
   history: History<unknown>,
   backfillId: string,
   isAssetBackfill: boolean,
 ) {
-  SharedToaster.show({
+  await showSharedToaster({
     intent: 'success',
     message: (
       <div>

--- a/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionButtons.tsx
@@ -1,7 +1,7 @@
 import {Box, Button, Group, Icon} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {filterByQuery, GraphQueryItem} from '../app/GraphQueryImpl';
 import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
 import {LaunchButtonConfiguration, LaunchButtonDropdown} from '../launchpad/LaunchButton';
@@ -29,11 +29,11 @@ export const CancelRunButton: React.FC<{run: RunFragment}> = ({run}) => {
   const closeDialog = React.useCallback(() => setShowDialog(false), []);
 
   const onComplete = React.useCallback(
-    (terminationState: TerminationState) => {
+    async (terminationState: TerminationState) => {
       const {errors} = terminationState;
       const error = runId && errors[runId];
       if (error && 'message' in error) {
-        SharedToaster.show({
+        await showSharedToaster({
           message: error.message,
           icon: 'error',
           intent: 'danger',

--- a/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunActionsMenu.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import {useHistory} from 'react-router-dom';
 
 import {AppContext} from '../app/AppContext';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
 import {useCopyToClipboard} from '../app/browser';
 import {ReexecutionStrategy} from '../graphql/types';
@@ -282,9 +282,9 @@ export const RunActionsMenu: React.FC<{
         <DialogFooter topBorder>
           <Button
             intent="none"
-            onClick={() => {
+            onClick={async () => {
               copyConfig(runConfigYaml || '');
-              SharedToaster.show({
+              await showSharedToaster({
                 intent: 'success',
                 icon: 'copy_to_clipboard_done',
                 message: 'Copied!',

--- a/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunDetails.tsx
@@ -20,7 +20,7 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import {AppContext} from '../app/AppContext';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
 import {RunStatus} from '../graphql/types';
 import {NO_LAUNCH_PERMISSION_MESSAGE} from '../launchpad/LaunchRootExecutionButton';
@@ -137,9 +137,9 @@ export const RunConfigDialog: React.FC<{run: RunFragment; isJob: boolean}> = ({r
   const copy = useCopyToClipboard();
   const history = useHistory();
 
-  const copyConfig = () => {
+  const copyConfig = async () => {
     copy(runConfigYaml);
-    SharedToaster.show({
+    await showSharedToaster({
       intent: 'success',
       icon: 'copy_to_clipboard_done',
       message: 'Copied!',

--- a/js_modules/dagit/packages/core/src/runs/RunTags.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTags.tsx
@@ -1,11 +1,11 @@
 import {Box} from '@dagster-io/ui';
 import * as React from 'react';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
 import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
 
-import {DagsterTag, RunTag, TagType} from './RunTag';
+import {DagsterTag, RunTag, TagAction, TagType} from './RunTag';
 import {RunFilterToken} from './RunsFilterInput';
 
 // Sort these tags to the start of the list.
@@ -33,9 +33,9 @@ export const RunTags: React.FC<{
   const copyAction = React.useMemo(
     () => ({
       label: 'Copy tag',
-      onClick: (tag: TagType) => {
+      onClick: async (tag: TagType) => {
         copy(`${tag.key}:${tag.value}`);
-        SharedToaster.show({intent: 'success', message: 'Copied tag!'});
+        await showSharedToaster({intent: 'success', message: 'Copied tag!'});
       },
     }),
     [copy],
@@ -55,7 +55,7 @@ export const RunTags: React.FC<{
   );
 
   const actionsForTag = (tag: TagType) => {
-    const list = [copyAction];
+    const list: TagAction[] = [copyAction];
     if (addToFilterAction && canAddTagToFilter(tag.key)) {
       list.push(addToFilterAction);
     }

--- a/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunUtils.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import {Mono} from '../../../ui/src';
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {Timestamp} from '../app/time/Timestamp';
@@ -62,7 +62,7 @@ export function useDidLaunchEvent(cb: () => void, delay = 1500) {
 
 export type LaunchBehavior = 'open' | 'open-in-new-tab' | 'toast';
 
-export function handleLaunchResult(
+export async function handleLaunchResult(
   pipelineName: string,
   result: void | null | LaunchPipelineExecutionMutation['launchPipelineExecution'],
   history: History<unknown>,
@@ -84,7 +84,7 @@ export function handleLaunchResult(
     } else if (options.behavior === 'open') {
       openInSameTab();
     } else {
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'success',
         message: (
           <div>

--- a/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagit/packages/core/src/schedules/SchedulesNextTicks.tsx
@@ -24,7 +24,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {useCopyToClipboard} from '../app/browser';
@@ -468,9 +468,9 @@ const NextTickDialog: React.FC<{
         {selectedRunRequest ? (
           <Button
             autoFocus={false}
-            onClick={() => {
+            onClick={async () => {
               copy(selectedRunRequest.runConfigYaml);
-              SharedToaster.show({
+              await showSharedToaster({
                 intent: 'success',
                 icon: 'copy_to_clipboard_done',
                 message: 'Copied!',

--- a/js_modules/dagit/packages/core/src/sensors/EditCursorDialog.tsx
+++ b/js_modules/dagit/packages/core/src/sensors/EditCursorDialog.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 import 'chartjs-adapter-date-fns';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {SensorSelector} from '../graphql/types';
@@ -42,10 +42,10 @@ export const EditCursorDialog: React.FC<{
       variables: {sensorSelector, cursor: cursorValue},
     });
     if (data?.setSensorCursor.__typename === 'Sensor') {
-      SharedToaster.show({message: 'Cursor value updated', intent: 'success'});
+      await showSharedToaster({message: 'Cursor value updated', intent: 'success'});
     } else if (data?.setSensorCursor) {
       const error = data.setSensorCursor;
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'danger',
         message: (
           <Group direction="row" spacing={8}>

--- a/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagit/packages/core/src/ticks/SensorDryRunDialog.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {assertUnreachable} from '../app/Util';
@@ -177,11 +177,11 @@ const SensorDryRun: React.FC<Props> = ({repoAddress, name, currentCursor, onClos
       variables: {sensorSelector, cursor},
     });
     if (data?.setSensorCursor.__typename === 'Sensor') {
-      SharedToaster.show({message: 'Cursor value updated', intent: 'success'});
+      await showSharedToaster({message: 'Cursor value updated', intent: 'success'});
       setCursorState('Persisted');
     } else if (data?.setSensorCursor) {
       const error = data.setSensorCursor;
-      SharedToaster.show({
+      await showSharedToaster({
         intent: 'danger',
         message: (
           <Group direction="row" spacing={8}>

--- a/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/CodeLocationRowSet.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import {SharedToaster} from '../app/DomUtils';
+import {showSharedToaster} from '../app/DomUtils';
 import {useCopyToClipboard} from '../app/browser';
 import {
   NO_RELOAD_PERMISSION_TEXT,
@@ -113,9 +113,9 @@ export const ImageName: React.FC<{metadata: WorkspaceDisplayMetadataFragment[]}>
   const imageKV = metadata.find(({key}) => key === 'image');
   const value = imageKV?.value || '';
 
-  const onClick = React.useCallback(() => {
+  const onClick = React.useCallback(async () => {
     copy(value);
-    SharedToaster.show({
+    await showSharedToaster({
       intent: 'success',
       icon: 'done',
       message: 'Image string copied!',

--- a/js_modules/dagit/packages/ui/src/components/Toaster.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Toaster.tsx
@@ -1,10 +1,16 @@
 // eslint-disable-next-line no-restricted-imports
-import {Toaster as BlueprintToaster, IToasterProps, IToaster, IToastProps} from '@blueprintjs/core';
+import {
+  Toaster as BlueprintToaster,
+  IToasterProps,
+  ToasterInstance,
+  ToastProps,
+} from '@blueprintjs/core';
 import React from 'react';
 import {createGlobalStyle} from 'styled-components/macro';
 
 import {Colors} from './Colors';
 import {IconName, Icon} from './Icon';
+import {createToaster} from './createToaster';
 
 export const GlobalToasterStyle = createGlobalStyle`
   .dagster-toaster {
@@ -52,30 +58,38 @@ export const GlobalToasterStyle = createGlobalStyle`
 `;
 
 // Patch the Blueprint Toaster to take a Dagster iconName instead of a Blueprint iconName
-type DToasterShowFn = (
-  props: Omit<IToastProps, 'icon'> & {icon?: IconName},
-  key?: string,
-) => string;
-type DToaster = Omit<IToaster, 'show'> & {show: DToasterShowFn};
+export type DToasterShowProps = Omit<ToastProps, 'icon'> & {icon?: IconName};
+export type DToasterShowFn = (props: DToasterShowProps, key?: string) => string;
+export type DToaster = Omit<ToasterInstance, 'show'> & {show: DToasterShowFn};
 
-export const Toaster: {
-  create: (props?: IToasterProps, container?: HTMLElement) => DToaster;
-} = {
-  create: (props, container) => {
-    const instance = BlueprintToaster.create({...props, className: 'dagster-toaster'}, container);
-    const show = instance.show;
-    const showWithDagsterIcon: DToasterShowFn = ({icon, ...rest}, key) => {
-      if (icon && typeof icon === 'string') {
-        rest.message = (
-          <>
-            <Icon name={icon} color={Colors.White} />
-            {rest.message}
-          </>
-        );
-      }
-      return show.apply(instance, [rest, key]);
-    };
+const setup = (instance: ToasterInstance): DToaster => {
+  const show = instance.show;
+  const showWithDagsterIcon: DToasterShowFn = ({icon, ...rest}, key) => {
+    if (icon && typeof icon === 'string') {
+      rest.message = (
+        <>
+          <Icon name={icon} color={Colors.White} />
+          {rest.message}
+        </>
+      );
+    }
+    return show.apply(instance, [rest, key]);
+  };
 
-    return Object.assign(instance, {show: showWithDagsterIcon}) as DToaster;
-  },
+  return Object.assign(instance, {show: showWithDagsterIcon}) as DToaster;
+};
+
+const create = (props?: IToasterProps, container?: HTMLElement): DToaster => {
+  const instance = BlueprintToaster.create({...props, className: 'dagster-toaster'}, container);
+  return setup(instance);
+};
+
+const asyncCreate = async (props?: IToasterProps, container?: HTMLElement): Promise<DToaster> => {
+  const instance = await createToaster({...props, className: 'dagster-toaster'}, container);
+  return setup(instance);
+};
+
+export const Toaster = {
+  create,
+  asyncCreate,
 };

--- a/js_modules/dagit/packages/ui/src/components/__stories__/Toaster.stories.tsx
+++ b/js_modules/dagit/packages/ui/src/components/__stories__/Toaster.stories.tsx
@@ -1,13 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
-import {Intent, Position} from '@blueprintjs/core';
+import {Intent} from '@blueprintjs/core';
 import {Meta} from '@storybook/react';
 import * as React from 'react';
 
 import {Button} from '../Button';
 import {Group} from '../Group';
-import {GlobalToasterStyle, Toaster} from '../Toaster';
-
-const SharedToaster = Toaster.create({position: Position.TOP}, document.body);
+import {DToaster, DToasterShowProps, GlobalToasterStyle, Toaster} from '../Toaster';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -15,13 +13,28 @@ export default {
 } as Meta;
 
 export const Sizes = () => {
+  const sharedToaster = React.useRef<DToaster | null>(null);
+
+  React.useEffect(() => {
+    const makeToaster = async () => {
+      sharedToaster.current = await Toaster.asyncCreate({position: 'top'}, document.body);
+    };
+    makeToaster();
+  }, []);
+
+  const showSharedToaster = async (config: DToasterShowProps) => {
+    if (sharedToaster.current) {
+      sharedToaster.current.show(config);
+    }
+  };
+
   return (
     <Group direction="column" spacing={16}>
       <GlobalToasterStyle />
 
       <Button
-        onClick={() =>
-          SharedToaster.show({
+        onClick={async () =>
+          await showSharedToaster({
             intent: Intent.NONE,
             message: 'Code location reloaded',
             timeout: 300000,
@@ -32,8 +45,8 @@ export const Sizes = () => {
         Basic Toast with Icon
       </Button>
       <Button
-        onClick={() =>
-          SharedToaster.show({
+        onClick={async () =>
+          await showSharedToaster({
             intent: Intent.SUCCESS,
             timeout: 300000,
             message: (
@@ -50,8 +63,8 @@ export const Sizes = () => {
         Success Toast with React Content
       </Button>
       <Button
-        onClick={() =>
-          SharedToaster.show({
+        onClick={async () =>
+          await showSharedToaster({
             intent: Intent.DANGER,
             timeout: 300000,
             message: 'This is an error message',
@@ -62,8 +75,8 @@ export const Sizes = () => {
         Error Toast
       </Button>
       <Button
-        onClick={() =>
-          SharedToaster.show({
+        onClick={async () =>
+          await showSharedToaster({
             intent: Intent.PRIMARY,
             timeout: 5000,
             message: 'This is a primary toaster',

--- a/js_modules/dagit/packages/ui/src/components/createToaster.tsx
+++ b/js_modules/dagit/packages/ui/src/components/createToaster.tsx
@@ -1,0 +1,26 @@
+// eslint-disable-next-line no-restricted-imports
+import {IToasterProps, Toaster} from '@blueprintjs/core';
+import * as React from 'react';
+import {createRoot} from 'react-dom/client';
+
+// https://github.com/palantir/blueprint/issues/5212#issuecomment-1318397270
+export const createToaster = (props?: IToasterProps, container = document.body) => {
+  const containerElement = document.createElement('div');
+  container.appendChild(containerElement);
+  const root = createRoot(containerElement);
+  return new Promise<Toaster>((resolve, reject) => {
+    root.render(
+      <Toaster
+        {...props}
+        usePortal={false}
+        ref={(instance) => {
+          if (!instance) {
+            reject(new Error('[Blueprint] Unable to create toaster.'));
+          } else {
+            resolve(instance);
+          }
+        }}
+      />,
+    );
+  });
+};


### PR DESCRIPTION
## Summary & Motivation

Remove `ReactDOM.render` from the app root and toaster usage. This includes updating toaster callsites to be async.

## How I Tested These Changes

Load app, verify that the React 18 warning is gone from toast and console.
