### PR TITLE
Don't assume run group lists are ordered

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1,6 +1,7 @@
 import sys
 import tempfile
 import time
+import unittest
 from datetime import datetime, timedelta
 
 import pendulum
@@ -1036,8 +1037,9 @@ class TestRunStorage:
 
         assert len(run_group_two[1]) == 7
 
-        assert run_group_one[0] == run_group_two[0]
-        assert run_group_one[1] == run_group_two[1]
+        # The order of runs in each run run group is not deterministic
+        unittest.TestCase().assertCountEqual(run_group_one[0], run_group_two[0])
+        unittest.TestCase().assertCountEqual(run_group_one[1], run_group_two[1])
 
     def test_fetch_run_group_not_found(self, storage: RunStorage):
         assert storage


### PR DESCRIPTION
We recently had a test flake because this comparison assumes the order of runs in run groups are deterministic. But that doesn't appear to always be the case:

https://buildkite.com/dagster/internal/builds/43597#01880c16-9d42-4124-8eb2-c39a066c80d0

The alternative is to force run groups to return in a deterministic order. I don't know enough about how they're used to know if that's the behavior we want.