### PR TITLE
[ui] Fix code location expansion key encoding bug

### DIFF
--- a/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagit/packages/core/src/ui/SectionedLeftNav.tsx
@@ -76,7 +76,8 @@ export const SectionedLeftNav = () => {
       return {
         repo,
         repoAddress,
-        key: repoAddressAsHumanString(repoAddress),
+        key: repoAddressAsURLString(repoAddress),
+        label: repoAddressAsHumanString(repoAddress),
         jobItems: getJobItemsForOption(repo),
         assetGroupItems: getAssetGroupItemsForOption(repo),
         resourceItems: flagSidebarResources ? getTopLevelResourceDetailsItemsForOption(repo) : [],
@@ -101,7 +102,7 @@ export const SectionedLeftNav = () => {
   // Sort repositories alphabetically, then move empty repos to the bottom.
   const sortedRepos = React.useMemo(() => {
     const alphaSorted = [...visibleReposAndKeys].sort((a, b) =>
-      a.key.toLocaleLowerCase().localeCompare(b.key.toLocaleLowerCase()),
+      a.label.toLocaleLowerCase().localeCompare(b.label.toLocaleLowerCase()),
     );
     const reposWithJobs = [];
     const reposWithoutJobs = [];


### PR DESCRIPTION
## Summary & Motivation

Fix an issue where code location names containing characters that would be URI-encoded are not expanding correctly in the left nav.

This is because the encoded string for the `RepoAddress` is what we use as the expansion key, but the code currently checks whether the human string is expanded.

## How I Tested These Changes

Add a code location that contains a space, "my file.py", alongside the rest of the toys module. Verify that I can expand/collapse the "my file.py" code location in the left nav.
