### PR TITLE
[Cancel asset backfill 1/3] Display asset backfill run statuses

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2430,7 +2430,7 @@ type PartitionBackfill {
   runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
-  partitionStatuses: PartitionStatuses!
+  backfillRunStatuses: PartitionStatuses!
   partitionStatusCounts: [PartitionStatusCounts!]!
   isAssetBackfill: Boolean!
   assetBackfillData: AssetBackfillData

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2305,6 +2305,7 @@ export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
   assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
+  backfillRunStatuses: PartitionStatuses;
   endTimestamp: Maybe<Scalars['Float']>;
   error: Maybe<PythonError>;
   fromFailure: Scalars['Boolean'];
@@ -2319,7 +2320,6 @@ export type PartitionBackfill = {
   partitionSet: Maybe<PartitionSet>;
   partitionSetName: Maybe<Scalars['String']>;
   partitionStatusCounts: Array<PartitionStatusCounts>;
-  partitionStatuses: PartitionStatuses;
   reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
   status: BulkActionStatus;
@@ -8215,6 +8215,12 @@ export const buildPartitionBackfill = (
         : buildAssetBackfillData({}, relationshipsToOmit),
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    backfillRunStatuses:
+      overrides && overrides.hasOwnProperty('backfillRunStatuses')
+        ? overrides.backfillRunStatuses!
+        : relationshipsToOmit.has('PartitionStatuses')
+        ? ({} as PartitionStatuses)
+        : buildPartitionStatuses({}, relationshipsToOmit),
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 0.33,
     error:
@@ -8260,12 +8266,6 @@ export const buildPartitionBackfill = (
       overrides && overrides.hasOwnProperty('partitionStatusCounts')
         ? overrides.partitionStatusCounts!
         : [],
-    partitionStatuses:
-      overrides && overrides.hasOwnProperty('partitionStatuses')
-        ? overrides.partitionStatuses!
-        : relationshipsToOmit.has('PartitionStatuses')
-        ? ({} as PartitionStatuses)
-        : buildPartitionStatuses({}, relationshipsToOmit),
     reexecutionSteps:
       overrides && overrides.hasOwnProperty('reexecutionSteps') ? overrides.reexecutionSteps! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -98,7 +98,7 @@ export const BackfillRow = ({
       );
       return {counts, statuses: null};
     }
-    const statuses = data.partitionBackfillOrError.partitionStatuses.results;
+    const statuses = data.partitionBackfillOrError.backfillRunStatuses.results;
     const counts = countBy(statuses, (k) => k.runStatus);
     return {counts, statuses};
   }, [data]);
@@ -498,7 +498,7 @@ export const SINGLE_BACKFILL_STATUS_DETAILS_QUERY = gql`
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
         id
-        partitionStatuses {
+        backfillRunStatuses {
           ...PartitionStatusesForBackfill
         }
       }

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -1,4 +1,4 @@
-import {gql, QueryResult, useLazyQuery} from '@apollo/client';
+import {gql, useLazyQuery} from '@apollo/client';
 import {Box, Button, Colors, Icon, MenuItem, Menu, Popover, Tag, Mono} from '@dagster-io/ui';
 import countBy from 'lodash/countBy';
 import * as React from 'react';
@@ -31,11 +31,6 @@ import {
   SingleBackfillQueryVariables,
 } from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
-
-const NoBackfillStatusQuery = [
-  () => Promise.resolve({data: undefined} as QueryResult<undefined>),
-  {data: undefined, called: true, loading: false} as QueryResult<undefined>,
-] as const;
 
 export const BackfillRow = ({
   backfill,
@@ -78,11 +73,10 @@ export const BackfillRow = ({
   // If the number of partitions or partition names are missing, we use a mock to
   // avoid executing any query at all. This is a bit awkward, but seems cleaner than
   // making the hooks below support an optional query function / result.
-  const [statusQueryFn, statusQueryResult] = statusUnsupported
-    ? NoBackfillStatusQuery
-    : (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
-    ? statusCounts
-    : statusDetails;
+  const [statusQueryFn, statusQueryResult] =
+    (backfill.numPartitions || 0) > BACKFILL_PARTITIONS_COUNTS_THRESHOLD
+      ? statusCounts
+      : statusDetails;
 
   useDelayedRowQuery(statusQueryFn);
   useQueryRefreshAtInterval(statusQueryResult, FIFTEEN_SECONDS);

--- a/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillTerminationDialog.tsx
@@ -39,7 +39,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     if (!backfill || !data || data.partitionBackfillOrError.__typename !== 'PartitionBackfill') {
       return {};
     }
-    const unfinishedPartitions = data.partitionBackfillOrError.partitionStatuses.results.filter(
+    const unfinishedPartitions = data.partitionBackfillOrError.backfillRunStatuses.results.filter(
       (partition) =>
         partition.runStatus && partition.runId && cancelableStatuses.has(partition.runStatus),
     );

--- a/js_modules/dagit/packages/core/src/instance/__fixtures__/BackfillTable.fixtures.ts
+++ b/js_modules/dagit/packages/core/src/instance/__fixtures__/BackfillTable.fixtures.ts
@@ -175,7 +175,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
       __typename: 'DagitQuery',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'sjqzcfhe',
-        partitionStatuses: buildPartitionStatuses({
+        backfillRunStatuses: buildPartitionStatuses({
           results: BackfillTableFragmentFailedError.partitionNames!.map((n) =>
             buildPartitionStatus({
               id: `__NO_PARTITION_SET__:${n}:ccpbwdbq`,
@@ -247,7 +247,7 @@ export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<Single
       __typename: 'DagitQuery',
       partitionBackfillOrError: {
         id: 'pwgcpiwc',
-        partitionStatuses: {
+        backfillRunStatuses: {
           results: [
             {
               id: 'asset_job_partition_set:TN|2023-01-24:pwgcpiwc',
@@ -374,7 +374,7 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'pqdiepuf',
         isAssetBackfill: true,
-        partitionStatuses: buildPartitionStatuses({
+        backfillRunStatuses: buildPartitionStatuses({
           results: [
             buildPartitionStatus({
               id: 'op_job_partition_set:2022-07-01:pqdiepuf',

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
@@ -33,7 +33,7 @@ export type SingleBackfillQuery = {
     | {
         __typename: 'PartitionBackfill';
         id: string;
-        partitionStatuses: {
+        backfillRunStatuses: {
           __typename: 'PartitionStatuses';
           results: Array<{
             __typename: 'PartitionStatus';

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         GraphenePartitionSets,
         GraphenePartitionStatus,
         GraphenePartitionStatusCounts,
+        GraphenePartitionStatuses,
         GraphenePartitionTags,
     )
 
@@ -252,49 +253,58 @@ def get_partition_set_partition_statuses(
         raise DagsterUserCodeProcessError.from_error_info(names_result.error)
 
     return partition_statuses_from_run_partition_data(
-        partition_set_name, run_partition_data, names_result.partition_names
+        run_partition_data, partition_set_name, names_result.partition_names
     )
 
 
-def partition_statuses_from_run_partition_data(
-    partition_set_name: Optional[str],
-    run_partition_data: Sequence[RunPartitionData],
-    partition_names: Sequence[str],
+def _get_partition_id(
+    partition_name: str,
     backfill_id: Optional[str] = None,
-) -> Sequence["GraphenePartitionStatus"]:
+    partition_set_name: Optional[str] = None,
+):
+    suffix = f":{backfill_id}" if backfill_id else ""
+    return f'{partition_set_name or "__NO_PARTITION_SET__"}:{partition_name}{suffix}'
+
+
+def partition_statuses_from_run_partition_data(
+    run_partition_data: Sequence[RunPartitionData],
+    partition_set_name: Optional[str] = None,
+    partition_names: Optional[Sequence[str]] = None,
+    backfill_id: Optional[str] = None,
+) -> "GraphenePartitionStatuses":
     from ..schema.partition_sets import GraphenePartitionStatus, GraphenePartitionStatuses
 
     partition_data_by_name = {
         partition_data.partition: partition_data for partition_data in run_partition_data
     }
 
-    suffix = f":{backfill_id}" if backfill_id else ""
-
-    results = []
-    for name in partition_names:
-        partition_id = f'{partition_set_name or "__NO_PARTITION_SET__"}:{name}{suffix}'
-        if not partition_data_by_name.get(name):
-            results.append(
-                GraphenePartitionStatus(
-                    id=partition_id,
-                    partitionName=name,
-                )
-            )
-            continue
-        partition_data = partition_data_by_name[name]
-        results.append(
-            GraphenePartitionStatus(
-                id=partition_id,
-                partitionName=name,
-                runId=partition_data.run_id,
-                runStatus=partition_data.status.value,
-                runDuration=partition_data.end_time - partition_data.start_time
-                if partition_data.end_time and partition_data.start_time
-                else None,
-            )
+    status_by_partition = {}
+    for name, partition_data in partition_data_by_name.items():
+        status_by_partition[name] = GraphenePartitionStatus(
+            id=_get_partition_id(name, backfill_id, partition_set_name),
+            partitionName=name,
+            runId=partition_data.run_id,
+            runStatus=partition_data.status.value,
+            runDuration=partition_data.end_time - partition_data.start_time
+            if partition_data.end_time and partition_data.start_time
+            else None,
         )
 
-    return GraphenePartitionStatuses(results=results)
+    if partition_names:
+        results = []
+        for name in partition_names:
+            if name not in status_by_partition:
+                results.append(
+                    GraphenePartitionStatus(
+                        id=_get_partition_id(name, backfill_id, partition_set_name),
+                        partitionName=name,
+                    )
+                )
+            else:
+                results.append(status_by_partition[name])
+        return GraphenePartitionStatuses(results=results)
+    else:
+        return GraphenePartitionStatuses(results=status_by_partition.values())
 
 
 def partition_status_counts_from_run_partition_data(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -54,7 +54,7 @@ SINGLE_BACKFILL_QUERY = """
   query SingleBackfillQuery($backfillId: String!) {
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
-        partitionStatuses {
+        backfillRunStatuses {
           results {
             id
             partitionName
@@ -292,7 +292,7 @@ def test_launch_asset_backfill():
             assert not single_backfill_result.errors
             assert single_backfill_result.data
             partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
-                "partitionStatuses"
+                "backfillRunStatuses"
             ]["results"]
             assert len(partition_status_results) == 2
             assert {
@@ -347,7 +347,7 @@ def test_remove_partitions_defs_after_backfill():
             assert not single_backfill_result.errors
             assert single_backfill_result.data
             partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
-                "partitionStatuses"
+                "backfillRunStatuses"
             ]["results"]
             assert len(partition_status_results) == 0
             assert {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -72,7 +72,6 @@ BACKFILL_STATUS_BY_ASSET = """
     partitionBackfillOrError(backfillId: $backfillId) {
       __typename
       ... on PartitionBackfill {
-        numCancelablePartitions
         backfillRunStatuses {
           results {
             partitionName
@@ -697,7 +696,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             BACKFILL_STATUS_BY_ASSET,
             variables={"backfillId": backfill_id},
         )
-        assert result.data["partitionBackfillOrError"]["numCancelablePartitions"] == 6
 
         run_statuses = result.data["partitionBackfillOrError"]["backfillRunStatuses"]["results"]
         assert len(run_statuses) == 6
@@ -732,7 +730,6 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
 
         assert not result.errors
         assert result.data
-        assert result.data["partitionBackfillOrError"]["numCancelablePartitions"] == 0
 
         run_statuses = result.data["partitionBackfillOrError"]["backfillRunStatuses"]["results"]
         assert len(run_statuses) == 6


### PR DESCRIPTION
This PR enables displaying:
- The run statuses for runs requested within an asset backfill
- A "terminate unfinished runs" button in the backfill menu, which marks all unfinished runs as canceled

In order to support this, the `backfillRunStatuses` resolver (renamed from `partitionStatuses` for clarity) now returns back the status for each partitioned run launched from an asset backfill.

One assumption here is that all runs with the same partition key target the same assets. This is to handle run retries, so only the status of the latest run per partition key is displayed. 

For asset backfills it's possible that multiple runs will target the same partition key but different assets i.e. for a hourly -> daily -> hourly asset graph a run for partition X will be generated for each hourly asset. Subsequently, only the latest run for partition X would be displayed in the counts. I think that this case is fairly unlikely so I haven't handled this case yet, but if we wanted to handle it it would involve deduping by the asset selection per partitioned run.

When each asset in the backfill does not target the same partitions, we display the counts:

<img width="1222" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/82a50a6a-a037-4e23-9bb9-4b6fc230ef32">

When each asset targets the same partitions, we display the row with missing/materialized/in progress partitions:

<img width="1229" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/e62ef894-c505-49fc-b353-cc9c1b4a043c">
