### PR TITLE
feedback

### DIFF
--- a/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunCreatedByCell.tsx
@@ -7,15 +7,17 @@ import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {DagsterTag} from './RunTag';
 import {runsPathWithFilters} from './RunsFilterInput';
 import {RunTableRunFragment} from './types/RunTable.types';
+import styled from 'styled-components/macro';
+import {RunFilterToken} from './RunsFilterInputNew';
+import {RunTags} from './RunTags';
 
 type Props = {
   run: RunTableRunFragment;
+  onAddTag?: (tag: RunFilterToken) => void;
 };
 
 export function RunCreatedByCell(props: Props) {
   const tags = props.run.tags || [];
-
-  const isReexecution = tags.some((tag) => tag.key === DagsterTag.ParentRunId);
 
   const backfillTag = tags.find((tag) => tag.key === DagsterTag.Backfill);
   const scheduleTag = tags.find((tag) => tag.key === DagsterTag.ScheduleName);
@@ -34,18 +36,8 @@ export function RunCreatedByCell(props: Props) {
 
   let creator;
 
-  if (isReexecution || user) {
-    /**
-     * If this is a re-executed run then it was created by a user manually.
-     * It will still have the original sensor/backfill/schedule tags because
-     * they're copied over from the original but we don't show them because
-     * they're only responsible for the original run
-     */
-    if (user) {
-      creator = <UserDisplay email={user.value} />;
-    } else {
-      creator = <Tag icon="account_circle">Launchpad</Tag>;
-    }
+  if (user) {
+    creator = <UserDisplay email={user.value} />;
   } else if (backfillTag) {
     const link = props.run.assetSelection?.length
       ? `/overview/backfills/${backfillTag.value}`
@@ -56,9 +48,19 @@ export function RunCreatedByCell(props: Props) {
           },
         ]);
     creator = (
-      <div key="backfill">
-        Backfill: <Link to={link}>{backfillTag.value}</Link>
-      </div>
+      <RunTagsWrapper>
+        <RunTags
+          tags={[
+            {
+              key: DagsterTag.Backfill,
+              value: backfillTag.value,
+              link,
+            },
+          ]}
+          mode={null}
+          onAddTag={props.onAddTag}
+        />
+      </RunTagsWrapper>
     );
   } else if (scheduleTag) {
     creator = (
@@ -78,9 +80,17 @@ export function RunCreatedByCell(props: Props) {
         Auto-materialize policy
       </Tag>
     );
+  } else {
+    creator = <Tag icon="account_circle">Launchpad</Tag>;
   }
 
   return (
     <Box flex={{direction: 'column', alignItems: 'flex-start'}}>{creator || createdBy?.value}</Box>
   );
 }
+const RunTagsWrapper = styled.div`
+  display: contents;
+  > * {
+    display: contents;
+  }
+`;

--- a/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunTableNew.tsx
@@ -163,13 +163,20 @@ export const RunTable = (props: RunTableProps) => {
     <>
       <ActionBar
         top={
-          <>
+          <Box
+            flex={{
+              direction: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              grow: 1,
+            }}
+          >
             {actionBarComponents}
             <RunBulkActionsMenu
               selected={selectedFragments}
               clearSelection={() => onToggleAll(false)}
             />
-          </>
+          </Box>
         }
         bottom={belowActionBarComponents}
       />
@@ -372,7 +379,7 @@ const RunRow: React.FC<{
       </td>
       {hideCreatedBy ? null : (
         <td>
-          <RunCreatedByCell run={run} />
+          <RunCreatedByCell run={run} onAddTag={onAddTag} />
         </td>
       )}
       <td>

--- a/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
+++ b/js_modules/dagit/packages/core/src/runs/RunsRootNew.tsx
@@ -5,8 +5,10 @@ import {
   ButtonLink,
   Colors,
   CursorHistoryControls,
+  Heading,
   NonIdealState,
   Page,
+  PageHeader,
   tokenToString,
 } from '@dagster-io/ui';
 import partition from 'lodash/partition';
@@ -145,20 +147,19 @@ export const RunsRoot = () => {
 
   function actionBar() {
     return (
-      <Box
-        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between', grow: 1}}
-      >
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-          {tabs}
-          {filtersSlot}
-        </Box>
-        <QueryRefreshCountdown refreshState={combinedRefreshState} />
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+        {tabs}
+        {filtersSlot}
       </Box>
     );
   }
 
   return (
     <Page>
+      <PageHeader
+        title={<Heading>Runs</Heading>}
+        right={<QueryRefreshCountdown refreshState={refreshState} />}
+      />
       {filtersPortal}
       {currentTab === 'queued' && canSeeConfig ? (
         <Box


### PR DESCRIPTION
## Summary & Motivation

1. Don't assume re-executions are made by users -- they can also be made by retry policies
2. Add back the gray page header
3. Convert Backfill into a tag so you can easily "Add tag to filter"

## How I Tested These Changes
![Screen Shot 2023-05-12 at 10 24 44 AM](https://github.com/dagster-io/dagster/assets/2286579/fa8f81b0-d64b-464d-977a-75307edfa166)
