### PR TITLE
[Cancel asset backfill 1/2] Enable cancel backfill buttons in UI

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2419,7 +2419,7 @@ type PartitionBackfill {
   partitionNames: [String!]
   isValidSerialization: Boolean!
   numPartitions: Int
-  numCancelable: Int!
+  numCancelablePartitions: Int!
   fromFailure: Boolean!
   reexecutionSteps: [String!]
   assetSelection: [AssetKey!]
@@ -2430,7 +2430,7 @@ type PartitionBackfill {
   runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
-  partitionStatuses: PartitionStatuses!
+  backfillRunStatuses: PartitionStatuses!
   partitionStatusCounts: [PartitionStatusCounts!]!
   isAssetBackfill: Boolean!
   assetBackfillData: AssetBackfillData

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2305,6 +2305,7 @@ export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
   assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
+  backfillRunStatuses: PartitionStatuses;
   endTimestamp: Maybe<Scalars['Float']>;
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean'];
@@ -2313,13 +2314,12 @@ export type PartitionBackfill = {
   id: Scalars['String'];
   isAssetBackfill: Scalars['Boolean'];
   isValidSerialization: Scalars['Boolean'];
-  numCancelable: Scalars['Int'];
+  numCancelablePartitions: Scalars['Int'];
   numPartitions: Maybe<Scalars['Int']>;
   partitionNames: Maybe<Array<Scalars['String']>>;
   partitionSet: Maybe<PartitionSet>;
   partitionSetName: Maybe<Scalars['String']>;
   partitionStatusCounts: Array<PartitionStatusCounts>;
-  partitionStatuses: PartitionStatuses;
   reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
   status: BulkActionStatus;
@@ -8215,6 +8215,12 @@ export const buildPartitionBackfill = (
         : buildAssetBackfillData({}, relationshipsToOmit),
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    backfillRunStatuses:
+      overrides && overrides.hasOwnProperty('backfillRunStatuses')
+        ? overrides.backfillRunStatuses!
+        : relationshipsToOmit.has('PartitionStatuses')
+        ? ({} as PartitionStatuses)
+        : buildPartitionStatuses({}, relationshipsToOmit),
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 0.33,
     error:
@@ -8240,8 +8246,10 @@ export const buildPartitionBackfill = (
       overrides && overrides.hasOwnProperty('isValidSerialization')
         ? overrides.isValidSerialization!
         : false,
-    numCancelable:
-      overrides && overrides.hasOwnProperty('numCancelable') ? overrides.numCancelable! : 53,
+    numCancelablePartitions:
+      overrides && overrides.hasOwnProperty('numCancelablePartitions')
+        ? overrides.numCancelablePartitions!
+        : 3631,
     numPartitions:
       overrides && overrides.hasOwnProperty('numPartitions') ? overrides.numPartitions! : 4165,
     partitionNames:
@@ -8260,12 +8268,6 @@ export const buildPartitionBackfill = (
       overrides && overrides.hasOwnProperty('partitionStatusCounts')
         ? overrides.partitionStatusCounts!
         : [],
-    partitionStatuses:
-      overrides && overrides.hasOwnProperty('partitionStatuses')
-        ? overrides.partitionStatuses!
-        : relationshipsToOmit.has('PartitionStatuses')
-        ? ({} as PartitionStatuses)
-        : buildPartitionStatuses({}, relationshipsToOmit),
     reexecutionSteps:
       overrides && overrides.hasOwnProperty('reexecutionSteps') ? overrides.reexecutionSteps! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -32,11 +32,6 @@ import {
 } from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
 
-const NoBackfillStatusQuery = [
-  () => Promise.resolve({data: undefined} as QueryResult<undefined>),
-  {data: undefined, called: true, loading: false} as QueryResult<undefined>,
-] as const;
-
 export const BackfillRow = ({
   backfill,
   allPartitions,
@@ -78,11 +73,10 @@ export const BackfillRow = ({
   // If the number of partitions or partition names are missing, we use a mock to
   // avoid executing any query at all. This is a bit awkward, but seems cleaner than
   // making the hooks below support an optional query function / result.
-  const [statusQueryFn, statusQueryResult] = statusUnsupported
-    ? NoBackfillStatusQuery
-    : (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
-    ? statusCounts
-    : statusDetails;
+  const [statusQueryFn, statusQueryResult] =
+    (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
+      ? statusCounts
+      : statusDetails;
 
   useDelayedRowQuery(statusQueryFn);
   useQueryRefreshAtInterval(statusQueryResult, FIFTEEN_SECONDS);
@@ -193,7 +187,6 @@ const BackfillMenu = ({
       value: `dagster/backfill=${backfill.id}`,
     },
   ]);
-
   return (
     <Popover
       content={

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -1,4 +1,4 @@
-import {gql, QueryResult, useLazyQuery} from '@apollo/client';
+import {gql, useLazyQuery} from '@apollo/client';
 import {Box, Button, Colors, Icon, MenuItem, Menu, Popover, Tag, Mono} from '@dagster-io/ui';
 import countBy from 'lodash/countBy';
 import * as React from 'react';
@@ -92,7 +92,7 @@ export const BackfillRow = ({
       );
       return {counts, statuses: null};
     }
-    const statuses = data.partitionBackfillOrError.partitionStatuses.results;
+    const statuses = data.partitionBackfillOrError.backfillRunStatuses.results;
     const counts = countBy(statuses, (k) => k.runStatus);
     return {counts, statuses};
   }, [data]);
@@ -187,13 +187,14 @@ const BackfillMenu = ({
       value: `dagster/backfill=${backfill.id}`,
     },
   ]);
+
   return (
     <Popover
       content={
         <Menu>
           {backfill.hasCancelPermission ? (
             <>
-              {backfill.numCancelable > 0 ? (
+              {backfill.numCancelablePartitions > 0 ? (
                 <MenuItem
                   text="Cancel backfill submission"
                   icon="cancel"
@@ -491,7 +492,7 @@ export const SINGLE_BACKFILL_STATUS_DETAILS_QUERY = gql`
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
         id
-        partitionStatuses {
+        backfillRunStatuses {
           ...PartitionStatusesForBackfill
         }
       }

--- a/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTable.tsx
@@ -133,7 +133,7 @@ export const BACKFILL_TABLE_FRAGMENT = gql`
     isAssetBackfill
     hasCancelPermission
     hasResumePermission
-    numCancelable
+    numCancelablePartitions
     partitionNames
     isValidSerialization
     numPartitions

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -39,7 +39,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     if (!backfill || !data || data.partitionBackfillOrError.__typename !== 'PartitionBackfill') {
       return {};
     }
-    const unfinishedPartitions = data.partitionBackfillOrError.partitionStatuses.results.filter(
+    const unfinishedPartitions = data.partitionBackfillOrError.backfillRunStatuses.results.filter(
       (partition) =>
         partition.runStatus && partition.runId && cancelableStatuses.has(partition.runStatus),
     );
@@ -55,7 +55,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     return null;
   }
 
-  const numUnscheduled = backfill.numCancelable;
+  const numUnscheduled = backfill.numCancelablePartitions;
   const cancel = async () => {
     setIsSubmitting(true);
     await cancelBackfill({variables: {backfillId: backfill.id}});

--- a/js_modules/dagit/packages/core/src/instance/__fixtures__/BackfillTable.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/instance/__fixtures__/BackfillTable.fixtures.ts
@@ -41,7 +41,7 @@ export const BackfillTableFragmentRequested2000AssetsPure: BackfillTableFragment
     partitionSetName: null,
     partitionSet: null,
     error: null,
-    numCancelable: 0,
+    numCancelablePartitions: 0,
     partitionNames: buildTimePartitionNames(new Date('2020-01-01'), 2000),
     assetSelection: [
       buildAssetKey({
@@ -105,7 +105,7 @@ export const BackfillTableFragmentCancelledAssetsPartitionSet: BackfillTableFrag
       }),
     }),
     error: null,
-    numCancelable: 0,
+    numCancelablePartitions: 0,
     partitionNames: buildTimePartitionNames(new Date('2020-01-01'), 5000),
     assetSelection: [
       buildAssetKey({
@@ -154,7 +154,7 @@ export const BackfillTableFragmentFailedError: BackfillTableFragment = buildPart
     stack: ['OMITTED FROM MOCKS'],
     errorChain: [],
   }),
-  numCancelable: 0,
+  numCancelablePartitions: 0,
   partitionNames: buildTimePartitionNames(new Date('2020-01-01'), 100),
   assetSelection: [
     buildAssetKey({
@@ -175,7 +175,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
       __typename: 'DagitQuery',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'sjqzcfhe',
-        partitionStatuses: buildPartitionStatuses({
+        backfillRunStatuses: buildPartitionStatuses({
           results: BackfillTableFragmentFailedError.partitionNames!.map((n) =>
             buildPartitionStatus({
               id: `__NO_PARTITION_SET__:${n}:ccpbwdbq`,
@@ -213,7 +213,7 @@ export const BackfillTableFragmentCompletedAssetJob: BackfillTableFragment = bui
       }),
     }),
     error: null,
-    numCancelable: 0,
+    numCancelablePartitions: 0,
     partitionNames: [
       'TN|2023-01-24',
       'VA|2023-01-24',
@@ -247,7 +247,7 @@ export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<Single
       __typename: 'DagitQuery',
       partitionBackfillOrError: {
         id: 'pwgcpiwc',
-        partitionStatuses: {
+        backfillRunStatuses: {
           results: [
             {
               id: 'asset_job_partition_set:TN|2023-01-24:pwgcpiwc',
@@ -356,7 +356,7 @@ export const BackfillTableFragmentCompletedOpJob: BackfillTableFragment = buildP
     }),
   }),
   error: null,
-  numCancelable: 0,
+  numCancelablePartitions: 0,
   partitionNames: ['2022-07-01', '2022-08-01', '2022-09-01', '2022-10-01'],
   assetSelection: null,
 });
@@ -374,7 +374,7 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'pqdiepuf',
         isAssetBackfill: true,
-        partitionStatuses: buildPartitionStatuses({
+        backfillRunStatuses: buildPartitionStatuses({
           results: [
             buildPartitionStatus({
               id: 'op_job_partition_set:2022-07-01:pqdiepuf',
@@ -419,7 +419,7 @@ export const BackfillTableFragmentInvalidPartitionSet: BackfillTableFragment = b
     partitionSetName: null,
     partitionSet: null,
     error: null,
-    numCancelable: 0,
+    numCancelablePartitions: 0,
     partitionNames: [],
     isAssetBackfill: true,
     assetSelection: [
@@ -461,7 +461,7 @@ export const BackfillTablePureAssetCountsOnly: BackfillTableFragment = buildPart
       }),
     ],
   }),
-  numCancelable: 0,
+  numCancelablePartitions: 0,
   partitionNames: null,
   assetSelection: [
     buildAssetKey({
@@ -491,7 +491,7 @@ const BackfillTablePureAssetNoCountsOrPartitionNames: BackfillTableFragment = bu
       stack: ['OMITTED FROM MOCKS'],
       errorChain: [],
     }),
-    numCancelable: 0,
+    numCancelablePartitions: 0,
     partitionNames: null,
     assetSelection: [
       buildAssetKey({

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
@@ -33,7 +33,7 @@ export type SingleBackfillQuery = {
     | {
         __typename: 'PartitionBackfill';
         id: string;
-        partitionStatuses: {
+        backfillRunStatuses: {
           __typename: 'PartitionStatuses';
           results: Array<{
             __typename: 'PartitionStatus';

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillTable.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillTable.types.ts
@@ -9,7 +9,7 @@ export type BackfillTableFragment = {
   isAssetBackfill: boolean;
   hasCancelPermission: boolean;
   hasResumePermission: boolean;
-  numCancelable: number;
+  numCancelablePartitions: number;
   partitionNames: Array<string> | null;
   isValidSerialization: boolean;
   numPartitions: number | null;

--- a/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/InstanceBackfills.types.ts
@@ -56,7 +56,7 @@ export type InstanceBackfillsQuery = {
           isAssetBackfill: boolean;
           hasCancelPermission: boolean;
           hasResumePermission: boolean;
-          numCancelable: number;
+          numCancelablePartitions: number;
           partitionNames: Array<string> | null;
           partitionSet: {
             __typename: 'PartitionSet';

--- a/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagit/packages/core/src/partitions/types/JobBackfillsTable.types.ts
@@ -23,7 +23,7 @@ export type JobBackfillsQuery = {
           isAssetBackfill: boolean;
           hasCancelPermission: boolean;
           hasResumePermission: boolean;
-          numCancelable: number;
+          numCancelablePartitions: number;
           partitionNames: Array<string> | null;
           isValidSerialization: boolean;
           numPartitions: number | null;

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -30,6 +30,24 @@ if TYPE_CHECKING:
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
 
+def _assert_permission_for_asset_graph(
+    graphene_info: "ResolveInfo", asset_graph: ExternalAssetGraph, permission: str
+) -> None:
+    location_names = set(
+        repo_handle.code_location_origin.location_name
+        for repo_handle in asset_graph.repository_handles_by_key.values()
+    )
+
+    if not location_names:
+        assert_permission(
+            graphene_info,
+            permission,
+        )
+    else:
+        for location_name in location_names:
+            assert_permission_for_location(graphene_info, permission, location_name)
+
+
 def create_and_launch_partition_backfill(
     graphene_info: "ResolveInfo",
     backfill_params: BackfillParams,
@@ -136,22 +154,9 @@ def create_and_launch_partition_backfill(
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
         asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
-
-        location_names = set(
-            repo_handle.code_location_origin.location_name
-            for repo_handle in asset_graph.repository_handles_by_key.values()
+        _assert_permission_for_asset_graph(
+            graphene_info, asset_graph, Permissions.LAUNCH_PARTITION_BACKFILL
         )
-
-        if not location_names:
-            assert_permission(
-                graphene_info,
-                Permissions.LAUNCH_PARTITION_BACKFILL,
-            )
-        else:
-            for location_name in location_names:
-                assert_permission_for_location(
-                    graphene_info, Permissions.LAUNCH_PARTITION_BACKFILL, location_name
-                )
 
         backfill = PartitionBackfill.from_asset_partitions(
             asset_graph=asset_graph,
@@ -184,11 +189,17 @@ def cancel_partition_backfill(
     if not backfill:
         check.failed(f"No backfill found for id: {backfill_id}")
 
-    partition_set_origin = check.not_none(backfill.partition_set_origin)
-    location_name = partition_set_origin.selector.location_name
-    assert_permission_for_location(
-        graphene_info, Permissions.CANCEL_PARTITION_BACKFILL, location_name
-    )
+    if backfill.serialized_asset_backfill_data:
+        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        _assert_permission_for_asset_graph(
+            graphene_info, asset_graph, Permissions.CANCEL_PARTITION_BACKFILL
+        )
+    else:
+        partition_set_origin = check.not_none(backfill.partition_set_origin)
+        location_name = partition_set_origin.selector.location_name
+        assert_permission_for_location(
+            graphene_info, Permissions.CANCEL_PARTITION_BACKFILL, location_name
+        )
 
     graphene_info.context.instance.update_backfill(backfill.with_status(BulkActionStatus.CANCELED))
     return GrapheneCancelBackfillSuccess(backfill_id=backfill_id)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -259,7 +259,7 @@ def get_partition_set_partition_statuses(
 def partition_statuses_from_run_partition_data(
     partition_set_name: Optional[str],
     run_partition_data: Sequence[RunPartitionData],
-    partition_names: Sequence[str],
+    partition_names: Optional[Sequence[str]],
     backfill_id: Optional[str] = None,
 ) -> Sequence["GraphenePartitionStatus"]:
     from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
@@ -269,22 +269,18 @@ def partition_statuses_from_run_partition_data(
     }
 
     suffix = f":{backfill_id}" if backfill_id else ""
+    partition_id = (
+        lambda partition: f'{partition_set_name or "__NO_PARTITION_SET__"}:{partition}{suffix}'
+    )
 
     results = []
-    for name in partition_names:
-        partition_id = f'{partition_set_name or "__NO_PARTITION_SET__"}:{name}{suffix}'
-        if not partition_data_by_name.get(name):
-            results.append(
-                GraphenePartitionStatus(
-                    id=partition_id,
-                    partitionName=name,
-                )
-            )
+    for name, partition_data in partition_data_by_name.items():
+        if partition_names and name not in partition_names:
             continue
-        partition_data = partition_data_by_name[name]
+
         results.append(
             GraphenePartitionStatus(
-                id=partition_id,
+                id=partition_id(name),
                 partitionName=name,
                 runId=partition_data.run_id,
                 runStatus=partition_data.status.value,
@@ -293,6 +289,16 @@ def partition_statuses_from_run_partition_data(
                 else None,
             )
         )
+
+    if partition_names:
+        for name in partition_names:
+            if not partition_data_by_name.get(name):
+                results.append(
+                    GraphenePartitionStatus(
+                        id=partition_id(name),
+                        partitionName=name,
+                    )
+                )
 
     return GraphenePartitionStatuses(results=results)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         GraphenePartitionSets,
         GraphenePartitionStatus,
         GraphenePartitionStatusCounts,
+        GraphenePartitionStatuses,
         GraphenePartitionTags,
     )
 
@@ -252,55 +253,58 @@ def get_partition_set_partition_statuses(
         raise DagsterUserCodeProcessError.from_error_info(names_result.error)
 
     return partition_statuses_from_run_partition_data(
-        partition_set_name, run_partition_data, names_result.partition_names
+        run_partition_data, partition_set_name, names_result.partition_names
     )
 
 
-def partition_statuses_from_run_partition_data(
-    partition_set_name: Optional[str],
-    run_partition_data: Sequence[RunPartitionData],
-    partition_names: Optional[Sequence[str]],
+def _get_partition_id(
+    partition_name: str,
     backfill_id: Optional[str] = None,
-) -> Sequence["GraphenePartitionStatus"]:
+    partition_set_name: Optional[str] = None,
+):
+    suffix = f":{backfill_id}" if backfill_id else ""
+    return f'{partition_set_name or "__NO_PARTITION_SET__"}:{partition_name}{suffix}'
+
+
+def partition_statuses_from_run_partition_data(
+    run_partition_data: Sequence[RunPartitionData],
+    partition_set_name: Optional[str] = None,
+    partition_names: Optional[Sequence[str]] = None,
+    backfill_id: Optional[str] = None,
+) -> "GraphenePartitionStatuses":
     from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
 
     partition_data_by_name = {
         partition_data.partition: partition_data for partition_data in run_partition_data
     }
 
-    suffix = f":{backfill_id}" if backfill_id else ""
-    partition_id = (
-        lambda partition: f'{partition_set_name or "__NO_PARTITION_SET__"}:{partition}{suffix}'
-    )
-
-    results = []
+    status_by_partition = {}
     for name, partition_data in partition_data_by_name.items():
-        if partition_names and name not in partition_names:
-            continue
-
-        results.append(
-            GraphenePartitionStatus(
-                id=partition_id(name),
-                partitionName=name,
-                runId=partition_data.run_id,
-                runStatus=partition_data.status.value,
-                runDuration=partition_data.end_time - partition_data.start_time
-                if partition_data.end_time and partition_data.start_time
-                else None,
-            )
+        status_by_partition[name] = GraphenePartitionStatus(
+            id=_get_partition_id(name, backfill_id, partition_set_name),
+            partitionName=name,
+            runId=partition_data.run_id,
+            runStatus=partition_data.status.value,
+            runDuration=partition_data.end_time - partition_data.start_time
+            if partition_data.end_time and partition_data.start_time
+            else None,
         )
 
     if partition_names:
+        results = []
         for name in partition_names:
-            if not partition_data_by_name.get(name):
+            if name not in status_by_partition:
                 results.append(
                     GraphenePartitionStatus(
-                        id=partition_id(name),
+                        id=_get_partition_id(name, backfill_id, partition_set_name),
                         partitionName=name,
                     )
                 )
-
-    return GraphenePartitionStatuses(results=results)
+            else:
+                results.append(status_by_partition[name])
+        return GraphenePartitionStatuses(results=results)
+    else:
+        return GraphenePartitionStatuses(results=status_by_partition.values())
 
 
 def partition_status_counts_from_run_partition_data(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -260,7 +260,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         return self._backfill_job.get_num_partitions(_graphene_info.context)
 
     def resolve_numCancelable(self, _graphene_info: ResolveInfo) -> int:
-        return self._backfill_job.get_num_cancelable()
+        return self._backfill_job.get_num_cancelable(_graphene_info.context)
 
     def resolve_partitionSet(self, graphene_info: ResolveInfo) -> Optional["GraphenePartitionSet"]:
         from ..schema.partition_sets import GraphenePartitionSet
@@ -276,15 +276,24 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         )
 
     def resolve_partitionStatuses(self, graphene_info: ResolveInfo):
+        """For asset backfills, returns only statuses for runs that have been created."""
         partition_set_origin = self._backfill_job.partition_set_origin
         partition_set_name = (
             partition_set_origin.partition_set_name if partition_set_origin else None
         )
         partition_run_data = self._get_partition_run_data(graphene_info)
+
+        if not self._backfill_job.is_asset_backfill:
+            partition_names = check.not_none(
+                self._backfill_job.get_partition_names(graphene_info.context)
+            )
+        else:
+            partition_names = None
+
         return partition_statuses_from_run_partition_data(
             partition_set_name,
             partition_run_data,
-            check.not_none(self._backfill_job.get_partition_names(graphene_info.context)),
+            partition_names,
             backfill_id=self._backfill_job.backfill_id,
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -54,7 +54,7 @@ SINGLE_BACKFILL_QUERY = """
   query SingleBackfillQuery($backfillId: String!) {
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
-        partitionStatuses {
+        backfillRunStatuses {
           results {
             id
             partitionName
@@ -292,7 +292,7 @@ def test_launch_asset_backfill():
             assert not single_backfill_result.errors
             assert single_backfill_result.data
             partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
-                "partitionStatuses"
+                "backfillRunStatuses"
             ]["results"]
             assert len(partition_status_results) == 2
             assert {
@@ -347,7 +347,7 @@ def test_remove_partitions_defs_after_backfill():
             assert not single_backfill_result.errors
             assert single_backfill_result.data
             partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
-                "partitionStatuses"
+                "backfillRunStatuses"
             ]["results"]
             assert len(partition_status_results) == 0
             assert {

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -224,24 +224,41 @@ class PartitionBackfill(
 
             return self.partition_names
 
-    def get_num_cancelable(self) -> int:
-        if self.is_asset_backfill:
-            return 0
+    def get_num_cancelable(self, workspace: IWorkspace) -> int:
+        """Returns the number of partitions that are have not yet been requested by the backfill.
 
+        For asset backfills, returns back the sum of the number of unrequested partitions of each of
+        the targeted assets, counting an unpartitioned asset as 1 partition.
+        """
         if self.status != BulkActionStatus.REQUESTED:
             return 0
 
-        if self.partition_names is None:
-            check.failed("Expected partition_names to not be None for job backfill")
+        if self.is_asset_backfill:
+            num_cancelable = 0
+            for asset_status in self.get_backfill_status_per_asset_key(workspace):
+                # partitions that do not have a status have not been requested yet
+                if isinstance(asset_status, PartitionedAssetBackfillStatus):
+                    num_cancelable += asset_status.num_targeted_partitions - sum(
+                        asset_status.partitions_counts_by_status.values()
+                    )
+                elif isinstance(asset_status, UnpartitionedAssetBackfillStatus):
+                    num_cancelable += 1 if asset_status.backfill_status is None else 0
+                else:
+                    check.failed("Should not reach")
+            return num_cancelable
 
-        checkpoint = self.last_submitted_partition_name
-        total_count = len(self.partition_names)
-        checkpoint_idx = (
-            self.partition_names.index(checkpoint) + 1
-            if checkpoint and checkpoint in self.partition_names
-            else 0
-        )
-        return max(0, total_count - checkpoint_idx)
+        else:
+            if self.partition_names is None:
+                check.failed("Expected partition_names to not be None for job backfill")
+
+            checkpoint = self.last_submitted_partition_name
+            total_count = len(self.partition_names)
+            checkpoint_idx = (
+                self.partition_names.index(checkpoint) + 1
+                if checkpoint and checkpoint in self.partition_names
+                else 0
+            )
+            return max(0, total_count - checkpoint_idx)
 
     def with_status(self, status):
         check.inst_param(status, "status", BulkActionStatus)

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -224,7 +224,7 @@ class PartitionBackfill(
 
             return self.partition_names
 
-    def get_num_cancelable(self, workspace: IWorkspace) -> int:
+    def get_num_cancelable_partitions(self, workspace: IWorkspace) -> int:
         """Returns the number of partitions that are have not yet been requested by the backfill.
 
         For asset backfills, returns back the sum of the number of unrequested partitions of each of
@@ -236,7 +236,7 @@ class PartitionBackfill(
         if self.is_asset_backfill:
             num_cancelable = 0
             for asset_status in self.get_backfill_status_per_asset_key(workspace):
-                # partitions that do not have a status have not been requested yet
+                # Partitions that do not have a status have not been requested yet
                 if isinstance(asset_status, PartitionedAssetBackfillStatus):
                     num_cancelable += asset_status.num_targeted_partitions - sum(
                         asset_status.partitions_counts_by_status.values()


### PR DESCRIPTION
This PR is part 1 of 2 for enabling cancellations for asset backfills. The following buttons are now displayed in the backfill menu, bringing asset backfill cancellation functionality up to parity with job backfill cancellation:
- `Cancel backfill submission`, which marks the backfill as canceled and prevents more runs in the backfill from being created.
- `Terminate unfinished runs`, which marks the unfinished runs in the backfill as canceled.

This involves making changes to two resolvers, adding renames to clarify behavior:
- `numCancelablePartitions`: This resolver now returns back the number of partitions for which runs have not yet been created. This information is used to display a "There are X partitions yet to be queued or launched" confirmation message.
- `backfillRunStatuses`: This resolver now returns back the status for each partitioned run launched from the backfill.

<img width="1223" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/457292df-f3c8-4f39-8aa0-adec0fe897e9">

When the same partitions are targeted in each asset, the UI displays the bar with missing/in progress/materialized partitions. When different partitions are targeted in each asset, the UI displays counts for in progress/successful/failed partitions.

Test plan: Tested locally and on BK.

Next steps:
- One major gap following this PR is that after the asset backfill is marked as canceled the backfill is not evaluated by the daemon again. This means that asset backfill page will continue to display the state of the backfill at the moment of cancellation, even if the runs have since finished. Part 2 of this stack resolves this gap.
- The status counts assume that each partition name in a backfill is unique. This is to handle run retries, so only the status of the latest run per partition key is displayed. For asset backfills it's possible but unlikely that multiple runs with the same partition key will be generated i.e. a hourly -> daily -> hourly asset graph will kick off multiple runs with the same hourly partition. This PR currently doesn't handle this case, so the status counts will be off. I plan on resolving this in a future TODO.
