### PR TITLE
Eliminate places where we are calling capture_error multiple times in a single request

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 from ..utils import (
     assert_permission,
     assert_permission_for_location,
-    capture_error,
 )
 from .backfill import (
     cancel_partition_backfill as cancel_partition_backfill,
@@ -145,7 +144,6 @@ def terminate_pipeline_execution(
     )
 
 
-@capture_error
 def delete_pipeline_run(
     graphene_info: "ResolveInfo", run_id: str
 ) -> Union["GrapheneDeletePipelineRunSuccess", "GrapheneRunNotFoundError"]:
@@ -321,7 +319,6 @@ async def gen_captured_log_data(
         subscription.dispose()
 
 
-@capture_error
 def wipe_assets(
     graphene_info: "ResolveInfo", asset_keys: Sequence[AssetKey]
 ) -> "GrapheneAssetWipeSuccess":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -14,7 +14,7 @@ from dagster._core.workspace.permissions import Permissions
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
-from ..utils import BackfillParams, assert_permission, assert_permission_for_location, capture_error
+from ..utils import BackfillParams, assert_permission, assert_permission_for_location
 
 BACKFILL_CHUNK_SIZE = 25
 
@@ -174,7 +174,6 @@ def create_and_launch_partition_backfill(
     return GrapheneLaunchBackfillSuccess(backfill_id=backfill_id)
 
 
-@capture_error
 def cancel_partition_backfill(
     graphene_info: "ResolveInfo", backfill_id: str
 ) -> "GrapheneCancelBackfillSuccess":
@@ -194,7 +193,6 @@ def cancel_partition_backfill(
     return GrapheneCancelBackfillSuccess(backfill_id=backfill_id)
 
 
-@capture_error
 def resume_partition_backfill(
     graphene_info: "ResolveInfo", backfill_id: str
 ) -> "GrapheneResumeBackfillSuccess":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
@@ -7,7 +7,7 @@ from dagster._core.workspace.permissions import Permissions
 
 from dagster_graphql.schema.errors import GrapheneDuplicateDynamicPartitionError
 
-from ..utils import UserFacingGraphQLError, assert_permission_for_location, capture_error
+from ..utils import UserFacingGraphQLError, assert_permission_for_location
 
 if TYPE_CHECKING:
     from ...schema.inputs import GrapheneRepositorySelector
@@ -53,7 +53,6 @@ def _repository_contains_dynamic_partitions_def(
     return False
 
 
-@capture_error
 def add_dynamic_partition(
     graphene_info,
     repository_selector: "GrapheneRepositorySelector",

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -12,7 +12,6 @@ from ..utils import (
     ExecutionMetadata,
     ExecutionParams,
     assert_permission_for_location,
-    capture_error,
 )
 from .run_lifecycle import create_valid_pipeline_run
 
@@ -21,14 +20,12 @@ if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
 
-@capture_error
 def launch_pipeline_reexecution(
     graphene_info: "ResolveInfo", execution_params: ExecutionParams
 ) -> "GrapheneLaunchRunSuccess":
     return _launch_pipeline_execution(graphene_info, execution_params, is_reexecuted=True)
 
 
-@capture_error
 def launch_pipeline_execution(
     graphene_info: "ResolveInfo", execution_params: ExecutionParams
 ) -> "GrapheneLaunchRunSuccess":
@@ -72,7 +69,6 @@ def _launch_pipeline_execution(
     return GrapheneLaunchRunSuccess(run=GrapheneRun(records[0]))
 
 
-@capture_error
 def launch_reexecution_from_parent_run(
     graphene_info: "ResolveInfo", parent_run_id: str, strategy: str
 ) -> "GrapheneLaunchRunSuccess":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -12,7 +12,7 @@ from dagster._core.host_representation.external import ExternalExecutionPlan
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
 
-from .utils import UserFacingGraphQLError, capture_error
+from .utils import UserFacingGraphQLError
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.errors import GrapheneRepositoryNotFoundError
@@ -107,7 +107,6 @@ def get_external_execution_plan_or_raise(
     )
 
 
-@capture_error
 def fetch_repositories(graphene_info: "ResolveInfo") -> GrapheneRepositoryConnection:
     from ..schema.external import GrapheneRepository, GrapheneRepositoryConnection
 
@@ -124,7 +123,6 @@ def fetch_repositories(graphene_info: "ResolveInfo") -> GrapheneRepositoryConnec
     )
 
 
-@capture_error
 def fetch_repository(
     graphene_info: "ResolveInfo", repository_selector: RepositorySelector
 ) -> Union[GrapheneRepository, GrapheneRepositoryNotFoundError]:
@@ -147,7 +145,6 @@ def fetch_repository(
     )
 
 
-@capture_error
 def fetch_workspace(workspace_request_context: WorkspaceRequestContext) -> GrapheneWorkspace:
     from ..schema.external import GrapheneWorkspace, GrapheneWorkspaceLocationEntry
 
@@ -163,7 +160,6 @@ def fetch_workspace(workspace_request_context: WorkspaceRequestContext) -> Graph
     return GrapheneWorkspace(locationEntries=nodes)
 
 
-@capture_error
 def fetch_location_statuses(
     workspace_request_context: WorkspaceRequestContext,
 ) -> GrapheneWorkspaceLocationStatusEntries:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -60,8 +60,6 @@ from dagster_graphql.implementation.loader import (
     StaleStatusLoader,
 )
 
-from .utils import capture_error
-
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode, GrapheneAssetNodeDefinitionCollision
     from ..schema.errors import GrapheneAssetNotFoundError
@@ -90,7 +88,6 @@ def _normalize_asset_cursor_str(cursor_string: Optional[str]) -> Optional[str]:
         return cursor_string
 
 
-@capture_error
 def get_assets(
     graphene_info: "ResolveInfo",
     prefix: Optional[Sequence[str]] = None,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Optional
 
 from dagster._core.execution.backfill import BulkActionStatus
 
-from .utils import capture_error
-
 if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
@@ -13,7 +11,6 @@ if TYPE_CHECKING:
     )
 
 
-@capture_error
 def get_backfill(graphene_info: "ResolveInfo", backfill_id: str) -> "GraphenePartitionBackfill":
     from ..schema.backfill import GrapheneBackfillNotFoundError, GraphenePartitionBackfill
 
@@ -24,7 +21,6 @@ def get_backfill(graphene_info: "ResolveInfo", backfill_id: str) -> "GraphenePar
     return GraphenePartitionBackfill(backfill_job)
 
 
-@capture_error
 def get_backfills(
     graphene_info: "ResolveInfo",
     status: Optional[BulkActionStatus] = None,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_env_vars.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_env_vars.py
@@ -9,10 +9,7 @@ from dagster_graphql.schema.env_vars import (
     GrapheneEnvVarWithConsumersListOrError,
 )
 
-from .utils import capture_error
 
-
-@capture_error
 def get_utilized_env_vars_or_error(
     graphene_info, repository_selector
 ) -> GrapheneEnvVarWithConsumersListOrError:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -8,8 +8,6 @@ from dagster._core.definitions.selector import InstigatorSelector
 from dagster._core.log_manager import DAGSTER_META_KEY
 from dagster._core.scheduler.instigation import InstigatorStatus
 
-from .utils import capture_error
-
 if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
@@ -21,7 +19,6 @@ if TYPE_CHECKING:
     )
 
 
-@capture_error
 def get_unloadable_instigator_states_or_error(
     graphene_info: "ResolveInfo", instigator_type: Optional[InstigatorType] = None
 ) -> "GrapheneInstigationStates":
@@ -56,7 +53,6 @@ def get_unloadable_instigator_states_or_error(
     )
 
 
-@capture_error
 def get_instigator_state_or_error(
     graphene_info: "ResolveInfo", selector: InstigatorSelector
 ) -> Union["GrapheneInstigationState", "GrapheneInstigationStateNotFoundError"]:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -24,8 +24,6 @@ from dagster._utils.yaml_utils import dump_run_config_yaml
 
 from dagster_graphql.schema.util import ResolveInfo
 
-from .utils import capture_error
-
 if TYPE_CHECKING:
     from dagster_graphql.schema.errors import GraphenePartitionSetNotFoundError
     from dagster_graphql.schema.partition_sets import (
@@ -41,7 +39,6 @@ if TYPE_CHECKING:
     )
 
 
-@capture_error
 def get_partition_sets_or_error(
     graphene_info: ResolveInfo, repository_selector: RepositorySelector, pipeline_name: str
 ) -> "GraphenePartitionSets":
@@ -75,7 +72,6 @@ def get_partition_sets_or_error(
     )
 
 
-@capture_error
 def get_partition_set(
     graphene_info: ResolveInfo, repository_selector: RepositorySelector, partition_set_name: str
 ) -> Union["GraphenePartitionSet", "GraphenePartitionSetNotFoundError"]:
@@ -96,7 +92,6 @@ def get_partition_set(
     return GraphenePartitionSetNotFoundError(partition_set_name)
 
 
-@capture_error
 def get_partition_by_name(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
@@ -115,7 +110,6 @@ def get_partition_by_name(
     )
 
 
-@capture_error
 def get_partition_config(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
@@ -141,7 +135,6 @@ def get_partition_config(
     return GraphenePartitionRunConfig(yaml=dump_run_config_yaml(result.run_config))
 
 
-@capture_error
 def get_partition_tags(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
@@ -171,7 +164,6 @@ def get_partition_tags(
     )
 
 
-@capture_error
 def get_partitions(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
@@ -227,7 +219,6 @@ def _apply_cursor_limit_reverse(
     return items[max(start, 0) : end]
 
 
-@capture_error
 def get_partition_set_partition_statuses(
     graphene_info: ResolveInfo, external_partition_set: ExternalPartitionSet
 ) -> Sequence["GraphenePartitionStatus"]:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
@@ -7,7 +7,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster_graphql.schema.util import ResolveInfo
 
 from .external import get_external_job_or_raise, get_full_external_job_or_raise
-from .utils import JobSubsetSelector, UserFacingGraphQLError, capture_error
+from .utils import JobSubsetSelector, UserFacingGraphQLError
 
 if TYPE_CHECKING:
     from ..schema.pipelines.pipeline import GraphenePipeline
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from ..schema.pipelines.snapshot import GraphenePipelineSnapshot
 
 
-@capture_error
 def get_job_snapshot_or_error_from_job_selector(
     graphene_info: ResolveInfo, job_selector: JobSubsetSelector
 ) -> "GraphenePipelineSnapshot":
@@ -25,7 +24,6 @@ def get_job_snapshot_or_error_from_job_selector(
     return GraphenePipelineSnapshot(get_full_external_job_or_raise(graphene_info, job_selector))
 
 
-@capture_error
 def get_job_snapshot_or_error_from_snapshot_id(
     graphene_info: ResolveInfo, snapshot_id: str
 ) -> "GraphenePipelineSnapshot":
@@ -52,7 +50,6 @@ def _get_job_snapshot_from_instance(
     return GraphenePipelineSnapshot(historical_pipeline)
 
 
-@capture_error
 def get_job_or_error(graphene_info: ResolveInfo, selector: JobSubsetSelector) -> "GraphenePipeline":
     """Returns a PipelineOrError."""
     return get_job_from_selector(graphene_info, selector)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
@@ -5,13 +5,12 @@ from dagster._core.definitions.selector import RepositorySelector, ResourceSelec
 from dagster._core.host_representation.code_location import CodeLocation
 from graphene import ResolveInfo
 
-from .utils import UserFacingGraphQLError, capture_error
+from .utils import UserFacingGraphQLError
 
 if TYPE_CHECKING:
     from ..schema.resources import GrapheneResourceDetails, GrapheneResourceDetailsList
 
 
-@capture_error
 def get_top_level_resources_or_error(
     graphene_info: "ResolveInfo", repository_selector: RepositorySelector
 ) -> "GrapheneResourceDetailsList":
@@ -39,7 +38,6 @@ def get_top_level_resources_or_error(
     return GrapheneResourceDetailsList(results=results)
 
 
-@capture_error
 def get_resource_or_error(
     graphene_info: "ResolveInfo", resource_selector: ResourceSelector
 ) -> "GrapheneResourceDetails":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -25,7 +25,6 @@ from dagster._core.storage.dagster_run import DagsterRunStatus, RunRecord, RunsF
 from dagster._core.storage.tags import TagType, get_tag_type
 
 from .external import ensure_valid_config, get_external_job_or_raise
-from .utils import capture_error
 
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetLatestInfo, GrapheneAssetNode
@@ -53,7 +52,6 @@ def get_run_by_id(
         return GrapheneRun(record)
 
 
-@capture_error
 def get_run_tag_keys(graphene_info: "ResolveInfo") -> "GrapheneRunTagKeys":
     from ..schema.runs import GrapheneRunTagKeys
 
@@ -66,7 +64,6 @@ def get_run_tag_keys(graphene_info: "ResolveInfo") -> "GrapheneRunTagKeys":
     )
 
 
-@capture_error
 def get_run_tags(
     graphene_info: "ResolveInfo",
     tag_keys: Optional[List[str]] = None,
@@ -88,7 +85,6 @@ def get_run_tags(
     )
 
 
-@capture_error
 def get_run_group(graphene_info: "ResolveInfo", run_id: str) -> "GrapheneRunGroup":
     from ..schema.errors import GrapheneRunGroupNotFoundError
     from ..schema.pipelines.pipeline import GrapheneRun
@@ -330,7 +326,6 @@ def get_run_groups(
     ]
 
 
-@capture_error
 def validate_pipeline_config(
     graphene_info: "ResolveInfo",
     selector: JobSubsetSelector,
@@ -345,7 +340,6 @@ def validate_pipeline_config(
     return GraphenePipelineConfigValidationValid(pipeline_name=external_job.name)
 
 
-@capture_error
 def get_execution_plan(
     graphene_info: "ResolveInfo",
     selector: JobSubsetSelector,
@@ -367,7 +361,6 @@ def get_execution_plan(
     )
 
 
-@capture_error
 def get_stats(graphene_info: "ResolveInfo", run_id: str) -> "GrapheneRunStatsSnapshot":
     from ..schema.pipelines.pipeline_run_stats import GrapheneRunStatsSnapshot
 
@@ -385,7 +378,6 @@ def get_step_stats(
     return [GrapheneRunStepStats(stats) for stats in step_stats]
 
 
-@capture_error
 def get_logs_for_run(
     graphene_info: "ResolveInfo",
     run_id: str,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -18,7 +18,6 @@ from .utils import (
     UserFacingGraphQLError,
     assert_permission,
     assert_permission_for_location,
-    capture_error,
 )
 
 if TYPE_CHECKING:
@@ -31,7 +30,6 @@ if TYPE_CHECKING:
     )
 
 
-@capture_error
 def start_schedule(
     graphene_info: ResolveInfo, schedule_selector: ScheduleSelector
 ) -> "GrapheneScheduleStateResult":
@@ -48,7 +46,6 @@ def start_schedule(
     return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
 
 
-@capture_error
 def stop_schedule(
     graphene_info: ResolveInfo, schedule_origin_id: str, schedule_selector_id: str
 ) -> "GrapheneScheduleStateResult":
@@ -84,7 +81,6 @@ def stop_schedule(
     return GrapheneScheduleStateResult(GrapheneInstigationState(schedule_state))
 
 
-@capture_error
 def get_scheduler_or_error(graphene_info: ResolveInfo) -> "GrapheneScheduler":
     from ..schema.errors import GrapheneSchedulerNotDefinedError
     from ..schema.schedules import GrapheneScheduler
@@ -97,7 +93,6 @@ def get_scheduler_or_error(graphene_info: ResolveInfo) -> "GrapheneScheduler":
     return GrapheneScheduler(scheduler_class=instance.scheduler.__class__.__name__)
 
 
-@capture_error
 def get_schedules_or_error(
     graphene_info: ResolveInfo,
     repository_selector: RepositorySelector,
@@ -164,7 +159,6 @@ def get_schedules_for_pipeline(
     return results
 
 
-@capture_error
 def get_schedule_or_error(
     graphene_info: ResolveInfo, schedule_selector: ScheduleSelector
 ) -> "GrapheneSchedule":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -18,19 +18,14 @@ from .utils import (
     UserFacingGraphQLError,
     assert_permission,
     assert_permission_for_location,
-    capture_error,
 )
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.instigation import GrapheneDryRunInstigationTick
 
-    from ..schema.instigation import (
-        GrapheneInstigationStates,
-    )
     from ..schema.sensors import GrapheneSensor, GrapheneSensors, GrapheneStopSensorMutationResult
 
 
-@capture_error
 def get_sensors_or_error(
     graphene_info: ResolveInfo,
     repository_selector: RepositorySelector,
@@ -70,7 +65,6 @@ def get_sensors_or_error(
     )
 
 
-@capture_error
 def get_sensor_or_error(graphene_info: ResolveInfo, selector: SensorSelector) -> "GrapheneSensor":
     from ..schema.errors import GrapheneSensorNotFoundError
     from ..schema.sensors import GrapheneSensor
@@ -90,7 +84,6 @@ def get_sensor_or_error(graphene_info: ResolveInfo, selector: SensorSelector) ->
     return GrapheneSensor(external_sensor, sensor_state)
 
 
-@capture_error
 def start_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) -> "GrapheneSensor":
     from ..schema.errors import GrapheneSensorNotFoundError
     from ..schema.sensors import GrapheneSensor
@@ -110,7 +103,6 @@ def start_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) ->
     return GrapheneSensor(external_sensor, sensor_state)
 
 
-@capture_error
 def stop_sensor(
     graphene_info: ResolveInfo, instigator_origin_id: str, instigator_selector_id: str
 ) -> "GrapheneStopSensorMutationResult":
@@ -145,40 +137,6 @@ def stop_sensor(
         external_sensor,
     )
     return GrapheneStopSensorMutationResult(state)
-
-
-@capture_error
-def get_unloadable_sensor_states_or_error(
-    graphene_info: ResolveInfo,
-) -> "GrapheneInstigationStates":
-    from ..schema.instigation import GrapheneInstigationState, GrapheneInstigationStates
-
-    sensor_states = graphene_info.context.instance.all_instigator_state(
-        instigator_type=InstigatorType.SENSOR
-    )
-    external_sensors = [
-        sensor
-        for repository_location in graphene_info.context.code_locations
-        for repository in repository_location.get_repositories().values()
-        for sensor in repository.get_external_sensors()
-    ]
-
-    sensor_origin_ids = {
-        external_sensor.get_external_origin_id() for external_sensor in external_sensors
-    }
-
-    unloadable_states = [
-        sensor_state
-        for sensor_state in sensor_states
-        if sensor_state.instigator_origin_id not in sensor_origin_ids
-    ]
-
-    return GrapheneInstigationStates(
-        results=[
-            GrapheneInstigationState(instigator_state=sensor_state)
-            for sensor_state in unloadable_states
-        ]
-    )
 
 
 def get_sensors_for_pipeline(
@@ -250,7 +208,6 @@ def get_sensor_next_tick(
     return GrapheneDryRunInstigationTick(external_sensor.sensor_selector, next_timestamp)
 
 
-@capture_error
 def set_sensor_cursor(
     graphene_info: ResolveInfo, selector: SensorSelector, cursor: Optional[str]
 ) -> "GrapheneSensor":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
@@ -3,7 +3,7 @@ from collections import OrderedDict, defaultdict
 import dagster._check as check
 from dagster._core.host_representation import ExternalRepository
 
-from .utils import GraphSelector, capture_error
+from .utils import GraphSelector
 
 
 def get_solid(repo, name):
@@ -51,7 +51,6 @@ def get_used_solid_map(repo):
     )
 
 
-@capture_error
 def get_graph_or_error(graphene_info, graph_selector):
     from ..schema.errors import GrapheneGraphNotFoundError
     from ..schema.pipelines.pipeline import GrapheneGraph

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
@@ -9,7 +9,7 @@ from dagster_graphql.schema.errors import GrapheneModeNotFoundError
 from dagster_graphql.schema.util import ResolveInfo
 
 from .external import get_external_job_or_raise
-from .utils import JobSubsetSelector, UserFacingGraphQLError, capture_error
+from .utils import JobSubsetSelector, UserFacingGraphQLError
 
 if TYPE_CHECKING:
     from ..schema.pipelines.config import (
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from ..schema.run_config import GrapheneRunConfigSchema
 
 
-@capture_error
 def resolve_run_config_schema_or_error(
     graphene_info: ResolveInfo, selector: JobSubsetSelector, mode: Optional[str] = None
 ) -> "GrapheneRunConfigSchema":
@@ -40,7 +39,6 @@ def resolve_run_config_schema_or_error(
     )
 
 
-@capture_error
 def resolve_is_run_config_valid(
     graphene_info: ResolveInfo,
     represented_pipeline: RepresentedJob,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -24,6 +24,7 @@ from dagster_graphql.implementation.fetch_partition_sets import (
     get_partitions,
 )
 from dagster_graphql.implementation.fetch_runs import get_runs
+from dagster_graphql.implementation.utils import capture_error
 
 from .asset_key import GrapheneAssetKey
 from .backfill import GraphenePartitionBackfill
@@ -202,6 +203,7 @@ class GraphenePartition(graphene.ObjectType):
             mode=external_partition_set.mode,
         )
 
+    @capture_error
     def resolve_runConfigOrError(self, graphene_info: ResolveInfo):
         return get_partition_config(
             graphene_info,
@@ -210,6 +212,7 @@ class GraphenePartition(graphene.ObjectType):
             self._partition_name,
         )
 
+    @capture_error
     def resolve_tagsOrError(self, graphene_info: ResolveInfo):
         return get_partition_tags(
             graphene_info,
@@ -303,6 +306,7 @@ class GraphenePartitionSet(graphene.ObjectType):
     def resolve_id(self, _graphene_info: ResolveInfo):
         return self._external_partition_set.get_external_origin_id()
 
+    @capture_error
     def resolve_partitionsOrError(
         self,
         graphene_info: ResolveInfo,
@@ -330,6 +334,7 @@ class GraphenePartitionSet(graphene.ObjectType):
     def resolve_partitionRuns(self, graphene_info: ResolveInfo):
         return get_partition_set_partition_runs(graphene_info, self._external_partition_set)
 
+    @capture_error
     def resolve_partitionStatusesOrError(self, graphene_info: ResolveInfo):
         return get_partition_set_partition_statuses(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -448,6 +448,7 @@ class GrapheneRun(graphene.ObjectType):
                 return snapshot.lineage_snapshot.parent_snapshot_id
         return None
 
+    @capture_error
     def resolve_stats(self, graphene_info: ResolveInfo):
         return get_stats(graphene_info, self.run_id)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -249,8 +249,6 @@ class GrapheneTerminateRunResult(graphene.Union):
 
 
 def create_execution_params_and_launch_pipeline_exec(graphene_info, execution_params_dict):
-    # refactored into a helper function here in order to wrap with @capture_error,
-    # because create_execution_params may raise
     execution_params = create_execution_params(graphene_info, execution_params_dict)
     assert_permission_for_location(
         graphene_info,
@@ -360,10 +358,7 @@ class GrapheneAddDynamicPartitionMutation(graphene.Mutation):
         )
 
 
-@capture_error
 def create_execution_params_and_launch_pipeline_reexec(graphene_info, execution_params_dict):
-    # refactored into a helper function here in order to wrap with @capture_error,
-    # because create_execution_params may raise
     execution_params = create_execution_params(graphene_info, execution_params_dict)
     assert_permission_for_location(
         graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -72,7 +72,11 @@ from ...implementation.loader import (
     StaleStatusLoader,
 )
 from ...implementation.run_config_schema import resolve_run_config_schema_or_error
-from ...implementation.utils import graph_selector_from_graphql, pipeline_selector_from_graphql
+from ...implementation.utils import (
+    capture_error,
+    graph_selector_from_graphql,
+    pipeline_selector_from_graphql,
+)
 from ..asset_graph import (
     GrapheneAssetLatestInfo,
     GrapheneAssetNode,
@@ -459,6 +463,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         description="Provides fields for testing behavior",
     )
 
+    @capture_error
     def resolve_repositoriesOrError(
         self,
         graphene_info: ResolveInfo,
@@ -475,6 +480,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             )
         return fetch_repositories(graphene_info)
 
+    @capture_error
     def resolve_repositoryOrError(
         self, graphene_info: ResolveInfo, repositorySelector: GrapheneRepositorySelector
     ):
@@ -482,12 +488,15 @@ class GrapheneDagitQuery(graphene.ObjectType):
             graphene_info, RepositorySelector.from_graphql_input(repositorySelector)
         )
 
+    @capture_error
     def resolve_workspaceOrError(self, graphene_info: ResolveInfo):
         return fetch_workspace(graphene_info.context)
 
+    @capture_error
     def resolve_locationStatusesOrError(self, graphene_info: ResolveInfo):
         return fetch_location_statuses(graphene_info.context)
 
+    @capture_error
     def resolve_pipelineSnapshotOrError(
         self,
         graphene_info: ResolveInfo,
@@ -509,6 +518,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
                 "Must set one of snapshotId or activePipelineSelector",
             )
 
+    @capture_error
     def resolve_graphOrError(
         self, graphene_info: ResolveInfo, selector: Optional[GrapheneGraphSelector] = None
     ):
@@ -519,9 +529,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
     def resolve_version(self, graphene_info: ResolveInfo):
         return graphene_info.context.version
 
+    @capture_error
     def resolve_scheduler(self, graphene_info: ResolveInfo):
         return get_scheduler_or_error(graphene_info)
 
+    @capture_error
     def resolve_scheduleOrError(
         self, graphene_info: ResolveInfo, schedule_selector: GrapheneScheduleSelector
     ):
@@ -529,6 +541,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             graphene_info, ScheduleSelector.from_graphql_input(schedule_selector)
         )
 
+    @capture_error
     def resolve_schedulesOrError(
         self,
         graphene_info: ResolveInfo,
@@ -548,6 +561,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             instigator_statuses,
         )
 
+    @capture_error
     def resolve_topLevelResourceDetailsOrError(self, graphene_info: ResolveInfo, resourceSelector):
         return get_resource_or_error(
             graphene_info, ResourceSelector.from_graphql_input(resourceSelector)
@@ -559,17 +573,20 @@ class GrapheneDagitQuery(graphene.ObjectType):
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
         )
 
+    @capture_error
     def resolve_utilizedEnvVarsOrError(self, graphene_info: ResolveInfo, **kwargs):
         return get_utilized_env_vars_or_error(
             graphene_info,
             RepositorySelector.from_graphql_input(kwargs.get("repositorySelector")),
         )
 
+    @capture_error
     def resolve_sensorOrError(
         self, graphene_info: ResolveInfo, sensorSelector: GrapheneRepositorySelector
     ):
         return get_sensor_or_error(graphene_info, SensorSelector.from_graphql_input(sensorSelector))
 
+    @capture_error
     def resolve_sensorsOrError(
         self,
         graphene_info,
@@ -588,6 +605,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             instigator_statuses,
         )
 
+    @capture_error
     def resolve_instigationStateOrError(
         self, graphene_info: ResolveInfo, instigationSelector: GrapheneInstigationSelector
     ):
@@ -595,12 +613,14 @@ class GrapheneDagitQuery(graphene.ObjectType):
             graphene_info, InstigatorSelector.from_graphql_input(instigationSelector)
         )
 
+    @capture_error
     def resolve_unloadableInstigationStatesOrError(
         self, graphene_info: ResolveInfo, instigationType: Optional[GrapheneInstigationType] = None
     ):
         instigation_type = InstigatorType(instigationType) if instigationType else None
         return get_unloadable_instigator_states_or_error(graphene_info, instigation_type)
 
+    @capture_error
     def resolve_pipelineOrError(self, graphene_info: ResolveInfo, params: GraphenePipelineSelector):
         return get_job_or_error(
             graphene_info,
@@ -656,6 +676,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             results=get_run_groups(graphene_info, selector, cursor, limit)
         )
 
+    @capture_error
     def resolve_partitionSetsOrError(
         self, graphene_info: ResolveInfo, repositorySelector: RepositorySelector, pipelineName: str
     ):
@@ -665,6 +686,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             pipelineName,
         )
 
+    @capture_error
     def resolve_partitionSetOrError(
         self,
         graphene_info: ResolveInfo,
@@ -678,9 +700,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
             partitionSetName,  # type: ignore
         )
 
+    @capture_error
     def resolve_runTagKeysOrError(self, graphene_info: ResolveInfo):
         return get_run_tag_keys(graphene_info)
 
+    @capture_error
     def resolve_runTagsOrError(
         self,
         graphene_info: ResolveInfo,
@@ -690,9 +714,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
     ):
         return get_run_tags(graphene_info, tagKeys, valuePrefix, limit)
 
+    @capture_error
     def resolve_runGroupOrError(self, graphene_info: ResolveInfo, runId):
         return get_run_group(graphene_info, runId)
 
+    @capture_error
     def resolve_isPipelineConfigValid(
         self,
         graphene_info: ResolveInfo,
@@ -706,6 +732,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             parse_run_config_input(runConfigData or {}, raise_on_error=False),
         )
 
+    @capture_error
     def resolve_executionPlanOrError(
         self,
         graphene_info: ResolveInfo,
@@ -719,6 +746,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
             parse_run_config_input(runConfigData or {}, raise_on_error=True),  # type: ignore  # (possible str)
         )
 
+    @capture_error
     def resolve_runConfigSchemaOrError(
         self,
         graphene_info: ResolveInfo,
@@ -841,6 +869,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
         asset_key_input = cast(Mapping[str, Sequence[str]], assetKey)
         return get_asset_node(graphene_info, AssetKey.from_graphql_input(asset_key_input))
 
+    @capture_error
     def resolve_assetsOrError(
         self,
         graphene_info: ResolveInfo,
@@ -868,9 +897,11 @@ class GrapheneDagitQuery(graphene.ObjectType):
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in raw_asset_keys)
         return get_asset_node_definition_collisions(graphene_info, asset_keys)
 
+    @capture_error
     def resolve_partitionBackfillOrError(self, graphene_info: ResolveInfo, backfillId: str):
         return get_backfill(graphene_info, backfillId)
 
+    @capture_error
     def resolve_partitionBackfillsOrError(
         self,
         graphene_info: ResolveInfo,
@@ -906,6 +937,7 @@ class GrapheneDagitQuery(graphene.ObjectType):
 
         return get_assets_latest_info(graphene_info, step_keys_by_asset)
 
+    @capture_error
     def resolve_logsForRun(
         self,
         graphene_info: ResolveInfo,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/run_config.py
@@ -8,6 +8,7 @@ from dagster._core.host_representation.external_data import DEFAULT_MODE_NAME
 from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
 
 from ..implementation.run_config_schema import resolve_is_run_config_valid
+from ..implementation.utils import capture_error
 from .config_types import GrapheneConfigType, to_config_type
 from .errors import (
     GrapheneInvalidSubsetError,
@@ -84,6 +85,7 @@ class GrapheneRunConfigSchema(graphene.ObjectType):
             ).root_config_key,
         )
 
+    @capture_error
     def resolve_isRunConfigValid(
         self,
         graphene_info: ResolveInfo,


### PR DESCRIPTION
Summary:
Prevent nested capture_error calls in a single graphql resolver by moving all capture_error decorators to the top-level resolver instead of helper functions

Test Plan: Existing graphql coverage should cover all endpoints that have a capture_error in them today

## Summary & Motivation

## How I Tested These Changes
