### PR TITLE
safer timestamp handling in data_time calculation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -429,7 +429,8 @@ class CachingDataTimeResolver:
             return current_data_time
 
         run_failure_time = datetime.datetime.utcfromtimestamp(
-            latest_run_record.end_time or latest_run_record.create_timestamp.timestamp()
+            latest_run_record.end_time
+            or latest_run_record.create_timestamp.replace(tzinfo=datetime.timezone.utc).timestamp()
         ).replace(tzinfo=datetime.timezone.utc)
         return self._get_in_progress_data_time_in_run(
             run_id=run_id, asset_key=asset_key, current_time=run_failure_time

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -429,8 +429,7 @@ class CachingDataTimeResolver:
             return current_data_time
 
         run_failure_time = datetime.datetime.utcfromtimestamp(
-            latest_run_record.end_time
-            or datetime_as_float(latest_run_record.create_timestamp)
+            latest_run_record.end_time or datetime_as_float(latest_run_record.create_timestamp)
         ).replace(tzinfo=datetime.timezone.utc)
         return self._get_in_progress_data_time_in_run(
             run_id=run_id, asset_key=asset_key, current_time=run_failure_time

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventLogRecord
 from dagster._core.storage.dagster_run import FINISHED_STATUSES, DagsterRunStatus, RunsFilter
-from dagster._utils import make_hashable
+from dagster._utils import datetime_as_float, make_hashable
 from dagster._utils.cached_method import cached_method
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -430,7 +430,7 @@ class CachingDataTimeResolver:
 
         run_failure_time = datetime.datetime.utcfromtimestamp(
             latest_run_record.end_time
-            or latest_run_record.create_timestamp.replace(tzinfo=datetime.timezone.utc).timestamp()
+            or datetime_as_float(latest_run_record.create_timestamp)
         ).replace(tzinfo=datetime.timezone.utc)
         return self._get_in_progress_data_time_in_run(
             run_id=run_id, asset_key=asset_key, current_time=run_failure_time


### PR DESCRIPTION
## Summary & Motivation

re: https://github.com/dagster-io/dagster/pull/14251

This part of the conditional should essentially never be called, as any run that fails should have an end timestamp, so this codepath was mostly there to keep type checkers happy.

Nevertheless, we should make sure that we're calling timestamp() in safe ways.

## How I Tested These Changes
