### PR TITLE
Asset policy evaluations storage methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_reason.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_reason.py
@@ -4,6 +4,7 @@ from typing import NamedTuple, Union
 from dagster._serdes import whitelist_for_serdes
 
 
+@whitelist_for_serdes
 class AutoMaterializeDecisionType(Enum):
     """Represents the set of results of the auto-materialize logic.
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -4,6 +4,7 @@ from typing import List, NamedTuple, Optional, Sequence, Union
 from typing_extensions import TypeAlias
 
 import dagster._check as check
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeAssetEvaluation
 
 # re-export
 from dagster._core.definitions.run_request import (
@@ -588,3 +589,8 @@ def _validate_tick_args(
             status == TickStatus.SKIPPED,
             "Tick status was not SKIPPED but skip_reason was provided",
         )
+
+
+class AutoMaterializeAssetEvaluationRecord(NamedTuple):
+    evaluation: AutoMaterializeAssetEvaluation
+    evaluation_id: int

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -661,7 +661,7 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
         )
 
     def get_auto_materialize_asset_evaluations(
-        self, asset_key: "AssetKey", limit: Optional[int] = None, cursor: Optional[int] = None
+        self, asset_key: "AssetKey", limit: int, cursor: Optional[int] = None
     ) -> Sequence["AutoMaterializeAssetEvaluationRecord"]:
         return self._storage.schedule_storage.get_auto_materialize_asset_evaluations(
             asset_key, limit, cursor

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -9,8 +9,11 @@ from typing import (
     Union,
 )
 
-from dagster import _check as check
+from dagster import (
+    _check as check,
+)
 from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeAssetEvaluation
 from dagster._core.event_api import EventHandlerFn
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import PrintFn
@@ -36,6 +39,7 @@ if TYPE_CHECKING:
     from dagster._core.host_representation.origin import ExternalJobOrigin
     from dagster._core.instance import DagsterInstance
     from dagster._core.scheduler.instigation import (
+        AutoMaterializeAssetEvaluationRecord,
         InstigatorState,
         InstigatorStatus,
         InstigatorTick,
@@ -645,6 +649,22 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
     ) -> None:
         return self._storage.schedule_storage.purge_ticks(
             origin_id, selector_id, before, tick_statuses
+        )
+
+    def add_auto_materialize_asset_evaluations(
+        self,
+        evaluation_id: int,
+        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+    ) -> None:
+        return self._storage.schedule_storage.add_auto_materialize_asset_evaluations(
+            evaluation_id, asset_evaluations
+        )
+
+    def get_auto_materialize_asset_evaluations(
+        self, asset_key: "AssetKey", limit: Optional[int] = None, cursor: Optional[int] = None
+    ) -> Sequence["AutoMaterializeAssetEvaluationRecord"]:
+        return self._storage.schedule_storage.get_auto_materialize_asset_evaluations(
+            asset_key, limit, cursor
         )
 
     def upgrade(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -147,7 +147,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abc.abstractmethod
     def get_auto_materialize_asset_evaluations(
-        self, asset_key: AssetKey, limit: Optional[int] = None, cursor: Optional[int] = None
+        self, asset_key: AssetKey, limit: int, cursor: Optional[int] = None
     ) -> Sequence[AutoMaterializeAssetEvaluationRecord]:
         """Get the policy evaluations for a given asset.
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -1,9 +1,12 @@
 import abc
 from typing import Mapping, Optional, Sequence, Set
 
+from dagster import AssetKey
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeAssetEvaluation
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.scheduler.instigation import (
+    AutoMaterializeAssetEvaluationRecord,
     InstigatorState,
     InstigatorStatus,
     InstigatorTick,
@@ -132,6 +135,26 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             selector_id (str): The logical instigator identifier
             before (datetime): All ticks before this datetime will get purged
             tick_statuses (Optional[List[TickStatus]]): The tick statuses to wipe
+        """
+
+    @abc.abstractmethod
+    def add_auto_materialize_asset_evaluations(
+        self,
+        evaluation_id: int,
+        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+    ) -> None:
+        """Add asset policy evaluations to storage."""
+
+    @abc.abstractmethod
+    def get_auto_materialize_asset_evaluations(
+        self, asset_key: AssetKey, limit: Optional[int] = None, cursor: Optional[int] = None
+    ) -> Sequence[AutoMaterializeAssetEvaluationRecord]:
+        """Get the policy evaluations for a given asset.
+
+        Args:
+            asset_key (AssetKey): The asset key to query
+            limit (Optional[int]): The maximum number of evaluations to return
+            cursor (Optional[int]): The cursor to paginate from
         """
 
     @abc.abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -20,9 +20,12 @@ import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
 
 import dagster._check as check
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.scheduler.instigation import (
+    AutoMaterializeAssetEvaluationRecord,
     InstigatorState,
     InstigatorStatus,
     InstigatorTick,
@@ -41,7 +44,13 @@ from .migration import (
     SCHEDULE_JOBS_SELECTOR_ID,
     SCHEDULE_TICKS_SELECTOR_ID,
 )
-from .schema import InstigatorsTable, JobTable, JobTickTable, SecondaryIndexMigrationTable
+from .schema import (
+    AssetPolicyEvaluationsTable,
+    InstigatorsTable,
+    JobTable,
+    JobTickTable,
+    SecondaryIndexMigrationTable,
+)
 
 T_NamedTuple = TypeVar("T_NamedTuple", bound=NamedTuple)
 
@@ -445,6 +454,57 @@ class SqlScheduleStorage(ScheduleStorage):
 
         with self.connect() as conn:
             conn.execute(query)
+
+    def add_auto_materialize_asset_evaluations(
+        self,
+        evaluation_id: int,
+        asset_evaluations: Sequence[AutoMaterializeAssetEvaluation],
+    ):
+        check.invariant(len(asset_evaluations) > 0)
+        with self.connect() as conn:
+            bulk_insert = AssetPolicyEvaluationsTable.insert().values(
+                [
+                    {
+                        "evaluation_id": evaluation_id,
+                        "asset_key": evaluation.asset_key.to_string(),
+                        "asset_evaluation_body": serialize_value(evaluation),
+                        "num_requested": evaluation.num_requested,
+                        "num_skipped": evaluation.num_skipped,
+                        "num_discarded": evaluation.num_discarded,
+                    }
+                    for evaluation in asset_evaluations
+                ]
+            )
+            conn.execute(bulk_insert)
+
+    def get_auto_materialize_asset_evaluations(
+        self, asset_key: AssetKey, limit: Optional[int] = None, cursor: Optional[int] = None
+    ) -> Sequence[AutoMaterializeAssetEvaluationRecord]:
+        with self.connect() as conn:
+            query = (
+                db.select(
+                    [
+                        AssetPolicyEvaluationsTable.c.asset_evaluation_body,
+                        AssetPolicyEvaluationsTable.c.evaluation_id,
+                    ]
+                )
+                .where(AssetPolicyEvaluationsTable.c.asset_key == asset_key.to_string())
+                .order_by(AssetPolicyEvaluationsTable.c.evaluation_id.desc())
+            )
+            if limit:
+                query = query.limit(limit)
+            if cursor:
+                query = query.where(AssetPolicyEvaluationsTable.c.evaluation_id < cursor)
+            rows = conn.execute(query)
+            return [
+                AutoMaterializeAssetEvaluationRecord(
+                    evaluation=deserialize_value(
+                        row["asset_evaluation_body"], AutoMaterializeAssetEvaluation
+                    ),
+                    evaluation_id=row["evaluation_id"],
+                )
+                for row in rows
+            ]
 
     def wipe(self) -> None:
         """Clears the schedule storage."""

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -4,6 +4,12 @@ import time
 import pendulum
 import pytest
 
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    AutoMaterializeAssetEvaluation,
+    AutoMaterializeCondition,
+    AutoMaterializeReason,
+)
+from dagster._core.definitions.events import AssetKey
 from dagster._core.host_representation import (
     ExternalRepositoryOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
@@ -669,3 +675,69 @@ class TestScheduleStorage:
         assert len(ticks_by_origin["sensor_one"]) == 1
         assert ticks_by_origin["sensor_one"][0].tick_id == b.tick_id
         assert ticks_by_origin["sensor_two"][0].tick_id == d.tick_id
+
+    def test_auto_materialize_asset_evaluations(self, storage):
+        storage.add_auto_materialize_asset_evaluations(
+            evaluation_id=10,
+            asset_evaluations=[
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_one"),
+                    materialize_reasons=[],
+                    skip_reasons=[],
+                    num_requested=0,
+                    num_skipped=0,
+                    num_discarded=0,
+                ),
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_two"),
+                    materialize_reasons=[AutoMaterializeReason(AutoMaterializeCondition.FRESHNESS)],
+                    skip_reasons=[],
+                    num_requested=1,
+                    num_skipped=0,
+                    num_discarded=0,
+                ),
+            ],
+        )
+
+        res = storage.get_auto_materialize_asset_evaluations(asset_key=AssetKey("asset_one"))
+        assert len(res) == 1
+        assert res[0].evaluation.asset_key == AssetKey("asset_one")
+        assert res[0].evaluation_id == 10
+        assert res[0].evaluation.num_requested == 0
+
+        res = storage.get_auto_materialize_asset_evaluations(asset_key=AssetKey("asset_two"))
+        assert len(res) == 1
+        assert res[0].evaluation.asset_key == AssetKey("asset_two")
+        assert res[0].evaluation_id == 10
+        assert res[0].evaluation.num_requested == 1
+
+        storage.add_auto_materialize_asset_evaluations(
+            evaluation_id=11,
+            asset_evaluations=[
+                AutoMaterializeAssetEvaluation(
+                    asset_key=AssetKey("asset_one"),
+                    materialize_reasons=[],
+                    skip_reasons=[],
+                    num_requested=0,
+                    num_skipped=0,
+                    num_discarded=0,
+                ),
+            ],
+        )
+
+        res = storage.get_auto_materialize_asset_evaluations(asset_key=AssetKey("asset_one"))
+        assert len(res) == 2
+        assert res[0].evaluation_id == 11
+        assert res[1].evaluation_id == 10
+
+        res = storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset_one"), limit=1
+        )
+        assert len(res) == 1
+        assert res[0].evaluation_id == 11
+
+        res = storage.get_auto_materialize_asset_evaluations(
+            asset_key=AssetKey("asset_one"), limit=1, cursor=11
+        )
+        assert len(res) == 1
+        assert res[0].evaluation_id == 10

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -57,6 +57,9 @@ class TestScheduleStorage:
     def can_purge(self):
         return True
 
+    def can_store_auto_materialize_asset_evaluations(self):
+        return True
+
     @staticmethod
     def fake_repo_target():
         return ExternalRepositoryOrigin(
@@ -676,6 +679,9 @@ class TestScheduleStorage:
         assert ticks_by_origin["sensor_two"][0].tick_id == d.tick_id
 
     def test_auto_materialize_asset_evaluations(self, storage):
+        if not self.can_store_auto_materialize_asset_evaluations():
+            pytest.skip("Storage cannot store auto materialize asset evaluations")
+
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=10,
             asset_evaluations=[

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_materialize_asset_evaluation.py
@@ -1,0 +1,82 @@
+from dagster import AssetKey, StaticPartitionsDefinition, asset
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_reconciliation_sensor import (
+    AutoMaterializeAssetEvaluation,
+    AutoMaterializeCondition,
+    AutoMaterializeReason,
+    AutoMaterializeSkipCondition,
+    AutoMaterializeSkipReason,
+)
+from dagster._core.definitions.events import AssetKeyPartitionKey
+
+partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])
+
+
+@asset(partitions_def=partitions)
+def my_asset(_):
+    pass
+
+
+def test_num_requested():
+    asset_graph = AssetGraph.from_assets([my_asset])
+
+    e1 = AutoMaterializeAssetEvaluation.from_reasons(
+        asset_graph=asset_graph,
+        asset_key=AssetKey("my_asset"),
+        materialize_reasons={},
+        skip_reasons={},
+    )
+    assert e1.num_requested == 0
+    assert e1.num_skipped == 0
+    assert e1.num_discarded == 0
+
+    e2 = AutoMaterializeAssetEvaluation.from_reasons(
+        asset_graph=asset_graph,
+        asset_key=AssetKey("my_asset"),
+        materialize_reasons={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeReason(
+                AutoMaterializeCondition.FRESHNESS
+            )
+        },
+        skip_reasons={},
+    )
+
+    assert e2.num_requested == 1
+    assert e2.num_skipped == 0
+
+    e3 = AutoMaterializeAssetEvaluation.from_reasons(
+        asset_graph=asset_graph,
+        asset_key=AssetKey("my_asset"),
+        materialize_reasons={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeReason(
+                AutoMaterializeCondition.FRESHNESS
+            )
+        },
+        skip_reasons={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeSkipReason(
+                AutoMaterializeSkipCondition.PARENT_OUTDATED
+            )
+        },
+    )
+    assert e3.num_requested == 0
+    assert e3.num_skipped == 1
+
+    e4 = AutoMaterializeAssetEvaluation.from_reasons(
+        asset_graph=asset_graph,
+        asset_key=AssetKey("my_asset"),
+        materialize_reasons={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeReason(
+                AutoMaterializeCondition.FRESHNESS
+            ),
+            AssetKeyPartitionKey(AssetKey("my_asset"), "b"): AutoMaterializeReason(
+                AutoMaterializeCondition.FRESHNESS
+            ),
+        },
+        skip_reasons={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeSkipReason(
+                AutoMaterializeSkipCondition.PARENT_OUTDATED
+            )
+        },
+    )
+    assert e4.num_requested == 1
+    assert e4.num_skipped == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_materialize_asset_evaluation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/test_auto_materialize_asset_evaluation.py
@@ -1,11 +1,9 @@
 from dagster import AssetKey, StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_reconciliation_sensor import (
-    AutoMaterializeAssetEvaluation,
-    AutoMaterializeCondition,
-    AutoMaterializeReason,
-    AutoMaterializeSkipCondition,
-    AutoMaterializeSkipReason,
+from dagster._core.definitions.asset_reconciliation_sensor import AutoMaterializeAssetEvaluation
+from dagster._core.definitions.auto_materialize_reason import (
+    MissingAutoMaterializeCondition,
+    ParentOutdatedAutoMaterializeCondition,
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
@@ -20,63 +18,54 @@ def my_asset(_):
 def test_num_requested():
     asset_graph = AssetGraph.from_assets([my_asset])
 
-    e1 = AutoMaterializeAssetEvaluation.from_reasons(
+    e1 = AutoMaterializeAssetEvaluation.from_conditions(
         asset_graph=asset_graph,
         asset_key=AssetKey("my_asset"),
-        materialize_reasons={},
-        skip_reasons={},
+        conditions_by_asset_partition={},
     )
     assert e1.num_requested == 0
     assert e1.num_skipped == 0
     assert e1.num_discarded == 0
 
-    e2 = AutoMaterializeAssetEvaluation.from_reasons(
+    e2 = AutoMaterializeAssetEvaluation.from_conditions(
         asset_graph=asset_graph,
         asset_key=AssetKey("my_asset"),
-        materialize_reasons={
-            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeReason(
-                AutoMaterializeCondition.FRESHNESS
-            )
+        conditions_by_asset_partition={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): {MissingAutoMaterializeCondition()}
         },
-        skip_reasons={},
     )
 
     assert e2.num_requested == 1
     assert e2.num_skipped == 0
+    assert e2.num_discarded == 0
 
-    e3 = AutoMaterializeAssetEvaluation.from_reasons(
+    e3 = AutoMaterializeAssetEvaluation.from_conditions(
         asset_graph=asset_graph,
         asset_key=AssetKey("my_asset"),
-        materialize_reasons={
-            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeReason(
-                AutoMaterializeCondition.FRESHNESS
-            )
-        },
-        skip_reasons={
-            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeSkipReason(
-                AutoMaterializeSkipCondition.PARENT_OUTDATED
-            )
+        conditions_by_asset_partition={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): {
+                MissingAutoMaterializeCondition(),
+                ParentOutdatedAutoMaterializeCondition(),
+            }
         },
     )
     assert e3.num_requested == 0
     assert e3.num_skipped == 1
+    assert e3.num_discarded == 0
 
-    e4 = AutoMaterializeAssetEvaluation.from_reasons(
+    e4 = AutoMaterializeAssetEvaluation.from_conditions(
         asset_graph=asset_graph,
         asset_key=AssetKey("my_asset"),
-        materialize_reasons={
-            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeReason(
-                AutoMaterializeCondition.FRESHNESS
-            ),
-            AssetKeyPartitionKey(AssetKey("my_asset"), "b"): AutoMaterializeReason(
-                AutoMaterializeCondition.FRESHNESS
-            ),
-        },
-        skip_reasons={
-            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): AutoMaterializeSkipReason(
-                AutoMaterializeSkipCondition.PARENT_OUTDATED
-            )
+        conditions_by_asset_partition={
+            AssetKeyPartitionKey(AssetKey("my_asset"), "a"): {
+                MissingAutoMaterializeCondition(),
+                ParentOutdatedAutoMaterializeCondition(),
+            },
+            AssetKeyPartitionKey(AssetKey("my_asset"), "b"): {
+                MissingAutoMaterializeCondition(),
+            },
         },
     )
     assert e4.num_requested == 1
     assert e4.num_skipped == 1
+    assert e4.num_discarded == 0


### PR DESCRIPTION
Insert 1 evaluation id at at time for many assets (for the daemon)
Read 1 asset at a time, with many evaluation ids (for the ui)