### PR TITLE
example: project_analytics uses pythonic io manager and dbt resources

### DIFF
--- a/examples/project_analytics/dagster_pypi_tests/test_defs.py
+++ b/examples/project_analytics/dagster_pypi_tests/test_defs.py
@@ -1,0 +1,5 @@
+from dagster_pypi import defs
+
+
+def test_def_can_load():
+    assert defs.get_job_def("dagster_pypi_job")


### PR DESCRIPTION
## Summary & Motivation
converts the remaining resources to pythonic resources. 

note: dagster-hex hasn't been updated, so we're leaving it as the old pattern.
## How I Tested These Changes
- `dagster dev` loads: 
<img width="377" alt="image" src="https://user-images.githubusercontent.com/4531914/236992875-417a08b9-ad99-43dd-94f8-7d9c5f6ceb63.png">

- unit test
