### PR TITLE
[ui] Try sticky header on virtualized Asset table

### DIFF
--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetRow.tsx
@@ -212,6 +212,7 @@ export const VirtualizedAssetCatalogHeader: React.FC<{
 }> = ({headerCheckbox, view}) => {
   return (
     <Box
+      background={Colors.White}
       border={{side: 'horizontal', width: 1, color: Colors.KeylineGray}}
       style={{
         display: 'grid',
@@ -219,6 +220,9 @@ export const VirtualizedAssetCatalogHeader: React.FC<{
         height: '32px',
         fontSize: '12px',
         color: Colors.Gray600,
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
       }}
     >
       <HeaderCell>{headerCheckbox}</HeaderCell>

--- a/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagit/packages/core/src/workspace/VirtualizedAssetTable.tsx
@@ -58,52 +58,50 @@ export const VirtualizedAssetTable: React.FC<Props> = (props) => {
   }, [prefixPath, groups]);
 
   return (
-    <>
-      <VirtualizedAssetCatalogHeader headerCheckbox={headerCheckbox} view={view} />
-      <div style={{overflow: 'hidden'}}>
-        <Container ref={parentRef}>
-          <Inner $totalHeight={totalHeight}>
-            {items.map(({index, key, size, start}) => {
-              const row: Row = rows[index];
-              const path = JSON.stringify(row.path);
-              const rowType = () => {
-                if (row.type === 'folder') {
-                  return 'folder';
-                }
-                return row.asset.definition ? 'asset' : 'asset_non_sda';
-              };
+    <div style={{overflow: 'hidden'}}>
+      <Container ref={parentRef}>
+        <VirtualizedAssetCatalogHeader headerCheckbox={headerCheckbox} view={view} />
+        <Inner $totalHeight={totalHeight}>
+          {items.map(({index, key, size, start}) => {
+            const row: Row = rows[index];
+            const path = JSON.stringify(row.path);
+            const rowType = () => {
+              if (row.type === 'folder') {
+                return 'folder';
+              }
+              return row.asset.definition ? 'asset' : 'asset_non_sda';
+            };
 
-              const repoAddress = () => {
-                if (row.type === 'folder' || !row.asset.definition) {
-                  return null;
-                }
-                const repository = row.asset.definition.repository;
-                return buildRepoAddress(repository.name, repository.location.name);
-              };
+            const repoAddress = () => {
+              if (row.type === 'folder' || !row.asset.definition) {
+                return null;
+              }
+              const repository = row.asset.definition.repository;
+              return buildRepoAddress(repository.name, repository.location.name);
+            };
 
-              const wipeableAssets = row.type === 'folder' ? row.assets : [row.asset];
+            const wipeableAssets = row.type === 'folder' ? row.assets : [row.asset];
 
-              return (
-                <VirtualizedAssetRow
-                  key={key}
-                  view={view}
-                  type={rowType()}
-                  path={row.path}
-                  definition={row.type === 'asset' ? row.asset.definition : null}
-                  repoAddress={repoAddress()}
-                  showCheckboxColumn
-                  showRepoColumn={showRepoColumn}
-                  height={size}
-                  start={start}
-                  checked={checkedPaths.has(path)}
-                  onToggleChecked={onToggleFactory(path)}
-                  onWipe={() => onWipe(wipeableAssets.map((a) => a.key))}
-                />
-              );
-            })}
-          </Inner>
-        </Container>
-      </div>
-    </>
+            return (
+              <VirtualizedAssetRow
+                key={key}
+                view={view}
+                type={rowType()}
+                path={row.path}
+                definition={row.type === 'asset' ? row.asset.definition : null}
+                repoAddress={repoAddress()}
+                showCheckboxColumn
+                showRepoColumn={showRepoColumn}
+                height={size}
+                start={start}
+                checked={checkedPaths.has(path)}
+                onToggleChecked={onToggleFactory(path)}
+                onWipe={() => onWipe(wipeableAssets.map((a) => a.key))}
+              />
+            );
+          })}
+        </Inner>
+      </Container>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Change virtualized asset table header to be sticky, in an effort to avoid grid alignment mismatches when the scrollbar of the virtualized table is present and occupying width.

## How I Tested These Changes

View asset catalog list, verify that the table header is sticky, sits on top of the rows, and has no alignment problems when the scrollbar is occupying horizontal space.
