### PR TITLE
[auto-materialize] Fix issue with freshness based logic when roots are unselected an unmaterialized

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -940,14 +940,15 @@ def determine_asset_partitions_to_auto_materialize_for_freshness(
             current_data_time = data_time_resolver.get_current_data_time(key, current_time)
 
             # figure out the expected data time of this asset if it were to be executed on this tick
+            # for root assets, this would just be the current time
             expected_data_time = min(
                 (
                     cast(datetime.datetime, expected_data_time_by_key[k])
                     for k in parents
                     if k in expected_data_time_by_key and expected_data_time_by_key[k] is not None
                 ),
-                default=current_time,
-            )
+                default=None
+            ) if asset_graph.has_non_source_parents(key) else current_data_time
 
             if key in target_asset_keys:
                 # calculate the data times you would expect after all currently-executing runs

--- a/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_reconciliation_sensor.py
@@ -941,14 +941,19 @@ def determine_asset_partitions_to_auto_materialize_for_freshness(
 
             # figure out the expected data time of this asset if it were to be executed on this tick
             # for root assets, this would just be the current time
-            expected_data_time = min(
-                (
-                    cast(datetime.datetime, expected_data_time_by_key[k])
-                    for k in parents
-                    if k in expected_data_time_by_key and expected_data_time_by_key[k] is not None
-                ),
-                default=None
-            ) if asset_graph.has_non_source_parents(key) else current_data_time
+            expected_data_time = (
+                min(
+                    (
+                        cast(datetime.datetime, expected_data_time_by_key[k])
+                        for k in parents
+                        if k in expected_data_time_by_key
+                        and expected_data_time_by_key[k] is not None
+                    ),
+                    default=None,
+                )
+                if asset_graph.has_non_source_parents(key)
+                else current_time
+            )
 
             if key in target_asset_keys:
                 # calculate the data times you would expect after all currently-executing runs

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/freshness_policy_scenarios.py
@@ -97,7 +97,7 @@ subsettable_multi_asset_complex = [
 
 daily_to_unpartitioned = [
     asset_def("daily", partitions_def=DailyPartitionsDefinition(start_date="2020-01-01")),
-    asset_def("unpartitioned", ["daily"], freshness_policy=freshness_30m)
+    asset_def("unpartitioned", ["daily"], freshness_policy=freshness_30m),
 ]
 
 freshness_policy_scenarios = {
@@ -105,6 +105,18 @@ freshness_policy_scenarios = {
         assets=diamond_freshness,
         unevaluated_runs=[],
         expected_run_requests=[run_request(asset_keys=["asset1", "asset2", "asset3", "asset4"])],
+    ),
+    "freshness_blank_slate_root_unselected": AssetReconciliationScenario(
+        assets=diamond_freshness,
+        asset_selection=AssetSelection.all()-AssetSelection.keys("asset1"),
+        unevaluated_runs=[],
+        expected_run_requests=[],
+    ),
+    "freshness_blank_slate_root_unselected_and_materialized": AssetReconciliationScenario(
+        assets=diamond_freshness,
+        asset_selection=AssetSelection.all()-AssetSelection.keys("asset1"),
+        unevaluated_runs=[run(["asset1"])],
+        expected_run_requests=[run_request(asset_keys=["asset2", "asset3", "asset4"])],
     ),
     "freshness_all_fresh": AssetReconciliationScenario(
         assets=diamond_freshness,
@@ -378,5 +390,5 @@ freshness_policy_scenarios = {
         current_time=create_pendulum_time(year=2020, month=1, day=2, hour=6, tz="UTC"),
         unevaluated_runs=[run(["daily"], partition_key="2020-01-01")],
         expected_run_requests=[run_request(["unpartitioned"])],
-    )
+    ),
 }

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_reconciliation_tests/freshness_policy_scenarios.py
@@ -108,13 +108,13 @@ freshness_policy_scenarios = {
     ),
     "freshness_blank_slate_root_unselected": AssetReconciliationScenario(
         assets=diamond_freshness,
-        asset_selection=AssetSelection.all()-AssetSelection.keys("asset1"),
+        asset_selection=AssetSelection.all() - AssetSelection.keys("asset1"),
         unevaluated_runs=[],
         expected_run_requests=[],
     ),
     "freshness_blank_slate_root_unselected_and_materialized": AssetReconciliationScenario(
         assets=diamond_freshness,
-        asset_selection=AssetSelection.all()-AssetSelection.keys("asset1"),
+        asset_selection=AssetSelection.all() - AssetSelection.keys("asset1"),
         unevaluated_runs=[run(["asset1"])],
         expected_run_requests=[run_request(asset_keys=["asset2", "asset3", "asset4"])],
     ),


### PR DESCRIPTION
## Summary & Motivation

Originally thought this was specific to partitioned -> unpartitioned but it's not. In the case that we have:
- multiple assets
- one downstream asset has a freshness policy
- its root assets are not part of the asset_selection (or do not have an AutoMaterializePolicy)
- those root assets are unmaterialized

this logic would erroneously assume that materializing a downstream asset would give it a data time of the current time. this has been fixed, and tests added.

## How I Tested These Changes
