### PR TITLE
bumped pandas version to greater than 2

### DIFF
--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -60,7 +60,7 @@ class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                     TableSchema(
                         columns=[
                             TableColumn(name=name, type=str(dtype))
-                            for name, dtype in obj.dtypes.iteritems()
+                            for name, dtype in obj.dtypes.items()
                         ]
                     )
                 ),

--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",
-        "pandas<2",  # See: https://github.com/dagster-io/dagster/issues/13339
+        "pandas>2",  # See: https://github.com/dagster-io/dagster/issues/13339
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
This PR aims to address #13339.
It's gonna be ready for review when following libraries are migrated/adapted to work with both pandas 1.0 and 2.0.

- [ ] assets-pandas-type-metadata
- [ ] assets-pandas-pyspark
- [ ] dagster-duckdb-pandas
- [ ] dagster-duckdb-pyspark
- [ ] dagster-gcp-pandas

## How I Tested These Changes
Tests run successfully on my local machine.
- [ ] assets-pandas-type-metadata
- [ ] assets-pandas-pyspark
- [ ] dagster-duckdb-pandas
- [ ] dagster-duckdb-pyspark
- [ ] dagster-gcp-pandas


pinging @smackesey 