### PR TITLE
feat(dbt-assets)[1/N]: add dbt_asset decorator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -1,0 +1,62 @@
+from typing import Callable, Optional
+
+from dagster import AssetsDefinition, multi_asset
+from dagster._annotations import experimental
+
+from .asset_utils import get_dbt_multi_asset_args, get_deps
+from .cli.resources_v2 import DbtManifest
+from .utils import ASSET_RESOURCE_TYPES, select_unique_ids_from_manifest
+
+
+@experimental
+def dbt_assets(
+    *,
+    manifest: DbtManifest,
+    select: str = "fqn:*",
+    exclude: Optional[str] = None,
+) -> Callable[..., AssetsDefinition]:
+    """Create a definition for how to compute a set of dbt resources, described by a manifest.json.
+
+    Args:
+        manifest (DbtManifest): The wrapper of a dbt manifest.json.
+        select (Optional[str]): A dbt selection string for the models in a project that you want
+            to include. Defaults to "*".
+        exclude (Optional[str]): A dbt selection string for the models in a project that you want
+            to exclude. Defaults to "".
+
+    Examples:
+        .. code-block:: python
+
+            @dbt_multi_asset(manifest=manifest)
+            def my_dbt_assets(dbt: ResourceParam["DbtCliClient"]):
+                yield from dbt.cli(["run"])
+    """
+    unique_ids = select_unique_ids_from_manifest(
+        select=select, exclude=exclude or "", manifest_json=manifest.raw_manifest
+    )
+    deps = get_deps(
+        dbt_nodes=manifest.node_info_by_dbt_unique_id,
+        selected_unique_ids=unique_ids,
+        asset_resource_types=ASSET_RESOURCE_TYPES,
+    )
+    (
+        non_argument_deps,
+        outs,
+        internal_asset_deps,
+    ) = get_dbt_multi_asset_args(
+        dbt_nodes=manifest.node_info_by_dbt_unique_id,
+        deps=deps,
+    )
+
+    def inner(fn) -> AssetsDefinition:
+        asset_definition = multi_asset(
+            outs=outs,
+            internal_asset_deps=internal_asset_deps,
+            non_argument_deps=non_argument_deps,
+            compute_kind="dbt",
+            can_subset=True,
+        )(fn)
+
+        return asset_definition
+
+    return inner

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -4,6 +4,7 @@ from typing import AbstractSet, Any, Dict, FrozenSet, List, Mapping, Optional, S
 
 from dagster import (
     AssetKey,
+    AssetOut,
     AutoMaterializePolicy,
     FreshnessPolicy,
     In,
@@ -101,6 +102,12 @@ def default_description_fn(node_info: Mapping[str, Any], display_raw_sql: bool =
     return "\n\n".join(filter(None, description_sections))
 
 
+def default_code_version_fn(node_info: Mapping[str, Any]) -> str:
+    return hashlib.sha1(
+        (node_info.get("raw_sql") or node_info.get("raw_code", "")).encode("utf-8")
+    ).hexdigest()
+
+
 ###################
 # DEPENDENCIES
 ###################
@@ -166,6 +173,49 @@ def get_deps(
     return frozen_asset_deps
 
 
+def get_dbt_multi_asset_args(
+    dbt_nodes: Mapping[str, Any],
+    deps: Mapping[str, FrozenSet[str]],
+) -> Tuple[Set[AssetKey], Dict[str, AssetOut], Dict[str, Set[AssetKey]],]:
+    """Use the standard defaults for dbt to construct the arguments for a dbt multi asset."""
+    non_argument_deps: Set[AssetKey] = set()
+    outs: Dict[str, AssetOut] = {}
+    internal_asset_deps: Dict[str, Set[AssetKey]] = {}
+
+    for unique_id, parent_unique_ids in deps.items():
+        node_info = dbt_nodes[unique_id]
+
+        output_name = output_name_fn(node_info)
+        asset_key = default_asset_key_fn(node_info)
+
+        outs[output_name] = AssetOut(
+            key=asset_key,
+            dagster_type=Nothing,
+            description=default_description_fn(node_info, display_raw_sql=False),
+            is_required=False,
+            metadata=default_metadata_fn(node_info),
+            group_name=default_group_fn(node_info),
+            code_version=default_code_version_fn(node_info),
+            freshness_policy=default_freshness_policy_fn(node_info),
+            auto_materialize_policy=default_auto_materialize_policy_fn(node_info),
+        )
+
+        # Translate parent unique ids to internal asset deps and non argument dep
+        output_internal_deps = internal_asset_deps.setdefault(output_name, set())
+        for parent_unique_id in parent_unique_ids:
+            parent_node_info = dbt_nodes[parent_unique_id]
+            parent_asset_key = default_asset_key_fn(parent_node_info)
+
+            # Add this parent as an internal dependency
+            output_internal_deps.add(parent_asset_key)
+
+            # Mark this parent as an input if it has no dependencies
+            if parent_unique_id not in deps:
+                non_argument_deps.add(parent_asset_key)
+
+    return non_argument_deps, outs, internal_asset_deps
+
+
 def get_asset_deps(
     dbt_nodes,
     deps,
@@ -223,9 +273,7 @@ def get_asset_deps(
                 metadata=metadata,
                 is_required=False,
                 dagster_type=Nothing,
-                code_version=hashlib.sha1(
-                    (node_info.get("raw_sql") or node_info.get("raw_code", "")).encode("utf-8")
-                ).hexdigest(),
+                code_version=default_code_version_fn(node_info),
             ),
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/__init__.py
@@ -3,4 +3,5 @@ from .resources import (
     DbtCliResource as DbtCliResource,
     dbt_cli_resource as dbt_cli_resource,
 )
+from .resources_v2 import DbtManifest as DbtManifest
 from .types import DbtCliOutput as DbtCliOutput

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/resources_v2.py
@@ -1,0 +1,76 @@
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+from dagster import AssetKey
+
+from ..asset_utils import default_asset_key_fn, output_name_fn
+
+
+@dataclass
+class DbtManifest:
+    """Helper class for dbt manifest operations."""
+
+    raw_manifest: Dict[str, Any]
+
+    @classmethod
+    def read(cls, path: str) -> "DbtManifest":
+        """Read the file path to a dbt manifest and create a DbtManifest object.
+
+        Args:
+            path(str): The path to the dbt manifest.json file.
+
+        Returns:
+            DbtManifest: A DbtManifest object.
+        """
+        with open(path, "r") as handle:
+            raw_manifest: Dict[str, Any] = json.loads(handle.read())
+
+        return cls(raw_manifest=raw_manifest)
+
+    @property
+    def node_info_by_dbt_unique_id(self) -> Mapping[str, Mapping[str, Any]]:
+        """A mapping of a dbt node's unique id to the node's dictionary representation in the manifest.
+        """
+        return {
+            **self.raw_manifest["nodes"],
+            **self.raw_manifest["sources"],
+            **self.raw_manifest["exposures"],
+            **self.raw_manifest["metrics"],
+        }
+
+    @classmethod
+    def node_info_to_asset_key(cls, node_info: Mapping[str, Any]) -> AssetKey:
+        return default_asset_key_fn(node_info)
+
+    @property
+    def node_info_by_asset_key(self) -> Mapping[AssetKey, Mapping[str, Any]]:
+        """A mapping of the default asset key for a dbt node to the node's dictionary representation in the manifest.
+        """
+        return {
+            self.node_info_to_asset_key(node): node
+            for node in self.node_info_by_dbt_unique_id.values()
+        }
+
+    @property
+    def node_info_by_output_name(self) -> Mapping[str, Mapping[str, Any]]:
+        """A mapping of the default output name for a dbt node to the node's dictionary representation in the manifest.
+        """
+        return {output_name_fn(node): node for node in self.node_info_by_dbt_unique_id.values()}
+
+    @property
+    def output_asset_key_replacements(self) -> Mapping[AssetKey, AssetKey]:
+        """A mapping of replacement asset keys for a dbt node to the node's dictionary representation in the manifest.
+        """
+        return {
+            DbtManifest.node_info_to_asset_key(node_info): self.node_info_to_asset_key(node_info)
+            for node_info in self.node_info_by_dbt_unique_id.values()
+        }
+
+    def get_node_info_by_output_name(self, output_name: str) -> Mapping[str, Any]:
+        """Get a dbt node's dictionary representation in the manifest by its Dagster output name."""
+        return self.node_info_by_output_name[output_name]
+
+    def get_node_info_by_asset_key(self, asset_key: AssetKey) -> Mapping[str, Any]:
+        """Get a dbt node's dictionary representation in the manifest by its Dagster output name."""
+        return self.node_info_by_asset_key[asset_key]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -245,6 +245,7 @@ def select_unique_ids_from_manifest(
     state_path: Optional[str] = None,
     manifest_json_path: Optional[str] = None,
     manifest_json: Optional[Mapping[str, Any]] = None,
+    manifest_parsed: Optional[Any] = None,
 ) -> AbstractSet[str]:
     """Method to apply a selection string to an existing manifest.json file."""
     import dbt.graph.cli as graph_cli
@@ -294,8 +295,11 @@ def select_unique_ids_from_manifest(
             },
         )
         child_map = manifest_json["child_map"]
+    elif manifest_parsed is not None:
+        manifest = manifest_parsed
+        child_map = manifest.child_map
     else:
-        check.failed("Must provide either a manifest_json_path or manifest_json.")
+        check.failed("Must provide either a manifest_json_path, manifest_json, or manifest_parsed.")
     graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
 
     # create a parsed selection from the select string

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/test_asset_decorator.py
@@ -1,0 +1,112 @@
+from typing import AbstractSet, Optional
+
+import pytest
+from dagster import AssetKey, file_relative_path
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.cli import DbtManifest
+
+manifest_path = file_relative_path(__file__, "sample_manifest.json")
+manifest = DbtManifest.read(path=manifest_path)
+
+
+@pytest.mark.parametrize(
+    "select,exclude,expected_asset_names",
+    [
+        (
+            "*",
+            None,
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+                "sort_hot_cereals_by_calories",
+                "orders_snapshot",
+                "cereals",
+            },
+        ),
+        (
+            "+least_caloric",
+            None,
+            {"sort_by_calories", "subdir_schema/least_caloric", "cereals"},
+        ),
+        (
+            "sort_by_calories least_caloric",
+            None,
+            {"sort_by_calories", "subdir_schema/least_caloric"},
+        ),
+        (
+            "tag:bar+",
+            None,
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+                "sort_hot_cereals_by_calories",
+                "orders_snapshot",
+            },
+        ),
+        (
+            "tag:foo",
+            None,
+            {"sort_by_calories", "cold_schema/sort_cold_cereals_by_calories"},
+        ),
+        (
+            "tag:foo,tag:bar",
+            None,
+            {"sort_by_calories"},
+        ),
+        (
+            None,
+            "sort_hot_cereals_by_calories",
+            {
+                "sort_by_calories",
+                "cold_schema/sort_cold_cereals_by_calories",
+                "subdir_schema/least_caloric",
+                "cereals",
+                "orders_snapshot",
+            },
+        ),
+        (
+            None,
+            "+least_caloric",
+            {
+                "cold_schema/sort_cold_cereals_by_calories",
+                "sort_hot_cereals_by_calories",
+                "orders_snapshot",
+            },
+        ),
+        (
+            None,
+            "sort_by_calories least_caloric",
+            {
+                "cold_schema/sort_cold_cereals_by_calories",
+                "sort_hot_cereals_by_calories",
+                "orders_snapshot",
+                "cereals",
+            },
+        ),
+        (
+            None,
+            "tag:foo",
+            {
+                "subdir_schema/least_caloric",
+                "sort_hot_cereals_by_calories",
+                "orders_snapshot",
+                "cereals",
+            },
+        ),
+    ],
+)
+def test_selections(
+    select: Optional[str], exclude: Optional[str], expected_asset_names: AbstractSet[str]
+) -> None:
+    @dbt_assets(
+        manifest=manifest,
+        select=select or "fqn:*",
+        exclude=exclude,
+    )
+    def my_dbt_assets():
+        ...
+
+    expected_asset_keys = {AssetKey(key.split("/")) for key in expected_asset_names}
+    assert my_dbt_assets.keys == expected_asset_keys


### PR DESCRIPTION
## Summary & Motivation
Begin the scaffold for a `dbt_asset` decorator. The decorator takes in a dbt manifest and dbt select statement syntax and creates the corresponding asset definitions for the dbt models. In later diffs in the stack, we provide support for the user to populate the compute function for the decorator. 

## How I Tested These Changes
pytest
