### PR TITLE
clarify lazy auto-materialize reasons in doc and UI

### DIFF
--- a/js_modules/dagit/packages/core/src/assets/AutomaterializePolicyTag.tsx
+++ b/js_modules/dagit/packages/core/src/assets/AutomaterializePolicyTag.tsx
@@ -18,7 +18,8 @@ export const automaterializePolicyDescription = (policy: {
     This asset is automatically re-materialized when:
     <ul style={{paddingLeft: 20, marginBottom: 0}}>
       <li>it is missing</li>
-      <li>it or any of its children have a freshness policy that require more up-to-date data</li>
+      <li>it has a freshness policy that requires more up-to-date data</li>
+      <li>any of its descendants have a freshness policy that require more up-to-date data</li>
       {policy.policyType === AutoMaterializePolicyType.EAGER && (
         <li>any of its parent assets / partitions have been updated more recently than it has</li>
       )}

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -35,15 +35,15 @@ class AutoMaterializePolicy(
     For eager reconciliation, an asset / partition will be (re)materialized when:
 
     - it is missing
-    - it or any of its children have a FreshnessPolicy that require more up-to-date data than it
-      currently has
+    - it has a freshness policy that requires more up-to-date data
+    - any of its descendants have a freshness policy that require more up-to-date data
     - any of its parent assets / partitions have been updated more recently than it has
 
     For lazy reconciliation, an asset / partition will be (re)materialized when:
 
     - it is missing
-    - it or any of its children have a FreshnessPolicy that require more up-to-date data than it
-      currently has
+    - it has a freshness policy that requires more up-to-date data
+    - any of its descendants have a freshness policy that require more up-to-date data
 
     In essence, an asset with eager reconciliation will always incorporate the most up-to-date
     version of its parents, while an asset with lazy reconciliation will only update when necessary


### PR DESCRIPTION
## Summary & Motivation

From Sean:

> I think I just mentally assumed each bullet point was one condition
> And my eye skipped ahead to "children freshness policy" and then I assumed "oh the condition for this bullet is about children freshness"

## How I Tested These Changes
