### PR TITLE
TagSelector: call Virtualizer.measure after dropdown measures.

### DIFF
--- a/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
+++ b/js_modules/dagit/packages/ui/src/components/TagSelector.tsx
@@ -189,6 +189,8 @@ export const TagSelector = ({
       }}
       content={<div ref={dropdownContainer}>{dropdown}</div>}
       targetTagName="div"
+      onOpening={rowVirtualizer.measure}
+      onOpened={rowVirtualizer.measure}
     >
       <Container
         onClick={() => {


### PR DESCRIPTION
## Summary & Motivation

I was able to repo the tagSelector not immediately measuring the full dropdown height. I added the `OnRender` component to call the virtualizer's measure function after the component renders. This may fix https://github.com/dagster-io/dagster/issues/13798 