### PR TITLE
Store postgres timestamps in UTC, even if the postgres DB is not in UTC

### DIFF
--- a/examples/deploy_docker/from_source/docker-compose.yml
+++ b/examples/deploy_docker/from_source/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       POSTGRES_USER: "postgres_user"
       POSTGRES_PASSWORD: "postgres_password"
       POSTGRES_DB: "postgres_db"
+    expose:
+      - "5432"
+    ports:
+      - "5432:5432"
     networks:
       - docker_example_network
 

--- a/examples/deploy_docker/from_source/psql.sh
+++ b/examples/deploy_docker/from_source/psql.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+PGPASSWORD=postgres_password psql -h localhost -p 5432 -U postgres_user postgres_db

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -181,6 +181,11 @@ def compiles_get_current_timestamp_mysql(_element, _compiler, **_kw) -> str:
     return f"CURRENT_TIMESTAMP({MYSQL_DATE_PRECISION})"
 
 
+@compiles(get_current_timestamp, "postgresql")
+def compiles_get_current_timestamp_postgres(_element, _compiler, **_kw) -> str:
+    return "TIMEZONE('utc', CURRENT_TIMESTAMP)"
+
+
 @compiles(get_current_timestamp)
 def compiles_get_current_timestamp_default(_element, _compiler, **_kw) -> str:
     return "CURRENT_TIMESTAMP"


### PR DESCRIPTION
Summary:
Fixes an issue where the current timestamp was stored in non-UTC if the postgres DB was using a non-UTC timezone

Test Plan:
Run deploy_docker/from_source and check the postgres DB - the time is now stored with a default value using this functino instead of the old CURRENT_TIMESTAMP
Change the timezone of the DB to a non-UTC timezone, launch a run, check the starting timestamp

## Summary & Motivation

## How I Tested These Changes
