### PR TITLE
[ui] Hide upstream data missing warning for partition-mapped backfills

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagit/packages/core/src/assets/LaunchAssetExecutionButton.tsx
@@ -609,6 +609,18 @@ export function buildAssetCollisionsAlert(data: LaunchAssetLoaderQuery) {
   };
 }
 
+const PARTITION_DEFINITION_FOR_LAUNCH_ASSET_FRAGMENT = gql`
+  fragment PartitionDefinitionForLaunchAssetFragment on PartitionDefinition {
+    description
+    type
+    name
+    dimensionTypes {
+      name
+      dynamicPartitionsDefinitionName
+    }
+  }
+`;
+
 const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
   fragment LaunchAssetExecutionAssetNodeFragment on AssetNode {
     id
@@ -617,7 +629,7 @@ const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
     graphName
     hasMaterializePermission
     partitionDefinition {
-      ...PartitionDefinitionForLaunchAsset
+      ...PartitionDefinitionForLaunchAssetFragment
     }
     isObservable
     isSource
@@ -641,17 +653,8 @@ const LAUNCH_ASSET_EXECUTION_ASSET_NODE_FRAGMENT = gql`
     ...AssetNodeConfigFragment
   }
 
-  fragment PartitionDefinitionForLaunchAsset on PartitionDefinition {
-    description
-    type
-    name
-    dimensionTypes {
-      name
-      dynamicPartitionsDefinitionName
-    }
-  }
-
   ${ASSET_NODE_CONFIG_FRAGMENT}
+  ${PARTITION_DEFINITION_FOR_LAUNCH_ASSET_FRAGMENT}
 `;
 
 export const LAUNCH_ASSET_LOADER_QUERY = gql`

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsQuery.fixtures.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetChoosePartitionsQuery.fixtures.tsx
@@ -6,17 +6,18 @@ import {
   buildInstance,
   buildRunLauncher,
 } from '../../graphql/types';
-import {LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY} from '../LaunchAssetChoosePartitionsDialog';
-import {LaunchAssetChoosePartitionsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
+import {LAUNCH_ASSET_WARNINGS_QUERY} from '../LaunchAssetChoosePartitionsDialog';
+import {LaunchAssetWarningsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
 
-export const ReleasesWorkspace: MockedResponse<LaunchAssetChoosePartitionsQuery> = {
+export const ReleasesWorkspace: MockedResponse<LaunchAssetWarningsQuery> = {
   request: {
-    query: LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY,
+    query: LAUNCH_ASSET_WARNINGS_QUERY,
     variables: {},
   },
   result: {
     data: {
       __typename: 'DagitQuery',
+      assetNodes: [],
       instance: buildInstance({
         daemonHealth: buildDaemonHealth({
           id: 'daemonHealth',

--- a/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -22,13 +22,13 @@ import {
   LaunchPipelineExecutionMutation,
   LaunchPipelineExecutionMutationVariables,
 } from '../../runs/types/RunUtils.types';
-import {LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY} from '../LaunchAssetChoosePartitionsDialog';
+import {LAUNCH_ASSET_WARNINGS_QUERY} from '../LaunchAssetChoosePartitionsDialog';
 import {
   LAUNCH_ASSET_CHECK_UPSTREAM_QUERY,
   LAUNCH_ASSET_LOADER_QUERY,
   LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
 } from '../LaunchAssetExecutionButton';
-import {LaunchAssetChoosePartitionsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
+import {LaunchAssetWarningsQuery} from '../types/LaunchAssetChoosePartitionsDialog.types';
 import {
   LaunchAssetCheckUpstreamQuery,
   LaunchAssetLoaderQuery,
@@ -190,14 +190,15 @@ export const ASSET_WEEKLY_ROOT: AssetNodeForGraphQueryFragment = {
   },
 };
 
-export const LaunchAssetChoosePartitionsMock: MockedResponse<LaunchAssetChoosePartitionsQuery> = {
+export const LaunchAssetWarningsMock: MockedResponse<LaunchAssetWarningsQuery> = {
   request: {
-    query: LAUNCH_ASSET_CHOOSE_PARTITIONS_QUERY,
+    query: LAUNCH_ASSET_WARNINGS_QUERY,
     variables: {},
   },
   result: {
     data: {
       __typename: 'DagitQuery',
+      assetNodes: [],
       instance: buildInstance({
         daemonHealth: buildDaemonHealth({
           id: 'daemonHealth',

--- a/js_modules/dagit/packages/core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagit/packages/core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -22,7 +22,7 @@ import {
   buildExpectedLaunchSingleRunMutation,
   buildLaunchAssetLoaderMock,
   LaunchAssetCheckUpstreamWeeklyRootMock,
-  LaunchAssetChoosePartitionsMock,
+  LaunchAssetWarningsMock,
   LaunchAssetLoaderResourceJob7Mock,
   LaunchAssetLoaderResourceJob8Mock,
   LaunchAssetLoaderResourceMyAssetJobMock,
@@ -356,7 +356,7 @@ async function renderButton({
   const assetKeys = ('all' in scope ? scope.all : scope.selected).map((s) => s.assetKey);
 
   const mocks: MockedResponse<Record<string, any>>[] = [
-    LaunchAssetChoosePartitionsMock,
+    LaunchAssetWarningsMock,
     LaunchAssetLoaderResourceJob7Mock,
     LaunchAssetLoaderResourceJob8Mock,
     LaunchAssetLoaderResourceMyAssetJobMock,

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -2,10 +2,26 @@
 
 import * as Types from '../../graphql/types';
 
-export type LaunchAssetChoosePartitionsQueryVariables = Types.Exact<{[key: string]: never}>;
+export type LaunchAssetWarningsQueryVariables = Types.Exact<{
+  upstreamAssetKeys: Array<Types.AssetKeyInput> | Types.AssetKeyInput;
+}>;
 
-export type LaunchAssetChoosePartitionsQuery = {
+export type LaunchAssetWarningsQuery = {
   __typename: 'DagitQuery';
+  assetNodes: Array<{
+    __typename: 'AssetNode';
+    id: string;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
+    partitionDefinition: {
+      __typename: 'PartitionDefinition';
+      description: string;
+      dimensionTypes: Array<{
+        __typename: 'DimensionDefinitionType';
+        name: string;
+        dynamicPartitionsDefinitionName: string | null;
+      }>;
+    } | null;
+  }>;
   instance: {
     __typename: 'Instance';
     id: string;

--- a/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagit/packages/core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -2,6 +2,18 @@
 
 import * as Types from '../../graphql/types';
 
+export type PartitionDefinitionForLaunchAssetFragment = {
+  __typename: 'PartitionDefinition';
+  description: string;
+  type: Types.PartitionDefinitionType;
+  name: string | null;
+  dimensionTypes: Array<{
+    __typename: 'DimensionDefinitionType';
+    name: string;
+    dynamicPartitionsDefinitionName: string | null;
+  }>;
+};
+
 export type LaunchAssetExecutionAssetNodeFragment = {
   __typename: 'AssetNode';
   id: string;
@@ -583,18 +595,6 @@ export type LaunchAssetExecutionAssetNodeFragment = {
           >;
         };
   } | null;
-};
-
-export type PartitionDefinitionForLaunchAssetFragment = {
-  __typename: 'PartitionDefinition';
-  description: string;
-  type: Types.PartitionDefinitionType;
-  name: string | null;
-  dimensionTypes: Array<{
-    __typename: 'DimensionDefinitionType';
-    name: string;
-    dynamicPartitionsDefinitionName: string | null;
-  }>;
 };
 
 export type LaunchAssetLoaderQueryVariables = Types.Exact<{

--- a/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillMessaging.tsx
@@ -130,7 +130,7 @@ export const DaemonNotRunningAlertBody = () => (
   />
 );
 
-export const USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT = gql`
+export const USING_DEFAULT_LAUNCHER_ALERT_INSTANCE_FRAGMENT = gql`
   fragment UsingDefaultLauncherAlertInstanceFragment on Instance {
     id
     runQueuingSupported

--- a/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagit/packages/core/src/partitions/BackfillSelector.tsx
@@ -40,7 +40,7 @@ import {
   showBackfillErrorToast,
   showBackfillSuccessToast,
   UsingDefaultLauncherAlert,
-  USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT,
+  USING_DEFAULT_LAUNCHER_ALERT_INSTANCE_FRAGMENT,
 } from './BackfillMessaging';
 import {DimensionRangeWizard} from './DimensionRangeWizard';
 import {countsByState, PartitionRunStatusCheckboxes} from './PartitionRunStatusCheckboxes';
@@ -466,7 +466,7 @@ const BACKFILL_SELECTOR_QUERY = gql`
 
   ${GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT}
   ${DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT}
-  ${USING_DEFAULT_LAUNCH_ERALERT_INSTANCE_FRAGMENT}
+  ${USING_DEFAULT_LAUNCHER_ALERT_INSTANCE_FRAGMENT}
 `;
 
 const Section = ({


### PR DESCRIPTION
## Summary & Motivation

This PR fixes a bug in the "upstream data missing" warning - it should only consider upstream assets that share the same partitioning as the root assets in your selection. Previously, selecting an asset to materialize that had partition-mapped upstream assets would result in this warning always appearing, since the upstream assets did not have the partition keys being selected.

## How I Tested These Changes

I tested this using the `mapped` asset group in the toys repo.
- Select asset with an upstream of the same partitioning, verify that the warning appears
- Select asset with an upstream of different partitioning, verify that the warning does not appear
