### PR TITLE
Remove invalid "trace" log level from dagster dev

### DIFF
--- a/python_modules/dagit/dagit/cli.py
+++ b/python_modules/dagit/dagit/cli.py
@@ -128,9 +128,7 @@ DEFAULT_POOL_RECYCLE = 3600  # 1 hr
     help="Set the log level for any code servers spun up by dagit.",
     show_default=True,
     default="info",
-    type=click.Choice(
-        ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
-    ),
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option(
     "--instance-ref",

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -51,9 +51,7 @@ def dev_command_options(f):
     help="Set the log level for code servers spun up by dagster services.",
     show_default=True,
     default="warning",
-    type=click.Choice(
-        ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
-    ),
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option("--dagit-port", "-p", help="Port to use for the Dagit UI.", required=False)
 @click.option("--dagit-host", "-h", help="Host to use for the Dagit UI.", required=False)

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -42,9 +42,7 @@ def _get_heartbeat_tolerance():
     help="Set the log level for any code servers spun up by the daemon.",
     show_default=True,
     default="warning",
-    type=click.Choice(
-        ["critical", "error", "warning", "info", "debug", "trace"], case_sensitive=False
-    ),
+    type=click.Choice(["critical", "error", "warning", "info", "debug"], case_sensitive=False),
 )
 @click.option(
     "--instance-ref",


### PR DESCRIPTION
Summary:
I foolishly copied this from the dagit --log-level arg orginally, not realizing that "trace" is a uvicorn-specific log level.

Test Plan:
dagster dev -h
dagit -h
dagster-daemon run -h

## Summary & Motivation

## How I Tested These Changes
