### PR TITLE
[ui] Remove old shared toaster

### DIFF
--- a/js_modules/dagit/packages/core/src/app/DomUtils.tsx
+++ b/js_modules/dagit/packages/core/src/app/DomUtils.tsx
@@ -1,9 +1,6 @@
 import {DToasterShowProps, Toaster} from '@dagster-io/ui';
 import memoize from 'lodash/memoize';
 
-// todo dish: Delete this after Cloud is updated.
-export const SharedToaster = Toaster.create({position: 'top'}, document.body);
-
 export const getSharedToaster = memoize(async () => {
   return await Toaster.asyncCreate({position: 'top'}, document.body);
 });

--- a/js_modules/dagit/packages/ui/src/components/Toaster.tsx
+++ b/js_modules/dagit/packages/ui/src/components/Toaster.tsx
@@ -1,10 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import {
-  Toaster as BlueprintToaster,
-  IToasterProps,
-  ToasterInstance,
-  ToastProps,
-} from '@blueprintjs/core';
+import {IToasterProps, ToasterInstance, ToastProps} from '@blueprintjs/core';
 import React from 'react';
 import {createGlobalStyle} from 'styled-components/macro';
 
@@ -79,17 +74,11 @@ const setup = (instance: ToasterInstance): DToaster => {
   return Object.assign(instance, {show: showWithDagsterIcon}) as DToaster;
 };
 
-const create = (props?: IToasterProps, container?: HTMLElement): DToaster => {
-  const instance = BlueprintToaster.create({...props, className: 'dagster-toaster'}, container);
-  return setup(instance);
-};
-
 const asyncCreate = async (props?: IToasterProps, container?: HTMLElement): Promise<DToaster> => {
   const instance = await createToaster({...props, className: 'dagster-toaster'}, container);
   return setup(instance);
 };
 
 export const Toaster = {
-  create,
   asyncCreate,
 };


### PR DESCRIPTION
## Summary & Motivation

Remove old `SharedToaster` and `Toaster.create`. I should have just taken care of this at the same time as cleaning up Cloud.

## How I Tested These Changes

Buildkite
