### PR TITLE
Allow filtering the new runs table by Asset

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2056,6 +2056,7 @@ input RunsFilter {
   updatedAfter: Float
   createdBefore: Float
   mode: String
+  assetKeys: [AssetKeyInput]
 }
 
 input PipelineSelector {

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -3335,6 +3335,7 @@ export type Runs = PipelineRuns & {
 };
 
 export type RunsFilter = {
+  assetKeys?: InputMaybe<Array<InputMaybe<AssetKeyInput>>>;
   createdBefore?: InputMaybe<Scalars['Float']>;
   mode?: InputMaybe<Scalars['String']>;
   pipelineName?: InputMaybe<Scalars['String']>;
@@ -10213,6 +10214,7 @@ export const buildRunsFilter = (
   const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
   relationshipsToOmit.add('RunsFilter');
   return {
+    assetKeys: overrides && overrides.hasOwnProperty('assetKeys') ? overrides.assetKeys! : [],
     createdBefore:
       overrides && overrides.hasOwnProperty('createdBefore') ? overrides.createdBefore! : 2.25,
     mode: overrides && overrides.hasOwnProperty('mode') ? overrides.mode! : 'voluptatem',

--- a/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsFilterInput.tsx
@@ -33,6 +33,7 @@ export type RunFilterTokenType =
   | 'status'
   | 'pipeline'
   | 'job'
+  | 'assetKey'
   | 'snapshotId'
   | 'tag'
   | 'backfill'

--- a/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
@@ -113,6 +113,7 @@ export const RunsRoot = () => {
       'snapshotId',
       'id',
       'job',
+      'assetKey',
       'pipeline',
       'backfill',
     ];

--- a/js_modules/dagit/packages/core/src/runs/types/RunsFilterInputNew.types.ts
+++ b/js_modules/dagit/packages/core/src/runs/types/RunsFilterInputNew.types.ts
@@ -2,10 +2,14 @@
 
 import * as Types from '../../graphql/types';
 
-export type RunTagKeysNewQueryVariables = Types.Exact<{[key: string]: never}>;
+export type RunFilterSpaceQueryVariables = Types.Exact<{[key: string]: never}>;
 
-export type RunTagKeysNewQuery = {
+export type RunFilterSpaceQuery = {
   __typename: 'DagitQuery';
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+  }>;
   runTagKeysOrError:
     | {__typename: 'PythonError'}
     | {__typename: 'RunTagKeys'; keys: Array<string>}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -31,6 +31,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     updatedAfter = graphene.InputField(graphene.Float)
     createdBefore = graphene.InputField(graphene.Float)
     mode = graphene.InputField(graphene.String)
+    assetKeys = graphene.List(GrapheneAssetKeyInput)
 
     class Meta:
         description = """This type represents a filter on Dagster runs."""

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -615,12 +615,13 @@ class GrapheneDagitQuery(graphene.ObjectType):
         limit: Optional[int] = None,
     ):
         selector = filter.to_selector() if filter is not None else None
-
-        return GrapheneRuns(
-            filters=selector,
-            cursor=cursor,
-            limit=limit,
+        asset_keys = (
+            [AssetKey(path=key.path) for key in filter.assetKeys]
+            if filter is not None and filter.assetKeys is not None
+            else None
         )
+
+        return GrapheneRuns(filters=selector, cursor=cursor, limit=limit, asset_keys=asset_keys)
 
     def resolve_pipelineRunOrError(self, graphene_info: ResolveInfo, runId: graphene.ID):
         return get_run_by_id(graphene_info, runId)
@@ -633,12 +634,13 @@ class GrapheneDagitQuery(graphene.ObjectType):
         limit: Optional[int] = None,
     ):
         selector = filter.to_selector() if filter is not None else None
-
-        return GrapheneRuns(
-            filters=selector,
-            cursor=cursor,
-            limit=limit,
+        asset_keys = (
+            [AssetKey(path=key.path) for key in filter.assetKeys]
+            if filter is not None and filter.assetKeys is not None
+            else None
         )
+
+        return GrapheneRuns(filters=selector, cursor=cursor, limit=limit, asset_keys=asset_keys)
 
     def resolve_runOrError(self, graphene_info: ResolveInfo, runId):
         return get_run_by_id(graphene_info, runId)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -104,18 +104,19 @@ class GrapheneRuns(graphene.ObjectType):
         interfaces = (GraphenePipelineRuns,)
         name = "Runs"
 
-    def __init__(self, filters, cursor, limit):
+    def __init__(self, filters, cursor, limit, asset_keys=None):
         super().__init__()
 
         self._filters = filters
         self._cursor = cursor
         self._limit = limit
+        self._asset_keys = asset_keys
 
     def resolve_results(self, graphene_info: ResolveInfo):
-        return get_runs(graphene_info, self._filters, self._cursor, self._limit)
+        return get_runs(graphene_info, self._filters, self._cursor, self._limit, self._asset_keys)
 
     def resolve_count(self, graphene_info: ResolveInfo):
-        return get_runs_count(graphene_info, self._filters)
+        return get_runs_count(graphene_info, self._filters, self._asset_keys)
 
 
 class GrapheneRunsOrError(graphene.Union):


### PR DESCRIPTION
## Summary & Motivation

Resolves https://github.com/dagster-io/dagster/issues/7963

This PR adds a new GraphQL `RunsFilter.assetKeys` option for filtering for runs involving a particular asset and implements it in the front-end filter dropdown.

On the backend, it's difficult to translate this into a filter within run storage. Instead, we parse the `GrapheneRunsFilter` into both a `RunsFilter` and the passed asset keys, resolve the asset keys to run IDs, and build a final `RunsFilter` with the run id selection.

This is admittedly a bit of a hack, but allows us to re-use the existing `instance.run_ids_for_asset_key` helper method which respects requests to wipe asset materializations and keeps run and event storage separate. Very open to other implementations!

![image](https://user-images.githubusercontent.com/1037212/236921391-9477c0ed-9c8e-4a96-808e-26932987861a.png)

## How I Tested These Changes

I added a new test that checks a variety of different combinations of this new filter param and the existing run_ids filter param for the correct results.