### PR TITLE
[Cancel asset backfill 1/2] Enable cancel backfill button

### DIFF
--- a/js_modules/dagit/packages/core/src/graphql/schema.graphql
+++ b/js_modules/dagit/packages/core/src/graphql/schema.graphql
@@ -2433,7 +2433,7 @@ type PartitionBackfill {
   runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
   error: PythonError
-  partitionStatuses: PartitionStatuses!
+  partitionStatuses: PartitionStatuses
   partitionStatusCounts: [PartitionStatusCounts!]!
   isAssetBackfill: Boolean!
   assetBackfillData: AssetBackfillData

--- a/js_modules/dagit/packages/core/src/graphql/types.ts
+++ b/js_modules/dagit/packages/core/src/graphql/types.ts
@@ -2382,7 +2382,7 @@ export type PartitionBackfill = {
   partitionSet: Maybe<PartitionSet>;
   partitionSetName: Maybe<Scalars['String']>;
   partitionStatusCounts: Array<PartitionStatusCounts>;
-  partitionStatuses: PartitionStatuses;
+  partitionStatuses: Maybe<PartitionStatuses>;
   reexecutionSteps: Maybe<Array<Scalars['String']>>;
   runs: Array<Run>;
   status: BulkActionStatus;

--- a/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
+++ b/js_modules/dagit/packages/core/src/instance/BackfillRow.tsx
@@ -98,7 +98,7 @@ export const BackfillRow = ({
       );
       return {counts, statuses: null};
     }
-    const statuses = data.partitionBackfillOrError.partitionStatuses.results;
+    const statuses = data.partitionBackfillOrError.partitionStatuses?.results;
     const counts = countBy(statuses, (k) => k.runStatus);
     return {counts, statuses};
   }, [data]);
@@ -147,7 +147,7 @@ export const BackfillRow = ({
       </td>
       <td>
         {backfill.isValidSerialization ? (
-          counts ? (
+          counts && statuses ? (
             <BackfillRunStatus backfill={backfill} counts={counts} statuses={statuses} />
           ) : (
             <LoadingOrNone queryResult={statusQueryResult} noneString={'\u2013'} />
@@ -200,7 +200,8 @@ const BackfillMenu = ({
         <Menu>
           {backfill.hasCancelPermission ? (
             <>
-              {backfill.numCancelable > 0 ? (
+              {(backfill.isAssetBackfill && backfill.status === BulkActionStatus.REQUESTED) ||
+              backfill.numCancelable > 0 ? (
                 <MenuItem
                   text="Cancel backfill submission"
                   icon="cancel"

--- a/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
+++ b/js_modules/dagit/packages/core/src/instance/types/BackfillRow.types.ts
@@ -42,7 +42,7 @@ export type SingleBackfillQuery = {
             runId: string | null;
             runStatus: Types.RunStatus | null;
           }>;
-        };
+        } | null;
       }
     | {__typename: 'PythonError'};
 };

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -30,6 +30,24 @@ if TYPE_CHECKING:
     from ...schema.errors import GraphenePartitionSetNotFoundError
 
 
+def _assert_permission_for_asset_graph(
+    graphene_info: "ResolveInfo", asset_graph: ExternalAssetGraph, permission: str
+) -> None:
+    location_names = set(
+        repo_handle.code_location_origin.location_name
+        for repo_handle in asset_graph.repository_handles_by_key.values()
+    )
+
+    if not location_names:
+        assert_permission(
+            graphene_info,
+            permission,
+        )
+    else:
+        for location_name in location_names:
+            assert_permission_for_location(graphene_info, permission, location_name)
+
+
 def create_and_launch_partition_backfill(
     graphene_info: "ResolveInfo",
     backfill_params: BackfillParams,
@@ -136,22 +154,9 @@ def create_and_launch_partition_backfill(
             raise DagsterError("fromFailure is not supported for pure asset backfills")
 
         asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
-
-        location_names = set(
-            repo_handle.code_location_origin.location_name
-            for repo_handle in asset_graph.repository_handles_by_key.values()
+        _assert_permission_for_asset_graph(
+            graphene_info, asset_graph, Permissions.LAUNCH_PARTITION_BACKFILL
         )
-
-        if not location_names:
-            assert_permission(
-                graphene_info,
-                Permissions.LAUNCH_PARTITION_BACKFILL,
-            )
-        else:
-            for location_name in location_names:
-                assert_permission_for_location(
-                    graphene_info, Permissions.LAUNCH_PARTITION_BACKFILL, location_name
-                )
 
         backfill = PartitionBackfill.from_asset_partitions(
             asset_graph=asset_graph,
@@ -183,11 +188,17 @@ def cancel_partition_backfill(
     if not backfill:
         check.failed(f"No backfill found for id: {backfill_id}")
 
-    partition_set_origin = check.not_none(backfill.partition_set_origin)
-    location_name = partition_set_origin.selector.location_name
-    assert_permission_for_location(
-        graphene_info, Permissions.CANCEL_PARTITION_BACKFILL, location_name
-    )
+    if backfill.serialized_asset_backfill_data:
+        asset_graph = ExternalAssetGraph.from_workspace(graphene_info.context)
+        _assert_permission_for_asset_graph(
+            graphene_info, asset_graph, Permissions.CANCEL_PARTITION_BACKFILL
+        )
+    else:
+        partition_set_origin = check.not_none(backfill.partition_set_origin)
+        location_name = partition_set_origin.selector.location_name
+        assert_permission_for_location(
+            graphene_info, Permissions.CANCEL_PARTITION_BACKFILL, location_name
+        )
 
     graphene_info.context.instance.update_backfill(backfill.with_status(BulkActionStatus.CANCELED))
     return GrapheneCancelBackfillSuccess(backfill_id=backfill_id)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -153,7 +153,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         limit=graphene.Int(),
     )
     error = graphene.Field(GraphenePythonError)
-    partitionStatuses = graphene.NonNull(
+    partitionStatuses = graphene.Field(
         "dagster_graphql.schema.partition_sets.GraphenePartitionStatuses"
     )
     partitionStatusCounts = non_null_list(
@@ -276,6 +276,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         )
 
     def resolve_partitionStatuses(self, graphene_info: ResolveInfo):
+        if self._backfill_job.is_asset_backfill:
+            return None
+
         partition_set_origin = self._backfill_job.partition_set_origin
         partition_set_name = (
             partition_set_origin.partition_set_name if partition_set_origin else None

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -291,14 +291,9 @@ def test_launch_asset_backfill():
             )
             assert not single_backfill_result.errors
             assert single_backfill_result.data
-            partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
-                "partitionStatuses"
-            ]["results"]
-            assert len(partition_status_results) == 2
-            assert {
-                partition_status_result["partitionName"]
-                for partition_status_result in partition_status_results
-            } == {"a", "b"}
+            assert (
+                single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
+            )
 
 
 def test_remove_partitions_defs_after_backfill():
@@ -346,14 +341,9 @@ def test_remove_partitions_defs_after_backfill():
             )
             assert not single_backfill_result.errors
             assert single_backfill_result.data
-            partition_status_results = single_backfill_result.data["partitionBackfillOrError"][
-                "partitionStatuses"
-            ]["results"]
-            assert len(partition_status_results) == 0
-            assert {
-                partition_status_result["partitionName"]
-                for partition_status_result in partition_status_results
-            } == set()
+            assert (
+                single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
+            )
 
 
 def test_launch_asset_backfill_with_non_partitioned_asset():

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -225,6 +225,11 @@ class PartitionBackfill(
             return self.partition_names
 
     def get_num_cancelable(self) -> int:
+        """This method is only valid for job backfills. It eturns the number of partitions that are have
+        not yet been requested by the backfill.
+
+        For asset backfills, returns 0.
+        """
         if self.is_asset_backfill:
             return 0
 


### PR DESCRIPTION
This PR adds support for canceling an asset backfill:
- Updates the `numCancelable` resolver to return the number of partitions for which runs have not yet been created. This is used to display a "There are X partitions yet to be queued or launched" confirmation message.
- Validates permissions and updates the backfill's bulk action status to be `CANCELED`.

One gap following this PR is that after the asset backfill is marked as canceled the backfill is not evaluated by the daemon again. This means that asset backfill page will continue to display the state of the backfill at the moment of cancellation, even if the runs have since finished. Part 3 of this stack resolves this gap: https://github.com/dagster-io/dagster/pull/14224

<img width="1225" alt="image" src="https://github.com/dagster-io/dagster/assets/29110579/51fde917-c08f-4516-9762-63cf56e40fa6">
