### PR TITLE
Revert "[dagit] Expose run.updateTime in the correct timezone (#13548)"

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import List, Optional, Sequence
 
 import dagster._check as check
@@ -571,8 +570,7 @@ class GrapheneRun(graphene.ObjectType):
 
     def resolve_updateTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
-        updated = run_record.update_timestamp.timestamp()
-        return datetime_as_float(datetime.datetime.utcfromtimestamp(updated))
+        return datetime_as_float(run_record.update_timestamp)
 
 
 class GrapheneIPipelineSnapshotMixin:


### PR DESCRIPTION
This reverts commit 65b59dea1bc39be0203c36f1dc545dd4d57e0607 - calling .timestamp() on a timezone-less datetime actually transforms it into the viewer's timezone, so I think the original code here was correct. There must be something else, probably postgres-specific, causing the timezone passed in here to be in the wrong timezone.

See the note here for the pitfalls of calling timestamp() on a non-UTC datetime: https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp

cc @OwenKephart - the blamerev referenced this other code as an inspiration, which makes me worried it may have a similar issue? https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/data_time.py#L432

## Summary & Motivation

## How I Tested These Changes
Launch a run locally, check the Runs tab - timezone is now correct again