### PR TITLE
[ui] Repair client-side `canTerminate` evaluation

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagit/packages/core/src/runs/LogsProvider.tsx
@@ -137,16 +137,11 @@ const useLogsProviderWithSubscription = (runId: string) => {
       });
 
       if (local) {
-        const toWrite = {...local, status};
-        if (
-          status === RunStatus.FAILURE ||
-          status === RunStatus.SUCCESS ||
-          status === RunStatus.STARTING ||
-          status === RunStatus.CANCELING ||
-          status === RunStatus.CANCELED
-        ) {
-          toWrite.canTerminate = false;
-        }
+        const toWrite = {
+          ...local,
+          canTerminate: status === RunStatus.QUEUED || status === RunStatus.STARTED,
+          status,
+        };
 
         client.writeFragment({
           fragmentName: 'PipelineRunLogsSubscriptionStatusFragment',


### PR DESCRIPTION
## Summary & Motivation

Update the conditional used to set `canTerminate` based on run logs to check whether the run is `QUEUED` or `STARTED`, matching what we do in Python.

This should resolve the issue where only force-terminate is given as an option in the termination dialog, even when the run should allow regular termination.

## How I Tested These Changes

Launch a `hammer` run, click "Terminate" at various times during the lifecycle of the run. Verify that the "Force" checkbox appears as an option when the run is `QUEUED` or `STARTED`, is otherwise only a "Force terminate" dialog for other statuses, and that the dialog updates correctly during the lifecycle when reopened.
