### PR TITLE
Asset policy evaluations table

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/039_d3a4c9e87af3_add_asset_daemon_asset_evaluations_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/039_d3a4c9e87af3_add_asset_daemon_asset_evaluations_table.py
@@ -1,4 +1,4 @@
-"""Add asset policy evaluations table
+"""Add asset daemon asset evaluations table
 
 Revision ID: d3a4c9e87af3
 Revises: 701913684cb4
@@ -20,9 +20,9 @@ depends_on = None
 
 
 def upgrade():
-    if not has_table("asset_daemon_evaluations"):
+    if not has_table("asset_daemon_asset_evaluations"):
         op.create_table(
-            "asset_daemon_evaluations",
+            "asset_daemon_asset_evaluations",
             db.Column(
                 "id",
                 db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
@@ -42,8 +42,8 @@ def upgrade():
             db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
         )
         op.create_index(
-            "idx_asset_daemon_evaluations_asset_key_evaluation_id",
-            "asset_daemon_evaluations",
+            "idx_asset_daemon_asset_evaluations_asset_key_evaluation_id",
+            "asset_daemon_asset_evaluations",
             ["asset_key", "evaluation_id"],
             mysql_length={"asset_key": 64},
             unique=True,
@@ -52,10 +52,12 @@ def upgrade():
 
 def downgrade():
     if has_index(
-        "asset_daemon_evaluations", "idx_asset_daemon_evaluations_asset_key_evaluation_id"
+        "asset_daemon_asset_evaluations",
+        "idx_asset_daemon_asset_evaluations_asset_key_evaluation_id",
     ):
         op.drop_index(
-            "idx_asset_daemon_evaluations_asset_key_evaluation_id", "asset_daemon_evaluations"
+            "idx_asset_daemon_asset_evaluations_asset_key_evaluation_id",
+            "asset_daemon_asset_evaluations",
         )
-    if has_table("asset_daemon_evaluations"):
-        op.drop_table("asset_daemon_evaluations")
+    if has_table("asset_daemon_asset_evaluations"):
+        op.drop_table("asset_daemon_asset_evaluations")

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/039_d3a4c9e87af3_add_asset_policy_evaluations_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/039_d3a4c9e87af3_add_asset_policy_evaluations_table.py
@@ -1,0 +1,61 @@
+"""Add asset policy evaluations table
+
+Revision ID: d3a4c9e87af3
+Revises: 701913684cb4
+Create Date: 2023-05-09 11:50:38.931820
+
+"""
+
+import sqlalchemy as db
+from alembic import op
+from dagster._core.storage.migration.utils import has_index, has_table
+from dagster._core.storage.sql import get_current_timestamp
+from sqlalchemy.dialects import sqlite
+
+# revision identifiers, used by Alembic.
+revision = "d3a4c9e87af3"
+down_revision = "701913684cb4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not has_table("asset_daemon_evaluations"):
+        op.create_table(
+            "asset_daemon_evaluations",
+            db.Column(
+                "id",
+                db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+                primary_key=True,
+                autoincrement=True,
+            ),
+            db.Column(
+                "evaluation_id",
+                db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+                index=True,
+            ),
+            db.Column("asset_key", db.Text),
+            db.Column("asset_evaluation_body", db.Text),
+            db.Column("num_requested", db.Integer),
+            db.Column("num_skipped", db.Integer),
+            db.Column("num_discarded", db.Integer),
+            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+        )
+        op.create_index(
+            "idx_asset_daemon_evaluations_asset_key_evaluation_id",
+            "asset_daemon_evaluations",
+            ["asset_key", "evaluation_id"],
+            mysql_length={"asset_key": 64},
+            unique=True,
+        )
+
+
+def downgrade():
+    if has_index(
+        "asset_daemon_evaluations", "idx_asset_daemon_evaluations_asset_key_evaluation_id"
+    ):
+        op.drop_index(
+            "idx_asset_daemon_evaluations_asset_key_evaluation_id", "asset_daemon_evaluations"
+        )
+    if has_table("asset_daemon_evaluations"):
+        op.drop_table("asset_daemon_evaluations")

--- a/python_modules/dagster/dagster/_core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/schema.py
@@ -1,4 +1,5 @@
 import sqlalchemy as db
+from sqlalchemy.dialects import sqlite
 
 from ..sql import MySQLCompatabilityTypes, get_current_timestamp
 
@@ -45,6 +46,27 @@ JobTickTable = db.Table(
     db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
 )
 
+AssetPolicyEvaluationsTable = db.Table(
+    "asset_daemon_evaluations",
+    ScheduleStorageSqlMetadata,
+    db.Column(
+        "id",
+        db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    db.Column(
+        "evaluation_id", db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"), index=True
+    ),
+    db.Column("asset_key", db.Text),
+    db.Column("asset_evaluation_body", db.Text),
+    db.Column("num_requested", db.Integer),
+    db.Column("num_skipped", db.Integer),
+    db.Column("num_discarded", db.Integer),
+    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+)
+
+
 # Secondary Index migration table, used to track data migrations, event_logs and runs.
 # This schema should match the schema in the event_log storage, run schema
 SecondaryIndexMigrationTable = db.Table(
@@ -64,3 +86,10 @@ db.Index(
 )
 db.Index("idx_job_tick_timestamp", JobTickTable.c.job_origin_id, JobTickTable.c.timestamp)
 db.Index("idx_tick_selector_timestamp", JobTickTable.c.selector_id, JobTickTable.c.timestamp)
+
+db.Index(
+    "idx_asset_daemon_evaluations_asset_key_evaluation_id",
+    AssetPolicyEvaluationsTable.c.asset_key,
+    AssetPolicyEvaluationsTable.c.evaluation_id,
+    unique=True,
+)

--- a/python_modules/dagster/dagster/_core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/schema.py
@@ -47,7 +47,7 @@ JobTickTable = db.Table(
 )
 
 AssetPolicyEvaluationsTable = db.Table(
-    "asset_daemon_evaluations",
+    "asset_daemon_asset_evaluations",
     ScheduleStorageSqlMetadata,
     db.Column(
         "id",
@@ -88,7 +88,7 @@ db.Index("idx_job_tick_timestamp", JobTickTable.c.job_origin_id, JobTickTable.c.
 db.Index("idx_tick_selector_timestamp", JobTickTable.c.selector_id, JobTickTable.c.timestamp)
 
 db.Index(
-    "idx_asset_daemon_evaluations_asset_key_evaluation_id",
+    "idx_asset_daemon_asset_evaluations_asset_key_evaluation_id",
     AssetPolicyEvaluationsTable.c.asset_key,
     AssetPolicyEvaluationsTable.c.evaluation_id,
     unique=True,


### PR DESCRIPTION
Storage for asset daemon evaluations scoped to individual assets. Each row has

- id (just a primary key)
- evaluation id (the asset daemon will use consecutive ids for each iteration. We can use this to show the most recent iteration, and to know in which iterations this asset wasn't considered)
- asset key
- num materialized (pulling this out of the serialized object so we can optimize queries to find evaluations that resulted in runs

Check that index gets used for the planned read query:
```
# explain select * from asset_daemon_evaluations where asset_key='foo' order by evaluation_id;
                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=11.31..11.31 rows=3 width=92)
   Sort Key: evaluation_id
   ->  Bitmap Heap Scan on asset_daemon_evaluations  (cost=4.17..11.28 rows=3 width=92)
         Recheck Cond: (asset_key = 'foo'::text)
         ->  Bitmap Index Scan on idx_asset_daemon_evaluations_asset_key_evaluation_id  (cost=0.00..4.17 rows=3 width=0)
               Index Cond: (asset_key = 'foo'::text)
```

Test plan:

`dagster instance migrate` succeeded